### PR TITLE
[Model] Add MetaCLIP-2 Support

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -835,6 +835,7 @@ The following table lists those that are tested in vLLM.
 | `ColPaliForRetrieval` | ColPali | T / I | `vidore/colpali-v1.3-hf` | | |
 | `LlamaNemotronVLModel` | Llama Nemotron Embedding + SigLIP | T + I | `nvidia/llama-nemotron-embed-vl-1b-v2` | | |
 | `LlavaNextForConditionalGeneration`<sup>C</sup> | LLaVA-NeXT-based | T / I | `royokong/e5-v` | | ✅︎ |
+| `MetaClip2Model` | MetaCLIP-2 | T / I | `facebook/metaclip-2-mt5-worldwide-s16`, etc. | | |
 | `Phi3VForCausalLM`<sup>C</sup> | Phi-3-Vision-based | T + I | `TIGER-Lab/VLM2Vec-Full` | | ✅︎ |
 | `Qwen3VLForConditionalGeneration`<sup>C</sup> | Qwen3-VL | T + I + V | `Qwen/Qwen3-VL-Embedding-2B`, etc. | ✅︎ | ✅︎ |
 | `SiglipModel` | SigLIP, SigLIP2 | T / I | `google/siglip-base-patch16-224`, `google/siglip2-base-patch16-224` | | |

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -593,6 +593,7 @@ _EMBEDDING_EXAMPLE_MODELS = {
         "nvidia/llama-nemotron-embed-vl-1b-v2", trust_remote_code=True
     ),
     "LlavaNextForConditionalGeneration": _HfExamplesInfo("royokong/e5-v"),
+    "MetaClip2Model": _HfExamplesInfo("facebook/metaclip-2-mt5-worldwide-s16"),
     "Phi3VForCausalLM": _HfExamplesInfo(
         "TIGER-Lab/VLM2Vec-Full", trust_remote_code=True
     ),

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -253,6 +253,7 @@ _EMBEDDING_MODELS = {
         "llava_next",
         "LlavaNextForConditionalGeneration",
     ),
+    "MetaClip2Model": ("clip", "CLIPEmbeddingModel"),
     "Phi3VForCausalLM": ("phi3v", "Phi3VForCausalLM"),
     "Qwen2VLForConditionalGeneration": ("qwen2_vl", "Qwen2VLForConditionalGeneration"),  # noqa: E501
     "SiglipModel": ("siglip", "SiglipEmbeddingModel"),


### PR DESCRIPTION
Fixes #35999

This PR adds support for the MetaClip2Model architecture as an alias to CLIPEmbeddingModel so that Meta-CLIP-2 models can be used directly for inference.

Changes:

Added registry alias for MetaClip2Model.

Updated test suite with facebook/metaclip-2-mt5-worldwide-s16 (0.1B) to validate the new architecture path while ensuring CI stability.

Updated supported_models.md documentation.