### PR TITLE
[Bugfix] Grammar was ignored when reasoning ended within speculated tokens

### DIFF
--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -214,6 +214,32 @@ class TestReasoningStructuredOutput:
         # Should return True since reasoning has ended
         assert result is True
 
+    def test_should_advance_with_new_token_ids_reasoning_ends_mid_batch(
+        self,
+        mock_vllm_config,
+        mock_request_with_structured_output,
+        mock_reasoning_parser,
+    ):
+        """When speculative decoding produces tokens containing </think>,
+        should_advance(new_token_ids=...) must return True so the caller
+        can process the post-reasoning tokens."""
+        manager = StructuredOutputManager(mock_vllm_config)
+        manager.reasoner = mock_reasoning_parser
+
+        struct_req = mock_request_with_structured_output.structured_output_request
+        struct_req.reasoning_ended = False
+
+        new_token_ids = [REASONING_TOKEN_A, THINK_END_TOKEN, JSON_TOKEN_A, JSON_TOKEN_B]
+        mock_reasoning_parser.is_reasoning_end_streaming.return_value = True
+
+        result = manager.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=new_token_ids,
+        )
+
+        assert result is True
+        assert struct_req.reasoning_ended is True
+
     def _make_manager_for_bitmask_test(
         self, mock_vllm_config, mock_reasoning_parser, num_spec_tokens=5
     ):

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -12,6 +12,12 @@ from vllm.reasoning import ReasoningParser
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
 
+THINK_END_TOKEN = 99
+REASONING_TOKEN_A = 10
+REASONING_TOKEN_B = 11
+JSON_TOKEN_A = 20
+JSON_TOKEN_B = 21
+
 
 class TestReasoningStructuredOutput:
     """Test reasoning-aware structured output functionality."""
@@ -207,3 +213,171 @@ class TestReasoningStructuredOutput:
 
         # Should return True since reasoning has ended
         assert result is True
+
+    def _make_manager_for_bitmask_test(
+        self, mock_vllm_config, mock_reasoning_parser, num_spec_tokens=5
+    ):
+        """Helper: create a StructuredOutputManager wired up for bitmask
+        tests with a mock backend and pre-allocated bitmask tensor."""
+        import torch
+
+        mock_vllm_config.speculative_config = Mock()
+        mock_vllm_config.speculative_config.num_speculative_tokens = num_spec_tokens
+        manager = StructuredOutputManager(mock_vllm_config)
+        manager.reasoner = mock_reasoning_parser
+
+        max_entries = mock_vllm_config.scheduler_config.max_num_seqs * (
+            1 + num_spec_tokens
+        )
+        manager._grammar_bitmask = torch.zeros(max_entries, 1, dtype=torch.int32)
+        manager.backend = Mock()
+        return manager
+
+    def _make_grammar_mock(self):
+        """Helper: create a mock grammar that tracks calls."""
+        grammar = Mock()
+        grammar.is_terminated.return_value = False
+        grammar.accept_tokens.return_value = True
+        grammar.fill_bitmask = Mock()
+        grammar.rollback = Mock()
+        return grammar
+
+    def test_grammar_bitmask_regression_think_end_in_spec_tokens(
+        self,
+        mock_vllm_config,
+        mock_reasoning_parser,
+    ):
+        """Regression test for production crash: when reasoning_ended=True
+        and spec tokens contain </think>, grammar must NOT try to accept
+        the </think> token.
+
+        Production scenario: previous step set reasoning_ended=True,
+        should_fill_bitmask returns True, spec tokens = [</think>],
+        grammar.accept_tokens(</think>) crashes because </think> is not
+        valid structured output."""
+        manager = self._make_manager_for_bitmask_test(
+            mock_vllm_config, mock_reasoning_parser, num_spec_tokens=1
+        )
+        grammar = self._make_grammar_mock()
+
+        def mock_streaming(all_ids, delta):
+            return delta == [THINK_END_TOKEN]
+
+        mock_reasoning_parser.is_reasoning_end_streaming.side_effect = mock_streaming
+        mock_reasoning_parser.is_reasoning_end.return_value = True
+
+        request = Mock(spec=Request)
+        request.structured_output_request = Mock()
+        request.structured_output_request.reasoning_ended = True
+        request.structured_output_request.grammar = grammar
+        request.use_structured_output = True
+        request.prompt_token_ids = [1, 2, 3]
+
+        req_id = "req-crash-test"
+
+        result = manager.grammar_bitmask(
+            requests={req_id: request},
+            structured_output_request_ids=[req_id],
+            scheduled_spec_decode_tokens={req_id: [THINK_END_TOKEN]},
+        )
+
+        # grammar.accept_tokens must NOT have been called with </think>
+        for call in grammar.accept_tokens.call_args_list:
+            _, tokens = call[0]
+            assert THINK_END_TOKEN not in tokens, (
+                f"grammar.accept_tokens was called with </think> token "
+                f"{THINK_END_TOKEN}, which should be skipped"
+            )
+        assert result is not None
+
+    def test_grammar_bitmask_reasoning_ends_mid_speculation(
+        self,
+        mock_vllm_config,
+        mock_reasoning_parser,
+    ):
+        """When reasoning_end appears mid-speculation, only post-reasoning
+        tokens should be grammar-constrained and accepted (then rolled
+        back)."""
+        manager = self._make_manager_for_bitmask_test(
+            mock_vllm_config, mock_reasoning_parser, num_spec_tokens=5
+        )
+        grammar = self._make_grammar_mock()
+
+        def mock_streaming(all_ids, delta):
+            return delta == [THINK_END_TOKEN]
+
+        mock_reasoning_parser.is_reasoning_end_streaming.side_effect = mock_streaming
+        mock_reasoning_parser.is_reasoning_end.return_value = False
+
+        request = Mock(spec=Request)
+        request.structured_output_request = Mock()
+        request.structured_output_request.reasoning_ended = False
+        request.structured_output_request.grammar = grammar
+        request.use_structured_output = True
+        request.prompt_token_ids = [1, 2, 3]
+
+        req_id = "req-mid-spec"
+        spec_tokens = [
+            REASONING_TOKEN_A,
+            THINK_END_TOKEN,
+            JSON_TOKEN_A,
+            JSON_TOKEN_B,
+        ]
+
+        result = manager.grammar_bitmask(
+            requests={req_id: request},
+            structured_output_request_ids=[req_id],
+            scheduled_spec_decode_tokens={req_id: spec_tokens},
+        )
+
+        assert result is not None
+        assert request.structured_output_request.reasoning_ended is True
+
+        # Only post-reasoning tokens should have been accepted
+        accepted_tokens = [
+            call[0][1][0] for call in grammar.accept_tokens.call_args_list
+        ]
+        assert THINK_END_TOKEN not in accepted_tokens
+        assert REASONING_TOKEN_A not in accepted_tokens
+        assert JSON_TOKEN_A in accepted_tokens
+        assert JSON_TOKEN_B in accepted_tokens
+
+        # Grammar advancements should be rolled back
+        if grammar.accept_tokens.call_count > 0:
+            grammar.rollback.assert_called_once_with(grammar.accept_tokens.call_count)
+
+    def test_grammar_bitmask_no_reasoning_end_in_spec_tokens(
+        self,
+        mock_vllm_config,
+        mock_reasoning_parser,
+    ):
+        """When reasoning hasn't ended and spec tokens don't contain
+        the end marker, all positions should be unconstrained."""
+        manager = self._make_manager_for_bitmask_test(
+            mock_vllm_config, mock_reasoning_parser, num_spec_tokens=3
+        )
+        grammar = self._make_grammar_mock()
+
+        mock_reasoning_parser.is_reasoning_end_streaming.return_value = False
+        mock_reasoning_parser.is_reasoning_end.return_value = False
+
+        request = Mock(spec=Request)
+        request.structured_output_request = Mock()
+        request.structured_output_request.reasoning_ended = False
+        request.structured_output_request.grammar = grammar
+        request.use_structured_output = True
+        request.prompt_token_ids = [1, 2, 3]
+
+        req_id = "req-no-end"
+        spec_tokens = [REASONING_TOKEN_A, REASONING_TOKEN_B]
+
+        result = manager.grammar_bitmask(
+            requests={req_id: request},
+            structured_output_request_ids=[req_id],
+            scheduled_spec_decode_tokens={req_id: spec_tokens},
+        )
+
+        assert result is not None
+        grammar.accept_tokens.assert_not_called()
+        grammar.fill_bitmask.assert_not_called()
+        assert request.structured_output_request.reasoning_ended is False

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -61,6 +61,11 @@ class TestReasoningStructuredOutput:
         """Create a mock ReasoningParser."""
         parser = Mock(spec=ReasoningParser)
         parser.is_reasoning_end = Mock(return_value=False)
