### PR TITLE
[Build] Upgrade xgrammar to get a security fix

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -24,7 +24,7 @@ outlines_core == 0.2.11
 # required for outlines backend disk cache
 diskcache == 5.6.3
 lark == 1.2.2
-xgrammar == 0.1.29; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
+xgrammar >= 0.1.32, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs


### PR DESCRIPTION
xgrammar 0.1.32 includes a CVE fix:

https://github.com/mlc-ai/xgrammar/security/advisories/GHSA-7rgv-gqhr-fxg3

While we're at it, don't pin to specific version of xgrammar. After
speaking to the primary maintainer, they feel it should be safe to not
pin to a specific version at this point. We still have a "< 1.0.0"
limit in place in case they want to do a major revision that may not
be backwards compatible.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
