### PR TITLE
Fix autotuned config selection for active LoRA & LoRA CUDA Graph Memory Reduction

### DIFF
--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -196,7 +196,11 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
                 max_lora_rank = self.w13_lora_a_stacked[0].shape[-2]
                 shrink_config, expand_config = self._get_lora_moe_configs(
                     op_prefix="w13",
-                    num_loras=self.max_loras,
+                    num_loras=(
+                        self.punica_wrapper.token_mapping_meta.num_active_loras_cpu.item()
+                        if self.punica_wrapper.lora_config.specialize_active_lora
+                        else self.max_loras
+                    ),
                     rank=max_lora_rank,
                     num_slices=self._w13_slices,
                     M=M,
@@ -287,7 +291,11 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
                 max_lora_rank = self.w2_lora_a_stacked[0].shape[-2]
                 shrink_config, expand_config = self._get_lora_moe_configs(
                     op_prefix="w2",
-                    num_loras=self.max_loras,
+                    num_loras=(
+                        self.punica_wrapper.token_mapping_meta.num_active_loras_cpu.item()
+                        if self.punica_wrapper.lora_config.specialize_active_lora
+                        else self.max_loras
+                    ),
                     rank=max_lora_rank,
                     num_slices=1,
                     M=M,

--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -197,8 +197,8 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
                 shrink_config, expand_config = self._get_lora_moe_configs(
                     op_prefix="w13",
                     num_loras=(
-                        self.punica_wrapper.token_mapping_meta.num_active_loras_cpu.item()
-                        if self.punica_wrapper.lora_config.specialize_active_lora
+                        self.punica_wrapper.token_mapping_meta.num_active_loras_cpu.item()  # type: ignore[attr-defined]
+                        if self.punica_wrapper.lora_config.specialize_active_lora  # type: ignore[attr-defined]
                         else self.max_loras
                     ),
                     rank=max_lora_rank,
@@ -292,8 +292,8 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
                 shrink_config, expand_config = self._get_lora_moe_configs(
                     op_prefix="w2",
                     num_loras=(
-                        self.punica_wrapper.token_mapping_meta.num_active_loras_cpu.item()
-                        if self.punica_wrapper.lora_config.specialize_active_lora
+                        self.punica_wrapper.token_mapping_meta.num_active_loras_cpu.item()  # type: ignore[attr-defined]
+                        if self.punica_wrapper.lora_config.specialize_active_lora  # type: ignore[attr-defined]
                         else self.max_loras
                     ),
                     rank=max_lora_rank,

--- a/vllm/lora/ops/triton_ops/lora_expand_op.py
+++ b/vllm/lora/ops/triton_ops/lora_expand_op.py
@@ -200,14 +200,13 @@ def _lora_expand(
 
     K = lora_b_weights[0].shape[-1]  # K= rank
     ADD_INPUTS = add_inputs
-    MAX_LORAS = lora_ids.size(0)
     CAST_TYPE = False
     NUM_SLICES = len(lora_b_weights)
 
     # Triton kernel configs.
     kernel_config = get_lora_op_configs(
         op_type="expand",
-        max_loras=MAX_LORAS,
+        max_loras=num_active_loras.item(),
         batch=M,
         hidden_size=MAX_N,
         rank=K,

--- a/vllm/lora/ops/triton_ops/lora_shrink_op.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink_op.py
@@ -191,12 +191,10 @@ def _lora_shrink(
     )
     N, K = lora_a_weights[0].shape[-2:]  # K=hidden_size,N=rank
     NUM_SLICES = len(lora_a_weights)
-    MAX_LORAS = lora_ids.size(0)
-
     # Triton kernel configs
     kernel_config = get_lora_op_configs(
         "shrink",
-        max_loras=MAX_LORAS,
+        max_loras=num_active_loras.item(),
         batch=M,
         hidden_size=K,
         rank=N,

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -50,8 +50,12 @@ class PunicaWrapperGPU(PunicaWrapperBase):
         self.max_loras = self.lora_config.max_loras
 
         # Compute captured LoRA counts for cudagraph specialization.
+        # Cap at max_batches (== max_num_seqs): at most that many distinct
+        # LoRA adapters can be active at the same time.
         captured_lora_counts = get_captured_lora_counts(
-            self.max_loras, self.lora_config.specialize_active_lora
+            self.max_loras,
+            self.lora_config.specialize_active_lora,
+            max_concurrent_loras=max_batches,
         )
 
         self.token_mapping_meta = LoRAKernelMeta.make(

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -57,11 +57,9 @@ def get_captured_lora_counts(
     When specialize=False: just [max_loras + 1].
 
     max_concurrent_loras: optional upper bound on the number of simultaneously
-        active LoRA adapters (e.g. max_num_seqs). Powers-of-2 counts above
-        this limit are omitted since they can never be reached at runtime,
-        reducing the number of captured CUDA graphs. The sentinel
-        (max_loras + 1) is also omitted when max_concurrent_loras < sentinel,
-        because num_active_loras can never reach it in that case.
+        active LoRA adapters (e.g. max_num_seqs). When provided and <=
+        max_loras, it becomes the catch-all upper bound (replacing sentinel),
+        so unreachable graph sizes are never captured.
 
     This is the single source of truth for LoRA capture cases, used by both
     CudagraphDispatcher and PunicaWrapperGPU.
@@ -70,17 +68,14 @@ def get_captured_lora_counts(
     if not specialize:
         return [sentinel]
 
-    # The sentinel (max_loras + 1) is a catch-all for active-LoRA counts that
-    # exceed all captured power-of-2 values.  When max_concurrent_loras caps
-    # what is reachable at runtime, num_active_loras can never reach sentinel,
-    # so capturing a graph for it wastes memory and capture time.
-    include_sentinel = max_concurrent_loras is None or max_concurrent_loras >= sentinel
-    return [
-        n
-        for n in range(1, sentinel + 1)
-        if (n & (n - 1)) == 0 or (n == sentinel and include_sentinel)
-        if max_concurrent_loras is None or n <= max_concurrent_loras or n == sentinel
-    ]
+    # Use max_concurrent_loras as the catch-all upper bound when it is a
+    # tighter cap than sentinel; otherwise fall back to sentinel.
+    upper = (
+        max_concurrent_loras
+        if max_concurrent_loras is not None and max_concurrent_loras <= max_loras
+        else sentinel
+    )
+    return [n for n in range(1, upper) if (n & (n - 1)) == 0] + [upper]
 
 
 _GLOBAL_LORA_ID = 0

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -45,21 +45,41 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-def get_captured_lora_counts(max_loras: int, specialize: bool) -> list[int]:
+def get_captured_lora_counts(
+    max_loras: int,
+    specialize: bool,
+    max_concurrent_loras: int | None = None,
+) -> list[int]:
     """
     Returns num_active_loras values for cudagraph capture.
 
     When specialize=True: powers of 2 up to max_loras, plus max_loras + 1.
     When specialize=False: just [max_loras + 1].
 
+    max_concurrent_loras: optional upper bound on the number of simultaneously
+        active LoRA adapters (e.g. max_num_seqs). Powers-of-2 counts above
+        this limit are omitted since they can never be reached at runtime,
+        reducing the number of captured CUDA graphs. The sentinel
+        (max_loras + 1) is also omitted when max_concurrent_loras < sentinel,
+        because num_active_loras can never reach it in that case.
+
     This is the single source of truth for LoRA capture cases, used by both
     CudagraphDispatcher and PunicaWrapperGPU.
     """
+    sentinel = max_loras + 1
     if not specialize:
-        return [max_loras + 1]
+        return [sentinel]
 
+    # The sentinel (max_loras + 1) is a catch-all for active-LoRA counts that
+    # exceed all captured power-of-2 values.  When max_concurrent_loras caps
+    # what is reachable at runtime, num_active_loras can never reach sentinel,
+    # so capturing a graph for it wastes memory and capture time.
+    include_sentinel = max_concurrent_loras is None or max_concurrent_loras >= sentinel
     return [
-        n for n in range(1, max_loras + 2) if (n & (n - 1)) == 0 or n == max_loras + 1
+        n
+        for n in range(1, sentinel + 1)
+        if (n & (n - 1)) == 0 or (n == sentinel and include_sentinel)
+        if max_concurrent_loras is None or n <= max_concurrent_loras or n == sentinel
     ]
 
 

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -116,8 +116,14 @@ class CudagraphDispatcher:
 
         # LoRA is enabled - capture graphs based on cudagraph_specialize_lora
         if self.compilation_config.cudagraph_specialize_lora:
+            # Cap at max_num_seqs: with N concurrent sequences at most N
+            # distinct LoRA adapters can be active simultaneously, so there
+            # is no need to capture graphs for higher active-LoRA counts.
+            max_num_seqs = self.vllm_config.scheduler_config.max_num_seqs
             captured_counts = get_captured_lora_counts(
-                lora_config.max_loras, self.specialize_lora_count
+                lora_config.max_loras,
+                self.specialize_lora_count,
+                max_concurrent_loras=max_num_seqs,
             )
             # Specialize: capture separate graphs for with and without LoRA
             return [0] + captured_counts


### PR DESCRIPTION
## Purpose
When LoRA specialization (cudagraph_specialize_lora) is enabled, vLLM captures a separate CUDA graph for each possible number of active LoRA adapters. Previously, the set of captured counts was derived purely from max_loras, without considering the actual runtime ceiling imposed by max_num_seqs. This caused unnecessary graph captures.

Additonally, this PR fixes the config selection logic when active_lora is enabled. Previously the tuner could load a mismatched tuned config that did not correspond to the current number of active LoRAs, which could lead to suboptimal kernel performance.

## Test Result
test commands
```
vllm serve openai/gpt-oss-120b \
  --no-enable-prefix-caching \
  --port 8000 \
  --max-loras 8 \
  --enable-lora \
  --lora-modules \
    lora1="$LORAPATH" \
    lora2="$LORAPATH" \
    lora3="$LORAPATH" \
    lora4="$LORAPATH" \
    lora5="$LORAPATH" \
    lora6="$LORAPATH" \
    lora7="$LORAPATH" \
    lora8="$LORAPATH" \
  --max-lora-rank 32 \
  --enable-chunked-prefill \
  --max-model-len 131072 \
  --tensor-parallel-size 1 \
  --max_num_seqs 1\
  --specialize-active-lora
```

before
graph capturing time: 94 secs,  memory 1.21 GiB
after
graph capturing time: 29 secs, memory 1.06 GiB


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

