### PR TITLE
[Performance] Add CUDA
   graph optimization for classify pooler

### DIFF
--- a/tests/v1/worker/test_pool_cudagraph.py
+++ b/tests/v1/worker/test_pool_cudagraph.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the pooler CUDA graph optimization in gpu_model_runner.py.
+
+Tests cover:
+- FlatClassifyPooler forward pass variants
+- PoolerCUDAGraphRunner size mapping logic
+- _parse_pool_cudagraph_batch_sizes env var parsing
+- _introspect_classify_pooler model introspection
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu_model_runner import (
+    FlatClassifyPooler,
+    PoolerCUDAGraphRunner,
+    _introspect_classify_pooler,
+    _parse_pool_cudagraph_batch_sizes,
+)
+
+# ── FlatClassifyPooler tests ──────────────────────────────────────────
+
+
+class TestFlatClassifyPooler:
+    def test_forward_with_all_ops(self):
+        """Test forward with classifier, logit_bias, activation, and
+        head_dtype."""
+        classifier = nn.Linear(8, 4, bias=False)
+        activation = nn.Sigmoid()
+        pooler = FlatClassifyPooler(
+            classifier=classifier,
+            logit_bias=0.5,
+            activation_fn=activation,
+            head_dtype=torch.float32,
+        )
+        x = torch.randn(2, 8, dtype=torch.float16)
+        out = pooler(x)
+        assert out.shape == (2, 4)
+        assert out.dtype == torch.float32
+        # sigmoid output should be in [0, 1] range (approximately, since
+        # we subtract bias first)
+        assert out.min() >= 0.0
+        assert out.max() <= 1.0
+
+    def test_forward_classifier_only(self):
+        """Test forward with only a classifier (no bias, no activation)."""
+        classifier = nn.Linear(8, 4, bias=False)
+        pooler = FlatClassifyPooler(
+            classifier=classifier,
+            logit_bias=None,
+            activation_fn=None,
+            head_dtype=None,
+        )
+        x = torch.randn(3, 8)
+        out = pooler(x)
+        assert out.shape == (3, 4)
+
+    def test_forward_no_classifier(self):
+        """Test forward with no classifier (passthrough with optional
+        dtype cast)."""
+        pooler = FlatClassifyPooler(
+            classifier=None,
+            logit_bias=None,
+            activation_fn=None,
+            head_dtype=torch.float32,
+        )
+        x = torch.randn(2, 8, dtype=torch.float16)
+        out = pooler(x)
+        assert out.shape == (2, 8)
+        assert out.dtype == torch.float32
+
+    def test_forward_logit_bias_only(self):
+        """Test that logit_bias is subtracted correctly."""
+        pooler = FlatClassifyPooler(
+            classifier=None,
+            logit_bias=1.0,
+            activation_fn=None,
+            head_dtype=None,
+        )
+        x = torch.tensor([[2.0, 3.0]])
+        out = pooler(x)
+        expected = torch.tensor([[1.0, 2.0]])
+        assert torch.allclose(out, expected)
+
+    def test_forward_activation_only(self):
+        """Test with only activation function."""
+        pooler = FlatClassifyPooler(
+            classifier=None,
+            logit_bias=None,
+            activation_fn=nn.Sigmoid(),
+            head_dtype=None,
+        )
+        x = torch.zeros(2, 4)
+        out = pooler(x)
+        expected = torch.full((2, 4), 0.5)
+        assert torch.allclose(out, expected)
+
+    def test_logit_bias_buffer_registered(self):
+        """Test that logit_bias is registered as a buffer (important for Cuda graph)."""
+        pooler = FlatClassifyPooler(
+            classifier=None,
+            logit_bias=2.5,
+            activation_fn=None,
+            head_dtype=None,
+        )
+        assert hasattr(pooler, "logit_bias_val")
+        assert pooler.logit_bias_val.item() == pytest.approx(2.5)
+
+    def test_no_logit_bias_buffer_when_none(self):
+        """Test that no buffer is registered when logit_bias is None."""
+        pooler = FlatClassifyPooler(
+            classifier=None,
+            logit_bias=None,
+            activation_fn=None,
+            head_dtype=None,
+        )
+        assert not hasattr(pooler, "logit_bias_val")
+        assert pooler.has_logit_bias is False
+
+
+# ── _parse_pool_cudagraph_batch_sizes tests ───────────────────────────
+
+
+class TestParsePoolCudagraphBatchSizes:
+    def test_default_sizes(self):
+        """Test default batch sizes when env var is not set."""
+        with patch.dict(os.environ, {}, clear=False):
+            # Make sure the env var is not set
+            os.environ.pop("VLLM_POOL_CUDAGRAPH_BATCH_SIZES", None)
+            with patch("vllm.v1.worker.gpu_model_runner.envs") as mock_envs:
+                mock_envs.VLLM_POOL_CUDAGRAPH_BATCH_SIZES = None
+                sizes = _parse_pool_cudagraph_batch_sizes()
+        assert 1 in sizes
+        assert 128 in sizes
+        assert sizes == sorted(sizes)
+
+    def test_custom_sizes_from_env(self):
+        """Test parsing custom batch sizes from env var."""
+        with patch("vllm.v1.worker.gpu_model_runner.envs") as mock_envs:
+            mock_envs.VLLM_POOL_CUDAGRAPH_BATCH_SIZES = "4,2,8,16"
+            sizes = _parse_pool_cudagraph_batch_sizes()
+        assert sizes == [2, 4, 8, 16]
+
+    def test_custom_sizes_deduplication(self):
+        """Test that duplicate sizes are removed."""
+        with patch("vllm.v1.worker.gpu_model_runner.envs") as mock_envs:
+            mock_envs.VLLM_POOL_CUDAGRAPH_BATCH_SIZES = "4,4,8,8,16"
+            sizes = _parse_pool_cudagraph_batch_sizes()
+        assert sizes == [4, 8, 16]
+
+    def test_single_size(self):
+        """Test with a single batch size."""
+        with patch("vllm.v1.worker.gpu_model_runner.envs") as mock_envs:
+            mock_envs.VLLM_POOL_CUDAGRAPH_BATCH_SIZES = "32"
+            sizes = _parse_pool_cudagraph_batch_sizes()
+        assert sizes == [32]
+
+
+# ── PoolerCUDAGraphRunner size map tests ──────────────────────────────
+
+
+class TestPoolerCUDAGraphRunnerSizeMap:
+    """Test the batch size mapping logic without actually capturing
+    CUDA graphs (requires GPU)."""
+
+    def _make_runner_with_size_map(self, capture_sizes):
+        """Create a runner and populate only the _size_map, skipping
+        actual CUDA graph capture."""
+        runner = object.__new__(PoolerCUDAGraphRunner)
+        runner._size_map = {}
+        sorted_sizes = sorted(capture_sizes)
+        for i in range(1, sorted_sizes[-1] + 1):
+            for s in sorted_sizes:
+                if i <= s:
+                    runner._size_map[i] = s
+                    break
+        return runner
+
+    def test_exact_match(self):
+        """Exact batch sizes map to themselves."""
+        runner = self._make_runner_with_size_map([1, 4, 8, 16])
+        assert runner.get_capture_size(1) == 1
+        assert runner.get_capture_size(4) == 4
+        assert runner.get_capture_size(8) == 8
+        assert runner.get_capture_size(16) == 16
+
+    def test_round_up(self):
+        """Non-captured sizes round up to the next captured size."""
+        runner = self._make_runner_with_size_map([1, 4, 8, 16])
+        assert runner.get_capture_size(2) == 4
+        assert runner.get_capture_size(3) == 4
+        assert runner.get_capture_size(5) == 8
+        assert runner.get_capture_size(7) == 8
+        assert runner.get_capture_size(9) == 16
+        assert runner.get_capture_size(15) == 16
+
+    def test_too_large(self):
+        """Batch sizes larger than max captured return None."""
+        runner = self._make_runner_with_size_map([1, 4, 8])
+        assert runner.get_capture_size(9) is None
+        assert runner.get_capture_size(100) is None
+
+    def test_single_capture_size(self):
+        """Single capture size maps batch size 1 to it."""
+        runner = self._make_runner_with_size_map([8])
+        assert runner.get_capture_size(1) == 8
+        assert runner.get_capture_size(8) == 8
+        assert runner.get_capture_size(9) is None
+
+
+# ── PoolerCUDAGraphRunner GPU tests ───────────────────────────────────
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="Need CUDA device")
+class TestPoolerCUDAGraphRunnerGPU:
+    """Tests that exercise actual CUDA graph capture and replay."""
+
+    def _make_flat_pooler(self, hidden_size=8, num_labels=4):
+        """Create a FlatClassifyPooler with all ops on CUDA."""
+        classifier = nn.Linear(hidden_size, num_labels, bias=False)
+        return FlatClassifyPooler(
+            classifier=classifier,
+            logit_bias=0.5,
+            activation_fn=nn.Sigmoid(),
+            head_dtype=torch.float32,
+        ).cuda()
+
+    def _make_runner(self, flat_pooler, hidden_size, num_labels, capture_sizes):
+        """Create a PoolerCUDAGraphRunner with its own graph pool to
+        avoid cross-test interference."""
+        with patch("vllm.platforms.current_platform") as mock_platform:
+            mock_platform.get_global_graph_pool.return_value = (
+                current_platform.graph_pool_handle()
+            )
+            runner = PoolerCUDAGraphRunner(
+                flat_pooler=flat_pooler,
+                hidden_size=hidden_size,
+                num_labels=num_labels,
+                device=torch.device("cuda"),
+                input_dtype=torch.float32,
+                output_dtype=torch.float32,
+                capture_sizes=capture_sizes,
+            )
+        return runner
+
+    def test_graph_replay_matches_eager(self):
+        """CUDA graph replay produces the same result as eager execution."""
+        hidden_size, num_labels = 8, 4
+        flat_pooler = self._make_flat_pooler(hidden_size, num_labels)
+        runner = self._make_runner(flat_pooler, hidden_size, num_labels, [4])
+
+        x = torch.randn(4, hidden_size, device="cuda")
+        eager_out = flat_pooler(x)
+        graph_out = runner.run(x, batch_size=4, capture_size=4)
+
+        assert torch.allclose(eager_out, graph_out, atol=1e-6)
+
+    def test_graph_replay_with_padding(self):
+        """When batch_size < capture_size, only the valid rows should
+        match the eager output."""
+        hidden_size, num_labels = 8, 4
+        flat_pooler = self._make_flat_pooler(hidden_size, num_labels)
+        runner = self._make_runner(flat_pooler, hidden_size, num_labels, [4, 8])
+
+        # Only 2 real samples, padded up to capture_size=4
+        x = torch.randn(2, hidden_size, device="cuda")
+        eager_out = flat_pooler(x)
+        graph_out = runner.run(x, batch_size=2, capture_size=4)
+
+        assert graph_out.shape == (2, num_labels)
+        assert torch.allclose(eager_out, graph_out, atol=1e-6)
+
+    def test_graph_replay_different_inputs(self):
+        """Multiple replays with different inputs produce different
+        (correct) results — verifies the graph isn't returning stale data."""
+        hidden_size, num_labels = 8, 4
+        flat_pooler = self._make_flat_pooler(hidden_size, num_labels)
+        runner = self._make_runner(flat_pooler, hidden_size, num_labels, [4])
+
+        x1 = torch.randn(4, hidden_size, device="cuda")
+        x2 = torch.randn(4, hidden_size, device="cuda")
+
+        out1 = runner.run(x1, batch_size=4, capture_size=4)
+        out2 = runner.run(x2, batch_size=4, capture_size=4)
+
+        eager1 = flat_pooler(x1)
+        eager2 = flat_pooler(x2)
+
+        assert torch.allclose(out1, eager1, atol=1e-6)
+        assert torch.allclose(out2, eager2, atol=1e-6)
+
+    def test_graph_replay_passthrough_no_classifier(self):
+        """Graph capture/replay works with no classifier (passthrough
+        with dtype cast and bias subtraction only)."""
+        hidden_size = 8
+        flat_pooler = FlatClassifyPooler(
+            classifier=None,
+            logit_bias=1.0,
+            activation_fn=None,
+            head_dtype=torch.float32,
+        ).cuda()
+        runner = self._make_runner(flat_pooler, hidden_size, hidden_size, [2])
+
+        x = torch.tensor(
+            [
+                [3.0, 5.0, 7.0, 1.0, 2.0, 4.0, 6.0, 8.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            ],
+            device="cuda",
+        )
+        graph_out = runner.run(x, batch_size=2, capture_size=2)
+        eager_out = flat_pooler(x)
+
+        assert torch.allclose(graph_out, eager_out, atol=1e-6)
+        # bias=1.0 is subtracted, so second row should be all zeros
+        assert torch.allclose(
+            graph_out[1],
+            torch.zeros(hidden_size, device="cuda", dtype=graph_out.dtype),
+            atol=1e-6,
+        )
+
+
+# ── _introspect_classify_pooler tests ─────────────────────────────────
+
+
+class TestIntrospectClassifyPooler:
+    def _make_mock_model(
+        self,
+        pooler_type="DispatchPooler",
+        classify_pooler_type="SequencePooler",
+        head_type="ClassifierPoolerHead",
+        has_classifier=True,
+    ):
+        """Build a mock model with a configurable pooler hierarchy."""
+        model = MagicMock()
+
+        classifier = nn.Linear(16, 4, bias=False) if has_classifier else None
+
+        head = MagicMock()
+        head.__class__.__name__ = head_type
+        head.classifier = classifier
+        head.logit_bias = 0.5
+        head.activation = nn.Sigmoid()
+        head.head_dtype = torch.float32
+
+        classify_pooler = MagicMock()
+        classify_pooler.__class__.__name__ = classify_pooler_type
+        classify_pooler.head = head
+
+        pooler = MagicMock()
+        pooler.__class__.__name__ = pooler_type
+        pooler.poolers_by_task = {"classify": classify_pooler}
+        model.pooler = pooler
+
+        return model, pooler, classify_pooler, head
+
+    @patch(
+        "vllm.v1.worker.gpu_model_runner._parse_pool_cudagraph_batch_sizes",
+        return_value=[1, 2, 4],
+    )
+    def test_valid_classify_pooler(self, mock_parse):
+        """Test successful introspection of a valid classify pooler."""
+        from vllm.model_executor.layers.pooler.seqwise.heads import (
+            ClassifierPoolerHead,
+        )
+        from vllm.model_executor.layers.pooler.seqwise.poolers import (
+            SequencePooler,
+        )
+        from vllm.model_executor.layers.pooler.special import DispatchPooler
+
+        # Build real-ish objects that pass isinstance checks
+        classifier = nn.Linear(16, 4, bias=False)
+        head = MagicMock(spec=ClassifierPoolerHead)
+        head.classifier = classifier
+        head.logit_bias = 0.5
+        head.activation = nn.Sigmoid()
+        head.head_dtype = torch.float32
+
+        classify_pooler = MagicMock(spec=SequencePooler)
+        classify_pooler.head = head
+
+        pooler = MagicMock(spec=DispatchPooler)
+        pooler.poolers_by_task = {"classify": classify_pooler}
+
+        model = MagicMock()
+        model.pooler = pooler
+
+        result = _introspect_classify_pooler(model)
+
+        assert result is not None
+        flat_pooler, graph_runner = result
+        assert isinstance(flat_pooler, FlatClassifyPooler)
+        # graph_runner may be None if CUDA is not available, that's fine
+
+    def test_non_dispatch_pooler_returns_none(self):
+        """Test that non-DispatchPooler returns None."""
+        model = MagicMock()
+        model.pooler = MagicMock()  # Not a DispatchPooler
+
+        result = _introspect_classify_pooler(model)
+        assert result is None
+
+    def test_missing_classify_task_returns_none(self):
+        """Test that missing 'classify' task returns None."""
+        model = MagicMock()
+        pooler = MagicMock()
+        pooler.poolers_by_task = {"embed": MagicMock()}  # No "classify"
+        model.pooler = pooler
+
+        with patch(
+            "vllm.model_executor.layers.pooler.special.DispatchPooler",
+            create=True,
+        ) as MockDP:
+            pooler.__class__ = MockDP
+            result = _introspect_classify_pooler(model)
+
+        assert result is None
+
+
+# ── Fast-path gating logic tests ─────────────────────────────────────
+
+
+class TestPoolCudagraphFastPathGating:
+    """Test the conditions that determine whether _pool() takes the
+    CUDA graph fast path or falls back to the default path.
+
+    The fast path requires:
+    1. All tasks are "classify"
+    2. All pooling_params have use_activation != False
+    """
+
+    def test_all_classify_with_activation_enables_fast_path(self):
+        """Fast path is enabled when all tasks are classify and
+        all use_activation is not False."""
+        tasks = ["classify", "classify", "classify"]
+        pooling_params = [
+            MagicMock(use_activation=True),
+            MagicMock(use_activation=True),
+            MagicMock(use_activation=None),  # None is also not False
+        ]
+
+        all_classify = all(t == "classify" for t in tasks)
+        all_use_activation = all_classify and all(
+            p.use_activation is not False for p in pooling_params
+        )
+
+        assert all_classify is True
+        assert all_use_activation is True
+
+    def test_mixed_tasks_disables_fast_path(self):
+        """Fast path is disabled when tasks include non-classify."""
+        tasks = ["classify", "embed", "classify"]
+        pooling_params = [
+            MagicMock(use_activation=True),
+            MagicMock(use_activation=True),
+            MagicMock(use_activation=True),
+        ]
+
+        all_classify = all(t == "classify" for t in tasks)
+        all_use_activation = all_classify and all(
+            p.use_activation is not False for p in pooling_params
+        )
+
+        assert all_classify is False
+        assert all_use_activation is False
+
+    def test_all_embed_disables_fast_path(self):
+        """Fast path is disabled when all tasks are embed."""
+        tasks = ["embed", "embed"]
+        pooling_params = [
+            MagicMock(use_activation=True),
+            MagicMock(use_activation=True),
+        ]
+
+        all_classify = all(t == "classify" for t in tasks)
+        all_use_activation = all_classify and all(
+            p.use_activation is not False for p in pooling_params
+        )
+
+        assert all_classify is False
+        assert all_use_activation is False
+
+    def test_use_activation_false_disables_fast_path(self):
+        """Fast path is disabled when any use_activation is False."""
+        tasks = ["classify", "classify"]
+        pooling_params = [
+            MagicMock(use_activation=True),
+            MagicMock(use_activation=False),
+        ]
+
+        all_classify = all(t == "classify" for t in tasks)
+        all_use_activation = all_classify and all(
+            p.use_activation is not False for p in pooling_params
+        )
+
+        assert all_classify is True
+        assert all_use_activation is False
+
+    def test_single_classify_request_enables_fast_path(self):
+        """Fast path works with a single classify request."""
+        tasks = ["classify"]
+        pooling_params = [MagicMock(use_activation=True)]
+
+        all_classify = all(t == "classify" for t in tasks)
+        all_use_activation = all_classify and all(
+            p.use_activation is not False for p in pooling_params
+        )
+
+        assert all_classify is True
+        assert all_use_activation is True
+
+    def test_use_activation_none_enables_fast_path(self):
+        """use_activation=None (default) should enable the fast path,
+        since the check is 'is not False'."""
+        tasks = ["classify"]
+        pooling_params = [MagicMock(use_activation=None)]
+
+        all_classify = all(t == "classify" for t in tasks)
+        all_use_activation = all_classify and all(
+            p.use_activation is not False for p in pooling_params
+        )
+
+        assert all_classify is True
+        assert all_use_activation is True

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -257,6 +257,7 @@ if TYPE_CHECKING:
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
+    VLLM_POOL_CUDAGRAPH_BATCH_SIZES: str | None = None
 
 
 def get_default_cache_root():
@@ -1709,6 +1710,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable simple KV offload.
     "VLLM_USE_SIMPLE_KV_OFFLOAD": lambda: bool(
         int(os.getenv("VLLM_USE_SIMPLE_KV_OFFLOAD", "0"))
+    ),
+    # Comma-separated list of batch sizes for pooler CUDA graph capture.
+    # When set, the pooler CUDA graph optimization will capture graphs for
+    # these batch sizes instead of the default range (1..128).
+    # Example: "1,2,4,8,16,32,64,128,256"
+    "VLLM_POOL_CUDAGRAPH_BATCH_SIZES": lambda: os.environ.get(
+        "VLLM_POOL_CUDAGRAPH_BATCH_SIZES", None
     ),
 }
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -372,6 +372,322 @@ class AsyncGPUPoolingModelRunnerOutput(AsyncModelRunnerOutput):
         return self._model_runner_output
 
 
