### PR TITLE
Populate multimedia pre-processing performance metrics via PerfStats in the vLLM engine

### DIFF
--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -172,6 +172,7 @@ class InputPreprocessor:
                 multi_modal_data,
                 parsed_content.get("mm_processor_kwargs") or {},
                 tokenization_kwargs=tokenization_kwargs,
+                mm_uuids=parsed_content.get("multi_modal_uuids"),
             )
         else:
             prompt_token_ids = self._tokenize_prompt(

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -1090,6 +1090,12 @@ class MultiModalInputs(_InputOptions):
     `prompt_token_ids`.
     """
 
+    mm_preprocess_time_s: NotRequired[float]
+    """Time in seconds spent in multimodal preprocessing."""
+
+    mm_cache_time_s: NotRequired[float]
+    """Time in seconds spent in multimodal cache operations."""
+
 
 def mm_inputs(
     prompt_token_ids: list[int],

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Generator, ItemsView, Iterable, Mapping, Sequence
@@ -1433,7 +1434,10 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
 
         _, passthrough_data = self._get_hf_mm_data(inputs.mm_data_items)
         if cache is None or passthrough_data:
+            self._last_cache_time_s = 0.0
             return self._apply_hf_processor(inputs, timing_ctx)
+
+        _cache_start = time.monotonic()
 
         with timing_ctx.record("get_mm_hashes"):
             mm_hashes = inputs.get_mm_hashes(self.info.model_id)
@@ -1444,6 +1448,8 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
                 mm_data_items=inputs.mm_data_items,
                 mm_hashes=mm_hashes,
             )
+
+        _cache_lookup_time = time.monotonic() - _cache_start
 
         # NOTE: `prompt` does not correspond to `mm_missing_data_items`,
         # so we can't apply prompt updates until the new multimodal
@@ -1474,6 +1480,8 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             mm_missing_kwargs,
         )
 
+        _cache_merge_start = time.monotonic()
+
         with timing_ctx.record("merge_mm_kwargs"):
             mm_kwargs, mm_prompt_updates = self._merge_mm_kwargs(
                 cache,
@@ -1482,6 +1490,9 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
                 mm_missing_kwargs=mm_missing_kwargs,
                 mm_missing_prompt_updates=mm_missing_prompt_updates,
             )
+
+        _cache_merge_time = time.monotonic() - _cache_merge_start
+        self._last_cache_time_s = _cache_lookup_time + _cache_merge_time
 
         mm_info = MultiModalProcessingInfo(
             kwargs=mm_kwargs,
@@ -1681,12 +1692,19 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             for modality, placeholders in mm_placeholders.items()
         }
 
-        return mm_inputs(
+        result = mm_inputs(
             prompt_token_ids=prompt_ids,
             mm_kwargs=mm_info.kwargs,
             mm_hashes=mm_info.hashes,
             mm_placeholders=mm_placeholder_ranges,
         )
+
+        cache_time = getattr(self, "_last_cache_time_s", 0.0)
+        if cache_time > 0.0:
+            result["mm_cache_time_s"] = cache_time
+            self._last_cache_time_s = 0.0
+
+        return result
 
 
 class EncDecMultiModalProcessor(BaseMultiModalProcessor[_I]):

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -560,8 +560,14 @@ class BaseRenderer(ABC, Generic[_T]):
         )
         mm_timing_ctx = self._mm_timing_registry.get(mm_req_id)
 
+        _preprocess_start = time.monotonic()
+
         with set_default_torch_num_threads():
             mm_inputs = mm_processor.apply(mm_processor_inputs, mm_timing_ctx)
+
+        _preprocess_elapsed = time.monotonic() - _preprocess_start
+        if _preprocess_elapsed > 0.0:
+            mm_inputs["mm_preprocess_time_s"] = _preprocess_elapsed
 
         self.update_mm_cache_stats()
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1287,6 +1287,7 @@ class Scheduler(SchedulerInterface):
         num_nans_in_logits = model_runner_output.num_nans_in_logits
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats = model_runner_output.cudagraph_stats
+        mm_encoder_time_s_map = model_runner_output.mm_encoder_time_s
 
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():
@@ -1420,6 +1421,15 @@ class Scheduler(SchedulerInterface):
             if num_nans_in_logits is not None and req_id in num_nans_in_logits:
                 request.num_nans_in_logits = num_nans_in_logits[req_id]
 
+            # Accumulate MM encoder timing for this request.
+            req_encoder_time_s = 0.0
+            if (
+                mm_encoder_time_s_map is not None
+                and req_id in mm_encoder_time_s_map
+            ):
+                request.mm_encoder_time_s += mm_encoder_time_s_map[req_id]
+                req_encoder_time_s = request.mm_encoder_time_s
+
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
             if (
@@ -1445,6 +1455,7 @@ class Scheduler(SchedulerInterface):
                         num_external_computed_tokens=request.num_external_computed_tokens,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
+                        mm_encoder_time_s=req_encoder_time_s,
                     )
                 )
             else:

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -102,6 +102,9 @@ class EngineCoreRequest(
 
     reasoning_ended: bool | None = None
 
+    mm_preprocess_time_s: float = 0.0
+    mm_cache_time_s: float = 0.0
+
     @property
     def params(self) -> SamplingParams | PoolingParams:
         """Return the processed params (sampling or pooling)."""
@@ -177,6 +180,8 @@ class EngineCoreOutput(
     # The number of NaNs in logits.
     # A value greater than 0 indicates that the output is corrupted.
     num_nans_in_logits: int = 0
+
+    mm_encoder_time_s: float = 0.0
 
     @property
     def finished(self) -> bool:

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -337,6 +337,10 @@ class InputProcessor:
                     )
                 )
 
+        # Extract MM timing metrics from processing results.
+        mm_preprocess_time_s = decoder_inputs.get("mm_preprocess_time_s", 0.0)
+        mm_cache_time_s = decoder_inputs.get("mm_cache_time_s", 0.0)
+
         return EngineCoreRequest(
             request_id=request_id,
             prompt_token_ids=prompt_token_ids,
@@ -351,6 +355,8 @@ class InputProcessor:
             data_parallel_rank=data_parallel_rank,
             trace_headers=trace_headers,
             resumable=resumable,
+            mm_preprocess_time_s=mm_preprocess_time_s,
+            mm_cache_time_s=mm_cache_time_s,
         )
 
     def _validate_prompt_len(

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -175,6 +175,10 @@ class RequestState:
 
         self.stats = RequestStateStats(arrival_time=arrival_time) if log_stats else None
 
+        # Multimodal timing metrics (set externally).
+        self.mm_preprocess_time_s: float = 0.0
+        self.mm_cache_time_s: float = 0.0
+
         # Stream Interval
         self.stream_interval = stream_interval
         self.sent_tokens_offset = 0  # Offset of sent tokens
@@ -243,7 +247,7 @@ class RequestState:
             output_kind = request.pooling_params.output_kind
 
         assert request.external_req_id is not None
-        return cls(
+        state = cls(
             request_id=request.request_id,
             external_req_id=request.external_req_id,
             parent_req=parent_req,
@@ -265,6 +269,15 @@ class RequestState:
             stream_interval=stream_interval,
             stream_input=request.resumable,
         )
+
+        # Forward MM timing from request to state (and stats).
+        state.mm_preprocess_time_s = request.mm_preprocess_time_s
+        state.mm_cache_time_s = request.mm_cache_time_s
+        if state.stats is not None:
+            state.stats.mm_preprocess_time_s = request.mm_preprocess_time_s
+            state.stats.mm_cache_time_s = request.mm_cache_time_s
+
+        return state
 
     def make_request_output(
         self,

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -218,6 +218,11 @@ class RequestStateStats:
     # Track if this request is corrupted (NaNs in logits)
     is_corrupted: bool = False
 
+    # Multimodal timing metrics (seconds).
+    mm_preprocess_time_s: float = 0.0
+    mm_cache_time_s: float = 0.0
+    mm_encoder_time_s: float = 0.0
+
 
 @dataclass
 class FinishedRequestStats:
@@ -362,6 +367,10 @@ class IterationStats:
             and output.num_nans_in_logits > 0
         ):
             req_stats.is_corrupted = True
+
+        # Propagate MM encoder timing.
+        if output.mm_encoder_time_s > 0.0:
+            req_stats.mm_encoder_time_s = output.mm_encoder_time_s
 
         # Process request-level engine core events
         if output.events is not None:

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -247,6 +247,10 @@ class ModelRunnerOutput:
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
 
+    # Per-request MM encoder timing (req_id -> seconds).
+    # Populated by gpu_model_runner via CUDA events.
+    mm_encoder_time_s: dict[str, float] | None = None
+
 
 # ModelRunnerOutput wrapper for async scheduling.
 class AsyncModelRunnerOutput(ABC):

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -163,6 +163,9 @@ class Request:
         # The number of tokens that have been computed remotely.
         self.num_external_computed_tokens = 0
 
+        # Multimodal encoder timing (seconds).
+        self.mm_encoder_time_s: float = 0.0
+
         self.block_hashes: list[BlockHash] = []
         # Store the block hasher without binding self to avoid creating a
         # reference cycle (Request -> partial -> Request) that prevents

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -640,6 +640,11 @@ class GPUModelRunner(
         self.encoder_timing_registry: dict[str, EncoderTimingStats] = {}
         self._encoder_timing_lock = threading.Lock()
 
+        # Non-blocking CUDA events for always-on MM encoder timing.
+        self._mm_encoder_events: (
+            tuple[torch.cuda.Event, torch.cuda.Event, set[str]] | None
+        ) = None
+
         # Persistent buffers for CUDA graphs.
         self.input_ids = self._make_buffer(self.max_num_tokens, dtype=torch.int32)
         self.positions = self._make_buffer(self.max_num_tokens, dtype=torch.int64)
@@ -2473,6 +2478,10 @@ class GPUModelRunner(
         if not mm_kwargs:
             return []
 
+        # Non-blocking CUDA event for encoder timing (always-on).
+        mm_start_event = torch.cuda.Event(enable_timing=True)
+        mm_start_event.record()
+
         should_time = bool(
             self.observability_config
             and self.observability_config.enable_mm_processor_stats
@@ -2613,6 +2622,12 @@ class GPUModelRunner(
             self.encoder_cache[mm_hash] = output
             logger.debug("Finish execute for mm hash %s", mm_hash)
             self.maybe_save_ec_to_connector(self.encoder_cache, mm_hash)
+
+        # Store events for deferred readback in sample_tokens().
+        mm_end_event = torch.cuda.Event(enable_timing=True)
+        mm_end_event.record()
+        mm_req_ids = set(scheduler_output.scheduled_encoder_inputs.keys())
+        self._mm_encoder_events = (mm_start_event, mm_end_event, mm_req_ids)
 
         return encoder_outputs
 
@@ -4009,6 +4024,23 @@ class GPUModelRunner(
                 else:
                     logger.error("RoutedExpertsCapturer not initialized.")
 
+            # Read deferred MM encoder timing (CUDA events).
+            # By this point the full model forward pass has completed,
+            # so end_evt.synchronize() returns immediately (no GPU wait).
+            mm_encoder_time_s: dict[str, float] | None = None
+            if self._mm_encoder_events is not None:
+                start_evt, end_evt, encoder_req_ids = self._mm_encoder_events
+                end_evt.synchronize()
+                total_ms = start_evt.elapsed_time(end_evt)
+                num_reqs = len(encoder_req_ids)
+                per_req_s = (
+                    (total_ms / 1000.0 / num_reqs) if num_reqs else 0.0
+                )
+                mm_encoder_time_s = {
+                    req_id: per_req_s for req_id in encoder_req_ids
+                }
+                self._mm_encoder_events = None
+
             output = ModelRunnerOutput(
                 req_ids=req_ids_output_copy,
                 req_id_to_index=req_id_to_index_output_copy,
@@ -4021,6 +4053,7 @@ class GPUModelRunner(
                 else None,
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
+                mm_encoder_time_s=mm_encoder_time_s,
             )
 
         if not self.use_async_scheduling:


### PR DESCRIPTION
Summary: This diff adds end-to-end instrumentation of multimedia pre-processing stages in vLLM and surface the per-request media processing latencies ResponseAPI and PredictAPI via PerfStats. Previously, stages like media download, video decoding, tensor pre-processing, multimodal encoding, and post-processing were not individually tracked or reported.

Test Plan:
---

#### CI Tests

---

#### E2E Tests
 
Initiate a local LLM service following the instructions in D94768584, then run the test script from D95171680. 

📗 **With the current diff (D95464665)**, the log shows that multimedia processing related timing metrics are available in the `PerfStats` values reported via Response/Predict API.

> 📬 **Response API** (use `--api-type response`)  {F1986431563} Full log: P2223875437

> 📬 **Response API** (use `--api-type response`, without any image)   {F1986431578} Full log: P2223879269

> 📬 **Predict API** (use `--api-type predict`) {F1986431600} Full log: P2223886392

📕**Without the current diff**, the log shows that multimedia processing relative timing metrics are missing from the reported `PerfStats` values.

> 📬 **Response API** (use `--api-type response`) {F1986415630} Full log: P2222828856

> 📬 **Predict API** (use `--api-type predict`) {F1986415532} Full log: P2222849783

E2E tests also show that when images with identical UUIDs/hash-keys are sent across requests; the caching mechanism renders the encoding step unnecessary (`Request_k` denotes the k-th request in a sequence of 5 requests).
{F1986437303}
---

Differential Revision: D95464665


