### PR TITLE
[CI] Fix BackgroundResources double-cleanup crash by adding guard

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -384,14 +384,22 @@ class BackgroundResources:
     # processing threads can access it without holding a ref to the client.
     engine_dead: bool = False
 
+    # Guard against double-cleanup
+    _cleaned_up: bool = False
+
     def __call__(self):
         """Clean up background resources."""
+        if self._cleaned_up:
+            return
+        self._cleaned_up = True
 
         self.engine_dead = True
         if self.engine_manager is not None:
             self.engine_manager.shutdown()
+            self.engine_manager = None
         if self.coordinator is not None:
             self.coordinator.shutdown()
+            self.coordinator = None
 
         if isinstance(self.output_socket, zmq.asyncio.Socket):
             # Async case.
@@ -424,8 +432,10 @@ class BackgroundResources:
                 del tasks
                 del close_sockets_and_tasks
                 close_sockets(sockets)
-                del self.output_queue_task
-                del self.stats_update_task
+
+            # Clear references instead of deleting attributes
+            self.output_queue_task = None
+            self.stats_update_task = None
         else:
             # Sync case.
 


### PR DESCRIPTION
Fixes regression after: #34730 

`BackgroundResources.__call__()` crashes with `AttributeError: 'BackgroundResources' object has no attribute 'output_queue_task'` when invoked more than once. This happens because the cleanup path uses `del self.output_queue_task` which removes the attribute entirely, so a second call fails.

This is triggered in practice when the engine monitor thread detects a dead engine and calls `shutdown()`, followed by the caller (e.g. a test) also calling `shutdown()` explicitly. Both paths end up invoking `self.resources()`.

- Add a `_cleaned_up` bool guard so `__call__` subsequent calls are a no-op.
- Replace `del self.output_queue_task` / `del self.stats_update_task` with `= None` assignments to clear references without removing the attribute.
- Nil out `engine_manager` and `coordinator` after shutdown to prevent double-shutdown when `MPClient.shutdown()` calls `engine_manager.shutdown(timeout=...)` followed by `self.resources()`.

cc @kenroche 