### PR TITLE
[KV Cache] Use a contiguous buffer for all layers

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6176,10 +6176,18 @@ class GPUModelRunner(
             corresponding memory buffer for KV cache.
         """
         kv_cache_raw_tensors: dict[str, torch.Tensor] = {}
+        alignment = 256
+        total_size = sum(
+            (t.size + alignment - 1) // alignment * alignment
+            for t in kv_cache_config.kv_cache_tensors
+        )
+        kv_cache_raw_tensor_global = torch.zeros(
+            total_size, dtype=torch.int8, device=self.device
+        )
+        offset = 0
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
-            tensor = torch.zeros(
-                kv_cache_tensor.size, dtype=torch.int8, device=self.device
-            )
+            tensor = kv_cache_raw_tensor_global[offset : offset + kv_cache_tensor.size]
+            offset += (kv_cache_tensor.size + alignment - 1) // alignment * alignment
             for layer_name in kv_cache_tensor.shared_by:
                 kv_cache_raw_tensors[layer_name] = tensor
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Ongoing efforts like https://github.com/vllm-project/vllm/pull/35219 needs extra operations to all layers. make all layers derive from the same tensor so that it can be done with one cuda operation.

CC @tdoublep 

## Test Plan

Run CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

