### PR TITLE
Fix Eagle3 with Transformers modelling backend

### DIFF
--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -517,7 +517,10 @@ class Base(
 
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         self.check_version("5.2.0", "Eagle3 support")
-        from transformers.utils.output_capturing import OutputRecorder
+        from transformers.utils.output_capturing import (
+            OutputRecorder,
+            maybe_install_capturing_hooks,
+        )
 
         # The default value in PreTrainedModel is None
         if self.model._can_record_outputs is None:
@@ -531,6 +534,9 @@ class Base(
             aux_hidden_state_i = OutputRecorder(target_class, layer_name=layer_name)
             self.model._can_record_outputs[layer_key] = aux_hidden_state_i
             self._output_aux_hidden_states_kwargs[f"output_{layer_key}"] = True
+
+        # Ensure that the capture hooks are installed before dynamo traces the model
+        maybe_install_capturing_hooks(self.model)
 
     def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
         num_layers = self.text_config.num_hidden_layers

--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -516,8 +516,8 @@ class Base(
             )
 
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
-        self.check_version("5.0.0", "Eagle3 support")
-        from transformers.utils.generic import OutputRecorder
+        self.check_version("5.2.0", "Eagle3 support")
+        from transformers.utils.output_capturing import OutputRecorder
 
         # The default value in PreTrainedModel is None
         if self.model._can_record_outputs is None:


### PR DESCRIPTION
This import was moved in https://github.com/huggingface/transformers/pull/43765 and was first released in 5.2.0.

This PR also changed the capture hooks to be registered lazily, which is a problem when we use `torch.compile`. This PR also eagerly registers those hooks if they're going to be used to avoid issues with Dynamo.