### PR TITLE
[kernel] Fix FP8 paged MQA fallback for CUDA graph capture

### DIFF
--- a/tests/kernels/attention/test_deepgemm_attention.py
+++ b/tests/kernels/attention/test_deepgemm_attention.py
@@ -450,8 +450,43 @@ def test_fp8_paged_mqa_logits_torch_cuda_graph_capture():
             max_model_len,
         )
 
+    # Update inputs in-place after capture and verify replay uses the new values.
+    q_new = torch.randn_like(q)
+    kv_cache_new = torch.randn_like(kv_cache)
+    weights_new = torch.randn_like(weights)
+    context_lens_new = torch.tensor([41, 71], device="cuda", dtype=torch.int32)
+    block_tables_new = torch.zeros_like(block_tables)
+
+    next_block = 0
+    for i, ctx_len in enumerate(context_lens_new.tolist()):
+        num_ctx_blocks = cdiv(ctx_len, blocksize)
+        block_tables_new[i, :num_ctx_blocks] = torch.tensor(
+            list(range(next_block, next_block + num_ctx_blocks)),
+            device="cuda",
+            dtype=torch.int32,
+        )
+        next_block += num_ctx_blocks
+
+    q_fp8.copy_(q_new.to(torch.float8_e4m3fn))
+    kv_cache_fp8.copy_(kv_cache_cast_to_fp8(kv_cache_new))
+    weights.copy_(weights_new)
+    context_lens.copy_(context_lens_new)
+    block_tables.copy_(block_tables_new)
+
+    expected_updated = fp8_paged_mqa_logits_torch(
+        q_fp8,
+        kv_cache_fp8,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+    )
+
     logits.zero_()
     graph.replay()
     torch.accelerator.synchronize()
 
-    torch.testing.assert_close(logits, expected, equal_nan=True)
+    torch.testing.assert_close(logits, expected_updated, equal_nan=True)
+
+    # Sanity check: output changed after replacing inputs.
+    assert not torch.allclose(expected, expected_updated, equal_nan=True)

--- a/tests/kernels/attention/test_deepgemm_attention.py
+++ b/tests/kernels/attention/test_deepgemm_attention.py
@@ -11,6 +11,7 @@ from vllm.utils.deep_gemm import (
     calc_diff,
     fp8_mqa_logits,
     fp8_paged_mqa_logits,
+    fp8_paged_mqa_logits_torch,
     get_num_sms,
     get_paged_mqa_logits_metadata,
 )
