### PR TITLE
[Bugfix] Handle TimeoutError in Voxtral buffer_realtime_audio to prevent silent hang

### DIFF
--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -271,10 +271,16 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
         # Feed output tokens back into buffer in background
         async def feed_tokens():
             while True:
-                all_outputs = await asyncio.wait_for(
-                    input_stream.get(),
-                    timeout=VLLM_ENGINE_ITERATION_TIMEOUT_S,
-                )
+                try:
+                    all_outputs = await asyncio.wait_for(
+                        input_stream.get(),
+                        timeout=VLLM_ENGINE_ITERATION_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Timeout waiting for output tokens in "
+                        "feed_tokens; retrying.")
+                    continue
                 await buffer.append_tokens(all_outputs[-1:])
 
         audio_task = asyncio.create_task(feed_audio())

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -270,16 +270,27 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
 
         # Feed output tokens back into buffer in background
         async def feed_tokens():
+            timeout_count = 0
             while True:
                 try:
                     all_outputs = await asyncio.wait_for(
                         input_stream.get(),
                         timeout=VLLM_ENGINE_ITERATION_TIMEOUT_S,
                     )
+                    if timeout_count > 0:
+                        logger.info(
+                            "feed_tokens received tokens after %d timeout(s).",
+                            timeout_count,
+                        )
+                        timeout_count = 0
                 except asyncio.TimeoutError:
-                    logger.warning(
-                        "Timeout waiting for output tokens in "
-                        "feed_tokens; retrying.")
+                    timeout_count += 1
+                    if timeout_count == 1 or timeout_count % 10 == 0:
+                        logger.warning(
+                            "Timeout #%d waiting for output tokens "
+                            "in feed_tokens; retrying.",
+                            timeout_count,
+                        )
                     continue
                 await buffer.append_tokens(all_outputs[-1:])
 


### PR DESCRIPTION
## Summary

Fixes #36015

The `feed_tokens` background task in `buffer_realtime_audio` uses `asyncio.wait_for` with a timeout to fetch output tokens from the engine. When the engine iteration takes longer than `VLLM_ENGINE_ITERATION_TIMEOUT_S` (e.g. due to GC pauses, queue buildup, or KV cache preemption), an unhandled `asyncio.TimeoutError` silently crashes the task.

Since the main async generator relies on `buffer.get_input_stream()` → `token_queue.get()`, and no new tokens are ever enqueued after the crash, the entire request **deadlocks permanently** with no error logged.

## Root Cause

```python
# Before (voxtral_realtime.py)
async def feed_tokens():
    while True:
        all_outputs = await asyncio.wait_for(   # <-- raises TimeoutError
            input_stream.get(),
            timeout=VLLM_ENGINE_ITERATION_TIMEOUT_S,
        )
        await buffer.append_tokens(all_outputs[-1:])
```

`asyncio.TimeoutError` propagates up → task dies → `token_queue` starves → deadlock.

## Fix

Wrap the `asyncio.wait_for` call in `try/except asyncio.TimeoutError`, log a warning, and `continue` the retry loop:

```python
async def feed_tokens():
    while True:
        try:
            all_outputs = await asyncio.wait_for(
                input_stream.get(),
                timeout=VLLM_ENGINE_ITERATION_TIMEOUT_S,
            )
        except asyncio.TimeoutError:
            logger.warning(
                "Timeout waiting for output tokens in "
                "feed_tokens; retrying.")
            continue
        await buffer.append_tokens(all_outputs[-1:])
```

Normal cancellation via `CancelledError` (triggered by the `finally` block's `token_task.cancel()`) is unaffected since only `TimeoutError` is caught.

## Test Plan

- Verified the change does not alter the normal (non-timeout) code path
- The timeout is a transient condition; retrying is the correct behavior since the engine will eventually produce tokens
- `CancelledError` still propagates normally, ensuring clean shutdown