### PR TITLE
[ROCm] Utilize persistent MLA kernel from AITER

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -382,6 +382,12 @@ def _rocm_aiter_mla_decode_fwd_impl(
     logit_cap: float = 0.0,
     q_scale: torch.Tensor | None = None,
     kv_scale: torch.Tensor | None = None,
+    work_meta_data: torch.Tensor | None = None,
+    work_indptr: torch.Tensor | None = None,
+    work_info_set: torch.Tensor | None = None,
+    reduce_indptr: torch.Tensor | None = None,
+    reduce_final_map: torch.Tensor | None = None,
+    reduce_partial_map: torch.Tensor | None = None,
 ) -> None:
     from aiter.mla import mla_decode_fwd
 
@@ -394,6 +400,19 @@ def _rocm_aiter_mla_decode_fwd_impl(
     if _check_aiter_mla_fp8_support():
         kwargs["q_scale"] = q_scale
         kwargs["kv_scale"] = kv_scale
+
+    if work_meta_data is not None:
+        assert work_indptr is not None, "work_indptr must be provided with work_meta_data"
+        assert work_info_set is not None, "work_info_set must be provided with work_meta_data"
+        assert reduce_indptr is not None, "reduce_indptr must be provided with work_meta_data"
+        assert reduce_final_map is not None, "reduce_final_map must be provided with work_meta_data"
+        assert reduce_partial_map is not None, "reduce_partial_map must be provided with work_meta_data"
+        kwargs["work_meta_data"] = work_meta_data
+        kwargs["work_indptr"] = work_indptr
+        kwargs["work_info_set"] = work_info_set
+        kwargs["reduce_indptr"] = reduce_indptr
+        kwargs["reduce_final_map"] = reduce_final_map
+        kwargs["reduce_partial_map"] = reduce_partial_map
 
     mla_decode_fwd(
         q,
@@ -421,6 +440,12 @@ def _rocm_aiter_mla_decode_fwd_fake(
     logit_cap: float = 0.0,
     q_scale: torch.Tensor | None = None,
     kv_scale: torch.Tensor | None = None,
+    work_meta_data: torch.Tensor | None = None,
+    work_indptr: torch.Tensor | None = None,
+    work_info_set: torch.Tensor | None = None,
+    reduce_indptr: torch.Tensor | None = None,
+    reduce_final_map: torch.Tensor | None = None,
+    reduce_partial_map: torch.Tensor | None = None,
 ) -> None:
     pass
 
@@ -1614,6 +1639,12 @@ class rocm_aiter_ops:
         logit_cap: float = 0.0,
         q_scale: torch.Tensor | None = None,
         kv_scale: torch.Tensor | None = None,
+        work_meta_data: torch.Tensor | None = None,
+        work_indptr: torch.Tensor | None = None,
+        work_info_set: torch.Tensor | None = None,
+        reduce_indptr: torch.Tensor | None = None,
+        reduce_final_map: torch.Tensor | None = None,
+        reduce_partial_map: torch.Tensor | None = None,
     ):
         torch.ops.vllm.rocm_aiter_mla_decode_fwd(
             q,
@@ -1628,6 +1659,12 @@ class rocm_aiter_ops:
             logit_cap=logit_cap,
             q_scale=q_scale,
             kv_scale=kv_scale,
+            work_meta_data=work_meta_data,
+            work_indptr=work_indptr,
+            work_info_set=work_info_set,
+            reduce_indptr=reduce_indptr,
+            reduce_final_map=reduce_final_map,
+            reduce_partial_map=reduce_partial_map,
         )
 
     @staticmethod

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -402,11 +402,21 @@ def _rocm_aiter_mla_decode_fwd_impl(
         kwargs["kv_scale"] = kv_scale
 
     if work_meta_data is not None:
-        assert work_indptr is not None, "work_indptr must be provided with work_meta_data"
-        assert work_info_set is not None, "work_info_set must be provided with work_meta_data"
-        assert reduce_indptr is not None, "reduce_indptr must be provided with work_meta_data"
-        assert reduce_final_map is not None, "reduce_final_map must be provided with work_meta_data"
-        assert reduce_partial_map is not None, "reduce_partial_map must be provided with work_meta_data"
+        assert work_indptr is not None, (
+            "work_indptr must be provided with work_meta_data"
+        )
+        assert work_info_set is not None, (
+            "work_info_set must be provided with work_meta_data"
+        )
+        assert reduce_indptr is not None, (
+            "reduce_indptr must be provided with work_meta_data"
+        )
+        assert reduce_final_map is not None, (
+            "reduce_final_map must be provided with work_meta_data"
+        )
+        assert reduce_partial_map is not None, (
+            "reduce_partial_map must be provided with work_meta_data"
+        )
         kwargs["work_meta_data"] = work_meta_data
         kwargs["work_indptr"] = work_indptr
         kwargs["work_info_set"] = work_info_set

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -111,6 +111,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
+    VLLM_ROCM_USE_AITER_MLA_PERSISTENT: bool = False
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -930,6 +931,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MLA": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MLA", "True").lower() in ("true", "1")
+    ),
+    "VLLM_ROCM_USE_AITER_MLA_PERSISTENT": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_MLA_PERSISTENT", "False").lower()
+        in ("true", "1")
     ),
     # Whether to use aiter mha ops.
     # By default is enabled.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -111,7 +111,6 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
