### PR TITLE
[BugFix] avoid infinite loop with VLLM_PORT and get_open_ports_list

### DIFF
--- a/tests/utils_/test_network_utils.py
+++ b/tests/utils_/test_network_utils.py
@@ -7,6 +7,7 @@ import zmq
 
 from vllm.utils.network_utils import (
     get_open_port,
+    get_open_ports_list,
     get_tcp_uri,
     join_host_port,
     make_zmq_path,
@@ -26,6 +27,25 @@ def test_get_open_port(monkeypatch: pytest.MonkeyPatch):
                 s2.bind(("localhost", get_open_port()))
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s3:
                     s3.bind(("localhost", get_open_port()))
+
+
+def test_get_open_ports_list_with_vllm_port(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_PORT", "5678")
+        ports = get_open_ports_list(5)
+        assert len(ports) == 5
+        assert len(set(ports)) == 5, "ports must be unique"
+
+        # verify every port is actually bindable
+        sockets = []
+        try:
+            for p in ports:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.bind(("localhost", p))
+                sockets.append(s)
+        finally:
+            for s in sockets:
+                s.close()
 
 
 @pytest.mark.parametrize(

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -167,16 +167,34 @@ def get_open_port() -> int:
 
 
 def get_open_ports_list(count: int = 5) -> list[int]:
-    """Get a list of open ports."""
-    ports = set[int]()
-    while len(ports) < count:
-        ports.add(get_open_port())
-    return list(ports)
+    """Get a list of unique open ports.
+
+    When VLLM_PORT is set, scans upward from that port, advancing
+    the start position after each find so every port is unique.
+    """
+    ports_set = set[int]()
+    if envs.VLLM_PORT is not None:
+        next_port = envs.VLLM_PORT
+        for _ in range(count):
+            port = _get_open_port(start_port=next_port, max_attempts=1000)
+            ports_set.add(port)
+            next_port = port + 1
+        return list(ports_set)
+    else:
+        while len(ports_set) < count:
+            ports_set.add(get_open_port())
+
+    return list(ports_set)
 
 
-def _get_open_port() -> int:
-    port = envs.VLLM_PORT
+def _get_open_port(
+    start_port: int | None = None,
+    max_attempts: int | None = None,
+) -> int:
+    start_port = start_port if start_port is not None else envs.VLLM_PORT
+    port = start_port
     if port is not None:
+        attempts = 0
         while True:
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -185,6 +203,12 @@ def _get_open_port() -> int:
             except OSError:
                 port += 1  # Increment port number if already in use
                 logger.info("Port %d is already in use, trying port %d", port - 1, port)
+            attempts += 1
+            if max_attempts is not None and attempts >= max_attempts:
+                raise RuntimeError(
+                    f"Could not find open port after {max_attempts} "
+                    f"attempts starting from port {start_port}"
+                )
     # try ipv4
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:


### PR DESCRIPTION
## Purpose
When `VLLM_PORT` is set and the specified port is in use, `_get_open_port()` always starts scanning from the same base port and returns the same next-available port on every call. This causes `get_open_ports_list()` to loop infinitely, since it collects ports into a set that never grows beyond one element, silently hanging some workflows (like DP) on startup.

The fix is to give `_get_open_port()` a flexible starting port to `get_open_ports_list()` can increment the starting port.

## Test Plan

Added a new `test_get_open_ports_list_with_vllm_port` to `tests/utils_/test_network_utils.py`. This loops endlessly without the fix 

## Test Result

`test_get_open_ports_list_with_vllm_port` passes ✅ 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