@@ -205,6 +206,89 @@ def _ref_fp8_paged_mqa_logits(
 @pytest.mark.skipif(
     not current_platform.has_device_capability(90), reason="SM90 and SM100 only"
 )
+def test_fp8_paged_mqa_logits_torch_matches_deepgemm():
+    torch.manual_seed(0)
+    random.seed(0)
+
+    max_model_len = 4096
+    num_blocks, blocksize = max_model_len * 2, 64
+    batch_size, next_n = 3, 2
+    heads, index_dim = 32, 128
+
+    q = torch.randn(
+        (batch_size, next_n, heads, index_dim),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    kv_cache = torch.randn(
+        (num_blocks, blocksize, 1, index_dim),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    weights = torch.randn(
+        (batch_size * next_n, heads),
+        device="cuda",
+        dtype=torch.float32,
+    )
+    context_lens = torch.tensor([1537, 2049, 3073], device="cuda", dtype=torch.int32)
+    max_block_len = cdiv(int(context_lens.max().item()), blocksize)
+    block_tables = torch.zeros(
+        (batch_size, max_block_len),
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    block_idx_pool = list(range(num_blocks))
+    random.shuffle(block_idx_pool)
+    counter = 0
+    for i, ctx_len in enumerate(context_lens.tolist()):
+        for j in range(cdiv(ctx_len, blocksize)):
+            block_tables[i, j] = block_idx_pool[counter]
+            counter += 1
+
+    q_fp8 = q.to(torch.float8_e4m3fn)
+    kv_cache_fp8 = kv_cache_cast_to_fp8(kv_cache)
+    schedule_metadata = get_paged_mqa_logits_metadata(
+        context_lens, blocksize, get_num_sms()
+    )
+
+    fallback_logits = fp8_paged_mqa_logits_torch(
+        q_fp8,
+        kv_cache_fp8,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+    )
+    deepgemm_logits = fp8_paged_mqa_logits(
+        q_fp8,
+        kv_cache_fp8,
+        weights,
+        context_lens,
+        block_tables,
+        schedule_metadata,
+        max_model_len,
+        clean_logits=True,
+    )
+
+    positions = torch.arange(max_model_len, device="cuda").unsqueeze(0)
+    row_indices = torch.arange(batch_size * next_n, device="cuda") // next_n
+    next_n_offset = torch.arange(batch_size * next_n, device="cuda") % next_n
+    valid_mask = positions <= (
+        context_lens[row_indices] - next_n + next_n_offset
+    ).unsqueeze(1)
+
+    fallback_logits = fallback_logits.masked_fill(~valid_mask, 0)
+    deepgemm_logits = deepgemm_logits.masked_fill(~valid_mask, 0)
+    diff = calc_diff(fallback_logits, deepgemm_logits)
+    assert diff < 1e-3, f"{diff=}"
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA only")
+@pytest.mark.skipif(not has_deep_gemm(), reason="DeepGEMM not available")
+@pytest.mark.skipif(
+    not current_platform.has_device_capability(90), reason="SM90 and SM100 only"
+)
 @pytest.mark.parametrize("clean_logits", [True, False])
 def test_deepgemm_fp8_paged_mqa_logits(clean_logits: bool):
     torch.manual_seed(0)
@@ -298,3 +382,76 @@ def test_deepgemm_fp8_paged_mqa_logits(clean_logits: bool):
                 ref_logits = ref_logits.masked_fill(~mask, 0)
                 diff = calc_diff(logits, ref_logits)
                 assert diff < 1e-3, f"{diff=}"
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA only")
+def test_fp8_paged_mqa_logits_torch_cuda_graph_capture():
+    torch.manual_seed(0)
+    random.seed(0)
+
+    batch_size, next_n = 2, 2
+    heads, index_dim = 4, 16
+    max_model_len, blocksize = 128, 16
+    num_blocks = 32
+
+    q = torch.randn(
+        (batch_size, next_n, heads, index_dim),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    kv_cache = torch.randn(
+        (num_blocks, blocksize, 1, index_dim),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    weights = torch.randn(
+        (batch_size * next_n, heads),
+        device="cuda",
+        dtype=torch.float32,
+    )
+    context_lens = torch.tensor([33, 58], device="cuda", dtype=torch.int32)
+    block_tables = torch.zeros(
+        (batch_size, cdiv(max_model_len, blocksize)),
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    next_block = 0
+    for i, ctx_len in enumerate(context_lens.tolist()):
+        num_ctx_blocks = cdiv(ctx_len, blocksize)
+        block_tables[i, :num_ctx_blocks] = torch.tensor(
+            list(range(next_block, next_block + num_ctx_blocks)),
+            device="cuda",
+            dtype=torch.int32,
+        )
+        next_block += num_ctx_blocks
+
+    q_fp8 = q.to(torch.float8_e4m3fn)
+    kv_cache_fp8 = kv_cache_cast_to_fp8(kv_cache)
+
+    expected = fp8_paged_mqa_logits_torch(
+        q_fp8,
+        kv_cache_fp8,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+    )
+    torch.accelerator.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        logits = fp8_paged_mqa_logits_torch(
+            q_fp8,
+            kv_cache_fp8,
+            weights,
+            context_lens,
+            block_tables,
+            max_model_len,
+        )
+
+    logits.zero_()
+    graph.replay()
+    torch.accelerator.synchronize()
+
+    torch.testing.assert_close(logits, expected, equal_nan=True)

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -464,7 +464,7 @@ def fp8_mqa_logits_torch(
     return logits
 
 
-def fp8_paged_mqa_logits_torch(
+def _fp8_paged_mqa_logits_torch_impl(
     q: torch.Tensor,
     kv_cache: torch.Tensor,
     weights: torch.Tensor,
@@ -495,96 +495,89 @@ def fp8_paged_mqa_logits_torch(
     """
     fp8_dtype = current_platform.fp8_dtype()
     batch_size, next_n, heads, dim = q.size()
-    num_blocks, block_size, _, packed_dim = kv_cache.size()
-    assert packed_dim == dim + 4, (
-        f"Expected packed KV cache last dim {dim + 4}, got {packed_dim}"
-    )
-
-    # Match DeepGEMM's packed layout:
-    # [block0 token bytes..., block0 scale bytes..., block1 ...]
-    kv_cache_flat = kv_cache.view(num_blocks, block_size * packed_dim)
-    kv_bytes = kv_cache_flat[:, : block_size * dim].view(num_blocks, block_size, 1, dim)
-    scale_bytes = kv_cache_flat[:, block_size * dim :].view(
-        num_blocks, block_size, 1, 4
-    )
-    scale = scale_bytes.contiguous().view(torch.float)
+    kv_cache, scale = kv_cache[..., :dim], kv_cache[..., dim:]
+    scale = scale.contiguous().view(torch.float)
     q = q.float()
-    kv_cache = kv_bytes.view(fp8_dtype).float() * scale
+    kv_cache = kv_cache.view(fp8_dtype).float() * scale
+    num_blocks, block_size, _, dim = kv_cache.size()
     logits = torch.full(
         [batch_size * next_n, max_model_len],
         float("-inf"),
         device=q.device,
         dtype=torch.float32,
     )
-    # Keep a single cudagraph-safe implementation. This avoids host sync
-    # (`.item()` / `.tolist()`) and prevents full decode capture from falling
-    # back to a Python loop over requests and blocks.
-    max_blocks = min(block_tables.shape[1], cdiv(max_model_len, block_size))
-    if max_blocks == 0:
-        return logits
-
-    blocks_per_chunk = 8
-    decode_offsets = torch.arange(next_n, device=q.device, dtype=context_lens.dtype)
-    block_offsets = torch.arange(block_size, device=q.device, dtype=context_lens.dtype)
-    num_context_blocks = torch.div(
-        context_lens + block_size - 1,
-        block_size,
-        rounding_mode="floor",
-    )
-    q_offsets = context_lens[:, None] - next_n + decode_offsets[None, :]
-    weight_slice = weights.view(batch_size, next_n, heads).permute(0, 2, 1).contiguous()
-    block_ids = block_tables[:, :max_blocks].clamp(min=0).to(torch.int64)
-    logits_view = logits.view(batch_size, next_n, max_model_len)
-
-    for block_start in range(0, max_blocks, blocks_per_chunk):
-        block_end = min(block_start + blocks_per_chunk, max_blocks)
-        chunk_blocks = block_end - block_start
-
-        k_chunk = kv_cache.index_select(
-            0, block_ids[:, block_start:block_end].reshape(-1)
+    for i in range(batch_size):
+        context_len = context_lens[i].item()
+        q_offsets = torch.arange(context_len - next_n, context_len, device=q.device)
+        weight_slice = (
+            weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
         )
-        k_chunk = k_chunk.squeeze(-2).view(batch_size, chunk_blocks, block_size, dim)
-
-        # [B, next_n, H, D] x [B, chunk_blocks, block_size, D]
-        # -> [B, H, next_n, chunk_blocks, block_size]
-        s = torch.einsum("bnhd,bmtd->bhnmt", q, k_chunk).to(logits.dtype)
-        s = torch.relu(s) * weight_slice[..., None, None]
-        s = s.sum(dim=1)
-
-        k_offsets = (
-            torch.arange(
-                block_start,
-                block_end,
-                device=q.device,
-                dtype=context_lens.dtype,
-            )[:, None]
-            * block_size
-            + block_offsets[None, :]
-        )
-        flat_offsets = k_offsets.reshape(-1)
-        valid_cols = flat_offsets < max_model_len
-        valid_blocks = (
-            torch.arange(
-                block_start,
-                block_end,
-                device=q.device,
-                dtype=context_lens.dtype,
-            )[None, :]
-            < num_context_blocks[:, None]
-        )
-        causal_mask = (
-            k_offsets[None, None, :, :] <= q_offsets[:, :, None, None]
-        ) & valid_blocks[:, None, :, None]
-        col_start = block_start * block_size
-        col_end = min(block_end * block_size, max_model_len)
-        if col_end - col_start < chunk_blocks * block_size:
-            causal_mask = causal_mask & valid_cols.view(1, 1, chunk_blocks, -1)
-
-        s = torch.where(causal_mask, s, float("-inf"))
-        logits_view[:, :, col_start:col_end] = s.reshape(batch_size, next_n, -1)[
-            :, :, : col_end - col_start
-        ]
+        for block_idx in range(cdiv(context_len, block_size)):
+            block_id = block_tables[i][block_idx]
+            qx, kx = q[i], kv_cache[block_id]
+            k_offsets = torch.arange(
+                block_idx * block_size, (block_idx + 1) * block_size, device=q.device
+            )
+            mask = (k_offsets[None, :] < context_len) & (
+                k_offsets[None, :] <= q_offsets[:, None]
+            )
+            s = torch.where(
+                mask[None, :, :],
+                (qx.transpose(0, 1) @ kx.transpose(0, 1).transpose(1, 2)).to(
+                    logits.dtype
+                ),
+                float("-inf"),
+            )
+            s = torch.relu(s) * weight_slice[..., None]
+            s = s.sum(dim=0)
+            logits[
+                i * next_n : (i + 1) * next_n,
+                block_idx * block_size : (block_idx + 1) * block_size,
+            ] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float("-inf"))
     return logits
+
+
+def fp8_paged_mqa_logits_torch(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    """Compute FP8 MQA logits using paged KV-cache (Triton kernel).
+
+    This implementation uses a Triton kernel to avoid memory blow-up during
+    CUDA Graph capture. Key features:
+    1. Single kernel launch (no Python loops)
+    2. On-the-fly FP8 dequantization in kernel
+    3. Direct paged memory access via block tables
+
+    Args:
+        q: Query tensor of shape [B, next_n, H, D]. Casted to
+            `torch.float8_e4m3fn` by caller.
+        kv_cache: Paged KV-cache in packed FP8+scale layout with shape
+            [num_blocks, block_size, 1, D+4], dtype `torch.uint8`. The last
+            4 bytes per (block,pos) store the `float` dequant scale.
+        weights: Tensor of shape [B * next_n, H], dtype `torch.float32`.
+        context_lens: Tensor of shape [B], dtype int32; effective context length
+            for each batch element.
+        block_tables: Tensor of shape [B, max_blocks], dtype int32; maps logical
+            block indices to physical blocks in the paged cache.
+        max_model_len: Maximum sequence length used to size the logits output.
+
+    Returns:
+        Logits tensor of shape [B * next_n, max_model_len], dtype
+        `torch.float32`.
+    """
+    # Import here to avoid circular dependency
+    from vllm.v1.attention.ops.triton_fp8_paged_mqa_logits import (
+        fp8_paged_mqa_logits_triton,
+    )
+
+    return fp8_paged_mqa_logits_triton(
+        q, kv_cache, weights, context_lens, block_tables, max_model_len
+    )
 
 
 __all__ = [

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -495,45 +495,95 @@ def fp8_paged_mqa_logits_torch(
     """
     fp8_dtype = current_platform.fp8_dtype()
     batch_size, next_n, heads, dim = q.size()
-    kv_cache, scale = kv_cache[..., :dim], kv_cache[..., dim:]
-    scale = scale.contiguous().view(torch.float)
+    num_blocks, block_size, _, packed_dim = kv_cache.size()
+    assert packed_dim == dim + 4, (
+        f"Expected packed KV cache last dim {dim + 4}, got {packed_dim}"
+    )
+
+    # Match DeepGEMM's packed layout:
+    # [block0 token bytes..., block0 scale bytes..., block1 ...]
+    kv_cache_flat = kv_cache.view(num_blocks, block_size * packed_dim)
+    kv_bytes = kv_cache_flat[:, : block_size * dim].view(num_blocks, block_size, 1, dim)
+    scale_bytes = kv_cache_flat[:, block_size * dim :].view(
+        num_blocks, block_size, 1, 4
+    )
+    scale = scale_bytes.contiguous().view(torch.float)
     q = q.float()
-    kv_cache = kv_cache.view(fp8_dtype).float() * scale
-    num_blocks, block_size, _, dim = kv_cache.size()
+    kv_cache = kv_bytes.view(fp8_dtype).float() * scale
     logits = torch.full(
         [batch_size * next_n, max_model_len],
         float("-inf"),
         device=q.device,
         dtype=torch.float32,
     )
-    for i in range(batch_size):
-        context_len = context_lens[i].item()
-        q_offsets = torch.arange(context_len - next_n, context_len, device=q.device)
-        weight_slice = (
-            weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
+    # Keep a single cudagraph-safe implementation. This avoids host sync
+    # (`.item()` / `.tolist()`) and prevents full decode capture from falling
+    # back to a Python loop over requests and blocks.
+    max_blocks = min(block_tables.shape[1], cdiv(max_model_len, block_size))
+    if max_blocks == 0:
+        return logits
+
+    blocks_per_chunk = 8
+    decode_offsets = torch.arange(next_n, device=q.device, dtype=context_lens.dtype)
+    block_offsets = torch.arange(block_size, device=q.device, dtype=context_lens.dtype)
+    num_context_blocks = torch.div(
+        context_lens + block_size - 1,
+        block_size,
+        rounding_mode="floor",
+    )
+    q_offsets = context_lens[:, None] - next_n + decode_offsets[None, :]
+    weight_slice = weights.view(batch_size, next_n, heads).permute(0, 2, 1).contiguous()
+    block_ids = block_tables[:, :max_blocks].clamp(min=0).to(torch.int64)
+    logits_view = logits.view(batch_size, next_n, max_model_len)
+
+    for block_start in range(0, max_blocks, blocks_per_chunk):
+        block_end = min(block_start + blocks_per_chunk, max_blocks)
+        chunk_blocks = block_end - block_start
+
+        k_chunk = kv_cache.index_select(
+            0, block_ids[:, block_start:block_end].reshape(-1)
         )
-        for block_idx in range(cdiv(context_len, block_size)):
-            block_id = block_tables[i][block_idx]
-            qx, kx = q[i], kv_cache[block_id]
-            k_offsets = torch.arange(
-                block_idx * block_size, (block_idx + 1) * block_size, device=q.device
-            )
-            mask = (k_offsets[None, :] < context_len) & (
-                k_offsets[None, :] <= q_offsets[:, None]
-            )
-            s = torch.where(
-                mask[None, :, :],
-                (qx.transpose(0, 1) @ kx.transpose(0, 1).transpose(1, 2)).to(
-                    logits.dtype
-                ),
-                float("-inf"),
-            )
-            s = torch.relu(s) * weight_slice[..., None]
-            s = s.sum(dim=0)
-            logits[
-                i * next_n : (i + 1) * next_n,
-                block_idx * block_size : (block_idx + 1) * block_size,
-            ] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float("-inf"))
+        k_chunk = k_chunk.squeeze(-2).view(batch_size, chunk_blocks, block_size, dim)
+
+        # [B, next_n, H, D] x [B, chunk_blocks, block_size, D]
+        # -> [B, H, next_n, chunk_blocks, block_size]
+        s = torch.einsum("bnhd,bmtd->bhnmt", q, k_chunk).to(logits.dtype)
+        s = torch.relu(s) * weight_slice[..., None, None]
+        s = s.sum(dim=1)
+
+        k_offsets = (
+            torch.arange(
+                block_start,
+                block_end,
+                device=q.device,
+                dtype=context_lens.dtype,
+            )[:, None]
+            * block_size
+            + block_offsets[None, :]
+        )
+        flat_offsets = k_offsets.reshape(-1)
+        valid_cols = flat_offsets < max_model_len
+        valid_blocks = (
+            torch.arange(
+                block_start,
+                block_end,
+                device=q.device,
+                dtype=context_lens.dtype,
+            )[None, :]
+            < num_context_blocks[:, None]
+        )
+        causal_mask = (
+            k_offsets[None, None, :, :] <= q_offsets[:, :, None, None]
+        ) & valid_blocks[:, None, :, None]
+        col_start = block_start * block_size
+        col_end = min(block_end * block_size, max_model_len)
+        if col_end - col_start < chunk_blocks * block_size:
+            causal_mask = causal_mask & valid_cols.view(1, 1, chunk_blocks, -1)
+
+        s = torch.where(causal_mask, s, float("-inf"))
+        logits_view[:, :, col_start:col_end] = s.reshape(batch_size, next_n, -1)[
+            :, :, : col_end - col_start
+        ]
     return logits
 
 

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -464,79 +464,6 @@ def fp8_mqa_logits_torch(
     return logits
 
 
-def _fp8_paged_mqa_logits_torch_impl(
-    q: torch.Tensor,
-    kv_cache: torch.Tensor,
-    weights: torch.Tensor,
-    context_lens: torch.Tensor,
-    block_tables: torch.Tensor,
-    max_model_len: int,
-) -> torch.Tensor:
-    """Compute FP8 MQA logits using paged KV-cache (CUDA fallback).
-
-    This is a pure PyTorch fallback for CUDA when DeepGEMM is not available.
-    Handles head_dim = 132 (128 + 4 for RoPE).
-
-    Args:
-        q: Query tensor of shape [B, next_n, H, D].
-        kv_cache: Paged KV-cache in packed FP8+scale layout with shape
-            [num_blocks, block_size, 1, D+4], dtype `torch.uint8`. The last
-            4 bytes per (block,pos) store the `float` dequant scale.
-        weights: Tensor of shape [B * next_n, H], dtype `torch.float32`.
-        context_lens: Tensor of shape [B], dtype int32; effective context length
-            for each batch element.
-        block_tables: Tensor of shape [B, max_blocks], dtype int32; maps logical
-            block indices to physical blocks in the paged cache.
-        max_model_len: Maximum sequence length used to size the logits output.
-
-    Returns:
-        Logits tensor of shape [B * next_n, max_model_len], dtype
-        `torch.float32`.
-    """
-    fp8_dtype = current_platform.fp8_dtype()
-    batch_size, next_n, heads, dim = q.size()
-    kv_cache, scale = kv_cache[..., :dim], kv_cache[..., dim:]
-    scale = scale.contiguous().view(torch.float)
-    q = q.float()
-    kv_cache = kv_cache.view(fp8_dtype).float() * scale
-    num_blocks, block_size, _, dim = kv_cache.size()
-    logits = torch.full(
-        [batch_size * next_n, max_model_len],
-        float("-inf"),
-        device=q.device,
-        dtype=torch.float32,
-    )
-    for i in range(batch_size):
-        context_len = context_lens[i].item()
-        q_offsets = torch.arange(context_len - next_n, context_len, device=q.device)
-        weight_slice = (
-            weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
-        )
-        for block_idx in range(cdiv(context_len, block_size)):
-            block_id = block_tables[i][block_idx]
-            qx, kx = q[i], kv_cache[block_id]
-            k_offsets = torch.arange(
-                block_idx * block_size, (block_idx + 1) * block_size, device=q.device
-            )
-            mask = (k_offsets[None, :] < context_len) & (
-                k_offsets[None, :] <= q_offsets[:, None]
-            )
-            s = torch.where(
-                mask[None, :, :],
-                (qx.transpose(0, 1) @ kx.transpose(0, 1).transpose(1, 2)).to(
-                    logits.dtype
-                ),
-                float("-inf"),
-            )
-            s = torch.relu(s) * weight_slice[..., None]
-            s = s.sum(dim=0)
-            logits[
-                i * next_n : (i + 1) * next_n,
-                block_idx * block_size : (block_idx + 1) * block_size,
-            ] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float("-inf"))
-    return logits
-
-
 def fp8_paged_mqa_logits_torch(
     q: torch.Tensor,
     kv_cache: torch.Tensor,
@@ -546,12 +473,6 @@ def fp8_paged_mqa_logits_torch(
     max_model_len: int,
 ) -> torch.Tensor:
     """Compute FP8 MQA logits using paged KV-cache (Triton kernel).
-
-    This implementation uses a Triton kernel to avoid memory blow-up during
-    CUDA Graph capture. Key features:
-    1. Single kernel launch (no Python loops)
-    2. On-the-fly FP8 dequantization in kernel
-    3. Direct paged memory access via block tables
 
     Args:
         q: Query tensor of shape [B, next_n, H, D]. Casted to

--- a/vllm/v1/attention/ops/triton_fp8_paged_mqa_logits.py
+++ b/vllm/v1/attention/ops/triton_fp8_paged_mqa_logits.py
@@ -1,14 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Triton kernel for FP8 paged MQA logits.
-
-This implementation is optimized for decode workloads by:
-- using a matrix-style head reduction (tl.dot) instead of per-head loops,
-- splitting KV data/scales in Python as zero-copy views to avoid byte-wise
-  scale reconstruction in the kernel,
-- preserving CUDA Graph compatibility (single launch, fixed output shape,
-  mask-based stores).
-"""
+"""Triton kernel for FP8 paged MQA logits."""
 
 import torch
 

--- a/vllm/v1/attention/ops/triton_fp8_paged_mqa_logits.py
+++ b/vllm/v1/attention/ops/triton_fp8_paged_mqa_logits.py
@@ -2,11 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Triton kernel for FP8 paged MQA logits.
 
-This kernel mirrors ``_fp8_paged_mqa_logits_torch_impl`` in
-``vllm/utils/deep_gemm.py`` while remaining CUDA Graph friendly:
-- single Triton launch (no Python loops over batches/blocks),
-- fixed output shape with masked writes,
-- on-the-fly FP8 + per-token scale dequantization in device code.
+This implementation is optimized for decode workloads by:
+- using a matrix-style head reduction (tl.dot) instead of per-head loops,
+- splitting KV data/scales in Python as zero-copy views to avoid byte-wise
+  scale reconstruction in the kernel,
+- preserving CUDA Graph compatibility (single launch, fixed output shape,
+  mask-based stores).
 """
 
 import torch
@@ -16,8 +17,9 @@ from vllm.triton_utils import tl, triton
 
 @triton.jit
 def _fp8_paged_mqa_logits_kernel(
-    q_ptr,  # [B, next_n, H, D], float8
-    kv_cache_ptr,  # [num_blocks, block_size, 1, D+4], uint8
+    q_ptr,  # [B, next_n, H, D], float16
+    k_data_ptr,  # [num_blocks, block_size, D], uint8(fp8 bitcast)
+    k_scale_ptr,  # [num_blocks, block_size], float32
     weights_ptr,  # [B * next_n, H], float32
     context_lens_ptr,  # [B], int32
     block_tables_ptr,  # [B, max_blocks], int32/int64
@@ -32,8 +34,13 @@ def _fp8_paged_mqa_logits_kernel(
     stride_q_n,
     stride_q_h,
     stride_q_d,
-    # kv_cache stride
-    stride_kv_block,
+    # k_data strides
+    stride_kd_blk,
+    stride_kd_pos,
+    stride_kd_d,
+    # k_scale strides
+    stride_ks_blk,
+    stride_ks_pos,
     # weights strides
     stride_w_row,
     stride_w_h,
@@ -62,15 +69,14 @@ def _fp8_paged_mqa_logits_kernel(
 
     offs_k = tl.arange(0, BLOCK_K)
     offs_d = tl.arange(0, BLOCK_D)
+    offs_h = tl.arange(0, BLOCK_H)
 
     kv_pos = block_start + offs_k
     in_block = offs_k < block_size
     in_ctx = kv_pos < context_len
     out_bounds = in_block & (kv_pos < max_model_len)
 
-    # Blocks at/after context_len are fully invalid; keep default -inf.
     block_active = block_start < context_len
-
     physical_block_id = tl.full((), 0, dtype=tl.int64)
     if block_active:
         physical_block_id = tl.load(
@@ -79,45 +85,47 @@ def _fp8_paged_mqa_logits_kernel(
 
     token_valid = block_active & in_block & in_ctx
 
-    # kv_cache layout is split in each block:
-    # [block_size * head_dim bytes of FP8 K] + [block_size * 4 bytes of FP32 scale]
-    # then viewed as [block_size, 1, head_dim + 4].
-    block_base = kv_cache_ptr + physical_block_id * stride_kv_block
-
-    # Load per-token FP8 K values from the K region.
-    k_ptrs = block_base + offs_k[:, None] * head_dim + offs_d[None, :]
+    # Load K tile [BLOCK_K, BLOCK_D] from packed FP8 bytes.
+    k_ptrs = (
+        k_data_ptr
+        + physical_block_id * stride_kd_blk
+        + offs_k[:, None] * stride_kd_pos
+        + offs_d[None, :] * stride_kd_d
+    )
     k_mask = token_valid[:, None] & (offs_d[None, :] < head_dim)
     k_u8 = tl.load(k_ptrs, mask=k_mask, other=0).to(tl.uint8)
-    k_vals = k_u8.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+    k_vals = k_u8.to(tl.float8e4nv, bitcast=True).to(tl.float16)
 
-    # Reconstruct float32 scale from 4 uint8 bytes at tail of each token.
-    scale_base = block_base + block_size * head_dim + offs_k * 4
-    b0 = tl.load(scale_base + 0, mask=token_valid, other=0).to(tl.uint32)
-    b1 = tl.load(scale_base + 1, mask=token_valid, other=0).to(tl.uint32)
-    b2 = tl.load(scale_base + 2, mask=token_valid, other=0).to(tl.uint32)
-    b3 = tl.load(scale_base + 3, mask=token_valid, other=0).to(tl.uint32)
-    scale_bits = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
-    k_scale = scale_bits.to(tl.float32, bitcast=True)
-    k_scale = tl.where(token_valid, k_scale, 0.0)
-
+    # Load scales [BLOCK_K] and apply dequantization in fp16 for MMA throughput.
+    k_scale = tl.load(
+        k_scale_ptr + physical_block_id * stride_ks_blk + offs_k * stride_ks_pos,
+        mask=token_valid,
+        other=0.0,
+    ).to(tl.float16)
     k_vals = k_vals * k_scale[:, None]
 
-    # Accumulate logits over heads:
-    # logits[pos] = sum_h relu(dot(q[h], k[pos])) * weight[h]
-    acc = tl.zeros((BLOCK_K,), dtype=tl.float32)
+    # Load Q tile [BLOCK_H, BLOCK_D].
+    q_ptrs = (
+        q_ptr
+        + b * stride_q_b
+        + n * stride_q_n
+        + offs_h[:, None] * stride_q_h
+        + offs_d[None, :] * stride_q_d
+    )
+    q_mask = (offs_h[:, None] < num_heads) & (offs_d[None, :] < head_dim)
+    q_vals = tl.load(q_ptrs, mask=q_mask, other=0.0).to(tl.float16)
 
-    q_row_base = q_ptr + b * stride_q_b + n * stride_q_n
-    w_row_base = weights_ptr + pid_row * stride_w_row
+    # Weights [BLOCK_H].
+    w = tl.load(
+        weights_ptr + pid_row * stride_w_row + offs_h * stride_w_h,
+        mask=offs_h < num_heads,
+        other=0.0,
+    )
 
-    for h in range(BLOCK_H):
-        if h < num_heads:
-            q_ptrs = q_row_base + h * stride_q_h + offs_d * stride_q_d
-            q_vals = tl.load(q_ptrs, mask=offs_d < head_dim, other=0.0).to(tl.float32)
-            w = tl.load(w_row_base + h * stride_w_h)
-
-            scores = tl.sum(q_vals[None, :] * k_vals, axis=1)
-            scores = tl.maximum(scores, 0.0) * w
-            acc += scores
+    # scores: [BLOCK_H, BLOCK_K] = Q @ K^T
+    scores = tl.dot(q_vals, tl.trans(k_vals))
+    scores = tl.maximum(scores, 0.0) * w[:, None]
+    acc = tl.sum(scores, axis=0)
 
     causal = kv_pos <= q_pos
     write_valid = token_valid & causal
@@ -135,10 +143,7 @@ def fp8_paged_mqa_logits_triton(
     block_tables: torch.Tensor,
     max_model_len: int,
 ) -> torch.Tensor:
-    """Compute FP8 paged MQA logits using Triton.
-
-    Semantics match ``_fp8_paged_mqa_logits_torch_impl``.
-    """
+    """Compute FP8 paged MQA logits using Triton."""
     if not q_fp8.is_cuda:
         raise ValueError("fp8_paged_mqa_logits_triton requires CUDA tensors")
 
@@ -151,13 +156,28 @@ def fp8_paged_mqa_logits_triton(
         )
 
     batch_size, next_n, num_heads, head_dim = q_fp8.shape
-    _, block_size, _, packed_dim = kv_cache_fp8.shape
+    num_blocks, block_size, _, packed_dim = kv_cache_fp8.shape
 
     if packed_dim != head_dim + 4:
         raise ValueError(
             f"kv_cache_fp8 last dim must be head_dim + 4 ({head_dim + 4}), "
             f"got {packed_dim}"
         )
+
+    # DeepGEMM-compatible packed layout expects contiguous memory.
+    if not kv_cache_fp8.is_contiguous():
+        kv_cache_fp8 = kv_cache_fp8.contiguous()
+
+    # Convert Q once outside the kernel to avoid repeated per-block conversion.
+    q = q_fp8.to(torch.float16)
+
+    # Split fused KV cache as zero-copy views:
+    #   [num_blocks, block_size * D] uint8 FP8 bytes
+    #   [num_blocks, block_size] float32 scales
+    kv_flat = kv_cache_fp8.view(num_blocks, -1)
+    split = block_size * head_dim
+    k_data = kv_flat[:, :split].view(num_blocks, block_size, head_dim)
+    k_scale = kv_flat[:, split:].view(num_blocks, block_size, 4).view(torch.float32)
 
     logits = torch.full(
         (batch_size * next_n, max_model_len),
@@ -173,13 +193,13 @@ def fp8_paged_mqa_logits_triton(
     block_d = triton.next_power_of_2(head_dim)
     block_h = triton.next_power_of_2(max(1, num_heads))
 
-    num_warps = 4
-    if block_d >= 128:
-        num_warps = 8
+    # Heuristics tuned for HxD(<=64x128)-by-KV(64) decode tiles.
+    num_warps = 8 if (block_d >= 128 or block_h >= 64) else 4
 
     _fp8_paged_mqa_logits_kernel[grid](
-        q_fp8,
-        kv_cache_fp8,
+        q,
+        k_data,
+        k_scale,
         weights,
         context_lens,
         block_tables,
@@ -189,11 +209,15 @@ def fp8_paged_mqa_logits_triton(
         head_dim,
         block_size,
         max_model_len,
-        q_fp8.stride(0),
-        q_fp8.stride(1),
-        q_fp8.stride(2),
-        q_fp8.stride(3),
-        kv_cache_fp8.stride(0),
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k_data.stride(0),
+        k_data.stride(1),
+        k_data.stride(2),
+        k_scale.stride(0),
+        k_scale.stride(1),
         weights.stride(0),
         weights.stride(1),
         context_lens.stride(0),
@@ -205,7 +229,7 @@ def fp8_paged_mqa_logits_triton(
         BLOCK_D=block_d,
         BLOCK_H=block_h,
         num_warps=num_warps,
-        num_stages=1,
+        num_stages=2,
     )
 
     return logits

--- a/vllm/v1/attention/ops/triton_fp8_paged_mqa_logits.py
+++ b/vllm/v1/attention/ops/triton_fp8_paged_mqa_logits.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton kernel for FP8 paged MQA logits.
+
+This kernel mirrors ``_fp8_paged_mqa_logits_torch_impl`` in
+``vllm/utils/deep_gemm.py`` while remaining CUDA Graph friendly:
+- single Triton launch (no Python loops over batches/blocks),
+- fixed output shape with masked writes,
+- on-the-fly FP8 + per-token scale dequantization in device code.
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _fp8_paged_mqa_logits_kernel(
+    q_ptr,  # [B, next_n, H, D], float8
+    kv_cache_ptr,  # [num_blocks, block_size, 1, D+4], uint8
+    weights_ptr,  # [B * next_n, H], float32
+    context_lens_ptr,  # [B], int32
+    block_tables_ptr,  # [B, max_blocks], int32/int64
+    logits_ptr,  # [B * next_n, max_model_len], float32
+    next_n,
+    num_heads,
+    head_dim,
+    block_size,
+    max_model_len,
+    # q strides
+    stride_q_b,
+    stride_q_n,
+    stride_q_h,
+    stride_q_d,
+    # kv_cache stride
+    stride_kv_block,
+    # weights strides
+    stride_w_row,
+    stride_w_h,
+    # context_lens stride
+    stride_ctx,
+    # block_tables strides
+    stride_bt_b,
+    stride_bt_blk,
+    # logits strides
+    stride_o_row,
+    stride_o_col,
+    BLOCK_K: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    pid_row = tl.program_id(0)
+    pid_block = tl.program_id(1)
+
+    b = pid_row // next_n
+    n = pid_row % next_n
+
+    context_len = tl.load(context_lens_ptr + b * stride_ctx)
+    q_pos = context_len - next_n + n
+
+    block_start = pid_block * block_size
+
+    offs_k = tl.arange(0, BLOCK_K)
+    offs_d = tl.arange(0, BLOCK_D)
+
+    kv_pos = block_start + offs_k
+    in_block = offs_k < block_size
+    in_ctx = kv_pos < context_len
+    out_bounds = in_block & (kv_pos < max_model_len)
+
+    # Blocks at/after context_len are fully invalid; keep default -inf.
+    block_active = block_start < context_len
+
+    physical_block_id = tl.full((), 0, dtype=tl.int64)
+    if block_active:
+        physical_block_id = tl.load(
+            block_tables_ptr + b * stride_bt_b + pid_block * stride_bt_blk
+        ).to(tl.int64)
+
+    token_valid = block_active & in_block & in_ctx
+
+    # kv_cache layout is split in each block:
+    # [block_size * head_dim bytes of FP8 K] + [block_size * 4 bytes of FP32 scale]
+    # then viewed as [block_size, 1, head_dim + 4].
+    block_base = kv_cache_ptr + physical_block_id * stride_kv_block
+
+    # Load per-token FP8 K values from the K region.
+    k_ptrs = block_base + offs_k[:, None] * head_dim + offs_d[None, :]
+    k_mask = token_valid[:, None] & (offs_d[None, :] < head_dim)
+    k_u8 = tl.load(k_ptrs, mask=k_mask, other=0).to(tl.uint8)
+    k_vals = k_u8.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+
+    # Reconstruct float32 scale from 4 uint8 bytes at tail of each token.
+    scale_base = block_base + block_size * head_dim + offs_k * 4
+    b0 = tl.load(scale_base + 0, mask=token_valid, other=0).to(tl.uint32)
+    b1 = tl.load(scale_base + 1, mask=token_valid, other=0).to(tl.uint32)
+    b2 = tl.load(scale_base + 2, mask=token_valid, other=0).to(tl.uint32)
+    b3 = tl.load(scale_base + 3, mask=token_valid, other=0).to(tl.uint32)
+    scale_bits = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+    k_scale = scale_bits.to(tl.float32, bitcast=True)
+    k_scale = tl.where(token_valid, k_scale, 0.0)
+
+    k_vals = k_vals * k_scale[:, None]
+
+    # Accumulate logits over heads:
+    # logits[pos] = sum_h relu(dot(q[h], k[pos])) * weight[h]
+    acc = tl.zeros((BLOCK_K,), dtype=tl.float32)
+
+    q_row_base = q_ptr + b * stride_q_b + n * stride_q_n
+    w_row_base = weights_ptr + pid_row * stride_w_row
+
+    for h in range(BLOCK_H):
+        if h < num_heads:
+            q_ptrs = q_row_base + h * stride_q_h + offs_d * stride_q_d
+            q_vals = tl.load(q_ptrs, mask=offs_d < head_dim, other=0.0).to(tl.float32)
+            w = tl.load(w_row_base + h * stride_w_h)
+
+            scores = tl.sum(q_vals[None, :] * k_vals, axis=1)
+            scores = tl.maximum(scores, 0.0) * w
+            acc += scores
+
+    causal = kv_pos <= q_pos
+    write_valid = token_valid & causal
+    out_vals = tl.where(write_valid, acc, float("-inf"))
+
+    out_ptrs = logits_ptr + pid_row * stride_o_row + kv_pos * stride_o_col
+    tl.store(out_ptrs, out_vals, mask=out_bounds)
+
+
+def fp8_paged_mqa_logits_triton(
+    q_fp8: torch.Tensor,
+    kv_cache_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    """Compute FP8 paged MQA logits using Triton.
+
+    Semantics match ``_fp8_paged_mqa_logits_torch_impl``.
+    """
+    if not q_fp8.is_cuda:
+        raise ValueError("fp8_paged_mqa_logits_triton requires CUDA tensors")
+
+    if q_fp8.ndim != 4:
+        raise ValueError(f"q_fp8 must be 4D [B, next_n, H, D], got {q_fp8.shape}")
+    if kv_cache_fp8.ndim != 4:
+        raise ValueError(
+            f"kv_cache_fp8 must be 4D [num_blocks, block_size, 1, D+4], "
+            f"got {kv_cache_fp8.shape}"
+        )
+
+    batch_size, next_n, num_heads, head_dim = q_fp8.shape
+    _, block_size, _, packed_dim = kv_cache_fp8.shape
+
+    if packed_dim != head_dim + 4:
+        raise ValueError(
+            f"kv_cache_fp8 last dim must be head_dim + 4 ({head_dim + 4}), "
+            f"got {packed_dim}"
+        )
+
+    logits = torch.full(
+        (batch_size * next_n, max_model_len),
+        float("-inf"),
+        device=q_fp8.device,
+        dtype=torch.float32,
+    )
+
+    block_cols = block_tables.shape[1]
+    grid = (batch_size * next_n, block_cols)
+
+    block_k = triton.next_power_of_2(block_size)
+    block_d = triton.next_power_of_2(head_dim)
+    block_h = triton.next_power_of_2(max(1, num_heads))
+
+    num_warps = 4
+    if block_d >= 128:
+        num_warps = 8
+
+    _fp8_paged_mqa_logits_kernel[grid](
+        q_fp8,
+        kv_cache_fp8,
+        weights,
+        context_lens,
+        block_tables,
+        logits,
+        next_n,
+        num_heads,
+        head_dim,
+        block_size,
+        max_model_len,
+        q_fp8.stride(0),
+        q_fp8.stride(1),
+        q_fp8.stride(2),
+        q_fp8.stride(3),
+        kv_cache_fp8.stride(0),
+        weights.stride(0),
+        weights.stride(1),
+        context_lens.stride(0),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        BLOCK_K=block_k,
+        BLOCK_D=block_d,
+        BLOCK_H=block_h,
+        num_warps=num_warps,
+        num_stages=1,
+    )
+
+    return logits


### PR DESCRIPTION

## Purpose
`fp8_paged_mqa_logits_torch` is not cudagraph compatible.
```
(Worker pid=3782129) (Worker_TP1 pid=3782129) ERROR 03-07 11:21:54 [multiproc_executor.py:927]   File "/mnt/data1/zjy/code/vllm-src/vllm/model_executor/layers/sparse_attn_indexer.py", line 193, in sparse_attn_indexer
(Worker pid=3782129) (Worker_TP1 pid=3782129) ERROR 03-07 11:21:54 [multiproc_executor.py:927]     logits = fp8_paged_mqa_logits_torch(
(Worker pid=3782129) (Worker_TP1 pid=3782129) ERROR 03-07 11:21:54 [multiproc_executor.py:927]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=3782129) (Worker_TP1 pid=3782129) ERROR 03-07 11:21:54 [multiproc_executor.py:927]   File "/mnt/data1/zjy/code/vllm-src/vllm/utils/deep_gemm.py", line 510, in fp8_paged_mqa_logits_torch
(Worker pid=3782129) (Worker_TP1 pid=3782129) ERROR 03-07 11:21:54 [multiproc_executor.py:927]     context_len = context_lens[i].item()
(Worker pid=3782129) (Worker_TP1 pid=3782129) ERROR 03-07 11:21:54 [multiproc_executor.py:927]                   ^^^^^^^^^^^^^^^^^^^^^^
(Worker pid=3782129) (Worker_TP1 pid=3782129) ERROR 03-07 11:21:54 [multiproc_executor.py:927] torch.AcceleratorError: CUDA error: operation not permitted when stream is capturing
(Worker pid=3782129) (Worker_TP1 pid=3782129) ERROR 03-07 11:21:54 [multiproc_executor.py:927] Search for `cudaErrorStreamCaptureUnsupported' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
```
This PR adds a triton kernel for this.

## Test Plan
```
VLLM_USE_DEEP_GEMM=0 vllm serve /mnt/data3/DSModels/models/deepseek-ai/DeepSeek-V3.2/ -tp 8 --served-model-name deepseek-ai/DeepSeek-V3.2 --tokenizer-mode deepseek_v32 --enable-auto-tool-choice --tool-call-parser deepseek_v32 --reasoning-parser deepseek_v3
```

## Test Result

```
curl http://localhost:8000/v1/chat/completions \
-H "Content-Type: application/json" \
-H "Authorization: Bearer EMPTY" \
-d '{
"model": "deepseek-ai/DeepSeek-V3.2",
"messages": [
{
"role": "user",
"content": "Solve this problem step by step: What is 15% of 4800?"
}
],
"max_tokens": 2048
}'
{"id":"chatcmpl-a95500daaf6a3517","object":"chat.completion","created":1772853307,"model":"deepseek-ai/DeepSeek-V3.2","choices":[{"index":0,"message":{"role":"assistant","content":"Alright, let's go step by step.  \n\n---\n\n**Step 1: Understand the question**  \nWe want to find 15% of 4800.  \n\"Percent\" means \"per hundred,\" so 15% means \\( 15 / 100 \\).\n\n---\n\n**Step 2: Convert percentage to decimal**  \n\\[\n15\\% = \\frac{15}{100} = 0.15\n\\]\n\n---\n\n**Step 3: Multiply decimal by the number**  \n\\[\n0.15 \\times 4800\n\\]\n\nFirst, \\( 0.15 = \\frac{15}{100} \\), so:  \n\\[\n0.15 \\times 4800 = \\frac{15}{100} \\times 4800\n\\]\n\n---\n\n**Step 4: Simplify the fraction multiplication**  \n\\[\n\\frac{15 \\times 4800}{100} = 15 \\times 48\n\\]\n(because \\( 4800 \\div 100 = 48 \\))\n\n---\n\n**Step 5: Multiply**  \n\\[\n15 \\times 48 = 720\n\\]\n\n---\n\n**Final answer:**  \n\\[\n\\boxed{720}\n\\]","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":21,"total_tokens":264,"completion_tokens":243,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

