### PR TITLE
[Bugfix] Fixed modelopt mixed precision quant format loading

### DIFF
--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -204,6 +204,8 @@ class ModelArchConfigConvertorBase:
                         quant_cfg["quant_method"] = "modelopt"
                     elif quant_algo_upper == "NVFP4":
                         quant_cfg["quant_method"] = "modelopt_fp4"
+                    elif quant_algo_upper == "MIXED_PRECISION":
+                        quant_cfg["quant_method"] = "modelopt_mixed"
                     else:
                         raise ValueError(f"Unknown ModelOpt quant algo: {quant_algo}")
 


### PR DESCRIPTION
## Purpose

#35047 ModelOpt's mixed precision support was added; however, the model fails to load because MIXED_PRECISION cannot be parsed when loading quantization_config.
This PR resolves this issue.

## Test Plan

Since there are no publicly available MIXED_PRECISION models, I tested it by adding a quantization_config to dummy weights.

```python
import os
os.environ["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"

import json
from huggingface_hub import snapshot_download
from vllm import LLM

model_id = "meta-llama/Llama-3.2-1B"
model_path = snapshot_download(model_id, local_dir="Llama-3.2-1B", ignore_patterns=["original/*"])

quant_config = {
    "producer": {
        "name": "modelopt",
        "version": "0.41.0"
    },
    "quantization": {
        "quant_algo": "MIXED_PRECISION",
        "kv_cache_quant_algo": "FP8",
        "quantized_layers": {
            "model.layers.0.mlp.gate_up_proj": {
                "quant_algo": "NVFP4",
                "group_size": 16
            },
            "model.layers.0.mlp.down_proj": {
                "quant_algo": "FP8"
            }
        }
    }
}

with open(os.path.join(model_path, "hf_quant_config.json"), "w") as f:
    json.dump(quant_config, f, indent=4)

llm = LLM(model=model_path, load_format="dummy")

def get_mlp_info(self):
    mlp = self.model_runner.model.model.layers[0].mlp
    return "\n".join([
        f"layers.0.mlp.gate_up_proj: {mlp.gate_up_proj.quant_method}",
        f"layers.0.mlp.down_proj: {mlp.down_proj.quant_method}",
    ])
print(llm.collective_rpc(get_mlp_info)[0]) 
```

## Test Result

before fix:
```
INFO 03-07 15:03:16 [utils.py:228] non-default args: {'load_format': 'dummy', 'disable_log_stats': True, 'model': '/home/kyamamoto/repos/vllm/Llama-3.2-1B'}
Traceback (most recent call last):
  File "/home/kyamamoto/repos/vllm/test_modelopt.py", line 34, in <module>
    llm = LLM(model=model_path, load_format="dummy")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kyamamoto/repos/vllm/vllm/entrypoints/llm.py", line 379, in __init__
    self.llm_engine = LLMEngine.from_engine_args(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kyamamoto/repos/vllm/vllm/v1/engine/llm_engine.py", line 169, in from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kyamamoto/repos/vllm/vllm/engine/arg_utils.py", line 1498, in create_engine_config
    model_config = self.create_model_config()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kyamamoto/repos/vllm/vllm/engine/arg_utils.py", line 1350, in create_model_config
    return ModelConfig(
           ^^^^^^^^^^^^
  File "/home/kyamamoto/repos/vllm/.venv/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
  Value error, Unknown ModelOpt quant algo: MIXED_PRECISION [type=value_error, input_value=ArgsKwargs((), {'model': ...rocessor_plugin': None}), input_type=ArgsKwargs]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
```

