### PR TITLE
[Bugfix] Disable FlashInfer TRTLLM BF16 path for non-gated MoE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -25,12 +25,12 @@ def _supports_current_device() -> bool:
 
 
 def _supports_no_act_and_mul() -> bool:
-    """Supports non-gated MoE."""
-    return True
+    """BF16 kernels do not support non-gated MoE"""
+    return False
 
 
 def _supports_activation(activation: MoEActivation) -> bool:
-    return activation in [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
+    return activation in [MoEActivation.SILU]
 
 
 def _supports_routing_method_bf16(


### PR DESCRIPTION
## Purpose
PR #32564 split the FlashInfer TRTLLM MoE code into precision-specific files (`trtllm_fp4_moe.py`, `trtllm_fp8_moe.py`), each with their own copies of `_supports_no_act_and_mul()` and `_supports_activation()`. The original `flashinfer_trtllm_moe.py` was left handling only the BF16 path, but its helper values were not updated to reflect this narrower scope.

PR #33506 added non-gated MoE support (for FP8/NVFP4) by modifying `_supports_no_act_and_mul()` (False→True) and `_supports_activation()` (added RELU2_NO_MUL) in `flashinfer_trtllm_moe.py`. At the time of authoring, there was only a single file handling all precisions, so the change was correct. However, after the split from PR 32564, these helpers only affect the BF16 path — where the underlying kernel hardcodes `ActivationType.Swiglu` and expects 2*intermediate_size` weight dimensions. This causes a shape mismatch crash for non-gated models (e.g., NemotronH with ReLU²).

  This PR fixes the BF16 helpers to match the kernel's actual capabilities -non-gated MoE is not supported, SwiGLU (gated SiLU) is the only available activation:
  - `_supports_no_act_and_mul()` → `False`
  - `_supports_activation()` → only `SILU`

## Test Plan

Launch a BF16 non-gated MoE model

## Test Result

Previously, launching an non-gated BF16 MoE model with `VLLM_USE_FLASHINFER_MOE_FP16=1` fails with a FlashInfer shape mismatch error. In other words, the FlashInfer TRTLLM MoE backend was mistakenly chosen.

Now, just setting `VLLM_USE_FLASHINFER_MOE_FP16=1` selects the triton MoE backend since FlashInfer isn't supported in this configuraion. When also setting `--moe-backend=flashinfer_trtllm` in the server launch command, startup fails gracefully with a nice error message: ` ValueError: FlashInfer TRTLLM MoE backend is not available for this configuration.`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

