### PR TITLE
[Bugfix] Fix Qwen3-Omni/Qwen2.5-Omni use_audio_in_video deployment issues

### DIFF
--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -27,7 +27,7 @@ def _deep_merge_mm_kwargs(
         ):
             result[k] = _deep_merge_mm_kwargs(dict(result[k]), v)
         else:
-            result[k] = copy.copy(v)
+            result[k] = v
     return result
 
 

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -13,6 +13,24 @@ from vllm.utils.hashing import safe_hash
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 
+def _deep_merge_mm_kwargs(
+    base: dict[str, object], override: Mapping[str, object]
+) -> dict[str, object]:
+    """Recursively merge override into base so nested keys are merged, not replaced."""
+    result = copy.deepcopy(base)
+    for k, v in override.items():
+        if (
+            k in result
+            and isinstance(result[k], dict)
+            and isinstance(v, Mapping)
+            and not isinstance(v, (str, bytes))
+        ):
+            result[k] = _deep_merge_mm_kwargs(dict(result[k]), v)
+        else:
+            result[k] = copy.deepcopy(v)
+    return result
+
+
 @dataclass
 class BaseDummyOptions:
     """Base options for generating dummy data during profiling."""
@@ -274,9 +292,12 @@ class MultiModalConfig:
         """
         Get the keyword arguments to pass to the multi-modal processor
         according to the extra arguments passed during inference.
+        Recursively merges so request-level only overrides the keys it
+        provides (e.g. only size.longest_edge) without blanking sibling
+        keys (e.g. size.shortest_edge) from the global config.
         """
-        kwargs = copy.deepcopy(self.mm_processor_kwargs or {})
-        return kwargs | dict(inference_kwargs)
+        base = copy.deepcopy(self.mm_processor_kwargs or {})
+        return _deep_merge_mm_kwargs(base, inference_kwargs)
 
     def is_multimodal_pruning_enabled(self):
         return self.video_pruning_rate is not None and self.video_pruning_rate > 0

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -17,7 +17,7 @@ def _deep_merge_mm_kwargs(
     base: dict[str, object], override: Mapping[str, object]
 ) -> dict[str, object]:
     """Recursively merge override into base so nested keys are merged, not replaced."""
