### PR TITLE
[Bugfix] Allow concurrency and memory_limit for runai_streamer_sharded

### DIFF
--- a/tests/model_executor/model_loader/test_sharded_state_loader.py
+++ b/tests/model_executor/model_loader/test_sharded_state_loader.py
@@ -12,6 +12,7 @@ import torch
 from huggingface_hub import snapshot_download
 
 from vllm import LLM, SamplingParams
+from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader import ShardedStateLoader
 from vllm.platforms import current_platform
 
@@ -48,6 +49,66 @@ def test_filter_subtensors():
     for key, tensor in filtered_state_dict.items():
         # NOTE: don't use `equal` here, as the tensor might contain NaNs
         assert tensor is state_dict[key]
+
+
+def test_sharded_state_loader_accepts_runai_tunable_params(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("RUNAI_STREAMER_CONCURRENCY", raising=False)
+    monkeypatch.delenv("RUNAI_STREAMER_MEMORY_LIMIT", raising=False)
+
+    loader = ShardedStateLoader(
+        LoadConfig(
+            load_format="runai_streamer_sharded",
+            model_loader_extra_config={
+                "pattern": "custom-rank-{rank}-part-{part}.safetensors",
+                "concurrency": 16,
+                "memory_limit": 5368709120,
+            },
+        )
+    )
+
+    assert loader.pattern == "custom-rank-{rank}-part-{part}.safetensors"
+    assert os.environ["RUNAI_STREAMER_CONCURRENCY"] == "16"
+    assert os.environ["RUNAI_STREAMER_MEMORY_LIMIT"] == "5368709120"
+
+
+@pytest.mark.parametrize(
+    ("extra_config", "unexpected_key"),
+    [
+        ({"distributed": True}, "distributed"),
+        ({"unexpected": "value"}, "unexpected"),
+    ],
+)
+def test_sharded_state_loader_rejects_unsupported_extra_config(
+    extra_config: dict[str, object],
+    unexpected_key: str,
+):
+    with pytest.raises(ValueError, match=unexpected_key):
+        ShardedStateLoader(
+            LoadConfig(
+                load_format="runai_streamer_sharded",
+                model_loader_extra_config=extra_config,
+            )
+        )
+
+
+def test_sharded_state_loader_rejects_runai_only_tunable_params(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("RUNAI_STREAMER_CONCURRENCY", raising=False)
+    monkeypatch.delenv("RUNAI_STREAMER_MEMORY_LIMIT", raising=False)
+
+    with pytest.raises(ValueError, match="concurrency"):
+        ShardedStateLoader(
+            LoadConfig(
+                load_format="sharded_state",
+                model_loader_extra_config={"concurrency": 16},
+            )
+        )
+
+    assert "RUNAI_STREAMER_CONCURRENCY" not in os.environ
+    assert "RUNAI_STREAMER_MEMORY_LIMIT" not in os.environ
 
 
 @pytest.fixture(scope="module")

--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -45,6 +45,15 @@ class ShardedStateLoader(BaseModelLoader):
             else load_config.model_loader_extra_config.copy()
         )
         self.pattern = extra_config.pop("pattern", self.DEFAULT_PATTERN)
+        if load_config.load_format == "runai_streamer_sharded":
+            concurrency = extra_config.pop("concurrency", None)
+            if isinstance(concurrency, int):
+                os.environ["RUNAI_STREAMER_CONCURRENCY"] = str(concurrency)
+
+            memory_limit = extra_config.pop("memory_limit", None)
+            if isinstance(memory_limit, int):
+                os.environ["RUNAI_STREAMER_MEMORY_LIMIT"] = str(memory_limit)
+
         if extra_config:
             raise ValueError(
                 f"Unexpected extra config keys for load format "


### PR DESCRIPTION

## Purpose

Fixes #30100.

`runai_streamer_sharded` currently rejects `concurrency` and `memory_limit` in `model_loader_extra_config`, even though the sharded Run:ai loader documentation says these tunables are supported.

This PR keeps the fix intentionally small:
- accept `concurrency` and map it to `RUNAI_STREAMER_CONCURRENCY`
- accept `memory_limit` and map it to `RUNAI_STREAMER_MEMORY_LIMIT`
- continue rejecting unsupported keys such as `distributed`

This matches the current maintainer guidance on the issue: `distributed` is not supported for sharded weights, but `concurrency` and `memory_limit` should work the same way as the default Run:ai loader.

## Test Plan

- Added focused unit tests for `ShardedStateLoader` constructor behavior
- Validation commands used locally:
  - `/home/rufus/code/oss/vllm/.venv/bin/python -m py_compile vllm/model_executor/model_loader/sharded_state_loader.py tests/model_executor/model_loader/test_sharded_state_loader.py`
  - constructor-level verification script against the patched loader to confirm:
    - `concurrency` is accepted and exported to `RUNAI_STREAMER_CONCURRENCY`
    - `memory_limit` is accepted and exported to `RUNAI_STREAMER_MEMORY_LIMIT`
    - `distributed` remains rejected

## Test Result

- `py_compile` passed for both modified files
- constructor-level verification passed for accepted and rejected config paths
- `pytest` was not runnable in the local `.venv` because `pytest` is not installed there

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
