### PR TITLE
[Doc]: Add README.md to examples directory

### DIFF
--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -374,7 +374,7 @@ The `--burstiness` parameter mathematically controls request arrival patterns us
 - Coefficient of Variation (CV): $\frac{1}{\sqrt{burstiness}}$
 - Traffic characteristics:
     - `burstiness = 0.1`: Highly bursty traffic (CV ≈ 3.16) - stress testing
-    - `burstiness = 1.0`: Natural Poisson traffic (CV = 1.0) - realistic simulation  
+    - `burstiness = 1.0`: Natural Poisson traffic (CV = 1.0) - realistic simulation
     - `burstiness = 5.0`: Uniform traffic (CV ≈ 0.45) - controlled load testing
 
 ![Load Pattern Examples](../assets/contributing/load-pattern-examples.png)

--- a/docs/benchmarking/dashboard.md
+++ b/docs/benchmarking/dashboard.md
@@ -52,7 +52,7 @@ The raw benchmarking results (in the format of json files) are in the `Artifacts
 
 The `compare-json-results.py` helps to compare benchmark results JSON files converted using `convert-results-json-to-markdown.py`.
 When run, benchmark script generates results under `benchmark/results` folder, along with the `benchmark_results.md` and `benchmark_results.json`.
-`compare-json-results.py` compares two `benchmark_results.json` files and provides performance ratio e.g. for Output Tput, Median TTFT and Median TPOT.  
+`compare-json-results.py` compares two `benchmark_results.json` files and provides performance ratio e.g. for Output Tput, Median TTFT and Median TPOT.
 If only one benchmark_results.json is passed, `compare-json-results.py` compares different TP and PP configurations in the benchmark_results.json instead.
 
 Here is an example using the script to compare result_a and result_b with max concurrency and qps for same Model, Dataset name, input/output length.
@@ -67,9 +67,9 @@ Here is an example using the script to compare result_a and result_b with max co
 | 2  | 24 | inf| 27.74  | 293.34 |  10.57 |
 | 3  | 32 | inf| 28.61  |306.69 | 10.72 |
 
-***compare-json-results.py – Command-Line Parameters***  
+***compare-json-results.py – Command-Line Parameters***
 
-compare-json-results.py provides configurable parameters to compare one or more benchmark_results.json files and generate summary tables and plots.  
+compare-json-results.py provides configurable parameters to compare one or more benchmark_results.json files and generate summary tables and plots.
 In most cases, users only need to specify --file to parse the desired benchmark results.
 
 | Parameter              | Type               | Default Value           | Description                                                                                           |
@@ -82,11 +82,11 @@ In most cases, users only need to specify --file to parse the desired benchmark 
 | `--ttft-max-ms`        | `float`            | `3000.0`                | Reference upper bound (milliseconds) for TTFT plots, typically used to visualize SLA thresholds.      |
 | `--tpot-max-ms`        | `float`            | `100.0`                 | Reference upper bound (milliseconds) for TPOT plots, typically used to visualize SLA thresholds.      |
 
-***Valid Max Concurrency Summary***  
+***Valid Max Concurrency Summary***
 
-Based on the configured TTFT and TPOT SLA thresholds, compare-json-results.py computes the maximum valid concurrency for each benchmark result.  
-The “Max # of max concurrency. (Both)” column represents the highest concurrency level that satisfies both TTFT and TPOT constraints simultaneously.  
-This value is typically used in capacity planning and sizing guides.  
+Based on the configured TTFT and TPOT SLA thresholds, compare-json-results.py computes the maximum valid concurrency for each benchmark result.
+The “Max # of max concurrency. (Both)” column represents the highest concurrency level that satisfies both TTFT and TPOT constraints simultaneously.
+This value is typically used in capacity planning and sizing guides.
 
 | # | Configuration  | Max # of max concurrency. (TTFT ≤ 10000 ms) | Max # of max concurrency. (TPOT ≤ 100 ms) | Max # of max concurrency. (Both) | Output Tput @ Both (tok/s) | TTFT @ Both (ms) | TPOT @ Both (ms) |
 | - | -------------- | ------------------------------------------- | ----------------------------------------- | -------------------------------- | -------------------------- | ---------------- | ---------------- |

--- a/docs/configuration/optimization.md
+++ b/docs/configuration/optimization.md
@@ -59,7 +59,7 @@ You can tune the performance by adjusting `max_num_batched_tokens`:
 - If `max_num_batched_tokens` is the same as `max_model_len`, that's almost the equivalent to the V0 default scheduling policy (except that it still prioritizes decodes).
 
 !!! warning
-    When chunked prefill is disabled, `max_num_batched_tokens` must be greater than `max_model_len`.  
+    When chunked prefill is disabled, `max_num_batched_tokens` must be greater than `max_model_len`.
     In that case, if `max_num_batched_tokens < max_model_len`, vLLM may crash at server start‑up.
 
 ```python

