### PR TITLE
Fix LFM2 MoE test for Transformers v5

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -347,7 +347,11 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
     ),
     "Lfm2ForCausalLM": _HfExamplesInfo("LiquidAI/LFM2-1.2B"),
     "Lfm2MoeForCausalLM": _HfExamplesInfo(
-        "LiquidAI/LFM2-8B-A1B", min_transformers_version="4.58"
+        "LiquidAI/LFM2-8B-A1B",
+        min_transformers_version="5.0.0",
+        use_original_num_layers=True,
+        # Initialize at least one MoE layer
+        hf_overrides={"num_hidden_layers": 4},
     ),
     "LlamaForCausalLM": _HfExamplesInfo(
         "meta-llama/Llama-3.2-1B-Instruct",
@@ -507,9 +511,7 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
         "stepfun-ai/Step-3.5-Flash",
         use_original_num_layers=True,
         # Initialize at least one MoE layer
-        hf_overrides={
-            "num_hidden_layers": 4,
-        },
+        hf_overrides={"num_hidden_layers": 4},
     ),
     "Step3TextForCausalLM": _HfExamplesInfo("stepfun-ai/step3", trust_remote_code=True),
     "SolarForCausalLM": _HfExamplesInfo(
@@ -1225,9 +1227,7 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
         speculative_model="stepfun-ai/Step-3.5-Flash",
         use_original_num_layers=True,
         # Initialize at least one MoE layer
-        hf_overrides={
-            "num_hidden_layers": 4,
-        },
+        hf_overrides={"num_hidden_layers": 4},
         is_available_online=False,
     ),
 }


### PR DESCRIPTION
- Use correct `min_transformers_version`
- Override the `num_hidden_layers` so that at least one MoE layer is initialised