### PR TITLE
[bugfix] fix nvlink for nixl/ucx

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1133,8 +1133,6 @@ class NixlConnectorWorker:
             "enforce_handshake_compat", True
         )
 
-        self.has_connected_agents = False
-
     def _nixl_handshake(
         self,
         host: str,
@@ -1143,6 +1141,19 @@ class NixlConnectorWorker:
         expected_engine_id: str,
     ) -> dict[int, str]:
         """Do a NIXL handshake with a remote instance."""
+
+        # the first time we connect to a remote agent.
+        # be careful, the handshake happens in a background thread.
+        # it does not have an active cuda context until any cuda runtime
+        # call is made. when UCX fails to find a valid cuda context, it will
+        # disable any cuda ipc communication, essentially disabling any NVLink
+        # communication.
+        # when we are using device buffers, we need to set the device
+        # explicitly to make sure the handshake background thread has a valid
+        # cuda context.
+        if not self.use_host_buffer:
+            current_platform.set_device(self.device_id)
+
         # When target instance TP > local TP, we need to perform multiple
         # handshakes. Do it in a single background job for simplicity.
         # Regardless, only handshake with the remote TP rank(s) that current
@@ -1692,20 +1703,6 @@ class NixlConnectorWorker:
             self._tp_size[engine_id] = remote_tp_size
         if engine_id not in self._block_size:
             self._block_size[engine_id] = nixl_agent_meta.block_size
-
-        if not self.has_connected_agents:
-            self.has_connected_agents = True
-            # the first time we connect to a remote agent.
-            # be careful, the handshake happens in a background thread.
-            # it does not have an active cuda context until any cuda runtime
-            # call is made. when UCX fails to find a valid cuda context, it will
-            # disable any cuda ipc communication, essentially disabling any NVLink
-            # communication.
-            # when we are using device buffers, we need to set the device
-            # explicitly to make sure the handshake background thread has a valid
-            # cuda context.
-            if not self.use_host_buffer:
-                current_platform.set_device(self.device_id)
 
         remote_agent_name = self.nixl_wrapper.add_remote_agent(
             nixl_agent_meta.agent_metadata

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1133,6 +1133,8 @@ class NixlConnectorWorker:
             "enforce_handshake_compat", True
         )
 
+        self.has_connected_agents = False
+
     def _nixl_handshake(
         self,
         host: str,
@@ -1690,6 +1692,20 @@ class NixlConnectorWorker:
             self._tp_size[engine_id] = remote_tp_size
         if engine_id not in self._block_size:
             self._block_size[engine_id] = nixl_agent_meta.block_size
+
+        if not self.has_connected_agents:
+            self.has_connected_agents = True
+            # the first time we connect to a remote agent.
+            # be careful, the handshake happens in a background thread.
+            # it does not have an active cuda context until any cuda runtime
+            # call is made. when UCX fails to find a valid cuda context, it will
+            # disable any cuda ipc communication, essentially disabling any NVLink
+            # communication.
+            # when we are using device buffers, we need to set the device
+            # explicitly to make sure the handshake background thread has a valid
+            # cuda context.
+            if not self.use_host_buffer:
+                current_platform.set_device(self.device_id)
 
         remote_agent_name = self.nixl_wrapper.add_remote_agent(
             nixl_agent_meta.agent_metadata


### PR DESCRIPTION
See https://forums.developer.nvidia.com/t/when-a-thread-has-a-primary-cuda-context-does-the-child-thread-it-creates-automatically-inherit-the-cuda-context/362810 , a new thread does not have any cuda context, which would fail UCX and disable nvlink transfer.

## Purpose

Currently nixl/ucx can only use RDMA NIC or host buffers to transfer between GPUs for the first pair of P/D instances. This PR fixes the issue.

## Test Plan

After this PR, running 1P1D setup with `export UCX_PROTO_INFO=y`, send a request, wait for finish. in the decode instance output, search for regex `.*ucp.*cuda.*cuda.*`, we can see `cuda_ipc` is used (i.e. nvlink).

## Test Result

[1773041646.804694] [gb200-14:494385:5]   | ucp_context_0 intra-node cfg#2 | remote memory read by ucp_get*(multi) into cuda/GPU0 from cuda/dev[0]    |
[1773041646.804694] [gb200-14:494385:5]   +--------------------------------+----------------------------------------------------------+---------------+
[1773041646.804695] [gb200-14:494385:5]   |                         0..inf | zero-copy                                                | cuda_ipc/cuda |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

