### PR TITLE
[Speculative Decoding] Add `norm_before_fc` for gpt-oss draft models

### DIFF
--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -150,7 +150,6 @@ class LlamaModel(nn.Module):
             self.use_aux_hidden_state = eagle_config["use_aux_hidden_state"]
         else:
             self.use_aux_hidden_state = True
-        # Only gpt-oss uses it (speculators sets during training).
         self.norm_before_fc = getattr(self.config, "norm_before_fc", False)
 
         current_vllm_config = get_current_vllm_config()

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -150,6 +150,8 @@ class LlamaModel(nn.Module):
             self.use_aux_hidden_state = eagle_config["use_aux_hidden_state"]
         else:
             self.use_aux_hidden_state = True
+        # Only gpt-oss uses it (speculators sets during training).
+        self.norm_before_fc = getattr(self.config, "norm_before_fc", False)
 
         current_vllm_config = get_current_vllm_config()
 
@@ -175,6 +177,15 @@ class LlamaModel(nn.Module):
                 fc_input_size = self.config.target_hidden_size * 3
             else:
                 fc_input_size = self.config.hidden_size * 3
+            # Optional RMSNorm on combined aux hidden states before fc (gpt-oss only;
+            # omitted for other models and old checkpoints).
+            if self.norm_before_fc:
+                self.input_norm = RMSNorm(
+                    fc_input_size,
+                    eps=self.config.rms_norm_eps,
+                )
+            else:
+                self.input_norm = None
             self.fc = ReplicatedLinear(
                 input_size=fc_input_size,
                 output_size=self.config.hidden_size,
@@ -357,6 +368,9 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         if not self.model.use_aux_hidden_state:
             return hidden_states
         # combine multiple auxiliary hidden states returned by eagle3
+
+        if self.model.norm_before_fc:
+            hidden_states = self.model.input_norm(hidden_states)
         return self.model.fc(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
@@ -403,6 +417,8 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             skip_substrs.append("embed_tokens")
         if not self.model.use_aux_hidden_state:
             skip_substrs.append("fc.")
+        if not self.model.norm_before_fc:
+            skip_substrs.append("input_norm.")
         loader = AutoWeightsLoader(
             self,
             skip_prefixes=None,

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -176,8 +176,6 @@ class LlamaModel(nn.Module):
                 fc_input_size = self.config.target_hidden_size * 3
             else:
                 fc_input_size = self.config.hidden_size * 3
-            # Optional RMSNorm on combined aux hidden states before fc (gpt-oss only;
-            # omitted for other models and old checkpoints).
             if self.norm_before_fc:
                 self.input_norm = RMSNorm(
                     fc_input_size,


### PR DESCRIPTION
## Purpose

- Support Eagle3 draft models that use optional pre-FC RMSNorm (`norm_before_fc`), e.g. gpt-oss checkpoints trained with the Speculators repository.
- Allows loading and serving such draft models without changing behavior for non–gpt-oss models or old checkpoints that do not use this norm.

## Summary of Changes

- **llama_eagle3.py**: Reads `norm_before_fc` from the draft config via `getattr(config, "norm_before_fc", False)` (same pattern as `norm_before_residual`). When True, creates an optional RMSNorm on the combined aux hidden states before the FC layer; when False, `input_norm` is not created and the FC receives the raw concatenation as before. Weight loading skips `input_norm` when `norm_before_fc` is False so checkpoints without the norm continue to load without error.

### API

- No API changes. The draft model config (from Speculators-converted or -trained checkpoints) may include `norm_before_fc: true` for gpt-oss; vLLM reads it and creates/applies the norm when loading the draft. The key is added to `config.json` by the [Speculators repository](https://github.com/vllm-project/speculators/pull/337) (config field + converter/training); Other models and legacy checkpoints omit the key and behave as before.

## Test Plan

- Serve a target model with `--speculative-config` pointing to an Eagle3 draft that has `norm_before_fc` in its config (e.g. gpt-oss draft converted with Speculators).
- Verify draft loads and speculative decoding runs without errors.
- Optionally serve with a draft that does not have `norm_before_fc` (or has it False) and confirm unchanged behavior.

Example:

```bash
vllm serve <target_model> --speculative-config '{"model":"<path-to-gpt-oss-eagle3-draft>","num_speculative_tokens":5,"method":"eagle3"}'
```

## Test Result

- Draft with `norm_before_fc: true` loads and runs speculative decoding successfully.
- Draft without `norm_before_fc` (or with `false`) loads and runs as before; no regression.

---

