### PR TITLE
[ROCm][CI] Enable AITER for failing `test_gpt_oss` test case on MI355

### DIFF
--- a/tests/models/quantization/test_gpt_oss.py
+++ b/tests/models/quantization/test_gpt_oss.py
@@ -21,6 +21,7 @@ import lm_eval
 import pytest
 from packaging import version
 
+from vllm.platforms.rocm import on_gfx950
 from vllm.utils.torch_utils import cuda_device_count_stateless
 
 MODEL_ACCURACIES = {
@@ -83,10 +84,16 @@ class EvaluationConfig:
 @pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
 @pytest.mark.parametrize("model_name, expected_accuracy", MODEL_ACCURACIES.items())
 def test_gpt_oss_attention_quantization(
-    model_name: str, tp_size: int, expected_accuracy: float
+    model_name: str,
+    tp_size: int,
+    expected_accuracy: float,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     if tp_size > cuda_device_count_stateless():
         pytest.skip("Not enough GPUs to run this test case")
+
+    if "amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8" in model_name and on_gfx950():
+        monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
 
     model_args = EvaluationConfig(model_name).get_model_args(tp_size)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
This test case is passing on MI325 but failing on MI350:
`pytest -v -s tests/models/quantization/test_gpt_oss.py::test_gpt_oss_attention_quantization[amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8-0.89-1]`

It fails with the following error:
```
(EngineCore_DP0 pid=143860)   File "/projects/vllm/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py", line 85, in _moe_forward
(EngineCore_DP0 pid=143860)     return layer.runner.forward_impl(
(EngineCore_DP0 pid=143860)            ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=143860)   File "/projects/vllm/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py", line 689, in forward_impl
(EngineCore_DP0 pid=143860)     final_hidden_states = self.quant_method.apply(
(EngineCore_DP0 pid=143860)                           ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=143860)   File "/projects/vllm/vllm/model_executor/layers/quantization/quark/quark_moe.py", line 1051, in apply
(EngineCore_DP0 pid=143860)     return rocm_aiter_fused_experts(
(EngineCore_DP0 pid=143860)            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=143860)   File "/projects/vllm/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py", line 205, in rocm_aiter_fused_experts
(EngineCore_DP0 pid=143860)     raise ValueError(f"Unsupported activation: {activation}")
(EngineCore_DP0 pid=143860) ValueError: Unsupported activation: MoEActivation.SWIGLUOAI
```

This is a known error that is being fixed, but in the meantime we enable AITER as a workaround.

cc @BowenBao 