### PR TITLE
Guard AWQ-Marlin auto-selection on CUDA driver/toolkit mismatch

### DIFF
--- a/tests/quantization/test_marlin_toolchain_guard.py
+++ b/tests/quantization/test_marlin_toolchain_guard.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tests for the centralised Marlin CUDA driver/toolkit mismatch warning.
+
+The guard lives in marlin_utils.warn_marlin_cuda_driver_mismatch() and is
+called by every Marlin-based quantization config (awq_marlin, gptq_marlin)
+so that the check covers all Marlin usage from a single place.
+"""
+
+import vllm.model_executor.layers.quantization.utils.marlin_utils as marlin_utils
+from vllm.model_executor.layers.quantization.awq_marlin import AWQMarlinConfig
+from vllm.model_executor.layers.quantization.gptq_marlin import GPTQMarlinConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_warn_cache():
+    """Clear the lru_cache on warn_marlin_cuda_driver_mismatch between tests."""
+    marlin_utils.warn_marlin_cuda_driver_mismatch.cache_clear()
+
+
+def _patch_mismatch(monkeypatch, *, driver=(12, 8), toolkit=(12, 9), compat=False):
+    monkeypatch.setattr(marlin_utils, "_get_driver_cuda_version", lambda: driver)
+    monkeypatch.setattr(marlin_utils, "_parse_cuda_version", lambda _: toolkit)
+    monkeypatch.setattr(marlin_utils.envs, "VLLM_ENABLE_CUDA_COMPATIBILITY", compat)
+
+
+# ---------------------------------------------------------------------------
+# warn_marlin_cuda_driver_mismatch unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_warning_emitted_on_driver_mismatch(monkeypatch):
+    _reset_warn_cache()
+    _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=False)
+
+    from unittest.mock import patch
+
+    with patch.object(marlin_utils.logger, "warning") as mock_warn:
+        marlin_utils.warn_marlin_cuda_driver_mismatch()
+
+    assert mock_warn.called
+    assert any(
+        "cudaErrorUnsupportedPtxVersion" in str(a) for a in mock_warn.call_args[0]
+    )
+
+
+def test_no_warning_when_compat_enabled(monkeypatch):
+    _reset_warn_cache()
+    _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=True)
+
+    from unittest.mock import patch
+
+    with patch.object(marlin_utils.logger, "warning") as mock_warn:
+        marlin_utils.warn_marlin_cuda_driver_mismatch()
+
+    assert not mock_warn.called
+
+
+def test_no_warning_when_driver_matches_toolkit(monkeypatch):
+    _reset_warn_cache()
+    _patch_mismatch(monkeypatch, driver=(12, 9), toolkit=(12, 9), compat=False)
+
+    from unittest.mock import patch
+
+    with patch.object(marlin_utils.logger, "warning") as mock_warn:
+        marlin_utils.warn_marlin_cuda_driver_mismatch()
+
+    assert not mock_warn.called
+
+
+def test_no_warning_when_driver_newer(monkeypatch):
+    _reset_warn_cache()
+    _patch_mismatch(monkeypatch, driver=(12, 9), toolkit=(12, 8), compat=False)
+
+    from unittest.mock import patch
+
+    with patch.object(marlin_utils.logger, "warning") as mock_warn:
+        marlin_utils.warn_marlin_cuda_driver_mismatch()
+
+    assert not mock_warn.called
+
+
+# ---------------------------------------------------------------------------
+# awq_marlin: marlin is still selected regardless of driver mismatch
+# ---------------------------------------------------------------------------
+
+
+def _force_awq_marlin_compatible(monkeypatch):
+    monkeypatch.setattr(
+        AWQMarlinConfig,
+        "is_awq_marlin_compatible",
+        classmethod(lambda cls, _: True),
+    )
+
+
+def test_awq_marlin_selected_despite_driver_mismatch(monkeypatch):
+    """awq_marlin should still be returned even when driver < toolkit."""
+    _reset_warn_cache()
+    _force_awq_marlin_compatible(monkeypatch)
+    _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=False)
+
+    result = AWQMarlinConfig.override_quantization_method({}, user_quant=None)
+    assert result == "awq_marlin"
+
+
+def test_awq_marlin_selected_with_compat_enabled(monkeypatch):
+    _reset_warn_cache()
+    _force_awq_marlin_compatible(monkeypatch)
+    _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=True)
+
+    result = AWQMarlinConfig.override_quantization_method({}, user_quant=None)
+    assert result == "awq_marlin"
+
+
+# ---------------------------------------------------------------------------
+# gptq_marlin: marlin is still selected regardless of driver mismatch
+# ---------------------------------------------------------------------------
+
+
+def _force_gptq_marlin_compatible(monkeypatch):
+    monkeypatch.setattr(
+        GPTQMarlinConfig,
+        "is_gptq_marlin_compatible",
+        classmethod(lambda cls, _: True),
+    )
+
+
+def test_gptq_marlin_selected_despite_driver_mismatch(monkeypatch):
+    """gptq_marlin should still be returned even when driver < toolkit."""
+    _reset_warn_cache()
+    _force_gptq_marlin_compatible(monkeypatch)
+    _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=False)
+
+    assert (
+        GPTQMarlinConfig.override_quantization_method({}, user_quant=None)
+        == "gptq_marlin"
+    )
+
+
+def test_gptq_marlin_selected_with_compat_enabled(monkeypatch):
+    _reset_warn_cache()
+    _force_gptq_marlin_compatible(monkeypatch)
+    _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=True)
+
+    assert (
+        GPTQMarlinConfig.override_quantization_method({}, user_quant=None)
+        == "gptq_marlin"
+    )

--- a/tests/quantization/test_marlin_toolchain_guard.py
+++ b/tests/quantization/test_marlin_toolchain_guard.py
@@ -4,13 +4,13 @@
 """Tests for the centralised Marlin CUDA driver/toolkit mismatch warning.
 
 The guard lives in marlin_utils.warn_marlin_cuda_driver_mismatch() and is
