### PR TITLE
[Bugfix] Fix issues in quark emulative logic

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -734,7 +734,8 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             current_platform.supports_mx()
             and self.ocp_mx_scheme.startswith("w_mxfp4")
             and self.mxfp4_backend is not None
-            and self.use_rocm_aiter_moe)
+            and self.use_rocm_aiter_moe
+        )
 
         # CK's pre-compiled MXFP4 MoE GEMM kernel instances have dimension
         # alignment requirements. When violated (e.g. MiniMax-M2.1 with

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -730,10 +730,11 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             get_current_vllm_config().model_config.hf_config, "model_type", None
         )
 
-        self.emulate = (
-            not current_platform.supports_mx()
-            or not self.ocp_mx_scheme.startswith("w_mxfp4")
-        ) and (self.mxfp4_backend is None or not self.use_rocm_aiter_moe)
+        self.emulate = not (
+            current_platform.supports_mx()
+            and self.ocp_mx_scheme.startswith("w_mxfp4")
+            and self.mxfp4_backend is not None
+            and self.use_rocm_aiter_moe)
 
         # CK's pre-compiled MXFP4 MoE GEMM kernel instances have dimension
         # alignment requirements. When violated (e.g. MiniMax-M2.1 with


### PR DESCRIPTION
## Issue

When running the model with **AITER disabled**, the **emulation path does not take effect**.  
This issue was introduced by PR: [#29008](https://github.com/vllm-project/vllm/pull/29008/changes#diff-81df2ed125290511a8464e44614dc9a3701cc089b2fe38abd2f19d8269b30eb6R706-R709).  

Specifically, the `self.emulate` logic in that PR incorrectly evaluates to `False` even when AITER is disabled via environment variables, causing the code to use the AITER execution path instead of the expected emulation path.

---

## Fix

The fix modifies the boolean logic for `self.emulate` to:

```python
not (current_platform.supports_mx() 
     and self.ocp_mx_scheme.startswith("w_mxfp4")
     and self.mxfp4_backend is not None
     and self.use_rocm_aiter_moe)
```
With this change:
- The emulation path is used whenever any of these conditions is not satisfied.
- The logic is simpler and more readable.
- AITER-related environment variables are respected as intended.

---

## Verification
### Test Setup

Tested using the Kimi-K2.5-MXFP4 model:
```bash
vllm serve /shareddata/amd/Kimi-K2.5-MXFP4 -tp 8 \
  --mm-encoder-tp-mode data \
  --tool-call-parser kimi_k2 \
  --reasoning-parser kimi_k2 \
  --trust-remote-code
```
### Observed Log Output
After the fix, the emulation path is correctly used:
```
(Worker pid=134790) (Worker_TP6 pid=134790) WARNING 03-09 10:41:12 [quark_moe.py:746] The current mode (supports_mx=True, use_mxfp4_aiter_moe=False, ocp_mx_scheme=OCP_MX_Scheme.w_mxfp4_a_mxfp4) does not support native MXFP4/MXFP6 computation. Simulated weight dequantization and activation QDQ (quantize and dequantize) will be used, with the linear layers computed in high precision.
```

### Functional Test
Using the following curl request:
```bash
curl http://localhost:8000/v1/completions \
-H 'Content-Type: application/json' \
-d '{"model": "amd/Kimi-K2.5-MXFP4", "prompt": "The capital of France is", "max_tokens": 256}'
```
We get the expected text completion result:
```json
{
  "id": "cmpl-a4a3d85eb2aa5781",
  "object": "text_completion",
  "created": 1773052587,
  "model": "/shareddata/amd/Kimi-K2.5-MXFP4",
  "choices": [
    {
      "index": 0,
      "text": " renowned for its dazzling architecture, remarkable culture, and classic landmarks. But did you know the City of Light is also a great place for thrifting? Whether you're looking for vintage clothing, antiques, or a unique gift, Paris has got you covered. Here are the best thrift stores in Paris. ## Vintage and Secondhand Clothing Each one of these stores has its own style and specialty. Whatever your taste, there is a secondhand shop that will call you back time and again. 860 Paris Vintage has two locations in the center of the city and a focus on men's American-style vintage. They're known for their jackets, especially the laid-back ones of the 1970s. Like many of the shops in Paris, no.860 also has an online presence with an Instagram page that updates potential in-person customers about their latest finds. There is always something new waiting for you. Address: 115 Rue Tiquetonne, 75002 Paris, France When you think 70s and 80s fashion in Paris, look no further than Episode. This Dutch chain set up its Paris headquarters in the Latin Quarter. The glitzy designs on display there are just the right touch to bridge the past and present. Address: 29-31 Rue Tiquetonne",
      "finish_reason": "length"
    }
  ]
}
```

---

## Summary
- Fixed self.emulate logic to respect AITER environment variables.
- Simplified boolean condition for clarity.
- Verified using Kimi-K2.5-MXFP4 with logs and curl response.
