### PR TITLE
Add kv_transfer_params to streaming responses

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -132,6 +132,11 @@ class ChatCompletionStreamResponse(OpenAIBaseModel):
     # not part of the OpenAI spec but for tracing the tokens
     prompt_token_ids: list[int] | None = None
 
+    # vLLM-specific fields that are not in OpenAI spec
+    kv_transfer_params: dict[str, Any] | None = Field(
+        default=None, description="KVTransfer parameters."
+    )
+
 
 class ChatCompletionToolsParam(OpenAIBaseModel):
     type: Literal["function"] = "function"

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -645,6 +645,8 @@ class OpenAIServingChat(OpenAIServing):
         finish_reason_sent = [False] * num_choices
         num_prompt_tokens = 0
         num_cached_tokens = None
+        kv_transfer_params_sent = False
+        kv_transfer_params: dict[str, Any] | None = None
         if self.use_harmony:
             harmony_parsers = [
                 get_streamable_parser_for_assistant() for _ in range(num_choices)
@@ -716,6 +718,10 @@ class OpenAIServingChat(OpenAIServing):
                     num_prompt_tokens = len(res.prompt_token_ids)
                     if res.encoder_prompt_token_ids is not None:
                         num_prompt_tokens += len(res.encoder_prompt_token_ids)
+
+                # Capture kv_transfer_params from the first result that has it
+                if res.kv_transfer_params and not kv_transfer_params:
+                    kv_transfer_params = res.kv_transfer_params
 
                 # We need to do it here, because if there are exceptions in
                 # the result_generator, it needs to be sent as the FIRST
@@ -1317,7 +1323,16 @@ class OpenAIServingChat(OpenAIServing):
                         created=created_time,
                         choices=[choice_data],
                         model=model_name,
+                        kv_transfer_params=(
+                            kv_transfer_params
+                            if kv_transfer_params and not kv_transfer_params_sent
+                            else None
+                        ),
                     )
+
+                    # Mark kv_transfer_params as sent after first chunk
+                    if kv_transfer_params and not kv_transfer_params_sent:
+                        kv_transfer_params_sent = True
 
                     # handle usage stats if requested & if continuous
                     if include_continuous_usage:

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -512,3 +512,8 @@ class CompletionStreamResponse(OpenAIBaseModel):
     model: str
     choices: list[CompletionResponseStreamChoice]
     usage: UsageInfo | None = Field(default=None)
+
+    # vLLM-specific fields that are not in OpenAI spec
+    kv_transfer_params: dict[str, Any] | None = Field(
+        default=None, description="KVTransfer parameters."
+    )

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -5,7 +5,7 @@ import asyncio
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
-from typing import cast
+from typing import Any, cast
 
 import jinja2
 from fastapi import Request
@@ -310,6 +310,8 @@ class OpenAIServingCompletion(OpenAIServing):
         num_prompt_tokens = [0] * num_prompts
         num_cached_tokens = None
         first_iteration = True
+        kv_transfer_params_sent = False
+        kv_transfer_params: dict[str, Any] | None = None
 
         stream_options = request.stream_options
         include_usage, include_continuous_usage = should_include_usage(
@@ -324,6 +326,10 @@ class OpenAIServingCompletion(OpenAIServing):
                 if first_iteration:
                     num_cached_tokens = res.num_cached_tokens
                     first_iteration = False
+
+                # Capture kv_transfer_params from the first result that has it
+                if res.kv_transfer_params and not kv_transfer_params:
+                    kv_transfer_params = res.kv_transfer_params
 
                 prompt_text = res.prompt
                 if prompt_text is None:
@@ -428,7 +434,17 @@ class OpenAIServingCompletion(OpenAIServing):
                                 ),
                             )
                         ],
+                        kv_transfer_params=(
+                            kv_transfer_params
+                            if kv_transfer_params and not kv_transfer_params_sent
+                            else None
+                        ),
                     )
+
+                    # Mark kv_transfer_params as sent after first chunk
+                    if kv_transfer_params and not kv_transfer_params_sent:
+                        kv_transfer_params_sent = True
+
                     if include_continuous_usage:
                         prompt_tokens = num_prompt_tokens[prompt_idx]
                         completion_tokens = previous_num_tokens[i]


### PR DESCRIPTION
Resolves: #36308 
Include kv_transfer_params in ChatCompletionStreamResponse and CompletionStreamResponse. 
Populate in first chunk with generated content