after fix:
```
INFO 03-07 15:05:08 [utils.py:228] non-default args: {'load_format': 'dummy', 'disable_log_stats': True, 'model': '/home/kyamamoto/repos/vllm/Llama-3.2-1B'}
INFO 03-07 15:05:08 [model.py:531] Resolved architecture: LlamaForCausalLM
INFO 03-07 15:05:08 [model.py:1554] Using max model len 131072
INFO 03-07 15:05:09 [cache.py:204] Using fp8 data type to store kv cache. It reduces the GPU memory footprint and boosts the performance. Meanwhile, it may cause accuracy drop without a proper scaling factor.
INFO 03-07 15:05:09 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=16384.
WARNING 03-07 15:05:09 [modelopt.py:370] Detected ModelOpt fp8 checkpoint (quant_algo=FP8). Please note that the format is experimental and could change.
WARNING 03-07 15:05:09 [modelopt.py:984] Detected ModelOpt NVFP4 checkpoint. Please note that the format is experimental and could change in future.
INFO 03-07 15:05:09 [vllm.py:753] Asynchronous scheduling is enabled.
WARNING 03-07 15:05:09 [serial_utils.py:57] Allowing insecure serialization using pickle due to VLLM_ALLOW_INSECURE_SERIALIZATION=1
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:09 [core.py:104] Initializing a V1 LLM engine (v0.17.0rc1.dev111+g5bd1ba2bf) with config: model='/home/kyamamoto/repos/vllm/Llama-3.2-1B', speculative_config=None, tokenizer='/home/kyamamoto/repos/vllm/Llama-3.2-1B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=131072, download_dir=None, load_format=dummy, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=modelopt_mixed, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=fp8_e4m3, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=/home/kyamamoto/repos/vllm/Llama-3.2-1B, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [16384], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:09 [parallel_state.py:1395] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://10.19.55.149:38599 backend=nccl
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:09 [parallel_state.py:1717] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:10 [gpu_model_runner.py:4258] Starting to load model /home/kyamamoto/repos/vllm/Llama-3.2-1B...
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:10 [cuda.py:405] Using FLASHINFER attention backend out of potential backends: ['FLASHINFER', 'TRITON_ATTN'].
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:10 [nvfp4_utils.py:85] Using NvFp4LinearBackend.VLLM_CUTLASS for NVFP4 GEMM
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:10 [__init__.py:257] Selected CutlassFP8ScaledMMLinearKernel for ModelOptFp8LinearMethod
(EngineCore_DP0 pid=1691386) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(EngineCore_DP0 pid=1691386) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(EngineCore_DP0 pid=1691386) WARNING 03-07 15:05:10 [kv_cache.py:94] Checkpoint does not provide a q scaling factor. Setting it to k_scale. This only matters for FP8 Attention backends (flash-attn or flashinfer).
(EngineCore_DP0 pid=1691386) WARNING 03-07 15:05:10 [kv_cache.py:108] Using KV cache scaling factor 1.0 for fp8_e4m3. If this is unintended, verify that k/v_scale scaling factors are properly set in the checkpoint.
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:10 [gpu_model_runner.py:4341] Model loading took 2.26 GiB memory and 0.307652 seconds
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:11 [decorators.py:465] Directly load AOT compilation from path /home/kyamamoto/.cache/vllm/torch_compile_cache/torch_aot_compile/1184ba76e3fbd969e112023cbdcdc068ea5185d7b7863783a55ba14809b11ca1/rank_0_0/model
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:11 [backends.py:913] Using cache directory: /home/kyamamoto/.cache/vllm/torch_compile_cache/f6a66f0b3d/rank_0_0/backbone for vLLM's torch.compile
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:11 [backends.py:973] Dynamo bytecode transform time: 0.66 s
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:11 [backends.py:283] Directly load the compiled graph(s) for compile range (1, 16384) from the cache, took 0.284 s
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:12 [monitor.py:35] torch.compile and initial profiling run took 1.08 s in total
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:12 [gpu_worker.py:425] Available KV cache memory: 81.25 GiB
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:12 [kv_cache_utils.py:1314] GPU KV cache size: 5,324,480 tokens
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:12 [kv_cache_utils.py:1319] Maximum concurrency for 131,072 tokens per request: 40.62x
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:12 [kernel_warmup.py:69] Warming up FlashInfer attention.
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 51/51 [00:00<00:00, 109.14it/s]
Capturing CUDA graphs (decode, FULL): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 51/51 [00:00<00:00, 115.16it/s]
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:13 [gpu_model_runner.py:5363] Graph capturing finished in 1 secs, took 0.73 GiB
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:13 [core.py:293] init engine (profile, create kv cache, warmup model) took 2.90 seconds
INFO 03-07 15:05:14 [llm.py:388] Supported tasks: ('generate',)
layers.0.mlp.gate_up_proj: <vllm.model_executor.layers.quantization.modelopt.ModelOptNvFp4LinearMethod object at 0x7749fea6ac30>
layers.0.mlp.down_proj: <vllm.model_executor.layers.quantization.modelopt.ModelOptFp8LinearMethod object at 0x7749fea6b020>
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:14 [core.py:1242] Shutdown initiated (timeout=0)
(EngineCore_DP0 pid=1691386) INFO 03-07 15:05:14 [core.py:1265] Shutdown complete
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

