### PR TITLE
fix(lora): fix variable shadowing in get_supported_lora_modules

### DIFF
--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -213,8 +213,8 @@ def get_supported_lora_modules(model: nn.Module) -> list[str]:
         # is not empty.
         embedding_modules = getattr(module, "embedding_modules", None)
         if embedding_modules is not None:
-            for name in embedding_modules:
-                supported_lora_modules.add(name)
+            for emb_name in embedding_modules:
+                supported_lora_modules.add(emb_name)
 
         # get all the linear subfixes.
         if isinstance(module, (LinearBase,)):


### PR DESCRIPTION
## Summary

Fix a variable shadowing bug in `get_supported_lora_modules` where the inner loop variable `name` overwrites the outer loop variable from `model.named_modules()`.

**The bug:** In `get_supported_lora_modules` (lora/utils.py), the code iterates over model modules with `for name, module in model.named_modules()`. Inside this loop, when `embedding_modules` is found on a module, it iterates with `for name in embedding_modules` — reusing the same variable `name`.

After the inner loop finishes, `name` no longer holds the module's fully-qualified path (e.g., `"model.layers.0.self_attn.q_proj"`) but instead holds the last key from the `embedding_modules` dict (e.g., `"embed_tokens"`). The subsequent `isinstance(module, LinearBase)` and `isinstance(module, FusedMoE)` checks then call `name.split(".")[-1]` on this wrong value, potentially adding incorrect module names to the supported LoRA modules set.

**Fix:** Rename the inner loop variable from `name` to `emb_name` to avoid shadowing.

## Test plan

- [ ] Existing LoRA unit tests pass
- [ ] Verify `get_supported_lora_modules` returns correct module names for models with embedding modules (e.g., multimodal models with `embed_tokens`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)