### PR TITLE
fix: Responses API streaming tool call support for non-harmony models

### DIFF
--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -94,6 +94,8 @@ from vllm.entrypoints.openai.responses.protocol import (
 from vllm.entrypoints.openai.responses.streaming_events import (
     StreamingState,
     emit_content_delta_events,
+    emit_function_call_delta_events,
+    emit_function_call_done_events,
     emit_previous_item_done_events,
     emit_tool_action_events,
 )
@@ -1259,6 +1261,13 @@ class OpenAIServingResponses(OpenAIServing):
         reasoning_parser = None
         if self.parser and self.parser.reasoning_parser_cls:
             reasoning_parser = self.parser.reasoning_parser_cls(tokenizer)
+        tool_parser = None
+        if self.parser and self.parser.tool_parser_cls:
+            tool_parser = self.parser.tool_parser_cls(tokenizer)
+        tool_streaming_state = StreamingState()
+        tools_streamed = False
+        reasoning_ended = False
+        tool_call_text_started = False
         previous_text = ""
         previous_token_ids: list[int] = []
         first_delta_sent = False
@@ -1271,21 +1280,79 @@ class OpenAIServingResponses(OpenAIServing):
                 output = ctx.last_output.outputs[0]
                 # finish_reason='error' indicates a retryable error
                 self._raise_if_error(output.finish_reason, request.request_id)
-                if reasoning_parser:
+                delta_text = output.text
+                delta_token_ids = list(output.token_ids)
+                current_text = previous_text + delta_text
+                current_token_ids = previous_token_ids + delta_token_ids
+
+                if reasoning_parser and tool_parser:
+                    # Both reasoning and tool calls: reasoning
+                    # first, then tool calls after reasoning ends.
+                    if not reasoning_ended:
+                        delta_message = reasoning_parser.extract_reasoning_streaming(
+                            previous_text=previous_text,
+                            current_text=current_text,
+                            delta_text=delta_text,
+                            previous_token_ids=previous_token_ids,
+                            current_token_ids=current_token_ids,
+                            delta_token_ids=delta_token_ids,
+                        )
+                        if reasoning_parser.is_reasoning_end(delta_token_ids):
+                            reasoning_ended = True
+                            # Reset text/token state so the tool
+                            # parser sees a fresh stream after
+                            # reasoning.
+                            current_token_ids = reasoning_parser.extract_content_ids(
+                                delta_token_ids
+                            )
+                            if delta_message and delta_message.content:
+                                current_text = delta_message.content
+                                delta_message.content = None
+                            else:
+                                current_text = ""
+
+                    if reasoning_ended:
+                        if not tool_call_text_started:
+                            tool_call_text_started = True
+                            previous_text = ""
+                            previous_token_ids = []
+                            delta_text = current_text
+                            delta_token_ids = current_token_ids
+
+                        delta_message = tool_parser.extract_tool_calls_streaming(
+                            previous_text=previous_text,
+                            current_text=current_text,
+                            delta_text=delta_text,
+                            previous_token_ids=previous_token_ids,
+                            current_token_ids=current_token_ids,
+                            delta_token_ids=delta_token_ids,
+                            request=request,
+                        )
+                elif reasoning_parser:
                     delta_message = reasoning_parser.extract_reasoning_streaming(
                         previous_text=previous_text,
-                        current_text=previous_text + output.text,
-                        delta_text=output.text,
+                        current_text=current_text,
+                        delta_text=delta_text,
                         previous_token_ids=previous_token_ids,
-                        current_token_ids=previous_token_ids + output.token_ids,
-                        delta_token_ids=output.token_ids,
+                        current_token_ids=current_token_ids,
+                        delta_token_ids=delta_token_ids,
+                    )
+                elif tool_parser:
+                    delta_message = tool_parser.extract_tool_calls_streaming(
+                        previous_text=previous_text,
+                        current_text=current_text,
+                        delta_text=delta_text,
+                        previous_token_ids=previous_token_ids,
+                        current_token_ids=current_token_ids,
+                        delta_token_ids=delta_token_ids,
+                        request=request,
                     )
                 else:
                     delta_message = DeltaMessage(
                         content=output.text,
                     )
-                previous_text += output.text
-                previous_token_ids += output.token_ids
+                previous_text = current_text
+                previous_token_ids = current_token_ids
                 if not delta_message:
                     continue
                 if not first_delta_sent:
@@ -1317,7 +1384,10 @@ class OpenAIServingResponses(OpenAIServing):
                                 ),
                             )
                         )
-                    else:
+                    elif not delta_message.tool_calls:
+                        # Only emit message output item for content,
+                        # not for tool calls (handled by
+                        # emit_function_call_delta_events)
                         yield _increment_sequence_number_and_return(
                             ResponseOutputItemAddedEvent(
                                 type="response.output_item.added",
@@ -1348,7 +1418,104 @@ class OpenAIServingResponses(OpenAIServing):
                             )
                         )
                     first_delta_sent = True
