### PR TITLE
[WIP][Proof of concept] Overlap model loading and torch.compile

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -48,6 +48,16 @@ from .passes.pass_manager import PostGradPassManager
 logger = init_logger(__name__)
 
 
+class CompilationDone(Exception):
+    """Raised in compile-only mode after compilation is complete.
+
+    This signals that the Inductor cache has been populated and
+    there is no need to actually execute the compiled code.
+    """
+
+    pass
+
+
 def make_copy_and_call(
     sym_tensor_indices: list[int],
     input_buffers: list[torch.Tensor | None],
@@ -838,7 +848,23 @@ class VllmBackend:
         # Compute config/compiler/code hashes once and reuse
         config_hash = vllm_config.compute_hash()
         compiler_hash = self.compiler_manager.compute_hash(vllm_config)
-        forward_code_files = list(sorted(self.compilation_config.traced_files))
+        if (
+            self.compilation_config.compile_only
+            or self.compilation_config.overlap_compile
+        ):
+            # TODO: Fix traced_files consistency between compile-only
+            # (FakeTensor weights) and normal (real weights) paths.
+            # FakeTensor weights cause Dynamo to trace a slightly
+            # different set of files (e.g. parameter.py is missing),
+            # which changes code_hash and thus the cache directory.
+            # For now, skip traced_files entirely when overlapping so
+            # both paths get the same cache dir. Eventually we should
+            # make the traced file sets consistent regardless of the
+            # weight loading method.
+            forward_code_files: list[str] = []
+            self.compilation_config.traced_files.clear()
+        else:
+            forward_code_files = list(sorted(self.compilation_config.traced_files))
 
         logger.debug(
             "Traced files (to be considered for compilation cache):\n%s",
@@ -1029,6 +1055,9 @@ class VllmBackend:
                 elapsed,
                 scope="local",
             )
+
+        if self.compilation_config.compile_only:
+            logger.info("Compile-only mode: Inductor cache has been populated.")
 
         from torch._guards import detect_fake_mode
 

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -562,8 +562,16 @@ def _support_torch_compile(
                 self.aot_compiled_fn = self.aot_compile(*args, **kwargs)
                 # All compilation is done at this point, save the AOT artifact.
                 self.save_aot_compiled_function()
+                if self.compilation_config.compile_only:
+                    from .backends import CompilationDone
+
+                    raise CompilationDone("Compilation and AOT save complete.")
                 output = self.aot_compiled_fn(self, *args, **kwargs)
             else:
+                if self.compilation_config.compile_only:
+                    from .backends import CompilationDone
+
+                    raise CompilationDone("Compilation complete (non-AOT path).")
                 output = TorchCompileWithNoGuardsWrapper.__call__(self, *args, **kwargs)  # type: ignore[arg-type]
 
         from .monitor import end_monitoring_torch_compile

--- a/vllm/compile_only.py
+++ b/vllm/compile_only.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compile-only mode: populate the torch.compile / Inductor cache
+without loading real model weights or allocating KV caches.
+
+Can be invoked in two ways:
+
+1. From CLI args (``vllm compile <model>``):
+   ``run_compile_only(args)`` builds an ``EngineArgs`` from the parsed
+   namespace, sets ``compile_only=True``, then creates an ``EngineCore``
+   which triggers compilation.
+
+2. From a serialized ``VllmConfig`` (overlap subprocess):
+   ``python -m vllm.compile_only --config-path <path>`` loads a
+   pickled ``VllmConfig``, patches it for compile-only mode, and
+   runs compilation directly.
+
+The compile-only flag causes the model loader to be wrapped with
+FakeTensorMode (see ``fake_loader.wrap_loader_with_fake``), so the
+user's original ``load_format`` is preserved and the real loader's
+full pipeline runs — just with fake tensors instead of real weights.
+"""
+
+import argparse
+import pickle
+
+from vllm.logger import init_logger
+from vllm.usage.usage_lib import UsageContext
+
+logger = init_logger(__name__)
+
+
+def run_compile_only(args: argparse.Namespace) -> None:
+    """Run compile-only mode from CLI arguments."""
+    from vllm.engine.arg_utils import EngineArgs
+
+    engine_args = EngineArgs.from_cli_args(args)
+    engine_args.enforce_eager = False
+
+    vllm_config = engine_args.create_engine_config(usage_context=UsageContext.LLM_CLASS)
+    vllm_config.compilation_config.compile_only = True
+
+    _run_compile_with_config(vllm_config)
+
+
+def run_compile_only_from_config(config_path: str) -> None:
+    """Run compile-only mode from a serialized VllmConfig."""
+    with open(config_path, "rb") as f:
+        vllm_config = pickle.load(f)
+
+    # Patch for compile-only mode
+    vllm_config.compilation_config.compile_only = True
+    vllm_config.compilation_config.overlap_compile = False
+
+    _run_compile_with_config(vllm_config)
+
+
+def _run_compile_with_config(vllm_config) -> None:
+    """Shared compile-only logic."""
+    from vllm.v1.engine.core import EngineCore
+    from vllm.v1.executor import Executor
+
+    executor_class = Executor.get_class(vllm_config)
+    engine_core = EngineCore(
+        vllm_config=vllm_config,
+        executor_class=executor_class,
+        log_stats=False,
+    )
+
+    logger.info("Compile-only mode complete. Cache populated.")
+    engine_core.shutdown()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="vLLM compile-only mode (internal)")
+    parser.add_argument(
+        "--config-path",
+        type=str,
+        required=True,
+        help="Path to pickled VllmConfig",
+    )
+    args = parser.parse_args()
+    run_compile_only_from_config(args.config_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -617,6 +617,18 @@ class CompilationConfig:
     local_cache_dir: str = field(default=None, init=False)  # type: ignore
     """local cache dir for each rank"""
 
+    compile_only: bool = False
+    """If True, run in compile-only mode: only torch.compile/Inductor
+    compilation, skip CUDA graph capture, kernel warmup, and sampler warmup.
+    Used to pre-populate the compilation cache without allocating KV caches
+    or setting up the full engine."""
+
+    overlap_compile: bool = False
+    """If True, launch a background compile-only subprocess during startup
+    to overlap compilation with weight loading. The subprocess uses
+    FakeTensor weights (no GPU memory) to run torch.compile and populate
+    the Inductor cache while the main process loads real weights."""
+
     fast_moe_cold_start: bool | None = None
     """Optimization for fast MOE cold start.
 
@@ -700,6 +712,9 @@ class CompilationConfig:
             "static_forward_context",
             "pass_config",  # handled separately below
             "dynamic_shapes_config",  # handled separately below
+            # Runtime-only flags that don’t affect the compiled graph
+            "compile_only",
+            "overlap_compile",
         }
 
         from vllm.config.utils import get_hash_factors, hash_factors

--- a/vllm/entrypoints/cli/compile.py
+++ b/vllm/entrypoints/cli/compile.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import argparse
+
+from vllm.entrypoints.cli.types import CLISubcommand
+from vllm.entrypoints.openai.cli_args import make_arg_parser
+from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
+from vllm.logger import init_logger
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+logger = init_logger(__name__)
+
+DESCRIPTION = """Pre-compile the torch.compile / Inductor cache for a model.
+
+This runs compilation using fake (zero-memory) weights so that the
+Inductor cache is populated without requiring full GPU memory for model
+weights.  Subsequent ``vllm serve`` or ``LLM(...)`` calls for the same
+model will hit the warm cache and skip compilation.
+"""
+
+
+class CompileSubcommand(CLISubcommand):
+    """The ``compile`` subcommand for the vLLM CLI."""
+
+    name = "compile"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        from vllm.compile_only import run_compile_only
+
+        if hasattr(args, "model_tag") and args.model_tag is not None:
+            args.model = args.model_tag
+        run_compile_only(args)
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        compile_parser = subparsers.add_parser(
+            self.name,
+            help="Pre-compile torch.compile cache for a model.",
+            description=DESCRIPTION,
+            usage="vllm compile [model_tag] [options]",
+        )
+        compile_parser = make_arg_parser(compile_parser)
+        compile_parser.epilog = VLLM_SUBCMD_PARSER_EPILOG.format(subcmd=self.name)
+        return compile_parser
+
+
+def cmd_init() -> list[CLISubcommand]:
+    return [CompileSubcommand()]

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -16,6 +16,7 @@ logger = init_logger(__name__)
 def main():
     import vllm.entrypoints.cli.benchmark.main
     import vllm.entrypoints.cli.collect_env
+    import vllm.entrypoints.cli.compile
     import vllm.entrypoints.cli.launch
     import vllm.entrypoints.cli.openai
     import vllm.entrypoints.cli.run_batch
@@ -26,6 +27,7 @@ def main():
     CMD_MODULES = [
         vllm.entrypoints.cli.openai,
         vllm.entrypoints.cli.serve,
+        vllm.entrypoints.cli.compile,
         vllm.entrypoints.cli.launch,
         vllm.entrypoints.cli.benchmark.main,
         vllm.entrypoints.cli.collect_env,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -213,6 +213,10 @@ class LLM:
             dictionary or an AttentionConfig instance. If a dictionary, it will
             be converted to an AttentionConfig. Allows specifying the attention
             backend and other attention-related settings.
+        compile_only: If True, run in compile-only mode: wraps the model
+            loader with FakeTensorMode (zero GPU memory) and runs
+            torch.compile to populate the Inductor cache, then returns
+            early. The resulting LLM object is NOT usable for inference.
         **kwargs: Arguments for [`EngineArgs`][vllm.EngineArgs].
 
     Note:
@@ -261,6 +265,7 @@ class LLM:
         kv_cache_memory_bytes: int | None = None,
         compilation_config: int | dict[str, Any] | CompilationConfig | None = None,
         logits_processors: list[str | type[LogitsProcessor]] | None = None,
+        compile_only: bool = False,
         **kwargs: Any,
     ) -> None:
         """LLM constructor."""
@@ -313,6 +318,9 @@ class LLM:
             compilation_config_instance = _make_config(
                 compilation_config, CompilationConfig
             )
+
+        if compile_only:
+            compilation_config_instance.compile_only = True
 
         structured_outputs_instance = _make_config(
             structured_outputs_config, StructuredOutputsConfig
@@ -374,7 +382,22 @@ class LLM:
             **kwargs,
         )
 
+        if compile_only:
+            engine_args.enforce_eager = False
+
         log_non_default_args(engine_args)
+
+        if compile_only:
+            # Bypass LLMEngine (which sets up multiprocess handshake,
+            # scheduler, etc.) and create EngineCore directly.
+            from vllm.compile_only import _run_compile_with_config
+
+            vllm_config = engine_args.create_engine_config(
+                usage_context=UsageContext.LLM_CLASS
+            )
+            _run_compile_with_config(vllm_config)
+            logger.info("Compile-only mode complete. Cache populated.")
+            return
 
         self.llm_engine = LLMEngine.from_engine_args(
             engine_args=engine_args, usage_context=UsageContext.LLM_CLASS

--- a/vllm/model_executor/model_loader/fake_loader.py
+++ b/vllm/model_executor/model_loader/fake_loader.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FakeTensorMode wrapper for model loaders.
+
+Wraps any BaseModelLoader so that its full pipeline (initialize_model →
+load_weights → process_weights_after_loading) runs under FakeTensorMode.
+All tensors appear as CUDA tensors with the correct post-processing
+dtypes/shapes but consume no GPU memory and perform no file I/O.
+
+This is used for compile-only mode where we only need the model graph
+structure to drive torch.compile / Inductor compilation and populate
+the cache.
+"""
+
+import torch
+import torch.nn as nn
+
+from vllm.config import ModelConfig, VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+
+logger = init_logger(__name__)
+
+
+def wrap_loader_with_fake(real_loader: BaseModelLoader) -> BaseModelLoader:
+    """Wrap a model loader so it runs entirely under FakeTensorMode.
+
+    The returned loader delegates to *real_loader* for model
+    initialization and weight post-processing, but replaces
+    ``load_weights`` with fake materialization (no file I/O) and
+    runs everything under ``FakeTensorMode`` (no GPU memory).
+    """
+
+    def _fake_load_weights(model: nn.Module, model_config: ModelConfig) -> None:
+        """Materialize meta-device parameters as fake tensors.
+
+        Online quantization methods (e.g. Fp8OnlineLinearMethod) create
+        weights on the meta device, expecting load_weights to
+        materialize them.  We replace them with fake tensors on the
+        target device so that process_weights_after_loading can run
+        the full quantization/post-processing pipeline.
+        """
+        target_device = torch.get_default_device()
+        for name, param in list(model.named_parameters()):
+            if param.device == torch.device("meta"):
+                parts = name.split(".")
+                mod = model
+                for p in parts[:-1]:
+                    mod = getattr(mod, p)
+                new_data = torch.empty(
+                    param.shape,
+                    dtype=param.dtype,
+                    device=target_device,
+                )
+                mod.register_parameter(
+                    parts[-1],
+                    nn.Parameter(new_data, requires_grad=param.requires_grad),
+                )
+
+    original_load_model = real_loader.load_model
+
+    def _fake_load_model(
+        vllm_config: VllmConfig,
+        model_config: ModelConfig,
+        prefix: str = "",
+    ) -> nn.Module:
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+        with fake_mode:
+            return original_load_model(vllm_config, model_config, prefix)
+
+    real_loader.load_weights = _fake_load_weights  # type: ignore[assignment]
+    real_loader.load_model = _fake_load_model  # type: ignore[assignment]
+    real_loader.download_model = lambda *a, **kw: None  # type: ignore[assignment]
+
+    return real_loader

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -19,6 +19,7 @@ import zmq
 
 import vllm.envs as envs
 from vllm.config import ParallelConfig, VllmConfig
+from vllm.config.compilation import CompilationMode
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.envs import enable_envs_cache
 from vllm.logger import init_logger
@@ -106,10 +107,30 @@ class EngineCore:
 
         self.log_stats = log_stats
 
+        # Phase 2: Optionally launch a background compile-only subprocess
+        # to overlap compilation with weight loading.
+        compile_proc = None
+        if (
+            vllm_config.compilation_config.overlap_compile
+            and vllm_config.compilation_config.mode != CompilationMode.NONE
+            and not vllm_config.compilation_config.compile_only
+        ):
+            compile_proc = _launch_compile_subprocess(vllm_config)
+
         # Setup Model.
         self.model_executor = executor_class(vllm_config)
         if executor_fail_callback is not None:
             self.model_executor.register_failure_callback(executor_fail_callback)
+
+        # Wait for compile subprocess before profiling/warmup
+        if compile_proc is not None:
+            _wait_for_compile_subprocess(compile_proc)
+
+        # In compile-only mode, skip KV cache allocation, scheduler setup,
+        # and everything else — just run compilation and return.
+        if vllm_config.compilation_config.compile_only:
+            self.model_executor.collective_rpc("compile_or_warm_up_model")
+            return
 
         self.available_gpu_memory_for_kv_cache = -1
 
@@ -545,16 +566,19 @@ class EngineCore:
             self.abort_requests(request_ids)
 
     def shutdown(self):
-        self.structured_output_manager.clear_backend()
-        if self.model_executor:
+        if hasattr(self, "structured_output_manager"):
+            self.structured_output_manager.clear_backend()
+        if getattr(self, "model_executor", None):
             self.model_executor.shutdown()
-        if self.scheduler:
+        if getattr(self, "scheduler", None):
             self.scheduler.shutdown()
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None):
         self.model_executor.profile(is_start, profile_prefix)
 
     def reset_mm_cache(self):
+        if not hasattr(self, "scheduler"):
+            return
         # NOTE: Since this is mainly for debugging, we don't attempt to
         # re-sync the internal caches (P0 sender, P1 receiver)
         if self.scheduler.has_unfinished_requests():
@@ -1962,3 +1986,50 @@ class EngineCoreActor(EngineCoreActorMixin, EngineCoreProc):
             log_stats,
             engine_index=dp_rank,
         )
+
+
+def _launch_compile_subprocess(vllm_config: VllmConfig):
+    """Launch a background compile-only subprocess.
+
+    Serializes the VllmConfig to a temp file and spawns a subprocess
+    that runs compile-only mode with fake weights.  The subprocess
+    populates the Inductor compilation cache while the main process
+    loads real weights concurrently.
+    """
+    import pickle
+    import subprocess
+    import sys
+    import tempfile
+
+    logger.info("Launching background compile-only subprocess...")
+    fd, config_path = tempfile.mkstemp(suffix=".pkl", prefix="vllm_compile_config_")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            pickle.dump(vllm_config, f)
+    except Exception:
+        os.unlink(config_path)
+        raise
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "vllm.compile_only", "--config-path", config_path],
+    )
+    # Store config_path on proc for cleanup
+    proc._compile_config_path = config_path  # type: ignore[attr-defined]
+    return proc
+
+
+def _wait_for_compile_subprocess(proc):
+    """Wait for the background compile-only subprocess to finish."""
+    logger.info("Waiting for background compile-only subprocess (pid=%d)...", proc.pid)
+    proc.wait()
+    config_path = getattr(proc, "_compile_config_path", None)
+    if config_path and os.path.exists(config_path):
+        os.unlink(config_path)
+    if proc.returncode != 0:
+        logger.warning(
+            "Background compile subprocess failed (rc=%d). "
+            "Check stderr output above for details.",
+            proc.returncode,
+        )
+    else:
+        logger.info("Background compile-only subprocess finished successfully.")

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4274,6 +4274,12 @@ class GPUModelRunner(
                 if load_dummy_weights:
                     self.load_config.load_format = "dummy"
                 model_loader = get_model_loader(self.load_config)
+                if self.vllm_config.compilation_config.compile_only:
+                    from vllm.model_executor.model_loader.fake_loader import (
+                        wrap_loader_with_fake,
+                    )
+
+                    model_loader = wrap_loader_with_fake(model_loader)
                 self.model = model_loader.load_model(
                     vllm_config=self.vllm_config, model_config=self.model_config
                 )

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -282,7 +282,12 @@ class Worker(WorkerBase):
 
             # take current memory snapshot
             self.init_snapshot = init_snapshot = MemorySnapshot(device=self.device)
-            self.requested_memory = request_memory(init_snapshot, self.cache_config)
+            if self.compilation_config.compile_only:
+                # In compile-only mode with fake weights, skip memory
+                # validation since we don't allocate real GPU memory.
+                self.requested_memory = 0
+            else:
+                self.requested_memory = request_memory(init_snapshot, self.cache_config)
             logger.debug("worker init memory snapshot: %r", self.init_snapshot)
             logger.debug(
                 "worker requested memory: %sGiB", format_gib(self.requested_memory)
@@ -506,6 +511,30 @@ class Worker(WorkerBase):
             for compile_range in compile_ranges:
                 if not any(x in compile_range for x in all_sizes):
                     warmup_sizes.append(compile_range.end)
+
+        if self.compilation_config.compile_only:
+            from vllm.compilation.backends import CompilationDone
+
+            # In compile-only mode, we need at least one _dummy_run to
+            # trigger torch.compile. VllmBackend compiles ALL ranges
+            # upfront, then raises CompilationDone to prevent execution
+            # with fake tensors (which would cause CUDA IMA).
+            if not warmup_sizes:
+                warmup_sizes = [1]
+            try:
+                for size in sorted(warmup_sizes, reverse=True):
+                    logger.info("Compile and warming up model for size %d", size)
+                    self.model_runner._dummy_run(
+                        size, skip_eplb=True, remove_lora=False
+                    )
+            except CompilationDone:
+                logger.info(
+                    "Compile-only mode: compilation complete. "
+                    "Skipping kernel warmup, CUDA graphs, and "
+                    "sampler warmup."
+                )
+            set_random_seed(self.model_config.seed)
+            return self.compilation_config.compilation_time
 
         # We skip EPLB here since we don't want to record dummy metrics
         for size in sorted(warmup_sizes, reverse=True):


### PR DESCRIPTION
## Problem

vLLM startup involves two expensive sequential steps:
1. Weight loading — I/O-bound (disk → CPU → GPU)
2. torch.compile / Inductor compilation — CPU/GPU-compute-bound

These can be overlapped because the compilation cache hash does not depend on weight values.

## Design

Also see design doc: https://docs.google.com/document/d/1hssZeQv_lJlKqOr0vfpoqEUNn4ASGHVRB9a49yhcY6E/edit?tab=t.0

Three layers, two user-facing APIs:

```
┌───────────────────────────────────────────────┬───────────────────────────────────────────────────────────────┐
│                      API                      │                           Use case                            │
├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│ LLM(compile_only=True) / vllm compile <model> │ Pre-populate compilation cache (e.g. Docker build step, CI)   │
├───────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│ compilation_config={"overlap_compile": True}  │ Overlap compilation with weight loading during normal startup │
└───────────────────────────────────────────────┴───────────────────────────────────────────────────────────────┘
```

The internal mechanism is compile_only on CompilationConfig, which is set automatically by both APIs.

### `vllm compile <model>`

In compile-only mode, we avoid loading real weights. The overall strategy is to run weight processing logic with FakeTensors (tensors without storage). Real kernels cannot be run on FakeTensors; for any compute that needs to run, we would need to create a custom operator for it (custom operators can have Fake kernels that work for FakeTensors registered on them).

compile-only mode wraps whatever model loader the user has configured (DefaultModelLoader, GGUFModelLoader, etc.) with wrap_loader_with_fake(). This:
- Replaces load_weights with fake materialization (meta-device params → fake tensors on target device, no file I/O)
- Wraps load_model in FakeTensorMode so the full pipeline runs — initialize_model → load_weights → process_weights_after_loading — with all tensor ops producing fake tensors (correct metadata, zero GPU memory)
- Preserves the real loader's pipeline, so online quantization (e.g. quantization="fp8") produces fake tensors with correct post-quantization dtypes/shapes

### Overlap mechanism:

When overlap_compile=True, EngineCore.__init__ serializes the VllmConfig to a temp file and spawns `python -m vllm.compile_only --config-path <path>` as a background subprocess before creating the executor. The subprocess runs compile-only mode (fake weights, populates both the Inductor CompilerManager cache and the AOT artifact cache), while the main process loads real weights concurrently. After weight loading, the main process waits for the subprocess, then proceeds — hitting warm caches for both the AOT load and the Inductor compilation.