### PR TITLE
[Perf] Reuse GDN attention buffer to reduce allocation overhead

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -175,10 +175,9 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
         # ============================================================
         # Part 2: Core Attention (Custom Op)
         # ============================================================
-        # Note: we should not use torch.empty here like other attention backends,
-        # see discussions in https://github.com/vllm-project/vllm/pull/28182
-        core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+        # NOTE: semantics unchanged vs torch.zeros(...) — still guaranteed zero init.
+        core_attn_out = self._get_zeroed_core_attn_out(
+            num_tokens,
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -175,7 +175,8 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
         # ============================================================
         # Part 2: Core Attention (Custom Op)
         # ============================================================
-        # NOTE: semantics unchanged vs torch.zeros(...) — still guaranteed zero init.
+        # Note: we should not use torch.empty here like other attention backends,
+        # see discussions in https://github.com/vllm-project/vllm/pull/28182
         core_attn_out = self._get_zeroed_core_attn_out(
             num_tokens,
             dtype=hidden_states.dtype,

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -481,6 +481,12 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
 
+        # =========================
+        # NEW: reusable workspace
+        # =========================
+        # persistent=False: Not included in state_dict; empty(0) is just a placeholder. The real buffer is allocated according to dtype/device/shape during the first forward pass.
+        self.register_buffer("_core_attn_out_buf", torch.empty(0), persistent=False)
+
     def create_qkvz_proj(
         self,
         hidden_size: int,
@@ -548,6 +554,56 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
         return query, key, value, z, b, a
 
+    # =========================
+    # NEW: workspace allocator
+    # =========================
+    def _get_zeroed_core_attn_out(
+        self,
+        num_tokens: int,
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Return a (num_tokens, nheads, head_dim) tensor that is zeroed,
+        reusing an internal buffer to avoid per-call allocation.
+
+        Semantics match: torch.zeros((num_tokens, ...), dtype=dtype, device=device)
+        """
+        # Tail dims are fixed per layer.
+        tail_shape = (self.num_v_heads // self.tp_size, self.head_v_dim)
+
+        buf = self._core_attn_out_buf
+
+        need_new = (
+            buf.numel() == 0
+            or buf.device != device
+            or buf.dtype != dtype
+            or buf.dim() != 3
+            or tuple(buf.shape[1:]) != tail_shape
+            or buf.shape[0] < num_tokens
+        )
+
+        if need_new:
+            # Growth strategy: reduce realloc frequency.
+            # If buf is empty/invalid, just allocate exactly num_tokens.
+            # Otherwise grow to max(num_tokens, ceil(old * 1.5)).
+            if buf.numel() == 0 or buf.dim() != 3 or tuple(buf.shape[1:]) != tail_shape:
+                new_cap = num_tokens
+            else:
+                new_cap = max(num_tokens, int(buf.shape[0] * 1.5) + 1)
+
+            self._core_attn_out_buf = torch.empty(
+                (new_cap, *tail_shape),
+                dtype=dtype,
+                device=device,
+            )
+            buf = self._core_attn_out_buf
+
+        out = buf[:num_tokens]
+        # Keep kernel semantics: input core_attn_out is all zeros.
+        out.zero_()
+        return out
+
     def rearrange_mixed_qkv(self, mixed_qkv):
         if mixed_qkv is None:
             return None, None, None
@@ -596,10 +652,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         # ============================================================
         # Part 2: Core Attention (Custom Op)
         # ============================================================
-        # Note: we should not use torch.empty here like other attention backends,
-        # see discussions in https://github.com/vllm-project/vllm/pull/28182
-        core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+        # NOTE: semantics unchanged vs torch.zeros(...) — still guaranteed zero init.
+        core_attn_out = self._get_zeroed_core_attn_out(
+            num_tokens,
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -652,7 +652,8 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         # ============================================================
         # Part 2: Core Attention (Custom Op)
         # ============================================================
-        # NOTE: semantics unchanged vs torch.zeros(...) — still guaranteed zero init.
+        # Note: we should not use torch.empty here like other attention backends,
+        # see discussions in https://github.com/vllm-project/vllm/pull/28182
         core_attn_out = self._get_zeroed_core_attn_out(
             num_tokens,
             dtype=hidden_states.dtype,


### PR DESCRIPTION
## Summary
This PR eliminates the per-forward `torch.zeros` allocation in `Qwen3NextGatedDeltaNet` and `Qwen3_5GatedDeltaNet` by introducing a reusable workspace buffer. The kernel semantics remain unchanged (output tensor is still zeroed before the custom op).

## Changes
- Add `_core_attn_out_buf` persistent buffer in `Qwen3NextGatedDeltaNet.__init__`
- Add `_get_zeroed_core_attn_out()` helper with capacity growth strategy (1.5x)
- Replace `torch.zeros(...)` calls in both `Qwen3NextGatedDeltaNet.forward` and `Qwen3_5GatedDeltaNet.forward`

## Performance Impact

###Benchmarks
Hardware: Nvidia H800, Software: CUDA/driver：13.0
Workload: model：Qwen3.5-35B-A3B

[before] 
``` python
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             100       
Benchmark duration (s):                  36.73     
Total input tokens:                      1013750   
Total generated tokens:                  100000    
Request throughput (req/s):              27.23     
Output token throughput (tok/s):         2722.89   
Peak output token throughput (tok/s):    6934.00   
Peak concurrent requests:                189.00    
Total token throughput (tok/s):          30326.15  
---------------Time to First Token----------------
Mean TTFT (ms):                          1274.34   
Median TTFT (ms):                        453.68    
P99 TTFT (ms):                           9623.89   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          24.09     
Median TPOT (ms):                        24.00     
P99 TPOT (ms):                           28.74     
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.84     
Median ITL (ms):                         14.86     
P99 ITL (ms):                            118.96    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          3658.80   
Median E2EL (ms):                        2828.67   
P99 E2EL (ms):                           12062.10  
==================================================
```
[after]

```python
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             100       
Benchmark duration (s):                  29.60     
Total input tokens:                      1013750   
Total generated tokens:                  100000    
Request throughput (req/s):              33.78     
Output token throughput (tok/s):         3377.84   
Peak output token throughput (tok/s):    6709.00   
Peak concurrent requests:                181.00    
Total token throughput (tok/s):          37620.68  
---------------Time to First Token----------------
Mean TTFT (ms):                          553.38    
Median TTFT (ms):                        454.27    
P99 TTFT (ms):                           2425.18   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          24.17     
Median TPOT (ms):                        24.20     
P99 TPOT (ms):                           27.54     
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.93     
Median ITL (ms):                         14.96     
P99 ITL (ms):                            118.02    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          2946.40   
Median E2EL (ms):                        2839.37   
P99 E2EL (ms):                           4890.67   
==================================================
```
####Accuracy/Precision Test Results
| DataSet                 | \[Feature] Score | Baseline Score | 
| -------------------- | ---------------- | -------------- | 
|C-Eval      |       0.9101    |  0.9049          | 
| mm_bench  |     0.9178    |  0.9168          | 

## Notes for Reviewers
- The workspace buffer is registered with `persistent=False` to avoid affecting checkpointing
- Zeroing is still performed (`out.zero_()`) to maintain exact kernel semantics
- Follow-up: Consider making kernel fully overwrite output to allow `torch.empty` (future PR)