-    VLLM_ROCM_USE_AITER_MLA_PERSISTENT: bool = False
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -931,10 +930,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MLA": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MLA", "True").lower() in ("true", "1")
-    ),
-    "VLLM_ROCM_USE_AITER_MLA_PERSISTENT": lambda: (
-        os.getenv("VLLM_ROCM_USE_AITER_MLA_PERSISTENT", "False").lower()
-        in ("true", "1")
     ),
     # Whether to use aiter mha ops.
     # By default is enabled.

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -6,7 +6,6 @@ from typing import ClassVar
 
 import torch
 
-from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
@@ -127,58 +126,54 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             max_num_pages, dtype=torch.int32, device=device
         )
 
-        if envs.VLLM_ROCM_USE_AITER_MLA_PERSISTENT:
-            from aiter import dtypes, get_mla_metadata_info_v1
+        from aiter import dtypes, get_mla_metadata_info_v1
 
-            num_attention_heads = vllm_config.model_config.get_num_attention_heads(
-                vllm_config.parallel_config
-            )
-            q_dtype = self.decode_attn_out_dtype
-            kv_cache_dtype_str = getattr(
-                vllm_config.cache_config, "cache_dtype", "auto"
-            )
-            if kv_cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):
-                kv_cache_dtype_str = "fp8"
-            else:
-                kv_cache_dtype_str = "bf16"
-            kv_dtype = dtypes.d_dtypes.get(kv_cache_dtype_str, dtypes.bf16)
-            (
-                (work_meta_data_size, work_meta_data_type),
-                (work_indptr_size, work_indptr_type),
-                (work_info_set_size, work_info_set_type),
-                (reduce_indptr_size, reduce_indptr_type),
-                (reduce_final_map_size, reduce_final_map_type),
-                (reduce_partial_map_size, reduce_partial_map_type),
-            ) = get_mla_metadata_info_v1(
-                max_num_reqs,
-                1,
-                num_attention_heads,
-                q_dtype,
-                kv_dtype,
-                is_sparse=False,
-                fast_mode=True,
-            )
-            self._mla_work_meta_data = torch.empty(
-                work_meta_data_size, dtype=work_meta_data_type, device=device
-            )
-            self._mla_work_indptr = torch.empty(
-                work_indptr_size, dtype=work_indptr_type, device=device
-            )
-            self._mla_work_info_set = torch.empty(
-                work_info_set_size, dtype=work_info_set_type, device=device
-            )
-            self._mla_reduce_indptr = torch.empty(
-                reduce_indptr_size, dtype=reduce_indptr_type, device=device
-            )
-            self._mla_reduce_final_map = torch.empty(
-                reduce_final_map_size, dtype=reduce_final_map_type, device=device
-            )
-            self._mla_reduce_partial_map = torch.empty(
-                reduce_partial_map_size,
-                dtype=reduce_partial_map_type,
-                device=device,
-            )
-            self._num_attention_heads = num_attention_heads
+        self._num_attention_heads = vllm_config.model_config.get_num_attention_heads(
+            vllm_config.parallel_config
+        )
+        q_dtype = self.decode_attn_out_dtype
+        kv_cache_dtype_str = getattr(vllm_config.cache_config, "cache_dtype", "auto")
+        if kv_cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):
+            kv_cache_dtype_str = "fp8"
+        else:
+            kv_cache_dtype_str = "bf16"
+        kv_dtype = dtypes.d_dtypes.get(kv_cache_dtype_str, dtypes.bf16)
+        (
+            (work_meta_data_size, work_meta_data_type),
+            (work_indptr_size, work_indptr_type),
+            (work_info_set_size, work_info_set_type),
+            (reduce_indptr_size, reduce_indptr_type),
+            (reduce_final_map_size, reduce_final_map_type),
+            (reduce_partial_map_size, reduce_partial_map_type),
+        ) = get_mla_metadata_info_v1(
+            max_num_reqs,
+            1,
+            self._num_attention_heads,
+            q_dtype,
+            kv_dtype,
+            is_sparse=False,
+            fast_mode=True,
+        )
+        self._mla_work_meta_data = torch.empty(
+            work_meta_data_size, dtype=work_meta_data_type, device=device
+        )
+        self._mla_work_indptr = torch.empty(
+            work_indptr_size, dtype=work_indptr_type, device=device
+        )
+        self._mla_work_info_set = torch.empty(
+            work_info_set_size, dtype=work_info_set_type, device=device
+        )
+        self._mla_reduce_indptr = torch.empty(
+            reduce_indptr_size, dtype=reduce_indptr_type, device=device
+        )
+        self._mla_reduce_final_map = torch.empty(
+            reduce_final_map_size, dtype=reduce_final_map_type, device=device
+        )
+        self._mla_reduce_partial_map = torch.empty(
+            reduce_partial_map_size,
+            dtype=reduce_partial_map_type,
+            device=device,
+        )
 
         if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
             self.paged_kv_indptr = torch.zeros(
@@ -248,28 +243,27 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 0, num_reqs + 1, step=1, dtype=torch.int32, device=device
             )
 