-                # todo(kebe7jun) tool call support
+                # Handle tool call deltas from the tool parser
+                if delta_message.tool_calls:
+                    if not tools_streamed:
+                        tools_streamed = True
+                        # Close the message output item if content was
+                        # emitted before tool calls (e.g. "Sure!\n\n
+                        # <tool_call>...").  Done events must precede
+                        # the function-call OutputItemAdded event.
+                        if previous_delta_messages:
+                            final_content = "".join(
+                                pm.content
+                                for pm in previous_delta_messages
+                                if pm.content is not None
+                            )
+                            yield _increment_sequence_number_and_return(
+                                ResponseTextDoneEvent(
+                                    type="response.output_text.done",
+                                    sequence_number=-1,
+                                    output_index=current_output_index,
+                                    content_index=current_content_index,
+                                    text=final_content,
+                                    logprobs=[],
+                                    item_id=current_item_id,
+                                )
+                            )
+                            yield _increment_sequence_number_and_return(
+                                ResponseContentPartDoneEvent(
+                                    type="response.content_part.done",
+                                    sequence_number=-1,
+                                    item_id=current_item_id,
+                                    output_index=current_output_index,
+                                    content_index=current_content_index,
+                                    part=ResponseOutputText(
+                                        text=final_content,
+                                        type="output_text",
+                                        annotations=[],
+                                    ),
+                                )
+                            )
+                            yield _increment_sequence_number_and_return(
+                                ResponseOutputItemDoneEvent(
+                                    type="response.output_item.done",
+                                    sequence_number=-1,
+                                    output_index=current_output_index,
+                                    item=ResponseOutputMessage(
+                                        type="message",
+                                        role="assistant",
+                                        content=[
+                                            ResponseOutputText(
+                                                text=final_content,
+                                                type="output_text",
+                                                annotations=[],
+                                            )
+                                        ],
+                                        status="completed",
+                                        id=current_item_id,
+                                    ),
+                                )
+                            )
+                            previous_delta_messages = []
+                            current_output_index += 1
+                        # Sync tool streaming state with current
+                        # output index so function call items get
+                        # the correct index.
+                        tool_streaming_state.current_output_index = current_output_index
+                    for tc in delta_message.tool_calls:
+                        if tc.function:
+                            fn_name = tc.function.name or ""
+                            args_delta = tc.function.arguments or ""
+                            # When a new tool call starts (id is set),
+                            # reset state for a new output item
+                            if tc.id is not None:
+                                if tool_streaming_state.is_first_function_call_delta:
+                                    # Previous tool call finished,
+                                    # advance to next output item
+                                    tool_streaming_state.reset_for_new_item()
+                            for event in emit_function_call_delta_events(
+                                args_delta,
+                                fn_name,
+                                tool_streaming_state,
+                            ):
+                                yield _increment_sequence_number_and_return(event)
+                            # When arguments close with "}", emit done
+                            # event immediately while state IDs are valid
+                            tc_idx = tc.index if tc.index is not None else 0
+                            assert tool_parser is not None
+                            if args_delta == "}" and tc_idx < len(
+                                tool_parser.prev_tool_call_arr
+                            ):
+                                tc_info = tool_parser.prev_tool_call_arr[tc_idx]
+                                for event in emit_function_call_done_events(
+                                    tc_info.get("name", fn_name),
+                                    tc_info.get("arguments", "{}"),
+                                    tool_streaming_state,
+                                ):
+                                    yield _increment_sequence_number_and_return(
+                                        event
+                                    )
 
                 # check delta message and previous delta message are
                 # same as content or reasoning content
@@ -1473,7 +1640,7 @@ class OpenAIServingResponses(OpenAIServing):
                             delta=delta_message.reasoning,
                         )
                     )
-                elif delta_message.content is not None:
+                elif delta_message.content and not tools_streamed:
                     yield _increment_sequence_number_and_return(
                         ResponseTextDeltaEvent(
                             type="response.output_text.delta",
@@ -1495,7 +1662,8 @@ class OpenAIServingResponses(OpenAIServing):
                         )
                     )
 
