### PR TITLE
Disable cascade attention by default

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -216,12 +216,13 @@ class ModelConfig:
     """Whether to disable sliding window. If True, we will disable the sliding
     window functionality of the model, capping to sliding window size. If the
     model does not support sliding window, this argument is ignored."""
-    disable_cascade_attn: bool = False
+    disable_cascade_attn: bool = True
     """Disable cascade attention for V1. While cascade attention does not
     change the mathematical correctness, disabling it could be useful for
-    preventing potential numerical issues. Note that even if this is set to
-    False, cascade attention will be only used when the heuristic tells that
-    it's beneficial."""
+    preventing potential numerical issues. This defaults to True, so users
+    must opt in to cascade attention by setting this to False. Even when this
+    is set to False, cascade attention will only be used when the heuristic
+    tells that it's beneficial."""
     skip_tokenizer_init: bool = False
     """Skip initialization of tokenizer and detokenizer. Expects valid
     `prompt_token_ids` and `None` for prompt from the input. The generated


### PR DESCRIPTION
### Motivation
- Make cascade attention opt-in to avoid potential numerical issues by default, requiring users to explicitly enable it.

### Description
- Change `ModelConfig.disable_cascade_attn` default from `False` to `True` in `vllm/config/model.py`.
- Update the `disable_cascade_attn` docstring to explain the new opt-in behavior and note that heuristics still gate usage.
- The change is limited to the config default and documentation; runtime heuristics and callers remain unchanged.

### Testing
- Ran a quick Python import/assertion that checks `ModelConfig.disable_cascade_attn` and `EngineArgs.disable_cascade_attn`, but it failed due to `ModuleNotFoundError: No module named 'torch'` so the runtime assertion could not be completed.
- No other automated test suites were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaf10a0c5c832995728fec713ad444)