### PR TITLE
feat(openai): add per-request timing metrics and completion_tokens_de…

### DIFF
--- a/docs/features/per_request_metrics.md
+++ b/docs/features/per_request_metrics.md
@@ -1,0 +1,143 @@
+# Per-Request Metrics
+
+vLLM can return per-request performance metrics and token usage details directly in API responses.
+This is useful for billing, SLA monitoring, and latency analysis at the individual request level,
+as a complement to the server-aggregated Prometheus metrics exposed at `/metrics`.
+
+## Enabling
+
+Start the server with `--enable-per-request-metrics`:
+
+```bash
+vllm serve meta-llama/Llama-3.1-8B-Instruct --enable-per-request-metrics
+```
+
+Then set `include_metrics: true` in the request body to receive metrics for that request.
+Metrics are only computed when both the server flag and the per-request parameter are set,
+which avoids throughput overhead for clients that do not need them.
+
+!!! note
+    At high concurrency, enabling per-request metrics computation introduces additional
+    CPU overhead. Benchmark your specific workload to evaluate the impact before enabling
+    in production.
+
+## Response Format
+
+### Timing Metrics
+
+When `include_metrics: true` is sent, the response includes a `metrics` object:
+
+```json
+{
+  "id": "chatcmpl-abc123",
+  "object": "chat.completion",
+  "model": "meta-llama/Llama-3.1-8B-Instruct",
+  "choices": [ ... ],
+  "usage": {
+    "prompt_tokens": 42,
+    "completion_tokens": 128,
+    "total_tokens": 170
+  },
+  "metrics": {
+    "time_to_first_token_ms": 85.2,
+    "time_to_first_content_token_ms": null,
+    "generation_time_ms": 1240.5,
+    "queue_time_ms": 12.3,
+    "mean_itl_ms": 9.1,
+    "tokens_per_second": 103.2
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `time_to_first_token_ms` | Time from when the request was scheduled until the first output token was generated (TTFT). For reasoning models, this is the time to the first reasoning token. |
+| `time_to_first_content_token_ms` | Time to the first non-reasoning (content) token. Only populated for reasoning models; `null` otherwise. |
+| `generation_time_ms` | Total time spent generating output tokens, excluding queue wait time. |
+| `queue_time_ms` | Time the request spent waiting in the scheduler queue before processing began. |
+| `mean_itl_ms` | Mean inter-token latency (average time between successive output tokens) during the decode phase. `null` for single-token responses. |
+| `tokens_per_second` | Output token throughput: `completion_tokens / generation_time_ms * 1000`. |
+
+All fields are `null` if the underlying timing data is not available for that request.
+
+### Reasoning Token Details
+
+For reasoning models (e.g. DeepSeek-R1, Apriel), the `usage` object includes a
+`completion_tokens_details` field that separates reasoning tokens from content tokens:
+
+```json
+{
+  "usage": {
+    "prompt_tokens": 55,
+    "completion_tokens": 512,
+    "total_tokens": 567,
+    "completion_tokens_details": {
+      "reasoning_tokens": 384,
+      "accepted_prediction_tokens": null,
+      "rejected_prediction_tokens": null
+    }
+  }
+}
+```
+
+The number of content (non-reasoning) tokens is `completion_tokens - reasoning_tokens`.
+
+`completion_tokens_details` is populated automatically whenever a `--reasoning-parser` is
+configured on the server. It does not require `include_metrics: true`.
+
+## Example Request
+
+=== "Non-streaming"
+
+    ```python
+    from openai import OpenAI
+
+    client = OpenAI(base_url="http://localhost:8000/v1", api_key="token")
+
+    response = client.chat.completions.create(
+        model="meta-llama/Llama-3.1-8B-Instruct",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        extra_body={"include_metrics": True},
+    )
+
+    print(response.usage)
+    print(response.model_extra.get("metrics"))
+    ```
+
+=== "Streaming"
+
+    Metrics are attached to the final usage chunk (the chunk sent after all content chunks,
+    when `stream_options.include_usage` is `true`):
+
+    ```python
+    from openai import OpenAI
+
+    client = OpenAI(base_url="http://localhost:8000/v1", api_key="token")
+
+    stream = client.chat.completions.create(
+        model="meta-llama/Llama-3.1-8B-Instruct",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        stream=True,
+        stream_options={"include_usage": True},
+        extra_body={"include_metrics": True},
+    )
+
+    for chunk in stream:
+        if chunk.usage:
+            print("Usage:", chunk.usage)
+            print("Metrics:", chunk.model_extra.get("metrics"))
+    ```
+
+## Completions API
+
+Per-request metrics are also available on the `/v1/completions` endpoint using the same
+`include_metrics` request parameter and the same `metrics` response field.
+
+## Relationship to Prometheus Metrics
+
+The `metrics` response field provides per-request values for a single request.
+The `/metrics` Prometheus endpoint exposes server-level histograms (e.g.
+`vllm:time_to_first_token_seconds`) that aggregate across all requests.
+Both are complementary: use Prometheus for fleet-level SLO monitoring and dashboards,
+and `include_metrics` for per-user billing, per-request debugging, or client-side
+latency attribution.

--- a/docs/features/per_request_metrics.md
+++ b/docs/features/per_request_metrics.md
@@ -62,7 +62,7 @@ All fields are `null` if the underlying timing data is not available for that re
 
 ### Reasoning Token Details
 
-For reasoning models (e.g. DeepSeek-R1, Apriel), the `usage` object includes a
+For reasoning models, the `usage` object includes a
 `completion_tokens_details` field that separates reasoning tokens from content tokens:
 
 ```json

