### PR TITLE
Remove unused disable_fallback field

### DIFF
--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -23,8 +23,6 @@ class StructuredOutputsConfig:
     regex, etc) by default. With "auto", we will make opinionated choices
     based on request contents and what the backend libraries currently support,
     so the behavior is subject to change in each release."""
-    disable_fallback: bool = False
-    """If `True`, vLLM will not fallback to a different backend on error."""
     disable_any_whitespace: bool = False
     """If `True`, json output will always be compact without any whitespace.
     If `False`, the model may generate whitespace between JSON fields,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -41,7 +41,6 @@ class StructuredOutputsParams:
     grammar: str | None = None
     json_object: bool | None = None
     # These are other options that can be set.
-    disable_fallback: bool = False
     disable_any_whitespace: bool = False
     disable_additional_properties: bool = False
     whitespace_pattern: str | None = None


### PR DESCRIPTION
## Purpose

Please correct me if I'm wrong but it seems like `disable_fallback` is never used in the code base.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

