### PR TITLE
Fix TypeError when rope factor is null during max length derivation

### DIFF
--- a/tests/config/test_model_max_len.py
+++ b/tests/config/test_model_max_len.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from transformers import PretrainedConfig
+
+from vllm.config.model import _get_and_verify_max_len
+from vllm.config.model_arch import ModelArchitectureConfig
+
+
+def _make_model_arch_config(derived_max_model_len: int = 4096) -> ModelArchitectureConfig:
+    return ModelArchitectureConfig(
+        architectures=["LlamaForCausalLM"],
+        model_type="llama",
+        text_model_type=None,
+        hidden_size=4096,
+        total_num_hidden_layers=32,
+        total_num_attention_heads=32,
+        head_size=128,
+        vocab_size=32000,
+        total_num_kv_heads=32,
+        num_experts=0,
+        quantization_config=None,
+        is_deepseek_mla=False,
+        derived_max_model_len_and_key=(derived_max_model_len, "max_position_embeddings"),
+    )
+
+
+def test_get_and_verify_max_len_handles_null_rope_factor():
+    hf_config = PretrainedConfig(model_type="llama")
+    hf_config.rope_parameters = {
+        "rope_type": "default",
+        "factor": None,
+    }
+
+    max_model_len = _get_and_verify_max_len(
+        hf_config=hf_config,
+        model_arch_config=_make_model_arch_config(4096),
+        tokenizer_config=None,
+        max_model_len=None,
+        disable_sliding_window=False,
+        sliding_window=None,
+    )
+
+    assert max_model_len == 4096
+
+
+def test_get_and_verify_max_len_still_applies_valid_rope_factor():
+    hf_config = PretrainedConfig(model_type="llama")
+    hf_config.rope_parameters = {
+        "rope_type": "linear",
+        "factor": 2.0,
+    }
+
+    max_model_len = _get_and_verify_max_len(
+        hf_config=hf_config,
+        model_arch_config=_make_model_arch_config(4096),
+        tokenizer_config=None,
+        max_model_len=None,
+        disable_sliding_window=False,
+        sliding_window=None,
+    )
+
+    assert max_model_len == 8192

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1988,7 +1988,11 @@ def _get_and_verify_max_len(
             if rope_type not in ("su", "longrope", "llama3"):
                 # NOTE: rope_type == "default" does not define factor https://github.com/huggingface/transformers/blob/v4.45.2/src/transformers/modeling_rope_utils.py
                 # NOTE: This assumes all layer types have the same scaling factor.
-                scaling_factor = rp.get("factor", scaling_factor)
+                # Some configs set `factor: null` explicitly; keep the previous
+                # scaling value in that case instead of overriding with None.
+                rope_factor = rp.get("factor")
+                if rope_factor is not None:
+                    scaling_factor = rope_factor
 
                 if rope_type == "yarn":
                     derived_max_model_len = rp["original_max_position_embeddings"]


### PR DESCRIPTION
## Summary
- guard against `rope_parameters.factor` being explicitly set to `null` when computing `derived_max_model_len`
- keep the previous scaling factor (default `1.0`) when factor is `None`
- add targeted unit tests for both `factor: null` and a valid scaling factor to prevent regressions

## Root cause
`dict.get("factor", default)` only uses the default when the key is missing. If config sets `"factor": null`, the old code overwrote `scaling_factor` with `None`, and `derived_max_model_len *= scaling_factor` raised a `TypeError`.

## Validation
- `PYTHONPATH=. python -m pytest --noconftest tests/config/test_model_max_len.py -q`

Fixes #36109
