### PR TITLE
[Bugfix][ROCm] Memory access fault fix for full graph capture for triton-attn - Option 2

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -117,6 +117,18 @@ class TritonAttentionMetadata:
 class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
 
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: AttentionSpec,
+    ) -> AttentionCGSupport:
+        # ROCm: full graph capture triggers "Write access to read-only page"
+        # (#35169). Use piecewise only for Triton attention.
+        if current_platform.is_rocm():
+            return AttentionCGSupport.NEVER
+        return cls._cudagraph_support
+
     def __init__(
         self,
         kv_cache_spec: AttentionSpec,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix https://github.com/vllm-project/vllm/issues/35169

Option 2: Piecewise only for Triton attention on ROCm
In TritonAttentionMetadataBuilder we now override get_cudagraph_support():
On ROCm: return AttentionCGSupport.NEVER so the engine uses piecewise CUDA graphs only (no full decode capture).
Other platforms: return cls._cudagraph_support (still ALWAYS), so behavior is unchanged.
No other changes: metadata and softmax segment allocation are unchanged; only the cudagraph support is overridden on ROCm. This avoids the “Write access to read-only page” fault by never doing full graph capture when using Triton attention on ROCm.

## Test Plan
run the basic.py (https://github.com/vllm-project/vllm/issues/35169) with the model="stepfun-ai/Step-3.5-Flash", tensor_parallel_size=4 no longer cause core dump.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

