### PR TITLE
[Bugfix] Guard fabric handle APIs for CUDA < 12.4 compatibility

### DIFF
--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -116,11 +116,13 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
     prop.allocFlags.gpuDirectRDMACapable = 1;
   }
   int fab_flag = 0;
+  #if CUDA_VERSION >= 12040
   CUDA_CHECK(cuDeviceGetAttribute(
       &fab_flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, device));
   if (fab_flag) {  // support fabric handle if possible
     prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
   }
+  #endif
 #endif
 
 #ifndef USE_ROCM


### PR DESCRIPTION
## Summary

- `CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED` and `CU_MEM_HANDLE_TYPE_FABRIC` were introduced in CUDA 12.4
- Without a version guard, `cumem_allocator.cpp` fails to compile on CUDA 12.0–12.3
- Wraps the fabric detection block in `#if CUDA_VERSION >= 12040` so older toolchains skip fabric support gracefully
- `fab_flag` remains initialized to 0, so the existing fallback logic at line 130 is unaffected

Introduced in #33540.

## Test plan

- [x] Compiles cleanly on CUDA 12.0 (V12.0.140) — fabric block skipped
- [x] Compiles cleanly on CUDA 12.8 (V12.8.61) — fabric detection still active
- [x] `pre-commit run --files csrc/cumem_allocator.cpp` passes (clang-format, typos)

Signed-off-by: Nikolaos Ioannidis <ni@aimbit.de>