### PR TITLE
[Bugfix] Fix MTP hidden_states regression for chained-layer models (Qwen3.5)

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -478,10 +478,19 @@ class SpecDecodeBaseProposer:
             positions = self.mrope_positions[:, token_indices_to_sample]
         else:
             positions = self.positions[token_indices_to_sample]
-        if self.method == "mtp":
-            hidden_states = self.hidden_states[token_indices_to_sample]
-        else:
-            hidden_states = hidden_states[token_indices_to_sample]
+        # For chained MTP models (e.g. Qwen3.5 with multiple distinct MTP
+        # layers), the model output hidden_states must propagate through each
+        # layer. Using self.hidden_states (target model's cached states) here
+        # breaks the chain and degrades draft quality.
+        #
+        # Before PR #34552, the check was:
+        #   if self.method in ("deepseek_mtp", "ernie_mtp", ...):
+        # which was dead code (config already converts all methods to "mtp"),
+        # so the else branch (using model output) always ran. PR #34552
+        # simplified this to `self.method == "mtp"`, inadvertently activating
+        # the if-branch for the first time, causing a ~30% acceptance rate
+        # regression for Qwen3.5-397B MTP speculative decoding.
+        hidden_states = hidden_states[token_indices_to_sample]
 
         if isinstance(attn_metadata, TreeAttentionMetadata):
             # Draft using tree attention - requires full logits for top-k


### PR DESCRIPTION
## Summary

PR #34552 introduced a regression in MTP speculative decoding acceptance rates for models with chained MTP layers (e.g., Qwen3.5-397B).

The root cause is a one-line change in `eagle.py` that simplified the MTP method check from an explicit list to `self.method == "mtp"`, inadvertently activating a previously dead code path.

## Root Cause

**Before #34552** (working):
```python
if self.method in ("deepseek_mtp", "ernie_mtp", "longcat_flash_mtp", "pangu_ultra_moe_mtp"):
    hidden_states = self.hidden_states[token_indices_to_sample]
else:
    hidden_states = hidden_states[token_indices_to_sample]
```

**After #34552** (broken):
```python
if self.method == "mtp":
    hidden_states = self.hidden_states[token_indices_to_sample]
else:
    hidden_states = hidden_states[token_indices_to_sample]
```

The old explicit list was **dead code** — `config/speculative.py` already converts all MTP method names (including `qwen3_next_mtp`) to `"mtp"` before `eagle.py` sees them. So the if-branch never matched, and all MTP models used the `else` path (model output hidden states). The simplification to `== "mtp"` made the if-branch match for the first time.

## Why This Matters

For models with **chained MTP layers** (Qwen3.5 has 5 distinct MTP layers), the model's forward pass output hidden states must propagate through each subsequent layer. Using `self.hidden_states` (the target model's cached states) breaks this chain — every MTP layer gets the same target states instead of the previous layer's output, degrading draft quality.

For **single-layer MTP models** (DeepSeek, ERNIE — the models in the original explicit list), reusing target hidden states may be correct since the same layer runs N times. However, since the original check was dead code, these models were also using model output hidden states and presumably working fine.

## Impact (Qwen3.5-397B-A17B-NVFP4, 4×RTX 6000 Pro, TP=4, MTP×5)

| Metric | Before fix (broken) | After fix | 
|--------|-------------------|-----------|
| Avg acceptance rate | 46–58% | 75–87% |
| Peak acceptance rate | 75% | 87% |
| Decode throughput | 85–108 tok/s | 140–161 tok/s |
| Per-position rate (pos 3–5) | 0.19–0.35 | 0.54–0.86 |

## Fix

Remove the conditional entirely — always use model output hidden states:
```python
hidden_states = hidden_states[token_indices_to_sample]
```

## Question for maintainers

How did this regression slip through CI? Are there acceptance rate tests for MTP speculative decoding, particularly for chained-layer models? If not, this seems like a gap worth addressing — the behavioral change was invisible at the code review level (looked like a harmless simplification of dead code) but caused a massive performance regression.

## Test plan

- [x] Verified on Qwen3.5-397B-A17B-NVFP4 with `--speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":5}'`
- [x] Acceptance rate restored from ~50% to ~80%, matching pre-#34552 behavior
- [x] No crash or correctness issues observed
- [ ] DeepSeek MTP models should be tested to confirm no regression (the old check was dead code, so they were already using model output hidden states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)