### PR TITLE
[Core] Add --hybrid-kv-cache-group-size to override KV cache grouping for hybrid attn models

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -135,6 +135,16 @@ class SchedulerConfig:
     and starting configuration.
     """
 
+    hybrid_kv_cache_group_size: int | None = None
+    """Override the group size used by the hybrid KV cache manager to split
+    layers into groups. Each group shares a block table and requires a
+    host-to-device copy per scheduling step. A larger group size reduces
+    H2D overhead but may waste KV cache memory due to padding.
+    When None (default), the group size is determined automatically based
+    on the layer ratio pattern (e.g., min_num_layers across attention types).
+    Only takes effect for hybrid models with multiple attention types.
+    """
+
     async_scheduling: bool | None = Field(default=None)
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -521,9 +521,7 @@ class EngineArgs:
     disable_hybrid_kv_cache_manager: bool | None = (
         SchedulerConfig.disable_hybrid_kv_cache_manager
     )
-    hybrid_kv_cache_group_size: int | None = (
-        SchedulerConfig.hybrid_kv_cache_group_size
-    )
+    hybrid_kv_cache_group_size: int | None = SchedulerConfig.hybrid_kv_cache_group_size
 
     structured_outputs_config: StructuredOutputsConfig = get_field(
         VllmConfig, "structured_outputs_config"

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -521,6 +521,9 @@ class EngineArgs:
     disable_hybrid_kv_cache_manager: bool | None = (
         SchedulerConfig.disable_hybrid_kv_cache_manager
     )
+    hybrid_kv_cache_group_size: int | None = (
+        SchedulerConfig.hybrid_kv_cache_group_size
+    )
 
     structured_outputs_config: StructuredOutputsConfig = get_field(
         VllmConfig, "structured_outputs_config"
@@ -1209,6 +1212,10 @@ class EngineArgs:
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
         scheduler_group.add_argument(
+            "--hybrid-kv-cache-group-size",
+            **scheduler_kwargs["hybrid_kv_cache_group_size"],
+        )
+        scheduler_group.add_argument(
             "--async-scheduling", **scheduler_kwargs["async_scheduling"]
         )
         scheduler_group.add_argument(
@@ -1763,6 +1770,7 @@ class EngineArgs:
             max_long_partial_prefills=self.max_long_partial_prefills,
             long_prefill_token_threshold=self.long_prefill_token_threshold,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
+            hybrid_kv_cache_group_size=self.hybrid_kv_cache_group_size,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,
         )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -955,6 +955,7 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
 
 def _get_kv_cache_groups_uniform_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
+    override_group_size: int | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache groups for hybrid models with multiple
@@ -1047,6 +1048,14 @@ def _get_kv_cache_groups_uniform_page_size(
         # pad it to (13 sw, 13 full) instead of (12 sw, 24 full). 1.25 is just a
         # magic number to avoid too many padding layers.
         group_size = max_num_layers
+    if override_group_size is not None:
+        logger.info(
+            "Overriding hybrid KV cache group_size=%d (was %d, "
+            "min_num_layers=%d, max_num_layers=%d)",
+            override_group_size, group_size,
+            min_num_layers, max_num_layers,
+        )
+        group_size = override_group_size
     grouped_layers = []
     for layers in same_type_layers.values():
         num_padding_layers = group_size - len(layers) % group_size
@@ -1254,7 +1263,11 @@ def get_kv_cache_groups(
     # have the same physical memory per block per layer. Split the layers
     # into groups with the same number of layers, and thus same total page
     # size.
-    return _get_kv_cache_groups_uniform_page_size(kv_cache_spec)
+    return _get_kv_cache_groups_uniform_page_size(
+        kv_cache_spec,
+        override_group_size=(
+            vllm_config.scheduler_config.hybrid_kv_cache_group_size),
+    )
 
 
 def generate_scheduler_kv_cache_config(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1052,8 +1052,10 @@ def _get_kv_cache_groups_uniform_page_size(
         logger.info(
             "Overriding hybrid KV cache group_size=%d (was %d, "
             "min_num_layers=%d, max_num_layers=%d)",
-            override_group_size, group_size,
-            min_num_layers, max_num_layers,
+            override_group_size,
+            group_size,
+            min_num_layers,
+            max_num_layers,
         )
         group_size = override_group_size
     grouped_layers = []
@@ -1265,8 +1267,7 @@ def get_kv_cache_groups(
     # size.
     return _get_kv_cache_groups_uniform_page_size(
         kv_cache_spec,
-        override_group_size=(
-            vllm_config.scheduler_config.hybrid_kv_cache_group_size),
+        override_group_size=(vllm_config.scheduler_config.hybrid_kv_cache_group_size),
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Add `--hybrid-kv-cache-group-size` to let users override the group size used by the hybrid KV cache manager.

The hybrid KV cache manager groups attention layers to share block tables, where each group incurs a block table copy per step. The current heuristic (`min_num_layers` or `max_num_layers`) works well for common n:1 patterns (e.g., Gemma3 5:1). But for architectures with extreme attn type ratios, like [YOCO](https://arxiv.org/pdf/2405.05254) with ~10s sliding-window layers but only 1 full-attention layer, `min_num_layers=1` creates num_of_layer groups — each requiring a separate block table copy — causing severe overhead (see the profiling below). Increasing group size reduces this overhead but wastes KV cache memory due to padding. Since this is an inherent performance/memory trade-off that depends on model architecture, hardware, and workload, exposing group size as a tunable parameter is more practical than relying on a fixed heuristic.

When unset (`None`), existing automatic logic is preserved with zero behavior change.

<img width="1208" height="442" alt="image" src="https://github.com/user-attachments/assets/e278b7b5-c848-4544-a7ed-b5d190aa34aa" />


Zoom-in
<img width="1309" height="394" alt="image" src="https://github.com/user-attachments/assets/69aac8d6-d30c-4b01-aaac-1e2d2d38bcf8" />


## Test Plan
To reproduce, use any hybrid model with an extreme attention type ratio (e.g., modify Qwen to replace most layers with sliding-window attention, keeping only the last layer as full attention).

```bash
# With override
vllm serve /path/to/hybrid_model --hybrid-kv-cache-group-size 10

# Without override (default, no behavior change)
vllm serve /path/to/hybrid_model

# Python API
from vllm import LLM
llm = LLM(model="...", hybrid_kv_cache_group_size=10)
```

## Test Result

Measured on a single NVIDIA B200 GPU (183 GB), YOCO model with 30 sliding-window + 1 full-attention layer, In=4096, Out=128, 500 prompts, max-num-seqs=128, max-num-batched-tokens=40000.

With the default heuristic (`group_size=1`), sliding-window attention performs worse than replacing all layers with full attention — because full attention uses a single block table and avoids triggering the hybrid KV cache manager entirely.

| group_size | 1 (heuristic) | 2 | 3 | 5 | 6 | 10 | 15 | 30 | disable-hybrid | all full-attn |
|---|---|---|---|---|---|---|---|---|---|---|
| **Req throughput** | 21.45 | 30.92 | 34.73 | 38.15 | 39.17 | 40.69 | 41.13 | 41.79 | 41.67 | 32.10 |
| **KV avg usage** | 4.96% | 5.72% | 6.59% | 8.19% | 8.94% | 12.17% | 16.06% | 27.86% | 24.03% | 24.84% |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

