### PR TITLE
[CI] Add mandatory H100 TP=2 smoke test

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -106,6 +106,19 @@ steps:
   - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 rlhf_nccl.py
   - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 rlhf_ipc.py
 
+- label: TP2 Smoke Test (2xH100)
+  timeout_in_minutes: 15
+  device: h100
+  num_devices: 2
+  source_file_dependencies:
+  - vllm/compilation/
+  - vllm/distributed/
+  - vllm/v1/worker/
+  - vllm/config/
+  - vllm/envs.py
+  commands:
+  - pytest -v -s tests/v1/distributed/test_tp2_smoke.py
+
 - label: Distributed Tests (8 GPUs)(H100)
   timeout_in_minutes: 10
   device: h100

--- a/tests/v1/distributed/test_tp2_smoke.py
+++ b/tests/v1/distributed/test_tp2_smoke.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Smoke test for TP=2 on Hopper/Blackwell with default config.
+
+Starts a vLLM server with TP=2 and default settings, verifies it can
+serve requests across dense, FP8, and MoE models.
+"""
+
+import pytest
+
+from tests.models.registry import HF_EXAMPLE_MODELS
+from tests.utils import RemoteOpenAIServer
+
+MODELS = [
+    "meta-llama/Llama-3.2-1B-Instruct",
+    "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8",
+    "microsoft/Phi-mini-MoE-instruct",
+]
+
+
+@pytest.mark.parametrize("model_id", MODELS)
+def test_tp2_smoke(model_id: str, num_gpus_available: int):
+    model_info = HF_EXAMPLE_MODELS.find_hf_info(model_id)
+    model_info.check_transformers_version(on_fail="skip")
+    model_info.check_available_online(on_fail="skip")
+
+    if num_gpus_available < 2:
+        pytest.skip("Need at least 2 GPUs")
+
+    args = [
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "2048",
+        "--max-num-seqs",
+        "8",
+        "--tensor-parallel-size",
+        "2",
+        "--distributed-executor-backend",
+        "mp",
+    ]
+
+    with RemoteOpenAIServer(model_id, args) as server:
+        client = server.get_client()
+        completion = client.completions.create(
+            model=model_id,
+            prompt="Hello",
+            max_tokens=16,
+            temperature=0,
+        )
+        assert len(completion.choices[0].text) > 0


### PR DESCRIPTION
## Summary

Add a mandatory test that starts a vLLM server with TP=2 on H100 using default settings and verifies it can serve requests across 3 models (dense BF16, dense FP8, MoE BF16).

## Context

No mandatory test currently starts a vLLM server on Hopper/Blackwell with TP>1, DP=1, and default config. On this hardware, vLLM auto-enables optimizations like `fuse_allreduce_rms` and cudagraphs. Existing mandatory tests either run on L4 (where these are disabled), use DP>1, or set `CUDAGraphMode.NONE`.

This means regressions in the default TP serving path on Hopper/Blackwell can go undetected until users hit them. For example, #34109 introduced a cudagraph capture hang (#35772) that passed all mandatory CI. The issue surfaced in an optional nightly LM eval test but took several days before it was noticed and reported.

## Models

| Model | Arch | Quant |
|-------|------|-------|
| meta-llama/Llama-3.2-1B-Instruct | Dense | BF16 |
| RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8 | Dense | FP8 |
| microsoft/Phi-mini-MoE-instruct | MoE | BF16 |

I chose these 3 models to cover dense, FP8, and MoE architectures with minimal overhead (~8 min total on H100). Open to suggestions for additional models, quantizations, or platforms.

## Test plan

- [x] Verify test passes on H100 with 2 GPUs
- [x] Confirm runtime fits within 15 min timeout