### PR TITLE
[Bugfix][Frontend] Do not persist load_inplace on stored LoRA requests

### DIFF
--- a/tests/entrypoints/openai/test_serving_models.py
+++ b/tests/entrypoints/openai/test_serving_models.py
@@ -99,6 +99,27 @@ async def test_load_lora_adapter_duplicate():
 
 
 @pytest.mark.asyncio
+async def test_load_lora_adapter_inplace_not_persisted_for_generation():
+    serving_models = await _async_serving_models_init()
+
+    initial_request = LoadLoRAAdapterRequest(
+        lora_name="adapter1", lora_path="/path/to/adapter1"
+    )
+    response = await serving_models.load_lora_adapter(initial_request)
+    assert response == LORA_LOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
+
+    inplace_reload_request = LoadLoRAAdapterRequest(
+        lora_name="adapter1",
+        lora_path="/path/to/adapter2",
+        load_inplace=True,
+    )
+    response = await serving_models.load_lora_adapter(inplace_reload_request)
+    assert response == LORA_LOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
+
+    assert serving_models.lora_requests["adapter1"].load_inplace is False
+
+
+@pytest.mark.asyncio
 async def test_unload_lora_adapter_success():
     serving_models = await _async_serving_models_init()
     request = LoadLoRAAdapterRequest(

--- a/vllm/entrypoints/openai/models/serving.py
+++ b/vllm/entrypoints/openai/models/serving.py
@@ -162,7 +162,15 @@ class OpenAIServingModels:
                     message=str(e), err_type=error_type, status_code=status_code
                 )
 
-            self.lora_requests[lora_name] = lora_request
+            # load_inplace is only for the one-time reload call and should not be
+            # carried into request-time LoRA objects.
+            self.lora_requests[lora_name] = LoRARequest(
+                lora_name=lora_name,
+                base_model_name=lora_request.base_model_name,
+                lora_int_id=lora_request.lora_int_id,
+                lora_path=lora_request.lora_path,
+                load_inplace=False,
+            )
             logger.info(
                 "Loaded new LoRA adapter: name '%s', path '%s'", lora_name, lora_path
             )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes LoRA runtime reload behavior for adapters loaded with `load_inplace=True`.

Fixes https://github.com/vllm-project/vllm/issues/33791.

Root cause:
- `load_inplace=True` was being persisted in `self.lora_requests[lora_name]`.
- That stored request is reused during normal serving (`_maybe_get_adapters`), so subsequent inference requests kept carrying `load_inplace=True`.
- In the LoRA worker manager, `load_inplace=True` forces reload path (`add_adapter`), which triggers repeated adapter reload work from checkpoint path.

Change in this PR:
- Treat `load_inplace` as a one-time control-plane load flag.
- After successful `add_lora`, clear `load_inplace` before storing the request used by serving.
- Add regression test to ensure `load_inplace` is not persisted in runtime request objects.

## Test Plan

1. Run targeted regression test:
```bash
.venv/bin/python -m pytest -q tests/entrypoints/openai/test_serving_models.py::test_load_lora_adapter_inplace_not_persisted_for_generation --confcutdir=tests/entrypoints/openai
```

2. Run related OpenAI serving models test file:
```bash
.venv/bin/python -m pytest -q tests/entrypoints/openai/test_serving_models.py --confcutdir=tests/entrypoints/openai
```

3. Run pre-commit on touched files:
```bash
PRE_COMMIT_HOME=.pre-commit-cache .venv/bin/pre-commit run --files \
  vllm/entrypoints/openai/models/serving.py \
  tests/entrypoints/openai/test_serving_models.py
```

## Test Result

1. Targeted regression test:
- `1 passed`.

2. OpenAI serving models tests:
- `8 passed`.

3. Pre-commit:
- Passed for the touched files (ruff check/format, typos, mypy-local hook, and project policy hooks).

Notes:
- Running this test file without `--confcutdir=tests/entrypoints/openai` on local macOS hit an unrelated teardown issue in global `tests/conftest.py` (`torch.accelerator.empty_cache()` MPS allocator assertion). The above tests were run with `--confcutdir` to isolate the unit scope for this frontend bugfix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).

</details>

