### PR TITLE
[ROCm][CI] Fix ROCm attention backend validation for head sizes, block sizes, and compute capability checks

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -213,4 +213,4 @@ configuration.
 | `ROCM_AITER_MLA` | fp16, bf16 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 1 | Any | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_MLA_SPARSE` | fp16, bf16 | `auto`, `bfloat16` | 1 | Any | ❌ | ✅ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_TRITON_MLA` | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
-| `TRITON_MLA` | fp16, bf16 | `auto`, `bfloat16` | Any | Any | ❌ | ❌ | ❌ | ✅ | Decoder | Any |
+| `TRITON_MLA` | fp16, bf16 | `auto`, `bfloat16` | %16 | Any | ❌ | ❌ | ❌ | ✅ | Decoder | Any |

--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -321,7 +321,7 @@ def test_mla_backend_selection(
             assert backend_path == expected_backend_path
 
 
-def test_aiter_fa_requires_gfx9(mock_vllm_config):
+def test_aiter_fa_requires_mi3xx(mock_vllm_config):
     """Test that ROCM_AITER_FA requires mi3xx architecture."""
     from vllm.platforms.rocm import RocmPlatform
 

--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -181,13 +181,13 @@ def test_standard_attention_backend_selection(
             AttentionBackendEnum.TRITON_MLA.get_path(),
             False,
         ),
-        # Test Case 2: TRITON_MLA with block_size == 1
+        # Test Case 2: TRITON_MLA with block_size == 1 (should raise)
         (
             {},
             "TRITON_MLA",
             1,
-            AttentionBackendEnum.TRITON_MLA.get_path(),
-            False,
+            None,
+            True,
         ),
         # Test Case 3: ROCM_AITER_MLA with block_size == 1
         (

--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -29,8 +29,15 @@ def mock_vllm_config():
 
 @pytest.fixture
 def mock_on_gfx9():
-    """Mock the on_gfx9 function to return True."""
+    """Mock gfx9 arch detection to return True."""
     with patch("vllm.platforms.rocm.on_gfx9", return_value=True):
+        yield
+
+
+@pytest.fixture
+def mock_on_mi3xx():
+    """Mock mi3xx arch detection to return True."""
+    with patch("vllm.platforms.rocm.on_mi3xx", return_value=True):
         yield
 
 
@@ -122,6 +129,7 @@ def test_standard_attention_backend_selection(
     expected_backend_path,
     mock_vllm_config,
     mock_on_gfx9,
+    mock_on_mi3xx,
     monkeypatch,
 ):
     """Test standard attention backend selection with various configurations."""
@@ -173,13 +181,13 @@ def test_standard_attention_backend_selection(
             AttentionBackendEnum.TRITON_MLA.get_path(),
             False,
         ),
-        # Test Case 2: TRITON_MLA with block_size == 1 (should raise)
+        # Test Case 2: TRITON_MLA with block_size == 1
         (
             {},
             "TRITON_MLA",
             1,
-            None,
-            True,
+            AttentionBackendEnum.TRITON_MLA.get_path(),
+            False,
         ),
         # Test Case 3: ROCM_AITER_MLA with block_size == 1
         (
@@ -314,15 +322,15 @@ def test_mla_backend_selection(
 
 
 def test_aiter_fa_requires_gfx9(mock_vllm_config):
-    """Test that ROCM_AITER_FA requires gfx9 architecture."""
+    """Test that ROCM_AITER_FA requires mi3xx architecture."""
     from vllm.platforms.rocm import RocmPlatform
 
-    # Mock on_gfx9 to return False
+    # Mock on_mi3xx to return False (used by supports_compute_capability)
     with (
-        patch("vllm.platforms.rocm.on_gfx9", return_value=False),
+        patch("vllm.platforms.rocm.on_mi3xx", return_value=False),
         pytest.raises(
             ValueError,
-            match="only supported on gfx9",
+            match="compute capability not supported",
         ),
     ):
         attn_selector_config = AttentionSelectorConfig(
@@ -342,11 +350,12 @@ def test_aiter_fa_requires_gfx9(mock_vllm_config):
 
 
 def test_sparse_not_supported(mock_vllm_config):
-    """Test that sparse attention is not supported on ROCm."""
+    """Test that sparse MLA without use_mla flag raises an error."""
     from vllm.platforms.rocm import RocmPlatform
 
     with pytest.raises(
-        AssertionError, match="Sparse MLA backend on ROCm only supports block size 1"
+        ValueError,
+        match="No valid attention backend found",
     ):
         attn_selector_config = AttentionSelectorConfig(
             head_size=128,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -31,6 +31,10 @@ class AiterMLABackend(MLACommonBackend):
         "fp8_e5m2",
     ]
 
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return []
+
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         return [1]

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -33,6 +33,10 @@ class TritonMLABackend(MLACommonBackend):
         "bfloat16",
     ]
 
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return []
+
     @staticmethod
     def get_name() -> str:
         return "TRITON_MLA"

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -19,6 +19,7 @@ from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backend import (
     AttentionLayer,
     AttentionType,
+    MultipleOf,
     is_quantized_kv_cache,
 )
 from vllm.v1.attention.ops.triton_decode_attention import decode_attention_fwd
@@ -36,6 +37,16 @@ class TritonMLABackend(MLACommonBackend):
     @classmethod
     def get_supported_head_sizes(cls) -> list[int]:
         return []
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [MultipleOf(16)]
+
+    @classmethod
+    def supports_block_size(cls, block_size: int | None) -> bool:
+        if block_size is None:
+            return True
+        return block_size % 16 == 0
 
     @staticmethod
     def get_name() -> str:

--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -30,6 +30,12 @@ class RocmAiterUnifiedAttentionBackend(RocmAttentionBackend):
         return [MultipleOf(16)]
 
     @classmethod
+    def supports_block_size(cls, block_size: int | None) -> bool:
+        if block_size is None:
+            return True
+        return block_size % 16 == 0
+
+    @classmethod
     def supports_head_size(cls, head_size: int) -> bool:
         return head_size >= 32
 

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -189,6 +189,12 @@ class RocmAttentionBackend(AttentionBackend):
         return [16, 32, 544]
 
     @classmethod
+    def supports_block_size(cls, block_size: int | None) -> bool:
+        if block_size is None:
+            return True
+        return block_size in (16, 32, 544)
+
+    @classmethod
     def get_supported_head_sizes(cls) -> list[int]:
         return [32, 64, 80, 96, 128, 160, 192, 224, 256]
 

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -273,6 +273,12 @@ class TritonAttentionBackend(AttentionBackend):
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         return [MultipleOf(16)]
 
+    @classmethod
+    def supports_block_size(cls, block_size: int | None) -> bool:
+        if block_size is None:
+            return True
+        return block_size % 16 == 0
+
     forward_includes_kv_cache_update: bool = False
 
     @staticmethod


### PR DESCRIPTION
This PR fixes several issues in the ROCm attention backend selection tests and underlying validation logic introduced by the move to validation-based backend selection in #35246 and refined in #36185.

MLA backends (TritonMLA, AiterMLA, AiterTritonMLA) were incorrectly rejecting common head sizes like 128 because they inherited a restrictive head size list from the base MLA class. These backends now correctly accept any head size. The AITER FA compute capability check was also not being tested properly since the test was patching the wrong function, it now correctly patches on_mi3xx, which is the actual gate for MI300-series support. The test fixtures for architecture mocking have been split into separate mock_on_gfx9 and mock_on_mi3xx fixtures to accurately reflect that these are distinct hardware capabilities. Additionally, backends like Triton attention, ROCm attention, and the AITER unified backend now override block size validation directly so they can accept non-standard block sizes (such as 272 or 544 used by hybrid blocks) without needing to modify the base validation or the global block size type definition.

Fixes the following test groups:
* mi325_1: Language Models Test (PPL)
* mi325_1: V1 Test attention (H100)
* mi325_2: Distributed Tests (2 GPUs)
* Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy

cc @kenroche 