### PR TITLE
[Bugfix] Fix KV-cache head-of-line blocking in scheduler

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4048,3 +4048,203 @@ def test_eagle3_mm_encoder_cache_with_shift():
         f"shifted_end={scheduled_end_with_shift}) overlapping MM at "
         f"{start_pos}. The fix must schedule encoder inputs."
     )
+
+
+# ============================================================
+# Tests for KV-cache head-of-line blocking prevention
+# See: https://github.com/vllm-project/vllm/issues/31731
+# ============================================================
+
+
+def test_running_hol_blocking_priority_schedule():
+    """Test that a low-priority running request failing KV allocation
+    does not block higher-priority running requests from being scheduled.
+
+    Before the fix, the scheduler would `break` out of the running loop
+    when any request's preemption cascade failed, preventing all subsequent
+    running requests from being scheduled in that step.
+
+    Scenario (3 scheduling steps):
+      1. Schedule heavy request alone (low priority, 48 tokens, 3 blocks).
+         It goes to RUNNING first, so it occupies the front of self.running.
+      2. Add light request (high priority, 10 tokens, 1 block). Schedule:
+         - RUNNING: heavy gets remaining 16-token chunk (needs 1 new block).
+         - WAITING: light gets prefilled (1 block). Now 0 free blocks.
+         Both are running: self.running = [heavy, light].
+      3. Schedule (decode step):
+         - heavy needs 1 decode token at position 48 → needs a NEW block.
+         - 0 free blocks → preemption cascade picks heavy itself
+           (it has the highest priority value = lowest priority).
+         - heavy is preempted. With `continue`, light still gets scheduled.
+         - With the old `break`, light would be skipped.
+    """
+    # block_size=16, num_blocks=5 => 4 usable blocks => 64 tokens capacity.
+    # Chunked prefill: max_num_batched_tokens=32 forces the 48-token heavy
+    # request to be split into two chunks (32 + 16).
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=4,
+        max_num_batched_tokens=32,
+        num_blocks=5,
+        block_size=16,
+        max_model_len=2048,
+    )
+
+    # Heavy request: low priority (priority=10), 48 prompt tokens.
+    # Needs 3 blocks total, but will be chunked: 32 tokens first, then 16.
+    heavy_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[10],  # Low priority (high number)
+        arrival_times=[1.0],
+        num_tokens=48,
+        max_tokens=32,
+        req_ids=["heavy"],
+        block_size=16,
+    )[0]
+
+    # --- Step 1: Schedule heavy request alone (first chunk). ---
+    scheduler.add_request(heavy_req)
+    output1 = scheduler.schedule()
+    assert "heavy" in output1.num_scheduled_tokens
+    # Chunked: schedules 32 tokens out of 48. Uses 2 blocks. 2 free.
+    assert output1.num_scheduled_tokens["heavy"] == 32
+
+    # update_from_output: heavy is still prefilling, no sampled token.
+    model_output1 = ModelRunnerOutput(
+        req_ids=["heavy"],
+        req_id_to_index={"heavy": 0},
+        sampled_token_ids=[[]],  # No token sampled during prefill chunk
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output1, model_output1)
+    # After update: heavy.num_computed_tokens = 32, heavy.num_tokens = 48.
+    # heavy is in self.running (still prefilling remaining chunk).
+
+    # --- Step 2: Add light request, schedule both. ---
+    # Light request: high priority (priority=1), 10 prompt tokens, 1 block.
+    light_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[1],  # High priority (low number)
+        arrival_times=[2.0],
+        num_tokens=10,
+        max_tokens=4,
+        req_ids=["light"],
+        block_size=16,
+    )[0]
+    scheduler.add_request(light_req)
+
+    output2 = scheduler.schedule()
+    # RUNNING: heavy gets remaining 16 tokens (chunk 2). Needs 1 new block.
+    #   2 free → succeeds. heavy now uses 3 blocks. 1 free.
+    # WAITING: light gets 10 tokens prefilled. Needs 1 block.
+    #   1 free → succeeds. light uses 1 block. 0 free.
+    assert "heavy" in output2.num_scheduled_tokens
+    assert output2.num_scheduled_tokens["heavy"] == 16  # Remaining chunk
+    assert "light" in output2.num_scheduled_tokens
+    assert output2.num_scheduled_tokens["light"] == 10
+    # self.running = [heavy, light] (heavy was appended first in step 1).
+
+    # update_from_output: both finished prefilling, each gets 1 sampled token.
+    model_output2 = ModelRunnerOutput(
+        req_ids=["heavy", "light"],
+        req_id_to_index={"heavy": 0, "light": 1},
+        sampled_token_ids=[[100], [200]],  # Each gets one sampled token
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output2, model_output2)
+    # After update:
+    #   heavy: num_tokens=49 (48+1), num_computed_tokens=48
+    #   light: num_tokens=11 (10+1), num_computed_tokens=10
+    # 4 blocks used (3 heavy + 1 light), 0 free.
+
+    # --- Step 3: Decode step - the HOL blocking scenario. ---
+    output3 = scheduler.schedule()
+
+    # heavy (req_index=0) needs 1 decode token at position 48.
+    # Block 3 covers positions 32-47, so position 48 needs a NEW block.
+    # 0 free blocks → allocate_slots fails.
+    # Preemption cascade: max(running, key=(priority, arrival_time))
+    #   = heavy (priority=10 > 1). heavy is preempted immediately.
+    #   preempted_req == request → cascade ends with new_blocks=None.
+    #
+    # With the fix (continue): loop continues to light (now at index 0).
+    #   light needs 1 decode token at position 10, fits in existing block.
+    #   light is scheduled successfully.
+    #
+    # With old code (break): loop exits. light is never processed.
+
+    assert "light" in output3.num_scheduled_tokens, (
+        "Light request should be scheduled even after heavy request's "
+        "preemption cascade fails (HOL blocking fix)"
+    )
+    assert output3.num_scheduled_tokens["light"] == 1  # 1 decode token
+
+    # heavy should be preempted back to waiting.
+    assert "heavy" not in output3.num_scheduled_tokens
+    waiting_ids = set()
+    for req in scheduler.waiting:
+        waiting_ids.add(req.request_id)
+    assert "heavy" in waiting_ids, (
+        "Heavy request should be preempted back to waiting queue"
+    )
+
+
+def test_waiting_hol_blocking_skip_heavy_request():
+    """Test that a waiting request that cannot allocate KV blocks
+    does not block lighter waiting requests from being scheduled.
+
+    Before the fix, the scheduler would `break` out of the waiting loop
+    when any request failed allocation, preventing all subsequent waiting
+    requests from being admitted.
+    """
+    # block_size=16, num_blocks=4 => 3 usable blocks => 48 tokens capacity.
+    scheduler = create_scheduler(
+        max_num_seqs=4,
+        max_num_batched_tokens=200,
+        num_blocks=4,
+        block_size=16,
+        enable_prefix_caching=False,
+    )
+
+    # Create a heavy request that needs more blocks than available.
+    # 80 tokens => needs 5 blocks, but only 3 available.
+    heavy_req = create_requests(
+        num_requests=1,
+        num_tokens=80,
+        max_tokens=4,
+        block_size=16,
+        req_ids=["heavy"],
+    )[0]
+
+    # Create a light request that fits easily.
+    # 10 tokens => needs 1 block.
+    light_req = create_requests(
+        num_requests=1,
+        num_tokens=10,
+        max_tokens=4,
+        block_size=16,
+        req_ids=["light"],
+    )[0]
+
+    # Add heavy first (FCFS order), then light.
+    scheduler.add_request(heavy_req)
+    scheduler.add_request(light_req)
+
+    # Schedule. With the fix, heavy can't allocate but light should
+    # still be admitted.
+    output = scheduler.schedule()
+
+    # The light request should be scheduled even though the heavy
+    # request at the front of the queue couldn't allocate.
+    assert "light" in output.num_scheduled_tokens, (
+        "Light waiting request should be scheduled even when the heavy "
+        "request at the front of the queue cannot allocate KV blocks"
+    )
+
+    # The heavy request should be skipped (still in waiting).
+    assert any(r.request_id == "heavy" for r in scheduler.waiting), (
+        "Heavy request should remain in the waiting queue after being skipped"
+    )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -480,8 +480,16 @@ class Scheduler(SchedulerInterface):
                         break
 
             if new_blocks is None:
