### PR TITLE
fix: check HTTP status in batch read_file to prevent silent failures

### DIFF
--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -320,6 +320,11 @@ class BatchProgressTracker:
 async def read_file(path_or_url: str) -> str:
     if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
         async with aiohttp.ClientSession() as session, session.get(path_or_url) as resp:
+            if resp.status != 200:
+                raise Exception(
+                    f"Failed to read file from URL: {path_or_url}. "
+                    f"Status: {resp.status}"
+                )
             return await resp.text()
     else:
         with open(path_or_url, encoding="utf-8") as f:

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -320,11 +320,7 @@ class BatchProgressTracker:
 async def read_file(path_or_url: str) -> str:
     if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
         async with aiohttp.ClientSession() as session, session.get(path_or_url) as resp:
-            if resp.status != 200:
-                raise Exception(
-                    f"Failed to read file from URL: {path_or_url}. "
-                    f"Status: {resp.status}"
-                )
+            resp.raise_for_status()
             return await resp.text()
     else:
         with open(path_or_url, encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- `read_file()` in `run_batch.py` did not check the HTTP response status when fetching batch input from a URL.
- On non-200 responses (404, 500, etc.), the error page HTML was silently returned as valid JSONL batch input, leading to confusing JSON parse failures downstream.
- Added a status check consistent with the existing `download_data()` function in the same file which already validates response status.

## Test plan
- [ ] Test batch processing with valid URL input
- [ ] Test with invalid/404 URLs to verify clear error message instead of JSON parse failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)