### PR TITLE
[CI] Fix startup error test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ fo = "fo"
 nd = "nd"
 eles = "eles"
 datas = "datas"
+ure = "ure"
 
 [tool.uv]
 no-build-isolation-package = ["torch"]

--- a/tests/v1/shutdown/test_startup_error.py
+++ b/tests/v1/shutdown/test_startup_error.py
@@ -68,7 +68,7 @@ def test_async_llm_startup_error(
     )
 
     # Confirm we get an exception.
-    with pytest.raises(Exception, match="initialization failed"):
+    with pytest.raises(Exception, match=r"initialization fail(ed|ure)"):
         _ = AsyncLLM.from_engine_args(engine_args)
 
     # Confirm all the processes are cleaned up.
@@ -111,7 +111,7 @@ def test_llm_startup_error(
 
         with pytest.raises(
             Exception,
-            match="initialization failed"
+            match=r"initialization fail(ed|ure)"
             if enable_multiprocessing
             else "Simulated Error in startup!",
         ):


### PR DESCRIPTION
I first saw this in https://buildkite.com/vllm/ci/builds/54873/steps/canvas?sid=019cc1cc-1104-4b2d-933f-08b59b9772f4&tab=output and was able to reproduce it on `main`, so here is a PR to make this check a bit more flexible.