### PR TITLE
[Feat] add rmsnorm fp4 quant fusion of flashinfer

### DIFF
--- a/benchmarks/fused_kernels/layernorm_rms_benchmarks.py
+++ b/benchmarks/fused_kernels/layernorm_rms_benchmarks.py
@@ -18,6 +18,20 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
 )
+from vllm.scalar_type import scalar_types
+from vllm.utils.flashinfer import flashinfer_fp4_quantize, has_flashinfer
+
+# FP4 constants
+FLOAT4_E2M1_MAX = scalar_types.float4_e2m1f.max()
+FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+# Check if FlashInfer fused rmsnorm+fp4quant ops are available
+flashinfer_rmsnorm_fp4quant_supported = has_flashinfer() and hasattr(
+    torch.ops.vllm, "flashinfer_rmsnorm_fp4quant"
+)
+flashinfer_add_rmsnorm_fp4quant_supported = has_flashinfer() and hasattr(
+    torch.ops.vllm, "flashinfer_add_rmsnorm_fp4quant"
+)
 
 
 @dataclass
@@ -60,6 +74,7 @@ def unfused_int8_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     # Norm
     torch_out = None
@@ -78,6 +93,7 @@ def unfused_fp8_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     # Norm
     torch_out = None
@@ -96,6 +112,7 @@ def unfused_groupwise_fp8_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     # Norm
     torch_out = None
