### PR TITLE
docs+tests: consolidate doc fixes and test assertion

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -183,7 +183,7 @@ There is a [GitHub CI workflow](https://github.com/pytorch/pytorch-integration-t
 
 ### How It Works
 
-The workflow currently runs weekly profiling sessions for selected models, generating detailed performance traces that can be analyzed using different tools to identify performance regressions or optimization opportunities. But, it can be triggered manually as well, using the Github Action tool.
+The workflow currently runs weekly profiling sessions for selected models, generating detailed performance traces that can be analyzed using different tools to identify performance regressions or optimization opportunities. But, it can be triggered manually as well, using the GitHub Actions tool.
 
 ### Adding New Models
 

--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -71,8 +71,8 @@ For mitigation strategies, please refer to the FAQ entry *Can the output of a pr
 
 ## Known Feature Incompatibility
 
-1. Pipeline parallelism is not composible with speculative decoding as of `vllm<=0.15.0`
-2. Speculative decoding with a draft models is not supported in `vllm<=0.10.0`
+1. Pipeline parallelism is not composable with speculative decoding as of `vllm<=0.15.0`
+2. Speculative decoding with draft models is not supported in `vllm<=0.10.0`
 
 ## Resources for vLLM contributors
 

--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -22,7 +22,7 @@ vLLM is a Python library that supports the following CPU variants. Select your C
 
 The main discussions happen in the `#sig-cpu` channel of [vLLM Slack](https://slack.vllm.ai/).
 
-When open a Github issue about the CPU backend, please add `[CPU Backend]` in the title and it will be labeled with `cpu` for better awareness.
+When opening a GitHub issue about the CPU backend, please add `[CPU Backend]` in the title and it will be labeled with `cpu` for better awareness.
 
 ## Requirements
 

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -43,8 +43,9 @@ def test_video_loader_registry():
     np.testing.assert_array_equal(output_2, FAKE_OUTPUT_2)
 
 
-def test_video_loader_type_doesnt_exist():
-    with pytest.raises(AssertionError):
+def test_video_loader_type_does_not_exist():
+    with pytest.raises(AssertionError,
+                       match="Extension class non_existing_video_loader not found"):
         VIDEO_LOADER_REGISTRY.load("non_existing_video_loader")
 
 


### PR DESCRIPTION
Consolidated PR per @DarkLight1337's request to reduce CI workload. Combines:

- `docs:` fix speculative decoding wording typos
- `docs:` capitalize GitHub Actions in profiling guide
- `docs:` fix grammar in CPU backend issue reporting sentence
- `tests:` assert missing video loader error message

Supersedes #36211, #36212, #36213, #36214.