--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -174,7 +174,7 @@ INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
       stringData:
         token: "REPLACE_WITH_TOKEN"
       ```
-  
+
       Next to create the deployment file for vLLM to run the model server. The following example deploys the `Mistral-7B-Instruct-v0.3` model.
 
       Here are two examples for using NVIDIA GPU and AMD GPU.

--- a/docs/design/cuda_graphs.md
+++ b/docs/design/cuda_graphs.md
@@ -109,8 +109,8 @@ batch_descriptor=BatchDescriptor(num_tokens=num_input_tokens, uniform_decode=...
 runtime_mode, batch_descriptor = cudagraphdispatcher.dispatch(batch_descriptor)
 # execution
 with set_forward_context(
-    ..., 
-    cudagraph_runtime_mode=runtime_mode, 
+    ...,
+    cudagraph_runtime_mode=runtime_mode,
     batch_descriptor=batch_descriptor,
 ):
      output = self.model(...)
@@ -161,7 +161,7 @@ class AttentionCGSupport(enum.Enum):
     """CUDA Graphs always supported; supports mixed-prefill-decode"""
     UNIFORM_BATCH = 2
     """CUDA Graphs supported for batches the only contain query lengths that are
-    the same, this can be used for spec-decode 
+    the same, this can be used for spec-decode
         i.e. "decodes" are 1 + num_speculative_tokens"""
     UNIFORM_SINGLE_TOKEN_DECODE = 1
     """CUDA Graphs supported for batches the only contain query_len==1 decodes"""

--- a/docs/design/custom_op.md
+++ b/docs/design/custom_op.md
@@ -282,7 +282,7 @@ Taking `MMEncoderAttention` as an example:
 
         def __init__(...):
             super().__init__(...)
-        
+
         def forward_oot(...):
             # Call optimized device-specific kernels.
             ...

--- a/docs/design/logits_processors.md
+++ b/docs/design/logits_processors.md
@@ -10,7 +10,7 @@ This document describes how the vLLM engine interacts with logits processors, an
 
 A logits processor adjusts the next-token probability distribution, usually with the intention of steering the model towards a desired type of behavior.
 
-In vLLM, logits processors operate at batch granularity. During a given engine step, the logits processor consumes a `(num_requests) x (vocab_size)` tensor of raw logits output by the model. For all requests which enable the logits processor, the logits processor applies a transformation to the corresponding row of the logits tensor, while leaving other rows unmodified. The transformed logits tensor is then passed to softmax.  
+In vLLM, logits processors operate at batch granularity. During a given engine step, the logits processor consumes a `(num_requests) x (vocab_size)` tensor of raw logits output by the model. For all requests which enable the logits processor, the logits processor applies a transformation to the corresponding row of the logits tensor, while leaving other rows unmodified. The transformed logits tensor is then passed to softmax.
 
 ## Logits Processors in the vLLM engine
 
@@ -82,7 +82,7 @@ The pseudocode below shows the process by which the vLLM persistent batch notifi
         removed: Sequence[RemovedRequest]
         added: Sequence[AddedRequest]
         moved: Sequence[MovedRequest]
-    
+
     ```
 
 ### Applying Logits Processors to the Model Output Logits
@@ -153,7 +153,7 @@ Note that the sampler will access the logits processors via `SamplingMetadata.lo
             ...
 
             # ...perform sampling and return sampling result...
-    ``` 
+    ```
 
 At sampling time, the sampler checks whether all requests in the persistent batch employ greedy sampling. If that is the case, the sampler saves compute by skipping "argmax-invariant" logits processors. Here, "argmax" is shorthand for the token ID with the highest logit value in a given row of the logits tensor (i.e. the token which the model weighted the highest for a given request).
 

--- a/docs/design/lora_resolver_plugins.md
+++ b/docs/design/lora_resolver_plugins.md
@@ -160,7 +160,7 @@ To implement your own resolver plugin:
    ```python
    from vllm.lora.resolver import LoRAResolver, LoRAResolverRegistry
    from vllm.lora.request import LoRARequest
