### PR TITLE
[Bug] Fix pooling model benchmark script

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -795,6 +795,17 @@ ASYNC_REQUEST_FUNCS: dict[str, RequestFunc] = {
     "vllm-rerank": async_request_vllm_rerank,
 }
 
+POOLING_BACKENDS = {
+    "openai-embeddings",
+    "openai-embeddings-chat",
+    "openai-embeddings-clip",
+    "openai-embeddings-vlm2vec",
+    "infinity-embeddings",
+    "infinity-embeddings-clip",
+    "vllm-pooling",
+    "vllm-rerank",
+}
+
 OPENAI_COMPATIBLE_BACKENDS = [
     k
     for k, v in ASYNC_REQUEST_FUNCS.items()

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1723,7 +1723,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
     backend = args.backend
     task_type = (
         TaskType.POOLING
-        if "embeddings" in backend or "rerank" in backend
+        if "embeddings" in backend or "rerank" in backend or backend == "vllm-pooling"
         else TaskType.GENERATION
     )
 

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -45,6 +45,7 @@ from vllm.benchmarks.datasets import SampleRequest, add_dataset_parser, get_samp
 from vllm.benchmarks.lib.endpoint_request_func import (
     ASYNC_REQUEST_FUNCS,
     OPENAI_COMPATIBLE_BACKENDS,
+    POOLING_BACKENDS,
     RequestFuncInput,
     RequestFuncOutput,
 )
@@ -1721,11 +1722,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
     goodput_config_dict = check_goodput_args(args)
 
     backend = args.backend
-    task_type = (
-        TaskType.POOLING
-        if "embeddings" in backend or "rerank" in backend or backend == "vllm-pooling"
-        else TaskType.GENERATION
-    )
+    task_type = TaskType.POOLING if backend in POOLING_BACKENDS else TaskType.GENERATION
 
     # Collect the sampling parameters.
     if task_type == TaskType.GENERATION:


### PR DESCRIPTION
## Purpose

We are missing `"vllm-pooling": async_request_vllm_pooling,` and related stuff in benchmark script, this PR fixes the issue.

## Test

Originally

```bash
============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  181.21    
Total input tokens:                      200       
Request throughput (req/s):              1.10      
Peak concurrent requests:                3.00      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          905.79    
Median E2EL (ms):                        905.17    
P50 E2EL (ms):                           905.17    
P90 E2EL (ms):                           908.75    
P99 E2EL (ms):                           911.63    
==================================================
```

## Now

```bash
============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  181.11    
Total input tokens:                      1400000   
Request throughput (req/s):              1.10      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          905.27    
Median E2EL (ms):                        904.79    
P50 E2EL (ms):                           904.79    
P90 E2EL (ms):                           908.89    
P99 E2EL (ms):                           912.43    
==================================================
```