### PR TITLE
[BugFix] Download mmproj GGUF files for multimodal models in download…

### DIFF
--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -14,8 +14,9 @@ from vllm.model_executor.model_loader.weight_utils import download_gguf
 class TestGGUFDownload:
     """Test GGUF model downloading functionality."""
 
+    @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
     @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
-    def test_download_gguf_single_file(self, mock_download):
+    def test_download_gguf_single_file(self, mock_download, mock_snapshot):
         """Test downloading a single GGUF file."""
         # Setup mock
         mock_folder = "/tmp/mock_cache"
@@ -46,8 +47,9 @@ class TestGGUFDownload:
             # Verify result is the file path, not folder
             assert result == f"{mock_folder}/model-IQ1_S.gguf"
 
+    @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
     @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
-    def test_download_gguf_sharded_files(self, mock_download):
+    def test_download_gguf_sharded_files(self, mock_download, mock_snapshot):
         """Test downloading sharded GGUF files."""
         mock_folder = "/tmp/mock_cache"
         mock_download.return_value = mock_folder
@@ -68,8 +70,9 @@ class TestGGUFDownload:
             # Should return the first file after sorting
             assert result == f"{mock_folder}/model-Q2_K-00001-of-00002.gguf"
 
+    @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
     @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
-    def test_download_gguf_subdir(self, mock_download):
+    def test_download_gguf_subdir(self, mock_download, mock_snapshot):
         """Test downloading GGUF files from subdirectory."""
         mock_folder = "/tmp/mock_cache"
         mock_download.return_value = mock_folder
@@ -85,9 +88,104 @@ class TestGGUFDownload:
 
             assert result == f"{mock_folder}/Q2_K/model-Q2_K.gguf"
 
+    @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
+    @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
+    def test_download_gguf_with_mmproj(self, mock_download, mock_snapshot):
+        """Test that mmproj files are downloaded via snapshot_download."""
+        mock_folder = "/tmp/mock_cache"
+        mock_download.return_value = mock_folder
+
+        with patch("glob.glob") as mock_glob:
+
+            def glob_side_effect(pattern, **kwargs):
+                if "Q4_K_S" in pattern:
+                    return [f"{mock_folder}/gemma-3-4b-it-Q4_K_S.gguf"]
+                return []
+
+            mock_glob.side_effect = glob_side_effect
+
+            result = download_gguf("unsloth/gemma-3-4b-it-GGUF", "Q4_K_S")
+
+            # Verify snapshot_download was called for mmproj with all
+            # key parameters passed through correctly
+            mock_snapshot.assert_called_once()
+            call_kwargs = mock_snapshot.call_args.kwargs
+            assert call_kwargs["allow_patterns"] == \
+                ["mmproj*.gguf", "*/mmproj*.gguf"]
+            assert call_kwargs["cache_dir"] is None
+            assert call_kwargs["revision"] is None
+            assert call_kwargs["ignore_patterns"] is None
+
+            # Verify result is the backbone file, not mmproj
+            assert result == f"{mock_folder}/gemma-3-4b-it-Q4_K_S.gguf"
+            assert "mmproj" not in result
+
+    @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
+    @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
+    def test_download_gguf_mmproj_passthrough_params(self, mock_download,
+                                                      mock_snapshot):
+        """Test that cache_dir, revision, ignore_patterns are passed through
+        to snapshot_download for mmproj."""
+        mock_folder = "/tmp/mock_cache"
+        mock_download.return_value = mock_folder
+
+        with patch("glob.glob") as mock_glob:
+
+            def glob_side_effect(pattern, **kwargs):
+                if "Q4_K_S" in pattern:
+                    return [f"{mock_folder}/gemma-3-4b-it-Q4_K_S.gguf"]
+                return []
+
+            mock_glob.side_effect = glob_side_effect
+
+            result = download_gguf(
+                "unsloth/gemma-3-4b-it-GGUF",
+                "Q4_K_S",
+                cache_dir="/custom/cache",
+                revision="dev",
+                ignore_patterns=["original/**/*"],
+            )
+
+            call_kwargs = mock_snapshot.call_args.kwargs
+            assert call_kwargs["cache_dir"] == "/custom/cache"
+            assert call_kwargs["revision"] == "dev"
+            assert call_kwargs["ignore_patterns"] == ["original/**/*"]
+            assert result == f"{mock_folder}/gemma-3-4b-it-Q4_K_S.gguf"
+
+    @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
+    @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
+    def test_download_gguf_mmproj_not_in_candidates(self, mock_download,
+                                                     mock_snapshot):
+        """Test that mmproj files never appear in return candidates
+        even when present on disk."""
+        mock_folder = "/tmp/mock_cache"
+        mock_download.return_value = mock_folder
+
+        with patch("glob.glob") as mock_glob:
+
+            def glob_side_effect(pattern, **kwargs):
+                if "Q4_K_S" in pattern:
+                    return [f"{mock_folder}/gemma-3-4b-it-Q4_K_S.gguf"]
+                return []
+
+            mock_glob.side_effect = glob_side_effect
+
+            result = download_gguf("unsloth/gemma-3-4b-it-GGUF", "Q4_K_S")
+
+            # glob should only be called with backbone patterns
+            glob_patterns = [
+                call.args[0] for call in mock_glob.call_args_list
+            ]
+            for p in glob_patterns:
+                assert "mmproj" not in p
+
+            assert result == f"{mock_folder}/gemma-3-4b-it-Q4_K_S.gguf"
+
+    @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
     @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
     @patch("glob.glob", return_value=[])
