### PR TITLE
bugfix(dcp, gdn): disabling DCP semantics for linear-attention KV/state groups

### DIFF
--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -17,11 +17,7 @@ from vllm.v1.core.single_type_kv_cache_manager import (
     SingleTypeKVCacheManager,
     get_manager_for_kv_cache_spec,
 )
-from vllm.v1.kv_cache_interface import (
-    FullAttentionSpec,
-    KVCacheConfig,
-    KVCacheSpec,
-)
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
 from vllm.v1.request import Request
 
 
@@ -56,17 +52,30 @@ class KVCacheCoordinator(ABC):
 
         # Needs special handling for find_longest_cache_hit if eagle is enabled
         self.use_eagle = use_eagle
+        self.group_dcp_world_sizes = tuple(
+            self._get_effective_group_dcp_world_size(
+                kv_cache_group.kv_cache_spec, dcp_world_size
+            )
+            for kv_cache_group in self.kv_cache_config.kv_cache_groups
+        )
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(
                 kv_cache_spec=kv_cache_group.kv_cache_spec,
                 block_pool=self.block_pool,
                 enable_caching=enable_caching,
                 kv_cache_group_id=i,
-                dcp_world_size=dcp_world_size,
+                dcp_world_size=self.group_dcp_world_sizes[i],
                 pcp_world_size=pcp_world_size,
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
+
+    @staticmethod
+    def _get_effective_group_dcp_world_size(
+        kv_cache_spec: KVCacheSpec,
+        dcp_world_size: int,
+    ) -> int:
+        return dcp_world_size if kv_cache_spec.supports_dcp else 1
 
     def get_num_blocks_to_allocate(
         self,
@@ -331,10 +340,10 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         )
         self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
         self.block_size = self.kv_cache_spec.block_size
-        self.dcp_world_size = dcp_world_size
+        self.dcp_world_size = self.group_dcp_world_sizes[0]
         self.pcp_world_size = pcp_world_size
-        if dcp_world_size > 1:
-            self.block_size *= dcp_world_size
+        if self.dcp_world_size > 1:
+            self.block_size *= self.dcp_world_size
         if pcp_world_size > 1:
             self.block_size *= pcp_world_size
         # For models using only Mamba, block_size is set to max_model_len when

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -26,6 +26,10 @@ class KVCacheSpec:
     block_size: int
 
     @property
+    def supports_dcp(self) -> bool:
+        return False
+
+    @property
     def page_size_bytes(self) -> int:
         """
         The size of a page with `block_size` tokens in bytes.
@@ -109,6 +113,10 @@ class FullAttentionSpec(AttentionSpec):
     def __post_init__(self):
         if self.head_size_v is None:
             object.__setattr__(self, "head_size_v", self.head_size)
+
+    @property
+    def supports_dcp(self) -> bool:
+        return True
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_model_len = vllm_config.model_config.max_model_len

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -18,9 +18,9 @@ class BlockTables:
         max_num_batched_tokens: int,
         max_model_len: int,
         device: torch.device,
-        cp_size: int = 1,
-        cp_rank: int = 0,
-        cp_interleave: int = 1,
+        cp_size: int | list[int] = 1,
+        cp_rank: int | list[int] = 0,
+        cp_interleave: int | list[int] = 1,
     ):
         self.block_sizes = block_sizes
         self.max_num_reqs = max_num_reqs
@@ -28,19 +28,31 @@ class BlockTables:
         self.max_model_len = max_model_len
         self.device = device
 
-        self.cp_size = cp_size
-        self.cp_rank = cp_rank
-        self.cp_interleave = cp_interleave
-
         self.num_kv_cache_groups = len(self.block_sizes)
+        self.cp_sizes = self._normalize_group_values(cp_size, "cp_size")
+        self.cp_ranks = self._normalize_group_values(cp_rank, "cp_rank")
+        self.cp_interleaves = self._normalize_group_values(
+            cp_interleave, "cp_interleave"
+        )
+        self.cp_sizes_tensor = torch.tensor(
+            self.cp_sizes, dtype=torch.int32, device=self.device
+        )
+        self.cp_ranks_tensor = torch.tensor(
+            self.cp_ranks, dtype=torch.int32, device=self.device
+        )
+        self.cp_interleaves_tensor = torch.tensor(
+            self.cp_interleaves, dtype=torch.int32, device=self.device
+        )
+
         # num_kv_cache_groups x [max_num_reqs, max_num_blocks]
         self.block_tables: list[StagedWriteTensor] = []
         for i in range(self.num_kv_cache_groups):
             block_size = self.block_sizes[i]
+            cp_size_i = self.cp_sizes[i]
             # When using DCP, each request's KV cache is sharded among different ranks.
             # As a result, one block on the current rank covers `block_size * cp_size`
             # tokens in the full, global (unsharded) sequence.
-            max_num_blocks = cdiv(self.max_model_len, block_size * self.cp_size)
+            max_num_blocks = cdiv(self.max_model_len, block_size * cp_size_i)
             block_table = StagedWriteTensor(
                 (self.max_num_reqs, max_num_blocks),
                 dtype=torch.int32,
@@ -77,6 +89,20 @@ class BlockTables:
             dtype=torch.int64,
             device=self.device,
         )
+
+    def _normalize_group_values(
+        self,
+        values: int | list[int],
+        name: str,
+    ) -> list[int]:
+        if isinstance(values, int):
+            return [values] * self.num_kv_cache_groups
+        if len(values) != self.num_kv_cache_groups:
+            raise ValueError(
+                f"{name} length ({len(values)}) must match the number of "
+                f"kv cache groups ({self.num_kv_cache_groups})."
+            )
+        return values
 
     def _make_ptr_tensor(self, x: Iterable[torch.Tensor]) -> torch.Tensor:
         # NOTE(woosuk): Use uint64 instead of int64 to cover all possible addresses.
@@ -143,11 +169,11 @@ class BlockTables:
             self.block_table_ptrs,
             self.block_table_strides,
             self.block_sizes_tensor,
+            self.cp_sizes_tensor,
+            self.cp_ranks_tensor,
+            self.cp_interleaves_tensor,
             self.slot_mappings,
             self.slot_mappings.stride(0),
-            self.cp_rank,
-            CP_SIZE=self.cp_size,
-            CP_INTERLEAVE=self.cp_interleave,
             PAD_ID=PAD_SLOT_ID,
             TRITON_BLOCK_SIZE=1024,  # type: ignore
         )
@@ -205,11 +231,11 @@ def _compute_slot_mappings_kernel(
     block_table_ptrs,  # [num_kv_cache_groups]
     block_table_strides,  # [num_kv_cache_groups]
     block_sizes,  # [num_kv_cache_groups]
+    cp_sizes,  # [num_kv_cache_groups]
+    cp_ranks,  # [num_kv_cache_groups]
+    cp_interleaves,  # [num_kv_cache_groups]
     slot_mappings_ptr,  # [num_kv_cache_groups, max_num_tokens]
     slot_mappings_stride,
-    cp_rank,
-    CP_SIZE: tl.constexpr,
-    CP_INTERLEAVE: tl.constexpr,
     PAD_ID: tl.constexpr,
     TRITON_BLOCK_SIZE: tl.constexpr,
 ):
@@ -228,6 +254,9 @@ def _compute_slot_mappings_kernel(
     block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
     block_table_stride = tl.load(block_table_strides + group_id)
     block_size = tl.load(block_sizes + group_id)
+    cp_size = tl.load(cp_sizes + group_id)
+    cp_rank = tl.load(cp_ranks + group_id)
+    cp_interleave = tl.load(cp_interleaves + group_id)
 
     req_state_idx = tl.load(idx_mapping + batch_idx)
     start_idx = tl.load(query_start_loc + batch_idx)
@@ -236,21 +265,21 @@ def _compute_slot_mappings_kernel(
         offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
         positions = tl.load(pos + offset, mask=offset < end_idx, other=0)
 
-        block_indices = positions // (block_size * CP_SIZE)
-        block_offsets = positions % (block_size * CP_SIZE)
+        block_indices = positions // (block_size * cp_size)
+        block_offsets = positions % (block_size * cp_size)
         block_numbers = tl.load(
             block_table_ptr + req_state_idx * block_table_stride + block_indices
         )
 
-        if CP_SIZE == 1:
+        if cp_size == 1:
             # Common case: Context parallelism is not used.
             slot_ids = block_numbers * block_size + block_offsets
         else:
             # Context parallelism is used.
-            is_local = block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
-            rounds = block_offsets // (CP_INTERLEAVE * CP_SIZE)
-            remainder = block_offsets % CP_INTERLEAVE
-            local_offsets = rounds * CP_INTERLEAVE + remainder
+            is_local = block_offsets // cp_interleave % cp_size == cp_rank
+            rounds = block_offsets // (cp_interleave * cp_size)
+            remainder = block_offsets % cp_interleave
+            local_offsets = rounds * cp_interleave + remainder
             slot_ids = block_numbers * block_size + local_offsets
             slot_ids = tl.where(is_local, slot_ids, PAD_ID)
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -401,14 +401,26 @@ def prepare_inputs_to_capture(
     )
 
     # HACK(woosuk): Special handling for DCP.
-    if block_tables.cp_size > 1:
+    dcp_group_ids = [
+        i for i, cp_size in enumerate(block_tables.cp_sizes) if cp_size > 1
+    ]
+    if dcp_group_ids:
+        dcp_group_id = dcp_group_ids[0]
+        dcp_size = block_tables.cp_sizes[dcp_group_id]
+        dcp_rank = block_tables.cp_ranks[dcp_group_id]
+        cp_interleave = block_tables.cp_interleaves[dcp_group_id]
+        assert all(block_tables.cp_sizes[i] == dcp_size for i in dcp_group_ids)
+        assert all(block_tables.cp_ranks[i] == dcp_rank for i in dcp_group_ids)
+        assert all(
+            block_tables.cp_interleaves[i] == cp_interleave for i in dcp_group_ids
+        )
         prepare_dcp_local_seq_lens(
             input_buffers.dcp_local_seq_lens,
             input_batch.seq_lens,
             num_reqs,
-            block_tables.cp_size,
-            block_tables.cp_rank,
-            block_tables.cp_interleave,
+            dcp_size,
+            dcp_rank,
+            cp_interleave,
         )
         input_batch.dcp_local_seq_lens = input_buffers.dcp_local_seq_lens[:num_reqs]
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -285,6 +285,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             kv_cache_group.kv_cache_spec.block_size
             for kv_cache_group in kv_cache_config.kv_cache_groups
         ]
+        cp_sizes = [
+            self.dcp_size if kv_cache_group.kv_cache_spec.supports_dcp else 1
+            for kv_cache_group in kv_cache_config.kv_cache_groups
+        ]
+        cp_ranks = [self.dcp_rank if cp_size > 1 else 0 for cp_size in cp_sizes]
+        cp_interleaves = [
+            self.cp_interleave if cp_size > 1 else 1 for cp_size in cp_sizes
+        ]
 
         self.block_tables = BlockTables(
             block_sizes=block_sizes,
@@ -292,9 +300,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_num_batched_tokens=self.max_num_tokens,
             max_model_len=self.max_model_len,
             device=self.device,
-            cp_size=self.dcp_size,
-            cp_rank=self.dcp_rank,
-            cp_interleave=self.cp_interleave,
+            cp_size=cp_sizes,
+            cp_rank=cp_ranks,
+            cp_interleave=cp_interleaves,
         )
 
         self.attn_backends, self.attn_groups = init_attn_backend(


### PR DESCRIPTION
## Purpose
This PR fixes Qwen3.5 behavior under Decode Context Parallel (DCP) by applying DCP only to full-attention KV cache groups and keeping linear-attention/Mamba state-cache groups on non-DCP semantics.

- Full-attention layers still benefit from DCP
- Linear-attention layers no longer inherit incorrect DCP block/state semantics
- This avoids the precision issues and occasional operator failures seen in Qwen3.5 under DCP, without adding DCP compatibility requirements for linear attention

## Test Plan
```
bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m Qwen/Qwen3.5-2B -b "auto" -l 1000 -f 5 -t 4
```

## Test Result
```
vllm ({'pretrained': 'Qwen/Qwen3.5-2B', 'tensor_parallel_size': 4, 'add_bos_token': True, 'max_model_len': 4096}), gen_kwargs: ({}), limit: 1000.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.576|±  |0.0156|
|     |       |strict-match    |     5|exact_match|↑  |0.576|±  |0.0156|
```

```
vllm ({'pretrained': 'Qwen/Qwen3.5-2B', 'tensor_parallel_size': 4, 'add_bos_token': True, 'max_model_len': 4096, 'decode_context_parallel_size': 2, 'enforce_eager': True, 'attention_backend': 'FLASHINFER'}), gen_kwargs: ({}), limit: 1000.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.590|±  |0.0156|
|     |       |strict-match    |     5|exact_match|↑  |0.591|±  |0.0156|
```

works well with FULL_DECODE_ONLY if cherry-pick #36503
```
vllm ({'pretrained': 'Qwen/Qwen3.5-2B', 'tensor_parallel_size': 4, 'add_bos_token': True, 'max_model_len': 4096, 'decode_context_parallel_size': 2, 'attention_backend': 'FLASHINFER'}), gen_kwargs: ({}), limit: 1000.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.577|±  |0.0156|
|     |       |strict-match    |     5|exact_match|↑  |0.576|±  |0.0156|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

