### PR TITLE
fix(tokenizer): handle TokenizersBackendFast class for Qwen3.5 GPTQ models

### DIFF
--- a/tests/tokenizers_/test_hf.py
+++ b/tests/tokenizers_/test_hf.py
@@ -2,12 +2,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import pickle
 from copy import deepcopy
+from unittest.mock import MagicMock, patch
 
 import pytest
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
 from vllm.tokenizers import TokenizerLike
-from vllm.tokenizers.hf import get_cached_tokenizer
+from vllm.tokenizers.hf import (
+    CachedHfTokenizer,
+    _load_tokenizers_backend_fast_fallback,
+    get_cached_tokenizer,
+)
 
 
 @pytest.mark.parametrize("model_id", ["gpt2", "zai-org/chatglm3-6b"])
@@ -41,3 +46,110 @@ def _check_consistency(target: TokenizerLike, expected: TokenizerLike):
     )
 
     assert target.encode("prompt") == expected.encode("prompt")
+
+
+class TestTokenizersBackendFastFallback:
+    """Tests for the TokenizersBackendFast fallback logic (issue #36443)."""
+
+    TOKENIZERS_BACKEND_FAST_ERROR = ValueError(
+        "Tokenizer class TokenizersBackendFast does not exist "
+        "or is not currently imported."
+    )
+
+    def test_fallback_tries_tokenizers_backend_fast_import(self):
+        """When AutoTokenizer fails to resolve TokenizersBackendFast,
+        the fallback should try importing it from transformers."""
+        mock_tokenizer = MagicMock(spec=PreTrainedTokenizerFast)
+
+        mock_cls = MagicMock()
+        mock_cls.from_pretrained.return_value = mock_tokenizer
+
+        with patch("vllm.tokenizers.hf.PreTrainedTokenizerFast") as mock_ptf:
+            fake_module = MagicMock()
+            fake_module.TokenizersBackendFast = mock_cls
+            with patch.dict(
+                "sys.modules",
+                {"transformers": fake_module},
+            ):
+                result = _load_tokenizers_backend_fast_fallback("fake/model")
+
+            assert result == mock_tokenizer
+            mock_cls.from_pretrained.assert_called_once_with("fake/model")
+            mock_ptf.from_pretrained.assert_not_called()
+
+    def test_fallback_to_pretrained_tokenizer_fast(self):
+        """When TokenizersBackendFast is not importable, fall back to
+        PreTrainedTokenizerFast."""
+        mock_tokenizer = MagicMock(spec=PreTrainedTokenizerFast)
+
+        with patch("vllm.tokenizers.hf.PreTrainedTokenizerFast") as mock_ptf:
+            mock_ptf.from_pretrained.return_value = mock_tokenizer
+
+            # Use a fake transformers module without TokenizersBackendFast
+            # so that `from transformers import TokenizersBackendFast` raises
+            # ImportError inside the fallback function.
+            fake_module = MagicMock(spec=["__name__"])
+            with patch.dict("sys.modules", {"transformers": fake_module}):
+                result = _load_tokenizers_backend_fast_fallback("fake/model")
+
+            assert result == mock_tokenizer
+            mock_ptf.from_pretrained.assert_called_once_with("fake/model")
+
+    def test_cached_hf_tokenizer_catches_tokenizers_backend_fast_error(self):
+        """CachedHfTokenizer.from_pretrained should catch the
+        TokenizersBackendFast ValueError and invoke the fallback."""
+        mock_tokenizer = MagicMock(spec=PreTrainedTokenizerFast)
+        mock_tokenizer.all_special_ids = []
+        mock_tokenizer.all_special_tokens = []
+        mock_tokenizer.get_vocab.return_value = {"a": 0}
+        mock_tokenizer.__len__ = lambda self: 1
+        mock_tokenizer.__class__ = PreTrainedTokenizerFast
+
+        with (
+            patch(
+                "vllm.tokenizers.hf.AutoTokenizer.from_pretrained",
+                side_effect=self.TOKENIZERS_BACKEND_FAST_ERROR,
+            ),
+            patch(
+                "vllm.tokenizers.hf._load_tokenizers_backend_fast_fallback",
+                return_value=mock_tokenizer,
+            ) as mock_fallback,
+            patch(
+                "vllm.tokenizers.hf.get_sentence_transformer_tokenizer_config",
+                return_value=None,
+            ),
+        ):
+            result = CachedHfTokenizer.from_pretrained("fake/model")
+
+            mock_fallback.assert_called_once()
+            assert result is not None
+
+    def test_other_value_errors_still_raise(self):
+        """Non-TokenizersBackendFast ValueErrors should propagate normally."""
+        other_error = ValueError("some other tokenizer error")
+
+        with (
+            patch(
+                "vllm.tokenizers.hf.AutoTokenizer.from_pretrained",
+                side_effect=other_error,
+            ),
+            pytest.raises(ValueError, match="some other tokenizer error"),
+        ):
+            CachedHfTokenizer.from_pretrained("fake/model")
+
+    def test_unknown_class_error_suggests_trust_remote_code(self):
+        """Unknown tokenizer class errors should still suggest
+        --trust-remote-code when trust_remote_code=False."""
+        unknown_error = ValueError(
+            "Tokenizer class MyCustomTokenizer does not exist "
+            "or is not currently imported."
+        )
+
+        with (
+            patch(
+                "vllm.tokenizers.hf.AutoTokenizer.from_pretrained",
+                side_effect=unknown_error,
+            ),
+            pytest.raises(RuntimeError, match="trust_remote_code"),
+        ):
+            CachedHfTokenizer.from_pretrained("fake/model", trust_remote_code=False)

