### PR TITLE
[CI] Don't leave docs preview comment on closed PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
   description: Automatically apply documentation label
   conditions:
     - label != stale
+    - -closed
     - or:
       - files~=^[^/]+\.md$
       - files~=^docs/


### PR DESCRIPTION
While cleaning up old PRs the bot started leaving comments on PRs I already closed. This shouldn't happen.