### PR TITLE
[Fix] always use loopback ip for `UniProcExecutor`

### DIFF
--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -12,7 +12,11 @@ import torch.distributed as dist
 
 import vllm.envs as envs
 from vllm.logger import init_logger
-from vllm.utils.network_utils import get_distributed_init_method, get_ip, get_open_port
+from vllm.utils.network_utils import (
+    get_distributed_init_method,
+    get_loopback_ip,
+    get_open_port,
+)
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.executor.abstract import Executor
 from vllm.v1.outputs import AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
@@ -50,7 +54,12 @@ class UniProcExecutor(Executor):
 
     def _distributed_args(self) -> tuple[str, int, int]:
         """Return (distributed_init_method, rank, local_rank)."""
-        distributed_init_method = get_distributed_init_method(get_ip(), get_open_port())
+        # UniProcExecutor only initializes a single local worker, so the
+        # rendezvous address should always use loopback instead of route-based
+        # IP autodetection.
+        distributed_init_method = get_distributed_init_method(
+            get_loopback_ip(), get_open_port()
+        )
         # set local rank as the device index if specified
         device_info = self.vllm_config.device_config.device.__str__().split(":")
         local_rank = int(device_info[1]) if len(device_info) > 1 else 0


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR changes the `UniProcExecutor` to always use the loopback IP address in `_distributed_args()` instead of route-based IP auto-detection, since it only initializes a single local worker.

On machines where the default route points at a tunnel / proxy interface, `get_ip()` can resolve to a non-local address (for example a `utun` address) and cause local `gloo` / `TCPStore` initialization to fail or hang.

## Test Plan

1. Enable a tunnel-based proxy.
2. Run `python -m vllm.entrypoints.cli.main serve`

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