-        if getattr(self, "_mla_work_meta_data", None) is not None:
-            from aiter import get_mla_metadata_v1
+        from aiter import get_mla_metadata_v1
 
-            get_mla_metadata_v1(
-                qo_indptr,
-                paged_kv_indptr,
-                paged_kv_last_page_len,
-                self._num_attention_heads,
-                1,
-                True,
-                self._mla_work_meta_data,
-                self._mla_work_info_set,
-                self._mla_work_indptr,
-                self._mla_reduce_indptr,
-                self._mla_reduce_final_map,
-                self._mla_reduce_partial_map,
-                page_size=1,
-                kv_granularity=16,
-                max_seqlen_qo=max_qo_len,
-                uni_seqlen_qo=max_qo_len,
-                fast_mode=True,
-            )
+        get_mla_metadata_v1(
+            qo_indptr,
+            paged_kv_indptr,
+            paged_kv_last_page_len,
+            self._num_attention_heads,
+            1,
+            True,
+            self._mla_work_meta_data,
+            self._mla_work_info_set,
+            self._mla_work_indptr,
+            self._mla_reduce_indptr,
+            self._mla_reduce_final_map,
+            self._mla_reduce_partial_map,
+            page_size=1,
+            kv_granularity=16,
+            max_seqlen_qo=max_qo_len,
+            uni_seqlen_qo=max_qo_len,
+            fast_mode=True,
+        )
 
         attn_metadata = AiterMLADecodeMetadata(
             block_table=block_table_tensor,
@@ -294,13 +288,12 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         attn_metadata = super().build(
             common_prefix_len, common_attn_metadata, fast_build
         )
-        if getattr(self, "_mla_work_meta_data", None) is not None:
-            attn_metadata.work_meta_data = self._mla_work_meta_data
-            attn_metadata.work_indptr = self._mla_work_indptr
-            attn_metadata.work_info_set = self._mla_work_info_set
-            attn_metadata.reduce_indptr = self._mla_reduce_indptr
-            attn_metadata.reduce_final_map = self._mla_reduce_final_map
-            attn_metadata.reduce_partial_map = self._mla_reduce_partial_map
+        attn_metadata.work_meta_data = self._mla_work_meta_data
+        attn_metadata.work_indptr = self._mla_work_indptr
+        attn_metadata.work_info_set = self._mla_work_info_set
+        attn_metadata.reduce_indptr = self._mla_reduce_indptr
+        attn_metadata.reduce_final_map = self._mla_reduce_final_map
+        attn_metadata.reduce_partial_map = self._mla_reduce_partial_map
         return attn_metadata
 
 

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -19,7 +19,12 @@ from vllm.model_executor.layers.attention.mla_attention import (
     QueryLenSupport,
 )
 from vllm.triton_utils import tl, triton
-from vllm.v1.attention.backend import AttentionCGSupport, AttentionLayer, MultipleOf
+from vllm.v1.attention.backend import (
+    AttentionCGSupport,
+    AttentionLayer,
+    CommonAttentionMetadata,
+    MultipleOf,
+)
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 
@@ -70,16 +75,15 @@ class AiterMLADecodeMetadata(MLACommonDecodeMetadata):
     # The max query output length: int
     max_qo_len: int | None = None
 
+
+@dataclass
+class AiterMLAMetadata(MLACommonMetadata[AiterMLADecodeMetadata]):
     work_meta_data: torch.Tensor | None = None
     work_indptr: torch.Tensor | None = None
     work_info_set: torch.Tensor | None = None
     reduce_indptr: torch.Tensor | None = None
     reduce_final_map: torch.Tensor | None = None
     reduce_partial_map: torch.Tensor | None = None
-
-
-class AiterMLAMetadata(MLACommonMetadata[AiterMLADecodeMetadata]):
-    pass
 
 
 class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
@@ -244,12 +248,6 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 0, num_reqs + 1, step=1, dtype=torch.int32, device=device
             )
 
