### PR TITLE
[Doc]: Add CUDA 13.0 recommendation for GPT-OSS on Blackwell GPUs

### DIFF
--- a/docs/getting_started/installation/gpu.cuda.inc.md
+++ b/docs/getting_started/installation/gpu.cuda.inc.md
@@ -35,6 +35,23 @@ We recommend leveraging `uv` to [automatically select the appropriate PyTorch in
 !!! note
     NVIDIA Blackwell GPUs (B200, GB200) require a minimum of CUDA 12.8, so make sure you are installing PyTorch wheels with at least that version. PyTorch itself offers a [dedicated interface](https://pytorch.org/get-started/locally/) to determine the appropriate pip command to run for a given target configuration.
 
+!!! note "GPT-OSS models on Blackwell GPUs"
+    For consumer Blackwell GPUs (e.g., RTX 5090) running GPT-OSS models (`openai/gpt-oss-120b`, `openai/gpt-oss-20b`), CUDA 13.0 is recommended for optimal stability. GPT-OSS models use MXFP4 kernels, FlashInfer, and MoE routing kernels that are optimized for Hopper/Blackwell architectures and work best with CUDA 13.0. If you encounter `CUBLAS_STATUS_INVALID_VALUE` errors with CUDA 12.x, install the CUDA 13.0 variant:
+
+    ```bash
+    export VLLM_VERSION=$(curl -s https://api.github.com/repos/vllm-project/vllm/releases/latest | jq -r .tag_name | sed 's/^v//')
+    export CPU_ARCH=$(uname -m)
+    uv pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cu130-cp38-abi3-manylinux_2_35_${CPU_ARCH}.whl --extra-index-url https://download.pytorch.org/whl/cu130
+    ```
+
+    Or use the nightly build with CUDA 13.0:
+
+    ```bash
+    uv pip install -U vllm \
+        --torch-backend=auto \
+        --extra-index-url https://wheels.vllm.ai/nightly/cu130
+    ```
+
 As of now, vLLM's binaries are compiled with CUDA 12.9 and public PyTorch release versions by default. We also provide vLLM binaries compiled with CUDA 12.8, 13.0, and public PyTorch release versions:
 
 ```bash


### PR DESCRIPTION
## Summary

- **Type**: Documentation improvement
- **Issue**: GPT-OSS models on Blackwell GPUs (RTX 5090) may fail with CUDA 12.x
- **Fix**: Add documentation note recommending CUDA 13.0 for optimal stability

Fixes #36313

## Problem

Users running GPT-OSS models (`openai/gpt-oss-120b`, `openai/gpt-oss-20b`) on consumer Blackwell GPUs (e.g., RTX 5090) encounter `CUBLAS_STATUS_INVALID_VALUE` errors when using CUDA 12.x. The issue is resolved by using CUDA 13.0.

**Root cause**: GPT-OSS models use MXFP4 kernels, FlashInfer, and MoE routing kernels that are optimized for Hopper/Blackwell architectures and work best with CUDA 13.0. CUDA 12.x builds may fall back to incompatible GEMM paths.

## Changes

- Added a documentation note in `docs/getting_started/installation/gpu.cuda.inc.md` explaining:
  - CUDA 13.0 is recommended for GPT-OSS models on Blackwell GPUs
  - Why this is necessary (MXFP4/FlashInfer/MoE kernel optimization)
  - Installation instructions for both stable and nightly CUDA 13.0 builds

## Effect on User Experience

**Before**: Users encounter confusing `CUBLAS_STATUS_INVALID_VALUE` errors with no clear guidance on resolution.

**After**: Users are informed upfront about the CUDA 13.0 requirement for GPT-OSS on Blackwell GPUs and have clear installation instructions.