### PR TITLE
[Bugfix]: Support transformers 5.x Qwen3_5MoeTextConfig

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -116,7 +116,10 @@ class Qwen3_5ProcessingInfo(Qwen3VLProcessingInfo):
 
 class Qwen3_5MoeProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
-        return self.ctx.get_hf_config(Qwen3_5MoeConfig)
+        return self.ctx.get_hf_config(
+            Qwen3_5MoeConfig,
+            Qwen3_5MoeTextConfig,
+        )
 
 
 class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -110,6 +110,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     qwen3_next="Qwen3NextConfig",
     qwen3_5="Qwen3_5Config",
     qwen3_5_moe="Qwen3_5MoeConfig",
+    qwen3_5_moe_text="Qwen3_5MoeConfig",
     lfm2_moe="Lfm2MoeConfig",
     tarsier2="Tarsier2Config",
 )


### PR DESCRIPTION
## Bug Fix

This PR adds support for transformers 5.x renamed config class Qwen3_5MoeTextConfig.

### Problem

Transformers 5.x renamed Qwen3_5MoeConfig to Qwen3_5MoeTextConfig. When loading a continual pre-trained Qwen3.5-MoE model trained with transformers 5.x, vLLM fails with:



### Solution

1. Add qwen3_5_moe_text to config mapping in transformers_utils/config.py
2. Update Qwen3_5MoeProcessingInfo to accept both config types
3. Remove strict type annotation in Qwen3_5MoeForConditionalGeneration

### Changes

- vllm/transformers_utils/config.py: Add qwen3_5_moe_text mapping
- vllm/model_executor/models/qwen3_5.py: Support both config classes

### Testing

- Fixes #36236

### Checklist

- [x] Bug fix (non-breaking change)
- [x] Code follows project style
- [x] Linked issue