### PR TITLE
[BugFix] Fix EPLB balancedness metric using wrong dimension

### DIFF
--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -571,18 +571,22 @@ class EplbState:
                     .float()
                 )
 
-                # Compute balancedness ratio:
-                # for each layer:
-                #   (mean load across ranks) / (max load across ranks)
-                avg_tokens_tensor = num_tokens_per_rank.mean(dim=0).sum(dim=0)
-                max_tokens_tensor = num_tokens_per_rank.max(dim=0).values.sum(dim=0)
+                # Compute per-layer balancedness ratio:
+                #   for each layer: (mean across ranks) / (max across ranks)
+                #   then average across layers.
+                # dim=-1 is the rank dimension.
+                avg_per_layer = num_tokens_per_rank.mean(dim=-1)
+                max_per_layer = num_tokens_per_rank.max(dim=-1).values
+                per_layer_balance = torch.where(
+                    max_per_layer > 0,
+                    avg_per_layer / max_per_layer,
+                    torch.ones_like(max_per_layer),
+                )
+                balancedness = float(per_layer_balance.mean().item())
 
-                # Just to make type checker happy
-                tokens_tensors: list[float] = torch.stack(
-                    [avg_tokens_tensor, max_tokens_tensor]
-                ).tolist()
-                avg_tokens, max_tokens = tokens_tensors
-                balancedness = avg_tokens / max_tokens if max_tokens > 0 else 0.0
+                # Summary stats for logging
+                avg_tokens = float(avg_per_layer.sum().item())
+                max_tokens = float(max_per_layer.sum().item())
 
                 if ep_group.rank() == 0:
                     logger.info(


### PR DESCRIPTION
## Summary

- The EPLB balancedness metric was computing `mean(dim=0)` / `max(dim=0)` on a `(num_moe_layers, num_ranks)` tensor. `dim=0` is the **layer** dimension, so this measured cross-layer consistency per rank, not cross-rank balance per layer.
- Fix: use `dim=-1` (the rank dimension) to correctly compute per-layer balancedness as `mean_across_ranks / max_across_ranks`, then average across layers.

### Concrete example

2 layers, 2 ranks, rank 1 always gets 2x the tokens:
| | Rank 0 | Rank 1 |
|---|---|---|
| Layer 1 | 100 | 200 |
| Layer 2 | 100 | 200 |

**Old metric**: `mean(dim=0)=[100,200]`, `max(dim=0)=[100,200]`, ratio = **1.0** (reports perfect balance)
**New metric**: per-layer `mean/max = 150/200 = 0.75` for both layers → **0.75** (correct)

The old metric reports perfect balance whenever the rank imbalance is consistent across layers, regardless of how severe it is.

## Test plan

- [ ] Verify with `log_balancedness=True` on an EP deployment
- [ ] Check that the new metric correctly reflects known imbalanced configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)