### PR TITLE
[Bugfix] Fix mypy errors in hermes_tool_parser

### DIFF
--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -378,6 +378,8 @@ class Hermes2ProToolParser(ToolParser):
 
             # main logic for tool parsing here - compare prev. partially-parsed
             #   JSON to the current partially-parsed JSON
+            if current_tool_call is None:
+                return None
             prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
                 "arguments"
             )


### PR DESCRIPTION
## Summary

`current_tool_call` can be `None` from partial JSON parsing but was used
without a guard in the streaming diff logic. Added an early return.