+# ── Pooler CUDA Graph Optimization ────────────────────────────────────
+# Captures the classify pooler's post-gather tensor operations (dtype cast,
+# classifier matmul, logit_bias subtract, activation) into CUDA graphs,
+# eliminating per-kernel CPU dispatch overhead for short-input workloads.
+
+_DEFAULT_POOL_CUDAGRAPH_BATCH_SIZES = [
+    1,
+    2,
+    4,
+    8,
+    16,
+    24,
+    32,
+    40,
+    48,
+    56,
+    64,
+    72,
+    80,
+    88,
+    96,
+    104,
+    112,
+    120,
+    128,
+]
+
+
+def _parse_pool_cudagraph_batch_sizes() -> list[int]:
+    """Parse batch sizes from env var or return defaults."""
+    env = envs.VLLM_POOL_CUDAGRAPH_BATCH_SIZES
+    if env:
+        sizes = sorted({int(x) for x in env.split(",")})
+        logger.info(
+            "Pooler CUDA graph optimization: using custom capture "
+            "batch sizes from env: %s",
+            sizes,
+        )
+        return sizes
+    return list(_DEFAULT_POOL_CUDAGRAPH_BATCH_SIZES)
+
+
+class FlatClassifyPooler(nn.Module):
+    """Flat nn.Module containing only the post-gather tensor operations
+    from the classify pooler pipeline, with no Python control flow.
+
+    The gather (hidden_states[last_token_indices]) is done outside this
+    module so that CUDA graph capture only needs a small
+    batch_size x hidden_size static buffer instead of the full
+    num_tokens x hidden_size hidden_states.
+    """
+
+    def __init__(
+        self,
+        classifier: nn.Module | None,
+        logit_bias: float | None,
+        activation_fn: nn.Module | None,
+        head_dtype: torch.dtype | None,
+    ):
+        super().__init__()
+        if classifier is not None and head_dtype is not None:
+            classifier = classifier.to(head_dtype)
+        self.classifier = classifier
+        self.has_logit_bias = logit_bias is not None
+        if logit_bias is not None:
+            self.register_buffer(
+                "logit_bias_val",
+                torch.tensor(logit_bias, dtype=torch.float32),
+            )
+        self.activation_fn = activation_fn
+        self.head_dtype = head_dtype
+
+    def forward(self, pooled: torch.Tensor) -> torch.Tensor:
+        """Takes already-gathered pooled hidden states
+        (batch_size x hidden_size)."""
+        if self.head_dtype is not None:
+            pooled = pooled.to(self.head_dtype)
+        if self.classifier is not None:
+            pooled = self.classifier(pooled)
+        if self.has_logit_bias:
+            pooled = pooled - self.logit_bias_val
+        if self.activation_fn is not None:
+            pooled = self.activation_fn(pooled)
+        return pooled
+
+
+class PoolerCUDAGraphRunner:
+    """Manages CUDA graph capture and replay for the post-gather
+    classify pooler ops (dtype cast, classifier mm, bias subtract,
+    activation).
+
+    The gather is done eagerly outside the graph so the static input
+    buffer is only batch_size x hidden_size (tiny), avoiding the
+    expensive copy of the full num_tokens x hidden_size hidden_states
+    tensor.
+    """
+
+    def __init__(
+        self,
+        flat_pooler: FlatClassifyPooler,
+        hidden_size: int,
+        num_labels: int,
+        device: torch.device,
+        input_dtype: torch.dtype,
+        output_dtype: torch.dtype,
+        capture_sizes: list[int],
+    ):
+        from vllm.platforms import current_platform
+
+        self.flat_pooler = flat_pooler
+        self.hidden_size = hidden_size
+        self.num_labels = num_labels
+        self.device = device
+        self.input_dtype = input_dtype
+        self.output_dtype = output_dtype
+
+        self.graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        self.static_input: dict[int, torch.Tensor] = {}
+        self.static_output: dict[int, torch.Tensor] = {}
+
+        # Map from any batch size to the next captured size
+        self._size_map: dict[int, int] = {}
+        sorted_sizes = sorted(capture_sizes)
+        for i in range(1, sorted_sizes[-1] + 1):
+            for s in sorted_sizes:
+                if i <= s:
+                    self._size_map[i] = s
+                    break
+
+        self.graph_pool = current_platform.get_global_graph_pool()
+        self._capture_all(sorted_sizes)
+
+    @torch.inference_mode()
+    def _capture_all(self, capture_sizes: list[int]) -> None:
+        """Capture CUDA graphs for all configured batch sizes."""
+        for batch_size in sorted(capture_sizes, reverse=True):
+            self._capture_one(batch_size)
+
+        logger.info(
+            "Pooler CUDA graph optimization: captured %d graphs for batch sizes %s",
+            len(self.graphs),
+            sorted(self.graphs.keys()),
+        )
+
+    def _capture_one(self, batch_size: int) -> None:
+        """Capture a single CUDA graph for the given batch size."""
+        static_in = torch.zeros(
+            batch_size,
+            self.hidden_size,
+            dtype=self.input_dtype,
+            device=self.device,
+        )
+        self.static_input[batch_size] = static_in
+
+        # Warmup run (required before CUDA graph capture)
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                _ = self.flat_pooler(static_in)
+        torch.cuda.current_stream().wait_stream(s)
+
+        # Capture
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, pool=self.graph_pool):
+            static_out = self.flat_pooler(static_in)
+
+        self.graphs[batch_size] = graph
+        self.static_output[batch_size] = static_out
+
+    def get_capture_size(self, batch_size: int) -> int | None:
+        """Return the captured size to use, or None if batch too large."""
+        return self._size_map.get(batch_size)
+
+    @torch.inference_mode()
+    def run(
+        self,
+        pooled: torch.Tensor,
+        batch_size: int,
+        capture_size: int,
+    ) -> torch.Tensor:
+        """Copy pre-gathered pooled input into static buffer, replay
+        the CUDA graph, and return the output slice for the actual
+        batch size.
+        """
+        static_in = self.static_input[capture_size]
+        static_in[:batch_size].copy_(pooled)
+        if batch_size < capture_size:
+            static_in[batch_size:].zero_()
+
+        self.graphs[capture_size].replay()
+
+        return self.static_output[capture_size][:batch_size].clone()
+
+
+def _introspect_classify_pooler(
+    model: VllmModelForPooling,
+) -> tuple[FlatClassifyPooler, PoolerCUDAGraphRunner | None] | None:
+    """Lazily introspect the model's pooler hierarchy, create a
+    FlatClassifyPooler, and capture CUDA graphs.
+
+    Returns (flat_pooler, graph_runner) or None if not applicable.
+    """
+    try:
+        from vllm.model_executor.layers.pooler.seqwise.heads import (
+            ClassifierPoolerHead,
+        )
+        from vllm.model_executor.layers.pooler.seqwise.poolers import (
+            SequencePooler,
+        )
+        from vllm.model_executor.layers.pooler.special import DispatchPooler
+
+        pooler = model.pooler
+        if not isinstance(pooler, DispatchPooler):
+            logger.info(
+                "Pooler CUDA graph optimization: pooler is %s, not "
+                "DispatchPooler; skipping",
+                type(pooler).__name__,
+            )
+            return None
+
+        classify_pooler = pooler.poolers_by_task.get("classify")
+        if classify_pooler is None or not isinstance(classify_pooler, SequencePooler):
+            logger.info(
+                "Pooler CUDA graph optimization: no SequencePooler for "
+                "'classify'; skipping"
+            )
+            return None
+
+        head = classify_pooler.head
+        if not isinstance(head, ClassifierPoolerHead):
+            logger.info(
+                "Pooler CUDA graph optimization: head is %s, not "
+                "ClassifierPoolerHead; skipping",
+                type(head).__name__,
+            )
+            return None
+
+        classifier = head.classifier
+        logit_bias = head.logit_bias
+        activation_fn = head.activation
+        head_dtype = head.head_dtype
+
+        if isinstance(head_dtype, str):
+            torch_dtype = getattr(torch, head_dtype, None)
+            if torch_dtype is None:
+                raise ValueError(
+                    f"Invalid head_dtype string from model config: '{head_dtype}'"
+                )
+            head_dtype = torch_dtype
+
+        flat_pooler = FlatClassifyPooler(
+            classifier=classifier,
+            logit_bias=logit_bias,
+            activation_fn=activation_fn,
+            head_dtype=head_dtype,
+        )
+
+        device = torch.device("cuda")
+        input_dtype = torch.float16
+        if classifier is not None and hasattr(classifier, "weight"):
+            device = classifier.weight.device
+            input_dtype = classifier.weight.dtype
+            num_labels = classifier.weight.shape[0]
+            hidden_size = classifier.weight.shape[1]
+        else:
+            logger.info(
+                "Pooler CUDA graph optimization: no classifier weight; "
+                "using flat pooler without CUDA graphs"
+            )
+            flat_pooler = flat_pooler.to(device)
+            return (flat_pooler, None)
+
+        flat_pooler = flat_pooler.to(device)
+        output_dtype = head_dtype if head_dtype is not None else input_dtype
+
+        capture_sizes = _parse_pool_cudagraph_batch_sizes()
+        graph_runner: PoolerCUDAGraphRunner | None = None
+        try:
+            graph_runner = PoolerCUDAGraphRunner(
+                flat_pooler=flat_pooler,
+                hidden_size=hidden_size,
+                num_labels=num_labels,
+                device=device,
+                input_dtype=input_dtype,
+                output_dtype=output_dtype,
+                capture_sizes=capture_sizes,
+            )
+        except Exception:
+            logger.warning(
+                "Pooler CUDA graph optimization: graph capture failed; "
+                "using flat pooler without graphs",
+                exc_info=True,
+            )
+
+        logger.info(
+            "Pooler CUDA graph optimization: initialized "
+            "(classifier=%s, logit_bias=%s, activation=%s, "
+            "head_dtype=%s, cuda_graphs=%s)",
+            type(classifier).__name__,
+            logit_bias,
+            type(activation_fn).__name__ if activation_fn else None,
+            head_dtype,
+            graph_runner is not None,
+        )
+        return (flat_pooler, graph_runner)
+
+    except Exception:
+        logger.warning(
+            "Pooler CUDA graph optimization: initialization failed; "
+            "falling back to default path",
+            exc_info=True,
+        )
+        return None
+
+
 class ExecuteModelState(NamedTuple):
     """Ephemeral cached state transferred between execute_model() and
     sample_tokens(), after execute_model() returns None."""