-        decode_work_meta_data = None
-        decode_work_indptr = None
-        decode_work_info_set = None
-        decode_reduce_indptr = None
-        decode_reduce_final_map = None
-        decode_reduce_partial_map = None
         if getattr(self, "_mla_work_meta_data", None) is not None:
             from aiter import get_mla_metadata_v1
 
@@ -272,12 +270,6 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 uni_seqlen_qo=max_qo_len,
                 fast_mode=True,
             )
-            decode_work_meta_data = self._mla_work_meta_data
-            decode_work_indptr = self._mla_work_indptr
-            decode_work_info_set = self._mla_work_info_set
-            decode_reduce_indptr = self._mla_reduce_indptr
-            decode_reduce_final_map = self._mla_reduce_final_map
-            decode_reduce_partial_map = self._mla_reduce_partial_map
 
         attn_metadata = AiterMLADecodeMetadata(
             block_table=block_table_tensor,
@@ -289,14 +281,26 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             dcp_tot_seq_lens=dcp_tot_seq_lens_device,
             max_qo_len=max_qo_len,
             attn_out_dtype=self.decode_attn_out_dtype,
-            work_meta_data=decode_work_meta_data,
-            work_indptr=decode_work_indptr,
-            work_info_set=decode_work_info_set,
-            reduce_indptr=decode_reduce_indptr,
-            reduce_final_map=decode_reduce_final_map,
-            reduce_partial_map=decode_reduce_partial_map,
         )
 
