### PR TITLE
logging: opt-in per-rank log files (Ray-friendly) (#23761)

### DIFF
--- a/docs/serving/distributed_troubleshooting.md
+++ b/docs/serving/distributed_troubleshooting.md
@@ -14,3 +14,16 @@ The error message `Error: No available node types can fulfill resource request` 
 
 Debugging a distributed system can be challenging due to the large scale and complexity. Ray provides a suite of tools to help monitor, debug, and optimize Ray applications and clusters. For more information about Ray observability, visit the [official Ray observability docs](https://docs.ray.io/en/latest/ray-observability/index.html). For more information about debugging Ray applications, visit the [Ray Debugging Guide](https://docs.ray.io/en/latest/ray-observability/user-guides/debug-apps/index.html). For information about troubleshooting Kubernetes clusters, see the
 [official KubeRay troubleshooting guide](https://docs.ray.io/en/latest/serve/advanced-guides/multi-node-gpu-troubleshooting.html).
+
+## Per-worker vLLM log files
+
+To keep one log file per distributed worker process, set `VLLM_LOGGING_FILE_DIR`
+on the driver and worker environments:
+
+```bash
+export VLLM_LOGGING_FILE_DIR=/tmp/vllm_logs
+```
+
+In Ray cluster scripts, pass it through each node's environment (for example,
+`-e VLLM_LOGGING_FILE_DIR=/tmp/vllm_logs` in
+`examples/online_serving/run_cluster.sh`).

--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -35,6 +35,8 @@ You can check if this is happening by trying the old defaults with `--generation
 If other strategies don't solve the problem, it's likely that the vLLM instance is stuck somewhere. You can use the following environment variables to help debug the issue:
 
 - `export VLLM_LOGGING_LEVEL=DEBUG` to turn on more logging.
+- `export VLLM_LOGGING_FILE_DIR=/tmp/vllm_logs` to write per-process log files
+  with rank and PID in the file name and rank in each log line.
 - `export VLLM_LOG_STATS_INTERVAL=1.` to get log statistics more frequently for tracking running queue, waiting queue and cache hit states.
 - `export CUDA_LAUNCH_BLOCKING=1` to identify which CUDA kernel is causing the problem.
 - `export NCCL_DEBUG=TRACE` to turn on more logging for NCCL.

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -103,6 +103,37 @@ def test_descendent_loggers_depend_on_and_propagate_logs_to_root_logger(monkeypa
     assert log_record.levelno == logging.INFO
 
 
+@pytest.mark.skip_global_cleanup
+def test_opt_in_per_rank_file_logging(monkeypatch, tmp_path):
+    monkeypatch.setenv("VLLM_CONFIGURE_LOGGING", "1")
+    monkeypatch.setenv("VLLM_LOGGING_COLOR", "1")
+    monkeypatch.setenv("VLLM_LOGGING_FILE_DIR", str(tmp_path))
+    monkeypatch.setenv("RANK", "7")
+
+    _configure_vllm_root_logger()
+
+    test_logger = init_logger(f"vllm.test_file_logger.{uuid4()}")
+    test_message = "per-rank file logging test"
+    test_logger.info(test_message)
+
+    for handler in logging.getLogger("vllm").handlers:
+        if isinstance(handler, logging.FileHandler):
+            handler.flush()
+
+    log_files = list(tmp_path.glob("vllm_*.log"))
+    assert len(log_files) == 1
+    assert log_files[0].name.endswith(f"_rank7_pid{os.getpid()}.log")
+
+    log_content = log_files[0].read_text(encoding="utf-8")
+    assert "[rank7]" in log_content
+    assert test_message in log_content
+    assert "\x1b[" not in log_content
+
+    # Restore the default logger configuration for subsequent tests.
+    monkeypatch.delenv("VLLM_LOGGING_FILE_DIR", raising=False)
+    _configure_vllm_root_logger()
+
+
 def test_logger_configuring_can_be_disabled(monkeypatch):
     """This test calls _configure_vllm_root_logger again to test custom logging
     config behavior, however mocks are used to ensure no changes in behavior or

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     VLLM_LOGGING_PREFIX: str = ""
     VLLM_LOGGING_STREAM: str = "ext://sys.stdout"
     VLLM_LOGGING_CONFIG_PATH: str | None = None
+    VLLM_LOGGING_FILE_DIR: str | None = None
     VLLM_LOGGING_COLOR: str = "auto"
     NO_COLOR: bool = False
     VLLM_LOG_STATS_INTERVAL: float = 10.0
@@ -664,6 +665,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_CONFIGURE_LOGGING", "1"))
     ),
     "VLLM_LOGGING_CONFIG_PATH": lambda: os.getenv("VLLM_LOGGING_CONFIG_PATH"),
+    # If set, vLLM writes per-process log files under this directory.
+    # Filenames include rank info and PID for distributed/Ray friendliness.
+    "VLLM_LOGGING_FILE_DIR": lambda: os.getenv("VLLM_LOGGING_FILE_DIR"),
     # this is used for configuring the default logging level
     "VLLM_LOGGING_LEVEL": lambda: os.getenv("VLLM_LOGGING_LEVEL", "INFO").upper(),
     # this is used for configuring the default logging stream
@@ -1746,6 +1750,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_LOGGING_PREFIX",
         "VLLM_LOGGING_STREAM",
         "VLLM_LOGGING_CONFIG_PATH",
+        "VLLM_LOGGING_FILE_DIR",
         "VLLM_LOGGING_COLOR",
         "VLLM_LOG_STATS_INTERVAL",
         "VLLM_DEBUG_LOG_API_SERVER_RESPONSE",

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Logging configuration for vLLM."""
 
+import copy
 import datetime
 import json
 import logging
 import os
+import socket
 import sys
 from collections.abc import Generator, Hashable
 from contextlib import contextmanager
@@ -13,14 +15,21 @@ from functools import lru_cache, partial
 from logging import Logger
 from logging.config import dictConfig
 from os import path
+from pathlib import Path
 from types import MethodType
 from typing import Any, Literal, cast
+
+import regex as re
 
 import vllm.envs as envs
 from vllm.logging_utils import ColoredFormatter, NewLineFormatter
 
 _FORMAT = (
     f"{envs.VLLM_LOGGING_PREFIX}%(levelname)s %(asctime)s "
+    "[%(fileinfo)s:%(lineno)d] %(message)s"
+)
+_FILE_FORMAT = (
+    f"{envs.VLLM_LOGGING_PREFIX}%(levelname)s %(asctime)s [%(rank_info)s] "
     "[%(fileinfo)s:%(lineno)d] %(message)s"
 )
 _DATE_FORMAT = "%m-%d %H:%M:%S"
@@ -156,6 +165,82 @@ _METHODS_TO_PATCH = {
 }
 
 
+class _RankInfoFilter(logging.Filter):
+    def __init__(self, rank_info: str):
+        super().__init__()
+        self._rank_info = rank_info
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.rank_info = self._rank_info
+        return True
+
+
+def _get_rank_info() -> str:
+    for key in ("RANK", "OMPI_COMM_WORLD_RANK", "PMI_RANK", "SLURM_PROCID"):
+        if value := os.getenv(key):
+            return f"rank{value}"
+    for key in ("LOCAL_RANK", "OMPI_COMM_WORLD_LOCAL_RANK", "SLURM_LOCALID"):
+        if value := os.getenv(key):
+            return f"local_rank{value}"
+    return "rank0"
+
+
+def _sanitize_for_filename(component: str) -> str:
+    sanitized = re.sub(r"[^a-zA-Z0-9_.-]+", "_", component).strip("._-")
+    return sanitized or "rank0"
+
+
+def _add_vllm_file_handler(logging_config: dict[str, dict[str, Any] | Any]) -> None:
+    if not envs.VLLM_LOGGING_FILE_DIR:
+        return
+
+    log_dir = Path(envs.VLLM_LOGGING_FILE_DIR)
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not create VLLM_LOGGING_FILE_DIR directory '{log_dir}': {exc}"
+        ) from exc
+
+    if not log_dir.is_dir():
+        raise RuntimeError(
+            f"VLLM_LOGGING_FILE_DIR must point to a directory, got: '{log_dir}'"
+        )
+
+    rank_info = _get_rank_info()
+    host_info = _sanitize_for_filename(socket.gethostname())
+    file_rank_info = _sanitize_for_filename(rank_info)
+    file_path = log_dir / f"vllm_{host_info}_{file_rank_info}_pid{os.getpid()}.log"
+
+    formatters = logging_config.setdefault("formatters", {})
+    formatters["vllm_file"] = {
+        "class": "vllm.logging_utils.NewLineFormatter",
+        "datefmt": _DATE_FORMAT,
+        "format": _FILE_FORMAT,
+    }
+
+    filters = logging_config.setdefault("filters", {})
+    filters["vllm_rank_info"] = {
+        "()": _RankInfoFilter,
+        "rank_info": rank_info,
+    }
+
+    handlers = logging_config.setdefault("handlers", {})
+    handlers["vllm_file"] = {
+        "class": "logging.FileHandler",
+        "formatter": "vllm_file",
+        "level": envs.VLLM_LOGGING_LEVEL,
+        "filename": str(file_path),
+        "encoding": "utf-8",
+        "filters": ["vllm_rank_info"],
+    }
+
+    logger_dict = logging_config.setdefault("loggers", {}).setdefault("vllm", {})
+    logger_handlers = logger_dict.setdefault("handlers", [])
+    if "vllm_file" not in logger_handlers:
+        cast(list[str], logger_handlers).append("vllm_file")
+
+
 def _configure_vllm_root_logger() -> None:
     logging_config: dict[str, dict[str, Any] | Any] = {}
 
@@ -168,7 +253,7 @@ def _configure_vllm_root_logger() -> None:
         )
 
     if envs.VLLM_CONFIGURE_LOGGING:
-        logging_config = DEFAULT_LOGGING_CONFIG
+        logging_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
 
         vllm_handler = logging_config["handlers"]["vllm"]
         # Refresh these values in case env vars have changed.
@@ -194,6 +279,9 @@ def _configure_vllm_root_logger() -> None:
                 type(custom_config).__name__,
             )
         logging_config = custom_config
+
+    if envs.VLLM_CONFIGURE_LOGGING and envs.VLLM_LOGGING_FILE_DIR:
+        _add_vllm_file_handler(logging_config)
 
     for formatter in logging_config.get("formatters", {}).values():
         # This provides backwards compatibility after #10134.


### PR DESCRIPTION
## Purpose

Adds opt-in per-rank/per-process file logging for distributed/Ray runs; this is also mentioned in #23761.

- New env var: `VLLM_LOGGING_FILE_DIR` (default `None`)
- No behavior change unless the env var is set
- When enabled:
  - add `FileHandler` to `vllm` logger
  - file name includes rank info + PID: `vllm_{rank_info}_pid{pid}.log`
  - every file log line includes `[rank_info]`
  - file logs use non-colored `NewLineFormatter`
  - ensure log dir exists (clear error if invalid)
- Stream logging remains unchanged

## Test Plan

- `pytest -q tests/test_logger.py::test_opt_in_per_rank_file_logging`

## Test Result

- Passed (`1 passed`)