### PR TITLE
[Feature] Add debug tensor dump for intermediate activations

### DIFF
--- a/docs/features/tensor_dump.md
+++ b/docs/features/tensor_dump.md
@@ -18,7 +18,7 @@ VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER=./dump \
 After sending requests, the dump directory will contain per-worker
 sub-directories with `.pt` files:
 
-```
+```text
 dump/
   TP0_PP0_Rank0_pid12345/
     Pass00000.pt
@@ -32,7 +32,7 @@ output tensors (on CPU).
 ## Environment Variables
 
 | Variable | Type | Default | Description |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER` | `str` | (unset) | Output directory. Feature is disabled when unset. |
 | `VLLM_DEBUG_TENSOR_DUMP_LAYERS` | `str` | (unset) | Comma-separated layer indices to dump (e.g. `"0,1,31"`). All layers when unset. |
 | `VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES` | `int` | `0` | Number of initial forward passes to skip (useful for skipping warmup passes). |

--- a/docs/features/tensor_dump.md
+++ b/docs/features/tensor_dump.md
@@ -1,0 +1,59 @@
+# Debug Tensor Dump
+
+The tensor dump feature captures intermediate activations from every leaf
+module of the model during inference.  Each forward pass produces a `.pt`
+file that you can load with `torch.load()` for offline analysis and
+debugging.
+
+## Quick Start
+
+Set the `VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER` environment variable to
+an output directory:
+
+```bash
+VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER=./dump \
+    python -m vllm.entrypoints.openai.api_server --model <model>
+```
+
+After sending requests, the dump directory will contain per-worker
+sub-directories with `.pt` files:
+
+```
+dump/
+  TP0_PP0_Rank0_pid12345/
+    Pass00000.pt
+    Pass00001.pt
+    ...
+```
+
+Each file is a dictionary mapping fully-qualified module names to their
+output tensors (on CPU).
+
+## Environment Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER` | `str` | (unset) | Output directory. Feature is disabled when unset. |
+| `VLLM_DEBUG_TENSOR_DUMP_LAYERS` | `str` | (unset) | Comma-separated layer indices to dump (e.g. `"0,1,31"`). All layers when unset. |
+| `VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES` | `int` | `0` | Number of initial forward passes to skip (useful for skipping warmup passes). |
+
+## Notes
+
+- When tensor dump is enabled, `torch.compile` and CUDA graph capture
+  are automatically disabled.  This has a significant performance impact
+  and should only be used for debugging.
+- Tensors are moved to CPU immediately inside the forward hook, which
+  adds overhead per forward pass.
+- The dump directory is organized by TP/PP rank and process ID, so
+  multi-GPU setups produce separate files per worker.
+
+## Loading Dumps
+
+```python
+import torch
+
+data = torch.load("dump/TP0_PP0_Rank0_pid12345/Pass00000.pt",
+                   weights_only=True)
+for name, tensor in sorted(data.items()):
+    print(f"{name}: shape={tensor.shape}, dtype={tensor.dtype}")
+```

--- a/docs/features/tensor_dump.md
+++ b/docs/features/tensor_dump.md
@@ -44,6 +44,11 @@ output tensors (on CPU).
 - When tensor dump is enabled, `torch.compile` and CUDA graph capture
   are automatically disabled.  This has a significant performance impact
   and should only be used for debugging.
+- **Not safe for multi-model serving.** Enabling tensor dump removes the
+  custom `__call__` from `@support_torch_compile` classes at the Python
+  class level.  This is a global, irreversible change within the process
+  and will affect all models loaded in the same worker.  Only use this
+  feature in single-model debugging scenarios.
 - Tensors are moved to CPU immediately inside the forward hook, which
   adds overhead per forward pass.
 - The dump directory is organized by TP/PP rank and process ID, so

--- a/docs/features/tensor_dump.md
+++ b/docs/features/tensor_dump.md
@@ -36,6 +36,8 @@ output tensors (on CPU).
 | `VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER` | `str` | (unset) | Output directory. Feature is disabled when unset. |
 | `VLLM_DEBUG_TENSOR_DUMP_LAYERS` | `str` | (unset) | Comma-separated layer indices to dump (e.g. `"0,1,31"`). All layers when unset. |
 | `VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES` | `int` | `0` | Number of initial forward passes to skip (useful for skipping warmup passes). |
