### PR TITLE
 Add adaptive decode chunking for SM100 fused TRTLLM path (TMP FIX)#34988

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -74,6 +74,10 @@ FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 # under very high decode request concurrency.
 TRTLLM_DECODE_CHUNK_TRIGGER_REQS = 512
 TRTLLM_DECODE_CHUNK_SIZE = 256
+TRTLLM_DECODE_CHUNK_THRESH_MID = 1024
+TRTLLM_DECODE_CHUNK_SIZE_MID = 384
+TRTLLM_DECODE_CHUNK_THRESH_HIGH = 1536
+TRTLLM_DECODE_CHUNK_SIZE_HIGH = 512
 
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
@@ -96,10 +100,10 @@ def _get_trtllm_decode_chunk_size(num_decodes: int) -> int:
     # Keep smaller chunks for moderate decode concurrency to avoid the
     # problematic kernel region, and use larger chunks at very high concurrency
     # to reduce launch/slicing overhead.
-    if num_decodes > 1536:
-        return 512
-    if num_decodes > 1024:
-        return 384
+    if num_decodes > TRTLLM_DECODE_CHUNK_THRESH_HIGH:
+        return TRTLLM_DECODE_CHUNK_SIZE_HIGH
+    if num_decodes > TRTLLM_DECODE_CHUNK_THRESH_MID:
+        return TRTLLM_DECODE_CHUNK_SIZE_MID
     return TRTLLM_DECODE_CHUNK_SIZE
 
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -70,6 +70,10 @@ from vllm.v1.kv_cache_interface import AttentionSpec, UniformTypeKVCacheSpecs
 from vllm.v1.utils import CpuGpuBuffer
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
+# Temporary mitigation for Blackwell TRTLLM decode performance saddle
+# under very high decode request concurrency.
+TRTLLM_DECODE_CHUNK_TRIGGER_REQS = 512
+TRTLLM_DECODE_CHUNK_SIZE = 256
 
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
@@ -1222,6 +1226,8 @@ class FlashInferImpl(AttentionImpl):
             self.sinks = sinks
 
         self.support_trtllm_attn = can_use_trtllm_attention(num_heads, num_kv_heads)
