### PR TITLE
docs: fix speculative decoding wording typos

### DIFF
--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -71,8 +71,8 @@ For mitigation strategies, please refer to the FAQ entry *Can the output of a pr
 
 ## Known Feature Incompatibility
 
-1. Pipeline parallelism is not composible with speculative decoding as of `vllm<=0.15.0`
-2. Speculative decoding with a draft models is not supported in `vllm<=0.10.0`
+1. Pipeline parallelism is not composable with speculative decoding as of `vllm<=0.15.0`
+2. Speculative decoding with draft models is not supported in `vllm<=0.10.0`
 
 ## Resources for vLLM contributors
 


### PR DESCRIPTION
## Summary\n- fix typo `composible` -> `composable` in known incompatibilities\n- fix wording `a draft models` -> `draft models`\n\n## Testing\n- not applicable (docs-only change)