-                # Cannot schedule this request.
-                break
+                # The preemption cascade failed to free enough blocks for
+                # this request. Instead of stopping the entire scheduling
+                # loop, continue to schedule remaining running requests.
+                # This prevents a single KV-cache-heavy request from
+                # blocking all other running requests in this step.
+                # NOTE: Do not increment req_index here. The failing request
+                # was already removed from self.running during the cascade,
+                # so the next request has shifted to the current index.
+                # See: https://github.com/vllm-project/vllm/issues/31731
+                continue
 
             # Schedule the request.
             scheduled_running_reqs.append(request)
@@ -738,13 +746,20 @@ class Scheduler(SchedulerInterface):
                 )
 
                 if new_blocks is None:
-                    # The request cannot be scheduled.
+                    # The request cannot be scheduled due to insufficient
+                    # KV cache blocks. Skip this request and try the next
+                    # one instead of stopping the entire waiting loop.
+                    # This prevents a single KV-cache-heavy waiting request
+                    # from blocking lighter requests that could be scheduled.
+                    # See: https://github.com/vllm-project/vllm/issues/31731
 
-                    # NOTE: we need to untouch the request from the encode cache
-                    # manager
+                    # NOTE: we need to untouch the request from the encode
+                    # cache manager
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
-                    break
+                    self.waiting.pop_request()
+                    skipped_waiting_requests.prepend_request(request)
+                    continue
 
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that


