### PR TITLE
Fix missing mmproj file download for multimodal GGUF models

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -433,11 +433,15 @@ def download_gguf(
     # - *-{quant_type}-*.gguf (root sharded)
     # - */*-{quant_type}.gguf (subdir)
     # - */*-{quant_type}-*.gguf (subdir sharded)
+    # - mmproj-{quant_type}.gguf (multimodal projector root)
+    # - */mmproj-{quant_type}.gguf (multimodal projector subdir)
     allow_patterns = [
         f"*-{quant_type}.gguf",
         f"*-{quant_type}-*.gguf",
         f"*/*-{quant_type}.gguf",
         f"*/*-{quant_type}-*.gguf",
+        f"mmproj-{quant_type}.gguf",
+        f"*/mmproj-{quant_type}.gguf",
     ]
 
     # Use download_weights_from_hf which handles caching and downloading


### PR DESCRIPTION
Fixes #36245. The download_gguf function was missing patterns for mmproj files, causing multimodal GGUF models like Gemma3 to fail with 'Could not find mm_proj file' error. Added patterns to download mmproj-{quant_type}.gguf files from both root and subdirectories.