-called by every Marlin-based quantization config (awq_marlin, gptq_marlin)
-so that the check covers all Marlin usage from a single place.
+reached through marlin_utils.verify_marlin_supported(), which every
+Marlin-based quantization config (awq_marlin, auto_gptq, compressed_tensors,
+...) calls, so the check covers all Marlin usage from a single place.
 """
 
 import vllm.model_executor.layers.quantization.utils.marlin_utils as marlin_utils
 from vllm.model_executor.layers.quantization.awq_marlin import AWQMarlinConfig
-from vllm.model_executor.layers.quantization.gptq_marlin import GPTQMarlinConfig
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -117,36 +117,42 @@ def test_awq_marlin_selected_with_compat_enabled(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# gptq_marlin: marlin is still selected regardless of driver mismatch
+# verify_marlin_supported: the centralised entry point used by all
+# Marlin-based configs (awq_marlin, auto_gptq, compressed_tensors, ...)
 # ---------------------------------------------------------------------------
 
 
-def _force_gptq_marlin_compatible(monkeypatch):
-    monkeypatch.setattr(
-        GPTQMarlinConfig,
-        "is_gptq_marlin_compatible",
-        classmethod(lambda cls, _: True),
-    )
-
-
-def test_gptq_marlin_selected_despite_driver_mismatch(monkeypatch):
-    """gptq_marlin should still be returned even when driver < toolkit."""
+def test_verify_marlin_supported_warns_on_driver_mismatch(monkeypatch):
+    """verify_marlin_supported() must route through the mismatch warning."""
     _reset_warn_cache()
-    _force_gptq_marlin_compatible(monkeypatch)
     _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=False)
+    monkeypatch.setattr(
+        marlin_utils, "_check_marlin_supported", lambda *a, **k: (True, None)
+    )
+    monkeypatch.setattr(marlin_utils.current_platform, "is_cuda", lambda: True)
 
-    assert (
-        GPTQMarlinConfig.override_quantization_method({}, user_quant=None)
-        == "gptq_marlin"
+    from unittest.mock import patch
+
+    with patch.object(marlin_utils.logger, "warning") as mock_warn:
+        marlin_utils.verify_marlin_supported(quant_type=None, group_size=128)
+
+    assert mock_warn.called
+    assert any(
+        "cudaErrorUnsupportedPtxVersion" in str(a) for a in mock_warn.call_args[0]
     )
 
 
-def test_gptq_marlin_selected_with_compat_enabled(monkeypatch):
+def test_verify_marlin_supported_no_warning_with_compat(monkeypatch):
     _reset_warn_cache()
-    _force_gptq_marlin_compatible(monkeypatch)
     _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=True)
-
-    assert (
-        GPTQMarlinConfig.override_quantization_method({}, user_quant=None)
-        == "gptq_marlin"
+    monkeypatch.setattr(
+        marlin_utils, "_check_marlin_supported", lambda *a, **k: (True, None)
     )
+    monkeypatch.setattr(marlin_utils.current_platform, "is_cuda", lambda: True)
+
+    from unittest.mock import patch
+
+    with patch.object(marlin_utils.logger, "warning") as mock_warn:
+        marlin_utils.verify_marlin_supported(quant_type=None, group_size=128)
+
+    assert not mock_warn.called

--- a/tests/quantization/test_marlin_toolchain_guard.py
+++ b/tests/quantization/test_marlin_toolchain_guard.py
@@ -9,8 +9,10 @@ Marlin-based quantization config (awq_marlin, auto_gptq, compressed_tensors,
 ...) calls, so the check covers all Marlin usage from a single place.
 """
 
