### PR TITLE
[Bugfix] Fix mypy errors in hermes_tool_parser.py

### DIFF
--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -368,6 +368,9 @@ class Hermes2ProToolParser(ToolParser):
             # now, the nitty-gritty of tool calls
             # now we have the portion to parse as tool call.
 
+            if current_tool_call is None:
+                return None
+
             logger.debug(
                 "Trying to parse current tool call with ID %s", self.current_tool_id
             )


### PR DESCRIPTION
## Purpose

Fix four mypy type errors in `vllm/tool_parsers/hermes_tool_parser.py`. The variable `current_tool_call` has type `Any | None` (returned by `partial_json_parser.loads`), but was used without a None guard, causing `union-attr`, `assignment`, and `arg-type` mypy errors.

The fix adds a single None check that resolves all four errors at once:
- Line 384: `current_tool_call.get("arguments")` on `Any | None`
- Line 414: `current_tool_call.get("name")` on `Any | None`
- Line 489: Assignment of `Any | None` to `dict[Any, Any]`
- Line 491: Appending `Any | None` to `list[dict[Any, Any]]`

## Test Plan

- `pre-commit run mypy-local --files vllm/tool_parsers/hermes_tool_parser.py` passes cleanly.

## Test Result

```
Run mypy locally for lowest supported Python version.......................Passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.
</details>