### PR TITLE
[Core] Fix benign error log during normal shutdown

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -539,6 +539,7 @@ class MPClient(EngineCoreClient):
         # exception is raised mid-construction.
         self.resources = BackgroundResources(ctx=sync_ctx)
         self._finalizer = weakref.finalize(self, self.resources)
+        self.is_shutting_down = False
         success = False
         try:
             # State used for data parallel.
@@ -638,10 +639,12 @@ class MPClient(EngineCoreClient):
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown engine manager under timeout and clean up resources."""
-        self._finalizer.detach()
-        if self.resources.engine_manager is not None:
-            self.resources.engine_manager.shutdown(timeout=timeout)
-        self.resources()
+        if not self.is_shutting_down:
+            self.is_shutting_down = True
+            self._finalizer.detach()
+            if self.resources.engine_manager is not None:
+                self.resources.engine_manager.shutdown(timeout=timeout)
+            self.resources()
 
     def _format_exception(self, e: Exception) -> Exception:
         """If errored, use EngineDeadError so root cause is clear."""
@@ -685,7 +688,7 @@ class MPClient(EngineCoreClient):
             sentinels = [proc.sentinel for proc in engine_processes]
             died = multiprocessing.connection.wait(sentinels)
             _self = self_ref()
-            if not _self or _self.resources.engine_dead:
+            if not _self or _self.is_shutting_down or _self.resources.engine_dead:
                 return
             _self.resources.engine_dead = True
             proc_name = next(

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -539,7 +539,6 @@ class MPClient(EngineCoreClient):
         # exception is raised mid-construction.
         self.resources = BackgroundResources(ctx=sync_ctx)
         self._finalizer = weakref.finalize(self, self.resources)
-        self.is_shutting_down = False
         success = False
         try:
             # State used for data parallel.
@@ -568,10 +567,7 @@ class MPClient(EngineCoreClient):
                 )
 
                 with launch_core_engines(
-                    vllm_config,
-                    executor_class,
-                    log_stats,
-                    addresses,
+                    vllm_config, executor_class, log_stats, addresses
                 ) as (engine_manager, coordinator, addresses):
                     self.resources.coordinator = coordinator
                     self.resources.engine_manager = engine_manager
@@ -639,9 +635,7 @@ class MPClient(EngineCoreClient):
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown engine manager under timeout and clean up resources."""
-        if not self.is_shutting_down:
-            self.is_shutting_down = True
-            self._finalizer.detach()
+        if self._finalizer.detach() is not None:
             if self.resources.engine_manager is not None:
                 self.resources.engine_manager.shutdown(timeout=timeout)
             self.resources()
@@ -688,7 +682,7 @@ class MPClient(EngineCoreClient):
             sentinels = [proc.sentinel for proc in engine_processes]
             died = multiprocessing.connection.wait(sentinels)
             _self = self_ref()
-            if not _self or _self.is_shutting_down or _self.resources.engine_dead:
+            if not _self or not _self._finalizer.alive or _self.resources.engine_dead:
                 return
             _self.resources.engine_dead = True
             proc_name = next(


### PR DESCRIPTION
Small follow-on fix to https://github.com/vllm-project/vllm/pull/34730.

The core client engine process monitor logs an error when the engine core process exits even in normal shutdown case.

<img width="1369" height="104" alt="image" src="https://github.com/user-attachments/assets/a946d839-a035-4713-a4c9-f4b56f27c5fb" />


cc @markmc 
