### PR TITLE
[Feature] Add LLM.shutdown() for explicit engine teardown

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -414,6 +414,28 @@ class LLM:
         """Create an LLM instance from EngineArgs."""
         return cls(**vars(engine_args))
 
+    def shutdown(self, timeout: float | None = None) -> None:
+        """Explicitly shut down the engine and release all resources.
+
+        Args:
+            timeout: Maximum seconds to wait for queued work to complete.
+                If ``None``, uses ``VllmConfig.shutdown_timeout``.
+                If ``0``, abort immediately.
+
+        This method is idempotent — it is safe to call multiple times.
+        """
+        engine = getattr(self, "llm_engine", None)
+        if engine is None:
+            return
+
+        if timeout is None:
+            timeout = engine.vllm_config.shutdown_timeout
+
+        engine.engine_core.shutdown(timeout=timeout)
+
+    def __del__(self):
+        self.shutdown(timeout=0)
+
     def get_tokenizer(self) -> TokenizerLike:
         return self.llm_engine.get_tokenizer()
 


### PR DESCRIPTION
Add a public shutdown() method to the LLM class so library users can explicitly release GPU memory and engine resources without waiting for garbage collection.

  llm = LLM(model="my-model")
  results = llm.generate(prompts)
  llm.shutdown()          # free resources immediately

The method delegates to engine_core.shutdown(timeout=...) and respects VllmConfig.shutdown_timeout when no explicit timeout is given.  A __del__ fallback ensures resources are freed even when shutdown() is not called explicitly.

Related to RFC #24885, complements #28953 (KV cache GPU memory cleanup on engine shutdown).

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

