### PR TITLE
[CI] Fix edge case that could lead to broken docs builds on main

### DIFF
--- a/docs/maybe_skip_pr_build.sh
+++ b/docs/maybe_skip_pr_build.sh
@@ -19,6 +19,6 @@ if [[ "$HTTP_CODE" -ne 200 ]]; then
 elif grep -qE '"name": *"(documentation|ready)"' /tmp/pr_response.json; then
   echo "Found required label, proceeding with build."
 else
-  echo "PR #${READTHEDOCS_VERSION} lacks 'documentation' or 'ready' label, skipping build."
-  exit 183
+  echo "PR #${READTHEDOCS_VERSION} lacks 'documentation' or 'ready' label, cancelling build."
+  exit 1
 fi


### PR DESCRIPTION
Skipped docs builds (exit code 183) appear as passes on GitHub. This is a problem because:

- Readthedocs is faster to start builds than Mergify is at adding the `documentation` label so the docs build will be illegitimately skipped
- Adding `ready` will not trigger a new docs build for a PR

In both of these cases GitHub will see the docs build as passing when it was skipped. Therefore, a PR could be merged with no docs build being run if there are no new commits added after the labels are added.

This PR changes the exit code to 1 so that a skipped build appears as a failure so that PRs must _always_ have a docs build passing before merging.