### PR TITLE
[Bugfix] Disable TMA on Blackwell GPUs to fix Triton autotuner OOM in fla/solve_trilfix: disable TMA on Blackwell (sm_12x) to prevent Triton autotuner OO…

### DIFF
--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -153,10 +153,13 @@ is_nvidia_hopper = is_nvidia and (
 use_cuda_graph = is_nvidia and os.environ.get("FLA_USE_CUDA_GRAPH", "0") == "1"
 is_gather_supported = hasattr(triton.language, "gather")
 
-is_tma_supported = (is_nvidia and 9 <= torch.cuda.get_device_capability(0)[0] < 12) and (
+is_tma_supported = (
+    is_nvidia and 9 <= torch.cuda.get_device_capability(0)[0] < 12
+) and (
     hasattr(triton.language, "_experimental_make_tensor_descriptor")
     or hasattr(triton.language, "make_tensor_descriptor")
 )  # Upper bound < 12 disables TMA on Blackwell (sm_12x): Triton autotuner OOM
+
 
 def get_all_max_shared_mem():
     try:

--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -152,11 +152,11 @@ is_nvidia_hopper = is_nvidia and (
 )
 use_cuda_graph = is_nvidia and os.environ.get("FLA_USE_CUDA_GRAPH", "0") == "1"
 is_gather_supported = hasattr(triton.language, "gather")
-is_tma_supported = (is_nvidia and torch.cuda.get_device_capability(0)[0] >= 9) and (
+
+is_tma_supported = (is_nvidia and 9 <= torch.cuda.get_device_capability(0)[0] < 12) and (
     hasattr(triton.language, "_experimental_make_tensor_descriptor")
     or hasattr(triton.language, "make_tensor_descriptor")
-) and torch.cuda.get_device_capability(0)[0] < 12  # Disable on Blackwell (sm_12x): Triton autotuner OOM
-
+)  # Upper bound < 12 disables TMA on Blackwell (sm_12x): Triton autotuner OOM
 
 def get_all_max_shared_mem():
     try:

--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -155,7 +155,7 @@ is_gather_supported = hasattr(triton.language, "gather")
 is_tma_supported = (is_nvidia and torch.cuda.get_device_capability(0)[0] >= 9) and (
     hasattr(triton.language, "_experimental_make_tensor_descriptor")
     or hasattr(triton.language, "make_tensor_descriptor")
-)
+) and torch.cuda.get_device_capability(0)[0] < 12  # Disable on Blackwell (sm_12x): Triton autotuner OOM
 
 
 def get_all_max_shared_mem():


### PR DESCRIPTION
## Summary
Fixes Triton autotuner OOM crash in `fla/ops/solve_tril.py` when running 
Qwen3.5 models on Blackwell GPUs (RTX 5090, compute capability sm_12x).

## Root Cause
`is_tma_supported` evaluates to `True` on any GPU with compute capability >= 9,
which includes Blackwell (sm_12x). During first inference, the Triton autotuner 
benchmarks the `merge_fn` kernel in `solve_tril` with TMA enabled, causing 
oversized descriptor buffer allocations that OOM even when model weights fit 
comfortably in VRAM.

## Error
RuntimeError: Triton Error [CUDA]: out of memory
File "fla/ops/solve_tril.py", line 545, in solve_tril
merge_fn[NT, B * H](..., USE_TMA=is_tma_supported)
File "triton/runtime/autotuner.py"
timings = {config: self._bench(*args, config=config, **kwargs) for config in pruned_configs}

## Fix
Add upper bound `< 12` to restrict TMA only to Hopper (sm_90x). TMA works 
correctly on Hopper but causes Triton autotuner OOM on Blackwell (sm_12x).

## Testing
- GPU: NVIDIA RTX 5090 (Blackwell, sm_120)
- vLLM: 0.17.0
- Model: Qwen3.5-35B-A3B-AWQ, Qwen3.5-27B-AWQ
- CUDA: 12.8

After this fix, Qwen3.5 AWQ models run successfully on RTX 5090 without 
`--enforce-eager`. Full inference pipeline verified working.

## Related Issues
- #35743 (Qwen3.5 AWQ CUDA graph failures on Blackwell)
- #35945 (causal_conv1d AssertionError - related GDN bug)