@@ -3115,10 +3431,38 @@ class GPUModelRunner(
             "Either all or none of the requests in a batch must be pooling request"
         )
 
+        pooling_metadata = self.input_batch.get_pooling_metadata()
+
+        # ── CUDA graph fast path for classify pooler ──────────────
+        # Check if all tasks are "classify" with activation enabled.
+        all_classify = all(t == "classify" for t in pooling_metadata.tasks)
+        all_use_activation = all_classify and all(
+            p.use_activation is not False for p in pooling_metadata.pooling_params
+        )
+
+        if all_use_activation:
+            model = cast(VllmModelForPooling, self.model)
+
+            # Lazy introspection: cache result on the instance.
+            if not hasattr(self, "_pooler_cudagraph_state"):
+                self._pooler_cudagraph_state = _introspect_classify_pooler(model)
+
+            state = self._pooler_cudagraph_state
+            if state is not None:
+                return self._pool_cudagraph_fast_path(
+                    hidden_states=hidden_states,
+                    num_scheduled_tokens=num_scheduled_tokens,
+                    num_scheduled_tokens_np=num_scheduled_tokens_np,
+                    kv_connector_output=kv_connector_output,
+                    num_reqs=num_reqs,
+                    pooling_metadata=pooling_metadata,
+                    state=state,
+                )
+
+        # ── Default path ──────────────────────────────────────────
         hidden_states = hidden_states[:num_scheduled_tokens]
         seq_lens_cpu = self.optimistic_seq_lens_cpu[:num_reqs]
 
