### PR TITLE
[Compile] Add MLA attention + FP8 static quant fusion support

### DIFF
--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -9,7 +9,11 @@ from tests.compile.backend import LazyInitPass, TestBackend
 from tests.utils import TestFP8Layer, flat_product
 from tests.v1.attention.utils import BatchSpec, create_common_attn_metadata
 from vllm._custom_ops import cutlass_scaled_fp4_mm, scaled_fp4_quant
-from vllm.compilation.passes.fusion.attn_quant_fusion import ATTN_OP, AttnFusionPass
+from vllm.compilation.passes.fusion.attn_quant_fusion import (
+    ATTN_OP,
+    MLA_ATTN_OP,
+    AttnFusionPass,
+)
 from vllm.compilation.passes.fusion.matcher_utils import QUANT_OPS
 from vllm.compilation.passes.fx_utils import find_op_nodes
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
@@ -27,6 +31,8 @@ from vllm.config import (
 )
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8StaticTensorSym,
@@ -36,7 +42,7 @@ from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
-from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
 
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
@@ -470,4 +476,333 @@ def test_attention_quant_pattern(
         )
 
     # Check that results are close
+    torch.testing.assert_close(result_unfused, result_fused, atol=1e-2, rtol=1e-2)
+
+
+# ====================================================================
+# MLA Attention + Quant Fusion Tests
+# ====================================================================
+
+# DeepSeek V3/R1 MLA dimensions
+MLA_KV_LORA_RANK = 512
+MLA_QK_NOPE_HEAD_DIM = 128
+MLA_QK_ROPE_HEAD_DIM = 64
+MLA_V_HEAD_DIM = 128
+MLA_NUM_HEADS = 16  # Reduced for test efficiency
+
+
+class MLAAttentionQuantPatternModel(torch.nn.Module):
+    """Base model for MLA Attention+Quant fusion testing."""
+
+    def __init__(
+        self,
+        num_heads: int,
+        kv_cache_dtype: torch.dtype,
+        device: torch.device,
+        vllm_config: VllmConfig,
+        **kwargs,
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        self.kv_lora_rank = MLA_KV_LORA_RANK
+        self.qk_nope_head_dim = MLA_QK_NOPE_HEAD_DIM
+        self.qk_rope_head_dim = MLA_QK_ROPE_HEAD_DIM
+        self.v_head_dim = MLA_V_HEAD_DIM
+        self.head_size = self.kv_lora_rank + self.qk_rope_head_dim
+        self.kv_cache_dtype = kv_cache_dtype
+        self.device = device
+        self.vllm_config = vllm_config
+
+        self.block_size = vllm_config.cache_config.block_size
+
+        # Create kv_b_proj (ColumnParallelLinear)
+        kv_b_proj = ColumnParallelLinear(
+            input_size=self.kv_lora_rank,
+            output_size=num_heads * (self.qk_nope_head_dim + self.v_head_dim),
+            bias=False,
+        ).to(device=device)
+
+        self.attn = MLAAttention(
+            num_heads=num_heads,
+            scale=1.0 / (self.head_size**0.5),
+            qk_nope_head_dim=self.qk_nope_head_dim,
+            qk_rope_head_dim=self.qk_rope_head_dim,
+            v_head_dim=self.v_head_dim,
+            q_lora_rank=None,
+            kv_lora_rank=self.kv_lora_rank,
+            kv_b_proj=kv_b_proj,
+            cache_config=vllm_config.cache_config,
+            prefix="model.layers.0.self_attn.attn",
+        )
+        self.attn._k_scale = self.attn._k_scale.to(device)
+
+        # Process weights (extracts W_UK_T, W_UV from kv_b_proj)
+        self.attn.process_weights_after_loading(torch.get_default_dtype())
+
+        # Initialize attn MetadataBuilder
+        self.builder = self.attn.attn_backend.get_builder_cls()(
+            kv_cache_spec=MLAAttentionSpec(
+                block_size=self.block_size,
+                num_kv_heads=1,
+                head_size=self.head_size,
+                dtype=self.kv_cache_dtype,
+            ),
+            layer_names=[self.attn.layer_name],
+            vllm_config=self.vllm_config,
+            device=self.device,
+        )
+
+    def build_attn_metadata(self, batch_size: int) -> AttentionMetadata:
+        """Initialize attention metadata for decode-only batch."""
+        batch_spec = BatchSpec(seq_lens=[32] * batch_size, query_lens=[1] * batch_size)
+        common_attn_metadata = create_common_attn_metadata(
+            batch_spec, self.block_size, self.device, arange_block_indices=True
+        )
+
+        max_blocks = (max(batch_spec.seq_lens) + self.block_size - 1) // self.block_size
+        num_blocks = batch_size * max_blocks
+
+        # MLA KV cache shape: (num_blocks, block_size, head_size)
+        kv_cache = torch.zeros(
+            num_blocks,
+            self.block_size,
+            self.head_size,
+            dtype=self.kv_cache_dtype,
+            device=self.device,
+        )
+        self.attn.kv_cache = [kv_cache]
+
+        self.attn_metadata = self.builder.build(
+            common_prefix_len=0, common_attn_metadata=common_attn_metadata
+        )
+        return self.attn_metadata
+
+
+class TestMLAAttentionFp8StaticQuantPatternModel(MLAAttentionQuantPatternModel):
+    """Test model for MLA Attention+Fp8StaticQuant fusion."""
+
+    quant_key = kFp8StaticTensorSym
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        hidden_size = self.num_heads * self.v_head_dim
+        self.fp8_linear = TestFP8Layer(
+            weight_shape=(hidden_size, hidden_size),
+            activation_quant_key=self.quant_key,
+            weight_quant_key=self.quant_key,
+            device=self.device,
+        )
+
+        w = kwargs.get("w")
+        if w is not None:
+            self.fp8_linear.weight = w["weight"]
+            self.fp8_linear.weight_scale = w["wscale"]
+            self.fp8_linear.input_scale = w["scale"]
+
+        self.w = {
+            "weight": self.fp8_linear.weight,
+            "wscale": self.fp8_linear.weight_scale,
+            "scale": self.fp8_linear.input_scale,
+        }
+
+    def forward(
+        self, q: torch.Tensor, kv_c_normed: torch.Tensor, k_pe: torch.Tensor
+    ):
+        """Forward pass that creates the MLA attention + quant pattern."""
+        output_shape = (q.shape[0], self.num_heads * self.v_head_dim)
+        attn_output = self.attn(q, kv_c_normed, k_pe, output_shape=output_shape)
+        return self.fp8_linear(attn_output)
+
+
+MLA_PATTERN_TEST_MODELS_FP8: list[tuple[str, type]] = []
+MLA_BACKENDS_FP8: list[AttentionBackendEnum] = []
+
+if current_platform.is_cuda():
+    MLA_PATTERN_TEST_MODELS_FP8 = [
+        (
+            "deepseek-ai/DeepSeek-V2-Lite-Chat",
+            TestMLAAttentionFp8StaticQuantPatternModel,
+        )
+    ]
+    MLA_BACKENDS_FP8 = [AttentionBackendEnum.FLASHMLA]
+
+
+@pytest.mark.parametrize("num_heads", [MLA_NUM_HEADS])
+@pytest.mark.parametrize(
+    "batch_size", [7, 256] if current_platform.is_cuda() else [8]
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize(
+    "backend, model_name, model_class, custom_ops",
+    list(
+        flat_product(
+            MLA_BACKENDS_FP8, MLA_PATTERN_TEST_MODELS_FP8, ["+quant_fp8", "-quant_fp8"]
+        )
+    ),
+)
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="Only test CUDA"
+)
+@pytest.mark.skipif(not current_platform.supports_fp8(), reason="Need FP8")
+def test_mla_attention_quant_pattern(
+    num_heads: int,
+    batch_size: int,
+    dtype: torch.dtype,
+    custom_ops: str,
+    model_name: str,
+    model_class: type[MLAAttentionQuantPatternModel],
+    backend: AttentionBackendEnum,
+    dist_init,
+    monkeypatch,
+    use_fresh_inductor_cache,
+):
+    """Test MLA Attention + Fp8StaticQuant fusion pass."""
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+
+    if backend == AttentionBackendEnum.FLASHMLA:
+        if not current_platform.is_device_capability((9, 0)):
+            pytest.skip("FlashMLA requires Hopper (sm90) or newer")
+        try:
+            from vllm.v1.attention.ops.flashmla import is_flashmla_dense_supported
+
+            supported, reason = is_flashmla_dense_supported()
+            if not supported:
+                pytest.skip(f"FlashMLA not supported: {reason}")
+        except ImportError:
+            pytest.skip("FlashMLA not available")
+
+    custom_ops_list = custom_ops.split(",") if custom_ops else []
+
+    device = torch.device("cuda:0")
+    torch.set_default_dtype(dtype)
+    torch.manual_seed(42)
+
+    model_config = ModelConfig(
+        model=model_name,
+        max_model_len=2048,
+        dtype=dtype,
+    )
+
+    block_size = 64  # FlashMLA requires block_size=64
+
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=1024,
+            max_model_len=model_config.max_model_len,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            custom_ops=custom_ops_list,
+        ),
+        cache_config=CacheConfig(cache_dtype="fp8", block_size=block_size),
+        attention_config=AttentionConfig(backend=backend),
+    )
+
+    # MLA input shapes
+    qk_head_dim = MLA_QK_NOPE_HEAD_DIM + MLA_QK_ROPE_HEAD_DIM
+    q = torch.randn(batch_size, num_heads, qk_head_dim, dtype=dtype, device=device)
+    kv_c_normed = torch.randn(
+        batch_size, MLA_KV_LORA_RANK, dtype=dtype, device=device
+    )
+    k_pe = torch.randn(
+        batch_size, 1, MLA_QK_ROPE_HEAD_DIM, dtype=dtype, device=device
+    )
+
+    torch._dynamo.mark_dynamic(q, 0)
+    torch._dynamo.mark_dynamic(kv_c_normed, 0)
+    torch._dynamo.mark_dynamic(k_pe, 0)
+
+    # Run model without fusion
+    vllm_config_unfused = copy.deepcopy(vllm_config)
+    with (
+        set_current_vllm_config(vllm_config_unfused),
+        set_forward_context(attn_metadata=None, vllm_config=vllm_config_unfused),
+    ):
+        model_unfused = model_class(
+            num_heads=num_heads,
+            kv_cache_dtype=FP8_DTYPE,
+            device=device,
+            vllm_config=vllm_config_unfused,
+        )
+        model_unfused = model_unfused.to(device)
+        result_unfused_0 = model_unfused(q, kv_c_normed, k_pe)  # noqa: F841
+
+        forward_ctx = get_forward_context()
+        forward_ctx.attn_metadata = model_unfused.build_attn_metadata(batch_size)
+
+        compiled_unfused = torch.compile(model_unfused, fullgraph=True)
+        result_unfused = compiled_unfused(q, kv_c_normed, k_pe)
+
+    # Run model with attn fusion enabled
+    vllm_config.compilation_config.pass_config = PassConfig(
+        fuse_attn_quant=True, eliminate_noops=True
+    )
+    with (
+        set_current_vllm_config(vllm_config),
+        set_forward_context(attn_metadata=None, vllm_config=vllm_config),
+    ):
+        model_fused = model_class(
+            num_heads=num_heads,
+            kv_cache_dtype=FP8_DTYPE,
+            device=device,
+            vllm_config=vllm_config,
+            w=model_unfused.w,
+        )
+        model_fused = model_fused.to(device)
+
+        forward_ctx = get_forward_context()
+        forward_ctx.attn_metadata = model_fused.build_attn_metadata(batch_size)
+
+        noop_pass = NoOpEliminationPass(vllm_config)
+        attn_pass = LazyInitPass(AttnFusionPass, vllm_config)
+        cleanup_pass = PostCleanupPass(vllm_config)
+
+        test_backend = TestBackend(noop_pass, attn_pass, cleanup_pass)
+        result_fused_0 = model_fused(q, kv_c_normed, k_pe)  # noqa: F841
+
+        compiled_fused = torch.compile(
+            model_fused, backend=test_backend, fullgraph=True
+        )
+        result_fused = compiled_fused(q, kv_c_normed, k_pe)
+
+    # Check attn fusion support
+    quant_key: QuantKey = model_class.quant_key
+    attn_fusion_supported = [
+        layer.impl.fused_output_quant_supported(quant_key)
+        for key, layer in vllm_config.compilation_config.static_forward_context.items()
+        if isinstance(layer, MLAAttention)
+    ]
+    assert sum(attn_fusion_supported) == len(attn_fusion_supported), (
+        "All MLA layers should support attention fusion"
+    )
+
+    # Check quantization ops in the graph
+    quant_op = (
+        torch.ops.aten.reciprocal
+        if "-quant_fp8" in custom_ops_list
+        else QUANT_OPS[quant_key]
+    )
+    test_backend.check_before_ops([quant_op], fully_replaced=False)
+
+    assert attn_pass.pass_.matched_count == sum(attn_fusion_supported)
+
+    # Check MLA attention ops in the graph
+    attn_nodes_pre = list(find_op_nodes(MLA_ATTN_OP, test_backend.graph_pre_pass))
+    attn_nodes_post = list(find_op_nodes(MLA_ATTN_OP, test_backend.graph_post_pass))
+
+    assert len(attn_nodes_pre) > 0, "Should have MLA attention nodes before fusion"
+    assert len(attn_nodes_pre) == len(attn_nodes_post), (
+        "Should have same number of MLA attention nodes before and after fusion"
+    )
+    assert attn_nodes_pre[0].kwargs.get("output_scale") is None, (
+        "MLA attention should not have output_scale before fusion"
+    )
+    assert attn_nodes_post[0].kwargs.get("output_scale") is not None, (
+        "MLA attention should have output_scale after fusion"
+    )
+
+    # Check results are close
     torch.testing.assert_close(result_unfused, result_fused, atol=1e-2, rtol=1e-2)

