### PR TITLE
[ROCm][CI] Making entrypoints more deterministic on ROCm

### DIFF
--- a/tests/entrypoints/openai/test_realtime_validation.py
+++ b/tests/entrypoints/openai/test_realtime_validation.py
@@ -13,7 +13,7 @@ import websockets
 
 from vllm.assets.audio import AudioAsset
 
-from ...utils import RemoteOpenAIServer
+from ...utils import ROCM_ENV_OVERRIDES, ROCM_EXTRA_ARGS, RemoteOpenAIServer
 from .conftest import add_attention_backend
 
 MISTRAL_FORMAT_ARGS = [
@@ -23,7 +23,7 @@ MISTRAL_FORMAT_ARGS = [
     "mistral",
     "--load_format",
     "mistral",
-]
+] + ROCM_EXTRA_ARGS
 
 MODEL_NAME = "mistralai/Voxtral-Mini-4B-Realtime-2602"
 
@@ -77,7 +77,9 @@ async def test_multi_chunk_streaming(
 
     add_attention_backend(server_args, rocm_aiter_fa_attention)
 
-    with RemoteOpenAIServer(model_name, server_args) as remote_server:
+    with RemoteOpenAIServer(
+        model_name, server_args, env_dict=ROCM_ENV_OVERRIDES
+    ) as remote_server:
         ws_url = _get_websocket_url(remote_server)
         async with websockets.connect(ws_url) as ws:
             # Receive session.created
@@ -178,7 +180,9 @@ async def test_empty_commit_does_not_crash_engine(
 
     add_attention_backend(server_args, rocm_aiter_fa_attention)
 
-    with RemoteOpenAIServer(model_name, server_args) as remote_server:
+    with RemoteOpenAIServer(
+        model_name, server_args, env_dict=ROCM_ENV_OVERRIDES
+    ) as remote_server:
         ws_url = _get_websocket_url(remote_server)
 
         # --- First connection: empty commit (no audio appended) ----------


### PR DESCRIPTION
Adding some options that are known to render tests' results more deterministic on ROCm. This particular PR targets `pytest -s -v entrypoints/openai/test_realtime_validation.py`. This test was tested in a loop 10 times before pushing the fix (all of them passed).

cc @kenroche 