### PR TITLE
mla: don't update kv cache on dummy forwards

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -905,6 +905,10 @@ def unified_mla_kv_cache_update(
     the data dependency between them to ensure torch.compile preserves ordering.
     """
     forward_context = get_forward_context()
+    if forward_context.attn_metadata is None:
+        # Dummy/profile forwards should not update live KV cache pages.
+        return torch.empty(0, device=kv_c_normed.device, dtype=kv_c_normed.dtype)
+
     attn_layer = forward_context.no_compile_layers[layer_name]
     kv_cache = attn_layer.kv_cache[forward_context.virtual_engine]
 


### PR DESCRIPTION
## Purpose
Before #34627, MLA only wrote KV inside forward_impl, after checking attn_metadata is not None.
With #34627, we started calling unified_mla_kv_cache_update unconditionally, so warmup/profile runs could still write into KV pages.

This breaks prefix cache after elastic ep reconfigure, since it involves a dummy run which can now overwrite KV pages without invalidating the prefix-cache entries.

This PR restores the original logic (skip KV cache update on dummy runs) by making unified_mla_kv_cache_update a no-op when attn_metadata is None.

## Test Results
`tests/distributed/test_elastic_ep.py` fails with #34627 due to precision drop after elastic ep reconfiguration.
With this PR, precision stays the same after multiple reconfigurations.