+
+        def mock_streaming(prefix, delta):
+            return THINK_END_TOKEN in delta
+
+        parser.is_reasoning_end_streaming = mock_streaming
         return parser
 
     @pytest.fixture
@@ -131,114 +136,156 @@ class TestReasoningStructuredOutput:
         # Should default to True when no reasoner
         assert result is True
 
-    def test_should_advance_with_enable_in_reasoning(
+    def test_update_reasoning_ended_with_new_token_ids_mid_batch(
         self,
         mock_vllm_config,
         mock_request_with_structured_output,
         mock_reasoning_parser,
     ):
-        """Test should_advance when enable_in_reasoning is True."""
-        # Enable enable_in_reasoning
-        mock_vllm_config.structured_outputs_config.enable_in_reasoning = True
-
-        manager = StructuredOutputManager(mock_vllm_config)
-        manager.reasoner = mock_reasoning_parser
-
-        # Should always return True when enable_in_reasoning is enabled
-        result = manager.should_advance(mock_request_with_structured_output)
-        assert result is True
-
-    def test_should_advance_reasoning_not_ended(
-        self,
-        mock_vllm_config,
-        mock_request_with_structured_output,
-        mock_reasoning_parser,
-    ):
-        """Test should_advance when reasoning has not ended."""
-        manager = StructuredOutputManager(mock_vllm_config)
-        manager.reasoner = mock_reasoning_parser
-
-        # Set reasoning as not ended
-        (
-            mock_request_with_structured_output.structured_output_request
-        ).reasoning_ended = False
-        mock_reasoning_parser.is_reasoning_end.return_value = False
-
-        result = manager.should_advance(mock_request_with_structured_output)
-
-        # Should return False since reasoning hasn't ended
-        assert result is False
-
-    def test_should_advance_reasoning_just_ended(
-        self,
-        mock_vllm_config,
-        mock_request_with_structured_output,
-        mock_reasoning_parser,
-    ):
-        """Test should_advance when reasoning ends in current step."""
-        manager = StructuredOutputManager(mock_vllm_config)
-        manager.reasoner = mock_reasoning_parser
-
-        # Set reasoning as not ended initially, but ends in this step
-        (
-            mock_request_with_structured_output.structured_output_request
-        ).reasoning_ended = False
-        mock_reasoning_parser.is_reasoning_end.return_value = True
-
-        result = manager.should_advance(mock_request_with_structured_output)
-
-        # Should set reasoning_ended to True but return False for this step
-        assert (
-            mock_request_with_structured_output.structured_output_request.reasoning_ended
-            is True
-        )
-        assert result is False
-
-    def test_should_advance_reasoning_already_ended(
-        self,
-        mock_vllm_config,
-        mock_request_with_structured_output,
-        mock_reasoning_parser,
-    ):
-        """Test should_advance when reasoning has already ended."""
-        manager = StructuredOutputManager(mock_vllm_config)
-        manager.reasoner = mock_reasoning_parser
-
-        # Set reasoning as already ended
-        (
-            mock_request_with_structured_output.structured_output_request
-        ).reasoning_ended = True
-
-        result = manager.should_advance(mock_request_with_structured_output)
-
-        # Should return True since reasoning has ended
-        assert result is True
-
-    def test_should_advance_with_new_token_ids_reasoning_ends_mid_batch(
-        self,
-        mock_vllm_config,
-        mock_request_with_structured_output,
-        mock_reasoning_parser,
-    ):
-        """When speculative decoding produces tokens containing </think>,
-        should_advance(new_token_ids=...) must return True so the caller
-        can process the post-reasoning tokens."""
         manager = StructuredOutputManager(mock_vllm_config)
         manager.reasoner = mock_reasoning_parser
 
         struct_req = mock_request_with_structured_output.structured_output_request
         struct_req.reasoning_ended = False
 
-        new_token_ids = [REASONING_TOKEN_A, THINK_END_TOKEN, JSON_TOKEN_A, JSON_TOKEN_B]
-        mock_reasoning_parser.is_reasoning_end_streaming.return_value = True
+        new_token_ids = [REASONING_TOKEN_A, THINK_END_TOKEN, JSON_TOKEN_A]
 
-        result = manager.should_advance(
+        manager.update_reasoning_ended(
             mock_request_with_structured_output,
             new_token_ids=new_token_ids,
         )
 
-        assert result is True
         assert struct_req.reasoning_ended is True
+
+    def test_update_reasoning_ended_no_end_found(
+        self,
+        mock_vllm_config,
+        mock_request_with_structured_output,
+        mock_reasoning_parser,
+    ):
+        manager = StructuredOutputManager(mock_vllm_config)
+        manager.reasoner = mock_reasoning_parser
+
+        struct_req = mock_request_with_structured_output.structured_output_request
+        struct_req.reasoning_ended = False
+
+        manager.update_reasoning_ended(
+            mock_request_with_structured_output,
+            new_token_ids=[REASONING_TOKEN_A, REASONING_TOKEN_B],
+        )
+
+        assert struct_req.reasoning_ended is False
+
+    def test_identify_constrained_draft_tokens_reasoning_ends_mid_draft(
+        self,
+        mock_vllm_config,
+        mock_request_with_structured_output,
+        mock_reasoning_parser,
+    ):
+        manager = StructuredOutputManager(mock_vllm_config)
+        manager.reasoner = mock_reasoning_parser
+
+        struct_req = mock_request_with_structured_output.structured_output_request
+        struct_req.reasoning_ended = False
+
+        draft_tokens = [
+            REASONING_TOKEN_A,
+            THINK_END_TOKEN,
+            JSON_TOKEN_A,
+            JSON_TOKEN_B,
+        ]
+        unconstrained, constrained = manager.identify_constrained_draft_tokens(
+            mock_request_with_structured_output, draft_tokens
+        )
+
+        # Tokens up to and including THINK_END_TOKEN are unconstrained
+        assert unconstrained == [REASONING_TOKEN_A, THINK_END_TOKEN]
+        # Tokens after the marker are constrained
+        assert constrained == [JSON_TOKEN_A, JSON_TOKEN_B]
+
+    def test_identify_constrained_draft_tokens_reasoning_already_ended(
+        self,
+        mock_vllm_config,
+        mock_request_with_structured_output,
+        mock_reasoning_parser,
+    ):
+        manager = StructuredOutputManager(mock_vllm_config)
+        manager.reasoner = mock_reasoning_parser
+
+        struct_req = mock_request_with_structured_output.structured_output_request
+        struct_req.reasoning_ended = True
+
+        # Include a spurious </think> — it should NOT cause a split
+        draft_tokens = [
+            JSON_TOKEN_A,
+            THINK_END_TOKEN,
+            JSON_TOKEN_B,
+        ]
+        unconstrained, constrained = manager.identify_constrained_draft_tokens(
+            mock_request_with_structured_output, draft_tokens
+        )
+
+        # When reasoning_ended=True, ALL draft tokens should be constrained
+        assert unconstrained == []
+        assert constrained == [JSON_TOKEN_A, THINK_END_TOKEN, JSON_TOKEN_B]
+
+    def test_validate_tokens_reasoning_aware_reasoning_ended(
+        self,
+        mock_vllm_config,
+        mock_request_with_structured_output,
+        mock_reasoning_parser,
+    ):
+        manager = StructuredOutputManager(mock_vllm_config)
+        manager.reasoner = mock_reasoning_parser
+
+        struct_req = mock_request_with_structured_output.structured_output_request
+        struct_req.reasoning_ended = True
+        # Mock validate_tokens to return a subset (simulating rejection)
+        struct_req.grammar.validate_tokens = Mock(return_value=[JSON_TOKEN_A])
+
+        draft_tokens = [JSON_TOKEN_A, JSON_TOKEN_B]
+        result = manager.validate_tokens_reasoning_aware(
+            mock_request_with_structured_output, draft_tokens
+        )
+
+        # validate_tokens was called with all draft tokens (since reasoning_ended=True)
+        struct_req.grammar.validate_tokens.assert_called_once_with(
+            [JSON_TOKEN_A, JSON_TOKEN_B]
+        )
+        # result must not contain draft token JSON_TOKEN_B, which didn't match grammar
+        assert result == [JSON_TOKEN_A]
+
+    def test_validate_tokens_reasoning_aware_reasoning_ends_mid_draft(
+        self,
+        mock_vllm_config,
+        mock_request_with_structured_output,
+        mock_reasoning_parser,
+    ):
+        manager = StructuredOutputManager(mock_vllm_config)
+        manager.reasoner = mock_reasoning_parser
+
+        struct_req = mock_request_with_structured_output.structured_output_request
+        struct_req.reasoning_ended = False
+
+        # Mock validate_tokens to return only the first valid token
+        struct_req.grammar.validate_tokens = Mock(return_value=[JSON_TOKEN_A])
+
+        draft_tokens = [
+            REASONING_TOKEN_A,
+            THINK_END_TOKEN,
+            JSON_TOKEN_A,
+            JSON_TOKEN_B,
+        ]
+        result = manager.validate_tokens_reasoning_aware(
+            mock_request_with_structured_output, draft_tokens
+        )
+
+        # Only post-reasoning tokens should be validated (since reasoning_ended=False)
+        struct_req.grammar.validate_tokens.assert_called_once_with(
+            [JSON_TOKEN_A, JSON_TOKEN_B]
+        )
+        # Result: unconstrained prefix + validated suffix
+        assert result == [REASONING_TOKEN_A, THINK_END_TOKEN, JSON_TOKEN_A]
 
     def _make_manager_for_bitmask_test(
         self, mock_vllm_config, mock_reasoning_parser, num_spec_tokens=5
@@ -268,54 +315,6 @@ class TestReasoningStructuredOutput:
         grammar.rollback = Mock()
         return grammar
 
-    def test_grammar_bitmask_regression_think_end_in_spec_tokens(
-        self,
-        mock_vllm_config,
-        mock_reasoning_parser,
-    ):
-        """Regression test for production crash: when reasoning_ended=True
-        and spec tokens contain </think>, grammar must NOT try to accept
-        the </think> token.
-
-        Production scenario: previous step set reasoning_ended=True,
-        should_fill_bitmask returns True, spec tokens = [</think>],
-        grammar.accept_tokens(</think>) crashes because </think> is not
-        valid structured output."""
-        manager = self._make_manager_for_bitmask_test(
-            mock_vllm_config, mock_reasoning_parser, num_spec_tokens=1
-        )
-        grammar = self._make_grammar_mock()
-
-        def mock_streaming(all_ids, delta):
-            return delta == [THINK_END_TOKEN]
-
-        mock_reasoning_parser.is_reasoning_end_streaming.side_effect = mock_streaming
-        mock_reasoning_parser.is_reasoning_end.return_value = True
-
-        request = Mock(spec=Request)
-        request.structured_output_request = Mock()
-        request.structured_output_request.reasoning_ended = True
-        request.structured_output_request.grammar = grammar
-        request.use_structured_output = True
-        request.prompt_token_ids = [1, 2, 3]
-
-        req_id = "req-crash-test"
-
-        result = manager.grammar_bitmask(
-            requests={req_id: request},
-            structured_output_request_ids=[req_id],
-            scheduled_spec_decode_tokens={req_id: [THINK_END_TOKEN]},
-        )
-
-        # grammar.accept_tokens must NOT have been called with </think>
-        for call in grammar.accept_tokens.call_args_list:
-            _, tokens = call[0]
-            assert THINK_END_TOKEN not in tokens, (
-                f"grammar.accept_tokens was called with </think> token "
-                f"{THINK_END_TOKEN}, which should be skipped"
-            )
-        assert result is not None
-
     def test_grammar_bitmask_reasoning_ends_mid_speculation(
         self,
         mock_vllm_config,
@@ -329,10 +328,6 @@ class TestReasoningStructuredOutput:
         )
         grammar = self._make_grammar_mock()
 
-        def mock_streaming(all_ids, delta):
-            return delta == [THINK_END_TOKEN]
-
-        mock_reasoning_parser.is_reasoning_end_streaming.side_effect = mock_streaming
         mock_reasoning_parser.is_reasoning_end.return_value = False
 
         request = Mock(spec=Request)
@@ -357,45 +352,47 @@ class TestReasoningStructuredOutput:
         )
 
         assert result is not None
-        assert request.structured_output_request.reasoning_ended is True
+        assert request.structured_output_request.reasoning_ended is False
 
         # Only post-reasoning tokens should have been accepted
         accepted_tokens = [
             call[0][1][0] for call in grammar.accept_tokens.call_args_list
         ]
-        assert THINK_END_TOKEN not in accepted_tokens
-        assert REASONING_TOKEN_A not in accepted_tokens
-        assert JSON_TOKEN_A in accepted_tokens
-        assert JSON_TOKEN_B in accepted_tokens
+        assert accepted_tokens == [JSON_TOKEN_A, JSON_TOKEN_B]
 
         # Grammar advancements should be rolled back
         if grammar.accept_tokens.call_count > 0:
             grammar.rollback.assert_called_once_with(grammar.accept_tokens.call_count)
 
-    def test_grammar_bitmask_no_reasoning_end_in_spec_tokens(
+    def test_grammar_bitmask_all_constrained_when_reasoning_ended(
         self,
         mock_vllm_config,
         mock_reasoning_parser,
     ):
-        """When reasoning hasn't ended and spec tokens don't contain
-        the end marker, all positions should be unconstrained."""
+        """After reasoning ended, ALL bitmask positions must be grammar-constrained"""
         manager = self._make_manager_for_bitmask_test(
-            mock_vllm_config, mock_reasoning_parser, num_spec_tokens=3
+            mock_vllm_config, mock_reasoning_parser, num_spec_tokens=5
         )
         grammar = self._make_grammar_mock()
 
-        mock_reasoning_parser.is_reasoning_end_streaming.return_value = False
-        mock_reasoning_parser.is_reasoning_end.return_value = False
+        mock_reasoning_parser.is_reasoning_end.return_value = True
 
         request = Mock(spec=Request)
         request.structured_output_request = Mock()
-        request.structured_output_request.reasoning_ended = False
+        request.structured_output_request.reasoning_ended = True
         request.structured_output_request.grammar = grammar
         request.use_structured_output = True
         request.prompt_token_ids = [1, 2, 3]
 
-        req_id = "req-no-end"
-        spec_tokens = [REASONING_TOKEN_A, REASONING_TOKEN_B]
+        req_id = "req-root-cause-bitmask"
+        # Spurious </think> at index 3 in the draft tokens
+        spec_tokens = [
+            JSON_TOKEN_A,
+            JSON_TOKEN_B,
+            REASONING_TOKEN_A,
+            THINK_END_TOKEN,
+            JSON_TOKEN_A,
+        ]
 
         result = manager.grammar_bitmask(
             requests={req_id: request},
@@ -404,6 +401,13 @@ class TestReasoningStructuredOutput:
         )
 
         assert result is not None
-        grammar.accept_tokens.assert_not_called()
-        grammar.fill_bitmask.assert_not_called()
-        assert request.structured_output_request.reasoning_ended is False
+
+        # ALL spec_tokens should have been accepted, since reasoning_ended=True
+        accepted_tokens = [
+            call[0][1][0] for call in grammar.accept_tokens.call_args_list
+        ]
+        assert accepted_tokens == spec_tokens
+
+        # All state advancements should be rolled back
+        if grammar.accept_tokens.call_count > 0:
+            grammar.rollback.assert_called_once_with(grammar.accept_tokens.call_count)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1676,6 +1676,30 @@ class Scheduler(SchedulerInterface):
                 # in the decoder's KV cache.
                 self.encoder_cache_manager.free_encoder_input(request, input_id)
 
+    def _validate_spec_tokens_with_reasoning(
+        self, request: Request, spec_token_ids: list[int]
+    ) -> list[int]:
+        """Validate speculative tokens against the grammar, handling
+        reasoning-end markers.
+
+        When the reasoning_end token appears within the draft tokens,
+        only tokens after the marker are validated by the grammar.
+        Tokens up to and including the marker pass through unvalidated.
+        """
+        metadata = request.structured_output_request
+        assert metadata is not None and metadata.grammar is not None
+
+        split_idx = self.structured_output_manager.find_reasoning_end_in_tokens(
+            spec_token_ids
+        )
+        if split_idx is not None:
+            pre = spec_token_ids[: split_idx + 1]
+            post = spec_token_ids[split_idx + 1 :]
+            validated_post = metadata.grammar.validate_tokens(post)
+            return pre + validated_post
+
+        return metadata.grammar.validate_tokens(spec_token_ids)
+
     def update_draft_token_ids(self, draft_token_ids: DraftTokenIds) -> None:
         for req_id, spec_token_ids in zip(
             draft_token_ids.req_ids,
@@ -1698,21 +1722,9 @@ class Scheduler(SchedulerInterface):
             if self.structured_output_manager.should_advance(
                 request, new_token_ids=spec_token_ids
             ):
-                metadata = request.structured_output_request
-                if TYPE_CHECKING:
-                    assert metadata is not None and metadata.grammar is not None
-                # When reasoning ends within the draft tokens, only
-                # validate tokens after the reasoning_end marker.
-                split_idx = self.structured_output_manager.find_reasoning_end_in_tokens(
-                    spec_token_ids
+                spec_token_ids = self._validate_spec_tokens_with_reasoning(
+                    request, spec_token_ids
                 )
-                if split_idx is not None:
-                    pre = spec_token_ids[: split_idx + 1]
-                    post = spec_token_ids[split_idx + 1 :]
-                    validated_post = metadata.grammar.validate_tokens(post)
-                    spec_token_ids = pre + validated_post
-                else:
-                    spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)
             request.spec_token_ids = spec_token_ids
 
     def update_draft_token_ids_in_output(
@@ -1744,20 +1756,9 @@ class Scheduler(SchedulerInterface):
             if self.structured_output_manager.should_advance(
                 request, new_token_ids=spec_token_ids
             ):
-                metadata = request.structured_output_request
-                assert metadata is not None and metadata.grammar is not None
-                # When reasoning ends within the draft tokens, only
-                # validate tokens after the reasoning_end marker.
-                split_idx = self.structured_output_manager.find_reasoning_end_in_tokens(
-                    spec_token_ids
+                spec_token_ids = self._validate_spec_tokens_with_reasoning(
+                    request, spec_token_ids
                 )
-                if split_idx is not None:
-                    pre = spec_token_ids[: split_idx + 1]
-                    post = spec_token_ids[split_idx + 1 :]
-                    validated_post = metadata.grammar.validate_tokens(post)
-                    spec_token_ids = pre + validated_post
-                else:
-                    spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)
             # Pad to original number of spec tokens.
             num_invalid_tokens = orig_num_spec_tokens - len(spec_token_ids)
             if num_invalid_tokens:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -5,7 +5,7 @@ import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
 from dataclasses import replace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -1406,18 +1406,27 @@ class Scheduler(SchedulerInterface):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 assert struct_output_request.grammar is not None
-                if not struct_output_request.grammar.accept_tokens(  # type: ignore[union-attr]
-                    req_id, new_token_ids
-                ):
-                    logger.error(
-                        "Unexpected: grammar rejected tokens %s for request %s. "
-                        "Terminating request.",
-                        new_token_ids,
-                        req_id,
+                # When reasoning ends within this token batch (e.g. during
+                # speculative decoding), only the tokens after the
+                # reasoning_end marker should be fed to the grammar.
+                tokens_for_grammar = (
+                    self.structured_output_manager.get_tokens_after_reasoning(
+                        request, new_token_ids
                     )
-                    request.status = RequestStatus.FINISHED_ERROR
-                    request.resumable = False
-                    stopped = True
+                )
+                if tokens_for_grammar:
+                    ok = struct_output_request.grammar.accept_tokens(
+                        req_id, tokens_for_grammar
+                    )
+                    if not ok:
+                        logger.warning(
+                            "Unexpected: grammar rejected tokens %s for request %s.",
+                            tokens_for_grammar,
+                            req_id,
+                        )
+                        request.status = RequestStatus.FINISHED_ERROR
+                        request.resumable = False
+                        stopped = True
 
             routed_experts = None
             finish_reason = None
@@ -1684,9 +1693,26 @@ class Scheduler(SchedulerInterface):
                 continue
 
             # Add newly generated spec token ids to the request.
-            if self.structured_output_manager.should_advance(request):
+            # Pass spec_token_ids to should_advance so it can detect
+            # reasoning_end within the draft tokens.
+            if self.structured_output_manager.should_advance(
+                request, new_token_ids=spec_token_ids
+            ):
                 metadata = request.structured_output_request
-                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)  # type: ignore[union-attr]
+                if TYPE_CHECKING:
+                    assert metadata is not None and metadata.grammar is not None
+                # When reasoning ends within the draft tokens, only
+                # validate tokens after the reasoning_end marker.
+                split_idx = self.structured_output_manager.find_reasoning_end_in_tokens(
+                    spec_token_ids
+                )
+                if split_idx is not None:
+                    pre = spec_token_ids[: split_idx + 1]
+                    post = spec_token_ids[split_idx + 1 :]
+                    validated_post = metadata.grammar.validate_tokens(post)
+                    spec_token_ids = pre + validated_post
+                else:
+                    spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)
             request.spec_token_ids = spec_token_ids
 
     def update_draft_token_ids_in_output(
@@ -1713,10 +1739,25 @@ class Scheduler(SchedulerInterface):
             # (needed for chunked prefill case for example).
             del spec_token_ids[orig_num_spec_tokens:]
             # Filter out spec tokens which do not adhere to the grammar.
-            if self.structured_output_manager.should_advance(request):
+            # Pass spec_token_ids to should_advance so it can detect
+            # reasoning_end within the draft tokens.
+            if self.structured_output_manager.should_advance(
+                request, new_token_ids=spec_token_ids
+            ):
                 metadata = request.structured_output_request
                 assert metadata is not None and metadata.grammar is not None
-                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)
+                # When reasoning ends within the draft tokens, only
+                # validate tokens after the reasoning_end marker.
+                split_idx = self.structured_output_manager.find_reasoning_end_in_tokens(
+                    spec_token_ids
+                )
+                if split_idx is not None:
+                    pre = spec_token_ids[: split_idx + 1]
+                    post = spec_token_ids[split_idx + 1 :]
+                    validated_post = metadata.grammar.validate_tokens(post)
+                    spec_token_ids = pre + validated_post
+                else:
+                    spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)
             # Pad to original number of spec tokens.
             num_invalid_tokens = orig_num_spec_tokens - len(spec_token_ids)
             if num_invalid_tokens:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -5,7 +5,7 @@ import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
 from dataclasses import replace
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1402,19 +1402,19 @@ class Scheduler(SchedulerInterface):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request):
-                struct_output_request = request.structured_output_request
-                assert struct_output_request is not None
-                assert struct_output_request.grammar is not None
+            if new_token_ids and self.structured_output_manager is not None:
                 # When reasoning ends within this token batch (e.g. during
                 # speculative decoding), only the tokens after the
                 # reasoning_end marker should be fed to the grammar.
-                tokens_for_grammar = (
-                    self.structured_output_manager.get_tokens_after_reasoning(
+                _, tokens_for_grammar = (
+                    self.structured_output_manager.identify_constrained_draft_tokens(
                         request, new_token_ids
                     )
                 )
                 if tokens_for_grammar:
+                    struct_output_request = request.structured_output_request
+                    assert struct_output_request is not None
+                    assert struct_output_request.grammar is not None
                     ok = struct_output_request.grammar.accept_tokens(
                         req_id, tokens_for_grammar
                     )
@@ -1427,6 +1427,10 @@ class Scheduler(SchedulerInterface):
                         request.status = RequestStatus.FINISHED_ERROR
                         request.resumable = False
                         stopped = True
+                # Update reasoning_ended state based on accepted tokens.
+                self.structured_output_manager.update_reasoning_ended(
+                    request, new_token_ids=new_token_ids
+                )
 
             routed_experts = None
             finish_reason = None
@@ -1676,30 +1680,6 @@ class Scheduler(SchedulerInterface):
                 # in the decoder's KV cache.
                 self.encoder_cache_manager.free_encoder_input(request, input_id)
 
-    def _validate_spec_tokens_with_reasoning(
-        self, request: Request, spec_token_ids: list[int]
-    ) -> list[int]:
-        """Validate speculative tokens against the grammar, handling
-        reasoning-end markers.
-
-        When the reasoning_end token appears within the draft tokens,
-        only tokens after the marker are validated by the grammar.
-        Tokens up to and including the marker pass through unvalidated.
-        """
-        metadata = request.structured_output_request
-        assert metadata is not None and metadata.grammar is not None
-
-        split_idx = self.structured_output_manager.find_reasoning_end_in_tokens(
-            spec_token_ids
-        )
-        if split_idx is not None:
-            pre = spec_token_ids[: split_idx + 1]
-            post = spec_token_ids[split_idx + 1 :]
-            validated_post = metadata.grammar.validate_tokens(post)
-            return pre + validated_post
-
-        return metadata.grammar.validate_tokens(spec_token_ids)
-
     def update_draft_token_ids(self, draft_token_ids: DraftTokenIds) -> None:
         for req_id, spec_token_ids in zip(
             draft_token_ids.req_ids,
@@ -1717,14 +1697,12 @@ class Scheduler(SchedulerInterface):
                 continue
 
             # Add newly generated spec token ids to the request.
-            # Pass spec_token_ids to should_advance so it can detect
-            # reasoning_end within the draft tokens.
-            if self.structured_output_manager.should_advance(
-                request, new_token_ids=spec_token_ids
-            ):
-                spec_token_ids = self._validate_spec_tokens_with_reasoning(
+            # Validate spec tokens against grammar if applicable.
+            spec_token_ids = (
+                self.structured_output_manager.validate_tokens_reasoning_aware(
                     request, spec_token_ids
                 )
+            )
             request.spec_token_ids = spec_token_ids
 
     def update_draft_token_ids_in_output(
@@ -1751,14 +1729,11 @@ class Scheduler(SchedulerInterface):
             # (needed for chunked prefill case for example).
             del spec_token_ids[orig_num_spec_tokens:]
             # Filter out spec tokens which do not adhere to the grammar.
-            # Pass spec_token_ids to should_advance so it can detect
-            # reasoning_end within the draft tokens.
-            if self.structured_output_manager.should_advance(
-                request, new_token_ids=spec_token_ids
-            ):
-                spec_token_ids = self._validate_spec_tokens_with_reasoning(
+            spec_token_ids = (
+                self.structured_output_manager.validate_tokens_reasoning_aware(
                     request, spec_token_ids
                 )
+            )
             # Pad to original number of spec tokens.
             num_invalid_tokens = orig_num_spec_tokens - len(spec_token_ids)
             if num_invalid_tokens:

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -257,43 +257,22 @@ class StructuredOutputManager:
                 grammar = structured_output_request.grammar
                 apply_bitmask = self.should_fill_bitmask(request)
 
-                # Determine where the reasoning_end token falls within
-                # the speculative tokens (if applicable). This handles
-                # two scenarios:
-                # 1. Reasoning not yet ended (apply_bitmask=False): the
-                #    reasoning_end token may appear mid-speculation;
-                #    positions after it need grammar constraints.
-                # 2. Reasoning already ended (apply_bitmask=True): the
-                #    spec tokens from the previous step may contain the
-                #    reasoning_end token; the grammar must NOT accept
-                #    reasoning tokens (up to and including the end
-                #    marker).
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
                 reasoning_end_idx: int | None = None
-                if (
-                    self.reasoner is not None
-                    and not self.enable_in_reasoning
-                    and req_tokens
-                ):
-                    reasoning_end_idx = self.find_reasoning_end_in_tokens(
+                if req_tokens and not apply_bitmask:
+                    # When reasoning hasn't already ended (apply_bitmask=False),
+                    # only positions after reasoning_end must be constrained.
+                    reasoning_end_idx = self._find_reasoning_end_in_tokens(
                         list(req_tokens)
                     )
 
                 state_advancements = 0
                 for tok_idx, token in enumerate(itertools.chain(req_tokens, (-1,))):
-                    # Determine whether grammar applies at this position.
                     # Tokens up to and including reasoning_end are
                     # unconstrained; tokens after are grammar-constrained.
                     if reasoning_end_idx is not None:
                         is_post_reasoning = tok_idx > reasoning_end_idx
                         pos_apply_bitmask = is_post_reasoning
-                        # Once we pass the reasoning_end position, mark
-                        # reasoning as ended so subsequent steps know.
-                        if (
-                            is_post_reasoning
-                            and not structured_output_request.reasoning_ended
-                        ):
-                            structured_output_request.reasoning_ended = True
                     else:
                         pos_apply_bitmask = apply_bitmask
 
@@ -344,56 +323,87 @@ class StructuredOutputManager:
             return request.structured_output_request.reasoning_ended
         return True
 
-    def should_advance(
+    def update_reasoning_ended(
         self,
         request: "Request",
-        new_token_ids: list[int] | None = None,
-    ) -> bool:
+        new_token_ids: list[int],
+    ) -> None:
+        """Update the reasoning_ended flag based on accepted tokens."""
         if not request.use_structured_output:
-            return False
+            return
 
-        # To determine whether we can advance the FSM.
-        # Supports thinking usage where we skip the reasoning components.
-        if TYPE_CHECKING:
-            assert request.structured_output_request is not None
-            assert request.structured_output_request.grammar is not None
-        # by default, we should always advance
-        # for cases that don't use thinking mode.
-        if self.reasoner is None:
-            return True
-
-        # if the model needs structured in reasoning, we should advance
-        if self.enable_in_reasoning:
-            return True
+        if self.reasoner is None or self.enable_in_reasoning:
+            return
 
         structured_req = request.structured_output_request
+        assert structured_req is not None
         if structured_req.reasoning_ended:
-            return True
+            return
 
-        # Check if reasoning ends in *this* step.
-        # When new_token_ids is provided (e.g. from speculative decoding
-        # verification), check those tokens for reasoning end. This handles
-        # the case where the reasoning_end token appears within a batch of
-        # accepted tokens — we need to return True so the caller can feed
-        # the post-reasoning tokens to the grammar.
-        if new_token_ids is not None:
-            all_token_ids = request.all_token_ids
-            if self.reasoner.is_reasoning_end_streaming(all_token_ids, new_token_ids):
-                structured_req.reasoning_ended = True
-                return True
-        else:
-            delta_from = request.num_computed_tokens - request.num_output_placeholders
-            all_token_ids = request.all_token_ids
-            if self.reasoner.is_reasoning_end_streaming(
-                all_token_ids, all_token_ids[delta_from:]
-            ):
-                # Reasoning just ended, so we shouldn't advance til
-                # next pass
-                structured_req.reasoning_ended = True
+        all_token_ids = request.all_token_ids
+        if self.reasoner.is_reasoning_end_streaming(all_token_ids, new_token_ids):
+            structured_req.reasoning_ended = True
 
-        return False
+    def validate_tokens_reasoning_aware(
+        self, request: "Request", spec_token_ids: list[int]
+    ) -> list[int]:
+        """Validate speculative tokens against the grammar, handling
+        reasoning-end markers.
+        """
+        unconstrained_tokens, constrained_tokens = (
+            self.identify_constrained_draft_tokens(request, spec_token_ids)
+        )
+        if constrained_tokens:
+            assert request.structured_output_request is not None
+            assert request.structured_output_request.grammar is not None
+            grammar = request.structured_output_request.grammar
+            grammar_validated_tokens = grammar.validate_tokens(constrained_tokens)
+            return unconstrained_tokens + grammar_validated_tokens
+        return spec_token_ids
 
-    def find_reasoning_end_in_tokens(self, token_ids: list[int]) -> int | None:
+    def identify_constrained_draft_tokens(
+        self, request: "Request", spec_token_ids: list[int]
+    ) -> tuple[list[int], list[int]]:
+        """Identify which draft tokens need to be constrained by grammar,
+        taking mid-batch reasoning-end markers correctly into account.
+
+        Returns:
+            tuple of (unconstrained draft tokens, constrained draft tokens)
+        """
+        if not request.use_structured_output:
+            unconstrained_tokens = spec_token_ids
+            return unconstrained_tokens, []
+
+        if self.reasoner is None:
+            constrained_tokens = spec_token_ids
+            return [], constrained_tokens
+
+        if self.enable_in_reasoning:
+            constrained_tokens = spec_token_ids
+            return [], constrained_tokens
+
+        structured_output_request = request.structured_output_request
+        assert structured_output_request is not None
+        assert structured_output_request.grammar is not None
+
+        # When reasoning already ended, validate ALL draft tokens.
+        if structured_output_request.reasoning_ended:
+            constrained_tokens = spec_token_ids
+            return [], constrained_tokens
+
+        # Reasoning hasn't ended yet — check if it ends mid-draft.
+        split_idx = self._find_reasoning_end_in_tokens(spec_token_ids)
+        if split_idx is None:
+            unconstrained_tokens = spec_token_ids
+            return unconstrained_tokens, []
+
+        # validate only tokens after reasoning_end marker;
+        # pass tokens up to reasoning_end through unvalidated
+        unconstrained_tokens = spec_token_ids[: split_idx + 1]
+        constrained_tokens = spec_token_ids[split_idx + 1 :]
+        return unconstrained_tokens, constrained_tokens
+
+    def _find_reasoning_end_in_tokens(self, token_ids: list[int]) -> int | None:
         """Find the index of the reasoning-end token within a token list.
 
         Uses is_reasoning_end_streaming to check progressively longer
@@ -413,41 +423,6 @@ class StructuredOutputManager:
             if self.reasoner.is_reasoning_end_streaming(prefix, [token]):
                 return i
         return None
-
-    def get_tokens_after_reasoning(
-        self,
-        request: "Request",
-        new_token_ids: list[int],
-    ) -> list[int]:
-        """Return the suffix of new_token_ids that comes after reasoning end.
-
-        If reasoning was already ended before these tokens, returns all of
-        them. If reasoning ends within these tokens, returns only the tokens
-        after the end marker. If reasoning doesn't end, returns empty list.
-        """
-        if self.reasoner is None or self.enable_in_reasoning:
-            return new_token_ids
-
-        assert request.structured_output_request is not None
-        structured_req = request.structured_output_request
-
-        if structured_req.reasoning_ended:
-            # Check whether reasoning_ended was set *before* this call
-            # (i.e. from a previous step) vs just now by should_advance.
-            # If it was set before, all tokens are post-reasoning.
-            # We need to check if the end marker is actually in new_token_ids.
-            idx = self.find_reasoning_end_in_tokens(new_token_ids)
-            if idx is not None:
-                # The end marker is in new_token_ids — reasoning ended
-                # within this batch. Return tokens after the end marker.
-                return new_token_ids[idx + 1 :]
-            else:
-                # End marker not in these tokens — reasoning ended before
-                # this batch. All tokens are post-reasoning.
-                return new_token_ids
-
-        # Reasoning hasn't ended — no tokens to process
-        return []
 
     def clear_backend(self) -> None:
         if self.backend is not None:

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -257,16 +257,60 @@ class StructuredOutputManager:
                 grammar = structured_output_request.grammar
                 apply_bitmask = self.should_fill_bitmask(request)
 
-                state_advancements = 0
+                # Determine where the reasoning_end token falls within
+                # the speculative tokens (if applicable). This handles
+                # two scenarios:
+                # 1. Reasoning not yet ended (apply_bitmask=False): the
+                #    reasoning_end token may appear mid-speculation;
+                #    positions after it need grammar constraints.
+                # 2. Reasoning already ended (apply_bitmask=True): the
+                #    spec tokens from the previous step may contain the
+                #    reasoning_end token; the grammar must NOT accept
+                #    reasoning tokens (up to and including the end
+                #    marker).
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
-                for token in itertools.chain(req_tokens, (-1,)):
-                    self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
+                reasoning_end_idx: int | None = None
+                if (
+                    self.reasoner is not None
+                    and not self.enable_in_reasoning
+                    and req_tokens
+                ):
+                    reasoning_end_idx = self.find_reasoning_end_in_tokens(
+                        list(req_tokens)
+                    )
+
+                state_advancements = 0
+                for tok_idx, token in enumerate(itertools.chain(req_tokens, (-1,))):
+                    # Determine whether grammar applies at this position.
+                    # Tokens up to and including reasoning_end are
+                    # unconstrained; tokens after are grammar-constrained.
+                    if reasoning_end_idx is not None:
+                        is_post_reasoning = tok_idx > reasoning_end_idx
+                        pos_apply_bitmask = is_post_reasoning
+                        # Once we pass the reasoning_end position, mark
+                        # reasoning as ended so subsequent steps know.
+                        if (
+                            is_post_reasoning
+                            and not structured_output_request.reasoning_ended
+                        ):
+                            structured_output_request.reasoning_ended = True
+                    else:
+                        pos_apply_bitmask = apply_bitmask
+
+                    self._fill_bitmasks(
+                        ((grammar, cumulative_index, pos_apply_bitmask),)
+                    )
                     if token == -1:
-                        # Stop advancing the grammar once we hit a padding token.
-                        apply_bitmask = False
-                    if apply_bitmask and not grammar.is_terminated():
+                        # Stop advancing the grammar once we hit a
+                        # padding token.
+                        pos_apply_bitmask = False
+                    if pos_apply_bitmask and not grammar.is_terminated():
                         accepted = grammar.accept_tokens(req_id, [token])
-                        assert accepted, (token, req_id, scheduled_spec_decode_tokens)
+                        assert accepted, (
+                            token,
+                            req_id,
+                            scheduled_spec_decode_tokens,
+                        )
                         state_advancements += 1
                     cumulative_index += 1
                 if state_advancements > 0:
@@ -300,7 +344,11 @@ class StructuredOutputManager:
             return request.structured_output_request.reasoning_ended
         return True
 
-    def should_advance(self, request: "Request") -> bool:
+    def should_advance(
+        self,
+        request: "Request",
+        new_token_ids: list[int] | None = None,
+    ) -> bool:
         if not request.use_structured_output:
             return False
 
@@ -322,20 +370,84 @@ class StructuredOutputManager:
         if structured_req.reasoning_ended:
             return True
 
-        # Check if reasoning ends in *this* step
-        delta_from = request.num_computed_tokens - request.num_output_placeholders
-        all_token_ids = request.all_token_ids
-        start = (
-            delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
-        )
-        if self.reasoner.is_reasoning_end_streaming(
-            all_token_ids, itertools.islice(all_token_ids, start, None)
-        ):
-            # Reasoning just ended, so we shouldn't advance til
-            # next pass
-            structured_req.reasoning_ended = True
+        # Check if reasoning ends in *this* step.
+        # When new_token_ids is provided (e.g. from speculative decoding
+        # verification), check those tokens for reasoning end. This handles
+        # the case where the reasoning_end token appears within a batch of
+        # accepted tokens — we need to return True so the caller can feed
+        # the post-reasoning tokens to the grammar.
+        if new_token_ids is not None:
+            all_token_ids = request.all_token_ids
+            if self.reasoner.is_reasoning_end_streaming(all_token_ids, new_token_ids):
+                structured_req.reasoning_ended = True
+                return True
+        else:
+            delta_from = request.num_computed_tokens - request.num_output_placeholders
+            all_token_ids = request.all_token_ids
+            if self.reasoner.is_reasoning_end_streaming(
+                all_token_ids, all_token_ids[delta_from:]
+            ):
+                # Reasoning just ended, so we shouldn't advance til
+                # next pass
+                structured_req.reasoning_ended = True
 
         return False
+
+    def find_reasoning_end_in_tokens(self, token_ids: list[int]) -> int | None:
+        """Find the index of the reasoning-end token within a token list.
+
+        Uses is_reasoning_end_streaming to check progressively longer
+        prefixes, supporting multi-token end markers.
+
+        Returns:
+            The index of the last token of the reasoning-end marker,
+            or None if not found.
+        """
+        if self.reasoner is None or self.enable_in_reasoning:
+            return None
+
+        for i, token in enumerate(token_ids):
+            # Check if reasoning ends at position i by testing the
+            # prefix up to and including this token.
+            prefix = token_ids[: i + 1]
+            if self.reasoner.is_reasoning_end_streaming(prefix, [token]):
+                return i
+        return None
+
+    def get_tokens_after_reasoning(
+        self,
+        request: "Request",
+        new_token_ids: list[int],
+    ) -> list[int]:
+        """Return the suffix of new_token_ids that comes after reasoning end.
+
+        If reasoning was already ended before these tokens, returns all of
+        them. If reasoning ends within these tokens, returns only the tokens
+        after the end marker. If reasoning doesn't end, returns empty list.
+        """
+        if self.reasoner is None or self.enable_in_reasoning:
+            return new_token_ids
+
+        assert request.structured_output_request is not None
+        structured_req = request.structured_output_request
+
+        if structured_req.reasoning_ended:
+            # Check whether reasoning_ended was set *before* this call
+            # (i.e. from a previous step) vs just now by should_advance.
+            # If it was set before, all tokens are post-reasoning.
+            # We need to check if the end marker is actually in new_token_ids.
+            idx = self.find_reasoning_end_in_tokens(new_token_ids)
+            if idx is not None:
+                # The end marker is in new_token_ids — reasoning ended
+                # within this batch. Return tokens after the end marker.
+                return new_token_ids[idx + 1 :]
+            else:
+                # End marker not in these tokens — reasoning ended before
+                # this batch. All tokens are post-reasoning.
+                return new_token_ids
+
+        # Reasoning hasn't ended — no tokens to process
+        return []
 
     def clear_backend(self) -> None:
         if self.backend is not None:


### PR DESCRIPTION
## Purpose

This PR attempts to fix a bug (#31858, #34650) when Speculative Decoding (such as MTP), Reasoning, and Structured Output / Grammar are used in combination: typically, grammar is not enabled during reasoning but only for the final answer. However, when the reasoning end token is generated, any subsequent draft tokens are not validated against the grammar, leading to an invalid final answer. 


## Test Plan

In general, the bug seems to be independent of the specific SpecDecode method; originally I had observed it with DeepSeek models and MTP, but for testing I recommend a smaller model like Qwen3-8B and using the same model as draft model. This way, we have high acceptance rates for our tests and a high likelihood that the original bug appears. 

```
vllm serve "Qwen/Qwen3-8B" \
  --max-model-len 40960 \
  --reasoning-parser qwen3 \
  --speculative-config '{"method":"draft_model","model":"Qwen/Qwen3-8B","num_speculative_tokens":5}'
```

The test request should have `response_format=json_schema` and a prompt that lurkes the model into generating not pure json, e.g.

<details>
<summary>example payload</summary>
<code>
{
  "model": "Qwen/Qwen3-8B",
  "messages": [
    {
      "role": "user",
      "content": "Imagine a Fantasy hero (10). Return valid json, wrapped in markdown fences: ```json\n[...]\n```"
    }
  ],
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "hero",
      "schema": {
        "$defs": {
          "CharacterRole": {"enum": ["mage", "warrior", "healer"], "title": "CharacterRole", "type": "string"}
        },
        "properties": {
          "name": {"description": "Character name", "title": "Name", "type": "string"},
          "age": {"description": "Character age", "title": "Age", "type": "integer"},
          "role": {"allOf": [{"$ref": "#/$defs/CharacterRole"}], "description": "Character class"}
        },
        "required": ["name", "age", "role"],
        "title": "Character",
        "type": "object"
      }
    }
  }
}
</code>
</details>

The original bug can also be reproduced for Model Runner V2, this bugfix works there as well. For testing, you should choose a different speculative method (since `draft_model` is not supported yet):
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve "Qwen/Qwen3-8B" \
  --max-model-len 40960 \
  --reasoning-parser qwen3 \
  --speculative-config '{"method":"eagle3","model":"RedHatAI/Qwen3-8B-speculator.eagle3","num_speculative_tokens":5}'
```

The original bug is still present in vllm v0.17.1. 

## Test Result

without bugfix, the `content` field contains invalid json, e.g. because of markdown fences
```
"content": "```json\n{\n\n\"name\": \"Eldrin the Flameheart\",\n\"age\": 32,\n\"role\": \"warrior\"\n}```"
```

with the bugfix, the `content` field contains valid json that satisfies the requested grammar
```
"content": "{\n\n\"name\": \"Eldrin the Flameheart\",\n\"age\": 32,\n\"role\": \"warrior\"\n}"
```
---

I am happy to receive feedback and suggestions on how to improve the PR: the interplay of spec decode, grammar, reasoning, and async scheduling seems to be quite complex. 

## Related
There had been several attempts to fix this bug before:  my first attempt in #34241 would reject all speculated tokens in the step where reasoning_end was detected, which was working fine, but was suboptimal.  #34978 started with a better approach that would validate all speculative tokens following reasoning_end, but contained some bugs in the end and was discontinued. 