--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -606,9 +606,7 @@ class TestMLAAttentionFp8StaticQuantPatternModel(MLAAttentionQuantPatternModel):
             "scale": self.fp8_linear.input_scale,
         }
 
-    def forward(
-        self, q: torch.Tensor, kv_c_normed: torch.Tensor, k_pe: torch.Tensor
-    ):
+    def forward(self, q: torch.Tensor, kv_c_normed: torch.Tensor, k_pe: torch.Tensor):
         """Forward pass that creates the MLA attention + quant pattern."""
         output_shape = (q.shape[0], self.num_heads * self.v_head_dim)
         attn_output = self.attn(q, kv_c_normed, k_pe, output_shape=output_shape)
@@ -629,9 +627,7 @@ if current_platform.is_cuda():
 
 
 @pytest.mark.parametrize("num_heads", [MLA_NUM_HEADS])
-@pytest.mark.parametrize(
-    "batch_size", [7, 256] if current_platform.is_cuda() else [8]
-)
+@pytest.mark.parametrize("batch_size", [7, 256] if current_platform.is_cuda() else [8])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize(
     "backend, model_name, model_class, custom_ops",
@@ -641,9 +637,7 @@ if current_platform.is_cuda():
         )
     ),
 )
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike(), reason="Only test CUDA"
-)
+@pytest.mark.skipif(not current_platform.is_cuda_alike(), reason="Only test CUDA")
 @pytest.mark.skipif(not current_platform.supports_fp8(), reason="Need FP8")
 def test_mla_attention_quant_pattern(
     num_heads: int,
@@ -704,12 +698,8 @@ def test_mla_attention_quant_pattern(
     # MLA input shapes
     qk_head_dim = MLA_QK_NOPE_HEAD_DIM + MLA_QK_ROPE_HEAD_DIM
     q = torch.randn(batch_size, num_heads, qk_head_dim, dtype=dtype, device=device)
-    kv_c_normed = torch.randn(
-        batch_size, MLA_KV_LORA_RANK, dtype=dtype, device=device
-    )
-    k_pe = torch.randn(
-        batch_size, 1, MLA_QK_ROPE_HEAD_DIM, dtype=dtype, device=device
-    )
+    kv_c_normed = torch.randn(batch_size, MLA_KV_LORA_RANK, dtype=dtype, device=device)
+    k_pe = torch.randn(batch_size, 1, MLA_QK_ROPE_HEAD_DIM, dtype=dtype, device=device)
 
     torch._dynamo.mark_dynamic(q, 0)
     torch._dynamo.mark_dynamic(kv_c_normed, 0)

--- a/vllm/compilation/passes/fusion/attn_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/attn_quant_fusion.py
@@ -3,7 +3,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any, ParamSpec
+from typing import TYPE_CHECKING, Any, ParamSpec
 
 import torch
 import torch._inductor.pattern_matcher as pm
@@ -28,12 +28,16 @@ from ..vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
 from .matcher_utils import MatcherQuantFP8
 from .rms_quant_fusion import QUANT_OPS, empty_bf16, empty_fp32, empty_i32
 
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+
 logger = init_logger(__name__)
 P = ParamSpec("P")
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
 
 ATTN_OP = torch.ops.vllm.unified_attention_with_output.default
+MLA_ATTN_OP = torch.ops.vllm.unified_mla_attention_with_output.default
 RESHAPE_OP = torch.ops.aten.reshape.default
 
 
@@ -319,6 +323,132 @@ class AttentionNvfp4QuantPattern(AttentionQuantPattern):
         )
 
 
+class MLAAttentionFp8StaticQuantPattern:
+    """
+    Fusion for MLA Attention+Fp8StaticQuant.
+
+    Only triggers when the MLA attention implementation returns True in
+    `fused_output_quant_supported()`. If the pattern is found, the
+    Fp8StaticQuant op will be removed from the graph, and its scale
+    will be passed into MLA Attention op as the `output_scale` argument.
+
+    MLA attention outputs a 2D tensor (tokens, num_heads * v_head_dim)
+    so no reshape is needed between attention and quantization.
+    """
+
+    def __init__(
+        self,
+        layer: "MLAAttention",
+        dtype: torch.dtype,
+        symmetric: bool = True,
+    ) -> None:
+        from vllm.model_executor.layers.attention.mla_attention import (
+            MLAAttention,
+        )
+
+        assert isinstance(layer, MLAAttention)
+        self.layer = layer
+        self.layer_name = layer.layer_name
+        self.num_heads = layer.num_heads
+        self.v_head_dim = layer.v_head_dim
+        self.dtype = dtype
+
+        quant_key = QuantKey(
+            dtype=FP8_DTYPE, scale=kStaticTensorScale, symmetric=symmetric
+        )
+        self.quant_key = quant_key
+        self.quant_dtype = quant_key.dtype
+        self.QUANT_OP = QUANT_OPS[quant_key]
+        self.quant_matcher = MatcherQuantFP8(quant_key)
+
+    def register_if_supported(self, pm_pass: PatternMatcherPass) -> None:
+        if self.layer.impl.fused_output_quant_supported(self.quant_key):
+            self._register(pm_pass)
+
+    def _register(self, pm_pass: PatternMatcherPass) -> None:
+        hidden_size = self.num_heads * self.v_head_dim
+
+        def pattern(
+            q: torch.Tensor,
+            kv_c_normed: torch.Tensor,
+            k_pe: torch.Tensor,
+            output_attn: torch.Tensor,
+            scale: torch.Tensor,
+            kv_cache_dummy_dep: torch.Tensor,
+        ) -> torch.Tensor:
+            at1 = auto_functionalized(
+                MLA_ATTN_OP,
+                q=q,
+                kv_c_normed=kv_c_normed,
+                k_pe=k_pe,
+                output=output_attn,
+                layer_name=self.layer_name,
+                output_scale=None,
+                output_block_scale=None,
+                kv_cache_dummy_dep=kv_cache_dummy_dep,
+            )
+            return self.quant_matcher(at1[1], scale)[0]
+
+        def replacement(
+            q: torch.Tensor,
+            kv_c_normed: torch.Tensor,
+            k_pe: torch.Tensor,
+            output_attn: torch.Tensor,
+            scale: torch.Tensor,
+            kv_cache_dummy_dep: torch.Tensor,
+        ) -> torch.Tensor:
+            # MLA attn output in quant_dtype
+            output_attn = torch.ops.aten.full.default(
+                [q.shape[0], hidden_size],
+                0.0,
+                dtype=self.quant_dtype,
+                device=q.device,
+            )
+            at1 = auto_functionalized(
+                MLA_ATTN_OP,
+                q=q,
+                kv_c_normed=kv_c_normed,
+                k_pe=k_pe,
+                output=output_attn,
+                layer_name=self.layer_name,
+                output_scale=scale,
+                output_block_scale=None,
+                kv_cache_dummy_dep=kv_cache_dummy_dep,
+            )
+            return at1[1]
+
+        # MLA q shape: (tokens, num_heads, qk_nope_head_dim + qk_rope_head_dim)
+        # but we use a generic shape for pattern matching since the pattern
+        # matcher only cares about the number of dimensions, not exact sizes.
+        qk_head_dim = self.layer.qk_nope_head_dim + self.layer.qk_rope_head_dim
+        inputs = [
+            torch.empty(
+                5, self.num_heads, qk_head_dim, dtype=self.dtype, device="cuda"
+            ),  # q
+            torch.empty(
+                5, self.layer.kv_lora_rank, dtype=self.dtype, device="cuda"
+            ),  # kv_c_normed
+            torch.empty(
+                5, 1, self.layer.qk_rope_head_dim, dtype=self.dtype, device="cuda"
+            ),  # k_pe
+            torch.empty(5, hidden_size, dtype=self.dtype, device="cuda"),  # output (2D)
+            empty_fp32(1, 1),  # scale
+            torch.empty(0, dtype=self.dtype, device="cuda"),  # kv_cache_dummy_dep
+        ]
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            inputs,
+            AttentionQuantPattern.wrap_trace_fn(
+                pm.fwd_only,
+                AttentionQuantPattern.fx_view_to_reshape,
+                AttentionQuantPattern.remove_noop_permutes,
+            ),
+            pm_pass,
+        )
+
+
 class AttnFusionPass(VllmPatternMatcherPass):
     """
     This pass fuses post-attention quantization onto attention if supported.
@@ -351,7 +481,19 @@ class AttnFusionPass(VllmPatternMatcherPass):
                 )
                 pattern_nvfp4.register_if_supported(self.patterns)
 
-        if len(attn_layers) == 0:
+        # MLA attention layers (e.g., DeepSeek V3/R1)
+        from vllm.model_executor.layers.attention.mla_attention import (
+            MLAAttention,
+        )
+
+        mla_layers = get_layers_from_vllm_config(config, MLAAttention)
+        for layer_name, layer in mla_layers.items():
+            mla_pattern_fp8 = MLAAttentionFp8StaticQuantPattern(
+                layer, config.model_config.dtype
+            )
+            mla_pattern_fp8.register_if_supported(self.patterns)
+
+        if len(attn_layers) == 0 and len(mla_layers) == 0:
             logger.warning(
                 "Attention + quant fusion is enabled, but no attention layers "
                 "were found in CompilationConfig.static_forward_context "
@@ -371,4 +513,5 @@ class AttnFusionPass(VllmPatternMatcherPass):
             AttentionQuantPattern,
             AttentionFp8StaticQuantPattern,
             AttentionNvfp4QuantPattern,
+            MLAAttentionFp8StaticQuantPattern,
         )

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -520,9 +520,16 @@ class MLAAttention(nn.Module, AttentionLayerBase):
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
 
-        if output_scale is not None or output_block_scale is not None:
-            raise NotImplementedError(
-                "fused output quantization is not yet supported for MLA"
+        # When fused output quantization is requested, the output buffer is
+        # in quantized dtype (e.g., FP8). We need a temporary buffer in
+        # compute dtype for internal work, then quantize at the end.
+        quant_output = None
+        if output_scale is not None:
+            quant_output = output
+            output = torch.empty(
+                quant_output.shape,
+                dtype=q.dtype,
+                device=quant_output.device,
             )
 
         if attn_metadata is None:
@@ -681,6 +688,16 @@ class MLAAttention(nn.Module, AttentionLayerBase):
 
             # v_up projection
             self._v_up_proj(attn_out, out=mqa_output_slice)
+
+        if quant_output is not None:
+            # Quantize the compute-dtype output into the FP8 output buffer
+            torch.ops._C.static_scaled_fp8_quant(
+                quant_output[:num_actual_toks],
+                output[:num_actual_toks],
+                output_scale,
+            )
+            return quant_output
+
         return output_padded
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -760,6 +760,17 @@ class AttentionImpl(AttentionImplBase[T], Generic[T]):
 class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
     """MLA attention implementation with forward_mqa and forward_mha methods."""
 
+    def fused_output_quant_supported(self, quant_key: "QuantKey"):
+        """
+        Does this MLA implementation support fused output quantization.
+        This is used by the AttnFusionPass to only fuse output quantization
+        onto implementations that support it.
+
+        :param quant_key: QuantKey object that describes the quantization op
+        :return: is fusion supported for this type of quantization
+        """
+        return False
+
     @abstractmethod
     def __init__(
         self,

--- a/vllm/v1/attention/backends/mla/cutlass_mla.py
+++ b/vllm/v1/attention/backends/mla/cutlass_mla.py
@@ -15,6 +15,10 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonMetadata,
     MLACommonMetadataBuilder,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kFp8StaticTensorSym,
+)
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.platform_utils import num_compute_units
 from vllm.v1.attention.backend import (
@@ -160,6 +164,11 @@ class CutlassMLAImpl(MLACommonImpl[MLACommonMetadata]):
 
         # Share workspace buffer across all executions
         self._workspace = g_sm100_workspace
+
+    def fused_output_quant_supported(self, quant_key: QuantKey) -> bool:
+        return (
+            self.kv_cache_dtype.startswith("fp8") and quant_key == kFp8StaticTensorSym
+        )
 
     def _sm100_cutlass_mla_decode(
         self,

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -15,6 +15,10 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonMetadataBuilder,
     QueryLenSupport,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kFp8StaticTensorSym,
+)
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backend import (
     AttentionCGSupport,
@@ -149,6 +153,11 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
         self._workspace_buffer = g_fi_workspace
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
+
+    def fused_output_quant_supported(self, quant_key: QuantKey) -> bool:
+        return (
+            self.kv_cache_dtype.startswith("fp8") and quant_key == kFp8StaticTensorSym
+        )
 
     def forward_mqa(
         self,

--- a/vllm/v1/attention/backends/mla/flashmla.py
+++ b/vllm/v1/attention/backends/mla/flashmla.py
@@ -20,6 +20,10 @@ from vllm.model_executor.layers.attention.mla_attention import (
 from vllm.model_executor.layers.batch_invariant import (
     vllm_is_batch_invariant,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kFp8StaticTensorSym,
+)
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.platform_utils import num_compute_units
 from vllm.v1.attention.backend import (
@@ -233,6 +237,11 @@ class FlashMLAImpl(MLACommonImpl[FlashMLAMetadata]):
                 "are not implemented for "
                 "FlashMLAImpl"
             )
+
+    def fused_output_quant_supported(self, quant_key: QuantKey) -> bool:
+        return (
+            self.kv_cache_dtype.startswith("fp8") and quant_key == kFp8StaticTensorSym
+        )
 
     def forward_mqa(
         self,


### PR DESCRIPTION
## Summary

Extends the `AttnFusionPass` to support fusing post-attention FP8 static quantization onto MLA (Multi-Latent Attention) layers used by DeepSeek V2/V3/R1 models. This eliminates a separate quantization kernel call after MLA attention during decode, reducing memory traffic.

Addresses #36266.

### Changes

- **`vllm/v1/attention/backend.py`**: Add `fused_output_quant_supported()` default method to `MLAAttentionImpl` base class
- **FlashMLA / CUTLASS MLA / FlashInfer MLA backends**: Override `fused_output_quant_supported()` to return `True` for FP8 static per-tensor symmetric quant when using FP8 KV cache
- **`vllm/compilation/passes/fusion/attn_quant_fusion.py`**: Add `MLAAttentionFp8StaticQuantPattern` that matches `unified_mla_attention_with_output` followed by FP8 quant op (no reshape needed since MLA output is 2D), and extend `AttnFusionPass.__init__` to discover `MLAAttention` layers
- **`vllm/model_executor/layers/attention/mla_attention.py`**: Implement fused output quantization in `forward_impl` using a temp buffer approach (allocate bf16 temp buffer for computation, then quantize into the FP8 output buffer at the end)
- **`tests/compile/passes/test_fusion_attn.py`**: Add MLA-specific fusion test cases following existing conventions

## Test plan

- [ ] Run `test_mla_attention_quant_pattern` on sm90+ (Hopper) or sm100+ (Blackwell) with FlashMLA backend
- [ ] Verify fusion pass correctly matches MLA attention + FP8 quant pattern and replaces with fused op
- [ ] Verify fused and unfused results match within tolerance
- [ ] Existing `test_attention_quant_pattern` tests should continue to pass (no regression)