-   
+
    class CustomResolver(LoRAResolver):
        async def resolve_lora(self, base_model_name: str, lora_name: str) -> Optional[LoRARequest]:
            # Your custom resolution logic here

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -587,7 +587,7 @@ see:
 - [Benchmarking LLM Workloads for Performance Evaluation and Autoscaling in Kubernetes](https://docs.google.com/document/d/1k4Q4X14hW4vftElIuYGDu5KDe2LtV1XammoG-Xi3bbQ)
 - [Inference Perf](https://github.com/kubernetes-sigs/wg-serving/tree/main/proposals/013-inference-perf)
 - <https://github.com/vllm-project/vllm/issues/5041> and <https://github.com/vllm-project/vllm/pull/12726>.
-  
+
 This is a non-trivial topic. Consider this comment from Rob:
 
 > I think this metric should focus on trying to estimate what the max

--- a/docs/design/prefix_caching.md
+++ b/docs/design/prefix_caching.md
@@ -28,9 +28,9 @@ In the example above, the KV cache in the first block can be uniquely identified
     - `sha256` (default): Uses Python's `pickle` for serialization. Hashes may not be reproducible across different Python or vLLM versions.
     - `sha256_cbor`: Uses `cbor2` for serialization, providing a reproducible, cross-language compatible hash. This is recommended for deterministic caching across environments.
     - `xxhash`: `Uses Pickle serialization with xxHash (128-bit) for faster, non-cryptographic hashing. Requires the optional `xxhash` package. IMPORTANT: Use of a hashing algorithm that is not considered cryptographically secure theoretically increases the risk of hash collisions, which can cause undefined behavior or even leak private information in multi-tenant environments. Even if collisions are still very unlikely, it is important to consider your security risk tolerance against the performance benefits before turning this on.
-    - `xxhash_cbor` combines canonical CBOR serialization with xxHash for reproducible hashing. Requires the optional `xxhash` package.    
+    - `xxhash_cbor` combines canonical CBOR serialization with xxHash for reproducible hashing. Requires the optional `xxhash` package.
 
-**A hashing example with multi-modality inputs**  
+**A hashing example with multi-modality inputs**
 In this example, we illustrate how prefix caching works with multi-modality inputs (e.g., images). Assuming we have a request with the following messages:
 
 ```text
@@ -120,18 +120,18 @@ class KVCacheBlock:
 
 There are two design points to highlight:
 
-1. We allocate all KVCacheBlock when initializing the KV cache manager to be a block pool. This avoids Python object creation overheads and can easily track all blocks all the time.  
-2. We introduce doubly linked list pointers directly in the KVCacheBlock, so that we could construct a free queue directly. This gives us two benefits:  
-    1. We could have O(1) complexity moving elements in the middle to the tail.  
+1. We allocate all KVCacheBlock when initializing the KV cache manager to be a block pool. This avoids Python object creation overheads and can easily track all blocks all the time.
+2. We introduce doubly linked list pointers directly in the KVCacheBlock, so that we could construct a free queue directly. This gives us two benefits:
+    1. We could have O(1) complexity moving elements in the middle to the tail.
     2. We could avoid introducing another Python queue (e.g., `deque`) which has a wrapper to the elements.
 
 As a result, we will have the following components when the KV cache manager is initialized:
 
 ![Component Overview](../assets/design/prefix_caching/overview.png)
 
-* Block Pool: A list of KVCacheBlock.  
-* Free Block Queue: Only store the pointers of head and tail blocks for manipulations.  
-* Cache blocks: Mapping from hash key to block IDs.  
+* Block Pool: A list of KVCacheBlock.
+* Free Block Queue: Only store the pointers of head and tail blocks for manipulations.
+* Cache blocks: Mapping from hash key to block IDs.
 * Request blocks: Mapping from request ID to allocated block IDs.
 
 ## Operations
@@ -140,21 +140,21 @@ As a result, we will have the following components when the KV cache manager is 
 
 **New request:** Workflow for the scheduler to schedule a new request with KV cache block allocation:
 
-1. The scheduler calls `kv_cache_manager.get_computed_blocks()` to get a sequence of blocks that have already been computed. This is done by hashing the prompt tokens in the request and looking up cache blocks.  
-2. The scheduler calls `kv_cache_manager.allocate_slots()`. It does the following steps:  
-    1. Compute the number of new required blocks, and return if there are no sufficient blocks to allocate.  
-    2. “Touch” the computed blocks. It increases the reference count of the computed block by one, and removes the block from the free queue if the block wasn’t used by other requests. This is to avoid these computed blocks being evicted. See the example in the next section for illustration.  
-    3. Allocate new blocks by popping the heads of the free queue. If the head block is a cached block, this also “evicts” the block so that no other requests can reuse it anymore from now on.  
+1. The scheduler calls `kv_cache_manager.get_computed_blocks()` to get a sequence of blocks that have already been computed. This is done by hashing the prompt tokens in the request and looking up cache blocks.
+2. The scheduler calls `kv_cache_manager.allocate_slots()`. It does the following steps:
+    1. Compute the number of new required blocks, and return if there are no sufficient blocks to allocate.
+    2. “Touch” the computed blocks. It increases the reference count of the computed block by one, and removes the block from the free queue if the block wasn’t used by other requests. This is to avoid these computed blocks being evicted. See the example in the next section for illustration.
+    3. Allocate new blocks by popping the heads of the free queue. If the head block is a cached block, this also “evicts” the block so that no other requests can reuse it anymore from now on.
     4. If an allocated block is already full of tokens, we immediately add it to the cache block, so that the block can be reused by other requests in the same batch.
 
 **Running request:** Workflow for the scheduler to schedule a running request with KV cache block allocation:
 
-1. The scheduler calls `kv_cache_manager.allocate_slots()`. It does the following steps:  
-    1. Compute the number of new required blocks, and return if there are no sufficient blocks to allocate.  
-    2. Allocate new blocks by popping the heads of the free queue. If the head block is a cached block, this also “evicts” the block so that no other requests can reuse it anymore from now on.  
+1. The scheduler calls `kv_cache_manager.allocate_slots()`. It does the following steps:
+    1. Compute the number of new required blocks, and return if there are no sufficient blocks to allocate.
+    2. Allocate new blocks by popping the heads of the free queue. If the head block is a cached block, this also “evicts” the block so that no other requests can reuse it anymore from now on.
     3. Append token IDs to the slots in existing blocks as well as the new blocks. If a block is full, we add it to the cache block to cache it.
 
-**Duplicated blocks**  
+**Duplicated blocks**
 Assuming block size is 4 and you send a request (Request 1\) with prompt ABCDEF and decoding length 3:
 
 ```text
@@ -203,8 +203,8 @@ When a request is finished, we free all its blocks if no other requests are usin
 
 When the head block (least recently used block) of the free queue is cached, we have to evict the block to prevent it from being used by other requests. Specifically, eviction involves the following steps:
 
-1. Pop the block from the head of the free queue. This is the LRU block to be evicted.  
-2. Remove the block ID from the cache block.  
+1. Pop the block from the head of the free queue. This is the LRU block to be evicted.
+2. Remove the block ID from the cache block.
 3. Remove the block hash.
 
 ## Example

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -54,7 +54,7 @@ th:not(:first-child) {
 | beam-search | ✅ | ✅ | ✅ | [❌](https://github.com/vllm-project/vllm/issues/6137) | ✅ | ❌ | ✅ | ✅ | ✅ | ❔ | [❌](https://github.com/vllm-project/vllm/issues/7968) | ❔ | ✅ | ✅ | |
 | [prompt-embeds](prompt_embeds.md) | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❔ | ❔ | ❌ | ❔ | ❔ | ✅ |
 
-\* Chunked prefill and prefix caching are only applicable to last-token or all pooling with causal attention.  
+\* Chunked prefill and prefix caching are only applicable to last-token or all pooling with causal attention.
 <sup>^</sup> LoRA is only applicable to the language backbone of multimodal models.
 
 ### Feature x Hardware

--- a/docs/features/custom_logitsprocs.md
+++ b/docs/features/custom_logitsprocs.md
@@ -12,7 +12,7 @@ This document shows how to write, load and use a custom logits processor.
 
 A logits processor adjusts the next-token probability distribution, usually with the intention of steering the model towards a desired type of behavior.
 
-In vLLM, logits processors operate at batch granularity. During a given engine step, the logits processor consumes a `(num_requests) x (vocab_size)` tensor of raw logits output by the model. For all requests which enable the logits processor, the logits processor applies a transformation to the corresponding row of the logits tensor, while leaving other rows unmodified. The transformed logits tensor is then passed to softmax.  
+In vLLM, logits processors operate at batch granularity. During a given engine step, the logits processor consumes a `(num_requests) x (vocab_size)` tensor of raw logits output by the model. For all requests which enable the logits processor, the logits processor applies a transformation to the corresponding row of the logits tensor, while leaving other rows unmodified. The transformed logits tensor is then passed to softmax.
 
 ## Creating a Custom Logits Processor
 
@@ -135,7 +135,7 @@ The contrived example below implements a custom logits processor which consumes 
                 if params.extra_args and (target_token :=
                                         params.extra_args.get("target_token")):
                     self.req_info[index] = target_token
-                else: 
+                else:
                     self.req_info.pop(index, None)
 
             if self.req_info:
@@ -419,7 +419,7 @@ The examples below show how a user would pass a custom argument (`target_token`)
 ??? code "Offline: configure custom logits processor for an `LLM` request"
 
     ``` python
-    outputs_logitproc = llm.generate("your prompt", 
+    outputs_logitproc = llm.generate("your prompt",
                                      SamplingParams(...,
                                         extra_args={"target_token": 67}))
     ```

--- a/docs/features/disagg_encoder.md
+++ b/docs/features/disagg_encoder.md
@@ -2,8 +2,8 @@
 
 A **disaggregated encoder** runs the vision-encoder stage of a multimodal LLM in a process that is separate from the pre-fill / decoder stage. Deploying these two stages in independent vLLM instances brings three practical benefits:
 
-1. **Independent, fine-grained scaling**  
-2. **Lower time-to-first-token (TTFT)**  
+1. **Independent, fine-grained scaling**
+2. **Lower time-to-first-token (TTFT)**
 3. **Cross-process reuse and caching of encoder outputs**
 
 Design doc: <https://docs.google.com/document/d/1aed8KtC6XkXtdoV87pWT0a8OJlZ-CpnuLLzmR8l9BAE>
@@ -14,25 +14,25 @@ Design doc: <https://docs.google.com/document/d/1aed8KtC6XkXtdoV87pWT0a8OJlZ-Cpn
 
 ### 1. Independent, fine-grained scaling
 
-* Vision encoders are lightweight, while language models are orders of magnitude larger.  
-* The language model can be parallelised without affecting the encoder fleet.  
+* Vision encoders are lightweight, while language models are orders of magnitude larger.
+* The language model can be parallelised without affecting the encoder fleet.
 * Encoder nodes can be added or removed independently.
 
 ### 2. Lower time-to-first-token (TTFT)
 
-* Language-only requests bypass the vision encoder entirely.  
+* Language-only requests bypass the vision encoder entirely.
 * Encoder output is injected only at required attention layers, shortening the pre-fill critical path.
 
 ### 3. Cross-process reuse and caching
 
-* In-process encoders confine reuse to a single worker.  
+* In-process encoders confine reuse to a single worker.
 * A remote, shared cache lets any worker retrieve existing embeddings, eliminating redundant computation.
 
 ---
 
 ## 2  Usage Example
 
-The current reference pathway is **ExampleConnector**.  
+The current reference pathway is **ExampleConnector**.
 Below ready-to-run scripts shows the workflow:
 
 1 Encoder instance + 1 PD instance:
@@ -51,17 +51,17 @@ Please refer to the directories `tests/v1/ec_connector`
 
 Disaggregated encoding is implemented by running two parts:
 
-* **Encoder instance** – a vLLM instance to performs vision encoding.  
+* **Encoder instance** – a vLLM instance to performs vision encoding.
 * **Prefill/Decode (PD) instance(s)** – runs language pre-fill and decode.
     * PD can be in either a single normal instance with `disagg_encoder_example.sh` (E->PD) or in disaggregated instances with `disagg_epd_example.sh` (E->P->D)
 
-A connector transfers encoder-cache (EC) embeddings from the encoder instance to the PD instance.  
+A connector transfers encoder-cache (EC) embeddings from the encoder instance to the PD instance.
 All related code is under `vllm/distributed/ec_transfer`.
 
 ### Key abstractions
 
-* **ECConnector** – interface for retrieving EC caches produced by the encoder.  
-    * *Scheduler role* – checks cache existence and schedules loads.  
+* **ECConnector** – interface for retrieving EC caches produced by the encoder.
+    * *Scheduler role* – checks cache existence and schedules loads.
     * *Worker role* – loads the embeddings into memory.
 
 Here is a figure illustrating disaggregate encoder flow:

--- a/docs/features/interleaved_thinking.md
+++ b/docs/features/interleaved_thinking.md
@@ -39,20 +39,20 @@ To use interleaved thinking with tool calls, specify a model that supports this 
       --enable-auto-tool-choice
     """
     import json
-    
+
     from openai import OpenAI
-    
+
     client = OpenAI(base_url="http://localhost:8000/v1",     api_key="dummy")
-    
-    
+
+
     def get_current_weather(location: str, unit: "str"):
         """Get the current weather in a given location"""
         if unit == "celsius":
             return f"The current temperature in {location} is 22°C."
         else:
             return f"The current temperature in {location} is 72°F."
-    
-    
+
+
     tools = [
         {
             "type": "function",
@@ -80,9 +80,9 @@ To use interleaved thinking with tool calls, specify a model that supports this 
         tools=tools,
         tool_choice="auto",
     )
-    
+
     tool_call = response.choices[0].message.tool_calls[0].function
-    
+
     messages.append(
         {
             "role": "assistant",
@@ -90,10 +90,10 @@ To use interleaved thinking with tool calls, specify a model that supports this 
             "reasoning": response.choices[0].message.reasoning, # append reasoning
         }
     )
-    
+
     # Simulate tool execution
     available_tools = {"get_weather": get_current_weather}
-    
+
     completion_tool_calls = response.choices[0].message.tool_calls
     for call in completion_tool_calls:
         tool_to_call = available_tools[call.function.name]

--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -442,7 +442,7 @@ You must enable this feature via `enable_mm_embeds=True`.
         "image": {
             # Shape: (num_images, num_slices, hidden_size)
             # num_slices can differ for each image
-            "image_embeds": [torch.load(...) for image in images],  
+            "image_embeds": [torch.load(...) for image in images],
             # Shape: (num_images, 2)
             # image_sizes is needed to calculate details of the sliced image.
             "image_sizes": [image.size for image in images],

--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -35,6 +35,52 @@ For reproducible measurements in your environment, use
 [`examples/offline_inference/spec_decode.py`](../../../examples/offline_inference/spec_decode.py)
 or the [benchmark CLI guide](../../benchmarking/cli.md).
 
+## Speculative Config Options
+
+The `--speculative-config` flag allows you to pass a JSON object with configuration options for speculative decoding. This is useful when you need to configure advanced options for the speculative method.
+
+### Usage Example
+
+```bash
+vllm serve meta-llama/Llama-2-7b-hf \
+    --speculative-config '{"model": "meta-llama/Llama-2-7b-hf", "num_speculative_tokens": 5, "method": "draft_model"}'
+```
+
+### Supported Configuration Keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `method` | string | `"draft_model"` | Speculative method to use. Options: `"draft_model"`, `"eagle"`, `"eagle3"`, `"mtp"`, `"ngram"`, `"suffix"`, `"medusa"`, `"mlp_speculator"` |
+| `model` | string | `null` | Draft model name, EAGLE head, or additional weights |
+| `num_speculative_tokens` | int | `null` | Number of speculative tokens to generate |
+| `draft_tensor_parallel_size` | int | `null` | Tensor parallelism degree for draft model (1 or same as target) |
+| `quantization` | string | `null` | Quantization method for draft model weights |
+| `max_model_len` | int | `null` | Maximum model length of the draft model |
+| `revision` | string | `null` | Model version (branch, tag, or commit) for draft model |
+| `disable_padded_drafter_batch` | bool | `false` | Disable input padding for speculative decoding |
+| `use_local_argmax_reduction` | bool | `false` | Use local argmax instead of all-gather for draft token generation |
+| `parallel_drafting` | bool | `false` | Enable parallel drafting (for EAGLE and draft model methods) |
+
+### N-gram Specific Options
+
+When using `"method": "ngram"`:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `prompt_lookup_min` | int | `5` | Minimum size of ngram token window |
+| `prompt_lookup_max` | int | `5` | Maximum size of ngram token window |
+
+### Suffix Decoding Specific Options
+
+When using `"method": "suffix"`:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `suffix_decoding_max_tree_depth` | int | `24` | Maximum depth of suffix decoding trees |
+| `suffix_decoding_max_cached_requests` | int | `10000` | Maximum number of requests to cache |
+| `suffix_decoding_max_spec_factor` | float | `1.0` | Maximum spec factor for suffix decoding |
+| `suffix_decoding_min_token_prob` | float | `0.1` | Minimum token probability for suffix decoding |
+
 ## Lossless guarantees of Speculative Decoding
 
 In vLLM, speculative decoding aims to enhance inference efficiency while maintaining accuracy. This section addresses the lossless guarantees of

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -56,13 +56,13 @@ This guide will help you quickly get started with vLLM to perform:
     !!! note
         It currently supports Python 3.12, ROCm 7.0 and `glibc >= 2.35`.
 
-    !!! note    
+    !!! note
         Note that, previously, docker images were published using AMD's docker release pipeline and were located `rocm/vllm-dev`. This is being deprecated by using vLLM's docker release pipeline.
 
 === "Google TPU"
 
     To run vLLM on Google TPUs, you need to install the `vllm-tpu` package.
-    
+
     ```bash
     uv pip install vllm-tpu
     ```
@@ -131,11 +131,11 @@ for output in outputs:
     The `llm.generate` method does not automatically apply the model's chat template to the input prompt. Therefore, if you are using an Instruct model or Chat model, you should manually apply the corresponding chat template to ensure the expected behavior. Alternatively, you can use the `llm.chat` method and pass a list of messages which have the same format as those passed to OpenAI's `client.chat.completions`:
 
     ??? code
-    
+
         ```python
         # Using tokenizer to apply chat template
         from transformers import AutoTokenizer
-    
+
         tokenizer = AutoTokenizer.from_pretrained("/path/to/chat_model")
         messages_list = [
             [{"role": "user", "content": prompt}]
@@ -146,16 +146,16 @@ for output in outputs:
             tokenize=False,
             add_generation_prompt=True,
         )
-        
+
         # Generate outputs
         outputs = llm.generate(texts, sampling_params)
-        
+
         # Print the outputs.
         for output in outputs:
             prompt = output.prompt
             generated_text = output.outputs[0].text
             print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
-    
+
         # Using chat interface.
         outputs = llm.chat(messages_list, sampling_params)
         for idx, output in enumerate(outputs):

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -527,7 +527,7 @@ These models primarily support the [`LLM.embed`](./pooling_models.md#llmembed) A
 | `RobertaModel`, `RobertaForMaskedLM` | RoBERTa-based | `sentence-transformers/all-roberta-large-v1`, etc. | | |
 | `*Model`<sup>C</sup>, `*ForCausalLM`<sup>C</sup>, etc. | Generative models | N/A | \* | \* |
 
-<sup>C</sup> Automatically converted into an embedding model via `--convert embed`. ([details](./pooling_models.md#model-conversion))  
+<sup>C</sup> Automatically converted into an embedding model via `--convert embed`. ([details](./pooling_models.md#model-conversion))
 \* Feature support is the same as that of the original model.
 
 !!! note
@@ -558,7 +558,7 @@ These models primarily support the [`LLM.classify`](./pooling_models.md#llmclass
 | `GPT2ForSequenceClassification` | GPT2 | `nie3e/sentiment-polish-gpt2-small` | | |
 | `*Model`<sup>C</sup>, `*ForCausalLM`<sup>C</sup>, etc. | Generative models | N/A | \* | \* |
 
-<sup>C</sup> Automatically converted into a classification model via `--convert classify`. ([details](./pooling_models.md#model-conversion))  
+<sup>C</sup> Automatically converted into a classification model via `--convert classify`. ([details](./pooling_models.md#model-conversion))
 \* Feature support is the same as that of the original model.
 
 If your model is not in the above list, we will try to automatically convert the model using
@@ -581,7 +581,7 @@ These models primarily support the [`LLM.score`](./pooling_models.md#llmscore) A
 | `XLMRobertaForSequenceClassification` | XLM-RoBERTa-based | `BAAI/bge-reranker-v2-m3`, etc. | N/A | | |
 | `*Model`<sup>C</sup>, `*ForCausalLM`<sup>C</sup>, etc. | Generative models | N/A | N/A | \* | \* |
 
-<sup>C</sup> Automatically converted into a classification model via `--convert classify`. ([details](./pooling_models.md#model-conversion))  
+<sup>C</sup> Automatically converted into a classification model via `--convert classify`. ([details](./pooling_models.md#model-conversion))
 \* Feature support is the same as that of the original model.
 
 !!! note
@@ -772,10 +772,10 @@ Some models are supported only via the [Transformers modeling backend](#transfor
 !!! note
     `Gemma3nForConditionalGeneration` is only supported on V1 due to shared KV caching and it depends on `timm>=1.0.17` to make use of its
     MobileNet-v5 vision backbone.
-  
+
     Performance is not yet fully optimized mainly due to:
-  
-    - Both audio and vision MM encoders use `transformers.AutoModel` implementation.  
+
+    - Both audio and vision MM encoders use `transformers.AutoModel` implementation.
     - There's no PLE caching or out-of-memory swapping support, as described in [Google's blog](https://developers.googleblog.com/en/introducing-gemma-3n/). These features might be too model-specific for vLLM, and swapping in particular may be better suited for constrained setups.
 
 !!! note
@@ -831,7 +831,7 @@ The following table lists those that are tested in vLLM.
 | `SiglipModel` | SigLIP, SigLIP2 | T / I | `google/siglip-base-patch16-224`, `google/siglip2-base-patch16-224` | | |
 | `*ForConditionalGeneration`<sup>C</sup>, `*ForCausalLM`<sup>C</sup>, etc. | Generative models | \* | N/A | \* | \* |
 
-<sup>C</sup> Automatically converted into an embedding model via `--convert embed`. ([details](./pooling_models.md#model-conversion))  
+<sup>C</sup> Automatically converted into an embedding model via `--convert embed`. ([details](./pooling_models.md#model-conversion))
 \* Feature support is the same as that of the original model.
 
 ---
@@ -847,7 +847,7 @@ These models primarily support the [`LLM.score`](./pooling_models.md#llmscore) A
 | `LlamaNemotronVLForSequenceClassification` | Llama Nemotron Reranker + SigLIP | T + I<sup>E+</sup> | `nvidia/llama-nemotron-rerank-vl-1b-v2` | | |
 | `Qwen3VLForSequenceClassification` | Qwen3-VL-Reranker | T + I<sup>E+</sup> + V<sup>E+</sup> | `Qwen/Qwen3-VL-Reranker-2B`(see note), etc. | ✅︎ | ✅︎ |
 
-<sup>C</sup> Automatically converted into a classification model via `--convert classify`. ([details](./pooling_models.md#model-conversion))  
+<sup>C</sup> Automatically converted into a classification model via `--convert classify`. ([details](./pooling_models.md#model-conversion))
 \* Feature support is the same as that of the original model.
 
 !!! note

--- a/docs/serving/expert_parallel_deployment.md
+++ b/docs/serving/expert_parallel_deployment.md
@@ -228,7 +228,7 @@ For production deployments requiring strict SLA guarantees for time-to-first-tok
 ### Architecture Overview
 
 - **Prefill Instance**: Uses `deepep_high_throughput` backend for optimal prefill performance
-- **Decode Instance**: Uses `deepep_low_latency` backend for minimal decode latency  
+- **Decode Instance**: Uses `deepep_low_latency` backend for minimal decode latency
 - **KV Cache Transfer**: Connects instances via NIXL or other KV connectors
 
 ### Setup Steps
@@ -248,7 +248,7 @@ import uuid
 try:
     # 1: Set up clients for prefill and decode instances
     openai_api_key = "EMPTY"  # vLLM doesn't require a real API key
-    
+
     # Replace these IP addresses with your actual instance addresses
     prefill_client = OpenAI(
         api_key=openai_api_key,
@@ -256,9 +256,9 @@ try:
     )
     decode_client = OpenAI(
         api_key=openai_api_key,
-        base_url="http://192.168.1.101:8001/v1",  # Decode instance URL  
+        base_url="http://192.168.1.101:8001/v1",  # Decode instance URL
     )
-    
+
     # Get model name from prefill instance
     models = prefill_client.models.list()
     model = models.data[0].id
@@ -268,7 +268,7 @@ try:
     # Generate unique request ID to link prefill and decode operations
     request_id = str(uuid.uuid4())
     print(f"Request ID: {request_id}")
-    
+
     prefill_response = prefill_client.completions.create(
         model=model,
         # Prompt must exceed vLLM's block size (16 tokens) for PD to work
@@ -286,11 +286,11 @@ try:
         },
         extra_headers={"X-Request-Id": request_id},
     )
-    
+
     print("-" * 50)
     print("✓ Prefill completed successfully")
     print(f"Prefill response: {prefill_response.choices[0].text}")
-    
+
     # 3: Decode Phase
     # Transfer KV cache parameters from prefill to decode instance
     decode_response = decode_client.completions.create(
@@ -302,7 +302,7 @@ try:
         },
         extra_headers={"X-Request-Id": request_id},  # Same request ID
     )
-    
+
     print("-" * 50)
     print("✓ Decode completed successfully")
     print(f"Final response: {decode_response.choices[0].text}")

--- a/docs/serving/openai_compatible_server.md
+++ b/docs/serving/openai_compatible_server.md
@@ -954,7 +954,7 @@ You can pass multi-modal inputs to scoring models by passing `content` including
 
         ```python
         import requests
-        
+
         response = requests.post(
             "http://localhost:8000/v1/score",
             json={

--- a/docs/serving/parallelism_scaling.md
+++ b/docs/serving/parallelism_scaling.md
@@ -210,7 +210,7 @@ spec:
     Then look for the NCCL version and the network used.
 
     - If you find `[send] via NET/IB/GDRDMA` in the logs, then NCCL is using InfiniBand with GPUDirect RDMA, which *is* efficient.
-    - If you find `[send] via NET/Socket` in the logs, NCCL used a raw TCP socket, which *is not* efficient for cross-node tensor parallelism. 
+    - If you find `[send] via NET/Socket` in the logs, NCCL used a raw TCP socket, which *is not* efficient for cross-node tensor parallelism.
 
 !!! tip "Pre-download Hugging Face models"
     If you use Hugging Face models, downloading the model before starting vLLM is recommended. Download the model on every node to the same path, or store the model on a distributed file system accessible by all nodes. Then pass the path to the model in place of the repository ID. Otherwise, supply a Hugging Face token by appending `-e HF_TOKEN=<TOKEN>` to `run_cluster.sh`.

--- a/docs/usage/reproducibility.md
+++ b/docs/usage/reproducibility.md
@@ -11,7 +11,7 @@ Example: [examples/offline_inference/reproducibility.py](../../examples/offline_
 
 !!! warning
 
-    Setting `VLLM_ENABLE_V1_MULTIPROCESSING=0` will change the random state of user code 
+    Setting `VLLM_ENABLE_V1_MULTIPROCESSING=0` will change the random state of user code
     (i.e. the code that constructs [LLM][vllm.LLM] class).
 
 !!! note
@@ -34,7 +34,7 @@ for workflows such as speculative decoding. For more information, see: <https://
 
 !!! note
 
-    The random state in user code (i.e. the code that constructs [LLM][vllm.LLM] class) is updated by vLLM 
+    The random state in user code (i.e. the code that constructs [LLM][vllm.LLM] class) is updated by vLLM
     only if the workers are run in the same process as user code, i.e.: `VLLM_ENABLE_V1_MULTIPROCESSING=0`.
 
     By default, `VLLM_ENABLE_V1_MULTIPROCESSING=1` so you can use vLLM without having to worry about

--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -351,9 +351,9 @@ If you use triton kernels with cuda 13, you might see an error like `ptxas fatal
 (EngineCore_0 pid=9492) triton.runtime.errors.PTXASError: PTXAS error: Internal Triton PTX codegen error
 (EngineCore_0 pid=9492) `ptxas` stderr:
 (EngineCore_0 pid=9492) ptxas fatal   : Value 'sm_110a' is not defined for option 'gpu-name'
-(EngineCore_0 pid=9492) 
+(EngineCore_0 pid=9492)
 (EngineCore_0 pid=9492) Repro command: /home/jetson/.venv/lib/python3.12/site-packages/triton/backends/nvidia/bin/ptxas -lineinfo -v --gpu-name=sm_110a /tmp/tmp95oy_b9d.ptx -o /tmp/tmp95oy_b9d.ptx.o
-(EngineCore_0 pid=9492) 
+(EngineCore_0 pid=9492)
     outputs = self.engine_core.get_output()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/home/jetson/.venv/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 668, in get_output

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,45 @@
+# vLLM Examples
+
+This directory contains example scripts demonstrating various vLLM features and use cases.
+
+## Directory Structure
+
+### `offline_inference/`
+
+Scripts for offline (batch) inference:
+
+- Basic inference examples
+- Structured output generation
+- Speculative decoding
+- Prefix caching
+- Multimodal inference (vision, audio)
+
+### `online_serving/`
+
+Scripts for online (server) serving:
+
+- OpenAI-compatible API server
+- Various serving backends
+
+### `pooling/`
+
+Examples for pooling models:
+
+- Classification tasks
+- Embedding generation
+- Custom pooling plugins
+
+### `others/`
+
+Miscellaneous examples:
+
+- Performance profiling
+- Custom model implementations
+
+## Getting Started
+
+For detailed documentation, visit:
+
+- [vLLM Documentation](https://docs.vllm.ai/)
+- [Offline Inference Guide](https://docs.vllm.ai/en/latest/getting_started/quickstart.html)
+- [Online Serving Guide](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)


### PR DESCRIPTION
## 📚 Documentation Update

This PR adds a README.md file to the examples/ directory to help users navigate the available example scripts.

### Changes

- Created examples/README.md with:
  - Directory structure overview
  - Brief description of each category (offline_inference, online_serving, pooling, others)
  - Links to relevant documentation

### Why

The examples/ directory contains many useful scripts but lacked an overview document to help users find what they need.

### Checklist

- [x] Documentation follows project style
- [x] No code changes (documentation only)
