### PR TITLE
[Bugfix] Fix `cudagraph_mode:FULL` dispatch (This does not impact `FULL_AND_PIECEWISE` (default))

### DIFF
--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -293,10 +293,6 @@ class CudagraphDispatcher:
                 )
                 effective_num_active_loras = self.vllm_config.lora_config.max_loras + 1
 
-        batch_desc = self._create_padded_batch_descriptor(
-            num_tokens, uniform_decode, has_lora, effective_num_active_loras
-        )
-
         normalized_uniform = uniform_decode and self.cudagraph_mode.separate_routine()
         batch_desc = self._create_padded_batch_descriptor(
                     num_tokens, normalized_uniform, has_lora, effective_num_active_loras
@@ -304,7 +300,6 @@ class CudagraphDispatcher:
 
         if CUDAGraphMode.FULL in allowed_modes:
             # check if key exists for full cudagraph
-            # For pure FULL mode, keys are registered with uniform=False.
             batch_desc_to_check = batch_desc
             if batch_desc_to_check in self.cudagraph_keys[CUDAGraphMode.FULL]:
                 return CUDAGraphMode.FULL, batch_desc_to_check

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -297,12 +297,15 @@ class CudagraphDispatcher:
             num_tokens, uniform_decode, has_lora, effective_num_active_loras
         )
 
+        normalized_uniform = uniform_decode and self.cudagraph_mode.separate_routine()
+        batch_desc = self._create_padded_batch_descriptor(
+                    num_tokens, normalized_uniform, has_lora, effective_num_active_loras
+        )
+
         if CUDAGraphMode.FULL in allowed_modes:
             # check if key exists for full cudagraph
             # For pure FULL mode, keys are registered with uniform=False.
             batch_desc_to_check = batch_desc
-            if self.cudagraph_mode == CUDAGraphMode.FULL:
-                batch_desc_to_check = replace(batch_desc, uniform=False)
             if batch_desc_to_check in self.cudagraph_keys[CUDAGraphMode.FULL]:
                 return CUDAGraphMode.FULL, batch_desc_to_check
 

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -295,7 +295,7 @@ class CudagraphDispatcher:
 
         normalized_uniform = uniform_decode and self.cudagraph_mode.separate_routine()
         batch_desc = self._create_padded_batch_descriptor(
-                    num_tokens, normalized_uniform, has_lora, effective_num_active_loras
+            num_tokens, normalized_uniform, has_lora, effective_num_active_loras
         )
 
         if CUDAGraphMode.FULL in allowed_modes:


### PR DESCRIPTION
## Purpose
Fixes a bug (causing a -50% performance regression) where FULL mode CUDA graphs are never dispatched for uniform decode batches (with speculative decoding for example), leading them to fall back to eager execution.

Root cause:
Mismatch between key capture and key lookup during dispatch when we are dealing with `CUDAGraphMode.FULL`, `uniform_decode=True` and `uniform_decode_query_len > 1`.

May have been introduced by https://github.com/vllm-project/vllm/pull/28579 that added the `num_reqs` attribute.

Capture (`initialize_cudagraph_keys`):
- mixed_mode = FULL -> enters mixed_mode branch
- Creates batch descriptor and registers with `uniform=False` -> `BatchDescriptor(num_tokens=num_tokens, uniform=False, num_reqs=num_tokens)`
- `decode_mode()` = FULL but `separate_routine()` = False -> skip decode branch, no keys registered
- Keys are stored as `uniform=False` and `num_reqs=num_tokens`

Dispatch (`dispatch`):
- Creates `batch_desc` with `uniform=True` -> `BatchDescriptor(num_tokens=num_tokens, uniform=True, num_reqs=num_tokens//uniform_decode_query_len)`
- Modifies the `batch_desc` to `uniform=False` -> `BatchDescriptor(num_tokens=num_tokens, uniform=False, num_reqs=num_tokens//uniform_decode_query_len)`
- Lookup fails because num_reqs is different between both keys.

The fix replaces the `uniform` modification during dispatch with normalization of `uniform`, only setting it to true when there are separate modes (`separate_routine()=True`); then creating the batch with this value instead of modifying it post-hoc (this ensures `num_reqs` is calculated the same between capture and dispatch).


## Test Plan
```
VLLM_LOGGING_LEVEL=DEBUG vllm bench latency \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --batch-size 4 \
    --input-len 128 \
    --output-len 256 \
    --speculative-config '{"model": "meta-llama/Llama-3.2-1B-Instruct", "num_speculative_tokens": 3}' \
    --compilation-config '{"cudagraph_mode": "FULL"}'
```

Verified via VLLM_LOGGING_LEVEL=DEBUG that decode batches dispatch correctly after the fix.

## Test Result
Avg. Latency before fix: 5.05s
Avg. Latency after fix: 3.43s

Tested on one H200 GPU.