+| `VLLM_DEBUG_TENSOR_DUMP_TOP_LEVEL_MODULE_NAME` | `str` | `"model"` | Name of the top-level sub-module inside the model to hook. |
+| `VLLM_DEBUG_TENSOR_DUMP_LAYERS_MODULE_NAME` | `str` | `"layers"` | Name of the layers container inside the top-level module. |
 
 ## Notes
 

--- a/tests/debug/__init__.py
+++ b/tests/debug/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/debug/test_tensor_dump.py
+++ b/tests/debug/test_tensor_dump.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for vllm.debug.tensor_dump."""
+
+import os
+import tempfile
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.debug.tensor_dump import TensorDumper, register_forward_hook_for_model
+
+
+class TestTensorDumper:
+    """Unit tests for TensorDumper."""
+
+    def test_add_tensor_single(self, tmp_path):
+        dumper = TensorDumper(str(tmp_path), None, 1, 0, 0)
+        t = torch.randn(2, 3)
+        dumper.add_tensor("layer.0.output", t)
+        assert "layer.0.output" in dumper._current_tensors
+        assert torch.equal(dumper._current_tensors["layer.0.output"], t.cpu())
+
+    def test_add_tensor_tuple(self, tmp_path):
+        dumper = TensorDumper(str(tmp_path), None, 1, 0, 0)
+        t1 = torch.randn(2, 3)
+        dumper.add_tensor("layer.0", (t1,))
+        assert torch.equal(dumper._current_tensors["layer.0"], t1.cpu())
+
+    def test_add_tensor_multi_tuple(self, tmp_path):
+        dumper = TensorDumper(str(tmp_path), None, 1, 0, 0)
+        t1 = torch.randn(2, 3)
+        t2 = torch.randn(4, 5)
+        dumper.add_tensor("layer.0", (t1, t2))
+        result = dumper._current_tensors["layer.0"]
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_dump_creates_file(self, tmp_path):
+        dumper = TensorDumper(str(tmp_path), None, 1, 0, 0)
+        dumper.add_tensor("x", torch.randn(2, 3))
+        dumper.dump_current_tensors()
+        pt_files = list(tmp_path.rglob("*.pt"))
+        assert len(pt_files) == 1
+        assert "Pass00000.pt" in pt_files[0].name
+
+    def test_dump_increments_pass_id(self, tmp_path):
+        dumper = TensorDumper(str(tmp_path), None, 1, 0, 0)
+        dumper.add_tensor("x", torch.randn(2, 3))
+        dumper.dump_current_tensors()
+        dumper.add_tensor("y", torch.randn(2, 3))
+        dumper.dump_current_tensors()
+        pt_files = sorted(tmp_path.rglob("*.pt"))
+        assert len(pt_files) == 2
+
+    def test_skip_passes(self, tmp_path):
+        dumper = TensorDumper(str(tmp_path), None, 1, 0, 0, skip_passes=2)
+        # First two passes should be skipped.
+        dumper.add_tensor("x", torch.randn(2, 3))
+        dumper.dump_current_tensors()
+        dumper.add_tensor("x", torch.randn(2, 3))
+        dumper.dump_current_tensors()
+        assert len(list(tmp_path.rglob("*.pt"))) == 0
+        # Third pass should produce output.
+        dumper.add_tensor("x", torch.randn(2, 3))
+        dumper.dump_current_tensors()
+        assert len(list(tmp_path.rglob("*.pt"))) == 1
+
+    def test_empty_dump_no_file(self, tmp_path):
+        dumper = TensorDumper(str(tmp_path), None, 1, 0, 0)
+        dumper.dump_current_tensors()
+        assert len(list(tmp_path.rglob("*.pt"))) == 0
+
+    def test_process_dir_naming(self, tmp_path):
+        dumper = TensorDumper(str(tmp_path), None, 4, 1, 2)
+        dir_name = os.path.basename(dumper.get_dump_dir())
+        assert dir_name.startswith("TP1_PP2_Rank9_pid")
+
+    def test_saved_tensors_loadable(self, tmp_path):
+        dumper = TensorDumper(str(tmp_path), None, 1, 0, 0)
+        original = torch.randn(3, 4)
+        dumper.add_tensor("test_tensor", original)
+        dumper.dump_current_tensors()
+        pt_files = list(tmp_path.rglob("*.pt"))
+        loaded = torch.load(pt_files[0], weights_only=True)
+        assert torch.equal(loaded["test_tensor"], original.cpu())
+
+
+class InnerModel(nn.Module):
+    """Inner model that mimics a real model's structure (e.g. LlamaModel)."""
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList([nn.Linear(4, 4) for _ in range(3)])
+        self.norm = nn.LayerNorm(4)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return self.norm(x)
+
+
+class SimpleModel(nn.Module):
+    """A minimal model with the structure expected by the hook registrar.
+
+    Mirrors the real vLLM pattern where the outer module has a ``model``
+    attribute whose ``forward()`` is called via ``self.model(x)``.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.model = InnerModel()
+
+    def forward(self, x):
+        return self.model(x)
+
+
+class TestRegisterForwardHook:
+    """Tests for register_forward_hook_for_model."""
+
+    def test_hooks_registered(self, tmp_path):
+        model = SimpleModel()
+        dumper = register_forward_hook_for_model(model, str(tmp_path))
+        assert dumper is not None
+        assert os.path.isdir(dumper.get_dump_dir())
+
+    def test_forward_produces_dump(self, tmp_path):
+        model = SimpleModel()
+        register_forward_hook_for_model(model, str(tmp_path))
+        x = torch.randn(2, 4)
+        model(x)
+        pt_files = list(tmp_path.rglob("*.pt"))
+        assert len(pt_files) >= 1
+
+    def test_dump_layers_filter(self, tmp_path):
+        model = SimpleModel()
+        # Only dump layer 0.
+        register_forward_hook_for_model(
+            model, str(tmp_path), dump_layers=[0]
+        )
+        x = torch.randn(2, 4)
+        model(x)
+        pt_files = list(tmp_path.rglob("*.pt"))
+        assert len(pt_files) >= 1
+        # Load and verify only layer 0 keys exist (not layer 1 or 2).
+        data = torch.load(pt_files[0], weights_only=True)
+        for key in data:
+            if "layers." in key:
+                layer_num = key.split("layers.")[1].split(".")[0]
+                assert layer_num == "0", f"Unexpected layer in dump: {key}"
+
+    def test_missing_top_level_raises(self, tmp_path):
+        # A model without a "model" sub-module should raise.
+        model = nn.Linear(4, 4)
+        with pytest.raises(AssertionError, match="model should have a module"):
+            register_forward_hook_for_model(model, str(tmp_path))

--- a/tests/debug/test_tensor_dump.py
+++ b/tests/debug/test_tensor_dump.py
@@ -3,7 +3,6 @@
 """Tests for vllm.debug.tensor_dump."""
 
 import os
-import tempfile
 
 import pytest
 import torch
@@ -136,9 +135,7 @@ class TestRegisterForwardHook:
     def test_dump_layers_filter(self, tmp_path):
         model = SimpleModel()
         # Only dump layer 0.
-        register_forward_hook_for_model(
-            model, str(tmp_path), dump_layers=[0]
-        )
+        register_forward_hook_for_model(model, str(tmp_path), dump_layers=[0])
         x = torch.randn(2, 4)
         model(x)
         pt_files = list(tmp_path.rglob("*.pt"))

--- a/vllm/debug/__init__.py
+++ b/vllm/debug/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/debug/tensor_dump.py
+++ b/vllm/debug/tensor_dump.py
@@ -299,6 +299,11 @@ def maybe_setup_tensor_dump(
             patched_classes.add(cls)
 
     logger.info("Tensor dump enabled: torch.compile and CUDAGraph disabled.")
+    logger.warning(
+        "Tensor dump patches __call__ at the class level. "
+        "This is a global, irreversible change within the process and is "
+        "NOT safe for multi-model serving."
+    )
 
     # --- Parse env vars and register hooks -----------------------------
     from vllm.distributed import get_pp_group, get_tp_group

--- a/vllm/debug/tensor_dump.py
+++ b/vllm/debug/tensor_dump.py
@@ -218,8 +218,10 @@ def register_forward_hook_for_model(
         pp_rank,
         skip_passes,
     )
-    top_level_module_name = os.getenv("TENSOR_DUMP_TOP_LEVEL_MODULE_NAME", "model")
-    layers_module_name = os.getenv("TENSOR_DUMP_LAYERS_MODULE_NAME", "layers")
+    import vllm.envs as envs
+
+    top_level_module_name = envs.VLLM_DEBUG_TENSOR_DUMP_TOP_LEVEL_MODULE_NAME
+    layers_module_name = envs.VLLM_DEBUG_TENSOR_DUMP_LAYERS_MODULE_NAME
     model_top_level_module_matched, _ = tensor_dumper._add_hook_recursive(
         model,
         "",

--- a/vllm/debug/tensor_dump.py
+++ b/vllm/debug/tensor_dump.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Debug tensor dump for capturing intermediate activations.
+
+Registers forward hooks on every leaf module of the model to capture
+intermediate activations during inference. Each forward pass produces a
+``.pt`` file containing all recorded tensors.
+
+Usage::
+
+    VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER=./dump \\
+        python -m vllm.entrypoints.openai.api_server --model <model>
+
+Environment variables:
+
+* ``VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER`` -- Output directory for dumps.
+  When unset the feature is disabled.
+* ``VLLM_DEBUG_TENSOR_DUMP_LAYERS`` -- Comma-separated layer indices to
+  dump (e.g. ``"0,1,31"``). When unset all layers are dumped.
+* ``VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES`` -- Number of initial forward
+  passes to skip (useful for skipping warmup). Default ``0``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import torch
+from torch import nn
+
+if TYPE_CHECKING:
+    from vllm.config import ParallelConfig, VllmConfig
+
+logger = logging.getLogger(__name__)
+
+
+class TensorDumper:
+    """Collects tensors from forward hooks and saves them per pass.
+
+    Args:
+        dump_dir: Base directory for output files.
+        dump_layers: Optional list of layer indices to capture. When
+            ``None`` all layers are captured.
+        tp_size: Tensor-parallel world size.
+        tp_rank: Tensor-parallel rank of this worker.
+        pp_rank: Pipeline-parallel rank of this worker.
+        skip_passes: Number of leading forward passes to skip before
+            recording (useful for warmup).
+    """
+
+    def __init__(
+        self,
+        dump_dir: str,
+        dump_layers: list[int] | None,
+        tp_size: int,
+        tp_rank: int,
+        pp_rank: int,
+        skip_passes: int = 0,
+    ) -> None:
+        self._dump_layers = dump_layers
+        self._forward_pass_id = 0
+        self._skip_passes = skip_passes
+        self._pid = os.getpid()
+        self._current_tensors: dict[str, torch.Tensor | list[torch.Tensor]] = {}
+        self._base_dir = Path(dump_dir)
+        rank = tp_size * pp_rank + tp_rank
+        self._process_dir = (
+            self._base_dir / f"TP{tp_rank}_PP{pp_rank}_Rank{rank}_pid{self._pid}"
+        )
+        self._process_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_dump_dir(self) -> str:
+        """Return the process-specific dump directory path."""
+        return str(self._process_dir)
+
+    def add_tensor(self, name: str, tensor_item: torch.Tensor | tuple | list) -> None:
+        """Record a tensor (or tuple/list of tensors) under *name*.
+
+        Tensors are moved to CPU immediately to avoid holding GPU memory.
+        If *skip_passes* has not yet been exhausted the call is a no-op.
+        """
+        if self._skip_passes > 0:
+            return
+        if isinstance(tensor_item, (tuple, list)):
+            tensors = [t.cpu() for t in tensor_item if isinstance(t, torch.Tensor)]
+            if len(tensors) == 1:
+                self._current_tensors[name] = tensors[0]
+            elif len(tensors) > 1:
+                self._current_tensors[name] = tensors
+        elif isinstance(tensor_item, torch.Tensor):
+            self._current_tensors[name] = tensor_item.cpu()
+        else:
+            logger.warning("Unsupported type: %s: %s", type(tensor_item), tensor_item)
+
+    def dump_current_tensors(self) -> None:
+        """Flush all accumulated tensors to a ``.pt`` file.
+
+        During the skip phase the tensors are silently discarded.
+        """
+        if self._skip_passes > 0:
+            self._skip_passes -= 1
+            self._current_tensors = {}
+            logger.info("Skipping warmup pass (remaining: %d)", self._skip_passes)
+            return
+        if len(self._current_tensors) == 0:
+            return
+        tensor_file = self._process_dir / f"Pass{self._forward_pass_id:05d}.pt"
+        logger.info("Dump %05dth pass to %s", self._forward_pass_id, tensor_file)
+        torch.save(self._current_tensors, str(tensor_file))
+        self._current_tensors = {}
+        self._forward_pass_id += 1
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _add_hook_recursive(
+        self,
+        model: nn.Module,
+        prefix: str,
+        top_level_module_name: str,
+        layers_module_name: str,
+    ) -> tuple[bool, int]:
+        """Walk *model* and attach forward hooks to leaf modules.
+
+        Returns:
+            A tuple ``(top_level_matched, child_count)``.
+        """
+        model_top_level_module_matched = False
+        layers_prefix = top_level_module_name + "." + layers_module_name
+        for name, module in model._modules.items():
+            top_level_model = False
+            if len(prefix) == 0:
+                cur_name = name
+                if cur_name == top_level_module_name:
+                    model_top_level_module_matched = True
+                    top_level_model = True
+            else:
+                cur_name = prefix + "." + name
+            if (
+                self._dump_layers is not None
+                and name.isdigit()
+                and prefix == layers_prefix
+            ):
+                cur_layer = int(name)
+                if cur_layer not in self._dump_layers:
+                    continue
+            if module is not None:
+                _, sub_count = self._add_hook_recursive(
+                    module,
+                    cur_name,
+                    top_level_module_name,
+                    layers_module_name,
+                )
+                if sub_count == 0 or top_level_model:
+                    module.register_forward_hook(
+                        self._dump_hook(cur_name, top_level_model)
+                    )
+        return model_top_level_module_matched, len(model._modules.items())
+
+    def _dump_hook(self, tensor_name: str, do_dump: bool):
+        """Return a forward-hook closure for *tensor_name*."""
+
+        def inner_dump_hook(module, input, output):  # noqa: A002
+            if do_dump:
+                # Top-level model hook: extract input_ids and positions
+                # from the model's forward() arguments.
+                # vLLM LlamaModel.forward(input_ids, positions, ...)
+                if isinstance(input, (tuple, list)) and len(input) >= 2:
+                    if isinstance(input[0], torch.Tensor):
+                        self.add_tensor(
+                            tensor_name + ".forward_batch_info.input_ids",
+                            input[0],
+                        )
+                    if isinstance(input[1], torch.Tensor):
+                        self.add_tensor(
+                            tensor_name + ".forward_batch_info.positions",
+                            input[1],
+                        )
+                self.dump_current_tensors()
+            if output is not None:
+                self.add_tensor(tensor_name, output)
+
+        return inner_dump_hook
+
+
+def register_forward_hook_for_model(
+    model: nn.Module,
+    dump_dir: str,
+    dump_layers: list[int] | None = None,
+    tp_size: int = 1,
+    tp_rank: int = 0,
+    pp_rank: int = 0,
+    skip_passes: int = 0,
+) -> TensorDumper:
+    """Register forward hooks on *model* and return the ``TensorDumper``.
+
+    Args:
+        model: The model to instrument.
+        dump_dir: Base output directory.
+        dump_layers: Optional layer indices to capture.
+        tp_size: Tensor-parallel world size.
+        tp_rank: Tensor-parallel rank.
+        pp_rank: Pipeline-parallel rank.
+        skip_passes: Forward passes to skip before recording.
+
+    Returns:
+        The :class:`TensorDumper` instance managing the hooks.
+    """
+    tensor_dumper = TensorDumper(
+        dump_dir,
+        dump_layers,
+        tp_size,
+        tp_rank,
+        pp_rank,
+        skip_passes,
+    )
+    top_level_module_name = os.getenv("TENSOR_DUMP_TOP_LEVEL_MODULE_NAME", "model")
+    layers_module_name = os.getenv("TENSOR_DUMP_LAYERS_MODULE_NAME", "layers")
+    model_top_level_module_matched, _ = tensor_dumper._add_hook_recursive(
+        model,
+        "",
+        top_level_module_name,
+        layers_module_name,
+    )
+    assert model_top_level_module_matched, (
+        f"model should have a module named {top_level_module_name}"
+    )
+    logger.info(
+        "Tensor dump hooks registered. Output dir: %s", tensor_dumper.get_dump_dir()
+    )
+    return tensor_dumper
+
+
+def maybe_setup_tensor_dump(
+    model: nn.Module,
+    vllm_config: VllmConfig,
+    parallel_config: ParallelConfig,
+) -> TensorDumper | None:
+    """Set up tensor dumping if enabled via environment variables.
+
+    This is the main entry point called from the model runner during model
+    loading.  When ``VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER`` is not set,
+    this function returns ``None`` and is effectively a no-op.
+
+    The function:
+
+    1. Disables ``torch.compile`` and CUDA graph capture (both are
+       incompatible with the ``.cpu()`` calls and ``torch.save`` inside
+       the forward hooks).
+    2. Removes custom ``__call__`` methods injected by
+       ``@support_torch_compile`` so that ``nn.Module.__call__`` (which
+       fires forward hooks) is used instead.
+    3. Registers forward hooks on every leaf module of *model*.
+
+    Args:
+        model: The loaded model.
+        vllm_config: The global vLLM configuration object.
+        parallel_config: Parallel (TP/PP) configuration.
+
+    Returns:
+        The :class:`TensorDumper` instance, or ``None`` if the feature is
+        disabled.
+    """
+    import vllm.envs as envs
+
+    dump_dir = envs.VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER
+    if dump_dir is None:
+        return None
+
+    # --- Disable torch.compile and CUDAGraph ---------------------------
+    from vllm.config import CompilationMode, CUDAGraphMode
+
+    vllm_config.compilation_config.mode = CompilationMode.NONE
+    vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+    for _, mod in model.named_modules():
+        if hasattr(mod, "do_not_compile"):
+            mod.do_not_compile = True
+
+    # --- Remove custom __call__ from @support_torch_compile ------------
+    # @support_torch_compile replaces cls.__call__ which bypasses
+    # nn.Module.__call__() where forward hooks are fired.
+    from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
+
+    patched_classes: set[type] = set()
+    for _, mod in model.named_modules():
+        cls = type(mod)
+        if (
+            cls not in patched_classes
+            and issubclass(cls, TorchCompileWithNoGuardsWrapper)
+            and "__call__" in cls.__dict__
+        ):
+            delattr(cls, "__call__")
+            patched_classes.add(cls)
+
+    logger.info("Tensor dump enabled: torch.compile and CUDAGraph disabled.")
+
+    # --- Parse env vars and register hooks -----------------------------
+    from vllm.distributed import get_pp_group, get_tp_group
+
+    tp_size = parallel_config.tensor_parallel_size
+    tp_rank = get_tp_group().rank_in_group
+    pp_rank = get_pp_group().rank_in_group
+
+    dump_layers_str = envs.VLLM_DEBUG_TENSOR_DUMP_LAYERS
+    dump_layers: list[int] | None = None
+    if dump_layers_str:
+        dump_layers = [int(x) for x in dump_layers_str.split(",")]
+
+    skip_passes = envs.VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES
+
+    return register_forward_hook_for_model(
+        model,
+        dump_dir=dump_dir,
+        dump_layers=dump_layers,
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        pp_rank=pp_rank,
+        skip_passes=skip_passes,
+    )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1604,21 +1604,26 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Output directory for debug tensor dumps of intermediate activations.
     # When set, forward hooks are registered on every leaf module to capture
     # activations. Each forward pass produces a .pt file.
-    "VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER":
-        lambda: os.environ.get("VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER", None),
+    "VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER": lambda: os.environ.get(
+        "VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER", None
+    ),
     # Comma-separated layer indices to dump (e.g. "0,1,31").
     # When unset all layers are dumped.
-    "VLLM_DEBUG_TENSOR_DUMP_LAYERS":
-        lambda: os.environ.get("VLLM_DEBUG_TENSOR_DUMP_LAYERS", None),
+    "VLLM_DEBUG_TENSOR_DUMP_LAYERS": lambda: os.environ.get(
+        "VLLM_DEBUG_TENSOR_DUMP_LAYERS", None
+    ),
     # Number of initial forward passes to skip before recording.
-    "VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES":
-        lambda: int(os.environ.get("VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES", "0")),
+    "VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES": lambda: int(
+        os.environ.get("VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES", "0")
+    ),
     # Name of the top-level sub-module inside the model (default "model").
-    "VLLM_DEBUG_TENSOR_DUMP_TOP_LEVEL_MODULE_NAME":
-        lambda: os.environ.get("VLLM_DEBUG_TENSOR_DUMP_TOP_LEVEL_MODULE_NAME", "model"),
+    "VLLM_DEBUG_TENSOR_DUMP_TOP_LEVEL_MODULE_NAME": lambda: os.environ.get(
+        "VLLM_DEBUG_TENSOR_DUMP_TOP_LEVEL_MODULE_NAME", "model"
+    ),
     # Name of the layers container inside the top-level module (default "layers").
-    "VLLM_DEBUG_TENSOR_DUMP_LAYERS_MODULE_NAME":
-        lambda: os.environ.get("VLLM_DEBUG_TENSOR_DUMP_LAYERS_MODULE_NAME", "layers"),
+    "VLLM_DEBUG_TENSOR_DUMP_LAYERS_MODULE_NAME": lambda: os.environ.get(
+        "VLLM_DEBUG_TENSOR_DUMP_LAYERS_MODULE_NAME", "layers"
+    ),
     # Disable using pytorch's pin memory for CPU offloading.
     "VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY": lambda: bool(
         int(os.getenv("VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY", "0"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -236,6 +236,9 @@ if TYPE_CHECKING:
     VLLM_USE_V2_MODEL_RUNNER: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
+    VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER: str | None = None
+    VLLM_DEBUG_TENSOR_DUMP_LAYERS: str | None = None
+    VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES: int = 0
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
     VLLM_DISABLE_LOG_LOGO: bool = False
@@ -1596,6 +1599,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_DEBUG_MFU_METRICS": lambda: bool(
         int(os.getenv("VLLM_DEBUG_MFU_METRICS", "0"))
     ),
+    # Output directory for debug tensor dumps of intermediate activations.
+    # When set, forward hooks are registered on every leaf module to capture
+    # activations. Each forward pass produces a .pt file.
+    "VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER":
+        lambda: os.environ.get("VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER", None),
+    # Comma-separated layer indices to dump (e.g. "0,1,31").
+    # When unset all layers are dumped.
+    "VLLM_DEBUG_TENSOR_DUMP_LAYERS":
+        lambda: os.environ.get("VLLM_DEBUG_TENSOR_DUMP_LAYERS", None),
+    # Number of initial forward passes to skip before recording.
+    "VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES":
+        lambda: int(os.environ.get("VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES", "0")),
     # Disable using pytorch's pin memory for CPU offloading.
     "VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY": lambda: bool(
         int(os.getenv("VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY", "0"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -239,6 +239,8 @@ if TYPE_CHECKING:
     VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER: str | None = None
     VLLM_DEBUG_TENSOR_DUMP_LAYERS: str | None = None
     VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES: int = 0
+    VLLM_DEBUG_TENSOR_DUMP_TOP_LEVEL_MODULE_NAME: str = "model"
+    VLLM_DEBUG_TENSOR_DUMP_LAYERS_MODULE_NAME: str = "layers"
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
     VLLM_DISABLE_LOG_LOGO: bool = False
@@ -1611,6 +1613,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Number of initial forward passes to skip before recording.
     "VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES":
         lambda: int(os.environ.get("VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES", "0")),
+    # Name of the top-level sub-module inside the model (default "model").
+    "VLLM_DEBUG_TENSOR_DUMP_TOP_LEVEL_MODULE_NAME":
+        lambda: os.environ.get("VLLM_DEBUG_TENSOR_DUMP_TOP_LEVEL_MODULE_NAME", "model"),
+    # Name of the layers container inside the top-level module (default "layers").
+    "VLLM_DEBUG_TENSOR_DUMP_LAYERS_MODULE_NAME":
+        lambda: os.environ.get("VLLM_DEBUG_TENSOR_DUMP_LAYERS_MODULE_NAME", "layers"),
     # Disable using pytorch's pin memory for CPU offloading.
     "VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY": lambda: bool(
         int(os.getenv("VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY", "0"))

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4544,9 +4544,8 @@ class GPUModelRunner(
         if not load_dummy_weights:
             # Register tensor dump hooks if enabled via env var.
             from vllm.debug.tensor_dump import maybe_setup_tensor_dump
-            maybe_setup_tensor_dump(
-                self.model, self.vllm_config, self.parallel_config
-            )
+
+            maybe_setup_tensor_dump(self.model, self.vllm_config, self.parallel_config)
 
             prepare_communication_buffer_for_model(self.model)
             if (drafter := getattr(self, "drafter", None)) and (

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4536,6 +4536,12 @@ class GPUModelRunner(
             scope="local",
         )
         if not load_dummy_weights:
+            # Register tensor dump hooks if enabled via env var.
+            from vllm.debug.tensor_dump import maybe_setup_tensor_dump
+            maybe_setup_tensor_dump(
+                self.model, self.vllm_config, self.parallel_config
+            )
+
             prepare_communication_buffer_for_model(self.model)
             if (drafter := getattr(self, "drafter", None)) and (
                 drafter_model := getattr(drafter, "model", None)


### PR DESCRIPTION
                                                                                                                                                                         
  ## Summary                                                

  - Add built-in support for dumping intermediate activations during inference, gated by environment variables
  - When `VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER` is set, forward hooks are registered on every leaf module to capture activations into `.pt` files
  - `torch.compile` and CUDAGraph are automatically disabled when enabled; zero overhead when disabled

  Closes #36502 

  ## Changes

  - **`vllm/debug/tensor_dump.py`**: `TensorDumper` class and `maybe_setup_tensor_dump()` entry point
  - **`vllm/envs.py`**: Add `VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER`, `VLLM_DEBUG_TENSOR_DUMP_LAYERS`, `VLLM_DEBUG_TENSOR_DUMP_SKIP_PASSES`
  - **`vllm/v1/worker/gpu_model_runner.py`**: Call `maybe_setup_tensor_dump()` in `load_model()`
  - **`tests/debug/test_tensor_dump.py`**: Unit tests (13 cases)
  - **`docs/features/tensor_dump.md`**: Usage documentation

  ## Test plan

  - [x] `pre-commit run --files` all passed
  - [x] `pytest tests/debug/test_tensor_dump.py -v` 13/13 passed on GPU server
  - [ ] End-to-end: `VLLM_DEBUG_TENSOR_DUMP_OUTPUT_FOLDER=./dump python -m vllm.entrypoints.openai.api_server --model TinyLlama/TinyLlama-1.1B-Chat-v1.0`

  ## Related

  - Inspired by SGLang's `tensor_dump_forward_hook.py`
  - Useful for cross-framework activation comparison and post-quantization debugging