+        return attn_metadata
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> AiterMLAMetadata:
+        attn_metadata = super().build(
+            common_prefix_len, common_attn_metadata, fast_build
+        )
+        if getattr(self, "_mla_work_meta_data", None) is not None:
+            attn_metadata.work_meta_data = self._mla_work_meta_data
+            attn_metadata.work_indptr = self._mla_work_indptr
+            attn_metadata.work_info_set = self._mla_work_info_set
+            attn_metadata.reduce_indptr = self._mla_reduce_indptr
+            attn_metadata.reduce_final_map = self._mla_reduce_final_map
+            attn_metadata.reduce_partial_map = self._mla_reduce_partial_map
         return attn_metadata
 
 
@@ -439,12 +443,12 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             attn_metadata.decode.paged_kv_last_page_len,
             q_scale=layer._q_scale,
             kv_scale=layer._k_scale,
-            work_meta_data=attn_metadata.decode.work_meta_data,
-            work_indptr=attn_metadata.decode.work_indptr,
-            work_info_set=attn_metadata.decode.work_info_set,
-            reduce_indptr=attn_metadata.decode.reduce_indptr,
-            reduce_final_map=attn_metadata.decode.reduce_final_map,
-            reduce_partial_map=attn_metadata.decode.reduce_partial_map,
+            work_meta_data=attn_metadata.work_meta_data,
+            work_indptr=attn_metadata.work_indptr,
+            work_info_set=attn_metadata.work_info_set,
+            reduce_indptr=attn_metadata.reduce_indptr,
+            reduce_final_map=attn_metadata.reduce_final_map,
+            reduce_partial_map=attn_metadata.reduce_partial_map,
         )
 
         if self._needs_head_repeat:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -6,10 +6,10 @@ from typing import ClassVar
 
 import torch
 
+from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
-from vllm import envs
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonBackend,
     MLACommonDecodeMetadata,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -9,6 +9,7 @@ import torch
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
+from vllm import envs
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonBackend,
     MLACommonDecodeMetadata,
@@ -69,6 +70,13 @@ class AiterMLADecodeMetadata(MLACommonDecodeMetadata):
     # The max query output length: int
     max_qo_len: int | None = None
 
+    work_meta_data: torch.Tensor | None = None
+    work_indptr: torch.Tensor | None = None
+    work_info_set: torch.Tensor | None = None
+    reduce_indptr: torch.Tensor | None = None
+    reduce_final_map: torch.Tensor | None = None
+    reduce_partial_map: torch.Tensor | None = None
+
 
 class AiterMLAMetadata(MLACommonMetadata[AiterMLADecodeMetadata]):
     pass
@@ -114,6 +122,59 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         self.paged_kv_indices = torch.zeros(
             max_num_pages, dtype=torch.int32, device=device
         )
