### PR TITLE
[CI] Add Blackwell DeepSeek MTP acceptance length regression test

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -186,3 +186,18 @@ steps:
   commands:
     - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
     - pytest -v -s v1/spec_decode/test_acceptance_length.py -m slow_test
+
+- label: MTP Acceptance Length (B300)
+  timeout_in_minutes: 60
+  device: b300
+  optional: true
+  num_devices: 4
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - vllm/v1/spec_decode/
+  - vllm/model_executor/models/deepseek_mtp.py
+  - tests/v1/spec_decode/test_acceptance_length.py
+  commands:
+    - pip install "vllm[bench]"
+    - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+    - pytest -v -s v1/spec_decode/test_acceptance_length.py::test_mtp_acceptance_length

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -187,9 +187,9 @@ steps:
     - export VLLM_ALLOW_INSECURE_SERIALIZATION=1
     - pytest -v -s v1/spec_decode/test_acceptance_length.py -m slow_test
 
-- label: MTP Acceptance Length (B300)
+- label: MTP Acceptance Length (B200)
   timeout_in_minutes: 60
-  device: b300
+  device: b200
   optional: true
   num_devices: 4
   working_dir: "/vllm-workspace/tests"

--- a/tests/v1/spec_decode/test_acceptance_length.py
+++ b/tests/v1/spec_decode/test_acceptance_length.py
@@ -341,8 +341,8 @@ class MTPModelConfig:
 MTP_MODEL_CONFIGS = [
     MTPModelConfig(
         verifier="deepseek-ai/DeepSeek-V3",
-        expected_acceptance_length=1.16,
-        expected_acceptance_lengths_per_pos=[0.16],
+        expected_acceptance_length=1.08,
+        expected_acceptance_lengths_per_pos=[0.08],
         id="deepseek-v3-mtp",
         tensor_parallel_size=4,
         gpu_memory_utilization=0.95,

--- a/tests/v1/spec_decode/test_acceptance_length.py
+++ b/tests/v1/spec_decode/test_acceptance_length.py
@@ -340,13 +340,13 @@ class MTPModelConfig:
 MTP_MODEL_CONFIGS = [
     MTPModelConfig(
         verifier="deepseek-ai/DeepSeek-V3",
-        expected_acceptance_length=1.08,
-        expected_acceptance_lengths_per_pos=[0.08],
+        expected_acceptance_length=1.04,
+        expected_acceptance_lengths_per_pos=[0.04],
         id="deepseek-v3-mtp",
         tensor_parallel_size=4,
         gpu_memory_utilization=0.95,
         marks=[pytest.mark.slow_test],
-        rtol=0.10,
+        rtol=0.15,
     ),
 ]
 

--- a/tests/v1/spec_decode/test_acceptance_length.py
+++ b/tests/v1/spec_decode/test_acceptance_length.py
@@ -310,3 +310,168 @@ def test_eagle3_acceptance_length(
             print(f"  Per-position: {[f'{v:.3f}' for v in actual_per_pos]}")
             if expected_per_pos:
                 print(f"  Expected:     {[f'{v:.3f}' for v in expected_per_pos]}")
+
+
+# ============================================================
+# MTP Acceptance Length Regression Tests
+# ============================================================
+
+
+@dataclass
+class MTPModelConfig:
+    """Model configuration for MTP acceptance length tests."""
+    verifier: str
+    expected_acceptance_length: float
+    expected_acceptance_lengths_per_pos: list[float] = field(
+        default_factory=list)
+    id: str = ""
+    num_speculative_tokens: int = 1
+    tensor_parallel_size: int = 1
+    max_model_len: int = DEFAULT_MAX_MODEL_LEN
+    gpu_memory_utilization: float = 0.7
+    excluded_backends: set[AttentionBackendEnum] = field(
+        default_factory=set)
+    marks: list = field(default_factory=list)
+    rtol: float | None = None
+
+
+# Baselines measured with examples/offline_inference/spec_decode.py
+# --method mtp --num_spec_tokens 1 --num-prompts 80 --temp 0
+# --dataset-name hf --dataset-path philschmid/mt-bench
+MTP_MODEL_CONFIGS = [
+    MTPModelConfig(
+        verifier="deepseek-ai/DeepSeek-V3",
+        expected_acceptance_length=1.16,
+        expected_acceptance_lengths_per_pos=[0.16],
+        id="deepseek-v3-mtp",
+        tensor_parallel_size=4,
+        gpu_memory_utilization=0.95,
+        marks=[pytest.mark.slow_test],
+        rtol=0.10,
+    ),
+]
+
+
+@large_gpu_mark(min_gb=40)
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="This test is only supported on CUDA platform.",
+)
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        pytest.param(config, id=config.id, marks=config.marks)
+        for config in MTP_MODEL_CONFIGS
+    ],
+)
+@pytest.mark.parametrize("attention_backend",
+                         get_attention_backend_params())
+def test_mtp_acceptance_length(
+    model_config: MTPModelConfig,
+    attention_backend: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    MTP Acceptance Length Regression Tests.
+
+    Verifies that acceptance lengths for MTP speculative decoding
+    do not regress across vLLM commits. Each test runs inference
+    on the MT-Bench dataset and asserts that the mean acceptance
+    length is within tolerance of the expected baseline.
+    """
+    backend_enum = AttentionBackendEnum[attention_backend]
+    if backend_enum in model_config.excluded_backends:
+        pytest.skip(
+            f"{attention_backend} incompatible with {model_config.id}")
+
+    num_spec_tokens = model_config.num_speculative_tokens
+
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+        with VllmRunner(
+            model_name=model_config.verifier,
+            speculative_config={
+                "method": "mtp",
+                "num_speculative_tokens": num_spec_tokens,
+            },
+            attention_config={"backend": attention_backend},
+            tensor_parallel_size=model_config.tensor_parallel_size,
+            gpu_memory_utilization=model_config.gpu_memory_utilization,
+            disable_log_stats=False,
+            max_model_len=model_config.max_model_len,
+            trust_remote_code=True,
+        ) as vllm_runner:
+            tokenizer = vllm_runner.llm.get_tokenizer()
+            prompt_ids = get_mt_bench_prompts(
+                tokenizer, DEFAULT_NUM_PROMPTS)
+
+            sampling_params = SamplingParams(
+                temperature=0,
+                max_tokens=DEFAULT_OUTPUT_LEN,
+            )
+            vllm_runner.llm.generate(
+                [TokensPrompt(prompt_token_ids=ids)
+                 for ids in prompt_ids],
+                sampling_params=sampling_params,
+            )
+
+            metrics = vllm_runner.llm.get_metrics()
+            results = extract_acceptance_metrics(
+                metrics, num_spec_tokens)
+
+            actual = results["acceptance_length"]
+            expected = model_config.expected_acceptance_length
+            actual_per_pos = results["acceptance_lengths_per_pos"]
+            expected_per_pos = (
+                model_config.expected_acceptance_lengths_per_pos)
+
+            rel_error = abs(actual - expected) / expected
+            rtol = (
+                model_config.rtol
+                if model_config.rtol is not None
+                else DEFAULT_RTOL
+            )
+
+            assert rel_error <= rtol, (
+                f"MTP acceptance length regression for "
+                f"{model_config.id}!\n"
+                f"  Expected: {expected:.3f}\n"
+                f"  Actual:   {actual:.3f}\n"
+                f"  Relative error: {rel_error:.2%} "
+                f"(tolerance: {rtol:.2%})\n"
+                f"  Drafts: {results['num_drafts']}, "
+                f"Accepted: {results['num_accepted_tokens']}")
+
+            if (expected_per_pos
+                    and len(expected_per_pos) == len(actual_per_pos)):
+                rtol = (model_config.rtol
+                        if model_config.rtol is not None
+                        else DEFAULT_RTOL)
+                for pos, (act, exp) in enumerate(
+                    zip(actual_per_pos, expected_per_pos)
+                ):
+                    if exp > 0:
+                        pos_err = abs(act - exp) / exp
+                        assert pos_err <= rtol, (
+                            f"Per-position regression at pos {pos} "
+                            f"for {model_config.id}!\n"
+                            f"  Expected: {exp:.3f}\n"
+                            f"  Actual:   {act:.3f}\n"
+                            f"  Error: {pos_err:.2%} "
+                            f"(tolerance: {rtol:.2%})")
+
+            print(
+                f"\n{model_config.id} "
+                f"[tp={model_config.tensor_parallel_size}, "
+                f"backend={attention_backend}]: "
+                f"acceptance_length={actual:.3f}"
+                f" (expected={expected:.3f}, "
+                f"rel_error={rel_error:.2%})")
+            print(
+                f"  Per-position: "
+                f"{[f'{v:.3f}' for v in actual_per_pos]}")
+            if expected_per_pos:
+                print(
+                    f"  Expected:     "
+                    f"{[f'{v:.3f}' for v in expected_per_pos]}")

--- a/tests/v1/spec_decode/test_acceptance_length.py
+++ b/tests/v1/spec_decode/test_acceptance_length.py
@@ -320,17 +320,16 @@ def test_eagle3_acceptance_length(
 @dataclass
 class MTPModelConfig:
     """Model configuration for MTP acceptance length tests."""
+
     verifier: str
     expected_acceptance_length: float
-    expected_acceptance_lengths_per_pos: list[float] = field(
-        default_factory=list)
+    expected_acceptance_lengths_per_pos: list[float] = field(default_factory=list)
     id: str = ""
     num_speculative_tokens: int = 1
     tensor_parallel_size: int = 1
     max_model_len: int = DEFAULT_MAX_MODEL_LEN
     gpu_memory_utilization: float = 0.7
-    excluded_backends: set[AttentionBackendEnum] = field(
-        default_factory=set)
+    excluded_backends: set[AttentionBackendEnum] = field(default_factory=set)
     marks: list = field(default_factory=list)
     rtol: float | None = None
 
@@ -364,8 +363,7 @@ MTP_MODEL_CONFIGS = [
         for config in MTP_MODEL_CONFIGS
     ],
 )
-@pytest.mark.parametrize("attention_backend",
-                         get_attention_backend_params())
+@pytest.mark.parametrize("attention_backend", get_attention_backend_params())
 def test_mtp_acceptance_length(
     model_config: MTPModelConfig,
     attention_backend: str,
@@ -381,8 +379,7 @@ def test_mtp_acceptance_length(
     """
     backend_enum = AttentionBackendEnum[attention_backend]
     if backend_enum in model_config.excluded_backends:
-        pytest.skip(
-            f"{attention_backend} incompatible with {model_config.id}")
+        pytest.skip(f"{attention_backend} incompatible with {model_config.id}")
 
     num_spec_tokens = model_config.num_speculative_tokens
 
@@ -403,35 +400,27 @@ def test_mtp_acceptance_length(
             trust_remote_code=True,
         ) as vllm_runner:
             tokenizer = vllm_runner.llm.get_tokenizer()
-            prompt_ids = get_mt_bench_prompts(
-                tokenizer, DEFAULT_NUM_PROMPTS)
+            prompt_ids = get_mt_bench_prompts(tokenizer, DEFAULT_NUM_PROMPTS)
 
             sampling_params = SamplingParams(
                 temperature=0,
                 max_tokens=DEFAULT_OUTPUT_LEN,
             )
             vllm_runner.llm.generate(
-                [TokensPrompt(prompt_token_ids=ids)
-                 for ids in prompt_ids],
+                [TokensPrompt(prompt_token_ids=ids) for ids in prompt_ids],
                 sampling_params=sampling_params,
             )
 
             metrics = vllm_runner.llm.get_metrics()
-            results = extract_acceptance_metrics(
-                metrics, num_spec_tokens)
+            results = extract_acceptance_metrics(metrics, num_spec_tokens)
 
             actual = results["acceptance_length"]
             expected = model_config.expected_acceptance_length
             actual_per_pos = results["acceptance_lengths_per_pos"]
-            expected_per_pos = (
-                model_config.expected_acceptance_lengths_per_pos)
+            expected_per_pos = model_config.expected_acceptance_lengths_per_pos
 
             rel_error = abs(actual - expected) / expected
-            rtol = (
-                model_config.rtol
-                if model_config.rtol is not None
-                else DEFAULT_RTOL
-            )
+            rtol = model_config.rtol if model_config.rtol is not None else DEFAULT_RTOL
 
             assert rel_error <= rtol, (
                 f"MTP acceptance length regression for "
@@ -441,16 +430,14 @@ def test_mtp_acceptance_length(
                 f"  Relative error: {rel_error:.2%} "
                 f"(tolerance: {rtol:.2%})\n"
                 f"  Drafts: {results['num_drafts']}, "
-                f"Accepted: {results['num_accepted_tokens']}")
+                f"Accepted: {results['num_accepted_tokens']}"
+            )
 
-            if (expected_per_pos
-                    and len(expected_per_pos) == len(actual_per_pos)):
-                rtol = (model_config.rtol
-                        if model_config.rtol is not None
-                        else DEFAULT_RTOL)
-                for pos, (act, exp) in enumerate(
-                    zip(actual_per_pos, expected_per_pos)
-                ):
+            if expected_per_pos and len(expected_per_pos) == len(actual_per_pos):
+                rtol = (
+                    model_config.rtol if model_config.rtol is not None else DEFAULT_RTOL
+                )
+                for pos, (act, exp) in enumerate(zip(actual_per_pos, expected_per_pos)):
                     if exp > 0:
                         pos_err = abs(act - exp) / exp
                         assert pos_err <= rtol, (
@@ -459,7 +446,8 @@ def test_mtp_acceptance_length(
                             f"  Expected: {exp:.3f}\n"
                             f"  Actual:   {act:.3f}\n"
                             f"  Error: {pos_err:.2%} "
-                            f"(tolerance: {rtol:.2%})")
+                            f"(tolerance: {rtol:.2%})"
+                        )
 
             print(
                 f"\n{model_config.id} "
@@ -467,11 +455,8 @@ def test_mtp_acceptance_length(
                 f"backend={attention_backend}]: "
                 f"acceptance_length={actual:.3f}"
                 f" (expected={expected:.3f}, "
-                f"rel_error={rel_error:.2%})")
-            print(
-                f"  Per-position: "
-                f"{[f'{v:.3f}' for v in actual_per_pos]}")
+                f"rel_error={rel_error:.2%})"
+            )
+            print(f"  Per-position: {[f'{v:.3f}' for v in actual_per_pos]}")
             if expected_per_pos:
-                print(
-                    f"  Expected:     "
-                    f"{[f'{v:.3f}' for v in expected_per_pos]}")
+                print(f"  Expected:     {[f'{v:.3f}' for v in expected_per_pos]}")


### PR DESCRIPTION
## Purpose

Add a DeepSeek MTP acceptance length regression test to cover speculative decoding accuracy.

This is a targeted regression test for DeepSeek MTP acceptance metrics under a single stable Blackwell configuration, rather than a full MTP parameter matrix.

Current gap:
- `tests/v1/spec_decode/test_acceptance_length.py` currently covers EAGLE3 only.
- Existing MTP coverage in `tests/v1/e2e/test_spec_decode.py::test_mtp_correctness`
  checks output similarity, but does not validate acceptance metrics.
- There is currently no DeepSeek MTP acceptance rate / acceptance length regression
  test in CI.

This PR adds:
- `test_mtp_acceptance_length` for `deepseek-ai/DeepSeek-V3`
- an optional/nightly B200 CI job in `.buildkite/test_areas/misc.yaml`

## Test Plan

Baseline generation command:
```bash
python3 examples/offline_inference/spec_decode.py \
    --method mtp \
    --num_spec_tokens 1 \
    --dataset-name hf \
    --dataset-path philschmid/mt-bench \
    --num-prompts 80 \
    --temp 0 \
    --top-p 1.0 \
    --top-k -1 \
    --tp 4 \
    --max-model-len 16384 \
    --gpu-memory-utilization 0.95 \
    --model deepseek-ai/DeepSeek-V3
```

CI test command:
```bash
pytest -v -s v1/spec_decode/test_acceptance_length.py::test_mtp_acceptance_length
```

## Test Result
baseline measured on:
`4x B200` = 1.04 / 0.04
`total_num_output_tokens`: 8369
`num_drafts`: 7991
`num_draft_tokens`: 7991
`num_accepted_tokens`: 303
`mean acceptance length`: 1.04
`acceptance at token 0`: 0.04


supplementary validation：
8x B200 = 1.08 / 0.08
`total_num_output_tokens`: 9582
`num_drafts`: 8859
`num_draft_tokens`: 8859
`num_accepted_tokens`: 665
`mean acceptance length`: 1.08
`acceptance at token 0`: 0.08


4x GB200 = 1.16 / 0.16
`total_num_output_tokens`: 8419
`num_drafts`: 7198
`num_draft_tokens`: 7198
`num_accepted_tokens`: 1148
`mean acceptance length`: 1.16
`acceptance at token 0`: 0.16