--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -7,9 +7,12 @@ from typing import TypeAlias
 
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
 
+from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_sentence_transformer_tokenizer_config
 
 from .protocol import TokenizerLike
+
+logger = init_logger(__name__)
 
 HfTokenizer: TypeAlias = PreTrainedTokenizer | PreTrainedTokenizerFast
 
@@ -91,12 +94,30 @@ class CachedHfTokenizer(TokenizerLike):
                 **kwargs,
             )
         except ValueError as e:
+            error_msg = str(e)
+
+            # TokenizersBackendFast is a native transformers tokenizer class
+            # (introduced in transformers >=4.57) that some newer models
+            # (e.g. Qwen3.5-27B GPTQ) reference in tokenizer_config.json.
+            # AutoTokenizer may fail to resolve it, so fall back gracefully.
+            if (
+                "TokenizersBackendFast" in error_msg
+                and "does not exist or is not currently imported." in error_msg
+            ):
+                tokenizer = _load_tokenizers_backend_fast_fallback(
+                    path_or_repo_id,
+                    *args,
+                    trust_remote_code=trust_remote_code,
+                    revision=revision,
+                    cache_dir=download_dir,
+                    **kwargs,
+                )
             # If the error pertains to the tokenizer class not existing or not
             # currently being imported,
             # suggest using the --trust-remote-code flag.
-            if not trust_remote_code and (
-                "does not exist or is not currently imported." in str(e)
-                or "requires you to execute the tokenizer file" in str(e)
+            elif not trust_remote_code and (
+                "does not exist or is not currently imported." in error_msg
+                or "requires you to execute the tokenizer file" in error_msg
             ):
                 err_msg = (
                     "Failed to load the tokenizer. If the tokenizer "
@@ -123,3 +144,31 @@ class CachedHfTokenizer(TokenizerLike):
             tokenizer.add_special_tokens(special_tokens_map)
 
         return get_cached_tokenizer(tokenizer)
+
+
+def _load_tokenizers_backend_fast_fallback(
+    path_or_repo_id: str | Path,
+    *args,
+    **kwargs,
+) -> HfTokenizer:
+    """Fall back when AutoTokenizer cannot resolve TokenizersBackendFast.
+
+    First tries to import the real class from transformers, then falls
+    back to the generic PreTrainedTokenizerFast which can load any
+    tokenizer.json-based tokenizer.
+    """
+    try:
+        from transformers import TokenizersBackendFast
+
+        logger.info(
+            "Loading tokenizer with TokenizersBackendFast for %s", path_or_repo_id
+        )
+        return TokenizersBackendFast.from_pretrained(path_or_repo_id, *args, **kwargs)
+    except ImportError:
+        logger.warning(
+            "TokenizersBackendFast is not available in this version "
+            "of transformers. Falling back to PreTrainedTokenizerFast "
+            "for %s",
+            path_or_repo_id,
+        )
+        return PreTrainedTokenizerFast.from_pretrained(path_or_repo_id, *args, **kwargs)


### PR DESCRIPTION
## Summary

Fixes #36443

When loading models whose `tokenizer_config.json` references the `TokenizersBackendFast` class (e.g. Qwen3.5-27B GPTQ), `AutoTokenizer.from_pretrained()` raises:

```
ValueError: Tokenizer class TokenizersBackendFast does not exist or is not currently imported.
```

`TokenizersBackendFast` is a native transformers tokenizer class introduced in v4.57 for models using the tokenizers backend directly. `AutoTokenizer` may fail to resolve it through its internal class mapping even when the class is available.

## Changes

**`vllm/tokenizers/hf.py`**
- Add a targeted catch for the `TokenizersBackendFast` `ValueError` in `CachedHfTokenizer.from_pretrained`
- Extract fallback logic into `_load_tokenizers_backend_fast_fallback()` which:
  1. Tries to import and use `TokenizersBackendFast` directly from transformers
  2. Falls back to `PreTrainedTokenizerFast` for older transformers versions

**`tests/tokenizers_/test_hf.py`**
- Add `TestTokenizersBackendFastFallback` test class covering:
  - Direct `TokenizersBackendFast` import path
  - `PreTrainedTokenizerFast` fallback when import fails
  - `CachedHfTokenizer` integration with fallback
  - Other `ValueError`s still propagate correctly
  - Unknown tokenizer class errors still suggest `--trust-remote-code`