### PR TITLE
[CI] Fix bge-m3 similarity reference values after *Defination* typo fix

### DIFF
--- a/tests/models/language/pooling/test_bge_m3.py
+++ b/tests/models/language/pooling/test_bge_m3.py
@@ -22,7 +22,7 @@ sentences_2 = [
     "of documents based on the query terms appearing in each document",
 ]
 
-similarity_reference = [[0.6265, 0.3477], [0.3499, 0.678]]
+similarity_reference = [[0.6259, 0.3474], [0.3309, 0.6734]]
 lexical_score_reference = [0.19554901123046875, 0.0]
 colbert_score_reference = [0.7797, 0.4620]
 


### PR DESCRIPTION
PR #34934 fixed the typo `"Defination of BM25"` to `"Definition of BM25"` in the bge-m3 test inputs but did not update the hardcoded similarity reference values, which were computed against the old misspelled input. Since the embedding model produces different vectors for the corrected spelling, the `test_bge_m3_api_server_embedding` test now fails with a similarity mismatch.

## Fix

Updated `similarity_reference` to values that match the corrected input string, using the midpoint of observed outputs across AMD and NVIDIA hardware to maximize margin within the existing `rtol=0.01` tolerance.

## Related

Follow-up to #34934


cc @kenroche 