### PR TITLE
fix: handle model validation error in realtime WebSocket session.update

### DIFF
--- a/vllm/entrypoints/openai/realtime/connection.py
+++ b/vllm/entrypoints/openai/realtime/connection.py
@@ -102,7 +102,14 @@ class RealtimeConnection:
         event_type = event.get("type")
         if event_type == "session.update":
             logger.debug("Session updated: %s", event)
-            self._check_model(event["model"])
+            model = event.get("model")
+            error = self._check_model(model)
+            if error is not None:
+                await self.send_error(
+                    error.message,
+                    "invalid_model",
+                )
+                return
             self._is_model_validated = True
         elif event_type == "input_audio_buffer.append":
             append_event = InputAudioBufferAppend(**event)

--- a/vllm/entrypoints/openai/realtime/connection.py
+++ b/vllm/entrypoints/openai/realtime/connection.py
@@ -106,7 +106,7 @@ class RealtimeConnection:
             error = self._check_model(model)
             if error is not None:
                 await self.send_error(
-                    error.message,
+                    error.error.message,
                     "invalid_model",
                 )
                 return


### PR DESCRIPTION
## Summary
- `handle_event()` in `RealtimeConnection` called `_check_model()` but discarded the return value, unconditionally setting `_is_model_validated = True` even when the model was invalid.
- This allowed transcription to proceed with a nonexistent model, failing later with confusing errors.
- Now properly checks the return value and sends an error event to the client if the model is not found.
- Also switched from `event["model"]` to `event.get("model")` to prevent `KeyError` when the key is missing.

## Test plan
- [ ] Send `session.update` with valid model - verify transcription works
- [ ] Send `session.update` with invalid model - verify error event is returned and transcription is blocked
- [ ] Send `session.update` without `model` key - verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)