### PR TITLE
[UX] Infer dtype for local checkpoint

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -1116,7 +1116,7 @@ def get_safetensors_params_metadata(
     revision: str | None = None,
 ) -> dict[str, Any]:
     """
-    Get the safetensors metadata for remote model repository.
+    Get the safetensors parameters metadata for remote/local model repository.
     """
     full_metadata = {}
     if (model_path := Path(model)).exists():

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -18,7 +18,7 @@ from vllm.config.utils import getattr_iter
 from vllm.logger import init_logger
 from vllm.transformers_utils.config import (
     ConfigFormat,
-    try_get_safetensors_metadata,
+    get_safetensors_params_metadata,
 )
 from vllm.utils.torch_utils import common_broadcastable_dtype
 
@@ -165,14 +165,14 @@ class ModelArchConfigConvertorBase:
         # Try to read the dtype of the weights if they are in safetensors format
         if config_dtype is None:
             with _maybe_patch_hf_hub_constants(config_format):
-                repo_mt = try_get_safetensors_metadata(model_id, revision=revision)
+                param_mt = get_safetensors_params_metadata(model_id, revision=revision)
 
-            if repo_mt and (files_mt := repo_mt.files_metadata):
+            if param_mt:
                 param_dtypes: set[torch.dtype] = {
-                    _SAFETENSORS_TO_TORCH_DTYPE[dtype_str]
-                    for file_mt in files_mt.values()
-                    for dtype_str in file_mt.parameter_count
-                    if dtype_str in _SAFETENSORS_TO_TORCH_DTYPE
+                    _SAFETENSORS_TO_TORCH_DTYPE[dtype]
+                    for info in param_mt.values()
+                    if (dtype := info.get("dtype", None))
+                    and _SAFETENSORS_TO_TORCH_DTYPE[dtype]
                 }
 
                 if param_dtypes:

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -172,7 +172,6 @@ class ModelArchConfigConvertorBase:
                     _SAFETENSORS_TO_TORCH_DTYPE[dtype]
                     for info in param_mt.values()
                     if (dtype := info.get("dtype", None))
-                    and _SAFETENSORS_TO_TORCH_DTYPE[dtype]
                 }
 
                 if param_dtypes:

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -172,6 +172,7 @@ class ModelArchConfigConvertorBase:
                     _SAFETENSORS_TO_TORCH_DTYPE[dtype]
                     for info in param_mt.values()
                     if (dtype := info.get("dtype", None))
+                    and dtype in _SAFETENSORS_TO_TORCH_DTYPE
                 }
 
                 if param_dtypes:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- `try_get_safetensors_metadata` only works for remote repo, and will cause error message for local repo.
- Avoid error messages when loading from local checkpoint:
```
(APIServer pid=73627) ERROR 03-06 14:34:05 [repo_utils.py:47] Error retrieving safetensors: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/mnt/data0/LLM/Qwen3-ASR-0.6B/'. Use `repo_type` argument if needed., retrying 1 of 2
(APIServer pid=73627) ERROR 03-06 14:34:07 [repo_utils.py:45] Error retrieving safetensors: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/mnt/data0/LLM/Qwen3-ASR-0.6B/'. Use `repo_type` argument if needed.
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

