### PR TITLE
fix(qwen3.5): prevent false gate_proj match from dropping MoE router gate weights

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -485,6 +485,11 @@ class Qwen3_5Model(Qwen3NextModel):
                 if weight_name not in name:
                     continue
 
+                # MoE router gate is a plain nn.Linear; skip the stacked parameter
+                # path and load it via the default path below.
+                if "mlp.gate." in name:
+                    continue
+
                 if "mlp.experts" in name:
                     continue
 


### PR DESCRIPTION
## Summary

`Qwen3_5Model.load_weights()` has a guard to prevent `mlp.experts` weights from going through the `stacked_params` path. That guard was placed at the top level of the loop, before the stacked-param check, with a `continue` that skipped **all** further processing:

```python
# BEFORE (buggy) — gate weights never loaded
if "mlp.gate.weight" in name or "mlp.gate.bias" in name:
    continue  # ← skips the entire weight, including normal loading below
```

The intent was to prevent the `"gate_proj"` entry in `stacked_params_mapping` from matching `"mlp.gate.weight"` via substring (since `"gate"` appears in both). But the placement caused the MoE router gate (`mlp.gate`, a plain `nn.Linear`) to be silently dropped — never loaded from the checkpoint.

## Fix

Move the guard **inside** the stacked-params loop, so `mlp.gate.weight` skips only the stacked-param path and falls through to normal weight loading:

```python
# AFTER (fixed) — gate weights skip stacked path, load normally
for param_name, weight_name, shard_id in stacked_params_mapping:
    if weight_name not in name:
        continue

    # Prevent false match: "gate_proj" substring matches "mlp.gate.weight".
    # MoE router gate is a plain nn.Linear — load it via the default path below.
    if "mlp.gate.weight" in name or "mlp.gate.bias" in name:
        continue
    ...
```

## Impact

Without this fix, all 40–48 MoE router gate weight matrices are left uninitialized (zeros or NaN). This causes:

- `router_logits` → all NaN/zero
- `topk_weights` → all NaN (from softmax over NaN logits)
- `GEMM2 × NaN topk_weights` → NaN MoE output
- NaN hidden states propagate through all layers
- Uniform logits → model outputs only token 0 (`"!"`) — the classic `"!!!!!"` symptom

Observed on `Qwen3.5-35B-A3B-NVFP4` and `Qwen3.5-122B-A10B-NVFP4` with `--language-model-only`. Both models produce correct output after this fix.

## Test plan

- [x] `Qwen3.5-35B-A3B-NVFP4` with `--language-model-only` — correct text output (no `"!!!!"`)
- [x] `Qwen3.5-122B-A10B-NVFP4` with `--language-model-only` — correct output (`"Paris"` for `"The capital of France is"`)
- [x] `Qwen3.5-35B-A3B-NVFP4` with vision enabled — unaffected
- [ ] Expert weights (`mlp.experts`) continue to use the stacked path (guard retained for experts)