+
+        if envs.VLLM_ROCM_USE_AITER_MLA_PERSISTENT:
+            from aiter import dtypes, get_mla_metadata_info_v1
+
+            num_attention_heads = vllm_config.model_config.get_num_attention_heads(
+                vllm_config.parallel_config
+            )
+            q_dtype = self.decode_attn_out_dtype
+            kv_cache_dtype_str = getattr(
+                vllm_config.cache_config, "cache_dtype", "auto"
+            )
+            if kv_cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):
+                kv_cache_dtype_str = "fp8"
+            else:
+                kv_cache_dtype_str = "bf16"
+            kv_dtype = dtypes.d_dtypes.get(kv_cache_dtype_str, dtypes.bf16)
+            (
+                (work_meta_data_size, work_meta_data_type),
+                (work_indptr_size, work_indptr_type),
+                (work_info_set_size, work_info_set_type),
+                (reduce_indptr_size, reduce_indptr_type),
+                (reduce_final_map_size, reduce_final_map_type),
+                (reduce_partial_map_size, reduce_partial_map_type),
+            ) = get_mla_metadata_info_v1(
+                max_num_reqs,
+                1,
+                num_attention_heads,
+                q_dtype,
+                kv_dtype,
+                is_sparse=False,
+                fast_mode=True,
+            )
+            self._mla_work_meta_data = torch.empty(
+                work_meta_data_size, dtype=work_meta_data_type, device=device
+            )
+            self._mla_work_indptr = torch.empty(
+                work_indptr_size, dtype=work_indptr_type, device=device
+            )
+            self._mla_work_info_set = torch.empty(
+                work_info_set_size, dtype=work_info_set_type, device=device
+            )
+            self._mla_reduce_indptr = torch.empty(
+                reduce_indptr_size, dtype=reduce_indptr_type, device=device
+            )
+            self._mla_reduce_final_map = torch.empty(
+                reduce_final_map_size, dtype=reduce_final_map_type, device=device
+            )
+            self._mla_reduce_partial_map = torch.empty(
+                reduce_partial_map_size,
+                dtype=reduce_partial_map_type,
+                device=device,
+            )
+            self._num_attention_heads = num_attention_heads
 
         if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
             self.paged_kv_indptr = torch.zeros(
@@ -183,6 +244,41 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 0, num_reqs + 1, step=1, dtype=torch.int32, device=device
             )
 
+        decode_work_meta_data = None
+        decode_work_indptr = None
+        decode_work_info_set = None
+        decode_reduce_indptr = None
+        decode_reduce_final_map = None
+        decode_reduce_partial_map = None
+        if getattr(self, "_mla_work_meta_data", None) is not None:
+            from aiter import get_mla_metadata_v1
+
+            get_mla_metadata_v1(
+                qo_indptr,
+                paged_kv_indptr,
+                paged_kv_last_page_len,
+                self._num_attention_heads,
+                1,
+                True,
+                self._mla_work_meta_data,
+                self._mla_work_info_set,
+                self._mla_work_indptr,
+                self._mla_reduce_indptr,
+                self._mla_reduce_final_map,
+                self._mla_reduce_partial_map,
+                page_size=1,
+                kv_granularity=16,
+                max_seqlen_qo=max_qo_len,
+                uni_seqlen_qo=max_qo_len,
+                fast_mode=True,
+            )
+            decode_work_meta_data = self._mla_work_meta_data
+            decode_work_indptr = self._mla_work_indptr
+            decode_work_info_set = self._mla_work_info_set
+            decode_reduce_indptr = self._mla_reduce_indptr
+            decode_reduce_final_map = self._mla_reduce_final_map
+            decode_reduce_partial_map = self._mla_reduce_partial_map
+
         attn_metadata = AiterMLADecodeMetadata(
             block_table=block_table_tensor,
             seq_lens=seq_lens_device,
@@ -193,6 +289,12 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             dcp_tot_seq_lens=dcp_tot_seq_lens_device,
             max_qo_len=max_qo_len,
             attn_out_dtype=self.decode_attn_out_dtype,
+            work_meta_data=decode_work_meta_data,
+            work_indptr=decode_work_indptr,
+            work_info_set=decode_work_info_set,
+            reduce_indptr=decode_reduce_indptr,
+            reduce_final_map=decode_reduce_final_map,
+            reduce_partial_map=decode_reduce_partial_map,
         )
 
         return attn_metadata
@@ -337,6 +439,12 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             attn_metadata.decode.paged_kv_last_page_len,
             q_scale=layer._q_scale,
             kv_scale=layer._k_scale,
