### PR TITLE
[Bugfix][ROCm] full graph capture on triton-attn fix - Option1

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -174,7 +174,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         # On ROCm, do not allocate segment buffers so unified_attention uses the
         # 2D kernel path (writes only to output). This avoids "Write access to
         # read-only page" during full graph capture (#35169), like AITER unified.
-        if current_platform.is_rocm():
+        if current_platform.is_rocm() and self.decode_cudagraph_enabled:
             self.softmax_segm_output = None
             self.softmax_segm_max = None
             self.softmax_segm_expsum = None

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -63,9 +63,6 @@ class TritonAttentionMetadata:
 
     seq_threshold_3D: int
     num_par_softmax_segments: int
-    softmax_segm_output: torch.Tensor
-    softmax_segm_max: torch.Tensor
-    softmax_segm_expsum: torch.Tensor
 
     # For cascade attention.
     use_cascade: bool
@@ -73,6 +70,12 @@ class TritonAttentionMetadata:
     cu_prefix_query_lens: torch.Tensor | None
     prefix_kv_lens: torch.Tensor | None
     suffix_kv_lens: torch.Tensor | None
+
+    # Optional on ROCm: when None, unified_attention uses 2D kernel (no segment
+    # buffer writes), avoiding "Write access to read-only page" during capture.
+    softmax_segm_output: torch.Tensor | None = None
+    softmax_segm_max: torch.Tensor | None = None
+    softmax_segm_expsum: torch.Tensor | None = None
 
     # Optional aot scheduling
     scheduler_metadata: torch.Tensor | None = None
@@ -168,26 +171,42 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
 
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)
-        self.softmax_segm_output = torch.empty(
-            (
-                self.seq_threshold_3D,
-                self.num_heads_q,
-                self.num_par_softmax_segments,
-                headdim_padded,
-            ),
-            dtype=torch.float32,
-            device=device,
-        )
-        self.softmax_segm_max = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
-            dtype=torch.float32,
-            device=device,
-        )
-        self.softmax_segm_expsum = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
-            dtype=torch.float32,
-            device=device,
-        )
+        # On ROCm, do not allocate segment buffers so unified_attention uses the
+        # 2D kernel path (writes only to output). This avoids "Write access to
+        # read-only page" during full graph capture (#35169), like AITER unified.
+        if current_platform.is_rocm():
+            self.softmax_segm_output = None
+            self.softmax_segm_max = None
+            self.softmax_segm_expsum = None
+        else:
+            self.softmax_segm_output = torch.empty(
+                (
+                    self.seq_threshold_3D,
+                    self.num_heads_q,
+                    self.num_par_softmax_segments,
+                    headdim_padded,
+                ),
+                dtype=torch.float32,
+                device=device,
+            )
+            self.softmax_segm_max = torch.empty(
+                (
+                    self.seq_threshold_3D,
+                    self.num_heads_q,
+                    self.num_par_softmax_segments,
+                ),
+                dtype=torch.float32,
+                device=device,
+            )
+            self.softmax_segm_expsum = torch.empty(
+                (
+                    self.seq_threshold_3D,
+                    self.num_heads_q,
+                    self.num_par_softmax_segments,
+                ),
+                dtype=torch.float32,
+                device=device,
+            )
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix https://github.com/vllm-project/vllm/issues/35169
Fix https://github.com/vllm-project/vllm/issues/34154


Fix ROCm full CUDA graph capture fault with Triton attention (#35169) and (#34154).


On ROCm, full graph capture triggered “Write access to read-only page” because the Triton 3D attention path writes to softmax segment buffers that HIP can treat as read-only during capture.

Change: On ROCm, do not allocate those segment buffers and pass None so unified_attention always uses the 2D kernel (writes only to output, like AITER). No change on CUDA.

File: vllm/v1/attention/backends/triton_attn.py — make softmax_segm_output / _max / _expsum optional; in the metadata builder, set them to None on ROCm and skip allocation.

## Test Plan
For #35169:

- ran the basic.py (https://github.com/vllm-project/vllm/issues/35169) with the `model="stepfun-ai/Step-3.5-Flash", tensor_parallel_size=4` no longer cause core dump.

- ran the benchmarking and eval on the model.

For #34154:

Ran on model="deepseek-ai/DeepSeek-OCR", with text and image input with default triton attn.


## Test Result

No crash.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

