### PR TITLE
Fix multi-node WorkerProc init ordering and compilation_time None

### DIFF
--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -120,6 +120,7 @@ class Executor(ABC):
         # With TP>1, compilation happens in worker processes, so the main
         # process config is never updated. Use max across workers since they
         # compile in parallel.
+        compilation_times = [t for t in compilation_times if t is not None]
         if compilation_times:
             self.vllm_config.compilation_config.compilation_time = max(
                 compilation_times

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -608,7 +608,6 @@ class WorkerProc:
         )
 
         # Load model
-        self._init_message_queues(input_shm_handle, vllm_config)
         is_eep_new_worker = envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH
         if not is_eep_new_worker:
             self.worker.init_device()
@@ -616,6 +615,8 @@ class WorkerProc:
             self.setup_proc_title_and_log_prefix(
                 enable_ep=vllm_config.parallel_config.enable_expert_parallel
             )
+        self._init_message_queues(input_shm_handle, vllm_config)
+        if not is_eep_new_worker:
             self.worker.load_model()
 
         # Enable environment variable cache (e.g. assume no more


### PR DESCRIPTION
Summary:
#34861  moved `init_device()` after `_init_message_queues()` which breaks the multi-node TP as  `_init_message_queues` needs `_INNER_DP_WORLD` which is set in `init_device()`. This swaps the order back.

#35503 also added `max(compilation_times)` but remote workers return None in multi-node, and this filters them out.

Test Plan: OSS

Differential Revision: D95475427


