### PR TITLE
[Docs] Remove the reo beacon

### DIFF
--- a/docs/mkdocs/javascript/reo.js
+++ b/docs/mkdocs/javascript/reo.js
@@ -1,3 +1,0 @@
-// Reo.Dev documentation tracking
-// https://docs.reo.dev/integrations/tracking-beacon/install-javascript-for-documentation
-!function(){var e,t,n;e="d5c4337961ef0ac",t=function(){Reo.init({clientID:"d5c4337961ef0ac"})},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.defer=!0,n.onload=t,document.head.appendChild(n)}();

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -146,7 +146,6 @@ extra_css:
   - mkdocs/stylesheets/extra.css
 
 extra_javascript:
-  - mkdocs/javascript/reo.js
   - mkdocs/javascript/run_llm_widget.js
   - mkdocs/javascript/mathjax.js
   - https://unpkg.com/mathjax@3.2.2/es5/tex-mml-chtml.js


### PR DESCRIPTION
## Purpose

This PR removes the Reo.Dev documentation tracking beacon from the project's documentation. This includes deleting the `reo.js` script and removing its reference from `mkdocs.yaml`.

## Test Plan

1. Verify that `docs/mkdocs/javascript/reo.js` has been deleted.
2. Verify that `mkdocs.yaml` no longer contains the `extra_javascript` entry for `javascript/reo.js`.
3. Build the documentation locally (`mkdocs serve` or `mkdocs build`) and ensure no build errors or warnings related to the removed script.
4. Inspect the generated HTML to confirm the Reo.Dev tracking script is no longer embedded.

## Test Result

- `docs/mkdocs/javascript/reo.js` was successfully deleted.
- The `extra_javascript` entry for `javascript/reo.js` was removed from `mkdocs.yaml`.
- Local documentation build completes without errors, and the tracking script is no longer present in the generated output.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