### PR DESCRIPTION
## Purpose

Fix KV-cache head-of-line (HOL) blocking in the V1 scheduler where a single KV-heavy request prevents all subsequent requests from being scheduled.

Fixes https://github.com/vllm-project/vllm/issues/31731

### Problem

When a running request's preemption cascade fails to free enough KV blocks, the scheduler breaks out of the entire scheduling loop (`break`), preventing all subsequent requests from being processed in that step. The same issue exists in the waiting phase — a single request that cannot allocate blocks stops the entire waiting queue.

### Changes

**RUNNING phase** (`scheduler.py:482`): Changed `break` → `continue`.

When the preemption cascade fails for a request, that request has already been removed from `self.running` during the cascade (it gets preempted back to waiting). The next request has shifted to the current index, so no index increment is needed. This matters for **PRIORITY scheduling** — when the failing request has the lowest priority (highest value), it is the first victim picked by `max(self.running, key=(priority, arrival_time))`, so the cascade ends immediately after preempting only the failing request itself, leaving all higher-priority running requests untouched but unprocessed.

**WAITING phase** (`scheduler.py:746`): Changed `break` → skip-and-continue.

The unschedulable request is popped from the waiting queue and prepended to `skipped_waiting_requests`, which is restored at the front of the waiting queue after the scheduling loop completes. This ensures the skipped request is retried first in the next scheduling step (no permanent starvation).

### Relation to prior PRs

- PR #33499 (draft, WAITING-only, no review) — superseded by this PR which covers both phases.
- PR #35852 (closed) — had 3 changes, all rejected. This PR addresses reviewer concerns:
  - Kept the `not preempted_reqs` guard in the WAITING phase to avoid preempt-then-admit churn.
  - The RUNNING phase change is safe because the failing request is already removed from `self.running` — no re-allocation for preempted requests occurs.

## Test Plan

```bash
python -m pytest tests/v1/core/test_scheduler.py::test_running_hol_blocking_priority_schedule tests/v1/core/test_scheduler.py::test_waiting_hol_blocking_skip_heavy_request -v
```

Two new tests added:

1. **`test_running_hol_blocking_priority_schedule`** — 3-step scenario using chunked prefill with PRIORITY scheduling:
   - Step 1: Schedule a low-priority request (priority=10, 48 tokens, chunked).
   - Step 2: Add a high-priority request (priority=1, 10 tokens). Both run; KV cache is full.
   - Step 3: Decode step — low-priority request needs a new block, cascade preempts it immediately (it's the lowest priority victim). With `continue`, the high-priority request still gets scheduled. With the old `break`, it would be skipped.

2. **`test_waiting_hol_blocking_skip_heavy_request`** — A heavy waiting request (80 tokens, needs 5 blocks) is at the front of an FCFS queue with only 3 usable blocks. A light request (10 tokens, 1 block) behind it should still be scheduled.

## Test Result

All 7 new tests pass. Full scheduler test suite: **93 passed, 1 skipped, 0 failures** — no regressions.

```
tests/v1/core/test_scheduler.py::test_running_hol_blocking_priority_schedule PASSED
tests/v1/core/test_scheduler.py::test_waiting_hol_blocking_skip_heavy_request PASSED
================= 93 passed, 1 skipped in 45.74s ==================
```