@@ -116,6 +133,7 @@ def fused_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     out, _ = ops.rms_norm_dynamic_per_token_quant(
         x, rms_norm_layer.weight, 1e-6, quant_dtype, residual=residual
@@ -128,6 +146,7 @@ def fused_groupwise_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     out, _ = ops.rms_norm_per_block_quant(
         x,
@@ -138,6 +157,87 @@ def fused_groupwise_impl(
         residual=residual,
         is_scale_transposed=True,
     )
+
+
+def get_fp4_output_tensors(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Allocate output tensors for FP4 quantization."""
+    m, n = x.shape
+    block_size = 16
+    # Two fp4 values will be packed into an uint8.
+    output = torch.empty((m, n // 2), device=x.device, dtype=torch.uint8)
+    # Swizzled scale layout for 128x4 tiles
+    round_up = lambda x, y: (x + y - 1) // y * y
+    rounded_m = round_up(m, 128)
+    scale_n = n // block_size
+    rounded_n = round_up(scale_n, 4)
+    output_scale = torch.empty(
+        (rounded_m, rounded_n // 4), device=x.device, dtype=torch.int32
+    )
+    return output, output_scale
+
+
+def unfused_flashinfer_nvfp4_impl(
+    rms_norm_layer: RMSNorm,
+    x: torch.Tensor,
+    residual: torch.Tensor | None,
+    quant_dtype: torch.dtype,
+    group_size: list[int],
+    global_scale: torch.Tensor | None = None,
+    **kwargs,
+):
+    """Unfused RMSNorm + FlashInfer FP4 quantization."""
+    # Norm
+    torch_out = None
+    if residual is None:
+        torch_out = rms_norm_layer.forward_cuda(x, residual)
+    else:
+        torch_out, _ = rms_norm_layer.forward_cuda(x, residual)
+
+    if global_scale is None:
+        global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.abs(
+            torch_out
+        ).max().to(torch.float32)
+
+    flashinfer_fp4_quantize(torch_out, global_scale)
+
+
+def fused_flashinfer_nvfp4_impl(
+    rms_norm_layer: RMSNorm,
+    x: torch.Tensor,
+    residual: torch.Tensor | None,
+    quant_dtype: torch.dtype,
+    group_size: list[int],
+    global_scale: torch.Tensor | None = None,
+    **kwargs,
+):
+    """Fused FlashInfer RMSNorm + FP4 quantization."""
+    if global_scale is None:
+        torch_out_ref = rms_norm_layer.forward_cuda(x, None)
+        global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.abs(
+            torch_out_ref
+        ).max().to(torch.float32)
+
+    output_quant, output_scale = get_fp4_output_tensors(x)
+
+    if residual is None:
+        torch.ops.vllm.flashinfer_rmsnorm_fp4quant(
+            output_quant,
+            output_scale,
+            x,
+            rms_norm_layer.weight,
+            global_scale,
+            1e-6,
+        )
+    else:
+        torch.ops.vllm.flashinfer_add_rmsnorm_fp4quant(
+            output_quant,
+            output_scale,
+            residual,
+            x,
+            rms_norm_layer.weight,
+            global_scale,
+            1e-6,
+        )
 
 
 # Bench functions
@@ -151,6 +251,7 @@ def bench_fn(
     sub_label: str,
     fn: Callable,
     description: str,
+    global_scale: torch.Tensor | None = None,
 ) -> TMeasurement:
     min_run_time = 1
 
@@ -160,10 +261,12 @@ def bench_fn(
         "residual": residual,
         "quant_dtype": quant_dtype,
         "group_size": group_size,
+        "global_scale": global_scale,
         "fn": fn,
     }
     return TBenchmark.Timer(
-        stmt="fn(rms_norm_layer, x, residual, quant_dtype, group_size)",
+        stmt="fn(rms_norm_layer, x, residual, quant_dtype,"
+        " group_size, global_scale=global_scale)",
         globals=globals,
         label=label,
         sub_label=sub_label,
@@ -279,6 +382,57 @@ def bench(params: bench_params_t, label: str, sub_label: str) -> Iterable[TMeasu
             "fused_groupwise_fp8_impl",
         )
     )
+
+    # NVFP4 benchmarks (only if supported, hidden_size is multiple of 16,
+    # and dtype is fp16/bf16 - NVFP4 does not support float32)
+    if params.hidden_size % 16 == 0 and params.dtype in (torch.float16, torch.bfloat16):
+        # Pre-compute global_scale ONCE before benchmark loop
+        # This simulates real inference where global_scale is calibrated offline
+        with torch.no_grad():
+            torch_out_ref = layer.forward_cuda(x, None)
+            nvfp4_global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.abs(
+                torch_out_ref
+            ).max().to(torch.float32)
+
+        # FlashInfer NVFP4 benchmarks
+        if (
+            flashinfer_rmsnorm_fp4quant_supported
+            or flashinfer_add_rmsnorm_fp4quant_supported
+        ):
+            # unfused flashinfer nvfp4 impl.
+            timers.append(
+                bench_fn(
+                    layer,
+                    x,
+                    residual,
+                    torch.uint8,
+                    params.group_size,
+                    label,
+                    sub_label,
+                    unfused_flashinfer_nvfp4_impl,
+                    "unfused_flashinfer_nvfp4_impl",
+                    global_scale=nvfp4_global_scale,
+                )
+            )
+
+        if (not params.add_residual and flashinfer_rmsnorm_fp4quant_supported) or (
+            params.add_residual and flashinfer_add_rmsnorm_fp4quant_supported
+        ):
+            # fused flashinfer nvfp4 impl
+            timers.append(
+                bench_fn(
+                    layer,
+                    x,
+                    residual,
+                    torch.uint8,
+                    params.group_size,
+                    label,
+                    sub_label,
+                    fused_flashinfer_nvfp4_impl,
+                    "fused_flashinfer_nvfp4_impl",
+                    global_scale=nvfp4_global_scale,
+                )
+            )
 
     print_timers(timers)
 

--- a/docs/design/fusions.md
+++ b/docs/design/fusions.md
@@ -38,19 +38,19 @@ The table below lists the quantization schemes supported by each fusion on each 
 **—** means the fusion is not available on that platform. The latest and in-progress work is available in the tracking issue:
 [#36066](https://github.com/vllm-project/vllm/issues/36066)
 
-| Fusion                       | SM100 (Blackwell)                        | SM90 (Hopper)                            | SM89 (Ada)                               | SM80 (Ampere) | ROCm                                     |
-| ---------------------------- | ---------------------------------------- | ---------------------------------------- | ---------------------------------------- | ------------- | ---------------------------------------- |
-| `fuse_allreduce_rms`         | FP16/BF16, FP8 static, NVFP4             | FP16/BF16, FP8 static                    | —                                        | —             | —                                        |
-| `fuse_minimax_qk_norm`\*     | FP16/BF16                                | FP16/BF16                                | FP16/BF16                                | FP16/BF16     | —                                        |
-| `fuse_attn_quant`\*          | FP8 static\*, NVFP4\*                    | FP8 static\*                             | FP8 static\*                             | —             | FP8 static\*                             |
-| `fuse_attn_quant` (MLA)\*    | FP8 static\*, NVFP4\*                    | FP8 static\*                             | FP8 static\*                             | —             | FP8 static(untested)\*                   |
-| `fuse_rope_kvcache`          | —                                        | —                                        | —                                        | —             | FP16/BF16                                |
-| `enable_qk_norm_rope_fusion` | FP16/BF16                                | FP16/BF16                                | FP16/BF16†                               | FP16/BF16†    | —                                        |
-| `enable_sp`                  | FP16/BF16, FP8 static†                   | FP16/BF16, FP8 static                    | FP16/BF16†                               | FP16/BF16†    | —                                        |
-| `fuse_gemm_comms`            | FP16/BF16, FP8 static†                   | FP16/BF16, FP8 static                    | FP16/BF16†                               | FP16/BF16†    | —                                        |
-| `fuse_norm_quant`            | FP8 static, FP8 per-token, FP8 per-group | FP8 static, FP8 per-token, FP8 per-group | FP8 static, FP8 per-token, FP8 per-group | —             | FP8 static, FP8 per-token, FP8 per-group |
-| `fuse_act_quant`             | FP8 static, NVFP4                        | FP8 static, FP8 per-group (128/64)       | FP8 static, FP8 per-group (128/64)       | —             | FP8 per-group                            |
-| `fuse_act_padding`           | —                                        | —                                        | —                                        | —             | FP16/BF16                                |
+| Fusion                       | SM100 (Blackwell)                                | SM90 (Hopper)                            | SM89 (Ada)                               | SM80 (Ampere) | ROCm                                     |
+| ---------------------------- | ------------------------------------------------ | ---------------------------------------- | ---------------------------------------- | ------------- | ---------------------------------------- |
+| `fuse_allreduce_rms`         | FP16/BF16, FP8 static, NVFP4                     | FP16/BF16, FP8 static                    | —                                        | —             | —                                        |
+| `fuse_minimax_qk_norm`\*     | FP16/BF16                                        | FP16/BF16                                | FP16/BF16                                | FP16/BF16     | —                                        |
+| `fuse_attn_quant`\*          | FP8 static\*, NVFP4\*                            | FP8 static\*                             | FP8 static\*                             | —             | FP8 static\*                             |
+| `fuse_attn_quant` (MLA)\*    | FP8 static\*, NVFP4\*                            | FP8 static\*                             | FP8 static\*                             | —             | FP8 static(untested)\*                   |
+| `fuse_rope_kvcache`          | —                                                | —                                        | —                                        | —             | FP16/BF16                                |
+| `enable_qk_norm_rope_fusion` | FP16/BF16                                        | FP16/BF16                                | FP16/BF16†                               | FP16/BF16†    | —                                        |
+| `enable_sp`                  | FP16/BF16, FP8 static†                           | FP16/BF16, FP8 static                    | FP16/BF16†                               | FP16/BF16†    | —                                        |
+| `fuse_gemm_comms`            | FP16/BF16, FP8 static†                           | FP16/BF16, FP8 static                    | FP16/BF16†                               | FP16/BF16†    | —                                        |
+| `fuse_norm_quant`            | FP8 static, FP8 per-token, FP8 per-group, NVFP4‡ | FP8 static, FP8 per-token, FP8 per-group | FP8 static, FP8 per-token, FP8 per-group | —             | FP8 static, FP8 per-token, FP8 per-group |
+| `fuse_act_quant`             | FP8 static, NVFP4                                | FP8 static, FP8 per-group (128/64)       | FP8 static, FP8 per-group (128/64)       | —             | FP8 per-group                            |
+| `fuse_act_padding`           | —                                                | —                                        | —                                        | —             | FP16/BF16                                |
 
 \* `fuse_attn_quant` support depends on the attention backend in use; not all backends support
 fused quantization output. See the [`fuse_attn_quant` section](#attention--quantization-fuse_attn_quant)
@@ -62,6 +62,10 @@ tensor parallelism (`tp_size > 1`) and the CUDA custom op `minimax_allreduce_rms
 † `enable_sp` and `fuse_gemm_comms` are only autoconfigured for SM90 today;
 other architectures support requires setting `PassConfig.sp_min_token_num` explicitly.
 SM100 support also requires setting `VLLM_DISABLED_KERNELS=FlashInferFP8ScaledMMLinearKernel`.
+
+‡ NVFP4 support for `fuse_norm_quant` uses FlashInfer kernels and is currently
+**disabled by default** at all optimization levels while performance is being
+tuned. To enable it manually, set `PassConfig(fuse_norm_quant=True)`.
 
 ## Enabling / Disabling Fusions
 
@@ -318,6 +322,11 @@ Supported hardware: CUDA (sm80+) only, tested only on sm90 and sm100.
     On NVIDIA, Inductor actually generates a faster fused kernel than our custom CUDA kernel.
     Hence, this fusion is only enabled when either `rms_norm` or `quant_fp8` is using a custom kernel.
 
+!!! info
+    NVFP4 support is available but **disabled by default** at all optimization levels while
+    kernel performance is being tuned. To experiment with the FlashInfer NVFP4 fused kernels,
+    set `PassConfig(fuse_norm_quant=True)` explicitly. Requires SM100+ (Blackwell) and FlashInfer.
+
 **What it fuses.** Combines the custom `rms_norm` / `fused_add_rms_norm`
 operations with subsequent quantization into a single fused kernel,
 eliminating an intermediate read/write of the full-precision activation tensor.
@@ -326,6 +335,12 @@ Two variants are fused:
 - *Plain RMSNorm + quant*: `rms_norm(x) → quant_fp8(y)`
 - *Fused-add RMSNorm + quant*: `fused_add_rms_norm(x, residual) → quant_fp8(y)` — also updates the residual in-place.
 
+For NVFP4-quantized models on SM100+ with FlashInfer, two additional patterns
+are matched:
+
+- *Plain RMSNorm + NVFP4 quant*: `rms_norm(x) → scaled_fp4_quant(y)` — replaced by `flashinfer_rmsnorm_fp4quant`
+- *Fused-add RMSNorm + NVFP4 quant*: `fused_add_rms_norm(x, residual) → scaled_fp4_quant(y)` — replaced by `flashinfer_add_rmsnorm_fp4quant`, also updates the residual in-place.
+
 Note that AITER fusions are currently in a separate pass in `vllm.compilation.passes.fusion.rocm_aiter_fusion`.
 
 Supported quantization scheme/hardware combinations:
@@ -333,12 +348,14 @@ Supported quantization scheme/hardware combinations:
 - FP8 static per-tensor: CUDA & HIP kernel
 - FP8 dynamic per-token: CUDA & HIP kernel, AITER
 - FP8 dynamic per-token-group (128/64): CUDA & HIP kernel, AITER
+- NVFP4 dynamic: CUDA sm100+ with FlashInfer (disabled by default)
 
 **Code locations.**
 
 - Pass: [`vllm/compilation/passes/fusion/rms_quant_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/rms_quant_fusion.py)
 - ROCm AITER pass: [`vllm/compilation/passes/fusion/rocm_aiter_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/rocm_aiter_fusion.py)
 - CUDA/HIP kernels: [`csrc/layernorm_quant_kernels.cu`](https://github.com/vllm-project/vllm/blob/main/csrc/layernorm_quant_kernels.cu)
+- FlashInfer NVFP4 kernels: [`vllm/utils/flashinfer.py`](https://github.com/vllm-project/vllm/blob/main/vllm/utils/flashinfer.py) (`flashinfer_rmsnorm_fp4quant`, `flashinfer_add_rmsnorm_fp4quant`)
 
 ### SiLU+Mul + Quantization (`fuse_act_quant`)
 

--- a/tests/compile/fusions_e2e/models.py
+++ b/tests/compile/fusions_e2e/models.py
@@ -92,11 +92,10 @@ llama3_8b_fp8 = ModelFusionInfo(
 llama3_8b_fp4 = ModelFusionInfo(
     model_name="nvidia/Llama-3.1-8B-Instruct-FP4",
     matches=lambda n_layers: Matches(
+        rms_quant_fusion=n_layers * 2,
         act_quant_fusion=n_layers,
         attn_quant_fusion=n_layers,
         ar_rms_fusion=n_layers * 2 + 1,
-        sequence_parallel=n_layers * 2 + 1,
-        async_tp=n_layers * 4,
     ),
 )
 
@@ -121,10 +120,9 @@ llama4_scout_fp4 = ModelFusionInfo(
     model_name="nvidia/Llama-4-Scout-17B-16E-Instruct-NVFP4",
     hf_overrides=lambda n_layers: {"text_config": {"num_hidden_layers": n_layers}},
     matches=lambda n_layers: Matches(
+        rms_quant_fusion=n_layers,
         attn_quant_fusion=n_layers,
         ar_rms_fusion=n_layers * 2,
-        sequence_parallel=n_layers * 2,
-        async_tp=n_layers * 2 - 1,
     ),
 )
 

--- a/tests/compile/fusions_e2e/test_tp1_quant.py
+++ b/tests/compile/fusions_e2e/test_tp1_quant.py
@@ -188,7 +188,12 @@ def test_tp1_fp4_fusions(
         ),
     )
 
-    matches_check = ["act_quant_fusion", "attn_quant_fusion", "norm_rope_fusion"]
+    matches_check = [
+        "rms_quant_fusion",
+        "act_quant_fusion",
+        "attn_quant_fusion",
+        "norm_rope_fusion",
+    ]
 
     run_e2e_fusion_test(
         model_name,

--- a/tests/compile/fusions_e2e/test_tp2_ar_rms.py
+++ b/tests/compile/fusions_e2e/test_tp2_ar_rms.py
@@ -147,6 +147,7 @@ def test_tp2_ar_rms_fp4_fusions(
         use_inductor_graph_partition=inductor_graph_partition,
         custom_ops=custom_ops.split(","),
         pass_config=PassConfig(
+            fuse_norm_quant=True,
             fuse_act_quant=True,
             fuse_attn_quant=True,
             fuse_allreduce_rms=True,
@@ -154,6 +155,7 @@ def test_tp2_ar_rms_fp4_fusions(
     )
 
     matches_check = [
+        "rms_quant_fusion",
         "act_quant_fusion",
         "attn_quant_fusion",
         "ar_rms_fusion",

--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -59,6 +59,7 @@ from vllm.utils.deep_gemm import (
 
 FP8_DTYPE = current_platform.fp8_dtype()
 
+RMS_OP = torch.ops._C.rms_norm.default
 RMS_ADD_OP = torch.ops._C.fused_add_rms_norm.default
 
 # Kernel and group_shape combinations: (kernel, group_shape)
@@ -314,10 +315,8 @@ class TestNvfp4Model(torch.nn.Module):
         ]
 
     def ops_in_model_before_partial(self):
-        return (
-            [torch.ops.vllm_ir.rms_norm, RMS_ADD_OP]
-            if self.enable_rms_norm_custom_op
-            else [torch.ops.aten.rsqrt]
+        return [torch.ops.vllm_ir.rms_norm] + (
+            [RMS_ADD_OP] if self.enable_rms_norm_custom_op else [torch.ops.aten.rsqrt]
         )
 
 
@@ -485,7 +484,10 @@ def test_fusion_rmsnorm_nvfp4_quant(
         ),
     )
 
-    with vllm.config.set_current_vllm_config(vllm_config):
+    with (
+        vllm.config.set_current_vllm_config(vllm_config),
+        vllm_config.kernel_config.ir_op_priority.set_priority(),
+    ):
         torch.set_default_device("cuda")
         torch.set_default_dtype(dtype)
         torch.manual_seed(1)

--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -9,8 +9,10 @@ import vllm.config
 import vllm.ir.ops
 import vllm.plugins
 from tests.compile.backend import TestBackend
+from tests.kernels.quantization.nvfp4_utils import quant_nvfp4_tensor
 from tests.utils import TestFP8Layer
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
+from vllm._custom_ops import cutlass_scaled_fp4_mm, scaled_fp4_quant
 from vllm.compilation.passes.fusion.matcher_utils import QUANT_OPS
 from vllm.compilation.passes.fusion.rms_quant_fusion import (
     FUSED_OPS,
@@ -45,6 +47,7 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     create_fp8_quant_key,
+    kNvfp4Dynamic,
 )
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     cutlass_block_fp8_supported,
@@ -247,6 +250,77 @@ class TestModel(torch.nn.Module):
         )
 
 
+class TestNvfp4Model(torch.nn.Module):
+    def __init__(self, hidden_size: int, eps: float):
+        super().__init__()
+        self.norm = [RMSNorm(hidden_size, eps) for _ in range(4)]
+        self.enable_rms_norm_custom_op = self.norm[0].enabled()
+
+        self.w = [torch.rand((hidden_size, hidden_size)) for _ in range(3)]
+        self.agscale = [torch.rand((1, 1), dtype=torch.float32) for _ in range(3)]
+
+        w_quant = [quant_nvfp4_tensor(w) for w in self.w]
+        self.wq = [q[0] for q in w_quant]
+        self.wscale = [q[1] for q in w_quant]
+        wgscale = [q[2] for q in w_quant]
+        self.alpha = [(1 / (w * a)).reshape(1) for w, a in zip(wgscale, self.agscale)]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = resid = torch.relu(x)
+        y = self.norm[0](x)
+
+        yq, y_scale = scaled_fp4_quant(y, self.agscale[0])
+        x2 = cutlass_scaled_fp4_mm(
+            yq,
+            self.wq[0],
+            y_scale,
+            self.wscale[0],
+            self.alpha[0],
+            out_dtype=y.dtype,
+        )
+
+        y2, resid = self.norm[1](x2, resid)
+        yq2, y_scale2 = scaled_fp4_quant(y2, self.agscale[1])
+        x3 = cutlass_scaled_fp4_mm(
+            yq2,
+            self.wq[1],
+            y_scale2,
+            self.wscale[1],
+            self.alpha[1],
+            out_dtype=y2.dtype,
+        )
+
+        y3, resid = self.norm[2](x3, resid)
+        yq3, y_scale3 = scaled_fp4_quant(y3, self.agscale[2])
+        x4 = cutlass_scaled_fp4_mm(
+            yq3,
+            self.wq[2],
+            y_scale3,
+            self.wscale[2],
+            self.alpha[2],
+            out_dtype=y3.dtype,
+        )
+
+        y4, _ = self.norm[3](x4, resid)
+        return y4
+
+    def ops_in_model_before(self):
+        return [QUANT_OPS[kNvfp4Dynamic]]
+
+    def ops_in_model_after(self):
+        return [
+            torch.ops.vllm.flashinfer_rmsnorm_fp4quant.default,
+            torch.ops.vllm.flashinfer_add_rmsnorm_fp4quant.default,
+        ]
+
+    def ops_in_model_before_partial(self):
+        return (
+            [torch.ops.vllm_ir.rms_norm, RMS_ADD_OP]
+            if self.enable_rms_norm_custom_op
+            else [torch.ops.aten.rsqrt]
+        )
+
+
 def _run_fusion_test(
     model,
     fusion_pass,
@@ -372,6 +446,76 @@ def test_fusion_rmsnorm_quant(
             # 6 = 3x2 (3xRMS_ADD, 2 each)
             assert n_add_nodes(backend.graph_pre_pass) == 6
             assert n_add_nodes(backend.graph_post_pass) == 2
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("hidden_size", [256])
+@pytest.mark.parametrize("num_tokens", [257])
+@pytest.mark.parametrize("eps", [1e-5, 1e-6])
+@pytest.mark.parametrize("enable_rms_norm_custom_op", [True, False])
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA only")
+def test_fusion_rmsnorm_nvfp4_quant(
+    dtype: torch.dtype,
+    hidden_size: int,
+    num_tokens: int,
+    eps: float,
+    enable_rms_norm_custom_op: bool,
+):
+    if not hasattr(torch.ops._C, "scaled_fp4_quant"):
+        pytest.skip("scaled_fp4_quant is not available")
+    if not current_platform.has_device_capability(100):
+        pytest.skip("NVFP4 is only supported on Blackwell")
+    if not hasattr(torch.ops, "vllm") or not hasattr(
+        torch.ops.vllm, "flashinfer_rmsnorm_fp4quant"
+    ):
+        pytest.skip("flashinfer_rmsnorm_fp4quant is not available")
+    if not hasattr(torch.ops.vllm, "flashinfer_add_rmsnorm_fp4quant"):
+        pytest.skip("flashinfer_add_rmsnorm_fp4quant is not available")
+
+    custom_ops = ["none"]
+    if enable_rms_norm_custom_op:
+        custom_ops.append("+rms_norm")
+
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(dtype=dtype),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            custom_ops=custom_ops,
+            pass_config=PassConfig(fuse_norm_quant=True, eliminate_noops=True),
+        ),
+    )
+
+    with vllm.config.set_current_vllm_config(vllm_config):
+        torch.set_default_device("cuda")
+        torch.set_default_dtype(dtype)
+        torch.manual_seed(1)
+
+        fusion_pass = RMSNormQuantFusionPass(vllm_config)
+        noop_pass = NoOpEliminationPass(vllm_config)
+        cleanup_pass = PostCleanupPass(vllm_config)
+
+        backend = TestBackend(noop_pass, fusion_pass, cleanup_pass)
+        backend2 = TestBackend(noop_pass, cleanup_pass)
+
+        model = TestNvfp4Model(hidden_size=hidden_size, eps=eps)
+
+        x = torch.rand(num_tokens, hidden_size)
+        torch._dynamo.mark_dynamic(x, 0)
+
+        model_fused = torch.compile(model, backend=backend)
+        result_fused = model_fused(x)
+
+        model_unfused = torch.compile(model, backend=backend2)
+        result_unfused = model_unfused(x)
+
+        torch.testing.assert_close(result_fused, result_unfused, atol=2e-1, rtol=2e-1)
+
+        assert fusion_pass.matched_count == 3
+        backend.check_before_ops(model.ops_in_model_before())
+        backend.check_after_ops(model.ops_in_model_after())
+        backend.check_before_ops(
+            model.ops_in_model_before_partial(), fully_replaced=False
+        )
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16])

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -621,7 +621,7 @@ class RMSNormNvfp4QuantPattern:
         input = torch.empty(5, 16, dtype=self.model_dtype, device=self.device)
         weight = torch.empty(16, dtype=self.model_dtype, device=self.device)
         quant_result = torch.empty(5, 8, dtype=FP4_DTYPE, device=self.device)
-        output_scale = torch.empty(128, 4, dtype=torch.int32, device=self.device)
+        output_scale = torch.empty(128, 1, dtype=torch.int32, device=self.device)
         input_scale = torch.empty(1, 1, dtype=torch.float32, device=self.device)
         return [quant_result, output_scale, input, weight, input_scale]
 
@@ -687,7 +687,7 @@ class FusedAddRMSNormNvfp4QuantPattern:
         weight = torch.empty(16, dtype=self.model_dtype, device=self.device)
         residual = torch.empty(5, 16, dtype=self.model_dtype, device=self.device)
         quant_result = torch.empty(5, 8, dtype=FP4_DTYPE, device=self.device)
-        output_scale = torch.empty(128, 4, dtype=torch.int32, device=self.device)
+        output_scale = torch.empty(128, 1, dtype=torch.int32, device=self.device)
         input_scale = torch.empty(1, 1, dtype=torch.float32, device=self.device)
         return [quant_result, output_scale, input, weight, residual, input_scale]
 

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -615,7 +615,6 @@ class RMSNormNvfp4QuantPattern:
         config = get_current_vllm_config()
         self.model_dtype = config.model_config.dtype if config.model_config else None
         self.device = config.device_config.device if config.device_config else None
-        self.rmsnorm_matcher = MatcherRMSNorm(epsilon)
 
     def get_inputs(self) -> list[torch.Tensor]:
         input = torch.empty(5, 16, dtype=self.model_dtype, device=self.device)
@@ -636,7 +635,7 @@ class RMSNormNvfp4QuantPattern:
             weight: torch.Tensor,
             input_scale: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor]:
-            rms_out = self.rmsnorm_matcher(input, weight)
+            rms_out = vllm.ir.ops.rms_norm(input, weight, self.epsilon)
             at = auto_functionalized(
                 STATIC_FP4_QUANT_OP,
                 output=quant_result,

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -131,7 +131,7 @@ FUSED_OPS: dict[FusedRMSQuantKey, OpOverload] = {
 
 STATIC_FP4_QUANT_OP: OpOverload | None = None
 if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
-    STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.default
+    STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.out
 
 FLASHINFER_RMSNORM_FP4QUANT_OP: OpOverload | None = None
 FLASHINFER_ADD_RMSNORM_FP4QUANT_OP: OpOverload | None = None

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -638,11 +638,11 @@ class RMSNormNvfp4QuantPattern:
             rms_out = vllm.ir.ops.rms_norm(input, weight, self.epsilon)
             at = auto_functionalized(
                 STATIC_FP4_QUANT_OP,
-                output=quant_result,
                 input=rms_out,
-                output_scale=output_scale,
                 input_scale=input_scale,
                 is_sf_swizzled_layout=True,
+                output=quant_result,
+                output_scale=output_scale,
             )
             return at[1], at[2]
 
@@ -705,11 +705,11 @@ class FusedAddRMSNormNvfp4QuantPattern:
             rms_out, residual = self.rmsnorm_matcher(input, weight, residual)
             at = auto_functionalized(
                 STATIC_FP4_QUANT_OP,
-                output=quant_result,
                 input=rms_out,
-                output_scale=output_scale,
                 input_scale=input_scale,
                 is_sf_swizzled_layout=True,
+                output=quant_result,
+                output_scale=output_scale,
             )
             return at[1], at[2], residual
 

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kStaticTensorScale,
 )
 from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer
 
 from ..inductor_pass import enable_fake_mode
 from ..vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
@@ -127,6 +128,22 @@ FUSED_OPS: dict[FusedRMSQuantKey, OpOverload] = {
         kFp8Dynamic64Sym, True
     ): torch.ops._C.rms_norm_per_block_quant.default,  # noqa: E501
 }
+
+STATIC_FP4_QUANT_OP: OpOverload | None = None
+if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
+    STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.default
+
+FLASHINFER_RMSNORM_FP4QUANT_OP: OpOverload | None = None
+FLASHINFER_ADD_RMSNORM_FP4QUANT_OP: OpOverload | None = None
+if has_flashinfer() and hasattr(torch.ops, "vllm"):
+    if hasattr(torch.ops.vllm, "flashinfer_rmsnorm_fp4quant"):
+        FLASHINFER_RMSNORM_FP4QUANT_OP = (
+            torch.ops.vllm.flashinfer_rmsnorm_fp4quant.default
+        )
+    if hasattr(torch.ops.vllm, "flashinfer_add_rmsnorm_fp4quant"):
+        FLASHINFER_ADD_RMSNORM_FP4QUANT_OP = (
+            torch.ops.vllm.flashinfer_add_rmsnorm_fp4quant.default
+        )
 
 
 class RMSNormQuantPattern:
@@ -590,6 +607,140 @@ class FusedAddRMSNormDynamicQuantPattern(RMSNormQuantPattern):
         )
 
 
+class RMSNormNvfp4QuantPattern:
+    """Fuses RMSNorm + scaled_fp4_quant into flashinfer_rmsnorm_fp4quant."""
+
+    def __init__(self, epsilon: float) -> None:
+        self.epsilon = epsilon
+        config = get_current_vllm_config()
+        self.model_dtype = config.model_config.dtype if config.model_config else None
+        self.device = config.device_config.device if config.device_config else None
+        self.rmsnorm_matcher = MatcherRMSNorm(epsilon)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        input = torch.empty(5, 16, dtype=self.model_dtype, device=self.device)
+        weight = torch.empty(16, dtype=self.model_dtype, device=self.device)
+        quant_result = torch.empty(5, 8, dtype=FP4_DTYPE, device=self.device)
+        output_scale = torch.empty(128, 4, dtype=torch.int32, device=self.device)
+        input_scale = torch.empty(1, 1, dtype=torch.float32, device=self.device)
+        return [quant_result, output_scale, input, weight, input_scale]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        assert STATIC_FP4_QUANT_OP is not None
+        assert FLASHINFER_RMSNORM_FP4QUANT_OP is not None
+
+        def pattern(
+            quant_result: torch.Tensor,
+            output_scale: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            input_scale: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            rms_out = self.rmsnorm_matcher(input, weight)
+            at = auto_functionalized(
+                STATIC_FP4_QUANT_OP,
+                output=quant_result,
+                input=rms_out,
+                output_scale=output_scale,
+                input_scale=input_scale,
+                is_sf_swizzled_layout=True,
+            )
+            return at[1], at[2]
+
+        def replacement(
+            quant_result: torch.Tensor,
+            output_scale: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            input_scale: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            input = input.to(dtype=self.model_dtype)
+            at = auto_functionalized(
+                FLASHINFER_RMSNORM_FP4QUANT_OP,
+                output=quant_result,
+                output_scale=output_scale,
+                input=input,
+                weight=weight,
+                global_scale=input_scale,
+                epsilon=self.epsilon,
+            )
+            return at[1], at[2]
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class FusedAddRMSNormNvfp4QuantPattern:
+    """Fuses FusedAddRMSNorm + scaled_fp4_quant into
+    flashinfer_add_rmsnorm_fp4quant."""
+
+    def __init__(self, epsilon: float) -> None:
+        self.epsilon = epsilon
+        config = get_current_vllm_config()
+        self.model_dtype = config.model_config.dtype if config.model_config else None
+        self.device = config.device_config.device if config.device_config else None
+        self.rmsnorm_matcher = MatcherFusedAddRMSNorm(epsilon)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        input = torch.empty(5, 16, dtype=self.model_dtype, device=self.device)
+        weight = torch.empty(16, dtype=self.model_dtype, device=self.device)
+        residual = torch.empty(5, 16, dtype=self.model_dtype, device=self.device)
+        quant_result = torch.empty(5, 8, dtype=FP4_DTYPE, device=self.device)
+        output_scale = torch.empty(128, 4, dtype=torch.int32, device=self.device)
+        input_scale = torch.empty(1, 1, dtype=torch.float32, device=self.device)
+        return [quant_result, output_scale, input, weight, residual, input_scale]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        assert STATIC_FP4_QUANT_OP is not None
+        assert FLASHINFER_ADD_RMSNORM_FP4QUANT_OP is not None
+
+        def pattern(
+            quant_result: torch.Tensor,
+            output_scale: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            residual: torch.Tensor,
+            input_scale: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            rms_out, residual = self.rmsnorm_matcher(input, weight, residual)
+            at = auto_functionalized(
+                STATIC_FP4_QUANT_OP,
+                output=quant_result,
+                input=rms_out,
+                output_scale=output_scale,
+                input_scale=input_scale,
+                is_sf_swizzled_layout=True,
+            )
+            return at[1], at[2], residual
+
+        def replacement(
+            quant_result: torch.Tensor,
+            output_scale: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            residual: torch.Tensor,
+            input_scale: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            input = input.to(dtype=self.model_dtype)
+            at = auto_functionalized(
+                FLASHINFER_ADD_RMSNORM_FP4QUANT_OP,
+                output=quant_result,
+                output_scale=output_scale,
+                residual=residual,
+                input=input,
+                weight=weight,
+                global_scale=input_scale,
+                epsilon=self.epsilon,
+            )
+            # at[1]=output, at[2]=output_scale, at[3]=residual
+            return at[1], at[2], at[3]
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class RMSNormQuantFusionPass(VllmPatternMatcherPass):
     """
     This pass fuses rms_norm & quant custom ops into a fused rms_norm_quant op.
@@ -649,6 +800,18 @@ class RMSNormQuantFusionPass(VllmPatternMatcherPass):
                                     is_tma_aligned=is_tma_aligned,
                                 ).register(self.patterns)
 
+            if (
+                STATIC_FP4_QUANT_OP is not None
+                and FLASHINFER_ADD_RMSNORM_FP4QUANT_OP is not None
+            ):
+                FusedAddRMSNormNvfp4QuantPattern(epsilon).register(self.patterns)
+
+            if (
+                STATIC_FP4_QUANT_OP is not None
+                and FLASHINFER_RMSNORM_FP4QUANT_OP is not None
+            ):
+                RMSNormNvfp4QuantPattern(epsilon).register(self.patterns)
+
         self.dump_patterns(config, self.patterns)
 
     @VllmInductorPass.time_and_log
@@ -666,4 +829,6 @@ class RMSNormQuantFusionPass(VllmPatternMatcherPass):
             FusedAddRMSNormStaticQuantPattern,
             FusedAddRMSNormDynamicQuantPattern,
             FusedAddRMSNormGroupQuantPattern,
+            RMSNormNvfp4QuantPattern,
+            FusedAddRMSNormNvfp4QuantPattern,
         )

--- a/vllm/compilation/passes/utility/fix_functionalization.py
+++ b/vllm/compilation/passes/utility/fix_functionalization.py
@@ -124,6 +124,18 @@ class FixFunctionalizationPass(VllmInductorPass):
                     5: "scale_out",
                 }
                 self.defunctionalize(graph, node, mutated_args)
