### PR TITLE
[ROCm][CI] Adding missing dependencies for Multi-modal models tests

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -91,7 +91,7 @@ timm==1.0.17
 # Required for plugins test
 albumentations==1.4.6
 # Pin transformers version
-transformers==4.57.3
+transformers==4.57.5
 # Pin HF Hub version
 huggingface-hub==0.36.2
 # Pin Mistral Common
@@ -106,3 +106,5 @@ imagehash==4.3.2
 bitsandbytes==0.49.2
 # Examples (tensorizer) tests
 tensorizer==2.10.1
+# Multi-modal models test (`allendou/FireRedASR2-LLM-vllm`)
+kaldi-native-fbank==1.22.3


### PR DESCRIPTION
Follow-up to: https://github.com/vllm-project/vllm/pull/35996

Adds the missing dependency for ROCm and upgrading transformers package.

cc @kenroche 