### PR TITLE
Perf: Optimize DeepEP prepare/finalize for identity mapping

### DIFF
--- a/tests/kernels/moe/test_deepep_optim.py
+++ b/tests/kernels/moe/test_deepep_optim.py
@@ -1,0 +1,100 @@
+
+import pytest
+import torch
+from unittest.mock import MagicMock
+import sys
+import traceback
+
+# Mock deep_ep module
+mock_deep_ep = MagicMock()
+sys.modules["deep_ep"] = mock_deep_ep
+mock_deep_ep.Buffer = MagicMock()
+
+# Mock vllm.logger to avoid initialization issues
+mock_logger = MagicMock()
+sys.modules["vllm.logger"] = mock_logger
+mock_logger.init_logger.return_value = MagicMock()
+
+# Mock vllm.envs
+sys.modules["vllm.envs"] = MagicMock()
+
+# Mock other dependencies
+sys.modules["vllm.v1.worker.ubatching"] = MagicMock()
+sys.modules["vllm.model_executor.layers.fused_moe.utils"] = MagicMock()
+sys.modules["vllm.model_executor.layers.fused_moe.topk_weight_and_reduce"] = MagicMock()
+sys.modules["vllm._custom_ops"] = MagicMock()
+
+# Mock modular_kernel entirely
+mk_mock = MagicMock()
+sys.modules["vllm.model_executor.layers.fused_moe.modular_kernel"] = mk_mock
+# Ensure base class is a type so inheritance works
+class MockBase:
+    def __init__(self): pass
+mk_mock.FusedMoEPrepareAndFinalizeModular = MockBase
+mk_mock.FusedMoEActivationFormat = MagicMock()
+
+try:
+    from vllm.model_executor.layers.fused_moe.deepep_ll_prepare_finalize import DeepEPLLPrepareAndFinalize
+except Exception:
+    traceback.print_exc()
+    sys.exit(1)
+
+def test_deepep_identity_optimization():
+    print("Starting test...")
+    # Setup
+    num_experts = 8
+    buffer = mock_deep_ep.Buffer()
+    max_tokens = 1024
+    num_dispatchers = 1
+    
+    # Case 1: Identity Mapping
+    global_to_physical = torch.arange(num_experts, dtype=torch.int32, device="cpu")
+    physical_to_global = torch.arange(num_experts, dtype=torch.int32, device="cpu")
+    local_expert_global_ids = torch.arange(num_experts, dtype=torch.int32, device="cpu")
+    
+    # Move to CUDA if available, else simulate with CPU (the logic is device agnostic but requires same device)
+    # We test on CPU for simplicity as the logic is just tensor comparison
+    
+    pf = DeepEPLLPrepareAndFinalize(
+        buffer=buffer,
+        max_tokens_per_rank=max_tokens,
+        num_dispatchers=num_dispatchers,
+        global_to_physical=global_to_physical,
+        physical_to_global=physical_to_global,
+        local_expert_global_ids=local_expert_global_ids
+    )
+    
+    # Assertions: Should be None
+    assert pf.global_to_physical is None
+    assert pf.physical_to_global is None
+    assert pf.local_expert_global_ids is None
+    
+    # Verify mapping functions return input directly
+    input_ids = torch.tensor([0, 1, 2], dtype=torch.int64)
+    assert pf._map_global_to_physical_ids(input_ids) is input_ids
+    assert pf._map_local_to_global_ids(input_ids) is input_ids
+
+    # Case 2: Non-Identity Mapping
+    global_to_physical_shuffled = torch.randperm(num_experts, dtype=torch.int32)
+    # Ensure it's not identity
+    while torch.equal(global_to_physical_shuffled, torch.arange(num_experts, dtype=torch.int32)):
+         global_to_physical_shuffled = torch.randperm(num_experts, dtype=torch.int32)
+         
+    pf_shuffled = DeepEPLLPrepareAndFinalize(
+        buffer=buffer,
+        max_tokens_per_rank=max_tokens,
+        num_dispatchers=num_dispatchers,
+        global_to_physical=global_to_physical_shuffled,
+    )
+    
+    # Assertions: Should NOT be None
+    assert pf_shuffled.global_to_physical is not None
+    assert torch.equal(pf_shuffled.global_to_physical, global_to_physical_shuffled)
+    
+    # Verify mapping function uses the map
+    mapped = pf_shuffled._map_global_to_physical_ids(input_ids)
+    expected = global_to_physical_shuffled[input_ids]
+    assert torch.equal(mapped, expected)
+
+if __name__ == "__main__":
+    test_deepep_identity_optimization()

--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -114,6 +114,56 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         self.physical_to_global = _maybe_cast(physical_to_global)
         self.local_expert_global_ids = _maybe_cast(local_expert_global_ids)
 
+        # Optimization: If the mappings are identity, set to None to avoid
+        # unnecessary kernel launches during prepare/finalize.
+        # This is especially important for latency-sensitive workloads like
+        # speculative decoding draft models.
+        if self.global_to_physical is not None:
+            num_experts = self.global_to_physical.numel()
+            if torch.equal(
+                self.global_to_physical,
+                torch.arange(
+                    num_experts,
+                    device=self.global_to_physical.device,
+                    dtype=self.global_to_physical.dtype,
+                ),
+            ):
+                self.global_to_physical = None
+
+        if self.physical_to_global is not None:
+            num_experts = self.physical_to_global.numel()
+            if torch.equal(
+                self.physical_to_global,
+                torch.arange(
+                    num_experts,
+                    device=self.physical_to_global.device,
+                    dtype=self.physical_to_global.dtype,
+                ),
+            ):
+                self.physical_to_global = None
+
+        if self.local_expert_global_ids is not None:
+            # For local_expert_global_ids, check if it's contiguous and starts
+            # at expected offset (rank * num_local_experts).
+            # But here we just check if it matches the slicing logic.
+            # Actually, simpler: if local_expert_global_ids matches what
+            # slicing would produce, we might optimize _map_local_to_global_ids?
+            # However, _map_local_to_global_ids uses indexing.
+            # If local_expert_global_ids is contiguous, we might use adding offset?
+            # For now, let's stick to the simple identity check if it applies
+            # (e.g. single GPU or simple sharding).
+            # In general case, let's keep it unless it's strictly identity [0, 1, ...].
+            num_local = self.local_expert_global_ids.numel()
+            if torch.equal(
+                self.local_expert_global_ids,
+                torch.arange(
+                    num_local,
+                    device=self.local_expert_global_ids.device,
+                    dtype=self.local_expert_global_ids.dtype,
+                ),
+            ):
+                self.local_expert_global_ids = None
+
         # We don't have enough information to determine if we should dispatch
         # activation scales in a packed ue8m0 format during object construction
         # time. This setting is handled by post_init_setup.


### PR DESCRIPTION
This change optimizes the DeepEPLLPrepareAndFinalize class by detecting identity mappings for global_to_physical, physical_to_global, and local_expert_global_ids. If these mappings are identity, they are set to None, avoiding unnecessary kernel launches during the prepare and finalize steps. This is particularly beneficial for latency-sensitive workloads like speculative decoding draft models where these mappings are often identity.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

