### PR TITLE
[Hybrid][KVCache] Adjust alignment block size according attn supported kernel sizes

### DIFF
--- a/tests/config/test_config_generation.py
+++ b/tests/config/test_config_generation.py
@@ -14,9 +14,7 @@ def test_cuda_empty_vs_unset_configs(monkeypatch: pytest.MonkeyPatch):
     """
 
     def create_config():
-        engine_args = EngineArgs(
-            model="deepseek-ai/DeepSeek-V2-Lite", trust_remote_code=True
-        )
+        engine_args = EngineArgs(model="Qwen/Qwen3-1.7B", trust_remote_code=True)
         return engine_args.create_engine_config()
 
     # Create config with CUDA_VISIBLE_DEVICES set normally
@@ -44,9 +42,7 @@ def test_ray_runtime_env(monkeypatch: pytest.MonkeyPatch):
     # In testing, this method needs to be nested inside as ray does not
     # see the test module.
     def create_config():
-        engine_args = EngineArgs(
-            model="deepseek-ai/DeepSeek-V2-Lite", trust_remote_code=True
-        )
+        engine_args = EngineArgs(model="Qwen/Qwen3-1.7B", trust_remote_code=True)
         return engine_args.create_engine_config()
 
     config = create_config()

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -318,6 +318,7 @@ def _test_backend_correctness(
     atol: float = 1e-2,
     rtol: float = 1e-2,
     tensor_parallel_size: int = 1,
+    attention_backend: AttentionBackendEnum | None = None,
 ):
     """
     Test that all backends produce similar outputs to a reference implementation
@@ -365,6 +366,7 @@ def _test_backend_correctness(
         block_size=block_size,
         num_gpu_blocks=8192,
         hf_config_override=hf_config_override,
+        attention_backend=attention_backend,
     )
     device = torch.device("cuda:0")
 
@@ -612,6 +614,7 @@ def test_causal_backend_correctness(
             causal_mask_mod,
             block_size=128,
             tensor_parallel_size=tensor_parallel_size,
+            attention_backend=AttentionBackendEnum.FLEX_ATTENTION,
         )
 
 
@@ -694,6 +697,7 @@ def test_sliding_window_backend_correctness(
             sliding_window_mask_mod_fn,
             block_size=128,
             tensor_parallel_size=tensor_parallel_size,
+            attention_backend=AttentionBackendEnum.FLEX_ATTENTION,
         )
 
 

