### PR TITLE
Set default value for --ready-check-timeout-sec flag in benchmarking script

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1551,7 +1551,7 @@ def add_cli_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--ready-check-timeout-sec",
         type=int,
-        default=0,
+        default=60,
         help="Maximum time to wait for the endpoint to become ready "
         "in seconds. Ready check will be skipped by default.",
     )

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1553,7 +1553,7 @@ def add_cli_args(parser: argparse.ArgumentParser):
         type=int,
         default=60,
         help="Maximum time to wait for the endpoint to become ready "
-        "in seconds. Ready check will be skipped by default.",
+        "in seconds. A value of 0 will skip the ready check.",
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Purpose
Set default value for `--ready-check-timeout-sec` flag  to 60 sec. Currently it is set to 0. When running series of benchmarks, and when server is being restarted user need to find this flag and increase it's value from 0. It is more convenient to  have default as 60 to avoid this extra search.