-    def test_download_gguf_no_files_found(self, mock_glob, mock_download):
+    def test_download_gguf_no_files_found(self, mock_glob, mock_download,
+                                          mock_snapshot):
         """Test error when no GGUF files are found."""
         mock_folder = "/tmp/mock_cache"
         mock_download.return_value = mock_folder

--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -110,8 +110,7 @@ class TestGGUFDownload:
             # key parameters passed through correctly
             mock_snapshot.assert_called_once()
             call_kwargs = mock_snapshot.call_args.kwargs
-            assert call_kwargs["allow_patterns"] == \
-                ["mmproj*.gguf", "*/mmproj*.gguf"]
+            assert call_kwargs["allow_patterns"] == ["mmproj*.gguf", "*/mmproj*.gguf"]
             assert call_kwargs["cache_dir"] is None
             assert call_kwargs["revision"] is None
             assert call_kwargs["ignore_patterns"] is None
@@ -122,8 +121,9 @@ class TestGGUFDownload:
 
     @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
     @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
-    def test_download_gguf_mmproj_passthrough_params(self, mock_download,
-                                                      mock_snapshot):
+    def test_download_gguf_mmproj_passthrough_params(
+        self, mock_download, mock_snapshot
+    ):
         """Test that cache_dir, revision, ignore_patterns are passed through
         to snapshot_download for mmproj."""
         mock_folder = "/tmp/mock_cache"
@@ -154,8 +154,7 @@ class TestGGUFDownload:
 
     @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
     @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
-    def test_download_gguf_mmproj_not_in_candidates(self, mock_download,
-                                                     mock_snapshot):
+    def test_download_gguf_mmproj_not_in_candidates(self, mock_download, mock_snapshot):
         """Test that mmproj files never appear in return candidates
         even when present on disk."""
         mock_folder = "/tmp/mock_cache"
@@ -173,9 +172,7 @@ class TestGGUFDownload:
             result = download_gguf("unsloth/gemma-3-4b-it-GGUF", "Q4_K_S")
 
             # glob should only be called with backbone patterns
-            glob_patterns = [
-                call.args[0] for call in mock_glob.call_args_list
-            ]
+            glob_patterns = [call.args[0] for call in mock_glob.call_args_list]
             for p in glob_patterns:
                 assert "mmproj" not in p
 
