### PR TITLE
skip triton when graph capture

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -661,6 +661,8 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         if attn_metadata is None:
             # V1 profile run
             return
+        if torch.cuda.is_current_stream_capturing():
+            return
 
         assert isinstance(attn_metadata, dict)
         attn_metadata = attn_metadata[self.prefix]

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -661,7 +661,10 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         if attn_metadata is None:
             # V1 profile run
             return
-        if torch.cuda.is_current_stream_capturing():
+        if (
+            current_platform.is_cuda_alike()
+            and torch.cuda.is_current_stream_capturing()
+        ):
             return
 
         assert isinstance(attn_metadata, dict)


### PR DESCRIPTION
when launch vllm serve Qwen/Qwen3.5-0.8B --speculative_config '{"method": "mtp", "num_speculative_tokens":2}', console show error,
<img width="2648" height="1290" alt="image" src="https://github.com/user-attachments/assets/e5385971-ceca-4661-8802-2dd0f73d222e" />
,after implement the code, everything work.
<img width="2380" height="1038" alt="image" src="https://github.com/user-attachments/assets/7f255f41-5913-4ad1-8cf8-7fbd777f98f8" />

Fix: Skip _forward_core during CUDA Graph capture to avoid Triton kernel errors
Problem
When running the Qwen3Next model with speculative decoding (MTP method) in vLLM, CUDA Graph capture in FULL mode fails with:

RuntimeError: Triton Error [CUDA]: operation not permitted when stream is capturing
Root cause: During CUDA Graph capture, the _forward_core method of Qwen3NextGatedDeltaNet is invoked as a custom op. This method calls Triton JIT kernels — causal_conv1d_update and fused_sigmoid_gating_delta_rule_update — which internally trigger _init_handles() → load_binary() → cuModuleLoadData(). The CUDA driver forbids cuModuleLoadData while a stream is being captured, causing the runtime error.

Solution
Added an early return guard in _forward_core (vllm/model_executor/models/qwen3_next.py) that detects CUDA Graph capture state via torch.cuda.is_current_stream_capturing() and skips the entire method body during capture.

if torch.cuda.is_current_stream_capturing():
    return
