### PR TITLE
tests: assert missing video loader error message

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -43,8 +43,9 @@ def test_video_loader_registry():
     np.testing.assert_array_equal(output_2, FAKE_OUTPUT_2)
 
 
-def test_video_loader_type_doesnt_exist():
-    with pytest.raises(AssertionError):
+def test_video_loader_type_does_not_exist():
+    with pytest.raises(AssertionError,
+                       match="Extension class non_existing_video_loader not found"):
         VIDEO_LOADER_REGISTRY.load("non_existing_video_loader")
 
 


### PR DESCRIPTION
## Summary
- rename `test_video_loader_type_doesnt_exist` to `test_video_loader_type_does_not_exist`
- strengthen assertion by matching the explicit missing-extension error message

## Testing
- attempted: `pytest -q tests/multimodal/test_video.py -k "type_does_not_exist"`
- blocked locally by missing test dependencies (`numpy`) in this environment
