### PR TITLE
[CI] Fix lint: mypy union-attr errors in hermes_tool_parser

### DIFF
--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -3,6 +3,7 @@
 
 import json
 from collections.abc import Sequence
+from typing import Any
 
 import partial_json_parser
 import regex as re
@@ -316,10 +317,10 @@ class Hermes2ProToolParser(ToolParser):
                 return delta
 
             try:
-                current_tool_call = (
+                current_tool_call: dict[str, Any] = (
                     partial_json_parser.loads(tool_call_portion or "{}", flags)
                     if tool_call_portion
-                    else None
+                    else {}
                 )
                 logger.debug("Parsed tool call %s", current_tool_call)
             except partial_json_parser.core.exceptions.MalformedJSON:


### PR DESCRIPTION
Fix lint error at TOT

```
Error: vllm/tool_parsers/hermes_tool_parser.py:384: error: Item "None" of "Any | None" has no attribute "get"  [union-attr]
Error: vllm/tool_parsers/hermes_tool_parser.py:414: error: Item "None" of "Any | None" has no attribute "get"  [union-attr]
Error: vllm/tool_parsers/hermes_tool_parser.py:489: error: Incompatible types in assignment (expression has type "Any | None", target has type "dict[Any, Any]")  [assignment]
Error: vllm/tool_parsers/hermes_tool_parser.py:491: error: Argument 1 to "append" of "list" has incompatible type "Any | None"; expected "dict[Any, Any]"  [arg-type]
```