### PR TITLE
[Misc] Remove duplicate parser registration

### DIFF
--- a/vllm/parser/__init__.py
+++ b/vllm/parser/__init__.py
@@ -22,13 +22,6 @@ _PARSERS_TO_REGISTER = {
     ),
 }
 
-# Register lazy parsers
-ParserManager.register_lazy_module(
-    name="minimax_m2",
-    module_path="vllm.parser.minimax_m2_parser",
-    class_name="MiniMaxM2Parser",
-)
-
 
 def register_lazy_parsers():
     for name, (file_name, class_name) in _PARSERS_TO_REGISTER.items():


### PR DESCRIPTION
## Summary

- Removed duplicate `ParserManager.register_lazy_module()` call for `minimax_m2` in `vllm/parser/__init__.py`
- The parser was registered twice: once via a direct call and again via the `register_lazy_parsers()` function that iterates `_PARSERS_TO_REGISTER`