### PR TITLE
feat(dcp, flashinfer): support FULL_DECODE_ONLY for flashinfer with DCP>1

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1717,13 +1717,13 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    total_num_heads = self.num_heads * self.dcp_world_size
+                    num_heads_in_dcp = self.num_heads * self.dcp_world_size
                     buffer_shape = (
                         num_decode_tokens,
-                        total_num_heads,
+                        num_heads_in_dcp,
                         self.head_size,
                     )
-                    lse_shape = (num_decode_tokens, total_num_heads)
+                    lse_shape = (num_decode_tokens, num_heads_in_dcp)
                     output_tmp, lse = current_workspace_manager().get_simultaneous(
                         (buffer_shape, query.dtype),
                         (lse_shape, torch.float32),

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -17,6 +17,7 @@ from flashinfer import (
 from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
 from flashinfer.prefill import trtllm_batch_context_with_kv_cache
 from flashinfer.utils import FP4Tensor
+from typing_extensions import override
 
 from vllm import envs
 from vllm.config import (
@@ -703,6 +704,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             with_numpy=True,
         )
 
+    @override  # type: ignore[misc]
     @classmethod
     def get_cudagraph_support(
         cls: type["FlashInferMetadataBuilder"],
@@ -981,6 +983,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # (block_tables, seq_lens) directly.
         needs_seq_lens_cpu = self.use_dcp or use_cascade or not all_uses_trtllm
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu if needs_seq_lens_cpu else None
+        seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
+        num_blocks_np = (
+            (seq_lens_np + (page_size - 1)) // page_size
+            if seq_lens_np is not None
+            else None
+        )
 
         # Adjust seq_lens_cpu for DCP
         if self.use_dcp:
@@ -1002,13 +1010,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 self.dcp_rank,
                 self.dcp_kv_cache_interleave_size,
             )
-
-        seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
-        num_blocks_np = (
-            (seq_lens_np + (page_size - 1)) // page_size
-            if seq_lens_np is not None
-            else None
-        )
 
         # Adjust num_block_np for cascade attention
         if use_cascade:
@@ -1367,7 +1368,7 @@ class FlashInferImpl(AttentionImpl):
         self,
         query: torch.Tensor,
         num_decode_tokens: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         assert self.dcp_world_size > 1
         total_num_heads = self.num_heads * self.dcp_world_size
         buffer_shape = (
@@ -1376,14 +1377,13 @@ class FlashInferImpl(AttentionImpl):
             self.head_size,
         )
         lse_shape = (num_decode_tokens, total_num_heads)
-        query_buffer, output_buffer, lse_buffer = (
+        output_buffer, lse_buffer = (
             current_workspace_manager().get_simultaneous(
-                (buffer_shape, query.dtype),
                 (buffer_shape, query.dtype),
                 (lse_shape, torch.float32),
             )
         )
-        return query_buffer, output_buffer, lse_buffer
+        return output_buffer, lse_buffer
 
     def forward(
         self,
@@ -1738,17 +1738,14 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    decode_query_buffer, output_tmp, lse = self._get_dcp_decode_buffers(
+                    output_tmp, lse = self._get_dcp_decode_buffers(
                         decode_query, num_decode_tokens
                     )
-                    decode_query_buffer.copy_(
-                        get_dcp_group().all_gather(
-                            decode_query.contiguous(),
-                            dim=-2,
-                        )
+                    decode_query = get_dcp_group().all_gather(
+                        decode_query.contiguous(), dim=-2
                     )
                     decode_wrapper.run(
-                        decode_query_buffer,
+                        decode_query,
                         kv_cache_permute,
                         k_scale=layer._k_scale_float,
                         v_scale=layer._v_scale_float,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1364,25 +1364,6 @@ class FlashInferImpl(AttentionImpl):
         if self.sinks is not None and self.sinks.dtype != torch.float32:
             self.sinks = self.sinks.to(torch.float32)
 
-    def _get_dcp_decode_buffers(
-        self,
-        query: torch.Tensor,
-        num_decode_tokens: int,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        assert self.dcp_world_size > 1
-        total_num_heads = self.num_heads * self.dcp_world_size
-        buffer_shape = (
-            num_decode_tokens,
-            total_num_heads,
-            self.head_size,
-        )
-        lse_shape = (num_decode_tokens, total_num_heads)
-        output_buffer, lse_buffer = current_workspace_manager().get_simultaneous(
-            (buffer_shape, query.dtype),
-            (lse_shape, torch.float32),
-        )
-        return output_buffer, lse_buffer
-
     def forward(
         self,
         layer: torch.nn.Module,
@@ -1736,8 +1717,16 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    output_tmp, lse = self._get_dcp_decode_buffers(
-                        decode_query, num_decode_tokens
+                    total_num_heads = self.num_heads * self.dcp_world_size
+                    buffer_shape = (
+                        num_decode_tokens,
+                        total_num_heads,
+                        self.head_size,
+                    )
+                    lse_shape = (num_decode_tokens, total_num_heads)
+                    output_tmp, lse = current_workspace_manager().get_simultaneous(
+                        (buffer_shape, query.dtype),
+                        (lse_shape, torch.float32),
                     )
                     decode_query = get_dcp_group().all_gather(
                         decode_query.contiguous(), dim=-2

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -982,12 +982,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # (block_tables, seq_lens) directly.
         needs_seq_lens_cpu = self.use_dcp or use_cascade or not all_uses_trtllm
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu if needs_seq_lens_cpu else None
-        seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
-        num_blocks_np = (
-            (seq_lens_np + (page_size - 1)) // page_size
-            if seq_lens_np is not None
-            else None
-        )
 
         # Adjust seq_lens_cpu for DCP
         if self.use_dcp:
@@ -1009,6 +1003,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 self.dcp_rank,
                 self.dcp_kv_cache_interleave_size,
             )
+
+        seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
+        num_blocks_np = (
+            (seq_lens_np + (page_size - 1)) // page_size
+            if seq_lens_np is not None
+            else None
+        )
 
         # Adjust num_block_np for cascade attention
         if use_cascade:
@@ -1324,6 +1325,26 @@ class FlashInferImpl(AttentionImpl):
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
         self.o_sf_scale: float | None = None
+        self.dcp_world_size = (
+            vllm_config.parallel_config.decode_context_parallel_size
+            if vllm_config is not None
+            else 1
+        )
+        speculative_config = (
+            vllm_config.speculative_config if vllm_config is not None else None
+        )
+        num_spec_tokens = (
+            speculative_config.num_speculative_tokens
+            if speculative_config is not None
+            else 0
+        )
+        max_num_reqs = (
+            vllm_config.scheduler_config.max_num_seqs if vllm_config is not None else 0
+        )
+        self._dcp_decode_max_tokens = (1 + num_spec_tokens) * max_num_reqs
+        self._dcp_decode_query_buffers: dict[torch.dtype, torch.Tensor] = {}
+        self._dcp_decode_output_buffers: dict[torch.dtype, torch.Tensor] = {}
+        self._dcp_decode_lse_buffer: torch.Tensor | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
         if self.is_kvcache_nvfp4 and vllm_config is not None:
@@ -1357,6 +1378,50 @@ class FlashInferImpl(AttentionImpl):
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         if self.sinks is not None and self.sinks.dtype != torch.float32:
             self.sinks = self.sinks.to(torch.float32)
+
+    def _get_dcp_decode_buffers(
+        self,
+        query: torch.Tensor,
+        num_decode_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert self.dcp_world_size > 1
+        assert self._dcp_decode_max_tokens > 0
+        total_num_heads = self.num_heads * self.dcp_world_size
+        buffer_shape = (
+            self._dcp_decode_max_tokens,
+            total_num_heads,
+            self.head_size,
+        )
+        query_buffer = self._dcp_decode_query_buffers.get(query.dtype)
+        if query_buffer is None:
+            query_buffer = torch.empty(
+                buffer_shape,
+                dtype=query.dtype,
+                device=query.device,
+            )
+            self._dcp_decode_query_buffers[query.dtype] = query_buffer
+
+        output_buffer = self._dcp_decode_output_buffers.get(query.dtype)
+        if output_buffer is None:
+            output_buffer = torch.empty(
+                buffer_shape,
+                dtype=query.dtype,
+                device=query.device,
+            )
+            self._dcp_decode_output_buffers[query.dtype] = output_buffer
+
+        if self._dcp_decode_lse_buffer is None:
+            self._dcp_decode_lse_buffer = torch.empty(
+                (self._dcp_decode_max_tokens, total_num_heads),
+                dtype=torch.float32,
+                device=query.device,
+            )
+
+        return (
+            query_buffer[:num_decode_tokens],
+            output_buffer[:num_decode_tokens],
+            self._dcp_decode_lse_buffer[:num_decode_tokens],
+        )
 
     def forward(
         self,
@@ -1711,17 +1776,17 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    decode_query = get_dcp_group().all_gather(
-                        decode_query.contiguous(), dim=-2
+                    decode_query_buffer, output_tmp, lse = self._get_dcp_decode_buffers(
+                        decode_query, num_decode_tokens
                     )
-                    output_tmp = torch.empty_like(decode_query)
-                    lse = torch.empty(
-                        (decode_query.size(0), decode_query.size(1)),
-                        dtype=torch.float32,
-                        device=decode_query.device,
+                    decode_query_buffer.copy_(
+                        get_dcp_group().all_gather(
+                            decode_query.contiguous(),
+                            dim=-2,
+                        )
                     )
                     decode_wrapper.run(
-                        decode_query,
+                        decode_query_buffer,
                         kv_cache_permute,
                         k_scale=layer._k_scale_float,
                         v_scale=layer._v_scale_float,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -17,7 +17,6 @@ from flashinfer import (
 from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
 from flashinfer.prefill import trtllm_batch_context_with_kv_cache
 from flashinfer.utils import FP4Tensor
-from typing_extensions import override
 
 from vllm import envs
 from vllm.config import (
@@ -75,6 +74,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.utils import CpuGpuBuffer
+from vllm.v1.worker.workspace import current_workspace_manager
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 
@@ -703,7 +703,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             with_numpy=True,
         )
 
-    @override  # type: ignore[misc]
     @classmethod
     def get_cudagraph_support(
         cls: type["FlashInferMetadataBuilder"],
@@ -1330,21 +1329,6 @@ class FlashInferImpl(AttentionImpl):
             if vllm_config is not None
             else 1
         )
-        speculative_config = (
-            vllm_config.speculative_config if vllm_config is not None else None
-        )
-        num_spec_tokens = (
-            speculative_config.num_speculative_tokens
-            if speculative_config is not None
-            else 0
-        )
-        max_num_reqs = (
-            vllm_config.scheduler_config.max_num_seqs if vllm_config is not None else 0
-        )
-        self._dcp_decode_max_tokens = (1 + num_spec_tokens) * max_num_reqs
-        self._dcp_decode_query_buffers: dict[torch.dtype, torch.Tensor] = {}
-        self._dcp_decode_output_buffers: dict[torch.dtype, torch.Tensor] = {}
-        self._dcp_decode_lse_buffer: torch.Tensor | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
         if self.is_kvcache_nvfp4 and vllm_config is not None:
@@ -1385,43 +1369,21 @@ class FlashInferImpl(AttentionImpl):
         num_decode_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert self.dcp_world_size > 1
-        assert self._dcp_decode_max_tokens > 0
         total_num_heads = self.num_heads * self.dcp_world_size
         buffer_shape = (
-            self._dcp_decode_max_tokens,
+            num_decode_tokens,
             total_num_heads,
             self.head_size,
         )
-        query_buffer = self._dcp_decode_query_buffers.get(query.dtype)
-        if query_buffer is None:
-            query_buffer = torch.empty(
-                buffer_shape,
-                dtype=query.dtype,
-                device=query.device,
+        lse_shape = (num_decode_tokens, total_num_heads)
+        query_buffer, output_buffer, lse_buffer = (
+            current_workspace_manager().get_simultaneous(
+                (buffer_shape, query.dtype),
+                (buffer_shape, query.dtype),
+                (lse_shape, torch.float32),
             )
-            self._dcp_decode_query_buffers[query.dtype] = query_buffer
-
-        output_buffer = self._dcp_decode_output_buffers.get(query.dtype)
-        if output_buffer is None:
-            output_buffer = torch.empty(
-                buffer_shape,
-                dtype=query.dtype,
-                device=query.device,
-            )
-            self._dcp_decode_output_buffers[query.dtype] = output_buffer
-
-        if self._dcp_decode_lse_buffer is None:
-            self._dcp_decode_lse_buffer = torch.empty(
-                (self._dcp_decode_max_tokens, total_num_heads),
-                dtype=torch.float32,
-                device=query.device,
-            )
-
-        return (
-            query_buffer[:num_decode_tokens],
-            output_buffer[:num_decode_tokens],
-            self._dcp_decode_lse_buffer[:num_decode_tokens],
         )
+        return query_buffer, output_buffer, lse_buffer
 
     def forward(
         self,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1377,11 +1377,9 @@ class FlashInferImpl(AttentionImpl):
             self.head_size,
         )
         lse_shape = (num_decode_tokens, total_num_heads)
-        output_buffer, lse_buffer = (
-            current_workspace_manager().get_simultaneous(
-                (buffer_shape, query.dtype),
-                (lse_shape, torch.float32),
-            )
+        output_buffer, lse_buffer = current_workspace_manager().get_simultaneous(
+            (buffer_shape, query.dtype),
+            (lse_shape, torch.float32),
         )
         return output_buffer, lse_buffer
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -2250,13 +2250,13 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    total_num_heads = self.num_heads * self.dcp_world_size
+                    num_heads_in_dcp = self.num_heads * self.dcp_world_size
                     buffer_shape = (
                         num_decode_tokens,
-                        total_num_heads,
+                        num_heads_in_dcp,
                         self.head_size,
                     )
-                    lse_shape = (num_decode_tokens, total_num_heads)
+                    lse_shape = (num_decode_tokens, num_heads_in_dcp)
                     output_tmp, lse = current_workspace_manager().get_simultaneous(
                         (buffer_shape, query.dtype),
                         (lse_shape, torch.float32),

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -2430,12 +2430,12 @@ class FlashInferImpl(AttentionImpl):
                 )
 
                 if use_dcp:
+                    assert self.dcp_manager is not None
                     assert isinstance(out, torch.Tensor)
                     assert lse is not None
-                    output[:num_decode_tokens] = self.dcp_combine(
+                    output[:num_decode_tokens] = self.dcp_manager.combine(
                         out,
                         lse,
-                        get_dcp_group(),
                     )
                 elif needs_fp8_out:
                     output[:num_decode_tokens].copy_(out.to(output.dtype))

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -18,7 +18,6 @@ from flashinfer import (
 from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
 from flashinfer.prefill import trtllm_batch_context_with_kv_cache
 from flashinfer.utils import FP4Tensor
-from typing_extensions import override
 
 from vllm import _custom_ops as custom_ops
 from vllm import envs
@@ -82,6 +81,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.utils import CpuGpuBuffer
+from vllm.v1.worker.workspace import current_workspace_manager
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 FLASHINFER_PREFILL_WORKSPACE_BYTES_PER_ELEM = 16
@@ -956,7 +956,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             with_numpy=True,
         )
 
-    @override  # type: ignore[misc]
     @classmethod
     def get_cudagraph_support(
         cls: type["FlashInferMetadataBuilder"],
@@ -1763,21 +1762,6 @@ class FlashInferImpl(AttentionImpl):
             if vllm_config is not None
             else 1
         )
-        speculative_config = (
-            vllm_config.speculative_config if vllm_config is not None else None
-        )
-        num_spec_tokens = (
-            speculative_config.num_speculative_tokens
-            if speculative_config is not None
-            else 0
-        )
-        max_num_reqs = (
-            vllm_config.scheduler_config.max_num_seqs if vllm_config is not None else 0
-        )
-        self._dcp_decode_max_tokens = (1 + num_spec_tokens) * max_num_reqs
-        self._dcp_decode_query_buffers: dict[torch.dtype, torch.Tensor] = {}
-        self._dcp_decode_output_buffers: dict[torch.dtype, torch.Tensor] = {}
-        self._dcp_decode_lse_buffer: torch.Tensor | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
         if self.is_kvcache_nvfp4 and vllm_config is not None:
@@ -1859,43 +1843,21 @@ class FlashInferImpl(AttentionImpl):
         num_decode_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert self.dcp_world_size > 1
-        assert self._dcp_decode_max_tokens > 0
         total_num_heads = self.num_heads * self.dcp_world_size
         buffer_shape = (
-            self._dcp_decode_max_tokens,
+            num_decode_tokens,
             total_num_heads,
             self.head_size,
         )
-        query_buffer = self._dcp_decode_query_buffers.get(query.dtype)
-        if query_buffer is None:
-            query_buffer = torch.empty(
-                buffer_shape,
-                dtype=query.dtype,
-                device=query.device,
+        lse_shape = (num_decode_tokens, total_num_heads)
+        query_buffer, output_buffer, lse_buffer = (
+            current_workspace_manager().get_simultaneous(
+                (buffer_shape, query.dtype),
+                (buffer_shape, query.dtype),
+                (lse_shape, torch.float32),
             )
-            self._dcp_decode_query_buffers[query.dtype] = query_buffer
-
-        output_buffer = self._dcp_decode_output_buffers.get(query.dtype)
-        if output_buffer is None:
-            output_buffer = torch.empty(
-                buffer_shape,
-                dtype=query.dtype,
-                device=query.device,
-            )
-            self._dcp_decode_output_buffers[query.dtype] = output_buffer
-
-        if self._dcp_decode_lse_buffer is None:
-            self._dcp_decode_lse_buffer = torch.empty(
-                (self._dcp_decode_max_tokens, total_num_heads),
-                dtype=torch.float32,
-                device=query.device,
-            )
-
-        return (
-            query_buffer[:num_decode_tokens],
-            output_buffer[:num_decode_tokens],
-            self._dcp_decode_lse_buffer[:num_decode_tokens],
         )
+        return query_buffer, output_buffer, lse_buffer
 
     def forward(
         self,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -82,7 +82,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.worker.workspace import current_workspace_manager
+from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 FLASHINFER_PREFILL_WORKSPACE_BYTES_PER_ELEM = 16
@@ -93,6 +93,72 @@ FP4_DTYPE = torch.uint8
 logger = init_logger(__name__)
 
 trtllm_workspace_buffer = None
+
+
+class _FlashInferDCPManager:
+    """Own persistent buffers and collectives for FlashInfer DCP decode."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        num_heads: int,
+        head_size: int,
+        dtype: torch.dtype,
+    ) -> None:
+        parallel_config = vllm_config.parallel_config
+        scheduler_config = vllm_config.scheduler_config
+        speculative_config = vllm_config.speculative_config
+
+        self.world_size = parallel_config.decode_context_parallel_size
+        self.max_seq_len = scheduler_config.max_num_seqs
+        num_spec_tokens = (
+            speculative_config.num_speculative_tokens
+            if speculative_config is not None
+            else 0
+        )
+        self.max_num_tokens = min(
+            scheduler_config.max_num_batched_tokens,
+            self.max_seq_len * (1 + num_spec_tokens),
+        )
+
+        num_heads_in_dcp = num_heads * self.world_size
+        num_ubatches = max(parallel_config.num_ubatches, 1)
+        self.output = torch.empty(
+            (
+                num_ubatches,
+                self.max_num_tokens,
+                num_heads_in_dcp,
+                head_size,
+            ),
+            dtype=dtype,
+            device="cuda",
+        )
+        self.lse = torch.empty(
+            (num_ubatches, self.max_num_tokens, num_heads_in_dcp),
+            dtype=torch.float32,
+            device="cuda",
+        )
+
+        combine_fn = (
+            dcp_a2a_lse_reduce
+            if parallel_config.dcp_comm_backend == "a2a"
+            else cp_lse_ag_out_rs
+        )
+        self.combine = partial(combine_fn, is_lse_base_on_e=False)
+
+    def get_decode_buffers(
+        self, num_decode_tokens: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if num_decode_tokens > self.max_num_tokens:
+            raise RuntimeError(
+                "FlashInfer DCP decode batch exceeds the persistent buffer: "
+                f"{num_decode_tokens} > {self.max_num_tokens}."
+            )
+        ubatch_id = dbo_current_ubatch_id()
+        return (
+            self.output[ubatch_id, :num_decode_tokens],
+            self.lse[ubatch_id, :num_decode_tokens],
+        )
 
 
 def _get_trtllm_workspace_buffer():
@@ -1763,6 +1829,16 @@ class FlashInferImpl(AttentionImpl):
             if vllm_config is not None
             else 1
         )
+        self.dcp_manager = (
+            _FlashInferDCPManager(
+                vllm_config,
+                num_heads,
+                head_size,
+                vllm_config.model_config.dtype,
+            )
+            if vllm_config is not None and self.dcp_world_size > 1
+            else None
+        )
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
         if self.is_kvcache_nvfp4 and vllm_config is not None:
@@ -1774,16 +1850,6 @@ class FlashInferImpl(AttentionImpl):
             )
         else:
             self._nvfp4_fp8_out = None
-
-        dcp_a2a = (
-            vllm_config is not None
-            and vllm_config.parallel_config.decode_context_parallel_size > 1
-            and vllm_config.parallel_config.dcp_comm_backend == "a2a"
-        )
-        if dcp_a2a:
-            self.dcp_combine = partial(dcp_a2a_lse_reduce, is_lse_base_on_e=False)
-        else:
-            self.dcp_combine = partial(cp_lse_ag_out_rs, is_lse_base_on_e=False)
 
     def fused_output_quant_supported(self, quant_key: QuantKey):
         # XQA does not support FP8/NVFP4 output, so require trtllm-gen
@@ -2250,16 +2316,9 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    num_heads_in_dcp = self.num_heads * self.dcp_world_size
-                    buffer_shape = (
-                        num_decode_tokens,
-                        num_heads_in_dcp,
-                        self.head_size,
-                    )
-                    lse_shape = (num_decode_tokens, num_heads_in_dcp)
-                    output_tmp, lse = current_workspace_manager().get_simultaneous(
-                        (buffer_shape, query.dtype),
-                        (lse_shape, torch.float32),
+                    assert self.dcp_manager is not None
+                    output_tmp, lse = self.dcp_manager.get_decode_buffers(
+                        num_decode_tokens
                     )
                     decode_query = get_dcp_group().all_gather(
                         decode_query.contiguous(), dim=-2
@@ -2276,7 +2335,7 @@ class FlashInferImpl(AttentionImpl):
                         kv_cache_sf=kv_cache_sf,
                         sinks=self.sinks,
                     )
-                    output[:num_decode_tokens] = self.dcp_combine(
+                    output[:num_decode_tokens] = self.dcp_manager.combine(
                         output_tmp,
                         lse,
                         get_dcp_group(),

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -18,6 +18,7 @@ from flashinfer import (
 from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
 from flashinfer.prefill import trtllm_batch_context_with_kv_cache
 from flashinfer.utils import FP4Tensor
+from typing_extensions import override
 
 from vllm import _custom_ops as custom_ops
 from vllm import envs
@@ -956,6 +957,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             with_numpy=True,
         )
 
+    @override  # type: ignore[misc]
     @classmethod
     def get_cudagraph_support(
         cls: type["FlashInferMetadataBuilder"],
@@ -1362,6 +1364,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # (block_tables, seq_lens) directly.
         needs_seq_lens_cpu = self.use_dcp or use_cascade or not all_uses_trtllm
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu if needs_seq_lens_cpu else None
+        seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
+        num_blocks_np = (
+            (seq_lens_np + (page_size - 1)) // page_size
+            if seq_lens_np is not None
+            else None
+        )
 
         # Adjust seq_lens_cpu for DCP
         if self.use_dcp:
@@ -1383,13 +1391,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 self.dcp_rank,
                 self.dcp_kv_cache_interleave_size,
             )
-
-        seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
-        num_blocks_np = (
-            (seq_lens_np + (page_size - 1)) // page_size
-            if seq_lens_np is not None
-            else None
-        )
 
         # Adjust num_block_np for cascade attention
         if use_cascade:
@@ -1841,7 +1842,7 @@ class FlashInferImpl(AttentionImpl):
         self,
         query: torch.Tensor,
         num_decode_tokens: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         assert self.dcp_world_size > 1
         total_num_heads = self.num_heads * self.dcp_world_size
         buffer_shape = (
@@ -1850,14 +1851,13 @@ class FlashInferImpl(AttentionImpl):
             self.head_size,
         )
         lse_shape = (num_decode_tokens, total_num_heads)
-        query_buffer, output_buffer, lse_buffer = (
+        output_buffer, lse_buffer = (
             current_workspace_manager().get_simultaneous(
-                (buffer_shape, query.dtype),
                 (buffer_shape, query.dtype),
                 (lse_shape, torch.float32),
             )
         )
-        return query_buffer, output_buffer, lse_buffer
+        return output_buffer, lse_buffer
 
     def forward(
         self,
@@ -2271,17 +2271,14 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    decode_query_buffer, output_tmp, lse = self._get_dcp_decode_buffers(
+                    output_tmp, lse = self._get_dcp_decode_buffers(
                         decode_query, num_decode_tokens
                     )
-                    decode_query_buffer.copy_(
-                        get_dcp_group().all_gather(
-                            decode_query.contiguous(),
-                            dim=-2,
-                        )
+                    decode_query = get_dcp_group().all_gather(
+                        decode_query.contiguous(), dim=-2
                     )
                     decode_wrapper.run(
-                        decode_query_buffer,
+                        decode_query,
                         kv_cache_for_fi,
                         q_scale=layer._q_scale_float,
                         k_scale=layer._k_scale_float,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1851,11 +1851,9 @@ class FlashInferImpl(AttentionImpl):
             self.head_size,
         )
         lse_shape = (num_decode_tokens, total_num_heads)
-        output_buffer, lse_buffer = (
-            current_workspace_manager().get_simultaneous(
-                (buffer_shape, query.dtype),
-                (lse_shape, torch.float32),
-            )
+        output_buffer, lse_buffer = current_workspace_manager().get_simultaneous(
+            (buffer_shape, query.dtype),
+            (lse_shape, torch.float32),
         )
         return output_buffer, lse_buffer
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -74,6 +74,7 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
 from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_utils import FlashInferDCPManager
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -82,7 +83,6 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 FLASHINFER_PREFILL_WORKSPACE_BYTES_PER_ELEM = 16
@@ -93,72 +93,6 @@ FP4_DTYPE = torch.uint8
 logger = init_logger(__name__)
 
 trtllm_workspace_buffer = None
-
-
-class _FlashInferDCPManager:
-    """Own persistent buffers and collectives for FlashInfer DCP decode."""
-
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        num_heads: int,
-        head_size: int,
-        dtype: torch.dtype,
-    ) -> None:
-        parallel_config = vllm_config.parallel_config
-        scheduler_config = vllm_config.scheduler_config
-        speculative_config = vllm_config.speculative_config
-
-        self.world_size = parallel_config.decode_context_parallel_size
-        self.max_seq_len = scheduler_config.max_num_seqs
-        num_spec_tokens = (
-            speculative_config.num_speculative_tokens
-            if speculative_config is not None
-            else 0
-        )
-        self.max_num_tokens = min(
-            scheduler_config.max_num_batched_tokens,
-            self.max_seq_len * (1 + num_spec_tokens),
-        )
-
-        num_heads_in_dcp = num_heads * self.world_size
-        num_ubatches = max(parallel_config.num_ubatches, 1)
-        self.output = torch.empty(
-            (
-                num_ubatches,
-                self.max_num_tokens,
-                num_heads_in_dcp,
-                head_size,
-            ),
-            dtype=dtype,
-            device="cuda",
-        )
-        self.lse = torch.empty(
-            (num_ubatches, self.max_num_tokens, num_heads_in_dcp),
-            dtype=torch.float32,
-            device="cuda",
-        )
-
-        combine_fn = (
-            dcp_a2a_lse_reduce
-            if parallel_config.dcp_comm_backend == "a2a"
-            else cp_lse_ag_out_rs
-        )
-        self.combine = partial(combine_fn, is_lse_base_on_e=False)
-
-    def get_decode_buffers(
-        self, num_decode_tokens: int
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        if num_decode_tokens > self.max_num_tokens:
-            raise RuntimeError(
-                "FlashInfer DCP decode batch exceeds the persistent buffer: "
-                f"{num_decode_tokens} > {self.max_num_tokens}."
-            )
-        ubatch_id = dbo_current_ubatch_id()
-        return (
-            self.output[ubatch_id, :num_decode_tokens],
-            self.lse[ubatch_id, :num_decode_tokens],
-        )
 
 
 def _get_trtllm_workspace_buffer():
@@ -1830,7 +1764,7 @@ class FlashInferImpl(AttentionImpl):
             else 1
         )
         self.dcp_manager = (
-            _FlashInferDCPManager(
+            FlashInferDCPManager(
                 vllm_config,
                 num_heads,
                 head_size,
@@ -2320,9 +2254,7 @@ class FlashInferImpl(AttentionImpl):
                     output_tmp, lse = self.dcp_manager.get_decode_buffers(
                         num_decode_tokens
                     )
-                    decode_query = get_dcp_group().all_gather(
-                        decode_query.contiguous(), dim=-2
-                    )
+                    decode_query = self.dcp_manager.gather_query(decode_query)
                     decode_wrapper.run(
                         decode_query,
                         kv_cache_for_fi,
@@ -2338,7 +2270,6 @@ class FlashInferImpl(AttentionImpl):
                     output[:num_decode_tokens] = self.dcp_manager.combine(
                         output_tmp,
                         lse,
-                        get_dcp_group(),
                     )
                 else:
                     decode_wrapper.run(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1363,12 +1363,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # (block_tables, seq_lens) directly.
         needs_seq_lens_cpu = self.use_dcp or use_cascade or not all_uses_trtllm
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu if needs_seq_lens_cpu else None
-        seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
-        num_blocks_np = (
-            (seq_lens_np + (page_size - 1)) // page_size
-            if seq_lens_np is not None
-            else None
-        )
 
         # Adjust seq_lens_cpu for DCP
         if self.use_dcp:
@@ -1390,6 +1384,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 self.dcp_rank,
                 self.dcp_kv_cache_interleave_size,
             )
+
+        seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
+        num_blocks_np = (
+            (seq_lens_np + (page_size - 1)) // page_size
+            if seq_lens_np is not None
+            else None
+        )
 
         # Adjust num_block_np for cascade attention
         if use_cascade:
@@ -1757,6 +1758,26 @@ class FlashInferImpl(AttentionImpl):
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
         self.o_sf_scale: float | None = None
+        self.dcp_world_size = (
+            vllm_config.parallel_config.decode_context_parallel_size
+            if vllm_config is not None
+            else 1
+        )
+        speculative_config = (
+            vllm_config.speculative_config if vllm_config is not None else None
+        )
+        num_spec_tokens = (
+            speculative_config.num_speculative_tokens
+            if speculative_config is not None
+            else 0
+        )
+        max_num_reqs = (
+            vllm_config.scheduler_config.max_num_seqs if vllm_config is not None else 0
+        )
+        self._dcp_decode_max_tokens = (1 + num_spec_tokens) * max_num_reqs
+        self._dcp_decode_query_buffers: dict[torch.dtype, torch.Tensor] = {}
+        self._dcp_decode_output_buffers: dict[torch.dtype, torch.Tensor] = {}
+        self._dcp_decode_lse_buffer: torch.Tensor | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
         if self.is_kvcache_nvfp4 and vllm_config is not None:
@@ -1831,6 +1852,50 @@ class FlashInferImpl(AttentionImpl):
             return query_quantized.view(num_tokens, num_heads, head_size)
 
         return query
+
+    def _get_dcp_decode_buffers(
+        self,
+        query: torch.Tensor,
+        num_decode_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert self.dcp_world_size > 1
+        assert self._dcp_decode_max_tokens > 0
+        total_num_heads = self.num_heads * self.dcp_world_size
+        buffer_shape = (
+            self._dcp_decode_max_tokens,
+            total_num_heads,
+            self.head_size,
+        )
+        query_buffer = self._dcp_decode_query_buffers.get(query.dtype)
+        if query_buffer is None:
+            query_buffer = torch.empty(
+                buffer_shape,
+                dtype=query.dtype,
+                device=query.device,
+            )
+            self._dcp_decode_query_buffers[query.dtype] = query_buffer
+
+        output_buffer = self._dcp_decode_output_buffers.get(query.dtype)
+        if output_buffer is None:
+            output_buffer = torch.empty(
+                buffer_shape,
+                dtype=query.dtype,
+                device=query.device,
+            )
+            self._dcp_decode_output_buffers[query.dtype] = output_buffer
+
+        if self._dcp_decode_lse_buffer is None:
+            self._dcp_decode_lse_buffer = torch.empty(
+                (self._dcp_decode_max_tokens, total_num_heads),
+                dtype=torch.float32,
+                device=query.device,
+            )
+
+        return (
+            query_buffer[:num_decode_tokens],
+            output_buffer[:num_decode_tokens],
+            self._dcp_decode_lse_buffer[:num_decode_tokens],
+        )
 
     def forward(
         self,
@@ -2244,17 +2309,17 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    decode_query = get_dcp_group().all_gather(
-                        decode_query.contiguous(), dim=-2
+                    decode_query_buffer, output_tmp, lse = self._get_dcp_decode_buffers(
+                        decode_query, num_decode_tokens
                     )
-                    output_tmp = torch.empty_like(decode_query)
-                    lse = torch.empty(
-                        (decode_query.size(0), decode_query.size(1)),
-                        dtype=torch.float32,
-                        device=decode_query.device,
+                    decode_query_buffer.copy_(
+                        get_dcp_group().all_gather(
+                            decode_query.contiguous(),
+                            dim=-2,
+                        )
                     )
                     decode_wrapper.run(
-                        decode_query,
+                        decode_query_buffer,
                         kv_cache_for_fi,
                         q_scale=layer._q_scale_float,
                         k_scale=layer._k_scale_float,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1838,25 +1838,6 @@ class FlashInferImpl(AttentionImpl):
 
         return query
 
-    def _get_dcp_decode_buffers(
-        self,
-        query: torch.Tensor,
-        num_decode_tokens: int,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        assert self.dcp_world_size > 1
-        total_num_heads = self.num_heads * self.dcp_world_size
-        buffer_shape = (
-            num_decode_tokens,
-            total_num_heads,
-            self.head_size,
-        )
-        lse_shape = (num_decode_tokens, total_num_heads)
-        output_buffer, lse_buffer = current_workspace_manager().get_simultaneous(
-            (buffer_shape, query.dtype),
-            (lse_shape, torch.float32),
-        )
-        return output_buffer, lse_buffer
-
     def forward(
         self,
         layer: torch.nn.Module,
@@ -2269,8 +2250,16 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    output_tmp, lse = self._get_dcp_decode_buffers(
-                        decode_query, num_decode_tokens
+                    total_num_heads = self.num_heads * self.dcp_world_size
+                    buffer_shape = (
+                        num_decode_tokens,
+                        total_num_heads,
+                        self.head_size,
+                    )
+                    lse_shape = (num_decode_tokens, total_num_heads)
+                    output_tmp, lse = current_workspace_manager().get_simultaneous(
+                        (buffer_shape, query.dtype),
+                        (lse_shape, torch.float32),
                     )
                     decode_query = get_dcp_group().all_gather(
                         decode_query.contiguous(), dim=-2

--- a/vllm/v1/attention/ops/dcp_utils.py
+++ b/vllm/v1/attention/ops/dcp_utils.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""MLA DCP collective selection and direct symmetric-memory implementations."""
+"""DCP managers, collective selection, and symmetric-memory implementations."""
 
 from __future__ import annotations
 
@@ -587,6 +587,80 @@ class DCPCombine(Protocol):
         seq_lens: torch.Tensor,
         query_start_loc: torch.Tensor,
     ) -> torch.Tensor: ...
+
+
+class FlashInferDCPManager:
+    """Own persistent buffers and collectives for FlashInfer DCP decode."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        num_heads: int,
+        head_size: int,
+        dtype: torch.dtype,
+    ) -> None:
+        parallel_config = vllm_config.parallel_config
+        scheduler_config = vllm_config.scheduler_config
+        speculative_config = vllm_config.speculative_config
+
+        self.group = get_dcp_group()
+        self.world_size = parallel_config.decode_context_parallel_size
+        self.max_seq_len = scheduler_config.max_num_seqs
+        num_spec_tokens = (
+            speculative_config.num_speculative_tokens
+            if speculative_config is not None
+            else 0
+        )
+        self.max_num_tokens = min(
+            scheduler_config.max_num_batched_tokens,
+            self.max_seq_len * (1 + num_spec_tokens),
+        )
+
+        num_heads_in_dcp = num_heads * self.world_size
+        num_ubatches = max(parallel_config.num_ubatches, 1)
+        self.output = torch.empty(
+            (
+                num_ubatches,
+                self.max_num_tokens,
+                num_heads_in_dcp,
+                head_size,
+            ),
+            dtype=dtype,
+            device="cuda",
+        )
+        self.lse = torch.empty(
+            (num_ubatches, self.max_num_tokens, num_heads_in_dcp),
+            dtype=torch.float32,
+            device="cuda",
+        )
+
+        combine_fn = (
+            dcp_a2a_lse_reduce
+            if parallel_config.dcp_comm_backend == "a2a"
+            else cp_lse_ag_out_rs
+        )
+        self.combine = functools.partial(
+            combine_fn,
+            cp_group=self.group,
+            is_lse_base_on_e=False,
+        )
+
+    def gather_query(self, query: torch.Tensor) -> torch.Tensor:
+        return self.group.all_gather(query.contiguous(), dim=-2)
+
+    def get_decode_buffers(
+        self, num_decode_tokens: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if num_decode_tokens > self.max_num_tokens:
+            raise RuntimeError(
+                "FlashInfer DCP decode batch exceeds the persistent buffer: "
+                f"{num_decode_tokens} > {self.max_num_tokens}."
+            )
+        ubatch_id = dbo_current_ubatch_id()
+        return (
+            self.output[ubatch_id, :num_decode_tokens],
+            self.lse[ubatch_id, :num_decode_tokens],
+        )
 
 
 class MLADCPManager:


### PR DESCRIPTION
## Purpose
Allocate persistent buffers for DCP-related variables to enable FULL_DECODE_ONLY support.

## Test Plan
```
bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m Qwen/Qwen2.5-1.5B-Instruct/ -b "auto" -l 1000 -f 5 -t 4
```
## Test Result
<!-- codex-accuracy-validation-start -->
### Full GSM8K accuracy validation (requires #48003)

> [!IMPORTANT]
> **PR #48003 is required for accuracy correctness.** PR #36503 alone still uses global sequence lengths for FlashInfer DCP paged-KV metadata and produces corrupted DCP output. Apply #48003 together with this PR before using FlashInfer with `decode_context_parallel_size > 1`, including `FULL_DECODE_ONLY` graph mode.

Accuracy was validated with #48003 temporarily stacked on top of this PR. The run used 4x NVIDIA H20 with `Qwen2.5-1.5B-Instruct`, FlashInfer, all 1,319 GSM8K samples, 5-shot prompting, greedy decoding (`temperature=0`), `max_tokens=256`, `max_model_len=4096`, and seed 42. The local weight directory did not contain tokenizer assets, so the matching official `Qwen/Qwen2.5-1.5B-Instruct` tokenizer/config files were overlaid for evaluation.

| Configuration | Correct | Accuracy | Invalid |
|---|---:|---:|---:|
| TP=4, DCP=1, eager | 730 / 1,319 | 55.345% | 0.227% |
| TP=4, DCP=2, eager | 738 / 1,319 | 55.951% | 0.152% |
| TP=4, DCP=2, `FULL_DECODE_ONLY` graph | 718 / 1,319 | 54.435% | 0.000% |

Without #48003, the same DCP cases produced only 9/1,319 (0.682%) correct in eager mode and 8/1,319 (0.607%) correct in graph mode. With #48003 applied, DCP eager is +0.607 percentage points versus the TP baseline and DCP graph is -0.910 percentage points versus the TP baseline, removing the catastrophic FlashInfer DCP corruption. Graph mode also captured all 51 `FULL_DECODE_ONLY` CUDA graphs successfully.
<!-- codex-accuracy-validation-end -->

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