+            elif (
+                hasattr(torch.ops.vllm, "flashinfer_rmsnorm_fp4quant")
+                and at_target == torch.ops.vllm.flashinfer_rmsnorm_fp4quant.default
+            ):
+                mutated_args = {1: "output", 2: "output_scale"}
+                self.defunctionalize(graph, node, mutated_args)
+            elif (
+                hasattr(torch.ops.vllm, "flashinfer_add_rmsnorm_fp4quant")
+                and at_target == torch.ops.vllm.flashinfer_add_rmsnorm_fp4quant.default
+            ):
+                mutated_args = {1: "output", 2: "output_scale", 3: "residual"}
+                self.defunctionalize(graph, node, mutated_args)
             # For some reason we need to specify the args for both
             # silu_and_mul and silu_and_mul_quant. The kwargs
             # pathway gets the wrong answer.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -94,15 +94,15 @@ IS_DENSE = False
 
 def enable_norm_fusion(cfg: "VllmConfig") -> bool:
     """Enable if either RMS norm or quant FP8 custom op is active;
-    otherwise Inductor handles fusion.
-    Also enable for FP4 models as FP4 quant is always custom so Inductor
-    cannot fuse it."""
+    otherwise Inductor handles fusion."""
 
     return (
         cfg.compilation_config.is_custom_op_enabled("rms_norm")
         or cfg.compilation_config.is_custom_op_enabled("quant_fp8")
         or cfg.kernel_config.ir_op_priority.rms_norm[0] != "native"
-        or (cfg.model_config is not None and cfg.model_config.is_nvfp4_quantized())
+    ) and not (
+        # NVFP4 fusion is disabled by default until kernel perf is tuned
+        cfg.model_config is not None and cfg.model_config.is_nvfp4_quantized()
     )
 
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -94,12 +94,15 @@ IS_DENSE = False
 
 def enable_norm_fusion(cfg: "VllmConfig") -> bool:
     """Enable if either RMS norm or quant FP8 custom op is active;
