### PR TITLE
[Bugfix] Fix hybrid Attention+Mamba models failing when hybrid KV cache manager is   disabled

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -38,6 +38,7 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
+    CrossAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
@@ -2136,3 +2137,19 @@ def test_unify_hybrid_kv_cache_specs():
     assert kv_cache_spec["sw_layer"].sliding_window == 1024
     # MambaSpec should be unchanged
     assert kv_cache_spec["mamba_layer"] == mamba_spec
+
+    # 7. CrossAttentionSpec + MambaSpec, should still raise ValueError
+    #    (unsupported mix - not all non-Mamba specs are unified)
+    cross_attn_spec = CrossAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float32,
+    )
+    kv_cache_spec = {
+        "cross_attn_layer": cross_attn_spec,
+        "attn_layer": new_kv_cache_spec(),
+        "mamba_layer": mamba_spec,
+    }
+    with pytest.raises(ValueError):
+        kv_cache_utils.unify_hybrid_kv_cache_specs(kv_cache_spec)

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -43,6 +43,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheTensor,
+    MambaSpec,
     MLAAttentionSpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
@@ -2094,3 +2095,44 @@ def test_unify_hybrid_kv_cache_specs():
 
     with pytest.raises(ValueError):
         kv_cache_utils.unify_hybrid_kv_cache_specs(kv_cache_spec)
+
+    # 5. FullAttentionSpec + MambaSpec (e.g., Qwen3.5), should not raise
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 64), (1, 128)),
+        dtypes=(torch.float32, torch.float32),
+        page_size_padded=32 * 1024,
+    )
+    kv_cache_spec = {
+        "attn_layer_1": new_kv_cache_spec(page_size_padded=32 * 1024),
+        "attn_layer_2": new_kv_cache_spec(page_size_padded=32 * 1024),
+        "mamba_layer_1": mamba_spec,
+    }
+    # Should not raise - MambaSpec + attention specs are handled by
+    # _get_kv_cache_groups_uniform_page_size downstream
+    kv_cache_utils.unify_hybrid_kv_cache_specs(kv_cache_spec)
+    # Attention specs should be unchanged
+    assert kv_cache_spec["attn_layer_1"] == new_kv_cache_spec(
+        page_size_padded=32 * 1024
+    )
+    assert kv_cache_spec["attn_layer_2"] == new_kv_cache_spec(
+        page_size_padded=32 * 1024
+    )
+    # MambaSpec should be unchanged
+    assert kv_cache_spec["mamba_layer_1"] == mamba_spec
+
+    # 6. FullAttentionSpec + SlidingWindowSpec + MambaSpec, should not raise
+    #    SlidingWindow should be converted to FullAttention, Mamba stays
+    kv_cache_spec = {
+        "attn_layer": new_kv_cache_spec(page_size_padded=32 * 1024),
+        "sw_layer": new_sliding_window_spec(
+            page_size_padded=32 * 1024, sliding_window=1024
+        ),
+        "mamba_layer": mamba_spec,
+    }
+    kv_cache_utils.unify_hybrid_kv_cache_specs(kv_cache_spec)
+    # SlidingWindow should be converted to FullAttention
+    assert isinstance(kv_cache_spec["sw_layer"], FullAttentionSpec)
+    assert kv_cache_spec["sw_layer"].sliding_window == 1024
+    # MambaSpec should be unchanged
+    assert kv_cache_spec["mamba_layer"] == mamba_spec

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -24,6 +24,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheTensor,
+    MambaSpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -1208,10 +1209,16 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
         is_kv_cache_spec_uniform(kv_cache_spec)
         or UniformTypeKVCacheSpecs.is_uniform_type(kv_cache_spec)
     ):
-        raise ValueError(
-            "Hybrid KV cache manager is disabled but failed to "
-            "convert the KV cache specs to one unified type."
-        )
+        # For hybrid Attention+Mamba models (e.g., Qwen3.5), we cannot unify
+        # MambaSpec with attention specs. This is fine because
+        # _get_kv_cache_groups_uniform_page_size can handle them as separate
+        # groups with equalized page sizes.
+        has_mamba = any(isinstance(spec, MambaSpec) for spec in kv_cache_spec.values())
+        if not has_mamba:
+            raise ValueError(
+                "Hybrid KV cache manager is disabled but failed to "
+                "convert the KV cache specs to one unified type."
+            )
 
 
 def get_kv_cache_groups(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1213,8 +1213,23 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
         # MambaSpec with attention specs. This is fine because
         # _get_kv_cache_groups_uniform_page_size can handle them as separate
         # groups with equalized page sizes.
-        has_mamba = any(isinstance(spec, MambaSpec) for spec in kv_cache_spec.values())
-        if not has_mamba:
+        # We only allow this bypass when the non-Mamba specs have been
+        # successfully unified (all FullAttentionSpec), to avoid masking
+        # unsupported mixes like CrossAttentionSpec + MambaSpec.
+        non_mamba_specs = {
+            name: spec
+            for name, spec in kv_cache_spec.items()
+            if not isinstance(spec, MambaSpec)
+        }
+        mamba_bypass = (
+            len(non_mamba_specs) < len(kv_cache_spec)
+            and len(non_mamba_specs) > 0
+            and (
+                is_kv_cache_spec_uniform(non_mamba_specs)
+                or UniformTypeKVCacheSpecs.is_uniform_type(non_mamba_specs)
+            )
+        )
+        if not mamba_bypass:
             raise ValueError(
                 "Hybrid KV cache manager is disabled but failed to "
                 "convert the KV cache specs to one unified type."


### PR DESCRIPTION

## Purpose                                                                 
  When running hybrid Attention+Mamba models (e.g., `Qwen/Qwen3.5-0.8B`) with features that disable the hybrid KV cache manager (such as `--kv-events-config`), the server fails to start with:
  `ValueError: Hybrid KV cache manager is disabled but failed to convert the KV cache specs to one unified type.`

  The root cause is that `unify_hybrid_kv_cache_specs` only knows how to convert `SlidingWindowSpec`/`ChunkedLocalAttentionSpec` → `FullAttentionSpec`, but cannot (and should not) unify `MambaSpec` with attention specs since they are fundamentally different cache types.

  This PR relaxes the final validation to allow `MambaSpec` + attention specs to coexist without raising an error. The downstream `_get_kv_cache_groups_uniform_page_size` path already handles this case correctly by grouping layers by spec type, and page sizes are already equalized upstream.

  ## Test plan
  - Run `Qwen/Qwen3.5-0.8B` with `--kv-events-config` and verify the model loads successfully
  - Verify pure-attention hybrid models (e.g., Gemma3) still work with and without `--disable-hybrid-kv-cache-manager`
  - Verify non-Mamba hybrid models that fail unification still raise the `ValueError`
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

