### PR TITLE
fix(tool_parser): fix hermes parser dropping final brace during MTP streaming

### DIFF
--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -281,32 +281,48 @@ class Hermes2ProToolParser(ToolParser):
                     logger.debug("attempting to close tool call, but no tool call")
                     return None
                 diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
-                if diff:
-                    diff = (
-                        diff.encode("utf-8").decode("unicode_escape")
-                        if diff is str
-                        else diff
-                    )
-                    if '"}' not in delta_text:
-                        return None
-                    end_loc = delta_text.rindex('"}')
-                    diff = delta_text[:end_loc] + '"}'
-                    logger.debug(
-                        "Finishing tool and found diff that had not "
-                        "been streamed yet: %s",
-                        diff,
-                    )
-                    self.streamed_args_for_tool[self.current_tool_id] += diff
-                    return DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                function=DeltaFunctionCall(arguments=diff).model_dump(
-                                    exclude_none=True
-                                ),
-                            )
-                        ]
-                    )
+                if diff is not None:
+                    # Compute the full arguments as a JSON string
+                    if isinstance(diff, str):
+                        full_args = diff
+                    else:
+                        full_args = json.dumps(diff, ensure_ascii=False)
+
+                    already_streamed = self.streamed_args_for_tool[self.current_tool_id]
+
+                    # Send any remaining unsent argument characters.
+                    # This replaces the previous '"}' substring check which
+                    # failed for non-string values (numbers, booleans, null)
+                    # and when MTP batched the closing tokens together.
+                    if full_args.startswith(already_streamed) and len(
+                        already_streamed
+                    ) < len(full_args):
+                        remaining = full_args[len(already_streamed) :]
+                        logger.debug(
+                            "Finishing tool and found diff that had not "
+                            "been streamed yet: %s",
+                            remaining,
+                        )
+                        self.streamed_args_for_tool[self.current_tool_id] = full_args
+                        return DeltaMessage(
+                            tool_calls=[
+                                DeltaToolCall(
+                                    index=self.current_tool_id,
+                                    function=DeltaFunctionCall(
+                                        arguments=remaining
+                                    ).model_dump(exclude_none=True),
+                                )
+                            ]
+                        )
+                    elif not full_args.startswith(already_streamed):
+                        logger.warning(
+                            "Closing tool call but streamed args do not "
+                            "match expected args. full_args=%r, "
+                            "already_streamed=%r",
+                            full_args,
+                            already_streamed,
+                        )
+                return None
 
             # case -- otherwise we're just generating text
             else:


### PR DESCRIPTION
## Summary

Fix hermes tool parser dropping the final JSON brace during streaming when Multi-Token Prediction (MTP) batches closing tokens together.

Closes #32152

## Root Cause

In `hermes_tool_parser.py`, the "closing tool call" branch checked:

```python
if '"}' not in delta_text:
    return None
```

This failed for **non-string argument values** (integers, booleans, null, nested objects) because the closing `}` has no preceding `"`. When MTP batched `}\n}\n</tool_call>` into a single chunk, the parser swallowed the final `}` and returned `None`, producing truncated arguments like `{"id": 42` instead of `{"id": 42}`.

## Fix

Replace the fragile `'"}' in delta_text` substring check with a robust remaining-characters calculation:

1. Compute the full arguments JSON from the already-parsed tool call (`self.prev_tool_call_arr`)
2. Compare against what has been streamed so far (`self.streamed_args_for_tool`)
3. Emit any remaining unsent characters as the final delta

This works regardless of argument value type (string, number, boolean, null, nested objects/arrays).

## Testing

Added 4 new unit tests covering the bug and related edge cases:

| Test | Scenario | Previously |
|------|----------|-----------|
| `test_hermes_parser_streaming_mtp_non_string_value` | Integer args with MTP closing chunk | ❌ Truncated `{"id": 42` |
| `test_hermes_parser_streaming_mtp_boolean_value` | Boolean args with MTP closing chunk | ❌ Truncated `{"enabled": true` |
| `test_hermes_parser_streaming_mtp_fused_closing_chunk` | String args with quote+braces+tag fused | ✅ Passed (by accident) |
| `test_hermes_parser_streaming_mtp_nested_json` | Nested JSON args with MTP closing | ✅ Passed |

Also validated with a standalone debug tracer (14 scenarios covering char-by-char, MTP chunking, various value types) — all pass after the fix.

## Impact

- **Affected**: Any streaming tool call where arguments end with a non-string value AND MTP is enabled
- **Not affected**: Non-streaming tool calls, string-only arguments (worked by accident before)
- **Risk**: Low — the fix is a strict improvement over the previous logic with no behavioral change for already-working cases