-                previous_delta_messages.append(delta_message)
+                if not tools_streamed:
+                    previous_delta_messages.append(delta_message)
         if previous_delta_messages:
             if previous_delta_messages[-1].reasoning is not None:
                 reason_content = "".join(


### PR DESCRIPTION
## Purpose

Fix Responses API streaming tool call support for non-harmony models.

Fixes [#36435](https://github.com/vllm-project/vllm/issues/36435)

`_process_simple_streaming_events` currently does not emit proper `response.function_call_arguments.delta` / `response.function_call_arguments.done` events during streaming. Instead, raw tool call XML (e.g. `<tool_call><function=name>...`) leaks into `response.output_text.delta` events.

Two root causes:

1. `reasoning_parser` and `tool_parser` are in a mutually exclusive `if/elif` chain. When a model has both (e.g. Qwen3.5 with `<think>` tags), the `elif tool_parser:` branch is never reached — after reasoning ends, tool call XML falls through as plain content.

2. Even without a reasoning parser, there was no code to convert `DeltaMessage.tool_calls` into Responses API function call events. The original code had `# todo(kebe7jun) tool call support`.

This PR modifies `_process_simple_streaming_events` to:
- Handle both reasoning and tool calls together (reasoning first, then tool calls after `is_reasoning_end()`, matching the Chat Completions streaming behavior)
- Handle tool-call-only models (no reasoning parser)
- Emit `ResponseFunctionCallArgumentsDeltaEvent` / `ResponseFunctionCallArgumentsDoneEvent` via existing `emit_function_call_delta_events` / `emit_function_call_done_events` helpers
- Properly close message output items before function call events when content precedes tool calls
- Sync `tool_streaming_state.current_output_index` with the main output index
- Suppress `ResponseTextDeltaEvent` once tool calls are detected

## Test Plan

```bash
vllm serve Qwen/Qwen3.5-9B \
  --enable-auto-tool-choice \
  --tool-call-parser qwen3_coder
```

```python
from openai import OpenAI

client = OpenAI(base_url="http://localhost:8000/v1", api_key="dummy")

with client.responses.create(
    model="Qwen/Qwen3.5-9B",
    input="What's the weather in Boston today?",
    tools=[{
        "type": "function",
        "name": "get_current_weather",
        "description": "Get the current weather in a given location",
        "parameters": {
            "type": "object",
            "properties": {
                "location": {"type": "string", "description": "The city and state"},
                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
            },
            "required": ["location", "unit"]
        }
    }],
    stream=True,
) as stream:
    for event in stream:
        print(event)
```

## Test Result

<details>
<summary>Before (broken): tool call XML in `response.output_text.delta`</summary>

```
ResponseOutputItemAddedEvent(
    item=ResponseOutputMessage(
        id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
        content=[],
        role='assistant',
        status='in_progress',
        type='message',
        phase=None
    ),
    output_index=1,
    sequence_number=102,
    type='response.output_item.added'
)
ResponseContentPartAddedEvent(
    content_index=0,
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    output_index=1,
    part=ResponseOutputText(annotations=[], text='', type='output_text', logprobs=[]),
    sequence_number=103,
    type='response.content_part.added'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=104,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='<tool_call>',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=105,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=106,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='<',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=107,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='function',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=108,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='=get',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=109,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='_current',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=110,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='_weather',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=111,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='>',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=112,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=113,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='<',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=114,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='parameter',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=115,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='=',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=116,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='location',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=117,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='>',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=118,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=119,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='Boston',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=120,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta=',',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=121,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta=' MA',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=122,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=123,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='</',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=124,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='parameter',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=125,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='>',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=126,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=127,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='<',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=128,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='parameter',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=129,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='=',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=130,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='unit',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=131,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='>',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=132,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=133,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='f',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=134,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='ahrenheit',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=135,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=136,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='</',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=137,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='parameter',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=138,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='>',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=139,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=140,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='</',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=141,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='function',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=142,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='>',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=143,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=144,
    type='response.output_text.delta'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='</tool_call>',
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=145,
    type='response.output_text.delta'
)
ResponseTextDoneEvent(
    content_index=0,
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    logprobs=[],
    output_index=1,
    sequence_number=146,
    text='\n\n<tool_call>\n<function=get_current_weather>\n<parameter=location>\nBoston, 
MA\n</parameter>\n<parameter=unit>\nfahrenheit\n</parameter>\n</function>\n</tool_call>',
    type='response.output_text.done'
)
ResponseContentPartDoneEvent(
    content_index=0,
    item_id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
    output_index=1,
    part=ResponseOutputText(
        annotations=[],
        text='\n\n<tool_call>\n<function=get_current_weather>\n<parameter=location>\nBoston, 
MA\n</parameter>\n<parameter=unit>\nfahrenheit\n</parameter>\n</function>\n</tool_call>',
        type='output_text',
        logprobs=None
    ),
    sequence_number=147,
    type='response.content_part.done'
)
ResponseOutputItemDoneEvent(
    item=ResponseOutputMessage(
        id='24cf2c7d-f2cb-406b-bb99-fe807143e38f',
        content=[
            ResponseOutputText(
                annotations=[],
                text='\n\n<tool_call>\n<function=get_current_weather>\n<parameter=location>\nBoston, 
MA\n</parameter>\n<parameter=unit>\nfahrenheit\n</parameter>\n</function>\n</tool_call>',
                type='output_text',
                logprobs=None
            )
        ],
        role='assistant',
        status='completed',
        type='message',
        phase=None,
        summary=[]
    ),
    output_index=1,
    sequence_number=148,
    type='response.output_item.done'
)
```

</details>

<details>
<summary>After (fixed): proper function call events</summary>

```
ResponseOutputItemAddedEvent(
    item=ResponseOutputMessage(
        id='4992e480-0e55-4d72-9cc8-f348218ef1cc',
        content=[],
        role='assistant',
        status='in_progress',
        type='message',
        phase=None
    ),
    output_index=1,
    sequence_number=102,
    type='response.output_item.added'
)
ResponseContentPartAddedEvent(
    content_index=0,
    item_id='4992e480-0e55-4d72-9cc8-f348218ef1cc',
    output_index=1,
    part=ResponseOutputText(annotations=[], text='', type='output_text', logprobs=[]),
    sequence_number=103,
    type='response.content_part.added'
)
ResponseTextDeltaEvent(
    content_index=0,
    delta='\n\n',
    item_id='4992e480-0e55-4d72-9cc8-f348218ef1cc',
    logprobs=[],
    output_index=1,
    sequence_number=104,
    type='response.output_text.delta'
)
ResponseTextDoneEvent(
    content_index=0,
    item_id='4992e480-0e55-4d72-9cc8-f348218ef1cc',
    logprobs=[],
    output_index=1,
    sequence_number=105,
    text='\n\n',
    type='response.output_text.done'
)
ResponseContentPartDoneEvent(
    content_index=0,
    item_id='4992e480-0e55-4d72-9cc8-f348218ef1cc',
    output_index=1,
    part=ResponseOutputText(annotations=[], text='\n\n', type='output_text', logprobs=None),
    sequence_number=106,
    type='response.content_part.done'
)
ResponseOutputItemDoneEvent(
    item=ResponseOutputMessage(
        id='4992e480-0e55-4d72-9cc8-f348218ef1cc',
        content=[ResponseOutputText(annotations=[], text='\n\n', type='output_text', logprobs=None)],
        role='assistant',
        status='completed',
        type='message',
        phase=None
    ),
    output_index=1,
    sequence_number=107,
    type='response.output_item.done'
)
ResponseOutputItemAddedEvent(
    item=ResponseFunctionToolCall(
        arguments='',
        call_id='call_8606b74d97bf7ffe',
        name='get_current_weather',
        type='function_call',
        id='fc_aae462a5c84e3692',
        status='in_progress'
    ),
    output_index=2,
    sequence_number=108,
    type='response.output_item.added'
)
ResponseFunctionCallArgumentsDeltaEvent(
    delta='',
    item_id='fc_aae462a5c84e3692',
    output_index=2,
    sequence_number=109,
    type='response.function_call_arguments.delta'
)
ResponseFunctionCallArgumentsDeltaEvent(
    delta='{',
    item_id='fc_aae462a5c84e3692',
    output_index=2,
    sequence_number=110,
    type='response.function_call_arguments.delta'
)
ResponseFunctionCallArgumentsDeltaEvent(
    delta='"location": "Boston, MA"',
    item_id='fc_aae462a5c84e3692',
    output_index=2,
    sequence_number=111,
    type='response.function_call_arguments.delta'
)
ResponseFunctionCallArgumentsDeltaEvent(
    delta=', "unit": "fahrenheit"',
    item_id='fc_aae462a5c84e3692',
    output_index=2,
    sequence_number=112,
    type='response.function_call_arguments.delta'
)
ResponseFunctionCallArgumentsDeltaEvent(
    delta='}',
    item_id='fc_aae462a5c84e3692',
    output_index=2,
    sequence_number=113,
    type='response.function_call_arguments.delta'
)
ResponseFunctionCallArgumentsDoneEvent(
    arguments='{"location": "Boston, MA", "unit": "fahrenheit"}',
    item_id='fc_aae462a5c84e3692',
    name='get_current_weather',
    output_index=2,
    sequence_number=114,
    type='response.function_call_arguments.done'
)
ResponseOutputItemDoneEvent(
    item=ResponseFunctionToolCall(
        arguments='{"location": "Boston, MA", "unit": "fahrenheit"}',
        call_id='call_8606b74d97bf7ffe',
        name='get_current_weather',
        type='function_call',
        id=None,
        status='completed',
        item_id='fc_aae462a5c84e3692',
        output_index=2,
        sequence_number=-1
    ),
    output_index=2,
    sequence_number=115,
    type='response.output_item.done'
)
```

</details>

`ResponseCompletedEvent` also correctly contains `ResponseFunctionToolCall` output items (via the existing non-streaming `_make_response_output_items` path).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