+            work_meta_data=attn_metadata.decode.work_meta_data,
+            work_indptr=attn_metadata.decode.work_indptr,
+            work_info_set=attn_metadata.decode.work_info_set,
+            reduce_indptr=attn_metadata.decode.reduce_indptr,
+            reduce_final_map=attn_metadata.decode.reduce_final_map,
+            reduce_partial_map=attn_metadata.decode.reduce_partial_map,
         )
 
         if self._needs_head_repeat:


### PR DESCRIPTION
## Purpose
Add support for aiter's persistent mode MLA decode kernel on ROCm. The persistent
kernel stays resident on GPU CUs and processes work items from pre-computed
scheduling metadata, avoiding per-batch kernel launch overhead.
- Pre-allocates six persistent scheduling buffers (`work_meta_data`, `work_indptr`,
  `work_info_set`, `reduce_indptr`, `reduce_final_map`, `reduce_partial_map`) during
  `AiterMLAMetadataBuilder` initialization via `aiter.get_mla_metadata_info_v1`.
- Fills the buffers each decode step via `aiter.get_mla_metadata_v1`.
- Stores them on `AiterMLAMetadata` and passes them through
  `rocm_aiter_ops.mla_decode_fwd` into `aiter.mla.mla_decode_fwd`, which uses
  the persistent kernel path.

## Test Plan
Build vllm image without and with the persistent MLA.
Base Image : `vllm/vllm-openai-rocm:v0.17.1`
AITER commit : `c3708fb74` (v0.1.10.post2)
vLLM commit (with persistent MLA) : ab8159d742559b029b731fe183ebfdb41d60b374
vLLM commit (without persistent MLA) : 87985077a45b721355efd7c406384254910f963f 

Deepseek-R1-0528-MXFP4, TP=8:
```
export AMDGCN_USE_BUFFER_OPS=1
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=True
```
```
$cat DeepSeek-R1-0528-MXFP4_mi355x_vllm.yaml
max-num-seqs: 64
no-enable-prefix-caching: True
max-num-batched-tokens: 65536
block-size: 16
gpu-memory-utilization: 0.9
async-scheduling: True
distributed_executor_backend: mp
kv-cache-dtype: fp8
tensor_parallel_size: 8
```
```
vllm serve /data/workloads-inference/models/DeepSeek-R1-0528-MXFP4 --host 0.0.0.0 --port 8888 --config DeepSeek-R1-0528-MXFP4_mi355x_vllm.yaml
```

## Test Results
Deepseek-R1-0528-MXFP4 TP=8, TTPS per GPU listed below:

| Config | Conc | Without persistent MLA | With persistent MLA | Uplift |
|--------|------|-------------------|----------------|--------|
| 1k1k   | 4    | 59                | 78             | 1.32   |
| 1k1k   | 64   | 509               | 623            | 1.23   |
| 1k8k   | 4    | 30                | 45             | 1.47   |
| 1k8k   | 64   | 332               | 402            | 1.21   |
| 8k1k   | 4    | 261               | 324              | 1.24  |
| 8k1k   | 64   | 1542              | 1895            | 1.23   |

### Accuracy

`lm_eval` scores for gsm8k 250 limit:
openai-completions ({'model': '/data/workloads-inference/models/DeepSeek-R1-0528-MXFP4', 'base_url': 'http://0.0.0.0:8888/v1/completions', 'add_bos_token': True, 'enforce_eager': True, 'num_concurrent': 64, 'max_retries': 10, 'max_gen_toks': 1024, 'tokenizer_backend': 'huggingface'}), gen_kwargs: ({}), limit: 250.0, num_fewshot: 5, batch_size: 64

Without persistent MLA:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.952|±  |0.0135|
|     |       |strict-match    |     5|exact_match|↑  |0.952|±  |0.0135|

With persistent MLA:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.964|±  |0.0118|
|     |       |strict-match    |     5|exact_match|↑  |0.964|±  |0.0118|

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