-    result = copy.deepcopy(base)
+    result = base.copy()
     for k, v in override.items():
         if (
             k in result

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import copy
 from collections.abc import Mapping
 from typing import Any, Literal, TypeAlias, TypedDict, final
 
@@ -274,7 +275,7 @@ class MultiModalConfig:
         Get the keyword arguments to pass to the multi-modal processor
         according to the extra arguments passed during inference.
         """
-        kwargs = self.mm_processor_kwargs or {}
+        kwargs = copy.deepcopy(self.mm_processor_kwargs or {})
         return kwargs | dict(inference_kwargs)
 
     def is_multimodal_pruning_enabled(self):

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -27,7 +27,7 @@ def _deep_merge_mm_kwargs(
         ):
             result[k] = _deep_merge_mm_kwargs(dict(result[k]), v)
         else:
-            result[k] = copy.deepcopy(v)
+            result[k] = copy.copy(v)
     return result
 
 

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -507,6 +507,10 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
             hf_inputs["second_per_grid_ts"] = video_second_per_grid
 
         use_audio_in_video = mm_kwargs.get("use_audio_in_video", False)
+        # Only enable interleaving when request has real audio (warmup has none).
+        has_audio = bool(audios) or bool(mm_data.get("audio"))
+        if use_audio_in_video and not has_audio:
+            use_audio_in_video = False
         hf_inputs["use_audio_in_video"] = torch.tensor(use_audio_in_video)
 
         return hf_inputs

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -1213,6 +1213,13 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
         mm_data = dict(mm_data)
         audios = mm_data.pop("audios", [])
 
+        # Merge use_audio_in_video from global --mm-processor-kwargs (request-level is often empty)
+        mm_config = self.info.ctx.model_config.get_multimodal_config()
+        global_mm_kwargs = mm_config.mm_processor_kwargs or {}
+        if "use_audio_in_video" not in mm_kwargs and "use_audio_in_video" in global_mm_kwargs:
+            mm_kwargs = dict(mm_kwargs)
+            mm_kwargs["use_audio_in_video"] = global_mm_kwargs["use_audio_in_video"]
+
         def pad_to_hop_length(x: np.ndarray, hop_length: int) -> np.ndarray:
             length = x.shape[-1]
             if length % hop_length != 0:
@@ -1475,7 +1482,14 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
             token_id = image_token_id if modality == "image" else video_token_id
             return [token_id] * (int(grid_thw.prod()) // merge_length)
 
-        use_audio_in_video = hf_processor_mm_kwargs.get("use_audio_in_video", False)
+        use_audio_in_video = hf_processor_mm_kwargs.get("use_audio_in_video", None)
+        if use_audio_in_video is None:
+            mm_config = self.info.ctx.model_config.get_multimodal_config()
+            global_mm_kwargs = mm_config.mm_processor_kwargs or {}
+            use_audio_in_video = global_mm_kwargs.get("use_audio_in_video", False)
+        # Disable interleaving when there is no audio (e.g. warmup) to avoid AssertionError
+        if use_audio_in_video and not audio_output_lengths:
+            use_audio_in_video = False
         thinker_config = self.info.get_hf_config()
 
         def get_replacement_qwen2_use_audio_in_video(item_idx: int):

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -1213,10 +1213,13 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
         mm_data = dict(mm_data)
         audios = mm_data.pop("audios", [])
 
-        # Merge use_audio_in_video from global --mm-processor-kwargs (request-level is often empty)
+        # Fall back to global use_audio_in_video when not set per-request.
         mm_config = self.info.ctx.model_config.get_multimodal_config()
         global_mm_kwargs = mm_config.mm_processor_kwargs or {}
-        if "use_audio_in_video" not in mm_kwargs and "use_audio_in_video" in global_mm_kwargs:
+        if (
+            mm_kwargs.get("use_audio_in_video") is None
+            and "use_audio_in_video" in global_mm_kwargs
+        ):
             mm_kwargs = dict(mm_kwargs)
             mm_kwargs["use_audio_in_video"] = global_mm_kwargs["use_audio_in_video"]
 
@@ -1487,7 +1490,7 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
             mm_config = self.info.ctx.model_config.get_multimodal_config()
             global_mm_kwargs = mm_config.mm_processor_kwargs or {}
             use_audio_in_video = global_mm_kwargs.get("use_audio_in_video", False)
-        # Disable interleaving when there is no audio (e.g. warmup) to avoid AssertionError
+        # Disable interleaving when no audio (e.g. warmup) to avoid AssertionError.
         if use_audio_in_video and not audio_output_lengths:
             use_audio_in_video = False
         thinker_config = self.info.get_hf_config()

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -255,10 +255,15 @@ class InputProcessingContext:
         assert callable(hf_processor)
 
         merged_kwargs = self.get_merged_mm_kwargs(kwargs)
+        # use_audio_in_video must not be passed to HF Processor; vLLM handles
+        # interleaving in _maybe_apply_prompt_updates to avoid StopIteration.
+        kwargs_for_processor = {
+            k: v for k, v in merged_kwargs.items() if k != "use_audio_in_video"
+        }
 
         allowed_kwargs = get_allowed_kwarg_only_overrides(
             hf_processor,
-            merged_kwargs,
+            kwargs_for_processor,
             requires_kw_only=False,
             allow_var_kwargs=True,
         )

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -194,7 +194,7 @@ class InputProcessingContext:
             typ = ProcessorMixin
 
         tokenizer = self.tokenizer
-        if is_mistral_tokenizer(tokenizer):
+        if tokenizer is not None and is_mistral_tokenizer(tokenizer):
             tokenizer = tokenizer.transformers_tokenizer
 
         merged_kwargs = self.get_merged_mm_kwargs(kwargs)


### PR DESCRIPTION
## Summary

Fixes four bugs when running Qwen3-Omni (and Qwen2.5-Omni) with `use_audio_in_video=True` (video+audio interleaving) in vLLM.

## Bugs fixed

### 1. `merge_mm_processor_kwargs` shallow merge (config mutation)

**File:** `vllm/config/multimodal.py`

`--mm-processor-kwargs` (e.g. `videos_kwargs.size.longest_edge=307200`) was being mutated after the first request because we merged with the same dict reference. HuggingFace processor's internal `_merge_kwargs` does in-place `.pop()` on nested dicts, so the global config was corrupted and the second request reverted to HF default (e.g. max_pixels), increasing video token count.

**Fix:** Use `copy.deepcopy(self.mm_processor_kwargs or {})` before merging so the global config is never mutated.

### 2. `use_audio_in_video` from global config not visible to model

**File:** `vllm/model_executor/models/qwen3_omni_moe_thinker.py`

When passing `--mm-processor-kwargs '{"use_audio_in_video": true}'`, the model code reads `use_audio_in_video` from request-level `mm_kwargs` / `hf_processor_mm_kwargs`, which are often empty. The global config is only merged when calling the HF processor, so the model never saw the flag and did not use the video+audio interleaving path.

**Fix:** In `_call_hf_processor`, after popping `audios`, copy `use_audio_in_video` from `model_config.get_multimodal_config().mm_processor_kwargs` into `mm_kwargs` when missing. In `_get_prompt_updates`, resolve `use_audio_in_video` from the same global config when not present in `hf_processor_mm_kwargs`.

### 3. Warmup / dummy requests with `use_audio_in_video=True` crash

**Files:** `vllm/model_executor/models/qwen2_5_omni_thinker.py`, `vllm/model_executor/models/qwen3_omni_moe_thinker.py`

With global `use_audio_in_video=True`, warmup/dummy requests have no audio data but still set the flag. Downstream mrope/prompt-update logic then expects `audio_output_lengths` (or equivalent) and raises AssertionError when it is empty.

**Fix:**
- **Qwen2.5:** Set `use_audio_in_video` to False when the current request has no audio (`audios` or `mm_data.get("audio")` is empty).
- **Qwen3:** In `_get_prompt_updates`, if `use_audio_in_video` is True but `audio_output_lengths` is empty, set `use_audio_in_video = False` so we do not enter the interleaving branch.

### 4. Passing `use_audio_in_video` to HF Processor causes StopIteration

**File:** `vllm/multimodal/processing/context.py`

If `use_audio_in_video=True` is passed to the HuggingFace processor, both HF and vLLM consume the same audio placeholders. vLLM's chat template produces separate `<|video_pad|>` and `<|audio_pad|>` placeholders; when HF also does audio-in-video handling, the shared iterator is exhausted and vLLM's `_maybe_apply_prompt_updates` hits StopIteration or wrong replacements.

**Fix:** In `call_hf_processor`, after merging kwargs, remove `use_audio_in_video` from the dict passed to `get_allowed_kwarg_only_overrides` / `hf_processor(...)`. Interleaving is handled only inside vLLM in `_maybe_apply_prompt_updates`.

## Testing

- Run Qwen3-Omni with `--mm-processor-kwargs '{"use_audio_in_video": true, "videos_kwargs": {"size": {"longest_edge": 307200}}}'`.
- Send multiple requests with video+audio; token counts and behavior should stay correct after the second request.
- Warmup should complete without AssertionError.
- No StopIteration when processing prompts with both video and audio placeholders.
