### PR TITLE
fix: Responses API streaming tool call support for non-harmony models

### DIFF
--- a/tests/entrypoints/openai/test_serving_responses.py
+++ b/tests/entrypoints/openai/test_serving_responses.py
@@ -8,6 +8,7 @@ import pytest
 import pytest_asyncio
 from openai.types.responses import (
     ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
     ResponseOutputItemDoneEvent,
     ResponseReasoningItem,
     ResponseReasoningTextDeltaEvent,
@@ -974,11 +975,16 @@ class TestStreamingToolCallEvents:
                 ]
             ),
         ]
+        prev_tool_call_arr_sequence = [
+            [{"name": "get_weather", "arguments": '{"lo'}],
+            [{"name": "get_weather", "arguments": '{"location": "Boston"}'}],
+        ]
         call_count = 0
 
         def mock_extract_tool_calls_streaming(**kwargs):
             nonlocal call_count
             result = delta_sequence[call_count]
+            mock_parser.prev_tool_call_arr = prev_tool_call_arr_sequence[call_count]
             call_count += 1
             return result
 
@@ -1022,6 +1028,12 @@ class TestStreamingToolCallEvents:
             e for e in events if isinstance(e, ResponseFunctionCallArgumentsDeltaEvent)
         ]
         assert len(fc_deltas) >= 1
+        fc_done = [
+            e for e in events if isinstance(e, ResponseFunctionCallArgumentsDoneEvent)
+        ]
+        assert len(fc_done) == 1
+        assert fc_done[0].name == "get_weather"
+        assert fc_done[0].arguments == '{"location": "Boston"}'
 
         # No raw XML text deltas
         text_deltas = [e for e in events if isinstance(e, ResponseTextDeltaEvent)]
@@ -1061,6 +1073,10 @@ class TestStreamingToolCallEvents:
                 ]
             ),
         ]
+        prev_tool_call_arr_sequence = [
+            [],
+            [{"name": "get_weather", "arguments": '{"location": "Boston"}'}],
+        ]
 
         reasoning_call_count = 0
         tool_call_count = 0
@@ -1086,6 +1102,9 @@ class TestStreamingToolCallEvents:
         def mock_extract_tool_calls_streaming(**kwargs):
             nonlocal tool_call_count
             result = tool_deltas[tool_call_count]
+            mock_tool_parser.prev_tool_call_arr = prev_tool_call_arr_sequence[
+                tool_call_count
+            ]
             tool_call_count += 1
             return result
 
@@ -1148,6 +1167,12 @@ class TestStreamingToolCallEvents:
             e for e in events if isinstance(e, ResponseFunctionCallArgumentsDeltaEvent)
         ]
         assert len(fc_deltas) >= 1
+        fc_done = [
+            e for e in events if isinstance(e, ResponseFunctionCallArgumentsDoneEvent)
+        ]
+        assert len(fc_done) == 1
+        assert fc_done[0].name == "get_weather"
+        assert fc_done[0].arguments == '{"location": "Boston"}'
 
         # No raw XML text deltas
         text_deltas = [e for e in events if isinstance(e, ResponseTextDeltaEvent)]

