### PR TITLE
[Bugfix] Routed experts capturer reinitialization after KV cache profiling

### DIFF
--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -158,3 +158,56 @@ def test_gpu_model_runner_binding_stage(monkeypatch):
     assert callable(dummy_module.router.capture_fn)
     dummy_module.router.capture_fn(torch.tensor([[9, 10]]))
     assert len(capturer.calls) == 1
+
+
+def test_routed_experts_capturer_cleanup_allows_recreate():
+    from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
+        RoutedExpertsCapturer,
+    )
+
+    existing = RoutedExpertsCapturer.get_instance()
+    if existing is not None:
+        existing.cleanup()
+
+    first = RoutedExpertsCapturer.create()
+    first._device_buffer = torch.zeros(1, dtype=torch.int32)
+
+    first.cleanup()
+    assert RoutedExpertsCapturer.get_instance() is None
+    assert first._device_buffer is None
+
+    second = RoutedExpertsCapturer.create()
+    assert second is not first
+    second.cleanup()
+
+
+def test_gpu_model_runner_cleanup_profiling_kv_cache_resets_capturer(monkeypatch):
+    from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
+        RoutedExpertsCapturer,
+    )
+    from vllm.v1.worker import gpu_model_runner as gmr
+
+    existing = RoutedExpertsCapturer.get_instance()
+    if existing is not None:
+        existing.cleanup()
+
+    accelerator = getattr(torch, "accelerator", types.SimpleNamespace())
+    monkeypatch.setattr(torch, "accelerator", accelerator, raising=False)
+    monkeypatch.setattr(accelerator, "synchronize", lambda: None, raising=False)
+    monkeypatch.setattr(accelerator, "empty_cache", lambda: None, raising=False)
+
+    dummy_self = types.SimpleNamespace(
+        cache_config=types.SimpleNamespace(num_gpu_blocks=1),
+        compilation_config=types.SimpleNamespace(
+            static_forward_context={"dummy": types.SimpleNamespace(kv_cache=[object()])}
+        ),
+    )
+
+    capturer = RoutedExpertsCapturer.create()
+    capturer._device_buffer = torch.zeros(1, dtype=torch.int32)
+
+    gmr.GPUModelRunner._cleanup_profiling_kv_cache(dummy_self)
+
+    assert RoutedExpertsCapturer.get_instance() is None
+    assert dummy_self.cache_config.num_gpu_blocks is None
+    assert dummy_self.compilation_config.static_forward_context["dummy"].kv_cache == []

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -218,6 +218,8 @@ class RoutedExpertsCapturer:
 
     def cleanup(self) -> None:
         """Explicitly clean up shared memory resources."""
+        global _global_experts_capturer
+
         if self._shm is not None:
             try:
                 self._shm.close()
@@ -226,6 +228,13 @@ class RoutedExpertsCapturer:
                 logger.debug("Exception during cleanup for capturer", exc_info=True)
             finally:
                 self._shm = None
+
+        self._device_buffer = None
+        self._host_buffer_view = None
+        self._lock_file = None
+
+        if _global_experts_capturer is self:
+            _global_experts_capturer = None
 
     def __del__(self) -> None:
         """Clean up shared memory on destruction."""

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5578,6 +5578,11 @@ class GPUModelRunner(
 
     def _cleanup_profiling_kv_cache(self) -> None:
         torch.accelerator.synchronize()
+
+        capturer = RoutedExpertsCapturer.get_instance()
+        if capturer is not None:
+            capturer.cleanup()
+
         if hasattr(self, "kv_caches") and self.kv_caches:
             for i in range(len(self.kv_caches)):
                 self.kv_caches[i] = None  # type: ignore


### PR DESCRIPTION

## Purpose

Fix a V1 GPU worker initialization failure when routed expert capture is enabled.

When `enable_return_routed_experts=True`, the worker can initialize a minimal KV cache during CUDA graph memory profiling before performing the real KV cache initialization. That profiling path was creating the process-global `RoutedExpertsCapturer`, and the later real initialization attempted to create it again, raising:

`RuntimeError: Experts capturer already created.`

This PR fixes the lifecycle bug by:
- resetting the global `RoutedExpertsCapturer` singleton during `cleanup()`
- clearing its buffer references during cleanup so it can be recreated safely
- cleaning up the capturer as part of profiling KV-cache teardown, so profiling state does not leak into the real initialization path
- adding regression tests covering both singleton recreation and profiling cleanup

This is a user-facing bug fix for MoE models with routed expert return enabled. No documentation update is needed. No release note update is included.

## Test Plan

- Targeted unit test added for this fix:
  - recreating `RoutedExpertsCapturer` after cleanup
  - resetting the capturer during profiling KV-cache cleanup
- Manual e2e validation by starting the server with a routed-expert-enabled MoE model and verify worker initialization completes without `Experts capturer already created`

## Test Result

- `python -m pytest -q tests/model_executor/test_routed_experts_capture.py` passed:
- Manual e2e validation ok.

### Before
Worker initialization fail after profiling KV cache / CUDA graph memory with:
`RuntimeError: Experts capturer already created.`

```log
Traceback (most recent call last):
  File "vllm/v1/executor/multiproc_executor.py", line 923, in worker_busy_loop
    output = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "vllm/v1/worker/worker_base.py", line 310, in initialize_from_config
    self.worker.initialize_from_config(kv_cache_config)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "vllm/tracing/otel.py", line 178, in sync_wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "vllm/v1/worker/gpu_worker.py", line 555, in initialize_from_config
    self.model_runner.initialize_kv_cache(kv_cache_config)
  File "vllm/v1/worker/gpu_model_runner.py", line 6472, in initialize_kv_cache
    self.init_routed_experts_capturer()
  File "vllm/v1/worker/gpu_model_runner.py", line 6479, in init_routed_experts_capturer
    routed_experts_capturer = RoutedExpertsCapturer.create()
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "vllm/model_executor/layers/fused_moe/routed_experts_capturer.py", line 100, in create
    raise RuntimeError("Experts capturer already created.")
RuntimeError: Experts capturer already created.
```

### After
Profiling cleanup releases the routed experts capturer, allowing the real KV cache initialization to recreate it successfully.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

