### PR TITLE
fix(s3): paginate list_objects_v2 to return all objects

### DIFF
--- a/vllm/transformers_utils/s3_utils.py
+++ b/vllm/transformers_utils/s3_utils.py
@@ -82,17 +82,12 @@ def list_files(
     prefix = "/".join(parts[1:])
     bucket_name = parts[0]
 
-    paths = []
-    continuation_token = None
-    while True:
-        kwargs = {"Bucket": bucket_name, "Prefix": prefix}
-        if continuation_token is not None:
-            kwargs["ContinuationToken"] = continuation_token
-        objects = s3.list_objects_v2(**kwargs)
-        paths.extend(obj["Key"] for obj in objects.get("Contents", []))
-        if not objects.get("IsTruncated", False):
-            break
-        continuation_token = objects.get("NextContinuationToken")
+    paginator = s3.get_paginator("list_objects_v2")
+    paths = [
+        obj["Key"]
+        for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix)
+        for obj in page.get("Contents", [])
+    ]
 
     paths = _filter_ignore(paths, ["*/"])
     if allow_pattern is not None:

--- a/vllm/transformers_utils/s3_utils.py
+++ b/vllm/transformers_utils/s3_utils.py
@@ -82,8 +82,17 @@ def list_files(
     prefix = "/".join(parts[1:])
     bucket_name = parts[0]
 
-    objects = s3.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
-    paths = [obj["Key"] for obj in objects.get("Contents", [])]
+    paths = []
+    continuation_token = None
+    while True:
+        kwargs = {"Bucket": bucket_name, "Prefix": prefix}
+        if continuation_token is not None:
+            kwargs["ContinuationToken"] = continuation_token
+        objects = s3.list_objects_v2(**kwargs)
+        paths.extend(obj["Key"] for obj in objects.get("Contents", []))
+        if not objects.get("IsTruncated", False):
+            break
+        continuation_token = objects.get("NextContinuationToken")
 
     paths = _filter_ignore(paths, ["*/"])
     if allow_pattern is not None:


### PR DESCRIPTION
## Summary

Fix silent truncation of S3 file listings when a bucket prefix contains more than 1000 objects.

**The bug:** `list_files` in `s3_utils.py` calls `s3.list_objects_v2()` once and uses the result directly. The S3 `ListObjectsV2` API returns at most 1000 keys per response. When more than 1000 objects exist under the given prefix, the response is truncated and only the first 1000 keys are returned — with no warning or error.

This can cause model loading failures when weight files are stored in S3 with many shards (e.g., large models with 1000+ safetensors files, or buckets with checkpoint history under the same prefix). The `glob` function that depends on `list_files` would return an incomplete list, leading to missing weight files.

**Fix:** Loop with `ContinuationToken` until `IsTruncated` is `False`, accumulating all keys across pages.

## Test plan

- [ ] Test with an S3 bucket containing >1000 objects under a prefix
- [ ] Verify all files are returned by `list_files` and `glob`
- [ ] Verify behavior with <1000 objects is unchanged (single API call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)