### PR TITLE
[Bugfix] Fix float-like CPU env int parsing for #35967

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -14,6 +14,7 @@ from vllm.envs import (
     env_set_with_choices,
     env_with_choices,
     environment_variables,
+    maybe_convert_int,
 )
 
 
@@ -93,6 +94,30 @@ def test_is_envs_cache_enabled() -> None:
 
     disable_envs_cache()
     assert not envs._is_envs_cache_enabled()
+
+
+def test_maybe_convert_int_handles_float_like_strings() -> None:
+    assert maybe_convert_int("4") == 4
+    assert maybe_convert_int("4.0") == 4
+    assert maybe_convert_int("1_000.0") == 1000
+    assert maybe_convert_int("9007199254740993.0") == 9007199254740993
+    assert maybe_convert_int(None) is None
+
+    with pytest.raises(ValueError):
+        maybe_convert_int("4.2")
+    with pytest.raises(ValueError):
+        maybe_convert_int("1e3")
+
+
+def test_cpu_env_ints_allow_float_like_strings(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_CPU_KVCACHE_SPACE", "4.0")
+    monkeypatch.setenv("VLLM_CPU_NUM_OF_RESERVED_CPU", "2.0")
+
+    if hasattr(envs.__getattr__, "cache_clear"):
+        envs.__getattr__.cache_clear()
+
+    assert envs.VLLM_CPU_KVCACHE_SPACE == 4
+    assert envs.VLLM_CPU_NUM_OF_RESERVED_CPU == 2
 
 
 class TestEnvWithChoices:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -11,6 +11,8 @@ import uuid
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
+import regex as re
+
 if TYPE_CHECKING:
     VLLM_HOST_IP: str = ""
     VLLM_PORT: int | None = None
@@ -260,10 +262,22 @@ def get_default_config_root():
     )
 
 
+_FLOAT_LIKE_INT_RE = re.compile(r"^[+-]?(?:\d(?:_?\d)*)\.(?:0(?:_?0)*)$")
+
+
 def maybe_convert_int(value: str | None) -> int | None:
     if value is None:
         return None
-    return int(value)
+    try:
+        return int(value)
+    except ValueError as int_err:
+        # Accept explicit float-like integer strings, e.g. "4.0" -> 4.
+        # Avoid using float() to preserve exact integer semantics.
+        stripped = value.strip()
+        if _FLOAT_LIKE_INT_RE.fullmatch(stripped):
+            integer_part = stripped.split(".", 1)[0].replace("_", "")
+            return int(integer_part)
+        raise int_err
 
 
 def maybe_convert_bool(value: str | None) -> bool | None:
@@ -693,7 +707,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_PP_LAYER_PARTITION": lambda: os.getenv("VLLM_PP_LAYER_PARTITION", None),
     # (CPU backend only) CPU key-value cache space.
     # default is None and will be set as 4 GB
-    "VLLM_CPU_KVCACHE_SPACE": lambda: int(os.getenv("VLLM_CPU_KVCACHE_SPACE", "0"))
+    "VLLM_CPU_KVCACHE_SPACE": lambda: maybe_convert_int(
+        os.getenv("VLLM_CPU_KVCACHE_SPACE")
+    )
     if "VLLM_CPU_KVCACHE_SPACE" in os.environ
     else None,
     # (CPU backend only) CPU core ids bound by OpenMP threads, e.g., "0-31",
@@ -701,8 +717,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_CPU_OMP_THREADS_BIND": lambda: os.getenv("VLLM_CPU_OMP_THREADS_BIND", "auto"),
     # (CPU backend only) CPU cores not used by OMP threads .
     # Those CPU cores will not be used by OMP threads of a rank.
-    "VLLM_CPU_NUM_OF_RESERVED_CPU": lambda: int(
-        os.getenv("VLLM_CPU_NUM_OF_RESERVED_CPU", "0")
+    "VLLM_CPU_NUM_OF_RESERVED_CPU": lambda: maybe_convert_int(
+        os.getenv("VLLM_CPU_NUM_OF_RESERVED_CPU")
     )
     if "VLLM_CPU_NUM_OF_RESERVED_CPU" in os.environ
     else None,


### PR DESCRIPTION


## Purpose
Fixes #35967.

On CPU/Mac startup, vLLM could fail with:

`ValueError: invalid literal for int() with base 10: '4.0'`

when env vars like `VLLM_CPU_KVCACHE_SPACE=4.0` were set.

## Summary
fixes a startup bug where vLLM could crash if a CPU setting was written like `4.0` instead of `4`. The main idea is to make number parsing more forgiving for that common case while still rejecting clearly wrong inputs. This prevents the old `invalid literal for int()` error and helps CPU/Mac users start the server more reliably.
## Test plan

- Runtime repro:
  - `export VLLM_CPU_KVCACHE_SPACE=4.0`
  - Start API server on CPU and verify startup continues without the original parsing crash.

## Test Result

- Original `int('4.0')` failure no longer occurs.
- Server reaches startup completion path with `VLLM_CPU_KVCACHE_SPACE=4.0`.
- Guardrails validated:
  - `4.2` -> still errors
  - `1e3` -> still errors
  - `9007199254740993.0` -> parsed exactly (no float precision loss)
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

