### PR TITLE
Patch for vLLM + FlashAttention4 + torch for GRPO colocated training

### DIFF
--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -100,6 +100,7 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
                     unsigned long long* chunk_sizes, size_t num_chunks) {
 #endif
   ensure_context(device);
+  error_code = no_error;
   // Define memory allocation properties
   CUmemAllocationProp prop = {};
   prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
@@ -201,6 +202,7 @@ void unmap_and_release(unsigned long long device, ssize_t size,
   // std::cout << "unmap_and_release: device=" << device << ", size=" << size <<
   // ", d_mem=" << d_mem << ", p_memHandle=" << p_memHandle << std::endl;
   ensure_context(device);
+  error_code = no_error;
 #ifndef USE_ROCM
   CUDA_CHECK(cuMemUnmap(d_mem, size));
   if (error_code != 0) {
@@ -426,6 +428,7 @@ void* my_malloc(ssize_t size, int device, CUstream stream) {
 
 // use CUstream instead of cudaStream_t, to avoid including cuda_runtime_api.h
 void my_free(void* ptr, ssize_t size, int device, CUstream stream) {
+  error_code = no_error;
   // get memory handle from the pointer
   if (!g_python_free_callback) {
     std::cerr << "ERROR: g_python_free_callback not set.\n";
@@ -517,13 +520,22 @@ void my_free(void* ptr, ssize_t size, int device, CUstream stream) {
   Py_DECREF(py_result);
   PyGILState_Release(gstate);
 
+  // sleeping block already freed by sleep(), skip CUDA ops
+  if (recv_d_mem == 0) {
+    return;
+  }
+
   CUmemGenericAllocationHandle* p_memHandle =
       (CUmemGenericAllocationHandle*)recv_p_memHandle;
-  unmap_and_release(device, size, d_mem, p_memHandle);
+  unmap_and_release(device, recv_size, d_mem, p_memHandle);
 #endif
 
   // free address and the handle
-  CUDA_CHECK(cuMemAddressFree(d_mem, size));
+  if (error_code == no_error) {
+    CUDA_CHECK(cuMemAddressFree(d_mem, recv_size));
+  } else {
+    error_code = no_error;
+  }
 #ifndef USE_ROCM
   free(p_memHandle);
 #else

--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -534,6 +534,9 @@ void my_free(void* ptr, ssize_t size, int device, CUstream stream) {
   if (error_code == no_error) {
     CUDA_CHECK(cuMemAddressFree(d_mem, recv_size));
   } else {
+    std::cerr << "WARNING: unmap_and_release failed, leaking virtual address "
+                 "range at "
+              << d_mem << " (" << recv_size << " bytes)." << std::endl;
     error_code = no_error;
   }
 #ifndef USE_ROCM

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -53,6 +53,7 @@ class AllocationData:
     handle: HandleType
     tag: str
     cpu_backup_tensor: torch.Tensor | None = None
+    mapped: bool = True
 
 
 def create_and_map(allocation_handle: HandleType) -> None:
@@ -138,6 +139,7 @@ class CuMemAllocator:
         self.pointer_to_data: dict[int, AllocationData] = {}
         self.current_tag: str = CuMemAllocator.default_tag
         self.allocator_and_pools: dict[str, Any] = {}
+        self.sleeping = False
         # Creating strong references to the two callbacks here to prevent
         # these ephemeral bound-method objects being garbage collected.
         # See discussions in https://github.com/vllm-project/vllm/pull/22724
@@ -164,6 +166,9 @@ class CuMemAllocator:
         """
         Internal method to look up the allocation data
         when memory is freed in the memory pool."""
+        if self.sleeping:
+            self.pointer_to_data.pop(ptr, None)
+            return (0, 0, 0, 0)
         data = self.pointer_to_data.pop(ptr)
         if data.cpu_backup_tensor is not None:
             data.cpu_backup_tensor = None
@@ -197,6 +202,8 @@ class CuMemAllocator:
         backup_bytes = 0
 
         for ptr, data in self.pointer_to_data.items():
+            if not data.mapped:
+                continue
             handle = data.handle
             total_bytes += handle[1]
             if data.tag in offload_tags:
@@ -212,6 +219,7 @@ class CuMemAllocator:
                 libcudart.cudaMemcpy(cpu_ptr, ptr, size_in_bytes)
                 data.cpu_backup_tensor = cpu_backup_tensor
             unmap_and_release(handle)
+            data.mapped = False
 
         logger.info(
             "CuMemAllocator: sleep freed %.2f GiB memory in total, of which "
@@ -222,8 +230,9 @@ class CuMemAllocator:
             (total_bytes - backup_bytes) / 1024**3,
         )
 
-        gc.collect()
-        torch.cuda.empty_cache()
+        self.sleeping = True
+#        gc.collect()
+#        torch.cuda.empty_cache()
 
     def wake_up(self, tags: list[str] | None = None) -> None:
         """
@@ -237,8 +246,10 @@ class CuMemAllocator:
         """
         for ptr, data in self.pointer_to_data.items():
             if tags is None or data.tag in tags:
-                handle = data.handle
-                create_and_map(handle)
+                if not data.mapped:
+                    handle = data.handle
+                    create_and_map(handle)
+                    data.mapped = True
                 if data.cpu_backup_tensor is not None:
                     cpu_backup_tensor = data.cpu_backup_tensor
                     if cpu_backup_tensor is not None:
@@ -248,6 +259,7 @@ class CuMemAllocator:
                         cpu_ptr = cpu_backup_tensor.data_ptr()
                         libcudart.cudaMemcpy(ptr, cpu_ptr, size_in_bytes)
                         data.cpu_backup_tensor = None
+        self.sleeping = False
 
     @contextmanager
     def use_memory_pool(self, tag: str | None = None):

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -9,7 +9,6 @@
 # not sure why, they are created from a different context.
 # the only successful approach is to call cuda driver API in C.
 import dataclasses
-import gc
 import os
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -231,8 +230,6 @@ class CuMemAllocator:
         )
 
         self.sleeping = True
-#        gc.collect()
-#        torch.cuda.empty_cache()
 
     def wake_up(self, tags: list[str] | None = None) -> None:
         """

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import math
-from importlib.util import find_spec
 
 import torch
 

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -134,10 +134,12 @@ class ApplyRotaryEmb(CustomOp):
         self.enable_fp32_compute = enable_fp32_compute
 
         self.apply_rotary_emb_flash_attn = None
-        if find_spec("flash_attn") is not None:
+        try:
             from flash_attn.ops.triton.rotary import apply_rotary
 
             self.apply_rotary_emb_flash_attn = apply_rotary
+        except (ImportError, ModuleNotFoundError):
+            pass
 
     @staticmethod
     def forward_static(


### PR DESCRIPTION
Fixes https://github.com/vllm-project/vllm/issues/36651

## Summary

- **cumem.py**: Track per-allocation mapped state to prevent double `cuMemRelease` when `sleep`/`wake_up` are called on already-unmapped or already-mapped allocations. Add a `sleeping` flag so `_python_free_callback` returns a dummy handle during sleep, avoiding CUDA ops on freed memory. Remove `gc.collect` + `empty_cache` in `sleep()` which can trigger frees during the sleeping window.
- **cumem_allocator.cpp**: Clear stale `error_code` at the top of `create_and_map`, `unmap_and_release`, and `my_free` to prevent leftover errors from previous operations propagating. Skip CUDA ops in `my_free` when `recv_d_mem == 0` (sleeping block already freed). Fix size mismatch by using `recv_size` instead of `size` in `unmap_and_release` and `cuMemAddressFree` calls. Log a warning when `unmap_and_release` fails and `cuMemAddressFree` is skipped to make virtual address leaks visible.
- **rotary_embedding/common.py**: Replace `find_spec` check with `try/except` for `flash_attn.ops` import to support Flash Attention 4 which restructured its module layout.

## Test plan

- [ ] Verify `sleep()` / `wake_up()` cycles work without CUDA errors in colocated training
- [ ] Verify no regressions in standard vLLM inference with cumem allocator enabled
- [ ] Verify rotary embedding works with both Flash Attention 2/3 and Flash Attention 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)