### PR TITLE
[Bugfix][Sparse MLA] report indexer CG support properly

### DIFF
--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass
-from typing import ClassVar
 
 import torch
 
@@ -25,6 +24,7 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
     split_prefill_chunks,
 )
+from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
 logger = init_logger(__name__)
@@ -202,9 +202,18 @@ def get_max_prefill_buffer_size(vllm_config: VllmConfig):
 
 
 class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
-    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
-
     reorder_batch_threshold: int = 1
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: AttentionSpec,
+    ) -> AttentionCGSupport:
+        if current_platform.is_cuda() and not is_deep_gemm_supported():
+            # The torch fallback (fp8_paged_mqa_logits_torch) is not CG compatible
+            return AttentionCGSupport.NEVER
+        return AttentionCGSupport.UNIFORM_BATCH
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -210,7 +210,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         vllm_config: VllmConfig,
         kv_cache_spec: AttentionSpec,
     ) -> AttentionCGSupport:
-        if current_platform.is_cuda() and not is_deep_gemm_supported():
+        if not is_deep_gemm_supported():
             logger.warning_once(
                 "DeepGEMM is not available. Disabling CUDA graph support "
                 "for sparse attention indexer. This may reduce performance.",

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -211,7 +211,10 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         kv_cache_spec: AttentionSpec,
     ) -> AttentionCGSupport:
         if current_platform.is_cuda() and not is_deep_gemm_supported():
-            # The torch fallback (fp8_paged_mqa_logits_torch) is not CG compatible
+            logger.warning_once(
+                "DeepGEMM is not available. Disabling CUDA graph support "
+                "for sparse attention indexer. This may reduce performance.",
+            )
             return AttentionCGSupport.NEVER
         return AttentionCGSupport.UNIFORM_BATCH
 


### PR DESCRIPTION

## Purpose
Right now, the indexer reports its CG support as `UNIFORM_BATCH`, but this is only true when DeepGEMM is available. The torch fallback, `fp8_paged_mqa_logits_torch`, is not cudagraph compatible. This causes errors like https://github.com/vllm-project/vllm/pull/30515#issuecomment-4023776086

This PR reports the CG support correctly.

## Test Plan
Without DeepGEMM installed,
```
vllm serve deepseek-ai/DeepSeek-V3.2
```

## Test Result
### Main
```
(EngineCore_DP0 pid=3340691)   File "/home/MatthewBonanni/local/vllm/vllm/utils/deep_gemm.py", line 510, in fp8_paged_mqa_logits_torch
(EngineCore_DP0 pid=3340691)     context_len = context_lens[i].item()
(EngineCore_DP0 pid=3340691) torch.AcceleratorError: CUDA error: operation not permitted when stream is capturing
...
(EngineCore_DP0 pid=3340691) torch.AcceleratorError: CUDA error: operation failed due to a previous error during capture
```

### PR
Starts up properly (with only `PIECEWISE` cudagraphs), and gives the proper warning:
```
(EngineCore_DP0 pid=3372626) WARNING 03-09 16:32:46 [gpu_model_runner.py:6013] CUDAGraphMode.FULL_AND_PIECEWISE is not supported with DeepseekV32IndexerBackend backend (support: AttentionCGSupport.NEVER); setting cudagraph_mode=PIECEWISE because attention is compiled piecewise
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
