### PR TITLE
[BugFix] Ensure contiguous input tensor in LoRA shrink kernel

### DIFF
--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -109,7 +109,7 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             scale (float): Scaling factor for the operation
         """
 
-        x = x.view(-1, x.shape[-1])
+        x = x.view(-1, x.shape[-1]).contiguous()
         lora_shrink(
             x,
             lora_a_stacked,


### PR DESCRIPTION
## Purpose

Bug Description
When running a model with multiple LoRA adapters in `--enforce-eager` mode, the LoRA shrink triton kernel fails with an assertion error: `assert inputs.is_contiguous()`

How to fix
Add `.contiguous()` in `PunicaWrapperGPU.add_shrink()` to guarantee contiguity 

## Test Plan

How to reproduce:

start server with lora in eager mode
```
vllm serve openai/gpt-oss-120b \
  --no-enable-prefix-caching \
  --port 8030 \
  --enable-lora \
  --max-loras 8 \
  --lora-modules \
    lora1="$LORAPATH" \
    lora2="$LORAPATH" \
    lora3="$LORAPATH" \
    lora4="$LORAPATH" \
    lora5="$LORAPATH" \
    lora6="$LORAPATH" \
    lora7="$LORAPATH" \
    lora8="$LORAPATH" \
  --max-lora-rank 32 \
  --enable-chunked-prefill \
  --max-model-len 131072 \
  --tensor-parallel-size 1 \
  --max_num_seqs 8 \
  --enforce-eager
```
then benchmark with

```
vllm bench serve \
  --model openai/gpt-oss-120b \
  --dataset-name sonnet \
  --dataset-path ./benchmarks/sonnet.txt \
  --input-len 1600 \
  --output-len 600 \
  --port 8030 \
  --num-prompts 200 \
  --max-concurrency 8 \
  --lora-modules lora1 lora2 lora3 lora4 lora5 lora6 lora7 lora8
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

