### PR TITLE
[Bug Fix] Defer record_metadata_for_reloading to avoid ~3x host memory regression

### DIFF
--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -70,10 +70,11 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     """
     Set up layerwise weight loading with deferred processing.
 
-    Must be called after `record_metadata_for_reloading`. This function:
-    1. Saves current kernel tensors for later copying
-    2. Restores layer parameters/buffers from metadata (on meta device)
-    3. Wraps weight loaders to defer processing until all weights are loaded
+    This function:
+    1. Records layer metadata for restoration (on-demand)
+    2. Saves current kernel tensors for later copying
+    3. Restores layer parameters/buffers from metadata (on meta device)
+    4. Wraps weight loaders to defer processing until all weights are loaded
 
     When all weights for a layer are loaded, the wrapped loaders will:
     1. Materialize the layer onto the target device
@@ -81,6 +82,11 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     3. Run quantization processing if applicable
     4. Copy processed values back to original tensor storage
     """
+    # Capture metadata on-demand rather than eagerly at model init.
+    # Previously this was called unconditionally in initialize_model(),
+    # but it is only needed when reload_weights() is actually used.
+    record_metadata_for_reloading(model)
+
     # disable torchao reloading to avoid infinite recursion
     model._original_do_torchao_reload = getattr(model, "_do_torchao_reload", False)
     model._do_torchao_reload = False

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -20,7 +20,6 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.model_loader.reload import (
-    record_metadata_for_reloading,
     set_torchao_reload_attrs,
 )
 from vllm.model_executor.models.interfaces import SupportsQuant
@@ -54,7 +53,6 @@ def initialize_model(
         # new-style model class
         with set_current_vllm_config(vllm_config, check_compile=True, prefix=prefix):
             model = model_class(vllm_config=vllm_config, prefix=prefix)
-            record_metadata_for_reloading(model)
             return model
 
     msg = (
@@ -86,7 +84,6 @@ def initialize_model(
         kwargs["scheduler_config"] = vllm_config.scheduler_config
     with set_current_vllm_config(vllm_config, check_compile=True, prefix=prefix):
         model = model_class(**kwargs)
-        record_metadata_for_reloading(model)
 
     return model
 


### PR DESCRIPTION
## Purpose

Fix https://github.com/vllm-project/vllm/issues/36537

`record_metadata_for_reloading()` runs unconditionally during `initialize_model()` for all users, even though it only benefits QeRL layerwise weight reloading. On `torch_xla` backends, this causes a ~3x host memory regression during `torch.compile` tracing (e.g. 7.5 GB → 22 GB for Qwen3-1.7B, up to ~435 GB for Qwen3-32B).

This PR moves `record_metadata_for_reloading()` from `initialize_model()` to `initialize_layerwise_reload()`, so metadata is captured on-demand when `reload_weights()` is first called rather than at model init.

## Test Plan

Tested on Tenstorrent hardware (torch_xla PJRT backend) by running vLLM inference with Qwen3 models and measuring peak host RSS with `/usr/bin/time -v`.

Note: the severe memory impact is specific to `torch_xla`'s graph capture mechanism. We were unable to reproduce on GPU with `eager`/`aot_eager` backends. QeRL reload tests should be verified by the QeRL team (@kylesayrs).

## Test Result

Peak host RSS (lower is better):

| Model | Before (v0.16.0) | After (this PR) |
|---|---|---|
| Qwen3-0.6B | 8.5 GB | 3.9 GB |
| Qwen3-1.7B | 22 GB | 8.0 GB |
| Qwen3-4B | 49.6 GB | ~17 GB |
| Qwen3-32B | ~435 GB | ~128 GB |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update.
- [ ] (Optional) Release notes update.
</details>