+        capability = current_platform.get_device_capability()
+        self._is_sm100 = capability is not None and capability.major == 10
         vllm_config = get_current_vllm_config_or_none()
         self.supports_quant_query_input = (
             self.support_trtllm_attn
@@ -1560,40 +1566,82 @@ class FlashInferImpl(AttentionImpl):
                 assert is_strictly_contiguous(block_tables_decode)
                 assert is_strictly_contiguous(seq_lens_decode)
 
-                if output.dtype == FP4_DTYPE:
-                    assert self.o_sf_scale is not None
-                    out = FP4Tensor(
-                        data=output[:num_decode_tokens],
-                        scale=output_block_scale,
-                        scale_start_index=0,
-                        original_shape=decode_query.shape,
-                    )
-                else:
-                    assert self.o_sf_scale is None
-                    out = output[:num_decode_tokens]
-
                 if num_decode_tokens % attn_metadata.num_decodes != 0:
                     # This gets triggered when the dummy_run forces
                     # attention to be initialized with q_len = 0
                     q_len_per_req = 1
+                    has_uniform_q_len = False
                 else:
                     q_len_per_req = num_decode_tokens // attn_metadata.num_decodes
+                    has_uniform_q_len = True
 
-                trtllm_batch_decode_with_kv_cache(
-                    query=decode_query,
-                    kv_cache=kv_cache_permute,
-                    workspace_buffer=workspace_buffer,
-                    block_tables=block_tables_decode,
-                    seq_lens=seq_lens_decode,
-                    max_seq_len=attn_metadata.decode.max_seq_len,
-                    bmm1_scale=self.bmm1_scale,
-                    bmm2_scale=self.bmm2_scale,
-                    window_left=self.window_left,
-                    sinks=self.sinks,
-                    o_sf_scale=self.o_sf_scale,
-                    out=out,
-                    q_len_per_req=q_len_per_req,
+                num_decodes = attn_metadata.num_decodes
+                use_chunked_decode = (
+                    has_uniform_q_len
+                    and self._is_sm100
+                    and output.dtype == FP4_DTYPE
+                    and attn_metadata.q_data_type == FP8_DTYPE
+                    and num_decodes > TRTLLM_DECODE_CHUNK_TRIGGER_REQS
                 )
+
+                if use_chunked_decode:
+                    assert self.o_sf_scale is not None
+                    assert output_block_scale is not None
+                    for req_start in range(0, num_decodes, TRTLLM_DECODE_CHUNK_SIZE):
+                        req_end = min(req_start + TRTLLM_DECODE_CHUNK_SIZE, num_decodes)
+                        tok_start = req_start * q_len_per_req
+                        tok_end = req_end * q_len_per_req
+                        decode_query_chunk = decode_query[tok_start:tok_end]
+
+                        out_chunk = FP4Tensor(
+                            data=output[tok_start:tok_end],
+                            scale=output_block_scale,
+                            scale_start_index=tok_start,
+                            original_shape=decode_query_chunk.shape,
+                        )
+                        trtllm_batch_decode_with_kv_cache(
+                            query=decode_query_chunk,
+                            kv_cache=kv_cache_permute,
+                            workspace_buffer=workspace_buffer,
+                            block_tables=block_tables_decode[req_start:req_end],
+                            seq_lens=seq_lens_decode[req_start:req_end],
+                            max_seq_len=attn_metadata.decode.max_seq_len,
+                            bmm1_scale=self.bmm1_scale,
+                            bmm2_scale=self.bmm2_scale,
+                            window_left=self.window_left,
+                            sinks=self.sinks,
+                            o_sf_scale=self.o_sf_scale,
+                            out=out_chunk,
+                            q_len_per_req=q_len_per_req,
+                        )
+                else:
+                    if output.dtype == FP4_DTYPE:
+                        assert self.o_sf_scale is not None
+                        out = FP4Tensor(
+                            data=output[:num_decode_tokens],
+                            scale=output_block_scale,
+                            scale_start_index=0,
+                            original_shape=decode_query.shape,
+                        )
+                    else:
+                        assert self.o_sf_scale is None
+                        out = output[:num_decode_tokens]
+
+                    trtllm_batch_decode_with_kv_cache(
+                        query=decode_query,
+                        kv_cache=kv_cache_permute,
+                        workspace_buffer=workspace_buffer,
+                        block_tables=block_tables_decode,
+                        seq_lens=seq_lens_decode,
+                        max_seq_len=attn_metadata.decode.max_seq_len,
+                        bmm1_scale=self.bmm1_scale,
+                        bmm2_scale=self.bmm2_scale,
+                        window_left=self.window_left,
+                        sinks=self.sinks,
+                        o_sf_scale=self.o_sf_scale,
+                        out=out,
+                        q_len_per_req=q_len_per_req,
+                    )
         return output_padded
 
     def do_kv_cache_update(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -92,6 +92,17 @@ def _get_trtllm_gen_workspace_buffer():
     return trtllm_gen_workspace_buffer
 
 
+def _get_trtllm_decode_chunk_size(num_decodes: int) -> int:
+    # Keep smaller chunks for moderate decode concurrency to avoid the
+    # problematic kernel region, and use larger chunks at very high concurrency
+    # to reduce launch/slicing overhead.
+    if num_decodes > 1536:
+        return 512
+    if num_decodes > 1024:
+        return 384
+    return TRTLLM_DECODE_CHUNK_SIZE
+
+
 @triton.jit
 def _trtllm_prefill_attn_kvfp8_dequant(
     kv_cache_ptr,
@@ -1587,8 +1598,9 @@ class FlashInferImpl(AttentionImpl):
                 if use_chunked_decode:
                     assert self.o_sf_scale is not None
                     assert output_block_scale is not None
-                    for req_start in range(0, num_decodes, TRTLLM_DECODE_CHUNK_SIZE):
-                        req_end = min(req_start + TRTLLM_DECODE_CHUNK_SIZE, num_decodes)
+                    chunk_size = _get_trtllm_decode_chunk_size(num_decodes)
+                    for req_start in range(0, num_decodes, chunk_size):
+                        req_end = min(req_start + chunk_size, num_decodes)
                         tok_start = req_start * q_len_per_req
                         tok_end = req_end * q_len_per_req
                         decode_query_chunk = decode_query[tok_start:tok_end]


### PR DESCRIPTION

## Purpose
find top kernel:https://paste.ubuntu.com/p/G4FytRwYnP/

res: https://paste.ubuntu.com/p/7MHTBdKYbB/

Add a temporary backend-side mitigation for SM100 decode saddle in FlashInfer TRTLLM fused path (FP8 Q + FP4 output), without introducing new flags.
#34988
## Test Plan
https://paste.ubuntu.com/p/zSdN9rptHd/

https://paste.ubuntu.com/p/KxKBHDkvcs/

. Both tables are delta tables:
d_xxx = metric(fused) - metric(unfused).

How to read columns:

d_mean_ttft / d_median_ttft / d_p99_ttft (ms): negative = fused better.
d_mean_tpot (ms/token): negative = fused better.
d_req_tput (req/s): positive = fused better.
## Test Result
```
rate | d_mean_ttft | d_median_ttft | d_p99_ttft | d_mean_tpot | d_req_tput
   1 | -1.46 | -1.39 | -3.67 | -0.09 | +0.00
   5 | -0.73 | -0.96 | -0.97 | -0.12 | +0.00
  10 | -0.91 | -0.80 | -1.01 | -0.16 | +0.00
  15 | -1.01 | -1.02 | -1.48 | -0.21 | +0.00
  20 | -1.25 | -1.18 | -1.63 | -0.25 | +0.01
```

```
rate | d_mean_ttft | d_median_ttft | d_p99_ttft | d_mean_tpot | d_req_tput
   1 | +0.61 | +0.78 | -0.28 | -0.01 | +0.00
   5 | +0.29 | +0.39 | +0.96 | -0.01 | +0.00
  10 | +0.56 | +0.55 | +0.59 | -0.01 | +0.00
  15 | +1.07 | +0.91 | +1.95 | +0.00 | +0.00
  20 | -9.56 | -9.10 | -31.02 | -0.48 | +0.01
 inf | -201.98 | -218.76 | -242.64 | -5.20 | +13.99
```

first table:https://paste.ubuntu.com/p/pBysT33KsR/
RATES=(1 5 10 15 20)
NUM_PROMPTS=1000
second table: https://paste.ubuntu.com/p/4rGp3T3HZp/
{"num-prompts": 120, "request-rate": 1},
{"num-prompts": 600, "request-rate": 5},
{"num-prompts": 1200, "request-rate": 10},
{"num-prompts": 1800, "request-rate": 15},
{"num-prompts": 2400, "request-rate": 20},
{"num-prompts": 1000, "request-rate": "inf"}

.... like the issue benchmark https://github.com/vllm-project/vllm/issues/34988
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