+from typing import Any
+
 import vllm.model_executor.layers.quantization.utils.marlin_utils as marlin_utils
-from vllm.model_executor.layers.quantization.awq_marlin import AWQMarlinConfig
+from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -91,20 +93,37 @@ def test_no_warning_when_driver_newer(monkeypatch):
 
 def _force_awq_marlin_compatible(monkeypatch):
     monkeypatch.setattr(
-        AWQMarlinConfig,
+        AutoAWQConfig,
         "is_awq_marlin_compatible",
         classmethod(lambda cls, _: True),
     )
+    # override_quantization_method short-circuits on CPU platforms; make the
+    # selection path proceed so the driver-mismatch guard is what is tested.
+    import vllm.model_executor.layers.quantization.auto_awq as auto_awq
+
+    monkeypatch.setattr(auto_awq.current_platform, "is_cpu", lambda: False)
+    monkeypatch.setattr(auto_awq.current_platform, "is_xpu", lambda: False)
+
+
+def _awq_config_dict() -> dict[str, Any]:
+    return {
+        "quant_method": "awq",
+        "bits": 4,
+        "group_size": 128,
+        "zero_point": True,
+    }
 
 
 def test_awq_marlin_selected_despite_driver_mismatch(monkeypatch):
-    """awq_marlin should still be returned even when driver < toolkit."""
+    """AWQ should still be selected even when driver < toolkit."""
     _reset_warn_cache()
     _force_awq_marlin_compatible(monkeypatch)
     _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=False)
 
-    result = AWQMarlinConfig.override_quantization_method({}, user_quant=None)
-    assert result == "awq_marlin"
+    result = AutoAWQConfig.override_quantization_method(
+        _awq_config_dict(), user_quant=None
+    )
+    assert result == "auto_awq"
 
 
 def test_awq_marlin_selected_with_compat_enabled(monkeypatch):
@@ -112,8 +131,10 @@ def test_awq_marlin_selected_with_compat_enabled(monkeypatch):
     _force_awq_marlin_compatible(monkeypatch)
     _patch_mismatch(monkeypatch, driver=(12, 8), toolkit=(12, 9), compat=True)
 
