### PR TITLE
[Kernel] Add swap AB optimization to fused_moe_kernel

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -37,6 +37,7 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
 from vllm.model_executor.layers.fused_moe.utils import (
     _resize_cache,
     disable_inplace,
+    enable_swap_ab,
     moe_kernel_quantize_input,
 )
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import dequant_mxfp4
@@ -365,6 +366,7 @@ def fused_moe_kernel(
     use_int8_w8a16: tl.constexpr,
     per_channel_quant: tl.constexpr,
     HAS_BIAS: tl.constexpr,
+    SWAP_AB: tl.constexpr,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -454,15 +456,25 @@ def fused_moe_kernel(
 
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (
-        offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
-    )
+    if SWAP_AB:
+        a_ptrs = a_ptr + (
+            offs_k[:, None] * stride_ak + offs_token[None, :] // top_k * stride_am
+        )
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + (offs_bn[:, None] * stride_bn + offs_k[None, :] * stride_bk)
+        )
+    else:
+        a_ptrs = a_ptr + (
+            offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
+        )
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+        )
 
-    b_ptrs = (
-        b_ptr
-        + off_experts * stride_be
-        + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
-    )
     if use_int8_w8a16:
         b_scale_ptrs = (
             b_scale_ptr + off_experts * stride_bse + offs_bn[None, :] * stride_bsn
@@ -499,16 +511,25 @@ def fused_moe_kernel(
     # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
     # of fp32 values for higher accuracy.
     # `accumulator` will be converted back to fp16 after the loop.
-    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    if SWAP_AB:
+        accumulator = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+    else:
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         # Load the next block of A and B, generate a mask by checking the
         # K dimension.
+        if SWAP_AB:
+            a_mask = (offs_k[:, None] < K - k * BLOCK_SIZE_K) & token_mask[None, :]
+            b_mask = offs_k[None, :] < K - k * BLOCK_SIZE_K
+        else:
+            a_mask = token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K)
+            b_mask = offs_k[:, None] < K - k * BLOCK_SIZE_K
         a = tl.load(
             a_ptrs,
-            mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            mask=a_mask,
             other=0.0,
         )
-        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        b = tl.load(b_ptrs, mask=b_mask, other=0.0)
         # We accumulate along the K dimension.
         if use_int8_w8a16:
             accumulator = tl.dot(a, b.to(compute_type), acc=accumulator)
@@ -520,12 +541,17 @@ def fused_moe_kernel(
                     a_scale_ptrs + offs_ks * stride_ask, mask=token_mask, other=0.0
                 )
                 b_scale = tl.load(b_scale_ptrs + offs_ks * stride_bsk)
-
-                accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
+                if SWAP_AB:
+                    accumulator += tl.dot(b, a) * b_scale[:, None] * a_scale[None, :]
+                else:
+                    accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
             else:
                 if use_fp8_w8a8:
                     # acc used to enable fp8_fast_accum
-                    accumulator = tl.dot(a, b, acc=accumulator)
+                    if SWAP_AB:
+                        accumulator = tl.dot(b, a, acc=accumulator)
+                    else:
+                        accumulator = tl.dot(a, b, acc=accumulator)
                 else:
                     accumulator += tl.dot(a, b)
         else:
@@ -533,6 +559,9 @@ def fused_moe_kernel(
         # Advance the ptrs to the next K block.
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    if SWAP_AB:
+        accumulator = tl.trans(accumulator, (1, 0))
 
     # Dequantization for supported quantization schemes:
     #   - int8_w8a16
@@ -751,6 +780,11 @@ def invoke_fused_moe_triton_kernel(
     assert topk_weights is None or topk_weights.stride(1) == 1
     assert sorted_token_ids is None or sorted_token_ids.stride(0) == 1
 
+    if use_fp8_w8a8:
+        SWAP_AB = enable_swap_ab(config["BLOCK_SIZE_M"], config["BLOCK_SIZE_N"])
+    else:
+        SWAP_AB = False
+
     if use_fp8_w8a8 or use_int8_w8a8:
         assert B_scale is not None
         assert block_shape is None or triton.cdiv(
@@ -832,6 +866,7 @@ def invoke_fused_moe_triton_kernel(
         naive_block_assignment=(sorted_token_ids is None),
         HAS_BIAS=HAS_BIAS,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
+        SWAP_AB=SWAP_AB,
         **config,
     )
 

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     per_tensor_dequantize,
 )
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import is_torch_equal_or_newer
@@ -343,3 +344,12 @@ def _validate_scale_shape(
 @functools.cache
 def disable_inplace() -> bool:
     return is_torch_equal_or_newer("2.9")
+
+
+@functools.lru_cache
+def enable_swap_ab(BLOCK_SIZE_M: int, BLOCK_SIZE_N: int) -> bool:
+    return (
+        current_platform.is_device_capability(90)
+        and BLOCK_SIZE_M < 64
+        and BLOCK_SIZE_N >= 64
+    )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR add swap AB optimization to `fused_moe_kernel` to make better use of WGMMA. Similar with #20396.

For small BLOCK_SIZE_M cases (BLOCK_SIZE_M <64), change the gemm from `a[M, K] @ b[K, N]-> c[M, N]` to `b[N, K] @ a[K, M] -> c[N, M]`.

## Test Plan
```
pytest -s -v tests/kernels/moe/test_moe.py
```

## Test Result

Unit tests passed.

## Micro bench

* DeepSeek-R1

```
python3 benchmarks/kernels/benchmark_moe.py --model deepseek-ai/DeepSeek-R1-0528 --dtype fp8_w8a8
```

Main:
```
Batch size: 1, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 77.42 us
Batch size: 2, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 112.23 us
Batch size: 4, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 190.77 us
Batch size: 8, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 350.54 us
Batch size: 16, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 569.15 us
Batch size: 24, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 743.40 us
Batch size: 32, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 879.89 us
Batch size: 48, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1099.06 us
Batch size: 64, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1210.07 us
Batch size: 96, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1481.82 us
Batch size: 128, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1540.03 us
Batch size: 256, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1596.26 us
Batch size: 512, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1679.71 us
Batch size: 1024, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1776.80 us
Batch size: 1536, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1888.53 us
Batch size: 2048, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 2409.44 us
Batch size: 3072, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 3112.84 us
Batch size: 4096, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 3852.81 us
```

PR:
```
Batch size: 1, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 73.41 us
Batch size: 2, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 107.10 us
Batch size: 4, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 183.95 us
Batch size: 8, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 339.62 us
Batch size: 16, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 546.56 us
Batch size: 24, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 715.63 us
Batch size: 32, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 847.44 us
Batch size: 48, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1043.57 us
Batch size: 64, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1153.64 us
Batch size: 96, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1474.32 us
Batch size: 128, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1540.14 us
Batch size: 256, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1595.65 us
Batch size: 512, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1658.19 us
Batch size: 1024, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1766.95 us
Batch size: 1536, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 1903.80 us
Batch size: 2048, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 2423.48 us
Batch size: 3072, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 3146.43 us
Batch size: 4096, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 3815.32 us
```

* Qwen3

```
python3 benchmarks/kernels/benchmark_moe.py --model Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 --dtype fp8_w8a8
```

Main:

```
Batch size: 1, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 29.97 us
Batch size: 2, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 33.00 us
Batch size: 4, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 46.43 us
Batch size: 8, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 62.29 us
Batch size: 16, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 99.91 us
Batch size: 24, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 118.64 us
Batch size: 32, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 136.56 us
Batch size: 48, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 169.88 us
Batch size: 64, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 189.83 us
Batch size: 96, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 272.29 us
Batch size: 128, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 294.82 us
Batch size: 256, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 318.91 us
Batch size: 512, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 333.79 us
Batch size: 1024, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 361.22 us
Batch size: 1536, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 387.79 us
Batch size: 2048, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 412.98 us
Batch size: 3072, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 512.36 us
Batch size: 4096, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 699.10 us
```

PR:

```
Batch size: 1, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 26.72 us
Batch size: 2, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 30.78 us
Batch size: 4, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 44.60 us
Batch size: 8, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 59.86 us
Batch size: 16, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 1, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 93.03 us
Batch size: 24, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 111.70 us
Batch size: 32, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 130.30 us
Batch size: 48, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 160.12 us
Batch size: 64, config: {'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 181.28 us
Batch size: 96, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 272.36 us
Batch size: 128, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 294.82 us
Batch size: 256, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 319.70 us
Batch size: 512, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 333.47 us
Batch size: 1024, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 361.00 us
Batch size: 1536, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 387.66 us
Batch size: 2048, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 413.07 us
Batch size: 3072, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 512.13 us
Batch size: 4096, config: {'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128, 'GROUP_SIZE_M': 32, 'SPLIT_K': 1, 'num_warps': 4, 'num_stages': 3}
Kernel time: 698.57 us
```

## Benchmark

* DeepSeek-R1

```
vllm serve deepseek-ai/DeepSeek-R1-0528 \
    --tensor-parallel-size 8 \
    --max-num-seqs 8 \
    --trust-remote-code \
    --no-enable-prefix-caching
```
```
vllm bench serve \
        --model deepseek-ai/DeepSeek-R1-0528 \
        --dataset-name sharegpt \
        --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
        --sharegpt-output-len 300 \
        --num-prompts ${num_prompts} \
        --max-concurrency ${concurrency} \
        --num-warmups 50 \
        --ignore-eos \
        --temperature 0
```
Main:

concurrency=1
```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  209.47    
Total input tokens:                      15195     
Total generated tokens:                  18000     
Request throughput (req/s):              0.29      
Output token throughput (tok/s):         85.93     
Peak output token throughput (tok/s):    95.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          158.47    
---------------Time to First Token----------------
Mean TTFT (ms):                          191.89    
Median TTFT (ms):                        160.02    
P99 TTFT (ms):                           878.15    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.03     
Median TPOT (ms):                        10.91     
P99 TPOT (ms):                           11.91     
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.03     
Median ITL (ms):                         10.94     
P99 ITL (ms):                            12.07     
==================================================
```

concurrency=8
```
============ Serving Benchmark Result ============
Successful requests:                     480       
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  375.39    
Total input tokens:                      105603    
Total generated tokens:                  144000    
Request throughput (req/s):              1.28      
Output token throughput (tok/s):         383.60    
Peak output token throughput (tok/s):    512.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          664.92    
---------------Time to First Token----------------
Mean TTFT (ms):                          330.34    
Median TTFT (ms):                        318.00    
P99 TTFT (ms):                           561.43    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.82     
Median TPOT (ms):                        19.74     
P99 TPOT (ms):                           22.45     
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.82     
Median ITL (ms):                         19.40     
P99 ITL (ms):                            22.97     
==================================================
```

concurrency=16
```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  582.40    
Total input tokens:                      220267    
Total generated tokens:                  288000    
Request throughput (req/s):              1.65      
Output token throughput (tok/s):         494.50    
Peak output token throughput (tok/s):    656.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          872.71    
---------------Time to First Token----------------
Mean TTFT (ms):                          407.43    
Median TTFT (ms):                        375.03    
P99 TTFT (ms):                           1354.25   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          31.10     
Median TPOT (ms):                        31.07     
P99 TPOT (ms):                           36.02     
---------------Inter-token Latency----------------
Mean ITL (ms):                           31.10     
Median ITL (ms):                         30.04     
P99 ITL (ms):                            38.12     
==================================================
```

PR:

concurrency=1
```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  180.77    
Total input tokens:                      15195     
Total generated tokens:                  18000     
Request throughput (req/s):              0.33      
Output token throughput (tok/s):         99.57     
Peak output token throughput (tok/s):    113.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          183.63    
---------------Time to First Token----------------
Mean TTFT (ms):                          176.97    
Median TTFT (ms):                        154.82    
P99 TTFT (ms):                           775.20    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.48      
Median TPOT (ms):                        9.36      
P99 TPOT (ms):                           10.35     
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.48      
Median ITL (ms):                         9.38      
P99 ITL (ms):                            10.51     
==================================================
```

concurrency=8
```
============ Serving Benchmark Result ============
Successful requests:                     480       
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  373.27    
Total input tokens:                      105603    
Total generated tokens:                  144000    
Request throughput (req/s):              1.29      
Output token throughput (tok/s):         385.78    
Peak output token throughput (tok/s):    512.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          668.69    
---------------Time to First Token----------------
Mean TTFT (ms):                          385.09    
Median TTFT (ms):                        410.68    
P99 TTFT (ms):                           1048.95   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.52     
Median TPOT (ms):                        19.45     
P99 TPOT (ms):                           22.24     
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.52     
Median ITL (ms):                         18.96     
P99 ITL (ms):                            22.43     
==================================================
```

concurrency=16
```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  573.25    
Total input tokens:                      220267    
Total generated tokens:                  288000    
Request throughput (req/s):              1.67      
Output token throughput (tok/s):         502.40    
Peak output token throughput (tok/s):    672.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          886.64    
---------------Time to First Token----------------
Mean TTFT (ms):                          514.17    
Median TTFT (ms):                        535.53    
P99 TTFT (ms):                           898.23    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.23     
Median TPOT (ms):                        30.11     
P99 TPOT (ms):                           34.33     
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.23     
Median ITL (ms):                         29.72     
P99 ITL (ms):                            35.83     
==================================================
```

* Qwen3

```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
    --tensor-parallel-size 1 \
    --max-num-seqs 8 \
    --no-enable-prefix-caching
```

(wip)


## Accuracy Testing

* DeepSeek-R1

```
python3 -m lm_eval --model local-completions \
  --model_args model=deepseek-ai/DeepSeek-R1-0528,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=16 \
  --tasks gsm8k
```

Main:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9568|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9560|±  |0.0056|
```

PR:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9575|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9568|±  |0.0056|
```

* Qwen3

```
python3 -m lm_eval --model local-completions \
  --model_args model=Qwen/Qwen3-Next-80B-A3B-Instruct-FP8,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=8 \
  --tasks gsm8k
```
(wip)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

