### PR TITLE
[Security] Respect user trust_remote_code setting in NemotronVL and KimiK25

### DIFF
--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -174,7 +174,8 @@ class KimiK25ProcessingInfo(BaseProcessingInfo):
         self.hf_config = self.get_hf_config()
         self.media_token_id = self.hf_config.media_placeholder_token_id
         media_processor = cached_get_image_processor(
-            self.ctx.model_config.model, trust_remote_code=True
+            self.ctx.model_config.model,
+            trust_remote_code=self.ctx.model_config.trust_remote_code,
         )
         self.media_processor = media_processor
         self.hf_processor = MoonshotKimiVAutoProcessor(

--- a/vllm/model_executor/models/nemotron_vl.py
+++ b/vllm/model_executor/models/nemotron_vl.py
@@ -402,6 +402,7 @@ class LlamaNemotronVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, Suppor
         multimodal_config = vllm_config.model_config.multimodal_config
 
         self.config = config
+        self.model_config = vllm_config.model_config
         self.multimodal_config = multimodal_config
         self._patch_quant_config(config, quant_config)
 
@@ -456,7 +457,10 @@ class LlamaNemotronVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, Suppor
         *,
         prefix: str,
     ):
-        return AutoModel.from_config(config.vision_config, trust_remote_code=True)
+        return AutoModel.from_config(
+            config.vision_config,
+            trust_remote_code=self.model_config.trust_remote_code,
+        )
 
     def _init_mlp1(
         self,


### PR DESCRIPTION
Replace hardcoded trust_remote_code=True with the user's configured
trust_remote_code setting from model_config in both nemotron_vl.py and
kimi_k25.py. This prevents bypassing the user's explicit
--trust-remote-code=False security opt-out when loading sub-components.

GHSA-7972-pg2x-xr59

Signed-off-by: Russell Bryant <rbryant@redhat.com>