--- a/tests/v1/attention/utils.py
+++ b/tests/v1/attention/utils.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from vllm.config import (
+    AttentionConfig,
     CacheConfig,
     CompilationConfig,
     DeviceConfig,
@@ -167,6 +168,7 @@ def create_vllm_config(
     enable_chunked_prefill: bool = True,
     add_mock_model_methods: bool = True,
     hf_config_override: dict | None = None,
+    attention_backend: AttentionBackendEnum | None = None,
 ) -> VllmConfig:
     """Create a VllmConfig for testing with reasonable defaults."""
 
@@ -203,6 +205,7 @@ def create_vllm_config(
     device_config = DeviceConfig()
     load_config = LoadConfig()
     compilation_config = CompilationConfig()
+    attention_config = AttentionConfig(backend=attention_backend)
 
     if add_mock_model_methods:
         # Add mock methods to satisfy backends that need them
@@ -233,6 +236,7 @@ def create_vllm_config(
         device_config=device_config,
         load_config=load_config,
         compilation_config=compilation_config,
+        attention_config=attention_config,
     )
 
 

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -113,6 +113,11 @@ class CacheConfig:
     - "align": only cache the mamba state of the last token of each scheduler step and
            when the token is at position i * block_size.
     """
+    mamba_alignment_kernel_block_size: int = Field(default=16, gt=0)
+    """The block size for full attention or mla attention to align with in hybrid mamba
+    models. `mamba_alignment_kernel_block_size` usually refers to the minimum block_size
+    among the supported kernel block sizes of the specified attention backend.
+    """
 
     # Will be set after profiling.
     num_gpu_blocks: int | None = field(default=None, init=False)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1598,9 +1598,9 @@ class VllmConfig:
         if architecture is None:
             return
 
-        from vllm.model_executor.layers.config import AttentionConfig
+        from vllm.model_executor.layers.config import AttentionVerifyAndUpdateConfig
 
-        AttentionConfig.verify_and_update_config(self)
+        AttentionVerifyAndUpdateConfig.verify_and_update_config(self)
 
         from vllm.model_executor.models.config import (
             MODELS_CONFIG_MAP,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1598,6 +1598,10 @@ class VllmConfig:
         if architecture is None:
             return
 
+        from vllm.model_executor.layers.config import AttentionConfig
+
+        AttentionConfig.verify_and_update_config(self)
+
         from vllm.model_executor.models.config import (
             MODELS_CONFIG_MAP,
             HybridAttentionMambaModelConfig,

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -46,6 +46,8 @@ class AttentionConfig(VerifyAndUpdateConfig):
             block_size=cache_config.block_size
             if cache_config.block_size is not None
             else 16,
+            use_mla=model_config.use_mla,
+            use_sparse=hasattr(model_config.hf_config, "index_topk"),
         )
         backend_cls = _cached_get_attn_backend(
             backend=attention_config.backend,

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-class AttentionConfig(VerifyAndUpdateConfig):
+class AttentionVerifyAndUpdateConfig(VerifyAndUpdateConfig):
     @classmethod
     def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         """
@@ -64,7 +64,10 @@ class AttentionConfig(VerifyAndUpdateConfig):
         cache_config.mamba_alignment_kernel_block_size = kernel_block_alignment_size
         if cache_config.block_size is None:
             cache_config.block_size = kernel_block_alignment_size
-        else:
+        elif cache_config.user_specified_block_size:
+            # Only validate block_size when the user explicitly set it via
+            # --block-size. Otherwise block_size is still the default and will
+            # be overwritten later by Platform.update_block_size_for_backend().
             is_valid_block_size = any(
                 (cache_config.block_size % kernel_block_size.base == 0)
                 if isinstance(kernel_block_size, MultipleOf)

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import TYPE_CHECKING
+
+from vllm.logger import init_logger
+from vllm.model_executor.models.config import VerifyAndUpdateConfig
+from vllm.v1.attention.backend import MultipleOf
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+logger = init_logger(__name__)
+
+
+class AttentionConfig(VerifyAndUpdateConfig):
+    @classmethod
+    def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        """
+        Set `cache_config.mamba_alignment_kernel_block_size` to attention
+        backend's minimum supported kernel block size, with which
+        cache_config.block_size will align.
+
+        Args:
+            vllm_config: vLLM Config
+        """
+        cache_config = vllm_config.cache_config
+        model_config = vllm_config.model_config
+        attention_config = vllm_config.attention_config
+        assert cache_config is not None
+        from vllm.v1.attention.selector import (
+            AttentionSelectorConfig,
+            _cached_get_attn_backend,
+        )
+
+        # NOTE: To avoid getting vllm_config, which will raise error outside
+        # the `set_current_vllm_config`, we use _cached_get_attn_backend
+        # instead of get_attn_backend to get the current attention backend.
+        # Notice that this backend may not be exactly same with that of
+        # runtime, cause we doesn't get the exact information of sinks,
+        # sparse attention, multi-modality prefix, and so on. Thus a clear
+        # of cache is required after this.
+        attn_selector_config = AttentionSelectorConfig(
+            head_size=model_config.get_head_size(),
+            dtype=model_config.dtype,
+            kv_cache_dtype=cache_config.cache_dtype,
+            block_size=cache_config.block_size
+            if cache_config.block_size is not None
+            else 16,
+        )
+        backend_cls = _cached_get_attn_backend(
+            backend=attention_config.backend,
+            attn_selector_config=attn_selector_config,
+        )
+        ori_supported_kernel_block_sizes = (
+            backend_cls.get_supported_kernel_block_sizes()
+        )
+        # clear the cache of attention backend to avoid influcing the
+        # attention backend selection during inference runtime
+        _cached_get_attn_backend.cache_clear()
+        supported_kernel_block_sizes = [
+            kernel_block_size.base
+            if isinstance(kernel_block_size, MultipleOf)
+            else kernel_block_size
+            for kernel_block_size in ori_supported_kernel_block_sizes
+        ]
+
+        kernel_block_alignment_size = min(supported_kernel_block_sizes)
+        cache_config.mamba_alignment_kernel_block_size = kernel_block_alignment_size
+        if cache_config.block_size is None:
+            cache_config.block_size = kernel_block_alignment_size
+        else:
+            is_valid_block_size = any(
+                (cache_config.block_size % kernel_block_size.base == 0)
+                if isinstance(kernel_block_size, MultipleOf)
+                else (cache_config.block_size == kernel_block_size)
+                for kernel_block_size in ori_supported_kernel_block_sizes
+            )
+            if not is_valid_block_size:
+                raise ValueError(
+                    f"Unexpected block_size {cache_config.block_size} for current"
+                    f" attention backend {attention_config.backend},"
+                    f" the supported block_sizes of {attention_config.backend}:"
+                    f" {supported_kernel_block_sizes}"
+                )

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -26,6 +26,7 @@ class AttentionConfig(VerifyAndUpdateConfig):
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
         attention_config = vllm_config.attention_config
+        parallel_config = vllm_config.parallel_config
         assert cache_config is not None
         from vllm.config import set_current_vllm_config
         from vllm.v1.attention.selector import (
@@ -38,14 +39,14 @@ class AttentionConfig(VerifyAndUpdateConfig):
         # multi-modality prefix, and so on. Thus a clear
         # of cache is required after this.
         with set_current_vllm_config(vllm_config):
+            num_heads = model_config.get_num_attention_heads(parallel_config)
             backend_cls = get_attn_backend(
                 head_size=model_config.get_head_size(),
                 dtype=model_config.dtype,
                 kv_cache_dtype=cache_config.cache_dtype,
                 use_mla=model_config.use_mla,
                 use_sparse=hasattr(model_config.hf_config, "index_topk"),
-                num_heads=model_config.hf_config.num_attention_heads
-                // vllm_config.parallel_config.tensor_parallel_size,
+                num_heads=num_heads,
             )
             ori_supported_kernel_block_sizes = (
                 backend_cls.get_supported_kernel_block_sizes()

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -27,38 +27,31 @@ class AttentionConfig(VerifyAndUpdateConfig):
         model_config = vllm_config.model_config
         attention_config = vllm_config.attention_config
         assert cache_config is not None
+        from vllm.config import set_current_vllm_config
         from vllm.v1.attention.selector import (
-            AttentionSelectorConfig,
             _cached_get_attn_backend,
+            get_attn_backend,
         )
 
-        # NOTE: To avoid getting vllm_config, which will raise error outside
-        # the `set_current_vllm_config`, we use _cached_get_attn_backend
-        # instead of get_attn_backend to get the current attention backend.
-        # Notice that this backend may not be exactly same with that of
+        # NOTE: Notice that this backend may not be exactly same with that of
         # runtime, cause we doesn't get the exact information of sinks,
-        # sparse attention, multi-modality prefix, and so on. Thus a clear
+        # multi-modality prefix, and so on. Thus a clear
         # of cache is required after this.
-        attn_selector_config = AttentionSelectorConfig(
-            head_size=model_config.get_head_size(),
-            dtype=model_config.dtype,
-            kv_cache_dtype=cache_config.cache_dtype,
-            block_size=cache_config.block_size
-            if cache_config.block_size is not None
-            else 16,
-            use_mla=model_config.use_mla,
-            use_sparse=hasattr(model_config.hf_config, "index_topk"),
-        )
-        backend_cls = _cached_get_attn_backend(
-            backend=attention_config.backend,
-            attn_selector_config=attn_selector_config,
-        )
-        ori_supported_kernel_block_sizes = (
-            backend_cls.get_supported_kernel_block_sizes()
-        )
-        # clear the cache of attention backend to avoid influcing the
-        # attention backend selection during inference runtime
-        _cached_get_attn_backend.cache_clear()
+        with set_current_vllm_config(vllm_config):
+            backend_cls = get_attn_backend(
+                head_size=model_config.get_head_size(),
+                dtype=model_config.dtype,
+                kv_cache_dtype=cache_config.cache_dtype,
+                use_mla=model_config.use_mla,
+                use_sparse=hasattr(model_config.hf_config, "index_topk"),
+                num_heads=model_config.hf_config.num_attention_heads
+                // vllm_config.parallel_config.tensor_parallel_size,
+            )
+            ori_supported_kernel_block_sizes = (
+                backend_cls.get_supported_kernel_block_sizes()
+            )
+            _cached_get_attn_backend.cache_clear()
+
         supported_kernel_block_sizes = [
             kernel_block_size.base
             if isinstance(kernel_block_size, MultipleOf)

--- a/vllm/model_executor/layers/config.py
+++ b/vllm/model_executor/layers/config.py
@@ -25,7 +25,6 @@ class AttentionVerifyAndUpdateConfig(VerifyAndUpdateConfig):
         """
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
-        attention_config = vllm_config.attention_config
         parallel_config = vllm_config.parallel_config
         assert cache_config is not None
         from vllm.config import set_current_vllm_config
@@ -77,7 +76,7 @@ class AttentionVerifyAndUpdateConfig(VerifyAndUpdateConfig):
             if not is_valid_block_size:
                 raise ValueError(
                     f"Unexpected block_size {cache_config.block_size} for current"
-                    f" attention backend {attention_config.backend},"
-                    f" the supported block_sizes of {attention_config.backend}:"
+                    f" attention backend {backend_cls},"
+                    f" the supported block_sizes of {backend_cls}:"
                     f" {supported_kernel_block_sizes}"
                 )

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -8,7 +8,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.models import ModelRegistry
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
-from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec, MLAAttentionSpec
 
 if TYPE_CHECKING:
@@ -134,7 +133,6 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
         # Enable FULL_AND_PIECEWISE by default
         MambaModelConfig.verify_and_update_config(vllm_config)
 
-        attention_config = vllm_config.attention_config
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
@@ -145,16 +143,8 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
             kv_cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
 
         # get attention page size (for 1 token)
-        # Attention backend constraints:
-        # - FlashAttention (FA) requires block size to be multiple of 16
-        # - MLA (Multi-head Latent Attention) requires larger alignment:
-        #   * CUTLASS_MLA backend: kernel_block_size 128 alignment
-        #   * Other MLA backends: kernel_block_size 64 alignment
+        kernel_block_alignment_size = cache_config.mamba_alignment_kernel_block_size
         if model_config.use_mla:
-            use_cutlass_mla = (
-                attention_config.backend == AttentionBackendEnum.CUTLASS_MLA
-            )
-            kernel_block_alignment_size = 128 if use_cutlass_mla else 64
             attn_page_size_1_token = MLAAttentionSpec(
                 block_size=1,
                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),
@@ -162,7 +152,6 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
                 dtype=kv_cache_dtype,
             ).page_size_bytes
         else:
-            kernel_block_alignment_size = 16
             attn_page_size_1_token = FullAttentionSpec(
                 block_size=1,
                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -627,7 +627,9 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
     @classmethod
     @cache
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability:
-        major, minor = torch.cuda.get_device_capability(device_id)
+        # use cuda_get_device_properties to avoid cuda re-initialization error
+        from vllm.utils.platform_utils import cuda_get_device_properties
+        major, minor = cuda_get_device_properties(device_id, ["major", "minor"])
         return DeviceCapability(major=major, minor=minor)
 
     @classmethod

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -22,6 +22,7 @@ import vllm._C  # noqa
 import vllm._C_stable_libtorch  # noqa
 from vllm.logger import init_logger
 from vllm.utils.import_utils import import_pynvml
+from vllm.utils.platform_utils import cuda_get_device_properties
 from vllm.utils.torch_utils import cuda_device_count_stateless
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -628,7 +629,6 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
     @cache
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability:
         # use cuda_get_device_properties to avoid cuda re-initialization error
-        from vllm.utils.platform_utils import cuda_get_device_properties
         major, minor = cuda_get_device_properties(device_id, ["major", "minor"])
         return DeviceCapability(major=major, minor=minor)
 

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -70,14 +70,9 @@ class FlashAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
-        try:
-            vllm_config = get_current_vllm_config()
-            model_config = vllm_config.model_config
-            cache_config = vllm_config.cache_config
-        except Exception:
-            # This branch works for the AttentionConfig to get supported
-            # kernel block sizes
-            model_config = None
+        vllm_config = get_current_vllm_config()
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
         if (
             model_config
             and model_config.is_hybrid

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -70,9 +70,14 @@ class FlashAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
-        vllm_config = get_current_vllm_config()
-        model_config = vllm_config.model_config
-        cache_config = vllm_config.cache_config
+        try:
+            vllm_config = get_current_vllm_config()
+            model_config = vllm_config.model_config
+            cache_config = vllm_config.cache_config
+        except Exception:
+            # This branch works for the AttentionConfig to get supported
+            # kernel block sizes
+            model_config = None
         if (
             model_config
             and model_config.is_hybrid

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1778,6 +1778,7 @@ def fast_plan_decode(
     # Warm up with the original plan if it is first call, and always run the
     # original plan if we run for dynamic shape. For fixed shape (cudagraph),
     # this warm up is to generate the _cached_module for the decode wrapper.
+    _import_flashinfer()
     if not self.is_cuda_graph_enabled or getattr(self, "vllm_first_call", True):
         self.plan(
             indptr=indptr_cpu,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -4,19 +4,10 @@
 
 from dataclasses import dataclass
 from functools import partial
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import torch
-from flashinfer import (
-    BatchDecodeWithPagedKVCacheWrapper,
-    BatchPrefillWithPagedKVCacheWrapper,
-    BatchPrefillWithRaggedKVCacheWrapper,
-    MultiLevelCascadeAttentionWrapper,
-)
-from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
-from flashinfer.prefill import trtllm_batch_context_with_kv_cache
-from flashinfer.utils import FP4Tensor
 from typing_extensions import override
 
 from vllm import envs
@@ -83,6 +74,74 @@ def _get_trtllm_gen_workspace_buffer():
             envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE, dtype=torch.uint8, device="cuda"
         )
     return trtllm_gen_workspace_buffer
+
+
+def _import_flashinfer():
+    """Lazily import flashinfer runtime symbols.
+
+    This must not run during parent-process config initialization, because
+    importing flashinfer may initialize CUDA. It is only safe to call this
+    from runtime paths after worker startup.
+    """
+    global BatchDecodeWithPagedKVCacheWrapper
+    global BatchPrefillWithPagedKVCacheWrapper
+    global BatchPrefillWithRaggedKVCacheWrapper
+    global MultiLevelCascadeAttentionWrapper
+    global fast_decode_plan
+    global trtllm_batch_decode_with_kv_cache
+    global trtllm_batch_context_with_kv_cache
+    global FP4Tensor
+
+    if BatchDecodeWithPagedKVCacheWrapper is not None:
+        return
+
+    from flashinfer import (  # noqa
+        BatchDecodeWithPagedKVCacheWrapper as _BatchDecodeWithPagedKVCacheWrapper,
+        BatchPrefillWithPagedKVCacheWrapper as _BatchPrefillWithPagedKVCacheWrapper,
+        BatchPrefillWithRaggedKVCacheWrapper as _BatchPrefillWithRaggedKVCacheWrapper,
+        MultiLevelCascadeAttentionWrapper as _MultiLevelCascadeAttentionWrapper,
+    )
+    from flashinfer.decode import (  # noqa
+        fast_decode_plan as _fast_decode_plan,
+        trtllm_batch_decode_with_kv_cache as _trtllm_batch_decode_with_kv_cache,
+    )
+    from flashinfer.prefill import (  # noqa
+        trtllm_batch_context_with_kv_cache as _trtllm_batch_context_with_kv_cache,
+    )
+    from flashinfer.utils import FP4Tensor as _FP4Tensor  # noqa
+
+    BatchDecodeWithPagedKVCacheWrapper = _BatchDecodeWithPagedKVCacheWrapper
+    BatchPrefillWithPagedKVCacheWrapper = _BatchPrefillWithPagedKVCacheWrapper
+    BatchPrefillWithRaggedKVCacheWrapper = _BatchPrefillWithRaggedKVCacheWrapper
+    MultiLevelCascadeAttentionWrapper = _MultiLevelCascadeAttentionWrapper
+    fast_decode_plan = _fast_decode_plan
+    trtllm_batch_decode_with_kv_cache = _trtllm_batch_decode_with_kv_cache
+    trtllm_batch_context_with_kv_cache = _trtllm_batch_context_with_kv_cache
+    FP4Tensor = _FP4Tensor
+
+
+if TYPE_CHECKING:
+    from flashinfer import (
+        BatchDecodeWithPagedKVCacheWrapper,
+        BatchPrefillWithPagedKVCacheWrapper,
+        BatchPrefillWithRaggedKVCacheWrapper,
+        MultiLevelCascadeAttentionWrapper,
+    )
+    from flashinfer.decode import (
+        fast_decode_plan,
+        trtllm_batch_decode_with_kv_cache,
+    )
+    from flashinfer.prefill import trtllm_batch_context_with_kv_cache
+    from flashinfer.utils import FP4Tensor
+else:
+    BatchDecodeWithPagedKVCacheWrapper = None
+    BatchPrefillWithPagedKVCacheWrapper = None
+    BatchPrefillWithRaggedKVCacheWrapper = None
+    MultiLevelCascadeAttentionWrapper = None
+    fast_decode_plan = None
+    trtllm_batch_decode_with_kv_cache = None
+    trtllm_batch_context_with_kv_cache = None
+    FP4Tensor = None
 
 
 @triton.jit
@@ -206,6 +265,7 @@ class BatchDCPPrefillWrapper:
         workspace_buffer: torch.Tensor | None = None,
         dcp_a2a: bool = False,
     ):
+        _import_flashinfer()
         if dcp_a2a:
             self._dcp_combine = partial(dcp_a2a_lse_reduce, is_lse_base_on_e=False)
         else:
@@ -518,7 +578,7 @@ class FlashInferMetadata:
     `prefill` and `decode` fields will both be None.
     """
 
-    cascade_wrapper: MultiLevelCascadeAttentionWrapper | None
+    cascade_wrapper: type["MultiLevelCascadeAttentionWrapper"] | None
 
 
 class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
@@ -532,6 +592,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         device: torch.device,
     ):
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        _import_flashinfer()
         self.cache_config = vllm_config.cache_config
         self.model_config = vllm_config.model_config
         self.attention_config = vllm_config.attention_config
@@ -728,7 +789,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
     def _get_prefill_wrapper(
         self,
-    ) -> BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper:
+    ) -> type["BatchPrefillWithPagedKVCacheWrapper"] | BatchDCPPrefillWrapper:
         if self._prefill_wrapper is None:
             if self.use_dcp:
                 self._prefill_wrapper = BatchDCPPrefillWrapper(
@@ -1207,6 +1268,8 @@ class FlashInferImpl(AttentionImpl):
         kv_sharing_target_layer_name: int | None = None,
         sinks: torch.Tensor | None = None,
     ) -> None:
+        _import_flashinfer()
+
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -119,6 +119,7 @@ class FlashInferMLABackend(MLACommonBackend):
     def get_required_kv_cache_layout(cls) -> "KVCacheLayoutType | None":
         return "HND"
 
+
 _fi_workspace: torch.Tensor | None = None
 
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
-from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
 
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
@@ -28,6 +27,31 @@ from vllm.v1.attention.backends.utils import KVCacheLayoutType
 logger = init_logger(__name__)
 
 FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE = 128 * 1024 * 1024
+
+
+def _import_flashinfer():
+    """Lazily import flashinfer runtime symbols.
+
+    This must not run during parent-process config initialization, because
+    importing flashinfer may initialize CUDA. It is only safe to call this
+    from runtime paths after worker startup.
+    """
+    global trtllm_batch_decode_with_kv_cache_mla
+
+    if trtllm_batch_decode_with_kv_cache_mla is not None:
+        return
+
+    from flashinfer.decode import (  # noqa
+        trtllm_batch_decode_with_kv_cache_mla as _trtllm_batch_decode_with_kv_cache_mla,
+    )
+
+    trtllm_batch_decode_with_kv_cache_mla = _trtllm_batch_decode_with_kv_cache_mla
+
+
+if TYPE_CHECKING:
+    from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+else:
+    trtllm_batch_decode_with_kv_cache_mla = None
 
 
 class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
@@ -95,12 +119,18 @@ class FlashInferMLABackend(MLACommonBackend):
     def get_required_kv_cache_layout(cls) -> "KVCacheLayoutType | None":
         return "HND"
 
+_fi_workspace: torch.Tensor | None = None
 
-g_fi_workspace = torch.zeros(
-    FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE,
-    dtype=torch.uint8,
-    device="cuda",
-)
+
+def _get_workspace_buffer(device: torch.device) -> torch.Tensor:
+    global _fi_workspace
+    if _fi_workspace is None or _fi_workspace.device != device:
+        _fi_workspace = torch.zeros(
+            FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE,
+            dtype=torch.uint8,
+            device=device,
+        )
+    return _fi_workspace
 
 
 class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
@@ -119,6 +149,7 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
         # MLA Specific Arguments
         **mla_args,
     ) -> None:
+        _import_flashinfer()
         super().__init__(
             num_heads,
             head_size,
@@ -148,7 +179,7 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
                 "FlashInferMLAImpl"
             )
 
-        self._workspace_buffer = g_fi_workspace
+        self._workspace_buffer: torch.Tensor | None = None
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
 
@@ -191,6 +222,9 @@ class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
             self.bmm2_scale = 1.0
             if self.kv_cache_dtype.startswith("fp8"):
                 self.bmm2_scale *= layer._k_scale_float
+
+        if self._workspace_buffer is None:
+            self._workspace_buffer = _get_workspace_buffer(q.device)
 
         # Reuse pre-allocated zero-init output buffer to avoid a memset
         # kernel on every CUDA graph replay.

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import torch
-from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
 
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
@@ -49,6 +48,31 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 FLASHINFER_MLA_SPARSE_WORKSPACE_BUFFER_SIZE = 128 * 1024 * 1024
+
+
+def _import_flashinfer():
+    """Lazily import flashinfer runtime symbols.
+
+    This must not run during parent-process config initialization, because
+    importing flashinfer may initialize CUDA. It is only safe to call this
+    from runtime paths after worker startup.
+    """
+    global trtllm_batch_decode_with_kv_cache_mla
+
+    if trtllm_batch_decode_with_kv_cache_mla is not None:
+        return
+
+    from flashinfer.decode import (  # noqa
+        trtllm_batch_decode_with_kv_cache_mla as _trtllm_batch_decode_with_kv_cache_mla,
+    )
+
+    trtllm_batch_decode_with_kv_cache_mla = _trtllm_batch_decode_with_kv_cache_mla
+
+
+if TYPE_CHECKING:
+    from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+else:
+    trtllm_batch_decode_with_kv_cache_mla = None
 
 
 class FlashInferMLASparseBackend(AttentionBackend):
@@ -241,7 +265,7 @@ _fi_sparse_workspace: torch.Tensor | None = None
 
 def _get_workspace_buffer(device: torch.device) -> torch.Tensor:
     global _fi_sparse_workspace
-    if _fi_sparse_workspace is None:
+    if _fi_sparse_workspace is None or _fi_sparse_workspace.device != device:
         _fi_sparse_workspace = torch.zeros(
             FLASHINFER_MLA_SPARSE_WORKSPACE_BUFFER_SIZE,
             dtype=torch.uint8,
@@ -274,6 +298,7 @@ class FlashInferMLASparseImpl(SparseMLAAttentionImpl[FlashInferMLASparseMetadata
         indexer: "Indexer | None" = None,
         **mla_args,
     ) -> None:
+        _import_flashinfer()
         unsupported_features = [alibi_slopes, sliding_window, logits_soft_cap]
         if any(unsupported_features):
             raise NotImplementedError(


### PR DESCRIPTION
## Purpose
Add `mamba_alignment_kernel_block_size` to cache config, which is set to the minimum of supported kernel block sizes of the attention backend. `mamba_alignment_kernel_block_size` is defined as the block size that the `cache_config.block_size`(the block size used by the `KVCacheManager`) to align with in mamba and full attention hybrid models.

This pr is a redo of https://github.com/vllm-project/vllm/pull/27704
## Test Plan
Test locally with qwen3.5, which is a hybrid model of linear attention and full attention.
```python
from vllm import LLM, SamplingParams

def main():
    prompts = [
        "The president of the United States is Mr.",
        "The capital of France is",
        "The future of AI is",
        "plz tell me a story: ",
    ]

    # Create a sampling params object.
    sampling_params = SamplingParams(max_tokens=50, temperature=0.0)
    # Create an LLM.
    llm = LLM(model="/shared/models/modelscope/models/models/Qwen/Qwen3.5-9B",
              tensor_parallel_size=2,
              max_model_len=2048,
              gpu_memory_utilization=0.4,
              )

    # Generate texts from the prompts.
    outputs = llm.generate(prompts, sampling_params)
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

if __name__ == "__main__":
    main()
```
## Test Result
Test pass with correct percision on A100

<details>

```bash
INFO 03-07 08:17:30 [utils.py:238] non-default args: {'max_model_len': 2048, 'tensor_parallel_size': 2, 'gpu_memory_utilization': 0.4, 'disable_log_stats': True, 'model': '/shared/models/modelscope/models/models/Qwen/Qwen3.5-9B'}
INFO 03-07 08:17:30 [model.py:530] Resolved architecture: Qwen3_5ForConditionalGeneration
INFO 03-07 08:17:30 [model.py:1553] Using max model len 2048
INFO 03-07 08:17:30 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 03-07 08:17:31 [cuda.py:405] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
INFO 03-07 08:17:32 [config.py:526] Setting attention block size to 528 tokens to ensure that attention page size is >= mamba page size.
INFO 03-07 08:17:32 [config.py:557] Padding mamba page size by 0.76% to ensure that mamba page size and attention page size are exactly equal.
INFO 03-07 08:17:32 [vllm.py:747] Asynchronous scheduling is enabled.
(EngineCore_DP0 pid=2960786) INFO 03-07 08:17:43 [core.py:101] Initializing a V1 LLM engine (v0.16.0rc2.dev771+ge2b31243c.d20260305) with config: model='/shared/models/modelscope/models/models/Qwen/Qwen3.5-9B', speculative_config=None, tokenizer='/shared/models/modelscope/models/models/Qwen/Qwen3.5-9B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=2048, download_dir=None, load_format=auto, tensor_parallel_size=2, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=/shared/models/modelscope/models/models/Qwen/Qwen3.5-9B, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=2960786) WARNING 03-07 08:17:43 [multiproc_executor.py:989] Reducing Torch parallelism from 64 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
(EngineCore_DP0 pid=2960786) INFO 03-07 08:17:43 [multiproc_executor.py:133] DP group leader: node_rank=0, node_rank_within_dp=0, master_addr=127.0.0.1, mq_connect_ip=10.1.56.164 (local), world_size=2, local_world_size=2
WARNING 03-07 08:17:49 [multiproc_executor.py:802] Exception closing inherited connection: [Errno 9] Bad file descriptor
WARNING 03-07 08:17:49 [multiproc_executor.py:802] Exception closing inherited connection: [Errno 9] Bad file descriptor
WARNING 03-07 08:17:49 [multiproc_executor.py:802] Exception closing inherited connection: [Errno 9] Bad file descriptor
WARNING 03-07 08:17:49 [multiproc_executor.py:802] Exception closing inherited connection: [Errno 9] Bad file descriptor
(Worker pid=2961663) INFO 03-07 08:17:51 [parallel_state.py:1393] world_size=2 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:52855 backend=nccl
(Worker pid=2961664) INFO 03-07 08:17:51 [parallel_state.py:1393] world_size=2 rank=1 local_rank=1 distributed_init_method=tcp://127.0.0.1:52855 backend=nccl
(Worker pid=2961663) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(Worker pid=2961663) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(Worker pid=2961663) INFO 03-07 08:17:51 [pynccl.py:111] vLLM is using nccl==2.27.5
(Worker pid=2961664) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(Worker pid=2961664) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(Worker pid=2961663) WARNING 03-07 08:17:52 [symm_mem.py:67] SymmMemCommunicator: Device capability 8.0 not supported, communicator is not available.
(Worker pid=2961664) WARNING 03-07 08:17:52 [symm_mem.py:67] SymmMemCommunicator: Device capability 8.0 not supported, communicator is not available.
(Worker pid=2961663) INFO 03-07 08:17:52 [parallel_state.py:1715] rank 0 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(Worker pid=2961664) INFO 03-07 08:17:52 [parallel_state.py:1715] rank 1 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 1, EP rank N/A, EPLB rank N/A
(Worker pid=2961663) INFO 03-07 08:17:57 [base.py:106] Offloader set to NoopOffloader
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:17:57 [gpu_model_runner.py:4255] Starting to load model /shared/models/modelscope/models/models/Qwen/Qwen3.5-9B...
(Worker pid=2961664) INFO 03-07 08:17:57 [base.py:106] Offloader set to NoopOffloader
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:17:57 [cuda.py:453] Using backend AttentionBackendEnum.FLASH_ATTN for vit attention
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:17:57 [mm_encoder_attention.py:215] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(Worker pid=2961664) (Worker_TP1 pid=2961664) INFO 03-07 08:17:57 [cuda.py:453] Using backend AttentionBackendEnum.FLASH_ATTN for vit attention
(Worker pid=2961664) (Worker_TP1 pid=2961664) INFO 03-07 08:17:57 [mm_encoder_attention.py:215] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:17:58 [cuda.py:405] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:17:58 [flash_attn.py:592] Using FlashAttention version 2
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:00<00:01,  2.07it/s]
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:01<00:01,  1.42it/s]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:02<00:00,  1.38it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:02<00:00,  1.51it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:02<00:00,  1.50it/s]
(Worker pid=2961663) (Worker_TP0 pid=2961663) 
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:01 [default_loader.py:293] Loading weights took 2.73 seconds
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:02 [gpu_model_runner.py:4338] Model loading took 8.91 GiB memory and 4.043948 seconds
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:02 [gpu_model_runner.py:5254] Encoder cache will be initialized with a budget of 16384 tokens, and profiled with 1 image items of the maximum feature size.
(Worker pid=2961664) (Worker_TP1 pid=2961664) INFO 03-07 08:18:02 [gpu_model_runner.py:5254] Encoder cache will be initialized with a budget of 16384 tokens, and profiled with 1 image items of the maximum feature size.
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:07 [decorators.py:465] Directly load AOT compilation from path /home/guocanlin/.cache/vllm/torch_compile_cache/torch_aot_compile/6a66d1627e4467252f28354cedeba4e03cd09da4624b45580f4d6c84711da564/rank_0_0/model
(Worker pid=2961664) (Worker_TP1 pid=2961664) INFO 03-07 08:18:07 [decorators.py:465] Directly load AOT compilation from path /home/guocanlin/.cache/vllm/torch_compile_cache/torch_aot_compile/6a66d1627e4467252f28354cedeba4e03cd09da4624b45580f4d6c84711da564/rank_1_0/model
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:07 [backends.py:916] Using cache directory: /home/guocanlin/.cache/vllm/torch_compile_cache/9e522ce226/rank_0_0/backbone for vLLM's torch.compile
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:07 [backends.py:976] Dynamo bytecode transform time: 1.52 s
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:09 [backends.py:266] Directly load the compiled graph(s) for compile range (1, 8192) from the cache, took 1.287 s
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:09 [monitor.py:35] torch.compile takes 3.32 s in total
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:10 [gpu_worker.py:424] Available KV cache memory: 20.79 GiB
(EngineCore_DP0 pid=2960786) INFO 03-07 08:18:10 [kv_cache_utils.py:1314] GPU KV cache size: 340,560 tokens
(EngineCore_DP0 pid=2960786) INFO 03-07 08:18:10 [kv_cache_utils.py:1319] Maximum concurrency for 2,048 tokens per request: 368.57x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|████████| 51/51 [00:01<00:00, 25.54it/s]
Capturing CUDA graphs (decode, FULL): 100%|███████████████████████████| 35/35 [00:01<00:00, 19.49it/s]
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:14 [custom_all_reduce.py:216] Registering 5504 cuda graph addresses
(Worker pid=2961664) (Worker_TP1 pid=2961664) INFO 03-07 08:18:14 [custom_all_reduce.py:216] Registering 5504 cuda graph addresses
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:15 [gpu_model_runner.py:5360] Graph capturing finished in 5 secs, took 0.71 GiB
(EngineCore_DP0 pid=2960786) INFO 03-07 08:18:15 [core.py:282] init engine (profile, create kv cache, warmup model) took 13.01 seconds
(EngineCore_DP0 pid=2960786) INFO 03-07 08:18:21 [vllm.py:747] Asynchronous scheduling is enabled.
INFO 03-07 08:18:21 [llm.py:388] Supported tasks: ['generate']
Rendering prompts: 100%|███████████████████████████████████████████████| 4/4 [00:00<00:00, 173.91it/s]
Processed prompts:   0%|    | 0/4 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s](Worker pid=2961663) (Worker_TP0 pid=2961663) /home/guocanlin/cmq/vllm/vllm/model_executor/layers/fla/ops/utils.py:113: UserWarning: Input tensor shape suggests potential format mismatch: seq_len (9) < num_heads (16). This may indicate the inputs were passed in head-first format [B, H, T, ...] when head_first=False was specified. Please verify your input tensor format matches the expected shape [B, T, H, ...].
(Worker pid=2961663) (Worker_TP0 pid=2961663)   return fn(*contiguous_args, **contiguous_kwargs)
(Worker pid=2961664) (Worker_TP1 pid=2961664) /home/guocanlin/cmq/vllm/vllm/model_executor/layers/fla/ops/utils.py:113: UserWarning: Input tensor shape suggests potential format mismatch: seq_len (9) < num_heads (16). This may indicate the inputs were passed in head-first format [B, H, T, ...] when head_first=False was specified. Please verify your input tensor format matches the expected shape [B, T, H, ...].
(Worker pid=2961664) (Worker_TP1 pid=2961664)   return fn(*contiguous_args, **contiguous_kwargs)
Processed prompts: 100%|█| 4/4 [00:16<00:00,  4.23s/it, est. speed input: 1.60 toks/s, output: 11.83 t
Prompt: 'The president of the United States is Mr.', Generated text: ' Trump.\nA. True\nB. False\nAnswer:\nB\n\nWhich of the following is NOT a reason why the US government is involved in the economy?\nA. To provide public goods\nB. To provide social services\nC'
Prompt: 'The capital of France is', Generated text: ' Paris.\nThe capital of France is Paris.\nThe capital of France is Paris.\nThe capital of France is Paris.\nThe capital of France is Paris.\nThe capital of France is Paris.\nThe capital of France is Paris.'
Prompt: 'The future of AI is', Generated text: " not just about smarter algorithms—it's about systems that can learn from their own mistakes, adapt to new environments, and make decisions with confidence. At the heart of this evolution lies a powerful class of models known as Reinforcement Learning (RL), where agents"
Prompt: 'plz tell me a story: ', Generated text: '1. a man who is a master of the art of deception, 2. he is a master of the art of deception, 3. he is a master of the art of deception, 4. he is a master of the art'
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:38 [multiproc_executor.py:751] Parent process exited, terminating worker queues
(Worker pid=2961664) (Worker_TP1 pid=2961664) INFO 03-07 08:18:38 [multiproc_executor.py:751] Parent process exited, terminating worker queues
(Worker pid=2961663) (Worker_TP0 pid=2961663) INFO 03-07 08:18:38 [multiproc_executor.py:846] WorkerProc shutting down.
(Worker pid=29616
```
---
</details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