@@ -184,8 +181,9 @@ class TestGGUFDownload:
     @patch("vllm.model_executor.model_loader.weight_utils.snapshot_download")
     @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
     @patch("glob.glob", return_value=[])
-    def test_download_gguf_no_files_found(self, mock_glob, mock_download,
-                                          mock_snapshot):
+    def test_download_gguf_no_files_found(
+        self, mock_glob, mock_download, mock_snapshot
+    ):
         """Test error when no GGUF files are found."""
         mock_folder = "/tmp/mock_cache"
         mock_download.return_value = mock_folder

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -464,8 +464,7 @@ def download_gguf(
         )
     except Exception as e:
         # mmproj files are optional — not all GGUF repos have them
-        logger.debug("Skipping optional mmproj download for %s: %s",
-                     repo_id, e)
+        logger.debug("Skipping optional mmproj download for %s: %s", repo_id, e)
 
     # Find the downloaded backbone file(s) — exclude mmproj from candidates
     local_files = []

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -427,13 +427,12 @@ def download_gguf(
     revision: str | None = None,
     ignore_patterns: str | list[str] | None = None,
 ) -> str:
-    # Use patterns that snapshot_download can handle directly
-    # Patterns to match:
+    # Backbone patterns: match the main model GGUF file(s)
     # - *-{quant_type}.gguf (root)
     # - *-{quant_type}-*.gguf (root sharded)
     # - */*-{quant_type}.gguf (subdir)
     # - */*-{quant_type}-*.gguf (subdir sharded)
-    allow_patterns = [
+    backbone_patterns = [
         f"*-{quant_type}.gguf",
         f"*-{quant_type}-*.gguf",
         f"*/*-{quant_type}.gguf",
@@ -444,15 +443,33 @@ def download_gguf(
     folder = download_weights_from_hf(
         model_name_or_path=repo_id,
         cache_dir=cache_dir,
-        allow_patterns=allow_patterns,
+        allow_patterns=backbone_patterns,
         revision=revision,
         ignore_patterns=ignore_patterns,
     )
 
-    # Find the downloaded file(s) in the folder
+    # Also download multimodal projector files (e.g. mmproj-*.gguf for Gemma3)
+    # if they exist in the repo. We use snapshot_download directly because
+    # download_weights_from_hf's pattern optimization can interfere with
+    # simple glob patterns.
+    try:
+        snapshot_download(
+            repo_id,
+            allow_patterns=["mmproj*.gguf", "*/mmproj*.gguf"],
+            ignore_patterns=ignore_patterns,
+            cache_dir=cache_dir,
+            tqdm_class=DisabledTqdm,
+            revision=revision,
+            local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
+        )
+    except Exception as e:
+        # mmproj files are optional — not all GGUF repos have them
+        logger.debug("Skipping optional mmproj download for %s: %s",
+                     repo_id, e)
+
+    # Find the downloaded backbone file(s) — exclude mmproj from candidates
     local_files = []
-    for pattern in allow_patterns:
-        # Convert pattern to glob pattern for local filesystem
+    for pattern in backbone_patterns:
         glob_pattern = os.path.join(folder, pattern)
         local_files.extend(glob.glob(glob_pattern))
 


### PR DESCRIPTION
  Fix #36245: download_gguf() now downloads multimodal projector files
  (mmproj*.gguf) alongside backbone GGUF files.

  Previously, only backbone files matching the quant_type pattern were
  downloaded. For multimodal models like Gemma3, this caused
  detect_gguf_multimodal() to fail because the mmproj file was missing
  from the cache directory.

  The fix uses a separate snapshot_download call for mmproj files because
  download_weights_from_hf's pattern optimization discards additional
  patterns after the first match. The mmproj download is best-effort —
  non-multimodal repos simply skip it.

  Added 3 unit tests verifying mmproj download behavior and parameter
  passthrough. Patched snapshot_download in all existing tests to prevent
  real network calls.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