-        pooling_metadata = self.input_batch.get_pooling_metadata()
         pooling_metadata.build_pooling_cursor(
             num_scheduled_tokens_np,
             seq_lens_cpu,
@@ -3149,6 +3493,77 @@ class GPUModelRunner(
         )
 
         if raw_pooler_output is None or not any(finished_mask):
+            model_runner_output.pooler_output = [None] * num_reqs
+            return model_runner_output
+
+        if self.use_async_scheduling:
+            return AsyncGPUPoolingModelRunnerOutput(
+                model_runner_output=model_runner_output,
+                raw_pooler_output=raw_pooler_output,
+                finished_mask=finished_mask,
+                async_output_copy_stream=self.async_output_copy_stream,
+            )
+
+        model_runner_output.pooler_output = _copy_pooler_output_to_cpu(
+            raw_pooler_output=raw_pooler_output,
+            finished_mask=finished_mask,
+        )
+        self._sync_device()
+
+        return model_runner_output
+
+    def _pool_cudagraph_fast_path(
+        self,
+        hidden_states: torch.Tensor,
+        num_scheduled_tokens: int,
+        num_scheduled_tokens_np: np.ndarray,
+        kv_connector_output: KVConnectorOutput | None,
+        num_reqs: int,
+        pooling_metadata: "PoolingMetadata",
+        state: tuple[FlatClassifyPooler, PoolerCUDAGraphRunner | None],
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
+        """Fast path using FlatClassifyPooler with optional CUDA graphs."""
+        hidden_states = hidden_states[:num_scheduled_tokens]
+        seq_lens_cpu = self.optimistic_seq_lens_cpu[:num_reqs]
+        pooling_metadata.build_pooling_cursor(
+            num_scheduled_tokens_np,
+            seq_lens_cpu,
+            device=hidden_states.device,
+            query_start_loc_gpu=self.query_start_loc.gpu[: num_reqs + 1],
+        )
+
+        flat_pooler, graph_runner = state
+        cursor = pooling_metadata.pooling_cursor
+        assert cursor is not None
+        indices = cursor.last_token_indices_gpu
+
+        # Gather eagerly (outside the graph) — one small kernel
+        pooled = hidden_states[indices]
+
+        # Try CUDA graph path for post-gather ops
+        capture_size = None
+        if graph_runner is not None:
+            capture_size = graph_runner.get_capture_size(num_reqs)
+
+        if capture_size is not None:
+            assert graph_runner is not None
+            result = graph_runner.run(pooled, num_reqs, capture_size)
+        else:
+            result = flat_pooler(pooled)
+
+        raw_pooler_output: PoolerOutput = list(result)
+
+        # Vectorized finished_mask
+        finished_mask_tensor = cursor.is_finished()
+        finished_mask = finished_mask_tensor.tolist()
+
+        model_runner_output = ModelRunnerOutput(
+            req_ids=self.input_batch.req_ids.copy(),
+            req_id_to_index=self.input_batch.req_id_to_index.copy(),
+            kv_connector_output=kv_connector_output,
+        )
+
+        if raw_pooler_output is None or not finished_mask_tensor.any().item():
             model_runner_output.pooler_output = [None] * num_reqs
             return model_runner_output
 


### PR DESCRIPTION
## Summary
  - Capture classify pooler post-gather ops into CUDA graphs
  - Eliminates per-kernel CPU dispatch overhead (~8% TTFT improvement
  for short-input classify workloads)
  - Auto-detects compatible pooler hierarchy and falls back gracefully
  - Configurable batch sizes via VLLM_POOL_CUDAGRAPH_BATCH_SIZES env
  var

  ## Test plan
  - [x] 28 unit tests in tests/v1/worker/test_pool_cudagraph.py (all
  passing)
  - [x] Existing gpu_model_runner tests unaffected
  - [x] Validated against an internal classification model at Meta on GPU

### E2E Test Details

Ran vLLM server:
```
CUDA_VISIBLE_DEVICES=1  vllm serve /data/
users/ilinam/models/llama-classify --convert classify --gpu-memory-utilization 0.8 --max-model-len 16384 --port 12345 --profiler-config '{"profiler":
 "torch", "torch_profiler_dir": "/home/ilinam/vllm_profile"}'
```

Sending a score request does not trigger the optimization (as expected):
`curl http://localhost:12345/v1/score -H "Content-Type: application/json" -d '{"model": "/data/users/ilinam/models/llama-classify", "text_1": "hello world", "text_2": "test"}'`

Sending the first classify request triggers the initial graph capture logic:
`curl http://localhost:12345/classify -H "Content-Type: application/json" -d '{"model": "/data/users/ilinam/models/llama-classify", "input": "hello world"}'`

```
(EngineCore_DP0 pid=600642) INFO 03-11 12:19:08 [gpu_model_runner.py:503] Pooler CUDA graph optimization: captured 19 graphs for batch sizes [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128]
(EngineCore_DP0 pid=600642) INFO 03-11 12:19:08 [gpu_model_runner.py:660] Pooler CUDA graph optimization: initialized (classifier=ReplicatedLinear, logit_bias=None, activation=PoolerClassify, head_dtype=torch.float32, cuda_graphs=True)
```

Then the subsequent classify request triggers the graph replay. 

Comparing the profiler outputs for Score vs Classify:

Score (no optimization) — 17 cudaGraphLaunch   
  The pooler ops ran as individual kernels:                                                       
  - aten::mm — classifier matmul                            
  - aten::sub — logit bias subtraction
  - aten::sigmoid — activation
  - Each dispatched separately with CPU overhead per kernel

  Classify (with optimization, post-capture) — 18 cudaGraphLaunch
  - 17 from the backbone (same as before)
  - 1 additional cudaGraphLaunch — that's the pooler graph replay
  - No aten::mm for the classifier (absorbed into the graph)
  - No aten::sigmoid (absorbed into the graph)
