### PR TITLE
[Bugfix]: Fix Qwen3.5 missing max_window_layers attribute

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -365,12 +365,16 @@ class Qwen2Model(nn.Module):
 
         # TODO (@robertgshaw2): see if this can be moved out
         if is_interleaved(vllm_config.model_config.hf_text_config):
-            assert config.max_window_layers == config.num_hidden_layers, (
+            # Some config types (e.g., Qwen3_5TextConfig) may not have max_window_layers
+            max_window_layers = getattr(
+                config, "max_window_layers", config.num_hidden_layers
+            )
+            assert max_window_layers == config.num_hidden_layers, (
                 "Sliding window for some but all layers is not supported. "
                 "This model uses sliding window but `max_window_layers` = {} "
                 "is less than `num_hidden_layers` = {}. Please open an issue "
                 "to discuss this feature.".format(
-                    config.max_window_layers,
+                    max_window_layers,
                     config.num_hidden_layers,
                 )
             )


### PR DESCRIPTION
## Bug Fix

This PR fixes the AttributeError when loading Qwen3.5 models.

### Problem

Qwen3_5TextConfig doesn't have the max_window_layers attribute, causing:


### Solution

Use getattr with a fallback to num_hidden_layers to handle config types that don't have max_window_layers.

### Changes

- Modified vllm/model_executor/models/qwen2.py to safely access max_window_layers

### Testing

- Fixes #36315

### Checklist

- [x] Bug fix (non-breaking change)
- [x] Code follows project style
- [x] Linked issue