--- a/tests/entrypoints/openai/test_serving_responses.py
+++ b/tests/entrypoints/openai/test_serving_responses.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 import pytest_asyncio
 from openai.types.responses import (
+    ResponseFunctionCallArgumentsDeltaEvent,
     ResponseOutputItemDoneEvent,
     ResponseReasoningItem,
     ResponseReasoningTextDeltaEvent,
@@ -23,7 +24,9 @@ from openai.types.responses.tool import (
 import vllm.envs as envs
 from vllm.entrypoints.mcp.tool_server import ToolServer
 from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
     DeltaMessage,
+    DeltaToolCall,
     ErrorResponse,
     RequestResponseMetadata,
 )
@@ -661,6 +664,7 @@ class TestStreamingReasoningToContentTransition:
         mock_parser.extract_reasoning_streaming = mock_extract_reasoning_streaming
         serving.parser = MagicMock()
         serving.parser.reasoning_parser_cls = MagicMock(return_value=mock_parser)
+        serving.parser.tool_parser_cls = None
 
         # Create contexts for each streaming chunk
         contexts = [
@@ -741,6 +745,7 @@ class TestStreamingReasoningToContentTransition:
         mock_parser.extract_reasoning_streaming = mock_extract_reasoning_streaming
         serving.parser = MagicMock()
         serving.parser.reasoning_parser_cls = MagicMock(return_value=mock_parser)
+        serving.parser.tool_parser_cls = None
 
         contexts = [
             _make_simple_context_with_output("chunk1", [10]),
@@ -814,6 +819,7 @@ class TestStreamingReasoningToContentTransition:
         mock_parser.extract_reasoning_streaming = mock_extract_reasoning_streaming
         serving.parser = MagicMock()
         serving.parser.reasoning_parser_cls = MagicMock(return_value=mock_parser)
+        serving.parser.tool_parser_cls = None
 
         contexts = [
             _make_simple_context_with_output("chunk1", [10]),
@@ -868,3 +874,281 @@ class TestStreamingReasoningToContentTransition:
         ]
         assert len(item_done_events) == 1
         assert isinstance(item_done_events[0].item, ResponseReasoningItem)
+
+
+def _make_serving_instance_with_tool_parser():
+    """Create an OpenAIServingResponses with a mocked tool parser."""
+    engine_client = MagicMock()
+    model_config = MagicMock()
+    model_config.max_model_len = 100
+    model_config.hf_config.model_type = "test"
+    model_config.hf_text_config = MagicMock()
+    model_config.get_diff_sampling_param.return_value = {}
+    engine_client.model_config = model_config
+    engine_client.input_processor = MagicMock()
+    engine_client.io_processor = MagicMock()
+    engine_client.renderer = MagicMock()
+
+    models = MagicMock()
+
+    serving = OpenAIServingResponses(
+        engine_client=engine_client,
+        models=models,
+        request_logger=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+        tool_parser="hermes",
+    )
+    return serving
+
+
+def _make_serving_instance_with_reasoning_and_tool_parser():
+    """Create an OpenAIServingResponses with both reasoning and tool parser."""
+    engine_client = MagicMock()
+    model_config = MagicMock()
+    model_config.max_model_len = 100
+    model_config.hf_config.model_type = "test"
+    model_config.hf_text_config = MagicMock()
+    model_config.get_diff_sampling_param.return_value = {}
+    engine_client.model_config = model_config
+    engine_client.input_processor = MagicMock()
+    engine_client.io_processor = MagicMock()
+    engine_client.renderer = MagicMock()
+
+    models = MagicMock()
+
+    serving = OpenAIServingResponses(
+        engine_client=engine_client,
+        models=models,
+        request_logger=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+        reasoning_parser="qwen3",
+        tool_parser="hermes",
+    )
+    return serving
+
+
+class TestStreamingToolCallEvents:
+    """Tests for _process_simple_streaming_events tool call support.
+
+    Verifies that tool calls from the tool parser are emitted as
+    ResponseFunctionCallArgumentsDeltaEvent / Done events instead of
+    leaking raw XML into ResponseTextDeltaEvent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tool_only_stream_emits_function_call_events(self, monkeypatch):
+        """When a tool parser returns tool_calls, the stream should emit
+        function call delta/done events, not text deltas."""
+
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_with_tool_parser()
+
+        # Simulate tool parser returning tool call deltas
+        delta_sequence = [
+            DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        id="call_1",
+                        index=0,
+                        type="function",
+                        function=DeltaFunctionCall(
+                            name="get_weather",
+                            arguments='{"lo',
+                        ),
+                    ),
+                ]
+            ),
+            DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        id=None,
+                        index=0,
+                        type="function",
+                        function=DeltaFunctionCall(
+                            name="",
+                            arguments='cation": "Boston"}',
+                        ),
+                    ),
+                ]
+            ),
+        ]
+        call_count = 0
+
+        def mock_extract_tool_calls_streaming(**kwargs):
+            nonlocal call_count
+            result = delta_sequence[call_count]
+            call_count += 1
+            return result
+
+        mock_parser = MagicMock()
+        mock_parser.extract_tool_calls_streaming = mock_extract_tool_calls_streaming
+        mock_parser.prev_tool_call_arr = []
+        serving.parser = MagicMock()
+        serving.parser.reasoning_parser_cls = None
+        serving.parser.tool_parser_cls = MagicMock(return_value=mock_parser)
+
+        contexts = [
+            _make_simple_context_with_output("<tool_call>", [10]),
+            _make_simple_context_with_output("args", [20]),
+        ]
+
+        async def result_generator():
+            for ctx in contexts:
+                yield ctx
+
+        request = ResponsesRequest(input="hi", tools=[], stream=True)
+        sampling_params = SamplingParams(max_tokens=64)
+        metadata = RequestResponseMetadata(request_id="req")
+        _identity_increment._counter = 0  # type: ignore
+
+        events = []
+        async for event in serving._process_simple_streaming_events(
+            request=request,
+            sampling_params=sampling_params,
+            result_generator=result_generator(),
+            context=SimpleContext(),
+            model_name="test-model",
+            tokenizer=MagicMock(),
+            request_metadata=metadata,
+            created_time=0,
+            _increment_sequence_number_and_return=_identity_increment,
+        ):
+            events.append(event)
+
+        # Should have function call argument deltas
+        fc_deltas = [
+            e for e in events if isinstance(e, ResponseFunctionCallArgumentsDeltaEvent)
+        ]
+        assert len(fc_deltas) >= 1
+
+        # No raw XML text deltas
+        text_deltas = [e for e in events if isinstance(e, ResponseTextDeltaEvent)]
+        assert len(text_deltas) == 0
+
+    @pytest.mark.asyncio
+    async def test_reasoning_then_tool_call_stream(self, monkeypatch):
+        """When a model has both reasoning and tool parsers, reasoning
+        should be emitted first, then tool calls after reasoning ends.
+        No raw XML should leak as text deltas."""
+
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_with_reasoning_and_tool_parser()
+
+        # Phase 1: reasoning parser returns reasoning content
+        reasoning_deltas = [
+            DeltaMessage(reasoning="thinking..."),
+            DeltaMessage(reasoning=" done"),
+        ]
+        # Phase 2: tool parser returns tool calls after reasoning ends.
+        # The tool parser is called once when reasoning ends (same
+        # iteration, with empty/reset state) and once for the next
+        # chunk.
+        tool_deltas = [
+            DeltaMessage(),  # no tool calls yet in the transition chunk
+            DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        id="call_1",
+                        index=0,
+                        type="function",
+                        function=DeltaFunctionCall(
+                            name="get_weather",
+                            arguments='{"location": "Boston"}',
+                        ),
+                    ),
+                ]
+            ),
+        ]
+
+        reasoning_call_count = 0
+        tool_call_count = 0
+        reasoning_end_triggered = False
+
+        def mock_extract_reasoning_streaming(**kwargs):
+            nonlocal reasoning_call_count
+            result = reasoning_deltas[reasoning_call_count]
+            reasoning_call_count += 1
+            return result
+
+        def mock_is_reasoning_end(input_ids):
+            nonlocal reasoning_end_triggered
+            # Reasoning ends after second chunk
+            if reasoning_call_count >= 2 and not reasoning_end_triggered:
+                reasoning_end_triggered = True
+                return True
+            return False
+
+        def mock_extract_content_ids(input_ids):
+            return []
+
+        def mock_extract_tool_calls_streaming(**kwargs):
+            nonlocal tool_call_count
+            result = tool_deltas[tool_call_count]
+            tool_call_count += 1
+            return result
+
+        mock_reasoning_parser = MagicMock()
+        mock_reasoning_parser.extract_reasoning_streaming = (
+            mock_extract_reasoning_streaming
+        )
+        mock_reasoning_parser.is_reasoning_end = mock_is_reasoning_end
+        mock_reasoning_parser.extract_content_ids = mock_extract_content_ids
+
+        mock_tool_parser = MagicMock()
+        mock_tool_parser.extract_tool_calls_streaming = (
+            mock_extract_tool_calls_streaming
+        )
+        mock_tool_parser.prev_tool_call_arr = []
+
+        serving.parser = MagicMock()
+        serving.parser.reasoning_parser_cls = MagicMock(
+            return_value=mock_reasoning_parser
+        )
+        serving.parser.tool_parser_cls = MagicMock(return_value=mock_tool_parser)
+
+        contexts = [
+            _make_simple_context_with_output("think1", [10]),
+            _make_simple_context_with_output("think2", [20]),
+            _make_simple_context_with_output("<tool_call>", [30]),
+        ]
+
+        async def result_generator():
+            for ctx in contexts:
+                yield ctx
+
+        request = ResponsesRequest(input="hi", tools=[], stream=True)
+        sampling_params = SamplingParams(max_tokens=64)
+        metadata = RequestResponseMetadata(request_id="req")
+        _identity_increment._counter = 0  # type: ignore
+
+        events = []
+        async for event in serving._process_simple_streaming_events(
+            request=request,
+            sampling_params=sampling_params,
+            result_generator=result_generator(),
+            context=SimpleContext(),
+            model_name="test-model",
+            tokenizer=MagicMock(),
+            request_metadata=metadata,
+            created_time=0,
+            _increment_sequence_number_and_return=_identity_increment,
+        ):
+            events.append(event)
+
+        # Should have reasoning deltas
+        reasoning_events = [
+            e for e in events if isinstance(e, ResponseReasoningTextDeltaEvent)
+        ]
+        assert len(reasoning_events) >= 1
+
+        # Should have function call argument deltas
+        fc_deltas = [
+            e for e in events if isinstance(e, ResponseFunctionCallArgumentsDeltaEvent)
+        ]
+        assert len(fc_deltas) >= 1
+
+        # No raw XML text deltas
+        text_deltas = [e for e in events if isinstance(e, ResponseTextDeltaEvent)]
+        assert len(text_deltas) == 0

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import json
 import time
 import uuid
 from collections import deque
@@ -9,7 +10,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
 from contextlib import AsyncExitStack
 from copy import copy
 from http import HTTPStatus
-from typing import Final
+from typing import Final, cast
 
 from fastapi import Request
 from openai.types.responses import (
@@ -46,6 +47,9 @@ from vllm.entrypoints.chat_utils import (
 )
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.mcp.tool_server import ToolServer
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
     ErrorResponse,
@@ -94,6 +98,8 @@ from vllm.entrypoints.openai.responses.protocol import (
 from vllm.entrypoints.openai.responses.streaming_events import (
     StreamingState,
     emit_content_delta_events,
+    emit_function_call_delta_events,
+    emit_function_call_done_events,
     emit_previous_item_done_events,
     emit_tool_action_events,
 )
@@ -1259,6 +1265,13 @@ class OpenAIServingResponses(OpenAIServing):
         reasoning_parser = None
         if self.parser and self.parser.reasoning_parser_cls:
             reasoning_parser = self.parser.reasoning_parser_cls(tokenizer)
+        tool_parser = None
+        if self.parser and self.parser.tool_parser_cls:
+            tool_parser = self.parser.tool_parser_cls(tokenizer)
+        tool_streaming_state = StreamingState()
+        tools_streamed = False
+        reasoning_ended = False
+        tool_call_text_started = False
         previous_text = ""
         previous_token_ids: list[int] = []
         first_delta_sent = False
@@ -1271,21 +1284,79 @@ class OpenAIServingResponses(OpenAIServing):
                 output = ctx.last_output.outputs[0]
                 # finish_reason='error' indicates a retryable error
                 self._raise_if_error(output.finish_reason, request.request_id)
-                if reasoning_parser:
+                delta_text = output.text
+                delta_token_ids = list(output.token_ids)
+                current_text = previous_text + delta_text
+                current_token_ids = previous_token_ids + delta_token_ids
+
+                if reasoning_parser and tool_parser:
+                    # Both reasoning and tool calls: reasoning
+                    # first, then tool calls after reasoning ends.
+                    if not reasoning_ended:
+                        delta_message = reasoning_parser.extract_reasoning_streaming(
+                            previous_text=previous_text,
+                            current_text=current_text,
+                            delta_text=delta_text,
+                            previous_token_ids=previous_token_ids,
+                            current_token_ids=current_token_ids,
+                            delta_token_ids=delta_token_ids,
+                        )
+                        if reasoning_parser.is_reasoning_end(delta_token_ids):
+                            reasoning_ended = True
+                            # Reset text/token state so the tool
+                            # parser sees a fresh stream after
+                            # reasoning.
+                            current_token_ids = reasoning_parser.extract_content_ids(
+                                delta_token_ids
+                            )
+                            if delta_message and delta_message.content:
+                                current_text = delta_message.content
+                                delta_message.content = None
+                            else:
+                                current_text = ""
+
+                    if reasoning_ended:
+                        if not tool_call_text_started:
+                            tool_call_text_started = True
+                            previous_text = ""
+                            previous_token_ids = []
+                            delta_text = current_text
+                            delta_token_ids = current_token_ids
+
+                        delta_message = tool_parser.extract_tool_calls_streaming(
+                            previous_text=previous_text,
+                            current_text=current_text,
+                            delta_text=delta_text,
+                            previous_token_ids=previous_token_ids,
+                            current_token_ids=current_token_ids,
+                            delta_token_ids=delta_token_ids,
+                            request=cast(ChatCompletionRequest, request),
+                        )
+                elif reasoning_parser:
                     delta_message = reasoning_parser.extract_reasoning_streaming(
                         previous_text=previous_text,
-                        current_text=previous_text + output.text,
-                        delta_text=output.text,
+                        current_text=current_text,
+                        delta_text=delta_text,
                         previous_token_ids=previous_token_ids,
-                        current_token_ids=previous_token_ids + output.token_ids,
-                        delta_token_ids=output.token_ids,
+                        current_token_ids=current_token_ids,
+                        delta_token_ids=delta_token_ids,
+                    )
+                elif tool_parser:
+                    delta_message = tool_parser.extract_tool_calls_streaming(
+                        previous_text=previous_text,
+                        current_text=current_text,
+                        delta_text=delta_text,
+                        previous_token_ids=previous_token_ids,
+                        current_token_ids=current_token_ids,
+                        delta_token_ids=delta_token_ids,
+                        request=cast(ChatCompletionRequest, request),
                     )
                 else:
                     delta_message = DeltaMessage(
                         content=output.text,
                     )
-                previous_text += output.text
-                previous_token_ids += output.token_ids
+                previous_text = current_text
+                previous_token_ids = current_token_ids
                 if not delta_message:
                     continue
                 if not first_delta_sent:
@@ -1317,7 +1388,10 @@ class OpenAIServingResponses(OpenAIServing):
                                 ),
                             )
                         )
-                    else:
+                    elif not delta_message.tool_calls:
+                        # Only emit message output item for content,
+                        # not for tool calls (handled by
+                        # emit_function_call_delta_events)
                         yield _increment_sequence_number_and_return(
                             ResponseOutputItemAddedEvent(
                                 type="response.output_item.added",
@@ -1348,7 +1422,122 @@ class OpenAIServingResponses(OpenAIServing):
                             )
                         )
                     first_delta_sent = True
-                # todo(kebe7jun) tool call support
+                # Handle tool call deltas from the tool parser
+                if delta_message.tool_calls:
+                    if not tools_streamed:
+                        tools_streamed = True
+                        # Close the message output item if content was
+                        # emitted before tool calls (e.g. "Sure!\n\n
+                        # <tool_call>...").  Done events must precede
+                        # the function-call OutputItemAdded event.
+                        if previous_delta_messages:
+                            final_content = "".join(
+                                pm.content
+                                for pm in previous_delta_messages
+                                if pm.content is not None
+                            )
+                            yield _increment_sequence_number_and_return(
+                                ResponseTextDoneEvent(
+                                    type="response.output_text.done",
+                                    sequence_number=-1,
+                                    output_index=current_output_index,
+                                    content_index=current_content_index,
+                                    text=final_content,
+                                    logprobs=[],
+                                    item_id=current_item_id,
+                                )
+                            )
+                            yield _increment_sequence_number_and_return(
+                                ResponseContentPartDoneEvent(
+                                    type="response.content_part.done",
+                                    sequence_number=-1,
+                                    item_id=current_item_id,
+                                    output_index=current_output_index,
+                                    content_index=current_content_index,
+                                    part=ResponseOutputText(
+                                        text=final_content,
+                                        type="output_text",
+                                        annotations=[],
+                                    ),
+                                )
+                            )
+                            yield _increment_sequence_number_and_return(
+                                ResponseOutputItemDoneEvent(
+                                    type="response.output_item.done",
+                                    sequence_number=-1,
+                                    output_index=current_output_index,
+                                    item=ResponseOutputMessage(
+                                        type="message",
+                                        role="assistant",
+                                        content=[
+                                            ResponseOutputText(
+                                                text=final_content,
+                                                type="output_text",
+                                                annotations=[],
+                                            )
+                                        ],
+                                        status="completed",
+                                        id=current_item_id,
+                                    ),
+                                )
+                            )
+                            previous_delta_messages = []
+                            current_output_index += 1
+                        # Sync tool streaming state with current
+                        # output index so function call items get
+                        # the correct index.
+                        tool_streaming_state.current_output_index = current_output_index
+                    for tc in delta_message.tool_calls:
+                        if tc.function:
+                            fn_name = tc.function.name or ""
+                            args_delta = tc.function.arguments or ""
+                            # When a new tool call starts (id is set),
+                            # reset state for a new output item
+                            if (
+                                tc.id is not None
+                                and tool_streaming_state.is_first_function_call_delta
+                            ):
+                                # Previous tool call finished,
+                                # advance to next output item
+                                tool_streaming_state.reset_for_new_item()
+                            for event in emit_function_call_delta_events(
+                                args_delta,
+                                fn_name,
+                                tool_streaming_state,
+                            ):
+                                yield _increment_sequence_number_and_return(event)
+                            # Check if accumulated arguments form
+                            # complete JSON — more robust than matching
+                            # the exact delta "}" which can fail when
+                            # the closing brace is batched with other
+                            # characters.
+                            tc_idx = tc.index if tc.index is not None else 0
+                            assert tool_parser is not None
+                            if (
+                                tc_idx < len(tool_parser.prev_tool_call_arr)
+                                and tc_idx
+                                not in tool_streaming_state.done_emitted_tc_indices
+                            ):
+                                tc_info = tool_parser.prev_tool_call_arr[tc_idx]
+                                accumulated_args = tc_info.get("arguments", "")
+                                if accumulated_args:
+                                    try:
+                                        json.loads(accumulated_args)
+                                        tool_streaming_state.done_emitted_tc_indices.add(
+                                            tc_idx
+                                        )
+                                        for event in emit_function_call_done_events(
+                                            tc_info.get("name", fn_name),
+                                            accumulated_args,
+                                            tool_streaming_state,
+                                        ):
+                                            yield (
+                                                _increment_sequence_number_and_return(
+                                                    event
+                                                )
+                                            )
+                                    except (json.JSONDecodeError, ValueError):
+                                        pass
 
                 # check delta message and previous delta message are
                 # same as content or reasoning content
@@ -1473,7 +1662,7 @@ class OpenAIServingResponses(OpenAIServing):
                             delta=delta_message.reasoning,
                         )
                     )
-                elif delta_message.content is not None:
+                elif delta_message.content and not tools_streamed:
                     yield _increment_sequence_number_and_return(
                         ResponseTextDeltaEvent(
                             type="response.output_text.delta",
@@ -1495,7 +1684,8 @@ class OpenAIServingResponses(OpenAIServing):
                         )
                     )
 
-                previous_delta_messages.append(delta_message)
+                if not tools_streamed:
+                    previous_delta_messages.append(delta_message)
         if previous_delta_messages:
             if previous_delta_messages[-1].reasoning is not None:
                 reason_content = "".join(

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -16,7 +16,7 @@ The file is organized as:
 """
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Final
 
 from openai.types.responses import (
@@ -96,6 +96,7 @@ class StreamingState:
     current_call_id: str = ""
     sent_output_item_added: bool = False
     is_first_function_call_delta: bool = False
+    done_emitted_tc_indices: set[int] = field(default_factory=set)
 
     def reset_for_new_item(self) -> None:
         """Reset state when expecting a new output item."""


### PR DESCRIPTION
## Purpose

Fix Responses API streaming tool call support for non-harmony models.

Fixes #36435

## Problem

When streaming responses from models that use XML-based tool calling (e.g., Qwen3.5 with `<think>` tags), the Responses API does not emit proper `response.function_call_arguments.delta` / `response.function_call_arguments.done` events. Instead, raw tool call XML leaks into `response.output_text.delta` events, breaking any client that relies on structured function call streaming. This affects all non-harmony models that combine reasoning and tool calling.

## Root Causes

1. **Mutually exclusive parser chain:** `reasoning_parser` and `tool_parser` are in an `if/elif` chain in `_process_simple_streaming_events`. When a model has both (e.g., Qwen3.5 with `<think>` tags), the `elif tool_parser:` branch is never reached, so tool calls are silently dropped.

2. **Missing event conversion:** No code existed to convert `DeltaMessage.tool_calls` into Responses API function call events. The original code had a `# todo(kebe7jun) tool call support` comment placeholder.

## Changes

- Handle both reasoning and tool calls together — reasoning is processed first, then tool calls are processed after `is_reasoning_end()`, removing the mutual exclusion
- Handle tool-call-only models (no reasoning parser) as a separate path
- Emit `ResponseFunctionCallArgumentsDeltaEvent` / `ResponseFunctionCallArgumentsDoneEvent` via existing helpers
- Close message output items before function call events when content precedes tool calls
- Sync `tool_streaming_state.current_output_index` with the main output index to keep event ordering consistent
- Suppress `ResponseTextDeltaEvent` once tool calls are detected, preventing XML leakage into text events

## Test Plan

Added two new unit tests in `test_serving_responses.py`:
- `test_tool_only_stream_emits_function_call_events` — verifies correct event sequence for models with only tool calling
- `test_reasoning_then_tool_call_stream` — verifies correct event sequence when reasoning precedes tool calls

All 18 existing tests in `test_serving_responses.py` continue to pass, confirming no regressions.