### PR TITLE
[Kernel] [Helion] [11/N] Retune configs for silu_mul_fp8

### DIFF
--- a/vllm/kernels/helion/configs/silu_mul_fp8.json
+++ b/vllm/kernels/helion/configs/silu_mul_fp8.json
@@ -363,7 +363,7 @@
     "intermediate_2048_numtokens_1": {
       "block_sizes": [
         1,
-        16
+        1
       ],
       "loop_orders": [
         [
@@ -375,7 +375,7 @@
         false
       ],
       "l2_groupings": [
-        1
+        2
       ],
       "range_unroll_factors": [
         0
@@ -391,17 +391,17 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "first",
+        "first"
       ],
-      "num_warps": 16,
-      "num_stages": 2,
+      "num_warps": 1,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -436,24 +436,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "first",
+        "last"
       ],
       "num_warps": 16,
-      "num_stages": 2,
+      "num_stages": 8,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_1": {
       "block_sizes": [
         1,
-        32
+        1
       ],
       "loop_orders": [
         [
@@ -465,7 +465,7 @@
         false
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -482,23 +482,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "first",
+        "first"
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 32,
+      "num_stages": 6,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
-      "pid_type": "flat"
+      "pid_type": "xyz"
     },
     "intermediate_8192_numtokens_1": {
       "block_sizes": [
         1,
-        32
+        1
       ],
       "loop_orders": [
         [
@@ -510,7 +510,7 @@
         false
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -527,23 +527,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "last",
+        "first"
       ],
-      "num_warps": 1,
-      "num_stages": 2,
+      "num_warps": 2,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_1": {
       "block_sizes": [
         1,
-        32
+        1
       ],
       "loop_orders": [
         [
@@ -552,10 +552,10 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -572,23 +572,23 @@
       ],
       "load_eviction_policies": [
         "first",
-        "",
-        ""
+        "last",
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 8,
+      "num_stages": 6,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_1": {
       "block_sizes": [
         1,
-        32
+        1
       ],
       "loop_orders": [
         [
@@ -600,7 +600,7 @@
         false
       ],
       "l2_groupings": [
-        2
+        64
       ],
       "range_unroll_factors": [
         0
@@ -617,11 +617,11 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        "first"
+        "last",
+        "last"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 5,
       "indexing": [
         "pointer",
         "pointer",
@@ -632,200 +632,20 @@
     },
     "intermediate_2048_numtokens_2": {
       "block_sizes": [
-        2,
-        16
+        1,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_2": {
-      "block_sizes": [
-        1,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_2": {
-      "block_sizes": [
-        2,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_2": {
-      "block_sizes": [
-        1,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_2": {
-      "block_sizes": [
-        1,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
+        8
       ],
       "range_unroll_factors": [
         0
@@ -846,7 +666,7 @@
         ""
       ],
       "num_warps": 4,
-      "num_stages": 2,
+      "num_stages": 5,
       "indexing": [
         "pointer",
         "pointer",
@@ -855,10 +675,190 @@
       ],
       "pid_type": "flat"
     },
+    "intermediate_2880_numtokens_2": {
+      "block_sizes": [
+        1,
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_2": {
+      "block_sizes": [
+        1,
+        1
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_8192_numtokens_2": {
+      "block_sizes": [
+        1,
+        1
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_2": {
+      "block_sizes": [
+        1,
+        16384
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "xyz"
+    },
     "intermediate_14336_numtokens_2": {
       "block_sizes": [
         1,
-        64
+        1
       ],
       "loop_orders": [
         [
@@ -886,12 +886,12 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
         "",
-        "",
-        ""
+        "first"
       ],
-      "num_warps": 8,
-      "num_stages": 2,
+      "num_warps": 4,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "pointer",
@@ -902,58 +902,105 @@
     },
     "intermediate_2048_numtokens_4": {
       "block_sizes": [
-        1,
-        256
+        2,
+        1
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
       ],
       "range_warp_specializes": [],
       "range_num_stages": [
-        0
+        2
       ],
       "range_multi_buffers": [
-        null
+        false
       ],
       "range_flattens": [
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "last",
+        "last"
       ],
-      "num_warps": 32,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 7,
       "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
-      "pid_type": "flat"
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 128,
+      "maxnreg": 64
     },
     "intermediate_2880_numtokens_4": {
       "block_sizes": [
-        1,
-        8
+        4,
+        64
       ],
       "loop_orders": [
         [
           0,
           1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_4096_numtokens_4": {
+      "block_sizes": [
+        1,
+        32
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
         ]
       ],
       "flatten_loops": [
@@ -976,59 +1023,14 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_4": {
-      "block_sizes": [
-        4,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
+        "first",
+        "first",
+        "last"
       ],
       "num_warps": 4,
-      "num_stages": 1,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
@@ -1038,7 +1040,7 @@
     "intermediate_8192_numtokens_4": {
       "block_sizes": [
         1,
-        16
+        2048
       ],
       "loop_orders": [
         [
@@ -1047,7 +1049,7 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
         1
@@ -1070,11 +1072,11 @@
         "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 8,
+      "num_stages": 8,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -1082,8 +1084,98 @@
     },
     "intermediate_11008_numtokens_4": {
       "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_14336_numtokens_4": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_2048_numtokens_8": {
+      "block_sizes": [
         1,
-        32
+        1
       ],
       "loop_orders": [
         [
@@ -1095,52 +1187,7 @@
         false
       ],
       "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_4": {
-      "block_sizes": [
-        4,
-        16
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
+        2
       ],
       "range_unroll_factors": [
         0
@@ -1160,65 +1207,20 @@
         "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_8": {
-      "block_sizes": [
-        8,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 8,
       "indexing": [
         "tensor_descriptor",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_8": {
       "block_sizes": [
-        8,
-        32
+        4,
+        2048
       ],
       "loop_orders": [
         [
@@ -1230,7 +1232,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -1246,81 +1248,36 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "last",
+        "last",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 5,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
-      "pid_type": "flat"
+      "pid_type": "xyz"
     },
     "intermediate_4096_numtokens_8": {
       "block_sizes": [
-        2,
-        32
+        1,
+        1
       ],
       "loop_orders": [
         [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_8": {
-      "block_sizes": [
-        4,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         false
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -1336,36 +1293,81 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "first",
+        "first",
         ""
       ],
       "num_warps": 1,
-      "num_stages": 1,
+      "num_stages": 4,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
         "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_8192_numtokens_8": {
+      "block_sizes": [
+        2,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
         "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_8": {
       "block_sizes": [
-        8,
-        128
+        1,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -1383,22 +1385,22 @@
       "load_eviction_policies": [
         "last",
         "",
-        ""
+        "first"
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 2,
+      "num_stages": 5,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_8": {
       "block_sizes": [
-        8,
-        32
+        1,
+        8
       ],
       "loop_orders": [
         [
@@ -1407,7 +1409,7 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -1428,2406 +1430,21 @@
       "load_eviction_policies": [
         "",
         "first",
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 8,
+      "num_stages": 3,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2048_numtokens_16": {
       "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_16": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_16": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_16": {
-      "block_sizes": [
-        4,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_16": {
-      "block_sizes": [
         8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_16": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_24": {
-      "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_24": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_24": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_24": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_24": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_24": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_32": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_32": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_32": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_32": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_32": {
-      "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_32": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_40": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_40": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_40": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_40": {
-      "block_sizes": [
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_40": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_40": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_48": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_48": {
-      "block_sizes": [
-        8,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_48": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_48": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_48": {
-      "block_sizes": [
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_48": {
-      "block_sizes": [
-        64,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_56": {
-      "block_sizes": [
-        2,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_56": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_56": {
-      "block_sizes": [
-        32,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_56": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_56": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_56": {
-      "block_sizes": [
-        64,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_64": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_64": {
-      "block_sizes": [
-        4,
-        64
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_64": {
-      "block_sizes": [
-        2,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_64": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_64": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_64": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_72": {
-      "block_sizes": [
-        4,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_72": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_72": {
-      "block_sizes": [
-        64,
-        16
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_72": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_72": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_72": {
-      "block_sizes": [
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_80": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_80": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_80": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_80": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_80": {
-      "block_sizes": [
-        64,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_80": {
-      "block_sizes": [
-        32,
         512
       ],
       "loop_orders": [
@@ -3840,7 +1457,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        64
       ],
       "range_unroll_factors": [
         0
@@ -3856,114 +1473,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "first",
-        ""
+        "last",
+        "last",
+        "first"
       ],
       "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_88": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
       "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_88": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
         "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
+        "pointer"
       ],
-      "pid_type": "flat"
+      "pid_type": "xyz"
     },
-    "intermediate_4096_numtokens_88": {
+    "intermediate_2880_numtokens_16": {
       "block_sizes": [
-        64,
-        32
+        1,
+        1024
       ],
       "loop_orders": [
         [
@@ -3975,7 +1502,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -3991,24 +1518,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "last",
+        "first",
         ""
       ],
-      "num_warps": 32,
+      "num_warps": 1,
       "num_stages": 1,
       "indexing": [
         "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
-      "pid_type": "flat"
+      "pid_type": "xyz"
     },
-    "intermediate_8192_numtokens_88": {
+    "intermediate_4096_numtokens_16": {
       "block_sizes": [
-        128,
-        64
+        16,
+        256
       ],
       "loop_orders": [
         [
@@ -4020,7 +1547,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -4036,11 +1563,11 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
+        "last",
+        "",
         "last"
       ],
-      "num_warps": 2,
+      "num_warps": 32,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -4050,15 +1577,15 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_88": {
+    "intermediate_8192_numtokens_16": {
       "block_sizes": [
-        32,
-        128
+        8,
+        512
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
@@ -4081,81 +1608,36 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_88": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
+        "last",
         "last",
         ""
       ],
       "num_warps": 8,
-      "num_stages": 1,
+      "num_stages": 2,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_96": {
+    "intermediate_11008_numtokens_16": {
       "block_sizes": [
-        128,
-        4
+        4,
+        16
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        2
+        4
       ],
       "range_unroll_factors": [
         0
@@ -4176,166 +1658,31 @@
         ""
       ],
       "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_96": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_96": {
-      "block_sizes": [
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
       "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_96": {
-      "block_sizes": [
-        64,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_96": {
+    "intermediate_14336_numtokens_16": {
       "block_sizes": [
-        64,
+        2,
         256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -4351,24 +1698,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "",
-        ""
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 16,
+      "num_stages": 7,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_96": {
+    "intermediate_2048_numtokens_24": {
       "block_sizes": [
-        32,
-        64
+        1,
+        1024
       ],
       "loop_orders": [
         [
@@ -4380,7 +1727,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -4400,20 +1747,20 @@
         "",
         "first"
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
-        "pointer",
         "tensor_descriptor",
-        "pointer"
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_104": {
+    "intermediate_2880_numtokens_24": {
       "block_sizes": [
-        32,
-        8
+        4,
+        1024
       ],
       "loop_orders": [
         [
@@ -4425,7 +1772,52 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_24": {
+      "block_sizes": [
+        8,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
       ],
       "range_unroll_factors": [
         0
@@ -4446,19 +1838,19 @@
         ""
       ],
       "num_warps": 16,
-      "num_stages": 2,
+      "num_stages": 5,
       "indexing": [
         "tensor_descriptor",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_104": {
+    "intermediate_8192_numtokens_24": {
       "block_sizes": [
-        64,
-        64
+        1,
+        2048
       ],
       "loop_orders": [
         [
@@ -4470,7 +1862,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -4487,11 +1879,56 @@
       ],
       "load_eviction_policies": [
         "",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_24": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
         "",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
@@ -4500,10 +1937,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_104": {
+    "intermediate_14336_numtokens_24": {
       "block_sizes": [
-        32,
-        32
+        8,
+        512
       ],
       "loop_orders": [
         [
@@ -4512,10 +1949,55 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        1
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_32": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
       ],
       "range_unroll_factors": [
         0
@@ -4532,23 +2014,113 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "last",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_32": {
+      "block_sizes": [
+        8,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_32": {
+      "block_sizes": [
+        4,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
+      "indexing": [
         "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_104": {
+    "intermediate_8192_numtokens_32": {
       "block_sizes": [
-        8,
-        8
+        4,
+        1024
       ],
       "loop_orders": [
         [
@@ -4577,35 +2149,35 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "last",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_104": {
+    "intermediate_11008_numtokens_32": {
       "block_sizes": [
-        128,
-        16
+        32,
+        2
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -4621,12 +2193,57 @@
         null
       ],
       "load_eviction_policies": [
-        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_32": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
         "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "tensor_descriptor",
@@ -4635,10 +2252,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_104": {
+    "intermediate_2048_numtokens_40": {
       "block_sizes": [
-        32,
-        16
+        1,
+        8
       ],
       "loop_orders": [
         [
@@ -4650,7 +2267,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -4667,11 +2284,146 @@
       ],
       "load_eviction_policies": [
         "",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_40": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
         "",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_40": {
+      "block_sizes": [
+        4,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
         ""
       ],
       "num_warps": 2,
-      "num_stages": 1,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_40": {
+      "block_sizes": [
+        2,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
@@ -4680,9 +2432,54 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_112": {
+    "intermediate_11008_numtokens_40": {
       "block_sizes": [
-        32,
+        1,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_40": {
+      "block_sizes": [
+        4,
         1024
       ],
       "loop_orders": [
@@ -4702,7 +2499,7 @@
       ],
       "range_warp_specializes": [],
       "range_num_stages": [
-        0
+        1
       ],
       "range_multi_buffers": [
         null
@@ -4713,79 +2510,36 @@
       "load_eviction_policies": [
         "first",
         "",
-        ""
+        "last"
       ],
-      "num_warps": 32,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 5,
       "indexing": [
-        "pointer",
         "tensor_descriptor",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
-      "pid_type": "flat"
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 32,
+      "maxnreg": 32
     },
-    "intermediate_2880_numtokens_112": {
+    "intermediate_2048_numtokens_48": {
       "block_sizes": [
-        32,
+        16,
         32
       ],
       "loop_orders": [
         [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_112": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -4801,969 +2555,24 @@
         null
       ],
       "load_eviction_policies": [
+        "",
         "last",
-        "",
-        ""
+        "last"
       ],
-      "num_warps": 16,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 2,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_112": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_112": {
-      "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_112": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_120": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_120": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_120": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_120": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_120": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_120": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_128": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_128": {
-      "block_sizes": [
-        128,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_128": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_128": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_128": {
-      "block_sizes": [
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_128": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_136": {
-      "block_sizes": [
-        128,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_136": {
+    "intermediate_2880_numtokens_48": {
       "block_sizes": [
         8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_136": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_136": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_136": {
-      "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_136": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_144": {
-      "block_sizes": [
-        8,
-        16
+        512
       ],
       "loop_orders": [
         [
@@ -5775,188 +2584,8 @@
         true
       ],
       "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_144": {
-      "block_sizes": [
-        256,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_144": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_144": {
-      "block_sizes": [
-        128,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_144": {
-      "block_sizes": [
-        32,
         4
       ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
       "range_unroll_factors": [
         0
       ],
@@ -5975,20 +2604,20 @@
         "last",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_144": {
+    "intermediate_4096_numtokens_48": {
       "block_sizes": [
-        32,
-        8
+        2,
+        16
       ],
       "loop_orders": [
         [
@@ -6020,458 +2649,8 @@
         "",
         "first"
       ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_152": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_152": {
-      "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_152": {
-      "block_sizes": [
-        64,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_152": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_152": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
       "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_152": {
-      "block_sizes": [
-        64,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_160": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_160": {
-      "block_sizes": [
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_160": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_160": {
-      "block_sizes": [
-        64,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
@@ -6480,55 +2659,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_160": {
+    "intermediate_8192_numtokens_48": {
       "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_160": {
-      "block_sizes": [
-        128,
-        128
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -6540,7 +2674,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        2
       ],
       "range_unroll_factors": [
         0
@@ -6556,114 +2690,69 @@
         null
       ],
       "load_eviction_policies": [
+        "first",
         "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_168": {
-      "block_sizes": [
-        128,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_168": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "last"
       ],
       "num_warps": 4,
       "num_stages": 2,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_168": {
+    "intermediate_11008_numtokens_48": {
       "block_sizes": [
-        64,
-        32
+        2,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_48": {
+      "block_sizes": [
+        8,
+        64
       ],
       "loop_orders": [
         [
@@ -6691,12 +2780,823 @@
         null
       ],
       "load_eviction_policies": [
+        "first",
         "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_56": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_56": {
+      "block_sizes": [
+        2,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        3
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        3
+      ],
+      "range_multi_buffers": [
+        false
+      ],
+      "range_flattens": [
+        false
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 64
+    },
+    "intermediate_4096_numtokens_56": {
+      "block_sizes": [
+        8,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_56": {
+      "block_sizes": [
+        1,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_56": {
+      "block_sizes": [
+        2,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_56": {
+      "block_sizes": [
+        2,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_64": {
+      "block_sizes": [
+        4,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_64": {
+      "block_sizes": [
+        64,
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_64": {
+      "block_sizes": [
+        8,
+        1
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
         "",
         "last"
       ],
       "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_64": {
+      "block_sizes": [
+        2,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_64": {
+      "block_sizes": [
+        1,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_64": {
+      "block_sizes": [
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_72": {
+      "block_sizes": [
+        8,
+        16
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_72": {
+      "block_sizes": [
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_72": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
       "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_72": {
+      "block_sizes": [
+        8,
+        16
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_72": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_72": {
+      "block_sizes": [
+        32,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
@@ -6705,10 +3605,325 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_168": {
+    "intermediate_2048_numtokens_80": {
+      "block_sizes": [
+        2,
+        16
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_80": {
+      "block_sizes": [
+        8,
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_80": {
+      "block_sizes": [
+        2,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_80": {
+      "block_sizes": [
+        4,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_80": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_80": {
+      "block_sizes": [
+        2,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_88": {
       "block_sizes": [
         64,
-        8
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_88": {
+      "block_sizes": [
+        4,
+        4096
       ],
       "loop_orders": [
         [
@@ -6736,36 +3951,36 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "first",
+        "first",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 4,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_168": {
+    "intermediate_4096_numtokens_88": {
       "block_sizes": [
-        64,
-        4
+        8,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -6786,7 +4001,142 @@
         ""
       ],
       "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_88": {
+      "block_sizes": [
+        1,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 8,
       "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_88": {
+      "block_sizes": [
+        16,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_88": {
+      "block_sizes": [
+        4,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
       "indexing": [
         "pointer",
         "pointer",
@@ -6795,9 +4145,504 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_168": {
+    "intermediate_2048_numtokens_96": {
+      "block_sizes": [
+        1,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_96": {
       "block_sizes": [
         32,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_96": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_96": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_96": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_96": {
+      "block_sizes": [
+        4,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_104": {
+      "block_sizes": [
+        1,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_104": {
+      "block_sizes": [
+        1,
+        64
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_104": {
+      "block_sizes": [
+        8,
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_104": {
+      "block_sizes": [
+        1,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_104": {
+      "block_sizes": [
+        2,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_104": {
+      "block_sizes": [
+        8,
         512
       ],
       "loop_orders": [
@@ -6826,24 +4671,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "last",
+        "last",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_176": {
+    "intermediate_2048_numtokens_112": {
       "block_sizes": [
-        32,
-        128
+        8,
+        8
       ],
       "loop_orders": [
         [
@@ -6871,36 +4716,36 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "last",
+        "first",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 2,
+      "num_warps": 1,
+      "num_stages": 5,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_176": {
+    "intermediate_2880_numtokens_112": {
       "block_sizes": [
         32,
-        32
+        2
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
+        2
       ],
       "range_unroll_factors": [
         0
@@ -6916,299 +4761,29 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "last",
+        "first",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 4,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_176": {
-      "block_sizes": [
-        4,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_176": {
-      "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_176": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_176": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_184": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_184": {
-      "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_184": {
+    "intermediate_4096_numtokens_112": {
       "block_sizes": [
-        32,
+        128,
         8
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
@@ -7231,24 +4806,24 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
         "",
-        "",
-        ""
+        "first"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 1,
+      "num_stages": 3,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_184": {
+    "intermediate_8192_numtokens_112": {
       "block_sizes": [
-        8,
-        64
+        4,
+        512
       ],
       "loop_orders": [
         [
@@ -7260,7 +4835,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
         0
@@ -7276,24 +4851,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "last",
+        "last"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_184": {
+    "intermediate_11008_numtokens_112": {
       "block_sizes": [
-        32,
-        32
+        4,
+        1024
       ],
       "loop_orders": [
         [
@@ -7306,51 +4881,6 @@
       ],
       "l2_groupings": [
         2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_184": {
-      "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
       ],
       "range_unroll_factors": [
         0
@@ -7370,64 +4900,19 @@
         "last",
         "last"
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_192": {
+    "intermediate_14336_numtokens_112": {
       "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_192": {
-      "block_sizes": [
-        8,
+        4,
         32
       ],
       "loop_orders": [
@@ -7440,7 +4925,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -7457,23 +4942,338 @@
       ],
       "load_eviction_policies": [
         "",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_120": {
+      "block_sizes": [
+        8,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_120": {
+      "block_sizes": [
+        64,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_120": {
+      "block_sizes": [
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
         "",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 2,
+      "num_warps": 16,
+      "num_stages": 3,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
         "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_120": {
+      "block_sizes": [
+        16,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_192": {
+    "intermediate_11008_numtokens_120": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_120": {
       "block_sizes": [
         32,
-        8
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_128": {
+      "block_sizes": [
+        8,
+        1
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_128": {
+      "block_sizes": [
+        4,
+        32
       ],
       "loop_orders": [
         [
@@ -7505,8 +5305,413 @@
         "",
         ""
       ],
-      "num_warps": 16,
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_128": {
+      "block_sizes": [
+        1,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_128": {
+      "block_sizes": [
+        8,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_128": {
+      "block_sizes": [
+        2,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_128": {
+      "block_sizes": [
+        2,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_136": {
+      "block_sizes": [
+        4,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_136": {
+      "block_sizes": [
+        16,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 32,
       "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_136": {
+      "block_sizes": [
+        1,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_136": {
+      "block_sizes": [
+        2,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_136": {
+      "block_sizes": [
+        4,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "pointer",
@@ -7515,10 +5720,1405 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_192": {
+    "intermediate_14336_numtokens_136": {
       "block_sizes": [
         4,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_144": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_144": {
+      "block_sizes": [
+        1,
         32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_144": {
+      "block_sizes": [
+        256,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_144": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_144": {
+      "block_sizes": [
+        256,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_144": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_152": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_152": {
+      "block_sizes": [
+        8,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_152": {
+      "block_sizes": [
+        64,
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_152": {
+      "block_sizes": [
+        64,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_152": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_152": {
+      "block_sizes": [
+        2,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_160": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_160": {
+      "block_sizes": [
+        8,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_160": {
+      "block_sizes": [
+        64,
+        1
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_160": {
+      "block_sizes": [
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_160": {
+      "block_sizes": [
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_160": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_168": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_168": {
+      "block_sizes": [
+        8,
+        4
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_168": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_168": {
+      "block_sizes": [
+        64,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_168": {
+      "block_sizes": [
+        4,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_168": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_176": {
+      "block_sizes": [
+        1,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_176": {
+      "block_sizes": [
+        8,
+        16
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_176": {
+      "block_sizes": [
+        128,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_176": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_176": {
+      "block_sizes": [
+        2,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_176": {
+      "block_sizes": [
+        1,
+        16384
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_184": {
+      "block_sizes": [
+        2,
+        256
       ],
       "loop_orders": [
         [
@@ -7550,6 +7150,96 @@
         "",
         ""
       ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_184": {
+      "block_sizes": [
+        2,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_184": {
+      "block_sizes": [
+        256,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
       "num_warps": 8,
       "num_stages": 1,
       "indexing": [
@@ -7560,9 +7250,324 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_192": {
+    "intermediate_8192_numtokens_184": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_184": {
       "block_sizes": [
         32,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_184": {
+      "block_sizes": [
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_192": {
+      "block_sizes": [
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_192": {
+      "block_sizes": [
+        128,
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_192": {
+      "block_sizes": [
+        8,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_192": {
+      "block_sizes": [
+        32,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_192": {
+      "block_sizes": [
+        16,
         256
       ],
       "loop_orders": [
@@ -7593,66 +7598,21 @@
       "load_eviction_policies": [
         "",
         "",
-        ""
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 32,
+      "num_stages": 7,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_192": {
       "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_200": {
-      "block_sizes": [
-        32,
+        16,
         32
       ],
       "loop_orders": [
@@ -7665,7 +7625,52 @@
         true
       ],
       "l2_groupings": [
-        2
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_200": {
+      "block_sizes": [
+        2,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
       ],
       "range_unroll_factors": [
         0
@@ -7682,11 +7687,11 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "first",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
@@ -7697,20 +7702,20 @@
     },
     "intermediate_2880_numtokens_200": {
       "block_sizes": [
-        32,
-        32
+        8,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -7726,24 +7731,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
         "last",
-        ""
+        "first",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 7,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_200": {
       "block_sizes": [
-        64,
-        32
+        4,
+        512
       ],
       "loop_orders": [
         [
@@ -7755,7 +7760,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -7771,59 +7776,59 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
         "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_200": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first"
       ],
       "num_warps": 1,
       "num_stages": 1,
       "indexing": [
         "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_200": {
+      "block_sizes": [
+        2,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
@@ -7832,17 +7837,17 @@
     },
     "intermediate_11008_numtokens_200": {
       "block_sizes": [
-        8,
-        32
+        1,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
         1
@@ -7861,15 +7866,15 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "first",
+        "first"
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -7878,7 +7883,7 @@
     "intermediate_14336_numtokens_200": {
       "block_sizes": [
         16,
-        8
+        128
       ],
       "loop_orders": [
         [
@@ -7890,7 +7895,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -7910,20 +7915,20 @@
         "",
         "first"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2048_numtokens_208": {
       "block_sizes": [
-        32,
-        128
+        16,
+        256
       ],
       "loop_orders": [
         [
@@ -7932,10 +7937,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -7951,24 +7956,24 @@
         null
       ],
       "load_eviction_policies": [
+        "first",
         "",
-        "",
-        ""
+        "last"
       ],
       "num_warps": 2,
-      "num_stages": 1,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_208": {
       "block_sizes": [
-        64,
-        64
+        256,
+        16
       ],
       "loop_orders": [
         [
@@ -7980,7 +7985,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        8
       ],
       "range_unroll_factors": [
         0
@@ -7996,159 +8001,24 @@
         null
       ],
       "load_eviction_policies": [
+        "first",
         "",
-        "",
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 32,
+      "num_stages": 8,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_208": {
       "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_208": {
-      "block_sizes": [
         256,
         32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_208": {
-      "block_sizes": [
-        64,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_208": {
-      "block_sizes": [
-        16,
-        128
       ],
       "loop_orders": [
         [
@@ -8176,17 +8046,152 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_208": {
+      "block_sizes": [
+        8,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
         ""
       ],
       "num_warps": 32,
-      "num_stages": 1,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_208": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_208": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
@@ -8202,10 +8207,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        4
       ],
       "range_unroll_factors": [
         0
@@ -8222,23 +8227,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "first",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 8,
+      "num_stages": 4,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_216": {
       "block_sizes": [
-        16,
-        128
+        4,
+        1024
       ],
       "loop_orders": [
         [
@@ -8250,7 +8255,52 @@
         true
       ],
       "l2_groupings": [
-        1
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_216": {
+      "block_sizes": [
+        64,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        8
       ],
       "range_unroll_factors": [
         0
@@ -8268,67 +8318,22 @@
       "load_eviction_policies": [
         "",
         "last",
-        ""
+        "first"
       ],
       "num_warps": 32,
-      "num_stages": 1,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_216": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_8192_numtokens_216": {
       "block_sizes": [
-        16,
-        32
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -8358,22 +8363,22 @@
       "load_eviction_policies": [
         "",
         "",
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 2,
+      "num_stages": 7,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_216": {
       "block_sizes": [
-        32,
-        4
+        1,
+        16384
       ],
       "loop_orders": [
         [
@@ -8385,7 +8390,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -8402,14 +8407,14 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        "first"
+        "first",
+        "last"
       ],
-      "num_warps": 1,
-      "num_stages": 2,
+      "num_warps": 4,
+      "num_stages": 4,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "pointer"
       ],
@@ -8417,8 +8422,143 @@
     },
     "intermediate_14336_numtokens_216": {
       "block_sizes": [
-        64,
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_224": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
         32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_224": {
+      "block_sizes": [
+        4,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_224": {
+      "block_sizes": [
+        8,
+        8
       ],
       "loop_orders": [
         [
@@ -8431,6 +8571,96 @@
       ],
       "l2_groupings": [
         2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_224": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_224": {
+      "block_sizes": [
+        32,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
       ],
       "range_unroll_factors": [
         0
@@ -8450,20 +8680,20 @@
         "",
         "last"
       ],
-      "num_warps": 32,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_224": {
+    "intermediate_14336_numtokens_224": {
       "block_sizes": [
-        32,
-        16
+        1,
+        2048
       ],
       "loop_orders": [
         [
@@ -8475,7 +8705,7 @@
         false
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -8492,125 +8722,35 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
+        "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 8,
+      "num_stages": 8,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_224": {
+    "intermediate_2048_numtokens_232": {
       "block_sizes": [
-        64,
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
         64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_224": {
-      "block_sizes": [
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_224": {
-      "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
       ],
       "range_unroll_factors": [
         0
@@ -8633,51 +8773,6 @@
       "num_warps": 16,
       "num_stages": 1,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_224": {
-      "block_sizes": [
-        256,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
         "tensor_descriptor",
         "pointer",
         "pointer",
@@ -8685,9 +8780,9 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_224": {
+    "intermediate_2880_numtokens_232": {
       "block_sizes": [
-        32,
+        256,
         8
       ],
       "loop_orders": [
@@ -8700,7 +8795,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -8717,104 +8812,14 @@
       ],
       "load_eviction_policies": [
         "last",
-        "",
-        "first"
+        "first",
+        "last"
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_232": {
-      "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_232": {
-      "block_sizes": [
-        64,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
         "pointer",
         "pointer"
       ],
@@ -8822,8 +8827,8 @@
     },
     "intermediate_4096_numtokens_232": {
       "block_sizes": [
-        16,
-        4
+        128,
+        128
       ],
       "loop_orders": [
         [
@@ -8835,7 +8840,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -8852,35 +8857,35 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "first",
+        "last"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 2,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_8192_numtokens_232": {
       "block_sizes": [
-        32,
-        32
+        256,
+        8
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        1
+        2
       ],
       "range_unroll_factors": [
         0
@@ -8898,9 +8903,9 @@
       "load_eviction_policies": [
         "",
         "",
-        ""
+        "first"
       ],
-      "num_warps": 4,
+      "num_warps": 16,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -8912,20 +8917,20 @@
     },
     "intermediate_11008_numtokens_232": {
       "block_sizes": [
-        16,
-        32
+        4,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -8941,429 +8946,69 @@
         null
       ],
       "load_eviction_policies": [
-        "",
+        "first",
         "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_232": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_240": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first"
       ],
       "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_240": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_240": {
-      "block_sizes": [
-        16,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
+      "num_stages": 8,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_240": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_240": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_240": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_248": {
-      "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_248": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
         "pointer",
         "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_248": {
+    "intermediate_14336_numtokens_232": {
       "block_sizes": [
-        256,
-        16
+        128,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_240": {
+      "block_sizes": [
+        64,
+        8
       ],
       "loop_orders": [
         [
@@ -9393,22 +9038,157 @@
       "load_eviction_policies": [
         "first",
         "",
-        ""
+        "last"
       ],
-      "num_warps": 16,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 5,
       "indexing": [
         "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_240": {
+      "block_sizes": [
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_240": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_248": {
+    "intermediate_8192_numtokens_240": {
       "block_sizes": [
-        64,
-        32
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_240": {
+      "block_sizes": [
+        4,
+        2048
       ],
       "loop_orders": [
         [
@@ -9436,24 +9216,249 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "first",
+        "last",
         "first"
       ],
-      "num_warps": 4,
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_240": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
       "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_248": {
+      "block_sizes": [
+        32,
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 8,
+      "indexing": [
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_248": {
+      "block_sizes": [
+        8,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_248": {
+      "block_sizes": [
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_248": {
+      "block_sizes": [
+        256,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_248": {
       "block_sizes": [
-        64,
-        4
+        1,
+        512
       ],
       "loop_orders": [
         [
@@ -9485,8 +9490,278 @@
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_248": {
+      "block_sizes": [
+        2,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_272": {
+      "block_sizes": [
+        256,
+        16
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_272": {
+      "block_sizes": [
+        16,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_272": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_272": {
+      "block_sizes": [
+        8,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_272": {
+      "block_sizes": [
+        8,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
       "indexing": [
         "pointer",
         "pointer",
@@ -9495,9 +9770,641 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_248": {
+    "intermediate_14336_numtokens_272": {
+      "block_sizes": [
+        512,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_288": {
       "block_sizes": [
         64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_288": {
+      "block_sizes": [
+        8,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_288": {
+      "block_sizes": [
+        512,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_288": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_288": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_288": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_304": {
+      "block_sizes": [
+        32,
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_304": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        2
+      ],
+      "range_multi_buffers": [
+        false
+      ],
+      "range_flattens": [
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 2,
+      "maxnreg": 64
+    },
+    "intermediate_4096_numtokens_304": {
+      "block_sizes": [
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_304": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_304": {
+      "block_sizes": [
+        256,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_304": {
+      "block_sizes": [
+        4,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_320": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_320": {
+      "block_sizes": [
+        256,
         256
       ],
       "loop_orders": [
@@ -9528,22 +10435,22 @@
       "load_eviction_policies": [
         "",
         "",
-        ""
+        "first"
       ],
       "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_272": {
+    "intermediate_4096_numtokens_320": {
       "block_sizes": [
-        128,
-        32
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -9552,10 +10459,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        64
       ],
       "range_unroll_factors": [
         0
@@ -9571,24 +10478,114 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_320": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_272": {
+    "intermediate_11008_numtokens_320": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_320": {
       "block_sizes": [
         8,
-        128
+        256
       ],
       "loop_orders": [
         [
@@ -9618,22 +10615,22 @@
       "load_eviction_policies": [
         "",
         "last",
-        ""
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
-        "pointer",
         "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_272": {
+    "intermediate_2048_numtokens_336": {
       "block_sizes": [
-        128,
-        32
+        1,
+        64
       ],
       "loop_orders": [
         [
@@ -9645,52 +10642,54 @@
         false
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
-        0
+        1
       ],
       "range_warp_specializes": [],
       "range_num_stages": [
         0
       ],
       "range_multi_buffers": [
-        null
+        true
       ],
       "range_flattens": [
-        null
+        true
       ],
       "load_eviction_policies": [
         "",
         "",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 1,
+      "num_stages": 3,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
-      "pid_type": "flat"
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 2,
+      "maxnreg": 256
     },
-    "intermediate_8192_numtokens_272": {
+    "intermediate_2880_numtokens_336": {
       "block_sizes": [
-        128,
-        32
+        64,
+        64
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        4
       ],
       "range_unroll_factors": [
         0
@@ -9707,20 +10706,20 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "last",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_272": {
+    "intermediate_4096_numtokens_336": {
       "block_sizes": [
         16,
         32
@@ -9732,100 +10731,10 @@
         ]
       ],
       "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_272": {
-      "block_sizes": [
-        64,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_288": {
-      "block_sizes": [
-        4,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
+        8
       ],
       "range_unroll_factors": [
         0
@@ -9843,22 +10752,22 @@
       "load_eviction_policies": [
         "last",
         "",
-        ""
+        "first"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
         "tensor_descriptor",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_288": {
+    "intermediate_8192_numtokens_336": {
       "block_sizes": [
-        8,
-        16
+        1,
+        512
       ],
       "loop_orders": [
         [
@@ -9867,10 +10776,10 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -9887,22 +10796,67 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "first",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 2,
+      "num_warps": 32,
+      "num_stages": 5,
       "indexing": [
+        "pointer",
         "tensor_descriptor",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_288": {
+    "intermediate_11008_numtokens_336": {
       "block_sizes": [
-        64,
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_336": {
+      "block_sizes": [
+        256,
         8
       ],
       "loop_orders": [
@@ -9915,413 +10869,8 @@
         true
       ],
       "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_288": {
-      "block_sizes": [
-        128,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_288": {
-      "block_sizes": [
-        256,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_288": {
-      "block_sizes": [
-        16,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_304": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_304": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_304": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_304": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_304": {
-      "block_sizes": [
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_304": {
-      "block_sizes": [
-        64,
         4
       ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
       "range_unroll_factors": [
         0
       ],
@@ -10336,69 +10885,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 16,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_320": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_320": {
+    "intermediate_2048_numtokens_352": {
       "block_sizes": [
-        64,
-        32
+        512,
+        1
       ],
       "loop_orders": [
         [
@@ -10410,7 +10914,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        8
       ],
       "range_unroll_factors": [
         0
@@ -10428,19 +10932,64 @@
       "load_eviction_policies": [
         "",
         "",
-        ""
+        "first"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 1,
+      "num_stages": 4,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_352": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_320": {
+    "intermediate_4096_numtokens_352": {
       "block_sizes": [
         512,
         4
@@ -10471,554 +11020,14 @@
         null
       ],
       "load_eviction_policies": [
+        "first",
         "last",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_320": {
-      "block_sizes": [
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_320": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_320": {
-      "block_sizes": [
-        128,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_336": {
-      "block_sizes": [
-        2,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_336": {
-      "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_336": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "last"
       ],
       "num_warps": 16,
-      "num_stages": 1,
+      "num_stages": 3,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_336": {
-      "block_sizes": [
-        64,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
         "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_336": {
-      "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_336": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_352": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_352": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_352": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -11027,8 +11036,8 @@
     },
     "intermediate_8192_numtokens_352": {
       "block_sizes": [
-        64,
-        32
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -11038,726 +11047,6 @@
       ],
       "flatten_loops": [
         false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_352": {
-      "block_sizes": [
-        8,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_352": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_368": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_368": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_368": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_368": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_368": {
-      "block_sizes": [
-        32,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_368": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_384": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_384": {
-      "block_sizes": [
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_384": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_384": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_384": {
-      "block_sizes": [
-        8,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_384": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_400": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_400": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
       ],
       "l2_groupings": [
         1
@@ -11778,381 +11067,21 @@
       "load_eviction_policies": [
         "",
         "last",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_400": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first"
       ],
       "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_400": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_400": {
-      "block_sizes": [
-        256,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 32,
       "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_400": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_416": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
         "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_416": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_416": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
         "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_416": {
+    "intermediate_11008_numtokens_352": {
       "block_sizes": [
-        128,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_416": {
-      "block_sizes": [
-        64,
+        16,
         128
       ],
       "loop_orders": [
@@ -12165,7 +11094,592 @@
         true
       ],
       "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_352": {
+      "block_sizes": [
+        512,
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_368": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_368": {
+      "block_sizes": [
+        128,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_368": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_368": {
+      "block_sizes": [
+        2,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
         2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_368": {
+      "block_sizes": [
+        128,
+        2
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_368": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_384": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_384": {
+      "block_sizes": [
+        512,
+        2
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_384": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_384": {
+      "block_sizes": [
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_384": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_384": {
+      "block_sizes": [
+        128,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
       ],
       "range_unroll_factors": [
         0
@@ -12183,22 +11697,22 @@
       "load_eviction_policies": [
         "first",
         "",
-        ""
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_416": {
+    "intermediate_2048_numtokens_400": {
       "block_sizes": [
-        32,
-        256
+        512,
+        32
       ],
       "loop_orders": [
         [
@@ -12226,23 +11740,473 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "first",
+        "last"
       ],
-      "num_warps": 32,
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_400": {
+      "block_sizes": [
+        1,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_400": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
       "num_stages": 1,
       "indexing": [
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_400": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_432": {
+    "intermediate_11008_numtokens_400": {
       "block_sizes": [
-        16,
+        2,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_400": {
+      "block_sizes": [
+        4,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_416": {
+      "block_sizes": [
+        256,
+        4
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_416": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_416": {
+      "block_sizes": [
+        512,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_416": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_416": {
+      "block_sizes": [
+        256,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_416": {
+      "block_sizes": [
+        128,
         16
       ],
       "loop_orders": [
@@ -12255,7 +12219,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        8
       ],
       "range_unroll_factors": [
         0
@@ -12271,12 +12235,57 @@
         null
       ],
       "load_eviction_policies": [
-        "",
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_432": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
         "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 8,
       "indexing": [
         "pointer",
         "pointer",
@@ -12287,53 +12296,8 @@
     },
     "intermediate_2880_numtokens_432": {
       "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_432": {
-      "block_sizes": [
-        16,
-        32
+        512,
+        128
       ],
       "loop_orders": [
         [
@@ -12361,15 +12325,60 @@
         null
       ],
       "load_eviction_policies": [
-        "",
+        "first",
         "last",
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 16,
+      "num_stages": 5,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_432": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -12377,7 +12386,7 @@
     },
     "intermediate_8192_numtokens_432": {
       "block_sizes": [
-        16,
+        256,
         64
       ],
       "loop_orders": [
@@ -12390,7 +12399,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -12407,14 +12416,14 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "first",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 2,
+      "num_warps": 32,
+      "num_stages": 5,
       "indexing": [
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor"
       ],
@@ -12422,20 +12431,20 @@
     },
     "intermediate_11008_numtokens_432": {
       "block_sizes": [
-        16,
-        8
+        1,
+        4096
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -12451,14 +12460,14 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "first",
+        "first"
       ],
       "num_warps": 1,
-      "num_stages": 1,
+      "num_stages": 8,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -12467,8 +12476,8 @@
     },
     "intermediate_14336_numtokens_432": {
       "block_sizes": [
-        32,
-        32
+        512,
+        4
       ],
       "loop_orders": [
         [
@@ -12497,740 +12506,20 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        ""
+        "first",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 1,
+      "num_stages": 7,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2048_numtokens_448": {
-      "block_sizes": [
-        4,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_448": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_448": {
-      "block_sizes": [
-        4,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_448": {
-      "block_sizes": [
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_448": {
-      "block_sizes": [
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_448": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_464": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_464": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_464": {
-      "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_464": {
-      "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_464": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_464": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_480": {
-      "block_sizes": [
-        4,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_480": {
-      "block_sizes": [
-        4,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_480": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_480": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_480": {
       "block_sizes": [
         64,
         128
@@ -13261,81 +12550,36 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "last"
+        "last",
+        "first"
       ],
       "num_warps": 1,
-      "num_stages": 1,
+      "num_stages": 7,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_480": {
+    "intermediate_2880_numtokens_448": {
       "block_sizes": [
-        16,
-        128
+        1,
+        4096
       ],
       "loop_orders": [
         [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_496": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         false
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -13352,23 +12596,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "last",
         ""
       ],
       "num_warps": 2,
-      "num_stages": 1,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_496": {
+    "intermediate_4096_numtokens_448": {
       "block_sizes": [
-        32,
-        128
+        8,
+        64
       ],
       "loop_orders": [
         [
@@ -13398,19 +12642,64 @@
       "load_eviction_policies": [
         "",
         "first",
-        ""
+        "last"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_496": {
+    "intermediate_8192_numtokens_448": {
+      "block_sizes": [
+        128,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_448": {
       "block_sizes": [
         16,
         32
@@ -13425,7 +12714,7 @@
         true
       ],
       "l2_groupings": [
-        4
+        8
       ],
       "range_unroll_factors": [
         0
@@ -13441,24 +12730,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "last",
+        "last",
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 8,
+      "num_stages": 2,
       "indexing": [
-        "pointer",
-        "pointer",
         "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_496": {
+    "intermediate_14336_numtokens_448": {
       "block_sizes": [
-        32,
-        8
+        64,
+        512
       ],
       "loop_orders": [
         [
@@ -13470,7 +12759,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -13486,24 +12775,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "last",
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_496": {
+    "intermediate_2048_numtokens_464": {
       "block_sizes": [
-        32,
-        128
+        1,
+        32
       ],
       "loop_orders": [
         [
@@ -13512,10 +12801,10 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -13533,55 +12822,10 @@
       "load_eviction_policies": [
         "",
         "",
-        ""
+        "last"
       ],
       "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_496": {
-      "block_sizes": [
-        256,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
+      "num_stages": 5,
       "indexing": [
         "pointer",
         "tensor_descriptor",
@@ -13590,10 +12834,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_512": {
+    "intermediate_2880_numtokens_464": {
       "block_sizes": [
-        32,
-        32
+        128,
+        1024
       ],
       "loop_orders": [
         [
@@ -13623,22 +12867,22 @@
       "load_eviction_policies": [
         "",
         "",
-        "last"
+        ""
       ],
       "num_warps": 32,
-      "num_stages": 1,
+      "num_stages": 2,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_512": {
+    "intermediate_4096_numtokens_464": {
       "block_sizes": [
-        16,
-        32
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -13650,7 +12894,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -13666,23 +12910,23 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "last",
+        "last"
       ],
-      "num_warps": 16,
-      "num_stages": 1,
+      "num_warps": 1,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
         "tensor_descriptor",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_512": {
+    "intermediate_8192_numtokens_464": {
       "block_sizes": [
-        128,
+        1,
         512
       ],
       "loop_orders": [
@@ -13711,12 +12955,147 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_464": {
+      "block_sizes": [
+        1,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
         "",
         "",
         ""
       ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_464": {
+      "block_sizes": [
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_480": {
+      "block_sizes": [
+        16,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
       "num_warps": 16,
-      "num_stages": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -13725,10 +13104,685 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_512": {
+    "intermediate_2880_numtokens_480": {
+      "block_sizes": [
+        128,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_480": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_480": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_480": {
       "block_sizes": [
         32,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_480": {
+      "block_sizes": [
+        1,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_496": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_496": {
+      "block_sizes": [
+        8,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_496": {
+      "block_sizes": [
+        1,
         128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_496": {
+      "block_sizes": [
+        16,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_496": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_496": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_512": {
+      "block_sizes": [
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_512": {
+      "block_sizes": [
+        8,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_512": {
+      "block_sizes": [
+        8,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_512": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_512": {
+      "block_sizes": [
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -13756,24 +13810,24 @@
         null
       ],
       "load_eviction_policies": [
+        "first",
         "",
-        "",
-        ""
+        "first"
       ],
-      "num_warps": 32,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 7,
       "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_512": {
+    "intermediate_14336_numtokens_512": {
       "block_sizes": [
-        32,
-        128
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -13785,7 +13839,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -13802,63 +13856,18 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "first",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 7,
       "indexing": [
         "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_512": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat",
-      "range_warp_specializes": []
     }
   },
   "nvidia_h100": {
@@ -27697,6 +27706,7 @@
       "range_unroll_factors": [
         0
       ],
+      "range_warp_specializes": [],
       "range_num_stages": [
         0
       ],
@@ -27719,8 +27729,7 @@
         "pointer",
         "pointer"
       ],
-      "pid_type": "flat",
-      "range_warp_specializes": []
+      "pid_type": "flat"
     }
   }
 }

--- a/vllm/kernels/helion/configs/silu_mul_fp8.json
+++ b/vllm/kernels/helion/configs/silu_mul_fp8.json
@@ -47,8 +47,8 @@
     },
     "intermediate_4096_numtokens_256": {
       "block_sizes": [
-        32,
-        512
+        256,
+        32
       ],
       "loop_orders": [
         [
@@ -60,7 +60,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -80,11 +80,11 @@
         "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -137,8 +137,8 @@
     },
     "intermediate_8192_numtokens_256": {
       "block_sizes": [
-        32,
-        8
+        256,
+        64
       ],
       "loop_orders": [
         [
@@ -167,23 +167,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
+        "",
         ""
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_256": {
       "block_sizes": [
-        16,
-        32
+        8,
+        4096
       ],
       "loop_orders": [
         [
@@ -215,13 +215,13 @@
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -272,8 +272,8 @@
     },
     "intermediate_7688_numtokens_256": {
       "block_sizes": [
-        8,
-        16
+        32,
+        512
       ],
       "loop_orders": [
         [
@@ -302,10 +302,10 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
+        "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -363,7 +363,7 @@
     "intermediate_2048_numtokens_1": {
       "block_sizes": [
         1,
-        1
+        256
       ],
       "loop_orders": [
         [
@@ -372,10 +372,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -391,16 +391,16 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 1,
+      "num_warps": 2,
       "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -408,7 +408,7 @@
     "intermediate_2880_numtokens_1": {
       "block_sizes": [
         1,
-        1
+        128
       ],
       "loop_orders": [
         [
@@ -417,7 +417,7 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -436,69 +436,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 8,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_1": {
       "block_sizes": [
         1,
-        1
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "first"
-      ],
-      "num_warps": 32,
-      "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "xyz"
-    },
-    "intermediate_8192_numtokens_1": {
-      "block_sizes": [
-        1,
-        1
+        256
       ],
       "loop_orders": [
         [
@@ -507,10 +462,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -527,23 +482,68 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "first"
+        "",
+        ""
       ],
       "num_warps": 2,
-      "num_stages": 6,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_1": {
+      "block_sizes": [
+        1,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_1": {
       "block_sizes": [
         1,
-        1
+        256
       ],
       "loop_orders": [
         [
@@ -552,55 +552,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last"
-      ],
-      "num_warps": 8,
-      "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_1": {
-      "block_sizes": [
-        1,
         1
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        64
       ],
       "range_unroll_factors": [
         0
@@ -617,11 +572,56 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_1": {
+      "block_sizes": [
+        1,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -632,53 +632,8 @@
     },
     "intermediate_2048_numtokens_2": {
       "block_sizes": [
-        1,
-        1024
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_2": {
-      "block_sizes": [
-        1,
-        1
+        2,
+        128
       ],
       "loop_orders": [
         [
@@ -687,10 +642,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -707,32 +662,77 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 8,
-      "num_stages": 2,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_2": {
+      "block_sizes": [
+        2,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_2": {
       "block_sizes": [
-        1,
-        1
+        2,
+        128
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -751,36 +751,36 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 8,
-      "num_stages": 3,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
-      "pid_type": "xyz"
+      "pid_type": "flat"
     },
     "intermediate_8192_numtokens_2": {
       "block_sizes": [
-        1,
-        1
+        2,
+        128
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -796,16 +796,16 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 3,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -857,8 +857,8 @@
     },
     "intermediate_14336_numtokens_2": {
       "block_sizes": [
-        1,
-        1
+        2,
+        128
       ],
       "loop_orders": [
         [
@@ -867,7 +867,7 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -886,12 +886,12 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 4,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -902,50 +902,48 @@
     },
     "intermediate_2048_numtokens_4": {
       "block_sizes": [
-        2,
-        1
+        4,
+        64
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
       ],
       "range_warp_specializes": [],
       "range_num_stages": [
-        2
+        0
       ],
       "range_multi_buffers": [
-        false
+        null
       ],
       "range_flattens": [
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 8,
-      "num_stages": 7,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 128,
-      "maxnreg": 64
+      "pid_type": "flat"
     },
     "intermediate_2880_numtokens_4": {
       "block_sizes": [
@@ -994,13 +992,13 @@
     },
     "intermediate_4096_numtokens_4": {
       "block_sizes": [
-        1,
-        32
+        4,
+        64
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
@@ -1023,14 +1021,14 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 6,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -1174,8 +1172,8 @@
     },
     "intermediate_2048_numtokens_8": {
       "block_sizes": [
-        1,
-        1
+        8,
+        32
       ],
       "loop_orders": [
         [
@@ -1184,10 +1182,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -1208,11 +1206,11 @@
         ""
       ],
       "num_warps": 2,
-      "num_stages": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -1264,20 +1262,20 @@
     },
     "intermediate_4096_numtokens_8": {
       "block_sizes": [
-        1,
-        1
+        8,
+        32
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -1293,19 +1291,19 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 4,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
-      "pid_type": "xyz"
+      "pid_type": "flat"
     },
     "intermediate_8192_numtokens_8": {
       "block_sizes": [
@@ -1399,8 +1397,8 @@
     },
     "intermediate_14336_numtokens_8": {
       "block_sizes": [
-        1,
-        8
+        8,
+        128
       ],
       "loop_orders": [
         [
@@ -1429,15 +1427,15 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 8,
-      "num_stages": 3,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -1489,20 +1487,20 @@
     },
     "intermediate_2880_numtokens_16": {
       "block_sizes": [
-        1,
-        1024
+        2,
+        256
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -1518,19 +1516,19 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 4,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
       ],
-      "pid_type": "xyz"
+      "pid_type": "flat"
     },
     "intermediate_4096_numtokens_16": {
       "block_sizes": [
@@ -1579,65 +1577,20 @@
     },
     "intermediate_8192_numtokens_16": {
       "block_sizes": [
-        8,
-        512
+        16,
+        64
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_16": {
-      "block_sizes": [
-        4,
-        16
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -1654,15 +1607,60 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
+        "",
         ""
       ],
       "num_warps": 4,
-      "num_stages": 3,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_16": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -1804,20 +1802,20 @@
     },
     "intermediate_4096_numtokens_24": {
       "block_sizes": [
-        8,
-        128
+        16,
+        64
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -1837,11 +1835,11 @@
         "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 5,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -1984,20 +1982,20 @@
     },
     "intermediate_2048_numtokens_32": {
       "block_sizes": [
-        1,
-        1024
+        32,
+        16
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2014,23 +2012,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
+        "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 3,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_32": {
       "block_sizes": [
-        8,
-        4
+        4,
+        256
       ],
       "loop_orders": [
         [
@@ -2042,7 +2040,7 @@
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2058,17 +2056,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
+        "",
+        "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 2,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -2164,20 +2162,20 @@
     },
     "intermediate_11008_numtokens_32": {
       "block_sizes": [
-        32,
-        2
+        2,
+        2048
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2193,17 +2191,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -2254,8 +2252,8 @@
     },
     "intermediate_2048_numtokens_40": {
       "block_sizes": [
-        1,
-        8
+        32,
+        32
       ],
       "loop_orders": [
         [
@@ -2267,7 +2265,7 @@
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2284,14 +2282,14 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 6,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -2344,8 +2342,8 @@
     },
     "intermediate_4096_numtokens_40": {
       "block_sizes": [
-        4,
-        4
+        32,
+        64
       ],
       "loop_orders": [
         [
@@ -2357,7 +2355,7 @@
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2373,16 +2371,16 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
+        "",
+        "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 3,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -2434,8 +2432,8 @@
     },
     "intermediate_11008_numtokens_40": {
       "block_sizes": [
-        1,
-        64
+        16,
+        256
       ],
       "loop_orders": [
         [
@@ -2447,7 +2445,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2463,17 +2461,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -2526,98 +2524,8 @@
     },
     "intermediate_2048_numtokens_48": {
       "block_sizes": [
-        16,
+        32,
         32
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_48": {
-      "block_sizes": [
-        8,
-        512
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_48": {
-      "block_sizes": [
-        2,
-        16
       ],
       "loop_orders": [
         [
@@ -2647,15 +2555,105 @@
       "load_eviction_policies": [
         "",
         "",
-        "first"
+        ""
       ],
-      "num_warps": 8,
-      "num_stages": 3,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_48": {
+      "block_sizes": [
+        16,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_48": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -2706,20 +2704,20 @@
     },
     "intermediate_11008_numtokens_48": {
       "block_sizes": [
-        2,
-        512
+        16,
+        256
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2737,34 +2735,34 @@
       "load_eviction_policies": [
         "",
         "",
-        "first"
+        ""
       ],
       "num_warps": 8,
-      "num_stages": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_48": {
       "block_sizes": [
-        8,
-        64
+        32,
+        256
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2780,24 +2778,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2048_numtokens_56": {
       "block_sizes": [
-        64,
-        128
+        32,
+        32
       ],
       "loop_orders": [
         [
@@ -2809,7 +2807,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2825,23 +2823,113 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 3,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_56": {
       "block_sizes": [
-        2,
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_56": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_56": {
+      "block_sizes": [
+        32,
         128
       ],
       "loop_orders": [
@@ -2854,53 +2942,7 @@
         true
       ],
       "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        3
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        3
-      ],
-      "range_multi_buffers": [
-        false
-      ],
-      "range_flattens": [
-        false
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 64
-    },
-    "intermediate_4096_numtokens_56": {
-      "block_sizes": [
-        8,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -2916,59 +2958,14 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
+        "",
+        "",
         ""
       ],
       "num_warps": 8,
-      "num_stages": 3,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_56": {
-      "block_sizes": [
-        1,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
@@ -2977,8 +2974,8 @@
     },
     "intermediate_11008_numtokens_56": {
       "block_sizes": [
-        2,
-        64
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -2990,7 +2987,7 @@
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3006,17 +3003,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -3067,20 +3064,20 @@
     },
     "intermediate_2048_numtokens_64": {
       "block_sizes": [
-        4,
-        128
+        64,
+        32
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3096,14 +3093,14 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
+        "",
         "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -3112,98 +3109,8 @@
     },
     "intermediate_2880_numtokens_64": {
       "block_sizes": [
-        64,
-        1
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_64": {
-      "block_sizes": [
-        8,
-        1
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 4,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_64": {
-      "block_sizes": [
-        2,
-        16
+        1,
+        2048
       ],
       "loop_orders": [
         [
@@ -3215,52 +3122,7 @@
         true
       ],
       "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_64": {
-      "block_sizes": [
-        1,
-        128
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3280,13 +3142,148 @@
         "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_64": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_64": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_64": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -3337,20 +3334,20 @@
     },
     "intermediate_2048_numtokens_72": {
       "block_sizes": [
-        8,
-        16
+        64,
+        32
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3366,36 +3363,36 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "last"
+        "",
+        ""
       ],
       "num_warps": 8,
-      "num_stages": 6,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_72": {
       "block_sizes": [
-        16,
-        512
+        32,
+        64
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3411,17 +3408,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -3472,20 +3469,20 @@
     },
     "intermediate_8192_numtokens_72": {
       "block_sizes": [
-        8,
-        16
+        64,
+        128
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3501,15 +3498,15 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -3607,20 +3604,20 @@
     },
     "intermediate_2048_numtokens_80": {
       "block_sizes": [
-        2,
-        16
+        64,
+        32
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3636,24 +3633,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_80": {
       "block_sizes": [
-        8,
-        1
+        32,
+        64
       ],
       "loop_orders": [
         [
@@ -3665,7 +3662,7 @@
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3682,23 +3679,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
+        "",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_80": {
       "block_sizes": [
-        2,
-        8
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -3710,7 +3707,7 @@
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -3726,17 +3723,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
+        "",
+        "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -3878,52 +3875,7 @@
     "intermediate_2048_numtokens_88": {
       "block_sizes": [
         64,
-        1024
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "first"
-      ],
-      "num_warps": 16,
-      "num_stages": 4,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_88": {
-      "block_sizes": [
-        4,
-        4096
+        32
       ],
       "loop_orders": [
         [
@@ -3951,36 +3903,36 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_88": {
+    "intermediate_2880_numtokens_88": {
       "block_sizes": [
         8,
-        1024
+        256
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -4000,19 +3952,64 @@
         "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 6,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_88": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_8192_numtokens_88": {
       "block_sizes": [
-        1,
+        64,
         128
       ],
       "loop_orders": [
@@ -4025,7 +4022,7 @@
         true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -4041,7 +4038,7 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
+        "",
         "",
         ""
       ],
@@ -4049,7 +4046,7 @@
       "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -4147,53 +4144,8 @@
     },
     "intermediate_2048_numtokens_96": {
       "block_sizes": [
-        1,
+        64,
         32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_96": {
-      "block_sizes": [
-        32,
-        1024
       ],
       "loop_orders": [
         [
@@ -4205,7 +4157,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -4225,13 +4177,58 @@
         "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_96": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -4282,8 +4279,8 @@
     },
     "intermediate_8192_numtokens_96": {
       "block_sizes": [
-        1,
-        8192
+        64,
+        128
       ],
       "loop_orders": [
         [
@@ -4292,7 +4289,7 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -4311,17 +4308,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 8,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -4417,103 +4414,13 @@
     },
     "intermediate_2048_numtokens_104": {
       "block_sizes": [
-        1,
-        64
+        64,
+        32
       ],
       "loop_orders": [
         [
           0,
           1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "last",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_104": {
-      "block_sizes": [
-        1,
-        64
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_104": {
-      "block_sizes": [
-        8,
-        2
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
         ]
       ],
       "flatten_loops": [
@@ -4538,21 +4445,21 @@
       "load_eviction_policies": [
         "",
         "",
-        "last"
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_104": {
+    "intermediate_2880_numtokens_104": {
       "block_sizes": [
-        1,
+        8,
         256
       ],
       "loop_orders": [
@@ -4581,16 +4488,106 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_104": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_104": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -4687,103 +4684,13 @@
     },
     "intermediate_2048_numtokens_112": {
       "block_sizes": [
-        8,
-        8
+        64,
+        32
       ],
       "loop_orders": [
         [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_112": {
-      "block_sizes": [
-        32,
-        2
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_112": {
-      "block_sizes": [
-        128,
-        8
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
@@ -4806,17 +4713,107 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 3,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_112": {
+      "block_sizes": [
+        2,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_112": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -4912,8 +4909,8 @@
     },
     "intermediate_14336_numtokens_112": {
       "block_sizes": [
-        4,
-        32
+        64,
+        256
       ],
       "loop_orders": [
         [
@@ -4925,7 +4922,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -4942,16 +4939,16 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 8,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -5002,8 +4999,8 @@
     },
     "intermediate_2880_numtokens_120": {
       "block_sizes": [
-        64,
-        1024
+        2,
+        2048
       ],
       "loop_orders": [
         [
@@ -5015,7 +5012,7 @@
         true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5031,69 +5028,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 3,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_120": {
       "block_sizes": [
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_120": {
-      "block_sizes": [
-        16,
-        8
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -5105,7 +5057,7 @@
         true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5121,15 +5073,60 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_120": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -5227,20 +5224,20 @@
     },
     "intermediate_2048_numtokens_128": {
       "block_sizes": [
-        8,
-        1
+        128,
+        16
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5256,23 +5253,68 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
+        "",
         "",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 6,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_128": {
       "block_sizes": [
-        4,
+        2,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_128": {
+      "block_sizes": [
+        128,
         32
       ],
       "loop_orders": [
@@ -5285,7 +5327,7 @@
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5301,69 +5343,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
+        "",
         "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_128": {
-      "block_sizes": [
-        1,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "first",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_8192_numtokens_128": {
       "block_sizes": [
-        8,
-        16
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -5375,7 +5372,7 @@
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5392,14 +5389,14 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -5452,7 +5449,7 @@
     },
     "intermediate_14336_numtokens_128": {
       "block_sizes": [
-        2,
+        4,
         4096
       ],
       "loop_orders": [
@@ -5465,7 +5462,7 @@
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5481,24 +5478,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2048_numtokens_136": {
       "block_sizes": [
-        4,
-        4
+        128,
+        32
       ],
       "loop_orders": [
         [
@@ -5510,7 +5507,7 @@
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5526,24 +5523,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
+        "",
+        "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_136": {
       "block_sizes": [
-        16,
-        2048
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -5555,7 +5552,7 @@
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5573,22 +5570,22 @@
       "load_eviction_policies": [
         "",
         "",
-        "first"
+        ""
       ],
-      "num_warps": 32,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_136": {
       "block_sizes": [
-        1,
-        128
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -5600,7 +5597,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5617,15 +5614,15 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -5812,8 +5809,8 @@
     },
     "intermediate_2880_numtokens_144": {
       "block_sizes": [
-        1,
-        32
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -5841,24 +5838,24 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
-        "last"
+        "",
+        "",
+        ""
       ],
       "num_warps": 8,
-      "num_stages": 5,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_144": {
       "block_sizes": [
-        256,
-        256
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -5870,7 +5867,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -5886,17 +5883,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -6082,8 +6079,8 @@
     },
     "intermediate_2880_numtokens_152": {
       "block_sizes": [
-        8,
-        8
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -6095,7 +6092,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -6112,13 +6109,13 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -6127,8 +6124,8 @@
     },
     "intermediate_4096_numtokens_152": {
       "block_sizes": [
-        64,
-        1
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -6137,10 +6134,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -6156,17 +6153,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 8,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -6352,8 +6349,8 @@
     },
     "intermediate_2880_numtokens_160": {
       "block_sizes": [
-        8,
-        4
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -6362,55 +6359,10 @@
         ]
       ],
       "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_160": {
-      "block_sizes": [
-        64,
-        1
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -6431,12 +6383,57 @@
         ""
       ],
       "num_warps": 8,
-      "num_stages": 3,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_160": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -6623,19 +6620,19 @@
     "intermediate_2880_numtokens_168": {
       "block_sizes": [
         8,
-        4
+        512
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -6651,69 +6648,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_168": {
       "block_sizes": [
-        1,
-        512
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        16
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 8,
-      "num_stages": 4,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_168": {
-      "block_sizes": [
-        64,
-        4
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -6725,7 +6677,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -6741,24 +6693,69 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_168": {
+      "block_sizes": [
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_168": {
       "block_sizes": [
-        4,
-        16384
+        64,
+        256
       ],
       "loop_orders": [
         [
@@ -6770,7 +6767,7 @@
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -6786,17 +6783,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -6847,8 +6844,8 @@
     },
     "intermediate_2048_numtokens_176": {
       "block_sizes": [
-        1,
-        64
+        128,
+        32
       ],
       "loop_orders": [
         [
@@ -6857,7 +6854,7 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -6877,13 +6874,13 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
+        "",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 6,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -6892,20 +6889,20 @@
     },
     "intermediate_2880_numtokens_176": {
       "block_sizes": [
-        8,
-        16
+        16,
+        256
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -6921,16 +6918,16 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
+        "",
+        "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -7027,8 +7024,8 @@
     },
     "intermediate_11008_numtokens_176": {
       "block_sizes": [
-        2,
-        128
+        64,
+        256
       ],
       "loop_orders": [
         [
@@ -7040,7 +7037,7 @@
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7056,12 +7053,12 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
-        "first"
+        "",
+        "",
+        ""
       ],
       "num_warps": 8,
-      "num_stages": 3,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -7072,20 +7069,20 @@
     },
     "intermediate_14336_numtokens_176": {
       "block_sizes": [
-        1,
-        16384
+        128,
+        256
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7101,17 +7098,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -7162,8 +7159,8 @@
     },
     "intermediate_2880_numtokens_184": {
       "block_sizes": [
-        2,
-        32
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -7175,7 +7172,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7192,23 +7189,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "last"
+        "",
+        ""
       ],
       "num_warps": 8,
-      "num_stages": 6,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_184": {
       "block_sizes": [
-        256,
-        256
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -7220,7 +7217,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7237,8 +7234,8 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "first"
+        "",
+        ""
       ],
       "num_warps": 8,
       "num_stages": 1,
@@ -7297,8 +7294,8 @@
     },
     "intermediate_11008_numtokens_184": {
       "block_sizes": [
-        32,
-        4
+        64,
+        256
       ],
       "loop_orders": [
         [
@@ -7310,7 +7307,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7326,17 +7323,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
+        "",
+        "",
         ""
       ],
       "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -7388,7 +7385,7 @@
     "intermediate_2048_numtokens_192": {
       "block_sizes": [
         128,
-        256
+        32
       ],
       "loop_orders": [
         [
@@ -7400,52 +7397,7 @@
         true
       ],
       "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first"
-      ],
-      "num_warps": 32,
-      "num_stages": 7,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_192": {
-      "block_sizes": [
-        128,
-        2
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7465,13 +7417,58 @@
         "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_192": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -7612,8 +7609,8 @@
     },
     "intermediate_14336_numtokens_192": {
       "block_sizes": [
-        16,
-        32
+        128,
+        256
       ],
       "loop_orders": [
         [
@@ -7625,7 +7622,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7641,24 +7638,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
+        "",
         "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2048_numtokens_200": {
       "block_sizes": [
-        2,
-        64
+        128,
+        32
       ],
       "loop_orders": [
         [
@@ -7670,7 +7667,7 @@
         true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7687,11 +7684,11 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
+        "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -7703,19 +7700,19 @@
     "intermediate_2880_numtokens_200": {
       "block_sizes": [
         8,
-        1024
+        512
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7731,17 +7728,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 32,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -7792,8 +7789,8 @@
     },
     "intermediate_8192_numtokens_200": {
       "block_sizes": [
-        2,
-        64
+        128,
+        128
       ],
       "loop_orders": [
         [
@@ -7821,14 +7818,14 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -7927,8 +7924,8 @@
     },
     "intermediate_2048_numtokens_208": {
       "block_sizes": [
-        16,
-        256
+        128,
+        32
       ],
       "loop_orders": [
         [
@@ -7940,7 +7937,7 @@
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -7956,16 +7953,16 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 3,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -8062,8 +8059,8 @@
     },
     "intermediate_8192_numtokens_208": {
       "block_sizes": [
-        8,
-        8192
+        128,
+        128
       ],
       "loop_orders": [
         [
@@ -8075,7 +8072,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -8091,17 +8088,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -8152,8 +8149,8 @@
     },
     "intermediate_14336_numtokens_208": {
       "block_sizes": [
-        1,
-        1024
+        128,
+        256
       ],
       "loop_orders": [
         [
@@ -8162,10 +8159,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -8181,17 +8178,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 32,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -8287,8 +8284,8 @@
     },
     "intermediate_4096_numtokens_216": {
       "block_sizes": [
-        64,
-        16
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -8297,10 +8294,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -8317,15 +8314,15 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 32,
-      "num_stages": 6,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -8422,8 +8419,8 @@
     },
     "intermediate_14336_numtokens_216": {
       "block_sizes": [
-        1,
-        512
+        128,
+        256
       ],
       "loop_orders": [
         [
@@ -8435,7 +8432,7 @@
         true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -8451,16 +8448,16 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -8513,12 +8510,12 @@
     "intermediate_2880_numtokens_224": {
       "block_sizes": [
         4,
-        128
+        2048
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
@@ -8541,24 +8538,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
-        "first"
+        "",
+        "",
+        ""
       ],
       "num_warps": 8,
-      "num_stages": 6,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_224": {
       "block_sizes": [
-        8,
-        8
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -8570,7 +8567,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -8586,15 +8583,15 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -8828,7 +8825,7 @@
     "intermediate_4096_numtokens_232": {
       "block_sizes": [
         128,
-        128
+        64
       ],
       "loop_orders": [
         [
@@ -8840,7 +8837,7 @@
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -8857,16 +8854,16 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -8962,8 +8959,8 @@
     },
     "intermediate_14336_numtokens_232": {
       "block_sizes": [
-        128,
-        4
+        8,
+        4096
       ],
       "loop_orders": [
         [
@@ -8975,7 +8972,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -8991,17 +8988,17 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -9052,20 +9049,20 @@
     },
     "intermediate_2880_numtokens_240": {
       "block_sizes": [
-        16,
-        128
+        4,
+        2048
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -9081,16 +9078,16 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -9277,8 +9274,8 @@
     },
     "intermediate_2048_numtokens_248": {
       "block_sizes": [
-        32,
-        1
+        128,
+        32
       ],
       "loop_orders": [
         [
@@ -9290,7 +9287,7 @@
         true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -9306,29 +9303,29 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
+        "",
+        "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 8,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_248": {
       "block_sizes": [
-        8,
-        128
+        4,
+        2048
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
@@ -9351,24 +9348,24 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 6,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_248": {
       "block_sizes": [
-        64,
-        512
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -9380,7 +9377,7 @@
         true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -9396,16 +9393,16 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
+        "",
         "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -9457,8 +9454,8 @@
     },
     "intermediate_11008_numtokens_248": {
       "block_sizes": [
-        1,
-        512
+        4,
+        8192
       ],
       "loop_orders": [
         [
@@ -9486,24 +9483,24 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
+        "",
         "",
         ""
       ],
       "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_248": {
       "block_sizes": [
-        2,
-        256
+        8,
+        4096
       ],
       "loop_orders": [
         [
@@ -9515,7 +9512,7 @@
         true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -9531,16 +9528,16 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 6,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -9548,51 +9545,6 @@
     "intermediate_2048_numtokens_272": {
       "block_sizes": [
         256,
-        16
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_272": {
-      "block_sizes": [
-        16,
         32
       ],
       "loop_orders": [
@@ -9605,7 +9557,7 @@
         true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -9621,17 +9573,62 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 32,
-      "num_stages": 3,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_272": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -10087,8 +10084,8 @@
     },
     "intermediate_2048_numtokens_304": {
       "block_sizes": [
-        32,
-        1
+        256,
+        32
       ],
       "loop_orders": [
         [
@@ -10100,7 +10097,7 @@
         true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -10116,17 +10113,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -10269,8 +10266,8 @@
     },
     "intermediate_11008_numtokens_304": {
       "block_sizes": [
-        256,
-        4
+        128,
+        256
       ],
       "loop_orders": [
         [
@@ -10282,7 +10279,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -10300,15 +10297,15 @@
       "load_eviction_policies": [
         "",
         "",
-        "first"
+        ""
       ],
-      "num_warps": 32,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -10404,8 +10401,8 @@
     },
     "intermediate_2880_numtokens_320": {
       "block_sizes": [
-        256,
-        256
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -10435,15 +10432,15 @@
       "load_eviction_policies": [
         "",
         "",
-        "first"
+        ""
       ],
       "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -10629,67 +10626,65 @@
     },
     "intermediate_2048_numtokens_336": {
       "block_sizes": [
-        1,
-        64
+        256,
+        32
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
       "range_warp_specializes": [],
       "range_num_stages": [
         0
       ],
       "range_multi_buffers": [
-        true
+        null
       ],
       "range_flattens": [
-        true
+        null
       ],
       "load_eviction_policies": [
         "",
         "",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 3,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 2,
-      "maxnreg": 256
+      "pid_type": "flat"
     },
     "intermediate_2880_numtokens_336": {
       "block_sizes": [
-        64,
-        64
+        16,
+        512
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -10706,13 +10701,13 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 6,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -10766,8 +10761,8 @@
     },
     "intermediate_8192_numtokens_336": {
       "block_sizes": [
-        1,
-        512
+        256,
+        128
       ],
       "loop_orders": [
         [
@@ -10776,10 +10771,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
         0
@@ -10796,15 +10791,15 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
+        "",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -11126,8 +11121,8 @@
     },
     "intermediate_14336_numtokens_352": {
       "block_sizes": [
-        512,
-        1
+        32,
+        512
       ],
       "loop_orders": [
         [
@@ -11155,17 +11150,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -11352,51 +11347,6 @@
     "intermediate_11008_numtokens_368": {
       "block_sizes": [
         128,
-        2
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_368": {
-      "block_sizes": [
-        4,
         256
       ],
       "loop_orders": [
@@ -11409,7 +11359,7 @@
         true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -11426,35 +11376,35 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_384": {
+    "intermediate_14336_numtokens_368": {
       "block_sizes": [
-        64,
-        128
+        32,
+        512
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -11471,15 +11421,60 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 32,
-      "num_stages": 6,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_384": {
+      "block_sizes": [
+        256,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -11711,8 +11706,8 @@
     },
     "intermediate_2048_numtokens_400": {
       "block_sizes": [
-        512,
-        32
+        1,
+        512
       ],
       "loop_orders": [
         [
@@ -11740,24 +11735,24 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 8,
-      "num_stages": 6,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_400": {
       "block_sizes": [
-        1,
-        128
+        16,
+        512
       ],
       "loop_orders": [
         [
@@ -11766,10 +11761,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -11785,17 +11780,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
         "",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -11982,52 +11977,7 @@
     "intermediate_2048_numtokens_416": {
       "block_sizes": [
         256,
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
         32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "last"
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_416": {
-      "block_sizes": [
-        1,
-        2048
       ],
       "loop_orders": [
         [
@@ -12036,10 +11986,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -12055,17 +12005,62 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
+        "",
+        "",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 6,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_416": {
+      "block_sizes": [
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -12251,53 +12246,8 @@
     },
     "intermediate_2048_numtokens_432": {
       "block_sizes": [
-        1,
-        1024
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 8,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_432": {
-      "block_sizes": [
-        512,
-        128
+        256,
+        32
       ],
       "loop_orders": [
         [
@@ -12309,7 +12259,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -12325,17 +12275,62 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "last",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 5,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_432": {
+      "block_sizes": [
+        8,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -12521,8 +12516,8 @@
     },
     "intermediate_2048_numtokens_448": {
       "block_sizes": [
-        64,
-        128
+        256,
+        32
       ],
       "loop_orders": [
         [
@@ -12551,15 +12546,15 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 1,
-      "num_stages": 7,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -12701,8 +12696,8 @@
     },
     "intermediate_11008_numtokens_448": {
       "block_sizes": [
-        16,
-        32
+        1,
+        512
       ],
       "loop_orders": [
         [
@@ -12714,7 +12709,7 @@
         true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -12730,15 +12725,15 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 8,
-      "num_stages": 2,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -12791,53 +12786,8 @@
     },
     "intermediate_2048_numtokens_464": {
       "block_sizes": [
-        1,
+        256,
         32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_464": {
-      "block_sizes": [
-        128,
-        1024
       ],
       "loop_orders": [
         [
@@ -12849,7 +12799,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -12869,12 +12819,57 @@
         "",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_464": {
+      "block_sizes": [
+        8,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -12926,8 +12921,8 @@
     },
     "intermediate_8192_numtokens_464": {
       "block_sizes": [
-        1,
-        512
+        256,
+        128
       ],
       "loop_orders": [
         [
@@ -12955,17 +12950,17 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
-        "first"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -13241,8 +13236,8 @@
     },
     "intermediate_11008_numtokens_480": {
       "block_sizes": [
-        32,
-        16
+        1,
+        1024
       ],
       "loop_orders": [
         [
@@ -13254,7 +13249,7 @@
         true
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -13270,15 +13265,15 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
       "num_warps": 4,
-      "num_stages": 6,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -13421,53 +13416,8 @@
     },
     "intermediate_4096_numtokens_496": {
       "block_sizes": [
-        1,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_496": {
-      "block_sizes": [
-        16,
-        8192
+        256,
+        64
       ],
       "loop_orders": [
         [
@@ -13495,15 +13445,60 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "first",
-        "last"
+        "",
+        "",
+        ""
       ],
-      "num_warps": 32,
-      "num_stages": 8,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_496": {
+      "block_sizes": [
+        256,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -13601,8 +13596,8 @@
     },
     "intermediate_2048_numtokens_512": {
       "block_sizes": [
-        128,
-        256
+        512,
+        16
       ],
       "loop_orders": [
         [
@@ -13614,7 +13609,7 @@
         true
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -13632,13 +13627,13 @@
       "load_eviction_policies": [
         "",
         "",
-        "first"
+        ""
       ],
-      "num_warps": 16,
-      "num_stages": 4,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -13647,7 +13642,7 @@
     "intermediate_2880_numtokens_512": {
       "block_sizes": [
         8,
-        8
+        2048
       ],
       "loop_orders": [
         [
@@ -13659,7 +13654,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -13675,15 +13670,15 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
+        "",
+        "",
         ""
       ],
       "num_warps": 8,
-      "num_stages": 3,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -13918,8 +13913,8 @@
     },
     "intermediate_4096_numtokens_256": {
       "block_sizes": [
-        32,
-        512
+        256,
+        32
       ],
       "loop_orders": [
         [
@@ -13931,7 +13926,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -13951,11 +13946,11 @@
         "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -14008,8 +14003,8 @@
     },
     "intermediate_8192_numtokens_256": {
       "block_sizes": [
-        32,
-        8
+        256,
+        64
       ],
       "loop_orders": [
         [
@@ -14038,23 +14033,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
+        "",
         ""
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_256": {
       "block_sizes": [
-        16,
-        32
+        8,
+        4096
       ],
       "loop_orders": [
         [
@@ -14086,13 +14081,13 @@
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
       ],
       "pid_type": "flat"
     },
@@ -14143,8 +14138,8 @@
     },
     "intermediate_7688_numtokens_256": {
       "block_sizes": [
-        8,
-        16
+        32,
+        512
       ],
       "loop_orders": [
         [
@@ -14173,10 +14168,10 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
+        "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -14234,187 +14229,7 @@
     "intermediate_2048_numtokens_1": {
       "block_sizes": [
         1,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_1": {
-      "block_sizes": [
-        1,
-        1
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_1": {
-      "block_sizes": [
-        1,
-        32
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_1": {
-      "block_sizes": [
-        1,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_1": {
-      "block_sizes": [
-        1,
-        32
+        256
       ],
       "loop_orders": [
         [
@@ -14427,96 +14242,6 @@
       ],
       "l2_groupings": [
         1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_1": {
-      "block_sizes": [
-        1,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_2": {
-      "block_sizes": [
-        2,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
       ],
       "range_unroll_factors": [
         0
@@ -14541,15 +14266,15 @@
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_2": {
+    "intermediate_2880_numtokens_1": {
       "block_sizes": [
         1,
-        4
+        128
       ],
       "loop_orders": [
         [
@@ -14558,7 +14283,7 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -14577,11 +14302,281 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
+        "",
         "",
         ""
       ],
-      "num_warps": 32,
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_1": {
+      "block_sizes": [
+        1,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_1": {
+      "block_sizes": [
+        1,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_1": {
+      "block_sizes": [
+        1,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_1": {
+      "block_sizes": [
+        1,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_2": {
+      "block_sizes": [
+        2,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_2": {
+      "block_sizes": [
+        2,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -14594,7 +14589,7 @@
     "intermediate_4096_numtokens_2": {
       "block_sizes": [
         2,
-        32
+        128
       ],
       "loop_orders": [
         [
@@ -14626,8 +14621,8 @@
         "",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 2,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -14638,8 +14633,8 @@
     },
     "intermediate_8192_numtokens_2": {
       "block_sizes": [
-        1,
-        32
+        2,
+        128
       ],
       "loop_orders": [
         [
@@ -14648,7 +14643,7 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -14667,14 +14662,14 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
+        "",
         "",
         ""
       ],
-      "num_warps": 8,
-      "num_stages": 2,
+      "num_warps": 2,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -14684,199 +14679,19 @@
     "intermediate_11008_numtokens_2": {
       "block_sizes": [
         1,
-        256
+        16384
       ],
       "loop_orders": [
         [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_2": {
-      "block_sizes": [
-        1,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_4": {
-      "block_sizes": [
-        1,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_4": {
-      "block_sizes": [
-        1,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_4": {
-      "block_sizes": [
-        4,
         16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
       ],
       "range_unroll_factors": [
         0
@@ -14893,10 +14708,190 @@
       ],
       "load_eviction_policies": [
         "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_14336_numtokens_2": {
+      "block_sizes": [
+        2,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
         "",
         ""
       ],
-      "num_warps": 4,
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_4": {
+      "block_sizes": [
+        4,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_4": {
+      "block_sizes": [
+        4,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_4096_numtokens_4": {
+      "block_sizes": [
+        4,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -14909,52 +14904,7 @@
     "intermediate_8192_numtokens_4": {
       "block_sizes": [
         1,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_4": {
-      "block_sizes": [
-        1,
-        32
+        2048
       ],
       "loop_orders": [
         [
@@ -14983,28 +14933,118 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
+        "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 1,
+      "num_warps": 8,
+      "num_stages": 8,
       "indexing": [
         "pointer",
-        "pointer",
         "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_4": {
+    "intermediate_11008_numtokens_4": {
       "block_sizes": [
         4,
-        16
+        2048
       ],
       "loop_orders": [
         [
           1,
           0
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_14336_numtokens_4": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_2048_numtokens_8": {
+      "block_sizes": [
+        8,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
         ]
       ],
       "flatten_loops": [
@@ -15031,7 +15071,7 @@
         "",
         ""
       ],
-      "num_warps": 16,
+      "num_warps": 2,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -15041,22 +15081,22 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_8": {
+    "intermediate_2880_numtokens_8": {
       "block_sizes": [
-        8,
-        256
+        4,
+        2048
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -15073,20 +15113,20 @@
       ],
       "load_eviction_policies": [
         "last",
-        "",
+        "last",
         ""
       ],
-      "num_warps": 32,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 5,
       "indexing": [
+        "pointer",
         "tensor_descriptor",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
-      "pid_type": "flat"
+      "pid_type": "xyz"
     },
-    "intermediate_2880_numtokens_8": {
+    "intermediate_4096_numtokens_8": {
       "block_sizes": [
         8,
         32
@@ -15121,52 +15161,7 @@
         "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_8": {
-      "block_sizes": [
-        2,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
+      "num_warps": 2,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -15178,8 +15173,8 @@
     },
     "intermediate_8192_numtokens_8": {
       "block_sizes": [
-        4,
-        64
+        2,
+        1024
       ],
       "loop_orders": [
         [
@@ -15188,10 +15183,10 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -15207,36 +15202,36 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "first",
+        "last",
         ""
       ],
       "num_warps": 1,
-      "num_stages": 1,
+      "num_stages": 8,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_8": {
       "block_sizes": [
-        8,
-        128
+        1,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -15254,22 +15249,22 @@
       "load_eviction_policies": [
         "last",
         "",
-        ""
+        "first"
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 2,
+      "num_stages": 5,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_8": {
       "block_sizes": [
         8,
-        32
+        128
       ],
       "loop_orders": [
         [
@@ -15278,7 +15273,7 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -15298,7 +15293,7 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
+        "",
         ""
       ],
       "num_warps": 4,
@@ -15313,8 +15308,8 @@
     },
     "intermediate_2048_numtokens_16": {
       "block_sizes": [
-        16,
-        64
+        8,
+        512
       ],
       "loop_orders": [
         [
@@ -15323,10 +15318,55 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "xyz"
+    },
+    "intermediate_2880_numtokens_16": {
+      "block_sizes": [
+        2,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
       ],
       "range_unroll_factors": [
         0
@@ -15347,51 +15387,6 @@
         ""
       ],
       "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_16": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -15404,7 +15399,97 @@
     "intermediate_4096_numtokens_16": {
       "block_sizes": [
         16,
-        32
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_16": {
+      "block_sizes": [
+        16,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_16": {
+      "block_sizes": [
+        1,
+        2048
       ],
       "loop_orders": [
         [
@@ -15437,7 +15522,7 @@
         ""
       ],
       "num_warps": 8,
-      "num_stages": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -15446,22 +15531,22 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_16": {
+    "intermediate_14336_numtokens_16": {
       "block_sizes": [
-        4,
-        32
+        2,
+        256
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -15477,24 +15562,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 7,
       "indexing": [
-        "pointer",
         "tensor_descriptor",
         "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_16": {
+    "intermediate_2048_numtokens_24": {
       "block_sizes": [
-        8,
-        32
+        1,
+        1024
       ],
       "loop_orders": [
         [
@@ -15506,7 +15591,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -15526,115 +15611,70 @@
         "",
         "first"
       ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_16": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 8,
       "indexing": [
         "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_24": {
-      "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_24": {
       "block_sizes": [
-        32,
+        4,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_24": {
+      "block_sizes": [
+        16,
         64
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
@@ -15664,17 +15704,17 @@
       "num_warps": 4,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_24": {
+    "intermediate_8192_numtokens_24": {
       "block_sizes": [
-        32,
-        32
+        1,
+        2048
       ],
       "loop_orders": [
         [
@@ -15686,7 +15726,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        32
       ],
       "range_unroll_factors": [
         0
@@ -15703,11 +15743,11 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
-        ""
+        "last",
+        "last"
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 5,
       "indexing": [
         "pointer",
         "pointer",
@@ -15716,22 +15756,22 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_24": {
+    "intermediate_11008_numtokens_24": {
       "block_sizes": [
-        16,
-        32
+        1,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
         false
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -15747,57 +15787,12 @@
         null
       ],
       "load_eviction_policies": [
-        "",
+        "last",
         "",
         ""
       ],
       "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_24": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
@@ -15809,19 +15804,19 @@
     "intermediate_14336_numtokens_24": {
       "block_sizes": [
         8,
-        32
+        512
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -15837,111 +15832,21 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        "last"
+        "last",
+        "first",
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_2048_numtokens_32": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_32": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_32": {
       "block_sizes": [
         32,
         16
@@ -15976,8 +15881,8 @@
         "",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 2,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -15986,10 +15891,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_32": {
+    "intermediate_2880_numtokens_32": {
       "block_sizes": [
-        32,
-        128
+        4,
+        256
       ],
       "loop_orders": [
         [
@@ -16019,10 +15924,10 @@
       "load_eviction_policies": [
         "",
         "",
-        "last"
+        ""
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 4,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -16031,22 +15936,67 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_32": {
+    "intermediate_4096_numtokens_32": {
       "block_sizes": [
-        16,
-        8
+        4,
+        4096
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
         true
       ],
       "l2_groupings": [
-        1
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_32": {
+      "block_sizes": [
+        4,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
       ],
       "range_unroll_factors": [
         0
@@ -16063,23 +16013,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "last",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_32": {
+    "intermediate_11008_numtokens_32": {
       "block_sizes": [
-        32,
-        8
+        2,
+        2048
       ],
       "loop_orders": [
         [
@@ -16112,7 +16062,7 @@
         ""
       ],
       "num_warps": 8,
-      "num_stages": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -16121,9 +16071,54 @@
       ],
       "pid_type": "flat"
     },
+    "intermediate_14336_numtokens_32": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
     "intermediate_2048_numtokens_40": {
       "block_sizes": [
-        64,
+        32,
         32
       ],
       "loop_orders": [
@@ -16136,7 +16131,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -16156,7 +16151,7 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 4,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -16168,20 +16163,20 @@
     },
     "intermediate_2880_numtokens_40": {
       "block_sizes": [
-        64,
-        32
+        1,
+        4096
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -16198,13 +16193,13 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
+        "last",
         "last"
       ],
       "num_warps": 8,
-      "num_stages": 2,
+      "num_stages": 4,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
@@ -16214,12 +16209,12 @@
     "intermediate_4096_numtokens_40": {
       "block_sizes": [
         32,
-        32
+        64
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
@@ -16249,7 +16244,7 @@
       "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -16258,8 +16253,8 @@
     },
     "intermediate_8192_numtokens_40": {
       "block_sizes": [
-        64,
-        128
+        2,
+        256
       ],
       "loop_orders": [
         [
@@ -16271,7 +16266,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
         0
@@ -16288,23 +16283,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "last",
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_40": {
       "block_sizes": [
-        64,
-        32
+        16,
+        256
       ],
       "loop_orders": [
         [
@@ -16336,7 +16331,7 @@
         "",
         ""
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -16348,6 +16343,53 @@
     },
     "intermediate_14336_numtokens_40": {
       "block_sizes": [
+        4,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        1
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 32,
+      "maxnreg": 32
+    },
+    "intermediate_2048_numtokens_48": {
+      "block_sizes": [
         32,
         32
       ],
@@ -16381,7 +16423,7 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 4,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -16391,55 +16433,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_48": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
     "intermediate_2880_numtokens_48": {
       "block_sizes": [
-        8,
-        8
+        16,
+        64
       ],
       "loop_orders": [
         [
@@ -16471,12 +16468,12 @@
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 4,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -16516,52 +16513,7 @@
         "",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_48": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -16571,10 +16523,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_48": {
+    "intermediate_8192_numtokens_48": {
       "block_sizes": [
-        16,
-        256
+        1,
+        4096
       ],
       "loop_orders": [
         [
@@ -16602,24 +16554,24 @@
         null
       ],
       "load_eviction_policies": [
+        "first",
         "",
-        "",
-        ""
+        "last"
       ],
-      "num_warps": 32,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 2,
       "indexing": [
         "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_48": {
+    "intermediate_11008_numtokens_48": {
       "block_sizes": [
-        64,
-        4
+        16,
+        256
       ],
       "loop_orders": [
         [
@@ -16651,10 +16603,55 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_48": {
+      "block_sizes": [
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
@@ -16663,52 +16660,7 @@
     },
     "intermediate_2048_numtokens_56": {
       "block_sizes": [
-        2,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_56": {
-      "block_sizes": [
-        8,
+        32,
         32
       ],
       "loop_orders": [
@@ -16751,10 +16703,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_56": {
+    "intermediate_2880_numtokens_56": {
       "block_sizes": [
-        32,
-        4
+        1,
+        2048
       ],
       "loop_orders": [
         [
@@ -16783,15 +16735,60 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
+        "",
         ""
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_56": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
@@ -16831,7 +16828,7 @@
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -16843,8 +16840,8 @@
     },
     "intermediate_11008_numtokens_56": {
       "block_sizes": [
-        32,
-        8
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -16873,10 +16870,10 @@
       ],
       "load_eviction_policies": [
         "",
-        "first",
-        "last"
+        "",
+        ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -16888,143 +16885,8 @@
     },
     "intermediate_14336_numtokens_56": {
       "block_sizes": [
-        64,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_64": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_64": {
-      "block_sizes": [
-        4,
-        64
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_64": {
-      "block_sizes": [
         2,
-        16
+        4096
       ],
       "loop_orders": [
         [
@@ -17033,10 +16895,10 @@
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -17053,608 +16915,23 @@
       ],
       "load_eviction_policies": [
         "first",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_64": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_64": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
+        "first",
         ""
       ],
       "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_64": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_72": {
-      "block_sizes": [
-        4,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_72": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_72": {
-      "block_sizes": [
-        64,
-        16
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_72": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_72": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_72": {
-      "block_sizes": [
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_80": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_80": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_80": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_80": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_stages": 4,
       "indexing": [
         "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_80": {
+    "intermediate_2048_numtokens_64": {
       "block_sizes": [
         64,
-        8
+        32
       ],
       "loop_orders": [
         [
@@ -17696,9 +16973,189 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_80": {
+    "intermediate_2880_numtokens_64": {
       "block_sizes": [
-        32,
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_64": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_64": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_64": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_64": {
+      "block_sizes": [
+        16,
         512
       ],
       "loop_orders": [
@@ -17711,7 +17168,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
         0
@@ -17731,158 +17188,23 @@
         "first",
         ""
       ],
-      "num_warps": 16,
+      "num_warps": 4,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_88": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_88": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
         "tensor_descriptor",
-        "pointer",
-        "pointer",
         "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_88": {
+    "intermediate_2048_numtokens_72": {
       "block_sizes": [
         64,
         32
       ],
       "loop_orders": [
         [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_88": {
-      "block_sizes": [
-        128,
-        64
-      ],
-      "loop_orders": [
-        [
           0,
           1
         ]
@@ -17907,98 +17229,8 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
-        "first",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_88": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
         "",
         "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_88": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
         ""
       ],
       "num_warps": 8,
@@ -18011,247 +17243,67 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_96": {
+    "intermediate_2880_numtokens_72": {
       "block_sizes": [
-        128,
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_72": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
         4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_96": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_96": {
-      "block_sizes": [
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_96": {
-      "block_sizes": [
-        64,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_96": {
-      "block_sizes": [
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_96": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
       ],
       "range_unroll_factors": [
         0
@@ -18271,20 +17323,20 @@
         "",
         "first"
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 16,
+      "num_stages": 2,
       "indexing": [
-        "pointer",
-        "pointer",
         "tensor_descriptor",
-        "pointer"
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_104": {
+    "intermediate_8192_numtokens_72": {
       "block_sizes": [
-        32,
-        8
+        64,
+        128
       ],
       "loop_orders": [
         [
@@ -18316,17 +17368,197 @@
         "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_104": {
+    "intermediate_11008_numtokens_72": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_72": {
+      "block_sizes": [
+        32,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_80": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_80": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_80": {
       "block_sizes": [
         64,
         64
@@ -18361,7 +17593,772 @@
         "",
         ""
       ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_80": {
+      "block_sizes": [
+        4,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_80": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_80": {
+      "block_sizes": [
+        2,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_88": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_88": {
+      "block_sizes": [
+        8,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_88": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_88": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_88": {
+      "block_sizes": [
+        16,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
       "num_warps": 32,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_88": {
+      "block_sizes": [
+        4,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_96": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_96": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_96": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_96": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_96": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_96": {
+      "block_sizes": [
+        4,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_104": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_104": {
+      "block_sizes": [
+        8,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -18373,8 +18370,8 @@
     },
     "intermediate_4096_numtokens_104": {
       "block_sizes": [
-        32,
-        32
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -18383,7 +18380,7 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
         1
@@ -18418,8 +18415,98 @@
     },
     "intermediate_8192_numtokens_104": {
       "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_104": {
+      "block_sizes": [
+        2,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_104": {
+      "block_sizes": [
         8,
-        8
+        512
       ],
       "loop_orders": [
         [
@@ -18447,6 +18534,51 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_112": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
         "",
         "",
         ""
@@ -18457,14 +18589,14 @@
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_104": {
+    "intermediate_2880_numtokens_112": {
       "block_sizes": [
-        128,
-        16
+        2,
+        2048
       ],
       "loop_orders": [
         [
@@ -18496,20 +18628,20 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_104": {
+    "intermediate_4096_numtokens_112": {
       "block_sizes": [
-        32,
-        16
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -18541,20 +18673,20 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_112": {
+    "intermediate_8192_numtokens_112": {
       "block_sizes": [
-        32,
-        1024
+        4,
+        512
       ],
       "loop_orders": [
         [
@@ -18566,7 +18698,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -18583,203 +18715,23 @@
       ],
       "load_eviction_policies": [
         "first",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_112": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_112": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
         "last",
-        "",
-        ""
+        "last"
       ],
       "num_warps": 16,
-      "num_stages": 1,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_112": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_112": {
       "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_112": {
-      "block_sizes": [
-        32,
-        8
+        4,
+        1024
       ],
       "loop_orders": [
         [
@@ -18808,23 +18760,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "last",
+        "last"
       ],
-      "num_warps": 1,
-      "num_stages": 2,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_120": {
+    "intermediate_14336_numtokens_112": {
       "block_sizes": [
-        32,
-        64
+        64,
+        256
       ],
       "loop_orders": [
         [
@@ -18856,7 +18808,7 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -18866,19 +18818,64 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_120": {
+    "intermediate_2048_numtokens_120": {
       "block_sizes": [
-        32,
-        16
+        8,
+        256
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_120": {
+      "block_sizes": [
+        2,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
       ],
       "l2_groupings": [
         1
@@ -18901,7 +18898,7 @@
         "",
         ""
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -18913,8 +18910,8 @@
     },
     "intermediate_4096_numtokens_120": {
       "block_sizes": [
-        32,
-        16
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -18926,7 +18923,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -18946,7 +18943,7 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -18959,97 +18956,7 @@
     "intermediate_8192_numtokens_120": {
       "block_sizes": [
         64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_120": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_120": {
-      "block_sizes": [
-        128,
-        32
+        128
       ],
       "loop_orders": [
         [
@@ -19091,10 +18998,100 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_128": {
+    "intermediate_11008_numtokens_120": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_120": {
       "block_sizes": [
         32,
-        64
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_128": {
+      "block_sizes": [
+        128,
+        16
       ],
       "loop_orders": [
         [
@@ -19126,8 +19123,8 @@
         "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -19138,8 +19135,8 @@
     },
     "intermediate_2880_numtokens_128": {
       "block_sizes": [
-        128,
-        64
+        2,
+        2048
       ],
       "loop_orders": [
         [
@@ -19168,10 +19165,10 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
+        "",
         ""
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -19214,97 +19211,7 @@
       "load_eviction_policies": [
         "",
         "",
-        "last"
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_128": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
         ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_128": {
-      "block_sizes": [
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
       ],
       "num_warps": 8,
       "num_stages": 1,
@@ -19316,99 +19223,9 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_128": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_136": {
+    "intermediate_8192_numtokens_128": {
       "block_sizes": [
         128,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_136": {
-      "block_sizes": [
-        8,
         64
       ],
       "loop_orders": [
@@ -19438,7 +19255,187 @@
       ],
       "load_eviction_policies": [
         "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_128": {
+      "block_sizes": [
+        2,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
         "first",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_128": {
+      "block_sizes": [
+        4,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_136": {
+      "block_sizes": [
+        128,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_136": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
         ""
       ],
       "num_warps": 8,
@@ -19453,8 +19450,8 @@
     },
     "intermediate_4096_numtokens_136": {
       "block_sizes": [
-        32,
-        16
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -19486,7 +19483,7 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -19498,8 +19495,8 @@
     },
     "intermediate_8192_numtokens_136": {
       "block_sizes": [
-        32,
-        128
+        2,
+        512
       ],
       "loop_orders": [
         [
@@ -19511,7 +19508,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -19527,204 +19524,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
+        "first",
         "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 7,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_11008_numtokens_136": {
       "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_136": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_144": {
-      "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_144": {
-      "block_sizes": [
-        256,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_144": {
-      "block_sizes": [
-        128,
-        32
+        4,
+        8192
       ],
       "loop_orders": [
         [
@@ -19736,97 +19553,7 @@
         false
       ],
       "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_144": {
-      "block_sizes": [
-        128,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_144": {
-      "block_sizes": [
-        32,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
+        8
       ],
       "range_unroll_factors": [
         0
@@ -19844,10 +19571,10 @@
       "load_eviction_policies": [
         "",
         "last",
-        ""
+        "last"
       ],
       "num_warps": 8,
-      "num_stages": 1,
+      "num_stages": 4,
       "indexing": [
         "pointer",
         "pointer",
@@ -19856,10 +19583,100 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_144": {
+    "intermediate_14336_numtokens_136": {
       "block_sizes": [
-        32,
+        4,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
         8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_144": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_144": {
+      "block_sizes": [
+        64,
+        64
       ],
       "loop_orders": [
         [
@@ -19872,6 +19689,726 @@
       ],
       "l2_groupings": [
         1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_144": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_144": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_144": {
+      "block_sizes": [
+        256,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_144": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_152": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_152": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_152": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_152": {
+      "block_sizes": [
+        64,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_152": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_152": {
+      "block_sizes": [
+        2,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_160": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_160": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_160": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_160": {
+      "block_sizes": [
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_160": {
+      "block_sizes": [
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_160": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        8
       ],
       "range_unroll_factors": [
         0
@@ -19891,20 +20428,65 @@
         "",
         "first"
       ],
-      "num_warps": 1,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
         "tensor_descriptor",
         "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_152": {
+    "intermediate_2048_numtokens_168": {
       "block_sizes": [
-        32,
-        8
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_168": {
+      "block_sizes": [
+        8,
+        512
       ],
       "loop_orders": [
         [
@@ -19936,7 +20518,7 @@
         "",
         ""
       ],
-      "num_warps": 16,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -19946,9 +20528,9 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_152": {
+    "intermediate_4096_numtokens_168": {
       "block_sizes": [
-        16,
+        128,
         64
       ],
       "loop_orders": [
@@ -19981,605 +20563,20 @@
         "",
         ""
       ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_152": {
-      "block_sizes": [
-        64,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_152": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_152": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
       "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_152": {
-      "block_sizes": [
-        64,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_160": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_160": {
-      "block_sizes": [
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_160": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_160": {
-      "block_sizes": [
-        64,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_160": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_160": {
-      "block_sizes": [
-        128,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_168": {
-      "block_sizes": [
-        128,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_168": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_168": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_8192_numtokens_168": {
       "block_sizes": [
-        64,
-        8
+        128,
+        128
       ],
       "loop_orders": [
         [
@@ -20624,7 +20621,7 @@
     "intermediate_11008_numtokens_168": {
       "block_sizes": [
         64,
-        4
+        256
       ],
       "loop_orders": [
         [
@@ -20656,7 +20653,7 @@
         "",
         ""
       ],
-      "num_warps": 16,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -20668,8 +20665,8 @@
     },
     "intermediate_14336_numtokens_168": {
       "block_sizes": [
-        32,
-        512
+        64,
+        32
       ],
       "loop_orders": [
         [
@@ -20681,7 +20678,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        64
       ],
       "range_unroll_factors": [
         0
@@ -20697,68 +20694,23 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "last",
+        "first"
       ],
       "num_warps": 2,
-      "num_stages": 1,
+      "num_stages": 6,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2048_numtokens_176": {
       "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_176": {
-      "block_sizes": [
-        32,
+        128,
         32
       ],
       "loop_orders": [
@@ -20791,7 +20743,7 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -20801,10 +20753,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_176": {
+    "intermediate_2880_numtokens_176": {
       "block_sizes": [
-        4,
-        8
+        16,
+        256
       ],
       "loop_orders": [
         [
@@ -20817,6 +20769,51 @@
       ],
       "l2_groupings": [
         1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_176": {
+      "block_sizes": [
+        128,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
       ],
       "range_unroll_factors": [
         0
@@ -20836,10 +20833,10 @@
         "",
         "first"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 4,
+      "num_stages": 6,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
@@ -20848,8 +20845,53 @@
     },
     "intermediate_8192_numtokens_176": {
       "block_sizes": [
-        8,
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
         16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_176": {
+      "block_sizes": [
+        64,
+        256
       ],
       "loop_orders": [
         [
@@ -20881,52 +20923,7 @@
         "",
         ""
       ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_176": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -20938,8 +20935,8 @@
     },
     "intermediate_14336_numtokens_176": {
       "block_sizes": [
-        8,
-        32
+        128,
+        256
       ],
       "loop_orders": [
         [
@@ -20971,7 +20968,7 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -20983,53 +20980,8 @@
     },
     "intermediate_2048_numtokens_184": {
       "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_184": {
-      "block_sizes": [
-        8,
-        16
+        2,
+        256
       ],
       "loop_orders": [
         [
@@ -21041,7 +20993,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        2
       ],
       "range_unroll_factors": [
         0
@@ -21062,19 +21014,64 @@
         ""
       ],
       "num_warps": 16,
-      "num_stages": 2,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor"
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_184": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_4096_numtokens_184": {
       "block_sizes": [
-        32,
-        8
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -21118,7 +21115,7 @@
     },
     "intermediate_8192_numtokens_184": {
       "block_sizes": [
-        8,
+        64,
         64
       ],
       "loop_orders": [
@@ -21131,7 +21128,52 @@
         true
       ],
       "l2_groupings": [
-        2
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_184": {
+      "block_sizes": [
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
       ],
       "range_unroll_factors": [
         0
@@ -21152,51 +21194,6 @@
         ""
       ],
       "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_184": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -21208,155 +21205,20 @@
     },
     "intermediate_14336_numtokens_184": {
       "block_sizes": [
-        16,
+        64,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
         64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_192": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_192": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_192": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
       ],
       "range_unroll_factors": [
         0
@@ -21374,21 +21236,21 @@
       "load_eviction_policies": [
         "first",
         "",
-        ""
+        "last"
       ],
-      "num_warps": 16,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 3,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_192": {
+    "intermediate_2048_numtokens_192": {
       "block_sizes": [
-        4,
+        128,
         32
       ],
       "loop_orders": [
@@ -21401,7 +21263,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -21431,9 +21293,144 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_192": {
+    "intermediate_2880_numtokens_192": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_192": {
+      "block_sizes": [
+        8,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_192": {
       "block_sizes": [
         32,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_192": {
+      "block_sizes": [
+        16,
         256
       ],
       "loop_orders": [
@@ -21464,22 +21461,22 @@
       "load_eviction_policies": [
         "",
         "",
-        ""
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 32,
+      "num_stages": 7,
       "indexing": [
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_192": {
       "block_sizes": [
-        8,
-        16
+        128,
+        256
       ],
       "loop_orders": [
         [
@@ -21511,11 +21508,11 @@
         "",
         ""
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer"
       ],
@@ -21523,7 +21520,7 @@
     },
     "intermediate_2048_numtokens_200": {
       "block_sizes": [
-        32,
+        128,
         32
       ],
       "loop_orders": [
@@ -21536,7 +21533,7 @@
         true
       ],
       "l2_groupings": [
-        2
+        1
       ],
       "range_unroll_factors": [
         0
@@ -21556,7 +21553,7 @@
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -21568,8 +21565,8 @@
     },
     "intermediate_2880_numtokens_200": {
       "block_sizes": [
-        32,
-        32
+        8,
+        512
       ],
       "loop_orders": [
         [
@@ -21598,10 +21595,10 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
+        "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -21613,8 +21610,8 @@
     },
     "intermediate_4096_numtokens_200": {
       "block_sizes": [
-        64,
-        32
+        4,
+        512
       ],
       "loop_orders": [
         [
@@ -21626,7 +21623,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
       ],
       "range_unroll_factors": [
         0
@@ -21642,24 +21639,24 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
         "",
-        "",
-        ""
+        "first"
       ],
-      "num_warps": 2,
+      "num_warps": 1,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_8192_numtokens_200": {
       "block_sizes": [
-        32,
-        32
+        128,
+        128
       ],
       "loop_orders": [
         [
@@ -21691,7 +21688,7 @@
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -21703,17 +21700,17 @@
     },
     "intermediate_11008_numtokens_200": {
       "block_sizes": [
-        8,
-        32
+        1,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
         1
@@ -21732,15 +21729,15 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        ""
+        "first",
+        "first",
+        "first"
       ],
-      "num_warps": 1,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer"
       ],
@@ -21749,7 +21746,7 @@
     "intermediate_14336_numtokens_200": {
       "block_sizes": [
         16,
-        8
+        128
       ],
       "loop_orders": [
         [
@@ -21761,7 +21758,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -21781,154 +21778,19 @@
         "",
         "first"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 6,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2048_numtokens_208": {
       "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_208": {
-      "block_sizes": [
-        64,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_208": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_208": {
-      "block_sizes": [
-        256,
+        128,
         32
       ],
       "loop_orders": [
@@ -21961,20 +21823,20 @@
         "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_208": {
+    "intermediate_2880_numtokens_208": {
       "block_sizes": [
-        64,
-        64
+        256,
+        16
       ],
       "loop_orders": [
         [
@@ -21986,7 +21848,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        8
       ],
       "range_unroll_factors": [
         0
@@ -22002,24 +21864,24 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
-        "last",
-        ""
+        "first",
+        "",
+        "last"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 8,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_208": {
+    "intermediate_4096_numtokens_208": {
       "block_sizes": [
-        16,
-        128
+        256,
+        32
       ],
       "loop_orders": [
         [
@@ -22047,11 +21909,146 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_208": {
+      "block_sizes": [
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
         "",
         "",
         ""
       ],
-      "num_warps": 32,
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_208": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_208": {
+      "block_sizes": [
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -22073,10 +22070,100 @@
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        2
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_216": {
+      "block_sizes": [
+        4,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_216": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
       ],
       "range_unroll_factors": [
         0
@@ -22096,7 +22183,7 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -22106,10 +22193,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_216": {
+    "intermediate_8192_numtokens_216": {
       "block_sizes": [
-        16,
-        128
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -22122,6 +22209,276 @@
       ],
       "l2_groupings": [
         1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_216": {
+      "block_sizes": [
+        1,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_216": {
+      "block_sizes": [
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_224": {
+      "block_sizes": [
+        32,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_224": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_224": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_224": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
       ],
       "range_unroll_factors": [
         0
@@ -22139,19 +22496,19 @@
       "load_eviction_policies": [
         "",
         "last",
-        ""
+        "first"
       ],
       "num_warps": 32,
       "num_stages": 1,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_216": {
+    "intermediate_11008_numtokens_224": {
       "block_sizes": [
         32,
         32
@@ -22166,142 +22523,7 @@
         true
       ],
       "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_216": {
-      "block_sizes": [
-        16,
         32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_216": {
-      "block_sizes": [
-        32,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_216": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
       ],
       "range_unroll_factors": [
         0
@@ -22321,20 +22543,20 @@
         "",
         "last"
       ],
-      "num_warps": 32,
-      "num_stages": 1,
+      "num_warps": 2,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_224": {
+    "intermediate_14336_numtokens_224": {
       "block_sizes": [
-        32,
-        16
+        1,
+        2048
       ],
       "loop_orders": [
         [
@@ -22346,7 +22568,7 @@
         false
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -22363,125 +22585,35 @@
       ],
       "load_eviction_policies": [
         "",
-        "last",
+        "",
         ""
       ],
-      "num_warps": 2,
-      "num_stages": 1,
+      "num_warps": 8,
+      "num_stages": 8,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_224": {
+    "intermediate_2048_numtokens_232": {
       "block_sizes": [
-        64,
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
         64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_224": {
-      "block_sizes": [
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_224": {
-      "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
       ],
       "range_unroll_factors": [
         0
@@ -22504,51 +22636,6 @@
       "num_warps": 16,
       "num_stages": 1,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_224": {
-      "block_sizes": [
-        256,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
         "tensor_descriptor",
         "pointer",
         "pointer",
@@ -22556,9 +22643,9 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_224": {
+    "intermediate_2880_numtokens_232": {
       "block_sizes": [
-        32,
+        256,
         8
       ],
       "loop_orders": [
@@ -22571,7 +22658,7 @@
         true
       ],
       "l2_groupings": [
-        1
+        4
       ],
       "range_unroll_factors": [
         0
@@ -22588,104 +22675,14 @@
       ],
       "load_eviction_policies": [
         "last",
-        "",
-        "first"
+        "first",
+        "last"
       ],
-      "num_warps": 4,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
         "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_232": {
-      "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_232": {
-      "block_sizes": [
-        64,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
         "pointer",
         "pointer"
       ],
@@ -22693,8 +22690,8 @@
     },
     "intermediate_4096_numtokens_232": {
       "block_sizes": [
-        16,
-        4
+        128,
+        64
       ],
       "loop_orders": [
         [
@@ -22738,20 +22735,20 @@
     },
     "intermediate_8192_numtokens_232": {
       "block_sizes": [
-        32,
-        32
+        256,
+        8
       ],
       "loop_orders": [
         [
-          1,
-          0
+          0,
+          1
         ]
       ],
       "flatten_loops": [
-        false
+        true
       ],
       "l2_groupings": [
-        1
+        2
       ],
       "range_unroll_factors": [
         0
@@ -22769,9 +22766,9 @@
       "load_eviction_policies": [
         "",
         "",
-        ""
+        "first"
       ],
-      "num_warps": 4,
+      "num_warps": 16,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -22783,20 +22780,20 @@
     },
     "intermediate_11008_numtokens_232": {
       "block_sizes": [
-        16,
-        32
+        4,
+        1024
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        32
       ],
       "range_unroll_factors": [
         0
@@ -22812,24 +22809,24 @@
         null
       ],
       "load_eviction_policies": [
-        "",
+        "first",
         "last",
-        ""
+        "first"
       ],
-      "num_warps": 2,
-      "num_stages": 2,
+      "num_warps": 1,
+      "num_stages": 8,
       "indexing": [
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
     "intermediate_14336_numtokens_232": {
       "block_sizes": [
-        32,
-        8
+        8,
+        4096
       ],
       "loop_orders": [
         [
@@ -22861,7 +22858,7 @@
         "",
         ""
       ],
-      "num_warps": 2,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -22873,368 +22870,8 @@
     },
     "intermediate_2048_numtokens_240": {
       "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_240": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_240": {
-      "block_sizes": [
-        16,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_240": {
-      "block_sizes": [
-        32,
+        64,
         8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_240": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_240": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_248": {
-      "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_248": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_248": {
-      "block_sizes": [
-        256,
-        16
       ],
       "loop_orders": [
         [
@@ -23264,9 +22901,54 @@
       "load_eviction_policies": [
         "first",
         "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_240": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
         ""
       ],
-      "num_warps": 16,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -23276,9 +22958,189 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_248": {
+    "intermediate_4096_numtokens_240": {
       "block_sizes": [
-        64,
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_240": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_240": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_240": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_248": {
+      "block_sizes": [
+        128,
         32
       ],
       "loop_orders": [
@@ -23309,10 +23171,10 @@
       "load_eviction_policies": [
         "",
         "",
-        "first"
+        ""
       ],
-      "num_warps": 4,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -23321,10 +23183,10 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_248": {
+    "intermediate_2880_numtokens_248": {
       "block_sizes": [
-        64,
-        4
+        4,
+        2048
       ],
       "loop_orders": [
         [
@@ -23352,11 +23214,146 @@
         null
       ],
       "load_eviction_policies": [
-        "last",
+        "",
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_248": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_248": {
+      "block_sizes": [
+        256,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_248": {
+      "block_sizes": [
+        4,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -23368,8 +23365,8 @@
     },
     "intermediate_14336_numtokens_248": {
       "block_sizes": [
-        64,
-        256
+        8,
+        4096
       ],
       "loop_orders": [
         [
@@ -23413,456 +23410,6 @@
     },
     "intermediate_2048_numtokens_272": {
       "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_272": {
-      "block_sizes": [
-        8,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_272": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          1,
-          0
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_272": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_272": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_272": {
-      "block_sizes": [
-        64,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_288": {
-      "block_sizes": [
-        4,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_288": {
-      "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_288": {
-      "block_sizes": [
-        64,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_288": {
-      "block_sizes": [
-        128,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_288": {
-      "block_sizes": [
         256,
         32
       ],
@@ -23876,51 +23423,6 @@
         true
       ],
       "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_288": {
-      "block_sizes": [
-        16,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
         1
       ],
       "range_unroll_factors": [
@@ -23941,7 +23443,7 @@
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -23951,9 +23453,9 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_2048_numtokens_304": {
+    "intermediate_2880_numtokens_272": {
       "block_sizes": [
-        8,
+        128,
         64
       ],
       "loop_orders": [
@@ -23964,96 +23466,6 @@
       ],
       "flatten_loops": [
         true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_304": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_304": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
       ],
       "l2_groupings": [
         1
@@ -24086,22 +23498,22 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_304": {
+    "intermediate_4096_numtokens_272": {
       "block_sizes": [
-        8,
-        64
+        1,
+        4096
       ],
       "loop_orders": [
         [
-          0,
-          1
+          1,
+          0
         ]
       ],
       "flatten_loops": [
-        true
+        false
       ],
       "l2_groupings": [
-        1
+        64
       ],
       "range_unroll_factors": [
         0
@@ -24119,157 +23531,22 @@
       "load_eviction_policies": [
         "",
         "last",
-        ""
+        "first"
       ],
-      "num_warps": 16,
+      "num_warps": 32,
       "num_stages": 1,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_304": {
-      "block_sizes": [
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_304": {
-      "block_sizes": [
-        64,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_320": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
+        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_2880_numtokens_320": {
+    "intermediate_8192_numtokens_272": {
       "block_sizes": [
-        64,
-        32
+        8,
+        512
       ],
       "loop_orders": [
         [
@@ -24281,7 +23558,97 @@
         true
       ],
       "l2_groupings": [
-        1
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_272": {
+      "block_sizes": [
+        8,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_272": {
+      "block_sizes": [
+        512,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
       ],
       "range_unroll_factors": [
         0
@@ -24299,19 +23666,109 @@
       "load_eviction_policies": [
         "",
         "",
-        ""
+        "last"
       ],
-      "num_warps": 4,
-      "num_stages": 1,
+      "num_warps": 8,
+      "num_stages": 8,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "pointer"
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_4096_numtokens_320": {
+    "intermediate_2048_numtokens_288": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_288": {
+      "block_sizes": [
+        8,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_288": {
       "block_sizes": [
         512,
         4
@@ -24326,7 +23783,97 @@
         true
       ],
       "l2_groupings": [
-        1
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_288": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_288": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        2
       ],
       "range_unroll_factors": [
         0
@@ -24344,10 +23891,10 @@
       "load_eviction_policies": [
         "last",
         "",
-        ""
+        "last"
       ],
-      "num_warps": 1,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "pointer",
@@ -24356,10 +23903,55 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_320": {
+    "intermediate_14336_numtokens_288": {
       "block_sizes": [
-        64,
-        128
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_304": {
+      "block_sizes": [
+        256,
+        32
       ],
       "loop_orders": [
         [
@@ -24401,10 +23993,102 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_320": {
+    "intermediate_2880_numtokens_304": {
       "block_sizes": [
-        32,
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        2
+      ],
+      "range_multi_buffers": [
+        false
+      ],
+      "range_flattens": [
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 2,
+      "maxnreg": 64
+    },
+    "intermediate_4096_numtokens_304": {
+      "block_sizes": [
+        16,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
         32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_304": {
+      "block_sizes": [
+        1,
+        1024
       ],
       "loop_orders": [
         [
@@ -24433,23 +24117,23 @@
       ],
       "load_eviction_policies": [
         "",
-        "",
-        ""
+        "last",
+        "last"
       ],
-      "num_warps": 8,
-      "num_stages": 1,
+      "num_warps": 32,
+      "num_stages": 4,
       "indexing": [
         "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
-        "pointer"
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_320": {
+    "intermediate_11008_numtokens_304": {
       "block_sizes": [
         128,
-        16
+        256
       ],
       "loop_orders": [
         [
@@ -24481,8 +24165,323 @@
         "",
         ""
       ],
-      "num_warps": 32,
+      "num_warps": 8,
       "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_304": {
+      "block_sizes": [
+        4,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_320": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_320": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_320": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_320": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_320": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_320": {
+      "block_sizes": [
+        8,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
       "indexing": [
         "pointer",
         "tensor_descriptor",
@@ -24493,7 +24492,7 @@
     },
     "intermediate_2048_numtokens_336": {
       "block_sizes": [
-        2,
+        256,
         32
       ],
       "loop_orders": [
@@ -24531,3029 +24530,14 @@
       "indexing": [
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
     "intermediate_2880_numtokens_336": {
       "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_336": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_336": {
-      "block_sizes": [
-        64,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_336": {
-      "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_336": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_352": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_352": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_352": {
-      "block_sizes": [
         16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_352": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_352": {
-      "block_sizes": [
-        8,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_352": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_368": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_368": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_368": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_368": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_368": {
-      "block_sizes": [
-        32,
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_368": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_384": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_384": {
-      "block_sizes": [
-        64,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_384": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_384": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_384": {
-      "block_sizes": [
-        8,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_384": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_400": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_400": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_400": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_400": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_400": {
-      "block_sizes": [
-        256,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 32,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_400": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_416": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_416": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_416": {
-      "block_sizes": [
-        64,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_416": {
-      "block_sizes": [
-        128,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_416": {
-      "block_sizes": [
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_416": {
-      "block_sizes": [
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_432": {
-      "block_sizes": [
-        16,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_432": {
-      "block_sizes": [
-        32,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_432": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_432": {
-      "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_432": {
-      "block_sizes": [
-        16,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_432": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_448": {
-      "block_sizes": [
-        4,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_448": {
-      "block_sizes": [
-        8,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_448": {
-      "block_sizes": [
-        4,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_448": {
-      "block_sizes": [
-        32,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_448": {
-      "block_sizes": [
-        16,
-        256
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_448": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_464": {
-      "block_sizes": [
-        32,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_464": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_464": {
-      "block_sizes": [
-        16,
-        64
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_464": {
-      "block_sizes": [
-        8,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_464": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 16,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_464": {
-      "block_sizes": [
-        128,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_480": {
-      "block_sizes": [
-        4,
-        16
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_480": {
-      "block_sizes": [
-        4,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_480": {
-      "block_sizes": [
-        8,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_480": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_480": {
-      "block_sizes": [
-        64,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        "last"
-      ],
-      "num_warps": 1,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_480": {
-      "block_sizes": [
-        16,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_496": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        false
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_496": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        ""
-      ],
-      "num_warps": 8,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_496": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_8192_numtokens_496": {
-      "block_sizes": [
-        32,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_11008_numtokens_496": {
-      "block_sizes": [
-        32,
-        128
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_14336_numtokens_496": {
-      "block_sizes": [
-        256,
-        8
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2048_numtokens_512": {
-      "block_sizes": [
-        32,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "last"
-      ],
-      "num_warps": 32,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_2880_numtokens_512": {
-      "block_sizes": [
-        16,
-        32
-      ],
-      "loop_orders": [
-        [
-          0,
-          1
-        ]
-      ],
-      "flatten_loops": [
-        true
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [
-        0
-      ],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        ""
-      ],
-      "num_warps": 16,
-      "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "pid_type": "flat"
-    },
-    "intermediate_4096_numtokens_512": {
-      "block_sizes": [
-        128,
         512
       ],
       "loop_orders": [
@@ -27586,8 +24570,8 @@
         "",
         ""
       ],
-      "num_warps": 16,
-      "num_stages": 2,
+      "num_warps": 8,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
@@ -27596,10 +24580,325 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_8192_numtokens_512": {
+    "intermediate_4096_numtokens_336": {
       "block_sizes": [
-        32,
+        16,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_336": {
+      "block_sizes": [
+        256,
         128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_336": {
+      "block_sizes": [
+        4,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_336": {
+      "block_sizes": [
+        256,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_352": {
+      "block_sizes": [
+        512,
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_352": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_352": {
+      "block_sizes": [
+        512,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_352": {
+      "block_sizes": [
+        1,
+        8192
       ],
       "loop_orders": [
         [
@@ -27628,10 +24927,100 @@
       ],
       "load_eviction_policies": [
         "",
+        "last",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_352": {
+      "block_sizes": [
+        16,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_352": {
+      "block_sizes": [
+        32,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
         "",
         ""
       ],
-      "num_warps": 32,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
         "pointer",
@@ -27641,9 +25030,1764 @@
       ],
       "pid_type": "flat"
     },
-    "intermediate_11008_numtokens_512": {
+    "intermediate_2048_numtokens_368": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_368": {
+      "block_sizes": [
+        128,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_368": {
+      "block_sizes": [
+        64,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_368": {
+      "block_sizes": [
+        2,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_368": {
+      "block_sizes": [
+        128,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_368": {
       "block_sizes": [
         32,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_384": {
+      "block_sizes": [
+        256,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_384": {
+      "block_sizes": [
+        512,
+        2
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_384": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_384": {
+      "block_sizes": [
+        128,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_384": {
+      "block_sizes": [
+        1,
+        8192
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_384": {
+      "block_sizes": [
+        128,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_400": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_400": {
+      "block_sizes": [
+        16,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_400": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_400": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_400": {
+      "block_sizes": [
+        2,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_400": {
+      "block_sizes": [
+        4,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_416": {
+      "block_sizes": [
+        256,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_416": {
+      "block_sizes": [
+        32,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_416": {
+      "block_sizes": [
+        512,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_416": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 8,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_416": {
+      "block_sizes": [
+        256,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_416": {
+      "block_sizes": [
+        128,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_432": {
+      "block_sizes": [
+        256,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_432": {
+      "block_sizes": [
+        8,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_432": {
+      "block_sizes": [
+        64,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_432": {
+      "block_sizes": [
+        256,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_432": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_432": {
+      "block_sizes": [
+        512,
+        4
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_448": {
+      "block_sizes": [
+        256,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_448": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 6,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_448": {
+      "block_sizes": [
+        8,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_448": {
+      "block_sizes": [
+        128,
+        8
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_448": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_448": {
+      "block_sizes": [
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        16
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 32,
+      "num_stages": 8,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_464": {
+      "block_sizes": [
+        256,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_464": {
+      "block_sizes": [
+        8,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_464": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_464": {
+      "block_sizes": [
+        256,
         128
       ],
       "loop_orders": [
@@ -27676,20 +26820,245 @@
         "",
         ""
       ],
-      "num_warps": 1,
+      "num_warps": 8,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
         "pointer",
         "pointer",
         "pointer"
       ],
       "pid_type": "flat"
     },
-    "intermediate_14336_numtokens_512": {
+    "intermediate_11008_numtokens_464": {
+      "block_sizes": [
+        1,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 6,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_464": {
+      "block_sizes": [
+        64,
+        512
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_480": {
       "block_sizes": [
         16,
+        32
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "first",
+        ""
+      ],
+      "num_warps": 16,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_480": {
+      "block_sizes": [
+        128,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_480": {
+      "block_sizes": [
+        64,
         128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        8
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_480": {
+      "block_sizes": [
+        1,
+        1024
       ],
       "loop_orders": [
         [
@@ -27718,16 +27087,646 @@
       ],
       "load_eviction_policies": [
         "first",
-        "",
+        "first",
         ""
       ],
       "num_warps": 1,
       "num_stages": 2,
       "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_480": {
+      "block_sizes": [
+        1,
+        1024
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 4,
+      "num_stages": 1,
+      "indexing": [
         "pointer",
         "pointer",
         "pointer",
         "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_480": {
+      "block_sizes": [
+        1,
+        16384
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "first"
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_496": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 7,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_496": {
+      "block_sizes": [
+        8,
+        256
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 8,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_496": {
+      "block_sizes": [
+        256,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_496": {
+      "block_sizes": [
+        256,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_496": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last"
+      ],
+      "num_warps": 8,
+      "num_stages": 4,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_496": {
+      "block_sizes": [
+        4,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "first"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2048_numtokens_512": {
+      "block_sizes": [
+        512,
+        16
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_2880_numtokens_512": {
+      "block_sizes": [
+        8,
+        2048
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_4096_numtokens_512": {
+      "block_sizes": [
+        8,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 16,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_8192_numtokens_512": {
+      "block_sizes": [
+        1,
+        2048
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        "last"
+      ],
+      "num_warps": 4,
+      "num_stages": 4,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_11008_numtokens_512": {
+      "block_sizes": [
+        1,
+        4096
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "",
+        "first"
+      ],
+      "num_warps": 16,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "pid_type": "flat"
+    },
+    "intermediate_14336_numtokens_512": {
+      "block_sizes": [
+        128,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 7,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
       ],
       "pid_type": "flat"
     }


### PR DESCRIPTION
Rerun autotune with "full" effort on H200 and manually tweaked some configs for small intermediate_size/num_tokens to be more effective. This overrides previous configs generated with "quick" autotune effort.

Updated perf:
 
``` 
Intermediate size: Geomean speedup (min/max speedups)
  2048:  1.29x (1.11x - 1.74x)
  2880:  1.42x (1.06x - 1.93x)
  4096:  1.50x (1.04x - 2.21x)
  8192:  1.84x (1.05x - 3.16x)
  11008: 2.07x (1.17x - 4.00x)
  14336: 2.31x (1.22x - 4.88x)
```
