### PR TITLE
Fix: Clone NVFP4 MoE weights on SM121 to prevent Marlin kernel NaN

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -557,6 +557,20 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
             is_act_and_mul=self.moe.is_act_and_mul,
         )
 
+        # GB10 (SM121) workaround: the Marlin MoE CUDA kernel produces NaN
+        # when reading weight tensors from certain CUDA unified memory
+        # addresses. Cloning forces fresh allocations at accessible addresses.
+        if torch.cuda.is_available() and torch.cuda.get_device_capability() == (12, 1):
+            logger.warning("GB10 workaround: cloning MoE weight tensors")
+            w13 = w13.clone()
+            w13_scale = w13_scale.clone()
+            if isinstance(w13_scale_2, torch.Tensor):
+                w13_scale_2 = w13_scale_2.clone()
+            w2 = w2.clone()
+            w2_scale = w2_scale.clone()
+            if isinstance(w2_scale_2, torch.Tensor):
+                w2_scale_2 = w2_scale_2.clone()
+
         replace_parameter(layer, "w13_weight", w13)
         replace_parameter(layer, "w13_weight_scale", w13_scale)
         replace_parameter(layer, "w2_weight", w2)


### PR DESCRIPTION
## Summary

On NVIDIA GB10 (SM121, CUDA 13.0, 119 GiB unified memory), Qwen3.5-NVFP4 models (35B and 122B) produce all-`!` output (token ID 0) with NaN logprobs. This PR adds a workaround that clones NVFP4 MoE weight tensors after format conversion on SM121 to prevent the Marlin kernel from producing NaN.

## Background

### Two issues on SM121

**Issue 1 — CUTLASS FP4 MoE produces all-zero output** (already fixed upstream in `oracle/nvfp4.py`):

Previously, a local note had incorrectly suppressed the `VLLM_TEST_FORCE_FP8_MARLIN` override for the NVFP4 MoE path with the comment:
> CUTLASS FP4 MoE IS supported on SM121 (Blackwell SM120 family), so we allow the auto-selection to choose it.

Testing showed that while CUTLASS FP4 MoE compiles and runs without error on SM121, it produces numerically incorrect all-zero output. The upstream fix correctly forces Marlin when `VLLM_TEST_FORCE_FP8_MARLIN=1`.

**Issue 2 — Marlin MoE produces NaN for certain weight allocations on SM121** (this PR):

Even with Marlin MoE selected, the kernel can produce NaN output when weight tensors reside at certain addresses in SM121's unified memory. After `convert_to_nvfp4_moe_kernel_format()`, tensors may be views or sub-allocations backed by mmap'd safetensors memory, which the Marlin CUDA kernel misreads on SM121's unified memory architecture.

### NaN propagation chain

```
Marlin GEMM2 reads NaN from weight memory
→ NaN topk_weights (softmax over NaN router logits)
→ GEMM2 x NaN topk_weights → NaN hidden_states
→ uniform logits → token 0 ("!")
```

### Evidence

```
# Without clone (broken):
GEMM1 (w13 gate/up): nan=False, mean=2.8e-01  OK
Activation (SiLU):   nan=False, mean=1.0e-02  OK
GEMM2 (w2 down):     nan=True,  mean=0.0e+00  BROKEN

# With clone (fixed):
GEMM1: nan=False  OK
GEMM2: nan=False  OK
Output: coherent text
```

## Fix

Clone all MoE weight tensors after `convert_to_nvfp4_moe_kernel_format()` on SM121, forcing new CUDA allocations at addresses the Marlin kernel can read correctly. The workaround is gated behind `torch.cuda.get_device_capability() == (12, 1)` so it only activates on SM121 devices.

## Test plan
- [x] Qwen3.5-35B-A3B-NVFP4 with vision enabled — correct text output
- [x] Qwen3.5-35B-A3B-NVFP4 with `--language-model-only` — correct text output
- [x] Qwen3.5-122B-A10B-NVFP4 with `--language-model-only` — correct output ("Paris" for "The capital of France is")
- [ ] No regression on non-SM121 GPUs (workaround is SM121-gated)