### PR TITLE
fix: guard against ZeroDivisionError in layerwise profiler

### DIFF
--- a/vllm/profiler/layerwise_profile.py
+++ b/vllm/profiler/layerwise_profile.py
@@ -252,7 +252,8 @@ class LayerwiseProfileResults(profile):
                 if cuda_time_us > 0:
                     logger.warning(
                         "cuda_time_us > 0 but total_cuda_time == 0, "
-                        "possible data inconsistency")
+                        "possible data inconsistency"
+                    )
                 return 0.0
             return (cuda_time_us / total_cuda_time) * 100
 

--- a/vllm/profiler/layerwise_profile.py
+++ b/vllm/profiler/layerwise_profile.py
@@ -245,6 +245,8 @@ class LayerwiseProfileResults(profile):
         total_cuda_time = self._total_cuda_time()
 
         def pct_cuda_time(cuda_time_us):
+            if total_cuda_time == 0:
+                return 0.0
             return (cuda_time_us / total_cuda_time) * 100
 
         def build_summary_stats_tree_df(

--- a/vllm/profiler/layerwise_profile.py
+++ b/vllm/profiler/layerwise_profile.py
@@ -12,6 +12,7 @@ from torch._C._profiler import _EventType, _ExperimentalConfig, _ProfilerEvent
 from torch.autograd.profiler import FunctionEvent
 from torch.profiler import ProfilerActivity, profile
 
+from vllm.logger import init_logger
 from vllm.profiler.utils import (
     TablePrinter,
     event_has_module,
@@ -21,6 +22,8 @@ from vllm.profiler.utils import (
     indent_string,
 )
 from vllm.utils.import_utils import PlaceholderModule
+
+logger = init_logger(__name__)
 
 try:
     import pandas as pd
@@ -246,6 +249,10 @@ class LayerwiseProfileResults(profile):
 
         def pct_cuda_time(cuda_time_us):
             if total_cuda_time == 0:
+                if cuda_time_us > 0:
+                    logger.warning(
+                        "cuda_time_us > 0 but total_cuda_time == 0, "
+                        "possible data inconsistency")
                 return 0.0
             return (cuda_time_us / total_cuda_time) * 100
 


### PR DESCRIPTION
## Summary
- `pct_cuda_time` in `layerwise_profile.py` divides by `total_cuda_time` without checking for zero.
- This crashes when profiling with no CUDA kernels recorded (e.g., CPU-only execution paths or empty profile traces).
- Added a zero-check to return 0.0 instead of raising `ZeroDivisionError`.

## Test plan
- [ ] Profile a model normally to verify no regression in percentage calculations
- [ ] Profile with CPU-only execution to verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)