### PR TITLE
[Bugfix] Fall back to TORCH_SDPA for encoder attention on SM<80 GPUs

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -175,7 +175,7 @@ Priority is **1 = highest** (tried first).
 | `ROCM_AITER_UNIFIED_ATTN` | | fp16, bf16 | `auto` | %16 | Any | ✅ | ✅ | ❌ | All | N/A |
 | `ROCM_ATTN` | | fp16, bf16, fp32 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32, 544 | 32, 64, 80, 96, 128, 160, 192, 224, 256 | ✅ | ✅ | ❌ | All | N/A |
 | `TREE_ATTN` | | fp16, bf16 | `auto` | %16 | 32, 64, 96, 128, 160, 192, 224, 256 | ❌ | ❌ | ❌ | Decoder | Any |
-| `TRITON_ATTN` | | fp16, bf16, fp32 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | Any | ✅ | ✅ | ❌ | All | Any |
+| `TRITON_ATTN` | | fp16, bf16, fp32 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | Any | ✅ | ✅ | ❌ | All | ≥8.0 |
 
 > **†** FlashInfer uses TRTLLM attention on Blackwell (SM100), which supports sinks. Disable via `--attention-config.use_trtllm_attention=0`.
 >

--- a/tests/v1/attention/test_triton_compute_capability.py
+++ b/tests/v1/attention/test_triton_compute_capability.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test that TritonAttentionBackend correctly rejects SM < 80 GPUs.
+
+Regression test for https://github.com/vllm-project/vllm/issues/36357
+Triton 3.3+ dropped support for SM < 80 (Volta/Turing), causing multimodal
+encoder profiling to hang on V100 and RTX 2080Ti.
+"""
+
+import pytest
+
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backends.triton_attn import TritonAttentionBackend
+
+
+@pytest.mark.parametrize(
+    "capability,expected",
+    [
+        # SM < 80 should NOT be supported (Volta, Turing)
+        (DeviceCapability(7, 0), False),  # V100
+        (DeviceCapability(7, 5), False),  # RTX 2080Ti
+        # SM >= 80 should be supported (Ampere+)
+        (DeviceCapability(8, 0), True),  # A100
+        (DeviceCapability(8, 6), True),  # RTX 3090
+        (DeviceCapability(8, 9), True),  # RTX 4090
+        (DeviceCapability(9, 0), True),  # H100
+    ],
+)
+def test_triton_attn_compute_capability(capability: DeviceCapability, expected: bool):
+    """Triton attention should only support SM >= 80 GPUs."""
+    assert TritonAttentionBackend.supports_compute_capability(capability) == expected

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -344,7 +344,11 @@ class TritonAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        return True
+        # Triton 3.3+ dropped official support for SM < 80 (Volta/Turing).
+        # On these GPUs, Triton attention kernels may hang or run extremely
+        # slowly (see https://github.com/vllm-project/vllm/issues/36357).
+        # Fall back to TORCH_SDPA on SM < 80 GPUs (e.g. V100, RTX 2080Ti).
+        return capability >= DeviceCapability(8, 0)
 
 
 class TritonAttentionImpl(AttentionImpl):


### PR DESCRIPTION
## Summary

Fixes #36357 — V100 multimodal encoder profiling hangs on SM 7.0.

**Root cause**: PR #32183 introduced `TRITON_ATTN` as the default attention backend for multimodal encoder layers. However, Triton 3.3+ [dropped official support for SM < 80](https://github.com/triton-lang/triton#Compatibility) (Volta/Turing). On V100 (SM 7.0) and RTX 2080Ti (SM 7.5), the Triton attention kernel either hangs or runs extremely slowly during encoder profiling, causing a startup deadlock.

**Fix**: Update `TritonAttentionBackend.supports_compute_capability()` to return `False` for SM < 80. This causes the existing `get_vit_attn_backend()` selection loop in `CudaPlatform` to skip `TRITON_ATTN` and fall through to `TORCH_SDPA` on these GPUs — consistent with the behavior before #32183. Ampere+ GPUs (SM >= 80) are unaffected.

This aligns with @ywang96's suggestion: "maybe we should just always use `TORCH_SDPA` when the platform does not support FA."

### Changes
- `vllm/v1/attention/backends/triton_attn.py`: `supports_compute_capability()` now requires `capability >= DeviceCapability(8, 0)`
- `tests/v1/attention/test_triton_compute_capability.py`: Regression test verifying SM < 80 is rejected and SM >= 80 is accepted

cc @ywang96 @Isotr0py

## Test plan
- [x] Added unit test `test_triton_compute_capability.py` covering V100 (7.0), RTX 2080Ti (7.5), A100 (8.0), RTX 3090 (8.6), RTX 4090 (8.9), H100 (9.0)
- [ ] Verified on V100 that multimodal models (e.g. Qwen2.5-VL) no longer hang during startup profiling
- [ ] Verified on Ampere+ GPU that TRITON_ATTN is still selected as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)