### PR TITLE
fix: handle float-like strings in int() parsing to prevent ValidationError

### DIFF
--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -443,5 +443,8 @@ def set_from_deprecated_env_if_set(
         if to_bool:
             field_value = env_value.lower() in ("1", "true")
         elif to_int:
-            field_value = int(env_value)
+            try:
+                field_value = int(env_value)
+            except ValueError:
+                field_value = int(float(env_value))
         setattr(config, field_name, field_value)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2250,8 +2250,11 @@ def human_readable_int(value: str) -> int:
                     f"{number}{suffix.lower()} instead?"
                 ) from e
 
-    # Regular plain number.
-    return int(value)
+    # Regular plain number. Use int(float(...)) to accept values like '4.0'.
+    try:
+        return int(value)
+    except ValueError:
+        return int(float(value))
 
 
 def human_readable_int_or_auto(value: str) -> int:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -263,7 +263,10 @@ def get_default_config_root():
 def maybe_convert_int(value: str | None) -> int | None:
     if value is None:
         return None
-    return int(value)
+    try:
+        return int(value)
+    except ValueError:
+        return int(float(value))
 
 
 def maybe_convert_bool(value: str | None) -> bool | None:
@@ -693,7 +696,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_PP_LAYER_PARTITION": lambda: os.getenv("VLLM_PP_LAYER_PARTITION", None),
     # (CPU backend only) CPU key-value cache space.
     # default is None and will be set as 4 GB
-    "VLLM_CPU_KVCACHE_SPACE": lambda: int(os.getenv("VLLM_CPU_KVCACHE_SPACE", "0"))
+    "VLLM_CPU_KVCACHE_SPACE":
+    lambda: int(float(os.getenv("VLLM_CPU_KVCACHE_SPACE", "0")))
     if "VLLM_CPU_KVCACHE_SPACE" in os.environ
     else None,
     # (CPU backend only) CPU core ids bound by OpenMP threads, e.g., "0-31",


### PR DESCRIPTION
## Summary

When users set environment variables like `VLLM_CPU_KVCACHE_SPACE=4.0` (a float-like string), Python's `int('4.0')` raises `ValueError`. This causes a Pydantic `ValidationError` during `VllmConfig` initialization, particularly affecting Mac M4 (CPU platform) users running models like Qwen3.5-2B.

The fix uses `int(float(value))` as a fallback in all int-parsing paths:

- **`vllm/envs.py`**: `VLLM_CPU_KVCACHE_SPACE` lambda and `maybe_convert_int()`
- **`vllm/engine/arg_utils.py`**: `human_readable_int()` plain number fallback
- **`vllm/config/utils.py`**: `set_from_deprecated_env_if_set()` `to_int` branch

## Root Cause

`int('4.0')` raises `ValueError` in Python because `int()` only accepts integer-formatted strings. When the value originates from an environment variable or CLI argument, users naturally write `4.0` for 4 GB. The error surfaces as:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
  Value error, invalid literal for int() with base 10: '4.0'
```

## Fix

Use `try: int(value) except ValueError: int(float(value))` pattern to gracefully accept float-like strings (e.g., `'4.0'` -> `4`) while preserving existing behavior for valid integer strings and still raising errors for truly invalid input.

Fixes #35967

## Test plan

- [x] Verified `int(float('4.0'))` correctly returns `4`
- [x] Verified `int(float('8'))` correctly returns `8` (no regression)
- [x] Verified invalid input like `'not_a_number'` still raises `ValueError`
- [x] Verified `None` handling in `maybe_convert_int` is preserved
- [ ] CI tests pass

Signed-off-by: OiPunk <codingpunk@gmail.com>