### PR TITLE
fix: register atexit handler to prevent ImportError during FlashInfer shutdown

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import atexit
+
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -144,6 +146,13 @@ def destroy_fi_ar_workspace():
     if _fi_ar_workspace is not None:
         _fi_ar_workspace.destroy()
         _fi_ar_workspace = None
+
+
+# Register atexit handler to destroy workspaces during interpreter shutdown,
+# before sys.meta_path is set to None. This prevents the
+# "ImportError: sys.meta_path is None" error in
+# AllReduceFusionWorkspace.__del__ when Python is shutting down (e.g. ctrl-c).
+atexit.register(destroy_fi_ar_workspace)
 
 
 class FlashInferAllReduce:


### PR DESCRIPTION
## Summary

When Python shuts down (e.g., via Ctrl+C), `AllReduceFusionWorkspace.__del__` tries to import modules but `sys.meta_path` is already `None`, causing `ImportError: sys.meta_path is None`.

This fix registers an `atexit` handler that calls `destroy_fi_ar_workspace()` before interpreter teardown begins, ensuring FlashInfer workspaces are cleaned up while the import system is still functional.

## Test plan

- Verified the change is minimal and only adds an `atexit.register` call for the existing `destroy_fi_ar_workspace()` function.
- The `destroy_fi_ar_workspace()` function already handles the case where `_fi_ar_workspace` is `None`, so repeated calls are safe.
- Ctrl+C during vLLM serving should no longer produce `ImportError: sys.meta_path is None` tracebacks.