### PR TITLE
[Build] Fix API rate limit exceeded when using `VLLM_USE_PRECOMPILED=1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -662,7 +662,7 @@ class precompiled_wheel_utils:
                 "-s",
                 "https://api.github.com/repos/vllm-project/vllm/commits/main",
             ]
-            github_token = os.environ.get("GITHUB_TOKEN")
+            github_token = os.getenv("GH_TOKEN", os.getenv("GITHUB_TOKEN"))
             if github_token:
                 curl_cmd += [
                     "-H",

--- a/setup.py
+++ b/setup.py
@@ -657,13 +657,18 @@ class precompiled_wheel_utils:
     def get_base_commit_in_main_branch() -> str:
         try:
             # Get the latest commit hash of the upstream main branch.
-            resp_json = subprocess.check_output(
-                [
-                    "curl",
-                    "-s",
-                    "https://api.github.com/repos/vllm-project/vllm/commits/main",
+            curl_cmd = [
+                "curl",
+                "-s",
+                "https://api.github.com/repos/vllm-project/vllm/commits/main",
+            ]
+            github_token = os.environ.get("GITHUB_TOKEN")
+            if github_token:
+                curl_cmd += [
+                    "-H",
+                    f"Authorization: token {github_token}",
                 ]
-            ).decode("utf-8")
+            resp_json = subprocess.check_output(curl_cmd).decode("utf-8")
             upstream_main_commit = json.loads(resp_json)["sha"]
             print(f"Upstream main branch latest commit: {upstream_main_commit}")
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Current code use `curl -s https://api.github.com/repos/vllm-project/vllm/commits/main` to get the latest commit from upstream. We found sometimes it just returned an API rate limitation message:
```
{"message":"API rate limit exceeded for <IP>. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```
From the installation log, it will fall back to use nightly wheel:
```
DEBUG   cpu = _conversion_method_template(device=torch.device("cpu"))
DEBUG Failed to get the base commit in the main branch. Using the nightly wheel. The libraries in this wheel may not be compatible with your dev branch: 'sha'
DEBUG /workspace/.cache/uv/builds-v0/.tmpKeTXhU/lib/python3.12/site-packages/setuptools_scm/_integration/version_inference.py:51: UserWarning: version of None already set
DEBUG   warnings.warn(self.message)
DEBUG Detected CUDA 13.0, using variant cu130
DEBUG VLLM_PRECOMPILED_WHEEL_COMMIT not valid: , trying to fetch base commit in main branch
DEBUG Using precompiled wheel commit nightly with variant cu130
DEBUG Trying to fetch nightly build metadata from https://wheels.vllm.ai/nightly/cu130/vllm/metadata.json
DEBUG Found precompiled wheel metadata: {'package_name': 'vllm', 'version': '0.17.0rc1.dev104+g27066d1b2', 'build_tag': None, 'python_tag': 'cp38', 'abi_tag': 'abi3', 'platform_tag': 'manylinux_2_35_x86_64', 'variant': 'cu130', 'filename': 'vllm-0.17.0rc1.dev104+g27066d1b2.cu130-cp38-abi3-manylinux_2_35_x86_64.whl', 'path': '../../../27066d1b2bd0dea89d617afa24da611d9a32e36a/vllm-0.17.0rc1.dev104%2Bg27066d1b2.cu130-cp38-abi3-manylinux_2_35_x86_64.whl'}
DEBUG Using precompiled wheel URL: https://wheels.vllm.ai/27066d1b2bd0dea89d617afa24da611d9a32e36a/vllm-0.17.0rc1.dev104%2Bg27066d1b2.cu130-cp38-abi3-manylinux_2_35_x86_64.whl
DEBUG Downloading wheel from https://wheels.vllm.ai/27066d1b2bd0dea89d617afa24da611d9a32e36a/vllm-0.17.0rc1.dev104%2Bg27066d1b2.cu130-cp38-abi3-manylinux_2_35_x86_64.whl to /tmp/vllm-wheels4dq9l0sj/vllm-0.17.0rc1.dev104+g27066d1b2.cu130-cp38-abi3-manylinux_2_35_x86_64.whl
```

This PR added `-H "Authorization: token ${GITHUB_TOKEN}"` to the `curl` to resolve this issue. The installation log:
```
DEBUG   cpu = _conversion_method_template(device=torch.device("cpu"))
DEBUG /workspace/.cache/uv/builds-v0/.tmpaLwvxd/lib/python3.12/site-packages/setuptools_scm/_integration/version_inference.py:51: UserWarning: version of None already set
DEBUG   warnings.warn(self.message)
DEBUG Detected CUDA 13.0, using variant cu130
DEBUG VLLM_PRECOMPILED_WHEEL_COMMIT not valid: , trying to fetch base commit in main branch
DEBUG Upstream main branch latest commit: 807d6803376ff8610efbf9da23f772a5dbd7b5ea
DEBUG Using precompiled wheel commit a1ffa56a1e6b644a176c0546053dae01f1823a61 with variant cu130
DEBUG Trying to fetch nightly build metadata from https://wheels.vllm.ai/a1ffa56a1e6b644a176c0546053dae01f1823a61/cu130/vllm/metadata.json
DEBUG Found precompiled wheel metadata: {'package_name': 'vllm', 'version': '0.17.0rc1.dev101+ga1ffa56a1', 'build_tag': None, 'python_tag': 'cp38', 'abi_tag': 'abi3', 'platform_tag': 'manylinux_2_35_x86_64', 'variant': 'cu130', 'filename': 'vllm-0.17.0rc1.dev101+ga1ffa56a1.cu130-cp38-abi3-manylinux_2_35_x86_64.whl', 'path': '../../../a1ffa56a1e6b644a176c0546053dae01f1823a61/vllm-0.17.0rc1.dev101%2Bga1ffa56a1.cu130-cp38-abi3-manylinux_2_35_x86_64.whl'}
DEBUG Using precompiled wheel URL: https://wheels.vllm.ai/a1ffa56a1e6b644a176c0546053dae01f1823a61/vllm-0.17.0rc1.dev101%2Bga1ffa56a1.cu130-cp38-abi3-manylinux_2_35_x86_64.whl
DEBUG Downloading wheel from https://wheels.vllm.ai/a1ffa56a1e6b644a176c0546053dae01f1823a61/vllm-0.17.0rc1.dev101%2Bga1ffa56a1.cu130-cp38-abi3-manylinux_2_35_x86_64.whl to /tmp/vllm-wheelslfqvyfpm/vllm-0.17.0rc1.dev101+ga1ffa56a1.cu130-cp38-abi3-manylinux_2_35_x86_64.whl
```


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

