### PR TITLE
uniform batch tokens when uniform_batch_tokens is set

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -146,6 +146,11 @@ class SchedulerConfig:
     while a larger value (e.g., 10) reduces host overhead and may increase throughput
     by batching multiple tokens before sending."""
 
+    uniform_batch_tokens: bool = False
+    """If True, prevent mixing prefill and decode requests in the same batch.
+    When running requests have decode tokens scheduled, waiting (prefill)
+    requests will be skipped for that iteration."""
+
     @staticmethod
     def default_factory(**kwargs):
         """

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -598,6 +598,7 @@ class EngineArgs:
     async_scheduling: bool | None = SchedulerConfig.async_scheduling
 
     stream_interval: int = SchedulerConfig.stream_interval
+    uniform_batch_tokens: bool = SchedulerConfig.uniform_batch_tokens
 
     kv_sharing_fast_prefill: bool = CacheConfig.kv_sharing_fast_prefill
     optimization_level: OptimizationLevel = VllmConfig.optimization_level
@@ -1778,6 +1779,7 @@ class EngineArgs:
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,
+            uniform_batch_tokens=self.uniform_batch_tokens,
         )
 
         if not model_config.is_multimodal_model and self.default_mm_loras:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -535,7 +535,18 @@ class Scheduler(SchedulerInterface):
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
         # Next, schedule the WAITING requests.
-        if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
+        # When uniform batch tokens mode is active, don't mix decode (running)
+        # and prefill (waiting) requests in the same batch.
+        has_running_decode = any(
+            num_scheduled_tokens.get(r.request_id, 0) == 1
+            for r in scheduled_running_reqs
+        )
+        skip_waiting = (
+            has_running_decode
+            and scheduled_running_reqs
+            and self.scheduler_config.uniform_batch_tokens
+        )
+        if not preempted_reqs and self._pause_state == PauseState.UNPAUSED and not skip_waiting:
             # Use a temporary RequestQueue to collect requests that need to be
             # skipped and put back at the head of the waiting queue later
             skipped_waiting_requests = create_request_queue(self.policy)


### PR DESCRIPTION
Summary: avoid mixing decode and prefill requests in the same batch

Test Plan: Sandcastle tests

Differential Revision: D95662795