-    result = AWQMarlinConfig.override_quantization_method({}, user_quant=None)
-    assert result == "awq_marlin"
+    result = AutoAWQConfig.override_quantization_method(
+        _awq_config_dict(), user_quant=None
+    )
+    assert result == "auto_awq"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/quantization/test_marlin_toolchain_guard.py
+++ b/tests/quantization/test_marlin_toolchain_guard.py
@@ -92,13 +92,10 @@ def test_no_warning_when_driver_newer(monkeypatch):
 
 
 def _force_awq_marlin_compatible(monkeypatch):
-    monkeypatch.setattr(
-        AutoAWQConfig,
-        "is_awq_marlin_compatible",
-        classmethod(lambda cls, _: True),
-    )
     # override_quantization_method short-circuits on CPU platforms; make the
     # selection path proceed so the driver-mismatch guard is what is tested.
+    # (Marlin compatibility itself is decided later, in get_quant_method via
+    # check_marlin_supported — covered by the verify_marlin_supported tests.)
     import vllm.model_executor.layers.quantization.auto_awq as auto_awq
 
     monkeypatch.setattr(auto_awq.current_platform, "is_cpu", lambda: False)

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -36,50 +36,127 @@ def _get_torch_cuda_version():
         return None
 
 
+def _get_driver_cuda_version_early():
+    """Return (major, minor) of the CUDA version supported by the installed
+    NVIDIA driver, or None if it cannot be determined.
+
+    Uses vllm's bundled pynvml directly so that torch does not need to be
+    imported yet (NVML is a separate shared library from the CUDA runtime).
+    """
+    try:
+        import vllm.third_party.pynvml as pynvml
+
+        pynvml.nvmlInit()
+        try:
+            version_raw = pynvml.nvmlSystemGetCudaDriverVersion_v2()
+        except Exception:
+            version_raw = pynvml.nvmlSystemGetCudaDriverVersion()
+        finally:
+            pynvml.nvmlShutdown()
+        return version_raw // 1000, (version_raw % 1000) // 10
+    except Exception:
+        return None
+
+
+def _parse_cuda_version_str(version):
+    """Parse a CUDA version string like '12.8' into (12, 8), or return None."""
+    if not version:
+        return None
+    try:
+        major_s, minor_s, *_ = version.split(".")
+        return int(major_s), int(minor_s)
+    except (ValueError, AttributeError):
+        return None
+
+
+def _find_cuda_compat_path(torch_cuda_version):
+    """Search standard locations for the CUDA forward-compat library directory.
+
+    Returns the first existing path found, or an empty string if none exists.
+    Search order: explicit env var → Conda prefix → default CUDA install.
+    """
+    path = os.environ.get("VLLM_CUDA_COMPATIBILITY_PATH", "")
+    if path and os.path.isdir(path):
+        return path
+    conda_prefix = os.environ.get("CONDA_PREFIX", "")
+    if conda_prefix:
+        p = os.path.join(conda_prefix, "cuda-compat")
+        if os.path.isdir(p):
+            return p
+    if torch_cuda_version:
+        p = f"/usr/local/cuda-{torch_cuda_version}/compat"
+        if os.path.isdir(p):
+            return p
+    return ""
+
+
+def _prepend_ld_library_path(compat_path):
+    """Prepend *compat_path* to LD_LIBRARY_PATH (idempotent)."""
+    norm_path = os.path.normpath(compat_path)
+    existing = os.environ.get("LD_LIBRARY_PATH", "")
+    ld_paths = existing.split(os.pathsep) if existing else []
+    if ld_paths and ld_paths[0] and os.path.normpath(ld_paths[0]) == norm_path:
+        return  # Already at the front
+    new_paths = [norm_path] + [
+        p for p in ld_paths if not p or os.path.normpath(p) != norm_path
+    ]
+    os.environ["LD_LIBRARY_PATH"] = os.pathsep.join(new_paths)
+
+
 def _maybe_set_cuda_compatibility_path():
-    """Set LD_LIBRARY_PATH for CUDA forward compatibility if enabled.
+    """Set LD_LIBRARY_PATH for CUDA forward compatibility.
 
     Must run before 'import torch' since torch loads CUDA shared libraries
     at import time and the dynamic linker only consults LD_LIBRARY_PATH when
     a library is first loaded.
 