--- a/tests/entrypoints/openai/test_per_request_metrics_protocol.py
+++ b/tests/entrypoints/openai/test_per_request_metrics_protocol.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatMessage,
+)
+from vllm.entrypoints.openai.completion.protocol import (
+    CompletionRequest,
+    CompletionResponse,
+    CompletionResponseChoice,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    CompletionTokensDetails,
+    PerRequestTimingMetrics,
+    UsageInfo,
+)
+from vllm.entrypoints.openai.engine.serving import (
+    build_per_request_timing_metrics as _build_per_request_timing_metrics,
+)
+from vllm.v1.metrics.stats import RequestStateStats
+
+# ---------------------------------------------------------------------------
+# CompletionTokensDetails
+# ---------------------------------------------------------------------------
+
+
+def test_completion_tokens_details_all_none():
+    details = CompletionTokensDetails()
+    assert details.reasoning_tokens is None
+    assert details.accepted_prediction_tokens is None
+    assert details.rejected_prediction_tokens is None
+
+
+def test_completion_tokens_details_reasoning_tokens():
+    details = CompletionTokensDetails(reasoning_tokens=42)
+    assert details.reasoning_tokens == 42
+    assert details.accepted_prediction_tokens is None
+    assert details.rejected_prediction_tokens is None
+
+
+def test_completion_tokens_details_serialization():
+    details = CompletionTokensDetails(reasoning_tokens=7)
+    data = details.model_dump()
+    assert data["reasoning_tokens"] == 7
+
+
+def test_completion_tokens_details_all_fields():
+    details = CompletionTokensDetails(
+        reasoning_tokens=10,
+        accepted_prediction_tokens=5,
+        rejected_prediction_tokens=2,
+    )
+    data = details.model_dump()
+    assert data["reasoning_tokens"] == 10
+    assert data["accepted_prediction_tokens"] == 5
+    assert data["rejected_prediction_tokens"] == 2
+
+
+# ---------------------------------------------------------------------------
+# PerRequestTimingMetrics
+# ---------------------------------------------------------------------------
+
+
+def test_per_request_timing_metrics_all_none():
+    m = PerRequestTimingMetrics()
+    assert m.time_to_first_token_ms is None
+    assert m.time_to_first_content_token_ms is None
+    assert m.generation_time_ms is None
+    assert m.queue_time_ms is None
+    assert m.mean_itl_ms is None
+    assert m.tokens_per_second is None
+
+
+def test_per_request_timing_metrics_all_set():
+    m = PerRequestTimingMetrics(
+        time_to_first_token_ms=100.0,
+        time_to_first_content_token_ms=120.0,
+        generation_time_ms=500.0,
+        queue_time_ms=50.0,
+        mean_itl_ms=44.4,
+        tokens_per_second=20.0,
+    )
+    assert m.time_to_first_token_ms == 100.0
+    assert m.time_to_first_content_token_ms == 120.0
+    assert m.generation_time_ms == 500.0
+    assert m.queue_time_ms == 50.0
+    assert m.mean_itl_ms == 44.4
+    assert m.tokens_per_second == 20.0
+
+
+def test_per_request_timing_metrics_serialization():
+    m = PerRequestTimingMetrics(time_to_first_token_ms=200.0)
+    data = m.model_dump()
+    assert data["time_to_first_token_ms"] == 200.0
+    assert data["generation_time_ms"] is None
+
+
+# ---------------------------------------------------------------------------
+# UsageInfo with completion_tokens_details
+# ---------------------------------------------------------------------------
+
+
+def test_usage_info_completion_tokens_details_default_none():
+    usage = UsageInfo(prompt_tokens=5, total_tokens=10, completion_tokens=5)
+    assert usage.completion_tokens_details is None
+
+
+def test_usage_info_completion_tokens_details_set():
+    details = CompletionTokensDetails(reasoning_tokens=3)
+    usage = UsageInfo(
+        prompt_tokens=5,
+        total_tokens=10,
+        completion_tokens=5,
+        completion_tokens_details=details,
+    )
+    assert usage.completion_tokens_details is not None
+    assert usage.completion_tokens_details.reasoning_tokens == 3
+
+
+# ---------------------------------------------------------------------------
+# _build_per_request_timing_metrics helper
+# ---------------------------------------------------------------------------
+
+
+def test_build_per_request_timing_metrics_none_input():
+    result = _build_per_request_timing_metrics(None, num_generation_tokens=10)
+    assert isinstance(result, PerRequestTimingMetrics)
+    assert result.time_to_first_token_ms is None
+    assert result.generation_time_ms is None
+    assert result.queue_time_ms is None
+    assert result.mean_itl_ms is None
+    assert result.tokens_per_second is None
+
+
+def test_build_per_request_timing_metrics_all_zero_timestamps():
+    stats = RequestStateStats(
+        queued_ts=0.0,
+        scheduled_ts=0.0,
+        first_token_ts=0.0,
+        last_token_ts=0.0,
+        num_generation_tokens=10,
+    )
+    result = _build_per_request_timing_metrics(stats, num_generation_tokens=10)
+    assert result.time_to_first_token_ms is None
+    assert result.generation_time_ms is None
+    assert result.queue_time_ms is None
+    assert result.mean_itl_ms is None
+    assert result.tokens_per_second is None
+
+
+def test_build_per_request_timing_metrics_valid_timestamps():
+    # queued_ts=1.0, scheduled_ts=1.5, first_token_ts=2.0, last_token_ts=3.0, 10 tokens
+    stats = RequestStateStats(
+        queued_ts=1.0,
+        scheduled_ts=1.5,
+        first_token_ts=2.0,
+        last_token_ts=3.0,
+        num_generation_tokens=10,
+    )
+    result = _build_per_request_timing_metrics(stats, num_generation_tokens=10)
+
+    # time_to_first_token_ms = (2.0 - 1.5) * 1000 = 500.0
+    assert result.time_to_first_token_ms == pytest.approx(500.0)
+    # generation_time_ms = (3.0 - 1.5) * 1000 = 1500.0
+    assert result.generation_time_ms == pytest.approx(1500.0)
+    # queue_time_ms = (1.5 - 1.0) * 1000 = 500.0
+    assert result.queue_time_ms == pytest.approx(500.0)
+    # mean_itl_ms = (3.0 - 2.0) / (10 - 1) * 1000 ≈ 111.11
+    assert result.mean_itl_ms == pytest.approx(1000.0 / 9, rel=1e-4)
+    # tokens_per_second = 10 / 1500.0 * 1000 ≈ 6.667
+    assert result.tokens_per_second == pytest.approx(10.0 / 1.5, rel=1e-4)
+
+
+def test_build_per_request_timing_metrics_single_token():
+    # With only 1 generation token, mean_itl_ms should be None
+    stats = RequestStateStats(
+        queued_ts=1.0,
+        scheduled_ts=1.5,
+        first_token_ts=2.0,
+        last_token_ts=2.0,
+        num_generation_tokens=1,
+    )
+    result = _build_per_request_timing_metrics(stats, num_generation_tokens=1)
+    assert result.mean_itl_ms is None
+
+
+def test_build_per_request_timing_metrics_partial_timestamps():
+    # Only queued_ts and scheduled_ts set; first_token and last_token are 0
+    stats = RequestStateStats(
+        queued_ts=1.0,
+        scheduled_ts=2.0,
+        first_token_ts=0.0,
+        last_token_ts=0.0,
+        num_generation_tokens=5,
+    )
+    result = _build_per_request_timing_metrics(stats, num_generation_tokens=5)
+    assert result.queue_time_ms == pytest.approx(1000.0)
+    assert result.time_to_first_token_ms is None
+    assert result.generation_time_ms is None
+    assert result.mean_itl_ms is None
+    assert result.tokens_per_second is None
+
+
+def test_build_per_request_timing_metrics_no_queue_info():
+    # queued_ts is 0, so queue_time_ms should be None
+    stats = RequestStateStats(
+        queued_ts=0.0,
+        scheduled_ts=1.5,
+        first_token_ts=2.0,
+        last_token_ts=3.0,
+        num_generation_tokens=5,
+    )
+    result = _build_per_request_timing_metrics(stats, num_generation_tokens=5)
+    assert result.queue_time_ms is None
+    assert result.time_to_first_token_ms == pytest.approx(500.0)
+    assert result.generation_time_ms == pytest.approx(1500.0)
+
+
+# ---------------------------------------------------------------------------
+# ChatCompletionRequest.include_metrics field
+# ---------------------------------------------------------------------------
+
+
+def test_chat_completion_request_include_metrics_default():
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    assert request.include_metrics is False
+
+
+def test_chat_completion_request_include_metrics_true():
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        include_metrics=True,
+    )
+    assert request.include_metrics is True
+
+
+# ---------------------------------------------------------------------------
+# ChatCompletionResponse.metrics field
+# ---------------------------------------------------------------------------
+
+
+def test_chat_completion_response_metrics_default_none():
+    response = ChatCompletionResponse(
+        model="test-model",
+        choices=[
+            ChatCompletionResponseChoice(
+                index=0,
+                message=ChatMessage(role="assistant", content="Hi"),
+                finish_reason="stop",
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=1),
+    )
+    assert response.metrics is None
+
+
+def test_chat_completion_response_metrics_set():
+    m = PerRequestTimingMetrics(time_to_first_token_ms=100.0)
+    response = ChatCompletionResponse(
+        model="test-model",
+        choices=[
+            ChatCompletionResponseChoice(
+                index=0,
+                message=ChatMessage(role="assistant", content="Hi"),
+                finish_reason="stop",
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=1),
+        metrics=m,
+    )
+    assert response.metrics is not None
+    assert response.metrics.time_to_first_token_ms == 100.0
+
+
+# ---------------------------------------------------------------------------
+# CompletionRequest.include_metrics field
+# ---------------------------------------------------------------------------
+
+
+def test_completion_request_include_metrics_default():
+    request = CompletionRequest(model="test-model", prompt="Hello")
+    assert request.include_metrics is False
+
+
+def test_completion_request_include_metrics_true():
+    request = CompletionRequest(
+        model="test-model", prompt="Hello", include_metrics=True
+    )
+    assert request.include_metrics is True
+
+
+# ---------------------------------------------------------------------------
+# CompletionResponse.metrics field
+# ---------------------------------------------------------------------------
+
+
+def test_completion_response_metrics_default_none():
+    response = CompletionResponse(
+        model="test-model",
+        choices=[
+            CompletionResponseChoice(
+                index=0,
+                text="Hi",
+                finish_reason="stop",
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=1),
+    )
+    assert response.metrics is None
+
+
+def test_completion_response_metrics_set():
+    m = PerRequestTimingMetrics(generation_time_ms=300.0)
+    response = CompletionResponse(
+        model="test-model",
+        choices=[
+            CompletionResponseChoice(
+                index=0,
+                text="Hi",
+                finish_reason="stop",
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=1),
+        metrics=m,
+    )
+    assert response.metrics is not None
+    assert response.metrics.generation_time_ms == 300.0

--- a/tests/entrypoints/openai/test_per_request_metrics_serving.py
+++ b/tests/entrypoints/openai/test_per_request_metrics_serving.py
@@ -165,9 +165,7 @@ async def test_metrics_disabled_include_metrics_true_returns_none():
         num_generation_tokens=2,
     )
     mock_engine = _make_mock_engine(metrics=stats)
-    serving_chat = _build_serving_chat(
-        mock_engine, enable_per_request_metrics=False
-    )
+    serving_chat = _build_serving_chat(mock_engine, enable_per_request_metrics=False)
 
     request = ChatCompletionRequest(
         model=MODEL_NAME,
@@ -184,9 +182,7 @@ async def test_metrics_disabled_include_metrics_true_returns_none():
 @pytest.mark.asyncio
 async def test_metrics_disabled_include_metrics_false_returns_none():
     mock_engine = _make_mock_engine()
-    serving_chat = _build_serving_chat(
-        mock_engine, enable_per_request_metrics=False
-    )
+    serving_chat = _build_serving_chat(mock_engine, enable_per_request_metrics=False)
 
     request = ChatCompletionRequest(
         model=MODEL_NAME,
@@ -215,9 +211,7 @@ async def test_metrics_enabled_include_metrics_false_returns_none():
         num_generation_tokens=2,
     )
     mock_engine = _make_mock_engine(metrics=stats)
-    serving_chat = _build_serving_chat(
-        mock_engine, enable_per_request_metrics=True
-    )
+    serving_chat = _build_serving_chat(mock_engine, enable_per_request_metrics=True)
 
     request = ChatCompletionRequest(
         model=MODEL_NAME,
@@ -241,9 +235,7 @@ async def test_metrics_enabled_include_metrics_true_returns_populated():
         num_generation_tokens=2,
     )
     mock_engine = _make_mock_engine(metrics=stats)
-    serving_chat = _build_serving_chat(
-        mock_engine, enable_per_request_metrics=True
-    )
+    serving_chat = _build_serving_chat(mock_engine, enable_per_request_metrics=True)
 
     request = ChatCompletionRequest(
         model=MODEL_NAME,
@@ -263,9 +255,7 @@ async def test_metrics_enabled_include_metrics_true_returns_populated():
 @pytest.mark.asyncio
 async def test_metrics_enabled_no_request_output_metrics():
     mock_engine = _make_mock_engine(metrics=None)
-    serving_chat = _build_serving_chat(
-        mock_engine, enable_per_request_metrics=True
-    )
+    serving_chat = _build_serving_chat(mock_engine, enable_per_request_metrics=True)
 
     request = ChatCompletionRequest(
         model=MODEL_NAME,

--- a/tests/entrypoints/openai/test_per_request_metrics_serving.py
+++ b/tests/entrypoints/openai/test_per_request_metrics_serving.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vllm.config.multimodal import MultiModalConfig
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.models.protocol import BaseModelPath
+from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.renderers.hf import HfRenderer
+from vllm.tokenizers.registry import tokenizer_args_from_config
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.metrics.stats import RequestStateStats
+
+MODEL_NAME = "openai-community/gpt2"
+MODEL_NAME_SHORT = "gpt2"
+BASE_MODEL_PATHS = [
+    BaseModelPath(name=MODEL_NAME, model_path=MODEL_NAME),
+    BaseModelPath(name=MODEL_NAME_SHORT, model_path=MODEL_NAME_SHORT),
+]
+
+
+@dataclass
+class MockHFConfig:
+    model_type: str = "any"
+
+
+@dataclass
+class MockModelConfig:
+    task = "generate"
+    runner_type = "generate"
+    model = MODEL_NAME
+    tokenizer = MODEL_NAME
+    trust_remote_code = False
+    tokenizer_mode = "auto"
+    max_model_len = 100
+    tokenizer_revision = None
+    multimodal_config = MultiModalConfig()
+    hf_config = MockHFConfig()
+    hf_text_config = MockHFConfig()
+    logits_processors: list[str] | None = None
+    diff_sampling_param: dict | None = None
+    allowed_local_media_path: str = ""
+    allowed_media_domains: list[str] | None = None
+    encoder_config = None
+    generation_config: str = "auto"
+    media_io_kwargs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    skip_tokenizer_init = False
+    is_encoder_decoder: bool = False
+    is_multimodal_model: bool = False
+
+    def get_diff_sampling_param(self):
+        return self.diff_sampling_param or {}
+
+
+@dataclass
+class MockParallelConfig:
+    _api_process_rank: int = 0
+
+
+@dataclass
+class MockVllmConfig:
+    model_config: MockModelConfig
+    parallel_config: MockParallelConfig
+
+
+def _build_renderer(model_config: MockModelConfig):
+    _, tokenizer_name, _, kwargs = tokenizer_args_from_config(model_config)
+    return HfRenderer.from_config(
+        MockVllmConfig(model_config, parallel_config=MockParallelConfig()),
+        tokenizer_kwargs={**kwargs, "tokenizer_name": tokenizer_name},
+    )
+
+
+def _build_serving_chat(
+    engine: AsyncLLM,
+    enable_per_request_metrics: bool = False,
+) -> OpenAIServingChat:
+    models = OpenAIServingModels(
+        engine_client=engine,
+        base_model_paths=BASE_MODEL_PATHS,
+    )
+    serving_chat = OpenAIServingChat(
+        engine,
+        models,
+        response_role="assistant",
+        request_logger=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+        enable_per_request_metrics=enable_per_request_metrics,
+    )
+
+    async def _fake_preprocess_chat(*args, **kwargs):
+        return (
+            [{"role": "user", "content": "Test"}],
+            [{"prompt_token_ids": [1, 2, 3]}],
+        )
+
+    serving_chat._preprocess_chat = AsyncMock(side_effect=_fake_preprocess_chat)
+    return serving_chat
+
+
+def _make_request_output(
+    metrics: RequestStateStats | None = None,
+    text: str = "Hello",
+    token_ids: tuple = (100, 101),
+) -> RequestOutput:
+    completion_output = CompletionOutput(
+        index=0,
+        text=text,
+        token_ids=list(token_ids),
+        cumulative_logprob=None,
+        logprobs=None,
+        finish_reason="stop",
+    )
+    return RequestOutput(
+        request_id="test-id",
+        prompt="Test prompt",
+        prompt_token_ids=[1, 2, 3],
+        prompt_logprobs=None,
+        outputs=[completion_output],
+        finished=True,
+        metrics=metrics,
+        lora_request=None,
+        encoder_prompt=None,
+        encoder_prompt_token_ids=None,
+    )
+
+
+def _make_mock_engine(metrics: RequestStateStats | None = None) -> MagicMock:
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    request_output = _make_request_output(metrics=metrics)
+
+    async def mock_generate(*args, **kwargs):
+        yield request_output
+
+    mock_engine.generate = MagicMock(side_effect=mock_generate)
+    return mock_engine
+
+
+# ---------------------------------------------------------------------------
+# enable_per_request_metrics=False (default): metrics never populated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metrics_disabled_include_metrics_true_returns_none():
+    stats = RequestStateStats(
+        queued_ts=1.0,
+        scheduled_ts=1.5,
+        first_token_ts=2.0,
+        last_token_ts=3.0,
+        num_generation_tokens=2,
+    )
+    mock_engine = _make_mock_engine(metrics=stats)
+    serving_chat = _build_serving_chat(
+        mock_engine, enable_per_request_metrics=False
+    )
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Test prompt"}],
+        max_tokens=10,
+        stream=False,
+        include_metrics=True,
+    )
+
+    response = await serving_chat.create_chat_completion(request)
+    assert response.metrics is None
+
+
+@pytest.mark.asyncio
+async def test_metrics_disabled_include_metrics_false_returns_none():
+    mock_engine = _make_mock_engine()
+    serving_chat = _build_serving_chat(
+        mock_engine, enable_per_request_metrics=False
+    )
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Test prompt"}],
+        max_tokens=10,
+        stream=False,
+        include_metrics=False,
+    )
+
+    response = await serving_chat.create_chat_completion(request)
+    assert response.metrics is None
+
+
+# ---------------------------------------------------------------------------
+# enable_per_request_metrics=True: gated by request.include_metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metrics_enabled_include_metrics_false_returns_none():
+    stats = RequestStateStats(
+        queued_ts=1.0,
+        scheduled_ts=1.5,
+        first_token_ts=2.0,
+        last_token_ts=3.0,
+        num_generation_tokens=2,
+    )
+    mock_engine = _make_mock_engine(metrics=stats)
+    serving_chat = _build_serving_chat(
+        mock_engine, enable_per_request_metrics=True
+    )
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Test prompt"}],
+        max_tokens=10,
+        stream=False,
+        include_metrics=False,
+    )
+
+    response = await serving_chat.create_chat_completion(request)
+    assert response.metrics is None
+
+
+@pytest.mark.asyncio
+async def test_metrics_enabled_include_metrics_true_returns_populated():
+    stats = RequestStateStats(
+        queued_ts=1.0,
+        scheduled_ts=1.5,
+        first_token_ts=2.0,
+        last_token_ts=3.0,
+        num_generation_tokens=2,
+    )
+    mock_engine = _make_mock_engine(metrics=stats)
+    serving_chat = _build_serving_chat(
+        mock_engine, enable_per_request_metrics=True
+    )
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Test prompt"}],
+        max_tokens=10,
+        stream=False,
+        include_metrics=True,
+    )
+
+    response = await serving_chat.create_chat_completion(request)
+    assert response.metrics is not None
+    assert response.metrics.time_to_first_token_ms == pytest.approx(500.0)
+    assert response.metrics.generation_time_ms == pytest.approx(1500.0)
+    assert response.metrics.queue_time_ms == pytest.approx(500.0)
+
+
+@pytest.mark.asyncio
+async def test_metrics_enabled_no_request_output_metrics():
+    mock_engine = _make_mock_engine(metrics=None)
+    serving_chat = _build_serving_chat(
+        mock_engine, enable_per_request_metrics=True
+    )
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Test prompt"}],
+        max_tokens=10,
+        stream=False,
+        include_metrics=True,
+    )
+
+    response = await serving_chat.create_chat_completion(request)
+    # metrics object is returned but all fields are None when RequestStateStats is None
+    assert response.metrics is not None
+    assert response.metrics.time_to_first_token_ms is None
+    assert response.metrics.generation_time_ms is None
+    assert response.metrics.queue_time_ms is None
+
+
+# ---------------------------------------------------------------------------
+# completion_tokens_details with reasoning tokens
+# ---------------------------------------------------------------------------
+
+
+def test_usage_completion_tokens_details_no_reasoning():
+    # When no reasoning parser is present, completion_tokens_details should be None
+    from vllm.entrypoints.openai.engine.protocol import (
+        UsageInfo,
+    )
+
+    usage = UsageInfo(prompt_tokens=3, completion_tokens=5, total_tokens=8)
+    assert usage.completion_tokens_details is None
+
+
+def test_usage_completion_tokens_details_with_reasoning():
+    from vllm.entrypoints.openai.engine.protocol import (
+        CompletionTokensDetails,
+        UsageInfo,
+    )
+
+    usage = UsageInfo(prompt_tokens=3, completion_tokens=5, total_tokens=8)
+    usage.completion_tokens_details = CompletionTokensDetails(reasoning_tokens=2)
+    assert usage.completion_tokens_details is not None
+    assert usage.completion_tokens_details.reasoning_tokens == 2
+
+
+# ---------------------------------------------------------------------------
+# RequestStateStats instantiation
+# ---------------------------------------------------------------------------
+
+
+def test_request_state_stats_defaults():
+    stats = RequestStateStats()
+    assert stats.queued_ts == 0.0
+    assert stats.scheduled_ts == 0.0
+    assert stats.first_token_ts == 0.0
+    assert stats.last_token_ts == 0.0
+    assert stats.num_generation_tokens == 0
+
+
+def test_request_state_stats_with_values():
+    stats = RequestStateStats(
+        queued_ts=1.0,
+        scheduled_ts=2.0,
+        first_token_ts=3.0,
+        last_token_ts=5.0,
+        num_generation_tokens=20,
+    )
+    assert stats.queued_ts == 1.0
+    assert stats.scheduled_ts == 2.0
+    assert stats.first_token_ts == 3.0
+    assert stats.last_token_ts == 5.0
+    assert stats.num_generation_tokens == 20

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -27,6 +27,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionDefinition,
     LegacyStructuralTagResponseFormat,
     OpenAIBaseModel,
+    PerRequestTimingMetrics,
     StreamOptions,
     StructuralTagResponseFormat,
     ToolCall,
@@ -110,6 +111,7 @@ class ChatCompletionResponse(OpenAIBaseModel):
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None, description="KVTransfer parameters."
     )
