### PR TITLE
Fix: Re-Enable EP for trtllm MoE FP8 backend

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -35,12 +35,6 @@ class TrtLlmFp8Experts(mk.FusedMoEExpertsMonolithic):
     ):
         super().__init__(moe_config, quant_config)
 
-        if moe_config.moe_parallel_config.use_ep and quant_config.is_per_tensor:
-            raise NotImplementedError(
-                "EP parallelism is not supported with TRTLLM"
-                "per-tensor FP8 quantization."
-            )
-
         self.routing_method_type = moe_config.routing_method
         self.topk = moe_config.experts_per_token
         self.intermediate_size_per_partition = (


### PR DESCRIPTION
## Purpose
Remove check to verify EP is not enabled when using trtllm MoE backend for FP8, as it works.
 
## Test Plan
Verify `lm_eval` on https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 with EP enabled on 4xB200.

## Test Result
Flashinfer 0.6.4 installed, so fp8 default to trtllm MoE backend
MODEL=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8

Eval command:
```
lm_eval \
  --model local-completions \
  --model_args base_url=http://127.0.0.1:8000/v1/completions,model=$MODEL,tokenized_requests=False,tokenizer_backend=None,num_concurrent=999,timeout=120,max_retries=5,max_length=8192 \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto --seed 42
```

Reference:
```
TP=4
python3 -m vllm.entrypoints.openai.api_server --model $MODEL -tp $TP --trust-remote-code &

result:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5489|±  |0.0137|
|     |       |strict-match    |     5|exact_match|↑  |0.8423|±  |0.0100|
```

EP enabled:
```
TP=4
python3 -m vllm.entrypoints.openai.api_server --model $MODEL -tp $TP --trust-remote-code --enable-expert-parallel &

result:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5701|±  |0.0136|
|     |       |strict-match    |     5|exact_match|↑  |0.8438|±  |0.0100|
```