### PR TITLE
docs: clarify CPU backend issue reporting sentence

### DIFF
--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -22,7 +22,7 @@ vLLM is a Python library that supports the following CPU variants. Select your C
 
 The main discussions happen in the `#sig-cpu` channel of [vLLM Slack](https://slack.vllm.ai/).
 
-When open a Github issue about the CPU backend, please add `[CPU Backend]` in the title and it will be labeled with `cpu` for better awareness.
+When opening a GitHub issue about the CPU backend, please add `[CPU Backend]` in the title and it will be labeled with `cpu` for better awareness.
 
 ## Requirements
 


### PR DESCRIPTION
Docs fix in CPU backend installation page:\n- "When open a Github issue" -> "When opening a GitHub issue".