### PR TITLE
[Bugfix] Fix TypeError during AWQ Marlin MoE loading by unwrapping traced tuple

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -692,15 +692,22 @@ def pack_rows(
     return q_res
 
 
+def _unwrap_size_n(size_n) -> int:
+    """Safely unwrap traced size_n tuples from PyTorch to prevent NumPy TypeErrors."""
+    if isinstance(size_n, tuple):
+        if not size_n:
+            raise ValueError("size_n tuple from tracer cannot be empty.")
+        size_n = size_n[0]
+    return int(size_n)
+
+
 def pack_cols(
     q_w: torch.Tensor,
     num_bits: int,
     size_k: int,
     size_n: int,
 ):
-    if isinstance(size_n, tuple):
-        size_n = size_n[0]
-    size_n = int(size_n)
+    size_n = _unwrap_size_n(size_n)
     assert q_w.shape == (size_k, size_n)
 
     pack_factor = get_pack_factor(num_bits)
@@ -727,9 +734,7 @@ def unpack_cols(
     size_k: int,
     size_n: int,
 ):
-    if isinstance(size_n, tuple):
-        size_n = size_n[0]
-    size_n = int(size_n)
+    size_n = _unwrap_size_n(size_n)
     pack_factor = get_pack_factor(num_bits)
     assert size_n % pack_factor == 0
     assert packed_q_w.shape == (size_k, size_n // pack_factor), (

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -698,6 +698,9 @@ def pack_cols(
     size_k: int,
     size_n: int,
 ):
+    if isinstance(size_n, tuple):
+        size_n = size_n[0]
+    size_n = int(size_n)
     assert q_w.shape == (size_k, size_n)
 
     pack_factor = get_pack_factor(num_bits)
@@ -724,6 +727,9 @@ def unpack_cols(
     size_k: int,
     size_n: int,
 ):
+    if isinstance(size_n, tuple):
+        size_n = size_n[0]
+    size_n = int(size_n)
     pack_factor = get_pack_factor(num_bits)
     assert size_n % pack_factor == 0
     assert packed_q_w.shape == (size_k, size_n // pack_factor), (


### PR DESCRIPTION
## Purpose
Fixes a `TypeError` during model initialization for MoE models using the `awq_marlin` quantization path (e.g., Qwen 3.5 AWQ). 

During tracing, PyTorch occasionally passes the `size_n` argument as a 1-element tuple (e.g., `(4096,)`) instead of a raw integer. When this reaches `pack_cols` and `unpack_cols` in `quant_utils.py`, it gets passed to `numpy.zeros()`. This causes a fatal crash because NumPy strictly requires an integer, throwing: `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'tuple'`

**The Fix:** Added a defensive `isinstance` check at the top of both functions to safely unwrap the tuple and cast it to an `int`. This intercepts the rogue tuple before it hits any shape assertions or downstream NumPy ops.

## Test Plan
Ran a minimal local Python script simulating the exact PyTorch tracing behavior to verify the functions safely handle the tuple without crashing NumPy:

```python
import torch
from vllm.model_executor.layers.quantization.utils.quant_utils import pack_cols, unpack_cols

size_k = 32
size_n_tuple = (128,)
num_bits = 4

q_w = torch.zeros((size_k, size_n_tuple[0]), dtype=torch.int32).cuda()

try:
    packed = pack_cols(q_w, num_bits, size_k, size_n_tuple)
    print("pack_cols: Success")
    
    unpacked = unpack_cols(packed, num_bits, size_k, size_n_tuple)
    print("unpack_cols: Success")
except Exception as e:
    print(f"Failed: {e}")
```

## Test Result
Successfully unwrapped the tuple and completed the packing/unpacking math on an NVIDIA GB10 (CUDA 12.1):

```text
pack_cols: Success
unpack_cols: Success
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