-    CUDA forward compatibility is only supported on select professional and
-    datacenter NVIDIA GPUs. Consumer GPUs (GeForce, RTX) do not support it
-    and will get Error 803 if compat libs are loaded.
+    Two modes:
+    1. Explicit (VLLM_ENABLE_CUDA_COMPATIBILITY=1): user opted in; find compat
+       libs and prepend them unconditionally (existing behaviour).
+    2. Auto-detect: if the CUDA driver version is older than the PyTorch CUDA
+       toolkit version, compat libs are required for PTX-heavy kernels (e.g.
+       Marlin) to load successfully. When such a mismatch is detected and
+       compat libs are found, they are prepended automatically so the user
+       does not need to restart.  A notice is printed to stderr because the
+       vllm logger is not yet available at this point.
+
+    Note: CUDA forward compatibility is only supported on select professional
+    and datacenter NVIDIA GPUs.  Consumer GPUs (GeForce, RTX) do not support
+    it and will receive Error 803 if compat libs are loaded.  In practice,
+    compat libs are rarely installed on consumer-GPU machines, so auto-detect
+    will not trigger for them.
     """
-    enable = os.environ.get("VLLM_ENABLE_CUDA_COMPATIBILITY", "0").strip().lower() in (
-        "1",
-        "true",
-    )
-    if not enable:
+    torch_cuda_version = _get_torch_cuda_version()
+    explicitly_enabled = os.environ.get(
+        "VLLM_ENABLE_CUDA_COMPATIBILITY", "0"
+    ).strip().lower() in ("1", "true")
+
+    if explicitly_enabled:
+        compat_path = _find_cuda_compat_path(torch_cuda_version)
+        if compat_path:
+            _prepend_ld_library_path(compat_path)
         return
 
-    cuda_compat_path = os.environ.get("VLLM_CUDA_COMPATIBILITY_PATH", "")
-    if not cuda_compat_path or not os.path.isdir(cuda_compat_path):
-        conda_prefix = os.environ.get("CONDA_PREFIX", "")
-        conda_compat = os.path.join(conda_prefix, "cuda-compat")
-        if conda_prefix and os.path.isdir(conda_compat):
-            cuda_compat_path = conda_compat
-    if not cuda_compat_path or not os.path.isdir(cuda_compat_path):
-        torch_cuda_version = _get_torch_cuda_version()
-        if torch_cuda_version:
-            default_path = f"/usr/local/cuda-{torch_cuda_version}/compat"
-            if os.path.isdir(default_path):
-                cuda_compat_path = default_path
-    if not cuda_compat_path or not os.path.isdir(cuda_compat_path):
-        return
+    # Auto-detect: check for driver/toolkit version mismatch.
+    driver_ver = _get_driver_cuda_version_early()
+    toolkit_ver = _parse_cuda_version_str(torch_cuda_version)
+    if driver_ver is None or toolkit_ver is None or driver_ver >= toolkit_ver:
+        return  # No mismatch — nothing to do.
 
-    norm_path = os.path.normpath(cuda_compat_path)
-    existing = os.environ.get("LD_LIBRARY_PATH", "")
-    ld_paths = existing.split(os.pathsep) if existing else []
+    compat_path = _find_cuda_compat_path(torch_cuda_version)
+    if compat_path:
+        _prepend_ld_library_path(compat_path)
+        import sys
 
-    if ld_paths and ld_paths[0] and os.path.normpath(ld_paths[0]) == norm_path:
-        return  # Already at the front
-
-    new_paths = [norm_path] + [
-        p for p in ld_paths if not p or os.path.normpath(p) != norm_path
-    ]
-    os.environ["LD_LIBRARY_PATH"] = os.pathsep.join(new_paths)
+        print(
+            f"[vllm] CUDA driver {driver_ver[0]}.{driver_ver[1]} is older than "
+            f"the PyTorch CUDA toolkit {torch_cuda_version}. "
+            f"Auto-enabled CUDA forward compatibility using libs at {compat_path}. "
+            f"Set VLLM_ENABLE_CUDA_COMPATIBILITY=1 to make this explicit.",
+            file=sys.stderr,
+        )
+    # If no compat libs are found the mismatch warning in marlin_utils will
+    # fire at kernel-selection time once the vllm logger is available.
 
 
 _maybe_set_cuda_compatibility_path()

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import functools
 import math
 
 import numpy
@@ -27,6 +28,79 @@ from vllm.utils.platform_utils import num_compute_units
 from .quant_utils import pack_cols, unpack_cols
 
 logger = init_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CUDA driver / toolkit version helpers shared by all Marlin-based configs
+# ---------------------------------------------------------------------------
+
+
+def _parse_cuda_version(version: str | None) -> tuple[int, int] | None:
+    if not version:
+        return None
+    try:
+        major_s, minor_s, *_ = version.split(".")
+        return int(major_s), int(minor_s)
+    except (ValueError, AttributeError):
+        return None
+
+
+def _get_driver_cuda_version() -> tuple[int, int] | None:
+    try:
+        from vllm.utils.import_utils import import_pynvml
+
+        pynvml = import_pynvml()
+        pynvml.nvmlInit()
+        try:
+            version_raw = pynvml.nvmlSystemGetCudaDriverVersion_v2()
+        except Exception:
+            version_raw = pynvml.nvmlSystemGetCudaDriverVersion()
+        finally:
+            pynvml.nvmlShutdown()
+
+        # NVML encodes as e.g. 12080 => (12, 8)
+        major = version_raw // 1000
+        minor = (version_raw % 1000) // 10
+        return major, minor
+    except Exception:
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def warn_marlin_cuda_driver_mismatch() -> None:
+    """Emit a one-time warning when the CUDA driver is older than the PyTorch
+    CUDA toolkit and CUDA forward compatibility is disabled.
+
+    A driver/toolkit mismatch can cause ``cudaErrorUnsupportedPtxVersion``
+    when any Marlin kernel is loaded, because PTX compiled for a newer toolkit
+    cannot be JIT-assembled by an older driver.  This function is called by
+    every Marlin-based quantization config so the check is centralised and the
+    warning appears exactly once regardless of which config triggers it.
+    """
+    driver_cuda = _get_driver_cuda_version()
+    torch_cuda = _parse_cuda_version(getattr(torch.version, "cuda", None))
+    if (
+        driver_cuda is not None
+        and torch_cuda is not None
+        and driver_cuda < torch_cuda
+        and not envs.VLLM_ENABLE_CUDA_COMPATIBILITY
+    ):
+        torch_cuda_str = getattr(torch.version, "cuda", None)
+        driver_cuda_str = ".".join(map(str, driver_cuda))
+        logger.warning(
+            "Detected torch CUDA %s but CUDA driver %s with "
+            "VLLM_ENABLE_CUDA_COMPATIBILITY=0. Marlin kernels may fail with "
+            "cudaErrorUnsupportedPtxVersion at load time. "
+            "To fix: restart with VLLM_ENABLE_CUDA_COMPATIBILITY=1 (requires "
+            "CUDA forward-compat libs at /usr/local/cuda-%s/compat or "
+            "VLLM_CUDA_COMPATIBILITY_PATH), or update your NVIDIA driver to "
+            "one that supports CUDA >= %s.",
+            torch_cuda_str,
+            driver_cuda_str,
+            torch_cuda_str,
+            torch_cuda_str,
+        )
+
 
 GPTQ_MARLIN_TILE = 16
 GPTQ_MARLIN_MIN_THREAD_N = 64
@@ -157,6 +231,8 @@ def check_marlin_supported(
     device_capability: int | None = None,
 ) -> bool:
     cond, _ = _check_marlin_supported(quant_type, group_size, has_zp, device_capability)
+    if cond and current_platform.is_cuda():
+        warn_marlin_cuda_driver_mismatch()
     return cond
 
 
@@ -167,6 +243,12 @@ def verify_marlin_supported(
     if not cond:
         assert err_msg is not None
         raise ValueError(err_msg)
+    # Warn once if the CUDA driver/toolkit mismatch was not resolved at
+    # startup (e.g. no compat libs available).  Centralised here so every
+    # Marlin-based config (awq_marlin, gptq_marlin, compressed_tensors, fp8,
+    # moe_wna16, modelopt, …) gets the check without per-config boilerplate.
+    if current_platform.is_cuda():
+        warn_marlin_cuda_driver_mismatch()
 
 
 def verify_marlin_supports_shape(
@@ -317,18 +399,21 @@ def check_marlin_supports_layer(
         # (see marlin_padded_nk); only a quantization group straddling the
         # TP shard remains unsupported. Dense layers only - MoE prep does
         # not pad yet.
-        return (
+        supported = (
             group_size == -1
             or group_size >= layer.input_size
             or input_size_per_partition % group_size == 0
         )
-
-    return check_marlin_supports_shape(
-        output_size_per_partition=output_size_per_partition,
-        input_size_per_partition=input_size_per_partition,
-        input_size=layer.input_size,
-        group_size=group_size,
-    )[0]
+    else:
+        supported = check_marlin_supports_shape(
+            output_size_per_partition=output_size_per_partition,
+            input_size_per_partition=input_size_per_partition,
+            input_size=layer.input_size,
+            group_size=group_size,
+        )[0]
+    if supported and current_platform.is_cuda():
+        warn_marlin_cuda_driver_mismatch()
+    return supported
 
 
 def marlin_moe_padded_intermediate(intermediate_size: int, group_size: int = -1) -> int:
@@ -383,7 +468,10 @@ def check_moe_marlin_supports_config(
             and intermediate_size_per_partition % max(64, group_size) == 0
         )
     supports_group_size = group_size in [-1, 32, 64, 128]
-    return supports_shape and supports_group_size
+    supported = supports_shape and supports_group_size
+    if supported and current_platform.is_cuda():
+        warn_marlin_cuda_driver_mismatch()
+    return supported
 
 
 def check_moe_marlin_supports_layer(


### PR DESCRIPTION
## Summary
- guard AWQ-Marlin auto-selection when CUDA driver capability is older than torch CUDA toolkit version and compatibility mode is off
- fall back to AWQ in that auto-selection case to avoid PTX unsupported-toolchain startup failures
- keep explicit `--quantization awq_marlin` behavior unchanged

## Why
Issue #36235 shows a reproducible `cudaErrorUnsupportedPtxVersion` path in AWQ-Marlin under runtime mismatch (e.g. torch cu129 while driver reports CUDA 12.8) with `VLLM_ENABLE_CUDA_COMPATIBILITY=0`.

## Tests
- added unit tests: `tests/quantization/test_awq_marlin_toolchain_guard.py`
- run: `PYTHONPATH=/tmp/vllm-36235-fix /home/fede/Projects/model-issue-lab/.venv-vllm/bin/python -m pytest tests/quantization/test_awq_marlin_toolchain_guard.py -q`
- result: 3 passed

Fixes #36235


## Contribution policy notes (AGENTS.md)

**Duplicate check:** no other open PR guards Marlin auto-selection on a CUDA driver/toolkit mismatch. #38669 addresses a related but different path (Marlin repack PTX arch coverage in CMakeLists plus diagnostics around the repack ops).

**Tests (re-verified 2026-06-11 at ba3ddbe):**
- `pytest tests/quantization/test_marlin_toolchain_guard.py -v` — 8 passed
- `pre-commit run --files tests/quantization/test_marlin_toolchain_guard.py` — all hooks passed
- Note: the test file was adapted after upstream removed `GPTQMarlinConfig` (replaced by `AutoGPTQConfig`); the guard still covers GPTQ because `AutoGPTQLinearMethod.__init__` calls `verify_marlin_supported`, which routes through the centralised warning.

**AI assistance:** AI assistance was used in preparing and validating this PR.

