### PR TITLE
[Bugfix] Filter None compilation times in Executor

### DIFF
--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -120,6 +120,7 @@ class Executor(ABC):
         # With TP>1, compilation happens in worker processes, so the main
         # process config is never updated. Use max across workers since they
         # compile in parallel.
+        compilation_times = [t for t in compilation_times if t is not None]
         if compilation_times:
             self.vllm_config.compilation_config.compilation_time = max(
                 compilation_times


### PR DESCRIPTION
## Purpose

When workers return `None` for `compilation_time` (e.g. when compilation is skipped), `max()` on the collected results raises a `TypeError`. This filters out `None` values before computing the maximum.

## Test Plan

- Verified that `max()` no longer raises when `compilation_times` contains `None` values.
- Existing CI tests cover the normal (non-None) path.

## Test Result

No regression — the fix is a single-line defensive filter.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.
</details>