+    metrics: PerRequestTimingMetrics | None = None
 
 
 class ChatCompletionResponseStreamChoice(OpenAIBaseModel):
@@ -131,6 +133,7 @@ class ChatCompletionStreamResponse(OpenAIBaseModel):
     usage: UsageInfo | None = Field(default=None)
     # not part of the OpenAI spec but for tracing the tokens
     prompt_token_ids: list[int] | None = None
+    metrics: PerRequestTimingMetrics | None = None
 
 
 class ChatCompletionToolsParam(OpenAIBaseModel):
@@ -353,6 +356,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
         "(e.g. 'abcdabcdabcd...' or '\\emoji \\emoji \\emoji ...'). This feature "
         "can detect such behavior and terminate early, saving time and tokens.",
     )
+
+    include_metrics: bool = False
 
     # --8<-- [end:chat-completion-extra-params]
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1343,8 +1343,9 @@ class OpenAIServingChat(OpenAIServing):
                     last_metrics = (
                         last_res.metrics if last_res is not None else None
                     )
+                    num_sequences = request.n or 1
                     stream_per_request_metrics = build_per_request_timing_metrics(
-                        last_metrics, completion_tokens
+                        last_metrics, completion_tokens // num_sequences
                     )
 
                 final_usage_chunk = ChatCompletionStreamResponse(
@@ -1754,8 +1755,9 @@ class OpenAIServingChat(OpenAIServing):
 
         per_request_metrics: PerRequestTimingMetrics | None = None
         if self.enable_per_request_metrics and request.include_metrics:
+            num_sequences = request.n or 1
             per_request_metrics = build_per_request_timing_metrics(
-                final_res.metrics, num_generated_tokens
+                final_res.metrics, num_generated_tokens // num_sequences
             )
 
         request_metadata.final_usage_info = usage

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1326,23 +1326,17 @@ class OpenAIServingChat(OpenAIServing):
 
                 if reasoning_parser is not None and last_res is not None:
                     reasoning_tokens = sum(
-                        reasoning_parser.count_reasoning_tokens(
-                            list(output.token_ids)
-                        )
+                        reasoning_parser.count_reasoning_tokens(list(output.token_ids))
                         for output in last_res.outputs
                     )
                     if reasoning_tokens > 0:
-                        final_usage.completion_tokens_details = (
-                            CompletionTokensDetails(
-                                reasoning_tokens=reasoning_tokens
-                            )
+                        final_usage.completion_tokens_details = CompletionTokensDetails(
+                            reasoning_tokens=reasoning_tokens
                         )
 
                 stream_per_request_metrics: PerRequestTimingMetrics | None = None
                 if self.enable_per_request_metrics and request.include_metrics:
-                    last_metrics = (
-                        last_res.metrics if last_res is not None else None
-                    )
+                    last_metrics = last_res.metrics if last_res is not None else None
                     num_sequences = request.n or 1
                     stream_per_request_metrics = build_per_request_timing_metrics(
                         last_metrics, completion_tokens // num_sequences
@@ -1743,9 +1737,7 @@ class OpenAIServingChat(OpenAIServing):
 
         if reasoning_parser is not None:
             reasoning_tokens = sum(
-                reasoning_parser.count_reasoning_tokens(
-                    list(output.token_ids)
-                )
+                reasoning_parser.count_reasoning_tokens(list(output.token_ids))
                 for output in final_res.outputs
             )
             if reasoning_tokens > 0:

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -39,11 +39,13 @@ from vllm.entrypoints.openai.chat_completion.stream_harmony import (
     extract_harmony_streaming_delta,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    CompletionTokensDetails,
     DeltaFunctionCall,
     DeltaMessage,
     DeltaToolCall,
     ErrorResponse,
     FunctionCall,
+    PerRequestTimingMetrics,
     PromptTokenUsageInfo,
     RequestResponseMetadata,
     ToolCall,
@@ -52,6 +54,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.entrypoints.openai.engine.serving import (
     GenerationError,
     OpenAIServing,
+    build_per_request_timing_metrics,
     clamp_prompt_logprobs,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
@@ -105,6 +108,7 @@ class OpenAIServingChat(OpenAIServing):
         enable_log_outputs: bool = False,
         enable_log_deltas: bool = True,
         default_chat_template_kwargs: dict[str, Any] | None = None,
+        enable_per_request_metrics: bool = False,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
@@ -136,6 +140,7 @@ class OpenAIServingChat(OpenAIServing):
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
+        self.enable_per_request_metrics = enable_per_request_metrics
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
         mc = self.model_config
         self.override_max_tokens = (
@@ -682,8 +687,10 @@ class OpenAIServingChat(OpenAIServing):
             stream_options, self.enable_force_include_usage
         )
 
+        last_res: RequestOutput | None = None
         try:
             async for res in result_generator:
+                last_res = res
                 if res.prompt_token_ids is not None:
                     num_prompt_tokens = len(res.prompt_token_ids)
                     if res.encoder_prompt_token_ids is not None:
@@ -1317,6 +1324,29 @@ class OpenAIServingChat(OpenAIServing):
                         cached_tokens=num_cached_tokens
                     )
 
+                if reasoning_parser is not None and last_res is not None:
+                    reasoning_tokens = sum(
+                        reasoning_parser.count_reasoning_tokens(
+                            list(output.token_ids)
+                        )
+                        for output in last_res.outputs
+                    )
+                    if reasoning_tokens > 0:
+                        final_usage.completion_tokens_details = (
+                            CompletionTokensDetails(
+                                reasoning_tokens=reasoning_tokens
+                            )
+                        )
+
+                stream_per_request_metrics: PerRequestTimingMetrics | None = None
+                if self.enable_per_request_metrics and request.include_metrics:
+                    last_metrics = (
+                        last_res.metrics if last_res is not None else None
+                    )
+                    stream_per_request_metrics = build_per_request_timing_metrics(
+                        last_metrics, completion_tokens
+                    )
+
                 final_usage_chunk = ChatCompletionStreamResponse(
                     id=request_id,
                     object=chunk_object_type,
@@ -1324,6 +1354,7 @@ class OpenAIServingChat(OpenAIServing):
                     choices=[],
                     model=model_name,
                     usage=final_usage,
+                    metrics=stream_per_request_metrics,
                 )
                 final_usage_data = final_usage_chunk.model_dump_json(
                     exclude_unset=True, exclude_none=True
@@ -1709,6 +1740,24 @@ class OpenAIServingChat(OpenAIServing):
                 cached_tokens=final_res.num_cached_tokens
             )
 
+        if reasoning_parser is not None:
+            reasoning_tokens = sum(
+                reasoning_parser.count_reasoning_tokens(
+                    list(output.token_ids)
+                )
+                for output in final_res.outputs
+            )
+            if reasoning_tokens > 0:
+                usage.completion_tokens_details = CompletionTokensDetails(
+                    reasoning_tokens=reasoning_tokens
+                )
+
+        per_request_metrics: PerRequestTimingMetrics | None = None
+        if self.enable_per_request_metrics and request.include_metrics:
+            per_request_metrics = build_per_request_timing_metrics(
+                final_res.metrics, num_generated_tokens
+            )
+
         request_metadata.final_usage_info = usage
 
         response = ChatCompletionResponse(
@@ -1722,6 +1771,7 @@ class OpenAIServingChat(OpenAIServing):
                 final_res.prompt_token_ids if request.return_token_ids else None
             ),
             kv_transfer_params=final_res.kv_transfer_params,
+            metrics=per_request_metrics,
         )
 
         # Log complete response if output logging is enabled

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -137,6 +137,11 @@ class BaseFrontendArgs:
     log. The default of None means unlimited."""
     enable_prompt_tokens_details: bool = False
     """If set to True, enable prompt_tokens_details in usage."""
+    enable_per_request_metrics: bool = False
+    """If set to True, enable per-request timing metrics in API responses.
+    When enabled, requests that include `include_metrics=True` will receive
+    timing metrics (TTFT, generation time, queue time, ITL, tokens/s) in
+    the response body."""
     enable_server_load_tracking: bool = False
     """If set to True, enable tracking server_load_metrics in the app state."""
     enable_force_include_usage: bool = False

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -16,6 +16,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     AnyResponseFormat,
     LegacyStructuralTagResponseFormat,
     OpenAIBaseModel,
+    PerRequestTimingMetrics,
     StreamOptions,
     StructuralTagResponseFormat,
     UsageInfo,
@@ -176,6 +177,8 @@ class CompletionRequest(OpenAIBaseModel):
         "(e.g. 'abcdabcdabcd...' or '\\emoji \\emoji \\emoji ...'). This feature "
         "can detect such behavior and terminate early, saving time and tokens.",
     )
+
+    include_metrics: bool = False
 
     # --8<-- [end:completion-extra-params]
 
@@ -484,6 +487,7 @@ class CompletionResponse(OpenAIBaseModel):
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None, description="KVTransfer parameters."
     )
+    metrics: PerRequestTimingMetrics | None = None
 
 
 class CompletionResponseStreamChoice(OpenAIBaseModel):
@@ -512,3 +516,4 @@ class CompletionStreamResponse(OpenAIBaseModel):
     model: str
     choices: list[CompletionResponseStreamChoice]
     usage: UsageInfo | None = Field(default=None)
+    metrics: PerRequestTimingMetrics | None = None

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -449,9 +449,7 @@ class OpenAIServingCompletion(OpenAIServing):
                     and request.include_metrics
                     and num_prompts == 1
                 ):
-                    last_metrics = (
-                        last_res.metrics if last_res is not None else None
-                    )
+                    last_metrics = last_res.metrics if last_res is not None else None
                     num_sequences = request.n or 1
                     stream_per_request_metrics = build_per_request_timing_metrics(
                         last_metrics,

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -444,12 +444,18 @@ class OpenAIServingCompletion(OpenAIServing):
 
             if include_usage:
                 stream_per_request_metrics: PerRequestTimingMetrics | None = None
-                if self.enable_per_request_metrics and request.include_metrics:
+                if (
+                    self.enable_per_request_metrics
+                    and request.include_metrics
+                    and num_prompts == 1
+                ):
                     last_metrics = (
                         last_res.metrics if last_res is not None else None
                     )
+                    num_sequences = request.n or 1
                     stream_per_request_metrics = build_per_request_timing_metrics(
-                        last_metrics, total_completion_tokens
+                        last_metrics,
+                        total_completion_tokens // num_sequences,
                     )
 
                 final_usage_chunk = CompletionStreamResponse(
@@ -582,12 +588,17 @@ class OpenAIServingCompletion(OpenAIServing):
         request_metadata.final_usage_info = usage
 
         per_request_metrics: PerRequestTimingMetrics | None = None
-        if self.enable_per_request_metrics and request.include_metrics:
+        if (
+            self.enable_per_request_metrics
+            and request.include_metrics
+            and len(final_res_batch) == 1
+        ):
             last_metrics = (
                 last_final_res.metrics if last_final_res is not None else None
             )
+            num_sequences = request.n or 1
             per_request_metrics = build_per_request_timing_metrics(
-                last_metrics, num_generated_tokens
+                last_metrics, num_generated_tokens // num_sequences
             )
 
         if final_res_batch:

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -21,6 +21,7 @@ from vllm.entrypoints.openai.completion.protocol import (
 )
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
+    PerRequestTimingMetrics,
     PromptTokenUsageInfo,
     RequestResponseMetadata,
     UsageInfo,
@@ -28,6 +29,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.entrypoints.openai.engine.serving import (
     GenerationError,
     OpenAIServing,
+    build_per_request_timing_metrics,
     clamp_prompt_logprobs,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
@@ -55,6 +57,7 @@ class OpenAIServingCompletion(OpenAIServing):
         return_tokens_as_token_ids: bool = False,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
+        enable_per_request_metrics: bool = False,
     ):
         super().__init__(
             engine_client=engine_client,
@@ -65,6 +68,7 @@ class OpenAIServingCompletion(OpenAIServing):
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
+        self.enable_per_request_metrics = enable_per_request_metrics
 
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
         mc = self.model_config
@@ -298,8 +302,10 @@ class OpenAIServingCompletion(OpenAIServing):
             stream_options, self.enable_force_include_usage
         )
 
+        last_res: RequestOutput | None = None
         try:
             async for prompt_idx, res in result_generator:
+                last_res = res
                 prompt_token_ids = res.prompt_token_ids
                 prompt_logprobs = res.prompt_logprobs
 
@@ -437,12 +443,22 @@ class OpenAIServingCompletion(OpenAIServing):
                 )
 
             if include_usage:
+                stream_per_request_metrics: PerRequestTimingMetrics | None = None
+                if self.enable_per_request_metrics and request.include_metrics:
+                    last_metrics = (
+                        last_res.metrics if last_res is not None else None
+                    )
+                    stream_per_request_metrics = build_per_request_timing_metrics(
+                        last_metrics, total_completion_tokens
+                    )
+
                 final_usage_chunk = CompletionStreamResponse(
                     id=request_id,
                     created=created_time,
                     model=model_name,
                     choices=[],
                     usage=final_usage_info,
+                    metrics=stream_per_request_metrics,
                 )
                 final_usage_data = final_usage_chunk.model_dump_json(
                     exclude_unset=False, exclude_none=True
@@ -564,6 +580,16 @@ class OpenAIServingCompletion(OpenAIServing):
             )
 
         request_metadata.final_usage_info = usage
+
+        per_request_metrics: PerRequestTimingMetrics | None = None
+        if self.enable_per_request_metrics and request.include_metrics:
+            last_metrics = (
+                last_final_res.metrics if last_final_res is not None else None
+            )
+            per_request_metrics = build_per_request_timing_metrics(
+                last_metrics, num_generated_tokens
+            )
+
         if final_res_batch:
             kv_transfer_params = final_res_batch[0].kv_transfer_params
         return CompletionResponse(
@@ -573,6 +599,7 @@ class OpenAIServingCompletion(OpenAIServing):
             choices=choices,
             usage=usage,
             kv_transfer_params=kv_transfer_params,
+            metrics=per_request_metrics,
         )
 
     def _create_completion_logprobs(

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -102,11 +102,27 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: int | None = None
 
 
+class CompletionTokensDetails(OpenAIBaseModel):
+    reasoning_tokens: int | None = None
+    accepted_prediction_tokens: int | None = None
+    rejected_prediction_tokens: int | None = None
+
+
 class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: int | None = 0
     prompt_tokens_details: PromptTokenUsageInfo | None = None
+    completion_tokens_details: CompletionTokensDetails | None = None
+
+
+class PerRequestTimingMetrics(OpenAIBaseModel):
+    time_to_first_token_ms: float | None = None
+    time_to_first_content_token_ms: float | None = None
+    generation_time_ms: float | None = None
+    queue_time_ms: float | None = None
+    mean_itl_ms: float | None = None
+    tokens_per_second: float | None = None
 
 
 class RequestResponseMetadata(BaseModel):

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -40,6 +40,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     FunctionDefinition,
     GenerationError,
+    PerRequestTimingMetrics,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.responses.context import (
@@ -122,8 +123,52 @@ from vllm.utils.async_utils import (
     merge_async_iterators,
 )
 from vllm.utils.mistral import is_mistral_tokenizer
+from vllm.v1.metrics.stats import RequestStateStats
 
 logger = init_logger(__name__)
+
+
+def build_per_request_timing_metrics(
+    metrics: RequestStateStats | None,
+    num_generation_tokens: int,
+) -> PerRequestTimingMetrics:
+    if metrics is None:
+        return PerRequestTimingMetrics()
+
+    scheduled_ts = metrics.scheduled_ts
+    first_token_ts = metrics.first_token_ts
+    last_token_ts = metrics.last_token_ts
+    queued_ts = metrics.queued_ts
+
+    time_to_first_token_ms: float | None = None
+    generation_time_ms: float | None = None
+    queue_time_ms: float | None = None
+    mean_itl_ms: float | None = None
+    tokens_per_second: float | None = None
+
+    if scheduled_ts > 0 and first_token_ts > 0:
+        time_to_first_token_ms = (first_token_ts - scheduled_ts) * 1000
+
+    if scheduled_ts > 0 and last_token_ts > 0:
+        generation_time_ms = (last_token_ts - scheduled_ts) * 1000
+
+    if queued_ts > 0 and scheduled_ts > 0:
+        queue_time_ms = (scheduled_ts - queued_ts) * 1000
+
+    if first_token_ts > 0 and last_token_ts > 0 and num_generation_tokens > 1:
+        decode_time = last_token_ts - first_token_ts
+        mean_itl_ms = decode_time / (num_generation_tokens - 1) * 1000
+
+    if generation_time_ms is not None and generation_time_ms > 0:
+        tokens_per_second = num_generation_tokens / generation_time_ms * 1000
+
+    return PerRequestTimingMetrics(
+        time_to_first_token_ms=time_to_first_token_ms,
+        generation_time_ms=generation_time_ms,
+        queue_time_ms=queue_time_ms,
+        mean_itl_ms=mean_itl_ms,
+        tokens_per_second=tokens_per_second,
+    )
 
 
 class RendererRequest(Protocol):

--- a/vllm/entrypoints/openai/generate/api_router.py
+++ b/vllm/entrypoints/openai/generate/api_router.py
@@ -110,6 +110,7 @@ async def init_generate_state(
             enable_force_include_usage=args.enable_force_include_usage,
             enable_log_outputs=args.enable_log_outputs,
             enable_log_deltas=args.enable_log_deltas,
+            enable_per_request_metrics=args.enable_per_request_metrics,
         )
         if any(task in supported_tasks for task in ("generate", "render"))
         else None
@@ -125,6 +126,7 @@ async def init_generate_state(
             return_tokens_as_token_ids=args.return_tokens_as_token_ids,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
+            enable_per_request_metrics=args.enable_per_request_metrics,
         )
         if any(task in supported_tasks for task in ("generate", "render"))
         else None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Add opt-in per-request performance metrics to `/v1/chat/completions` and `/v1/completions` API responses.                                      
   
  **Motivation:** Server-aggregated Prometheus histograms at `/metrics` are not sufficient for per-user billing, per-request SLA attribution, or  latency debugging of individual requests. This feature exposes the timing data that vLLM already tracks internally (via `RequestStateStats`) directly in the response body, on an opt-in basis.                                                                                             
                                                                                                                                               
  Additionally, reasoning model deployments need `reasoning_tokens` separated from content tokens in `usage` for independent cost attribution and analytics — this aligns with OpenAI's `completion_tokens_details` format.
                                                                                                                                                 
  **Changes:**                                                                                                                                 

  - `PerRequestTimingMetrics` — new optional `metrics` field in `ChatCompletionResponse`, `ChatCompletionStreamResponse`, `CompletionResponse`, and `CompletionStreamResponse`:
    - `time_to_first_token_ms` — time from scheduling to first output token                                                                      
    - `generation_time_ms` — total decode time (excludes queue wait)                                                                             
    - `queue_time_ms` — time spent waiting in the scheduler queue                                                                                
    - `mean_itl_ms` — mean inter-token latency during decode                                                                                     
    - `tokens_per_second` — output throughput                                                                                                    
    - `time_to_first_content_token_ms` — reserved for reasoning models (currently `null`, future work)                                           
                                                                                                                                                 
  - `CompletionTokensDetails` — new `completion_tokens_details` field in `UsageInfo` with `reasoning_tokens`, populated automatically when a `--reasoning-parser` is configured. Works in both streaming and non-streaming paths.                                                           
                                                                                                                                                 
  - `--enable-per-request-metrics` server flag + `include_metrics: bool` per-request parameter as a double gate. Metrics are computed only when both are set, avoiding CPU overhead for deployments that don't need them.
                                                                                                                                                 
  - `build_per_request_timing_metrics` shared helper in `engine/serving.py`, used by both chat and completion serving.                           
   
  - Docs: `docs/features/per_request_metrics.md`   
  
## Test Plan

**Unit tests (no GPU required):**                                                                                                              
  ```bash
  pytest tests/entrypoints/openai/test_per_request_metrics_protocol.py -v                                                                        
  pytest tests/entrypoints/openai/test_per_request_metrics_serving.py -v                                                                         
                                                                                                                                                 
  Integration tests (GPU required):                                                                                                              
  pytest tests/entrypoints/openai/test_chat_completion.py -v -k "metrics"                                                                        
  pytest tests/entrypoints/openai/test_completion.py -v -k "metrics"                                                                             
                                                                                                                                                 
  Manual verification:                                                                                                                           
  vllm serve meta-llama/Llama-3.1-8B-Instruct --enable-per-request-metrics                                                                       
                                                                                                                                                 
  curl http://localhost:8000/v1/chat/completions \                                                                                               
    -H "Content-Type: application/json" \                                                                                                        
    -d '{                                                                                                                                        
      "model": "meta-llama/Llama-3.1-8B-Instruct",                                                                                               
      "messages": [{"role": "user", "content": "Hello"}],                                                                                      
      "include_metrics": true                                                                                                                    
    }'


## Test Result
  Unit tests pass locally (no GPU). Full CI pending (draft PR).                                                                                  
   
  The test_per_request_metrics_protocol.py suite covers:                                                                                         
  - Model field defaults and serialization for CompletionTokensDetails, PerRequestTimingMetrics, UsageInfo                                     
  - build_per_request_timing_metrics helper with exact value assertions, edge cases (zero timestamps, single token, partial data)                
  - include_metrics field on requests and metrics field on responses for both chat and completion                                              
                                                                                                                                                 
  The test_per_request_metrics_serving.py suite covers:                                                                                          
  - Double-gate behavior: metrics suppressed when server flag is off even if include_metrics=True                                                
  - Metrics populated correctly when both gates are on, with expected timestamp math                                                             
  - Graceful null fields when RequestOutput.metrics is None                                                                                    
  - completion_tokens_details set/unset based on reasoning parser presence  
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

