### PR TITLE
[Docs] Add Apple MPS (Metal) GPU installation guide

### DIFF
--- a/docs/getting_started/installation/cpu.apple.inc.md
+++ b/docs/getting_started/installation/cpu.apple.inc.md
@@ -5,8 +5,8 @@ vLLM has experimental support for macOS with Apple Silicon. For now, users must 
 
 Currently the CPU implementation for macOS supports FP32 and FP16 datatypes.
 
-!!! tip "GPU-Accelerated Inference with vLLM-Metal"
-    For GPU-accelerated inference on Apple Silicon using Metal, check out [vllm-metal](https://github.com/vllm-project/vllm-metal), a community-maintained hardware plugin that uses MLX as the compute backend.
+!!! tip "GPU-Accelerated Inference with MPS"
+    For GPU-accelerated inference on Apple Silicon using Metal, see the [GPU installation guide](gpu.md) and select the "Apple MPS" tab.
 
 --8<-- [end:installation]
 --8<-- [start:requirements]

--- a/docs/getting_started/installation/gpu.md
+++ b/docs/getting_started/installation/gpu.md
@@ -18,9 +18,13 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 
     --8<-- "docs/getting_started/installation/gpu.xpu.inc.md:installation"
 
+=== "Apple MPS"
+
+    --8<-- "docs/getting_started/installation/gpu.mps.inc.md:installation"
+
 ## Requirements
 
-- OS: Linux
+- OS: Linux (CUDA, ROCm, XPU), macOS 15+ (MPS)
 - Python: 3.10 -- 3.13
 
 !!! note
@@ -37,6 +41,10 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 === "Intel XPU"
 
     --8<-- "docs/getting_started/installation/gpu.xpu.inc.md:requirements"
+
+=== "Apple MPS"
+
+    --8<-- "docs/getting_started/installation/gpu.mps.inc.md:requirements"
 
 ## Set up using Python
 
@@ -56,6 +64,10 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 
     --8<-- "docs/getting_started/installation/gpu.xpu.inc.md:set-up-using-python"
 
+=== "Apple MPS"
+
+    --8<-- "docs/getting_started/installation/gpu.mps.inc.md:set-up-using-python"
+
 ### Pre-built wheels {#pre-built-wheels}
 
 === "NVIDIA CUDA"
@@ -69,6 +81,10 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 === "Intel XPU"
 
     --8<-- "docs/getting_started/installation/gpu.xpu.inc.md:pre-built-wheels"
+
+=== "Apple MPS"
+
+    --8<-- "docs/getting_started/installation/gpu.mps.inc.md:pre-built-wheels"
 
 ### Build wheel from source
 
@@ -84,11 +100,16 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 
     --8<-- "docs/getting_started/installation/gpu.xpu.inc.md:build-wheel-from-source"
 
+=== "Apple MPS"
+
+    --8<-- "docs/getting_started/installation/gpu.mps.inc.md:build-wheel-from-source"
+
 ## Set up using Docker
 
 ### Pre-built images
 
---8<-- [start:pre-built-images]
+<!-- markdownlint-disable MD025 -->
+# --8<-- [start:pre-built-images]
 
 === "NVIDIA CUDA"
 
@@ -102,11 +123,19 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 
     --8<-- "docs/getting_started/installation/gpu.xpu.inc.md:pre-built-images"
 
---8<-- [end:pre-built-images]
+=== "Apple MPS"
 
+    --8<-- "docs/getting_started/installation/gpu.mps.inc.md:pre-built-images"
+
+# --8<-- [end:pre-built-images]
+<!-- markdownlint-enable MD025 -->
+
+<!-- markdownlint-disable MD001 -->
 ### Build image from source
+<!-- markdownlint-enable MD001 -->
 
---8<-- [start:build-image-from-source]
+<!-- markdownlint-disable MD025 -->
+# --8<-- [start:build-image-from-source]
 
 === "NVIDIA CUDA"
 
@@ -120,7 +149,12 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 
     --8<-- "docs/getting_started/installation/gpu.xpu.inc.md:build-image-from-source"
 
---8<-- [end:build-image-from-source]
+=== "Apple MPS"
+
+    --8<-- "docs/getting_started/installation/gpu.mps.inc.md:build-image-from-source"
+
+# --8<-- [end:build-image-from-source]
+<!-- markdownlint-enable MD025 -->
 
 ## Supported features
 
@@ -135,3 +169,7 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 === "Intel XPU"
 
     --8<-- "docs/getting_started/installation/gpu.xpu.inc.md:supported-features"
+
+=== "Apple MPS"
+
+    --8<-- "docs/getting_started/installation/gpu.mps.inc.md:supported-features"

--- a/docs/getting_started/installation/gpu.mps.inc.md
+++ b/docs/getting_started/installation/gpu.mps.inc.md
@@ -1,0 +1,150 @@
+# --8<-- [start:installation]
+
+vLLM has experimental support for GPU-accelerated inference on Apple Silicon using the MPS (Metal Performance Shaders) backend. This enables running LLM inference on the unified GPU in M1/M2/M3/M4 Macs.
+
+!!! warning "Experimental"
+    MPS support is under active development. Some features available on CUDA (PagedAttention, tensor parallelism, continuous batching for high-throughput serving) are not yet implemented. MPS is best suited for single-user local inference.
+
+# --8<-- [end:installation]
+# --8<-- [start:requirements]
+
+- Hardware: Apple Silicon Mac (M1, M2, M3, or M4 series)
+- OS: macOS 15 (Sequoia) or later
+- Memory: 16 GB unified memory minimum, 24+ GB recommended
+- Python: 3.10 -- 3.13
+- PyTorch: 2.9+ with MPS support
+
+# --8<-- [end:requirements]
+# --8<-- [start:set-up-using-python]
+
+There is no extra information on creating a new Python environment for this device.
+
+# --8<-- [end:set-up-using-python]
+# --8<-- [start:pre-built-wheels]
+
+Currently, there are no pre-built MPS wheels. You must build from source.
+
+# --8<-- [end:pre-built-wheels]
+# --8<-- [start:build-wheel-from-source]
+
+Clone the MPS support branch and install:
+
+```bash
+git clone https://github.com/robtaylor/vllm.git
+cd vllm
+git checkout mps-platform-support
+pip install -e ".[dev]"
+```
+
+Verify MPS platform detection:
+
+```bash
+python -c "
+import torch
+print('MPS available:', torch.backends.mps.is_available())
+from vllm.platforms import current_platform
+print('Platform:', current_platform.device_type)
+"
+```
+
+### Installing Metal quantization kernels (optional)
+
+For accelerated INT4 (AWQ/GPTQ) and GGUF inference, build and install the Metal dequantization kernels. These require [Nix](https://determinate.systems/nix-installer/) to build.
+
+```bash
+# INT4 dequantization (AWQ + GPTQ)
+cd kernels-community/dequant-int4
+nix build
+cp -r result/torch210-metal-aarch64-darwin/ \
+  $(python -c "import site; print(site.getsitepackages()[0])")/dequant_int4/
+
+# GGUF dequantization (Q4_0, Q8_0, Q4_K, and more)
+cd ../dequant-gguf
+nix build
+cp -r result/torch210-metal-aarch64-darwin/ \
+  $(python -c "import site; print(site.getsitepackages()[0])")/dequant_gguf/
+```
+
+Without these kernels, quantized models will still work but use a slower PyTorch fallback path.
+
+# --8<-- [end:build-wheel-from-source]
+# --8<-- [start:pre-built-images]
+
+Docker is not applicable for MPS. macOS does not support GPU passthrough to containers.
+
+# --8<-- [end:pre-built-images]
+# --8<-- [start:build-image-from-source]
+
+Docker is not applicable for MPS. macOS does not support GPU passthrough to containers.
+
+# --8<-- [end:build-image-from-source]
+# --8<-- [start:supported-features]
+
+### Running inference
+
+MPS requires spawn multiprocessing. Set the environment variable before running:
+
+```bash
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+```
+
+Example with a small model:
+
+```bash
+python -c "
+from vllm import LLM, SamplingParams
+llm = LLM(model='distilgpt2', dtype='float16', max_model_len=128)
+output = llm.generate(['Hello, world!'], SamplingParams(max_tokens=32))
+print(output[0].outputs[0].text)
+"
+```
+
+Example with a quantized model (requires Metal kernels above):
+
+```bash
+python -c "
+from vllm import LLM, SamplingParams
+llm = LLM(model='Qwen/Qwen2.5-1.5B-Instruct-AWQ', dtype='float16',
+          max_model_len=512, quantization='awq')
+print(llm.generate(['Explain quantum computing.'],
+                    SamplingParams(max_tokens=64))[0].outputs[0].text)
+"
+```
+
+### Performance
+
+Typical throughput on Apple Silicon (varies by chip and memory):
+
+| Model | Quantization | Throughput |
+|-------|-------------|------------|
+| GGUF small model | Q8_0 | ~62 tok/s |
+| GGUF small model | Q4_0 | ~45 tok/s |
+| Qwen2.5-1.5B | INT4 AWQ | ~17 tok/s |
+| Qwen2.5-1.5B | INT4 GPTQ | ~16 tok/s |
+
+### Memory guidelines
+
+MPS uses unified memory shared between CPU and GPU. When the KV cache exceeds approximately 40% of system RAM, Metal's memory manager can thrash, causing 50-100x slowdowns.
+
+The default KV cache allocation is set conservatively to 25% of system RAM. On a 24 GB system this allows roughly 9 GB for KV cache. Adjust with `gpu_memory_utilization` if needed.
+
+### Known limitations
+
+- No PagedAttention on Metal (uses PyTorch SDPA)
+- No tensor parallelism (single GPU only)
+- No continuous batching optimizations
+- GGUF Q4_K_M models may be slow if the model uses Q6_K layers (numpy fallback)
+- `fork()` crashes on MPS -- `VLLM_WORKER_MULTIPROC_METHOD=spawn` is required
+
+### Troubleshooting
+
+**Slow inference (50-100x slower than expected)**:
+KV cache memory thrashing. Try a smaller model or set `gpu_memory_utilization=0.2`.
+
+**SIGSEGV during startup**:
+Set `VLLM_WORKER_MULTIPROC_METHOD=spawn`.
+
+**"No module named 'vllm.platforms.mps'"**:
+Ensure you are on the `mps-platform-support` branch.
+
+# --8<-- [end:supported-features]


### PR DESCRIPTION
## Summary

- Add "Apple MPS" tab to the GPU installation docs alongside CUDA, ROCm, and XPU
- New `gpu.mps.inc.md` covering: requirements, build from source, Metal quantization kernels, usage examples, performance expectations, memory guidelines, troubleshooting
- Update `cpu.apple.inc.md` to cross-reference the new GPU/MPS docs

This documents the experimental MPS platform support for vLLM on Apple Silicon (M1/M2/M3/M4), enabling GPU-accelerated LLM inference on macOS using Metal.

The underlying implementation is on the `mps-platform-support` branch (robtaylor/vllm) and includes:
- MPS platform detection and device management
- Pure-PyTorch MPS attention backend
- INT4 (AWQ/GPTQ) and GGUF quantization via Metal compute kernels
- 349 tests passing (38 attention + 4 E2E + 307 kernel unit tests)

Performance on Apple Silicon: 17-62 tok/s depending on model and quantization format.

## Test plan

- [ ] Verify mkdocs renders the new MPS tabs correctly
- [ ] Test installation steps on a fresh Apple Silicon Mac
- [ ] Confirm cross-reference from CPU Apple docs resolves

## Related

- vLLM #1441 — Feature request for Apple Silicon support (86 reactions)
- robtaylor/vllm `mps-platform-support` branch — Implementation
- huggingface/kernels #308 — Metal kernel builder infrastructure