-    otherwise Inductor handles fusion."""
+    otherwise Inductor handles fusion.
+    Also enable for FP4 models as FP4 quant is always custom so Inductor
+    cannot fuse it."""
 
     return (
         cfg.compilation_config.is_custom_op_enabled("rms_norm")
         or cfg.compilation_config.is_custom_op_enabled("quant_fp8")
         or cfg.kernel_config.ir_op_priority.rms_norm[0] != "native"
+        or (cfg.model_config is not None and cfg.model_config.is_nvfp4_quantized())
     )
 
 

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -575,12 +575,7 @@ if has_flashinfer():
             rounded_m, rounded_n, dtype=torch.uint8, device=a.device
         )
 
-    @torch.library.custom_op(
-        "vllm::flashinfer_rmsnorm_fp4quant",
-        mutates_args=["output", "output_scale"],
-        device_types="cuda",
-    )
-    def flashinfer_rmsnorm_fp4quant(
+    def _flashinfer_rmsnorm_fp4quant(
         output: torch.Tensor,
         output_scale: torch.Tensor,
         input: torch.Tensor,
@@ -602,10 +597,7 @@ if has_flashinfer():
             is_sf_swizzled_layout=True,
         )
 
-    @torch.library.register_fake(
-        "vllm::flashinfer_rmsnorm_fp4quant",
-    )
-    def flashinfer_rmsnorm_fp4quant_fake(
+    def _flashinfer_rmsnorm_fp4quant_fake(
         output: torch.Tensor,
         output_scale: torch.Tensor,
         input: torch.Tensor,
@@ -615,12 +607,14 @@ if has_flashinfer():
     ) -> None:
         return
 
-    @torch.library.custom_op(
-        "vllm::flashinfer_add_rmsnorm_fp4quant",
-        mutates_args=["output", "output_scale", "residual"],
-        device_types="cuda",
+    direct_register_custom_op(
+        op_name="flashinfer_rmsnorm_fp4quant",
+        op_func=_flashinfer_rmsnorm_fp4quant,
+        mutates_args=["output", "output_scale"],
+        fake_impl=_flashinfer_rmsnorm_fp4quant_fake,
     )
-    def flashinfer_add_rmsnorm_fp4quant(
+
+    def _flashinfer_add_rmsnorm_fp4quant(
         output: torch.Tensor,
         output_scale: torch.Tensor,
         residual: torch.Tensor,
@@ -646,10 +640,7 @@ if has_flashinfer():
             is_sf_swizzled_layout=True,
         )
 
-    @torch.library.register_fake(
-        "vllm::flashinfer_add_rmsnorm_fp4quant",
-    )
-    def flashinfer_add_rmsnorm_fp4quant_fake(
+    def _flashinfer_add_rmsnorm_fp4quant_fake(
         output: torch.Tensor,
         output_scale: torch.Tensor,
         residual: torch.Tensor,
@@ -659,6 +650,13 @@ if has_flashinfer():
         epsilon: float,
     ) -> None:
         return
+
+    direct_register_custom_op(
+        op_name="flashinfer_add_rmsnorm_fp4quant",
+        op_func=_flashinfer_add_rmsnorm_fp4quant,
+        mutates_args=["output", "output_scale", "residual"],
+        fake_impl=_flashinfer_add_rmsnorm_fp4quant_fake,
+    )
 
     @torch.library.custom_op(
         "vllm::mm_mxfp8",

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -576,6 +576,91 @@ if has_flashinfer():
         )
 
     @torch.library.custom_op(
+        "vllm::flashinfer_rmsnorm_fp4quant",
+        mutates_args=["output", "output_scale"],
+        device_types="cuda",
+    )
+    def flashinfer_rmsnorm_fp4quant(
+        output: torch.Tensor,
+        output_scale: torch.Tensor,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        global_scale: torch.Tensor,
+        epsilon: float,
+    ) -> None:
+        from flashinfer.cute_dsl import rmsnorm_fp4quant as rmsnorm_fp4quant_
+
+        rmsnorm_fp4quant_(
+            input=input,
+            weight=weight,
+            y_fp4=output.view(torch.float4_e2m1fn_x2),
+            block_scale=output_scale.view(torch.uint8)
+            .view(torch.float8_e4m3fn)
+            .view(-1),
+            global_scale=global_scale.view(-1),
+            eps=epsilon,
+            is_sf_swizzled_layout=True,
+        )
+
+    @torch.library.register_fake(
+        "vllm::flashinfer_rmsnorm_fp4quant",
+    )
+    def flashinfer_rmsnorm_fp4quant_fake(
+        output: torch.Tensor,
+        output_scale: torch.Tensor,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        global_scale: torch.Tensor,
+        epsilon: float,
+    ) -> None:
+        return
+
+    @torch.library.custom_op(
+        "vllm::flashinfer_add_rmsnorm_fp4quant",
+        mutates_args=["output", "output_scale", "residual"],
+        device_types="cuda",
+    )
+    def flashinfer_add_rmsnorm_fp4quant(
+        output: torch.Tensor,
+        output_scale: torch.Tensor,
+        residual: torch.Tensor,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        global_scale: torch.Tensor,
+        epsilon: float,
+    ) -> None:
+        from flashinfer.cute_dsl import (
+            add_rmsnorm_fp4quant as add_rmsnorm_fp4quant_,
+        )
+
+        add_rmsnorm_fp4quant_(
+            input=input,
+            residual=residual,
+            weight=weight,
+            y_fp4=output.view(torch.float4_e2m1fn_x2),
+            block_scale=output_scale.view(torch.uint8)
+            .view(torch.float8_e4m3fn)
+            .view(-1),
+            global_scale=global_scale.view(-1),
+            eps=epsilon,
+            is_sf_swizzled_layout=True,
+        )
+
+    @torch.library.register_fake(
+        "vllm::flashinfer_add_rmsnorm_fp4quant",
+    )
+    def flashinfer_add_rmsnorm_fp4quant_fake(
+        output: torch.Tensor,
+        output_scale: torch.Tensor,
+        residual: torch.Tensor,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        global_scale: torch.Tensor,
+        epsilon: float,
+    ) -> None:
+        return
+
+    @torch.library.custom_op(
         "vllm::mm_mxfp8",
         mutates_args=[],
         device_types="cuda",


### PR DESCRIPTION
## Purpose
This commit implements rmsnorm + fp4 quant fusion using FlashInfer, and integrate to rmsnorm + quant fusion pass, fixing https://github.com/vllm-project/vllm/issues/32612

## Test Plan
The tests are divided into 4 groups across two sets of execution commands:

- Main branch: Default parameters
- Main branch: Forced rmsnorm fusion enabled
- Current PR: Default parameters
- Current PR: Forced rmsnorm fusion enabled

```
# default
vllm serve nvidia/Qwen3-30B-A3B-NVFP4
# fused
vllm serve nvidia/Qwen3-30B-A3B-NVFP4 --compilation-config '{"custom_ops":["-rms_norm"], "pass_config":{"fuse_norm_quant":true}}'
```

## Test Result
The following data is based on RTX 5090; B200 benchmarks are on the way.

### Summary
| Benchmark | MAIN | MAIN (fused) | PR | PR (fused) |
|---|---|---|---|---|
| guidellm Output Tokens/s Mean | 997.6 | 989.9 | 990.8 (-0.68%) | 982.6 (-0.74%) |
| vllm serve Output tok/s | 11706.16 | 11626.52 | 11899.95 (+1.66%) | 11851.89 (+1.94%) |
| gsm8k Accuracy | 0.885 | 0.888 | 0.890 (+0.56%) | 0.884 (-0.45%) |
| Latency input=512 (ms) | 19.01 | 18.90 | 18.74 (-1.42%) | 19.13 (+1.22%) |
| Latency input=2048 (ms) | 44.05 | 44.20 | 44.06 (+0.04%) | 43.98 (-0.49%) |
| Latency input=8192 (ms) | 246.42 | 246.56 | 245.95 (-0.19%) | 245.32 (-0.50%) |


### Raw Data
```
guidellm benchmark --target "http://localhost:8000/v1" --profile concurrent --rate 10 --data "prompt_tokens=64,output_tokens=128" --max-seconds 30

# MAIN
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|
| Benchmark  | Requests               |||| Input Tokens || Output Tokens || Total Tokens  ||
| Strategy   | Per Sec   || Concurrency || Per Sec      || Per Sec       || Per Sec       ||
|            | Mdn | Mean | Mdn   | Mean | Mdn   | Mean  | Mdn    | Mean  | Mdn   | Mean   |
|------------|-----|------|-------|------|-------|-------|--------|-------|-------|--------|
| concurrent | 1.8 | 7.7  | 10.0  | 10.0 | 339.7 | 584.5 | 924.9  | 997.6 | 940.7 | 1562.1 |
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|

# MAIN (fused)
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|
| Benchmark  | Requests               |||| Input Tokens || Output Tokens || Total Tokens  ||
| Strategy   | Per Sec   || Concurrency || Per Sec      || Per Sec       || Per Sec       ||
|            | Mdn | Mean | Mdn   | Mean | Mdn   | Mean  | Mdn    | Mean  | Mdn   | Mean   |
|------------|-----|------|-------|------|-------|-------|--------|-------|-------|--------|
| concurrent | 1.8 | 7.7  | 10.0  | 10.0 | 254.1 | 578.5 | 667.6  | 989.9 | 676.0 | 1549.2 |
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|

# PR
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|
| Benchmark  | Requests               |||| Input Tokens || Output Tokens || Total Tokens  ||
| Strategy   | Per Sec   || Concurrency || Per Sec      || Per Sec       || Per Sec       ||
|            | Mdn | Mean | Mdn   | Mean | Mdn   | Mean  | Mdn    | Mean  | Mdn   | Mean   |
|------------|-----|------|-------|------|-------|-------|--------|-------|-------|--------|
| concurrent | 1.6 | 7.7  | 10.0  | 10.0 | 117.4 | 580.4 | 782.3  | 990.8 | 794.1 | 1549.9 |
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|

# PR (fused)
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|
| Benchmark  | Requests               |||| Input Tokens || Output Tokens || Total Tokens  ||
| Strategy   | Per Sec   || Concurrency || Per Sec      || Per Sec       || Per Sec       ||
|            | Mdn | Mean | Mdn   | Mean | Mdn   | Mean  | Mdn    | Mean  | Mdn   | Mean   |
|------------|-----|------|-------|------|-------|-------|--------|-------|-------|--------|
| concurrent | 1.6 | 7.7  | 10.0  | 10.0 | 219.6 | 583.7 | 662.7  | 996.2 | 664.1 | 1557.3 |
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|

---

vllm bench serve --input-len 100 --output-len 100 --num-prompts 512

# MAIN
============ Serving Benchmark Result ============
Successful requests:                     512       
Failed requests:                         0         
Benchmark duration (s):                  4.37      
Total input tokens:                      51200     
Total generated tokens:                  51200     
Request throughput (req/s):              117.06    
Output token throughput (tok/s):         11706.16  
Peak output token throughput (tok/s):    13824.00  
Peak concurrent requests:                512.00    
Total token throughput (tok/s):          23412.32  
---------------Time to First Token----------------
Mean TTFT (ms):                          1506.33   
Median TTFT (ms):                        798.23    
P99 TTFT (ms):                           2538.11   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.54     
Median TPOT (ms):                        18.60     
P99 TPOT (ms):                           18.65     
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.54     
Median ITL (ms):                         18.74     
P99 ITL (ms):                            23.81     
==================================================

# MAIN (fused)
============ Serving Benchmark Result ============
Successful requests:                     512       
Failed requests:                         0         
Benchmark duration (s):                  4.40      
Total input tokens:                      51200     
Total generated tokens:                  51200     
Request throughput (req/s):              116.27    
Output token throughput (tok/s):         11626.52  
Peak output token throughput (tok/s):    13697.00  
Peak concurrent requests:                512.00    
Total token throughput (tok/s):          23253.04  
---------------Time to First Token----------------
Mean TTFT (ms):                          1537.94   
Median TTFT (ms):                        786.47    
P99 TTFT (ms):                           2570.47   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.56     
Median TPOT (ms):                        18.64     
P99 TPOT (ms):                           18.74     
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.57     
Median ITL (ms):                         18.74     
P99 ITL (ms):                            24.46     
==================================================

# PR
============ Serving Benchmark Result ============
Successful requests:                     512       
Failed requests:                         0         
Benchmark duration (s):                  4.30      
Total input tokens:                      51200     
Total generated tokens:                  51200     
Request throughput (req/s):              119.00    
Output token throughput (tok/s):         11899.95  
Peak output token throughput (tok/s):    13791.00  
Peak concurrent requests:                512.00    
Total token throughput (tok/s):          23799.91  
---------------Time to First Token----------------
Mean TTFT (ms):                          1408.71   
Median TTFT (ms):                        942.66    
P99 TTFT (ms):                           2443.44   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.61     
Median TPOT (ms):                        18.62     
P99 TPOT (ms):                           18.85     
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.62     
Median ITL (ms):                         18.75     
P99 ITL (ms):                            26.06     
==================================================

# PR (fused)
============ Serving Benchmark Result ============
Successful requests:                     512       
Failed requests:                         0         
Benchmark duration (s):                  4.22      
Total input tokens:                      51200     
Total generated tokens:                  51200     
Request throughput (req/s):              121.28    
Output token throughput (tok/s):         12127.85  
Peak output token throughput (tok/s):    13569.00  
Peak concurrent requests:                512.00    
Total token throughput (tok/s):          24255.71  
---------------Time to First Token----------------
Mean TTFT (ms):                          1351.82   
Median TTFT (ms):                        989.29    
P99 TTFT (ms):                           2380.34   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.54     
Median TPOT (ms):                        18.59     
P99 TPOT (ms):                           18.68     
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.54     
Median ITL (ms):                         18.73     
P99 ITL (ms):                            24.61     
==================================================

---

python tests/evals/gsm8k/gsm8k_eval.py --port 8000

# MAIN
Results:
Accuracy: 0.885

# MAIN (fused)
Results:
Accuracy: 0.888

# PR
Results:
Accuracy: 0.890

# PR (fused)
Results:
Accuracy: 0.884

---

vllm bench latency --input-len 512 --output-len 1 --batch-size 1 --model nvidia/Qwen3-30B-A3B-NVFP4

# MAIN
Avg latency (median run): 0.019008840341120957 seconds

# MAIN (fused)
Avg latency (median run): 0.018896393943578005 seconds

# PR
Avg latency (median run): 0.018739946062366168 seconds

# PR (fused)
Avg latency (median run): 0.01912623771155874 seconds

---

vllm bench latency --input-len 2048 --output-len 1 --batch-size 1 --model nvidia/Qwen3-30B-A3B-NVFP4

# MAIN
Avg latency (median run): 0.044046607023725905 seconds

# MAIN (fused)
Avg latency (median run): 0.04420289099216461 seconds

# PR
Avg latency (median run): 0.04406242870415251 seconds

# PR (fused)
Avg latency (median run): 0.043984875672807296 seconds

---

vllm bench latency --input-len 8192 --output-len 1 --batch-size 1 --model nvidia/Qwen3-30B-A3B-NVFP4

# MAIN
Avg latency (median run): 0.24642020681252083 seconds

# MAIN (fused)
Avg latency (median run): 0.24655509091292818 seconds

# PR
Avg latency (median run): 0.24594708305473129 seconds

# PR (fused)
Avg latency (median run): 0.2453248108116289 seconds
```