### PR TITLE
[Kernel] Flush L2 cache in benchmark_moe to reduce cache warmth bias

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -318,6 +318,10 @@ def benchmark_config(
         graph.replay()
     torch.accelerator.synchronize()
 
+    # Flush L2 cache with 256 MB data
+    cache_flush = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda")
+    cache_flush.zero_()
+
     start_event = torch.Event(enable_timing=True)
     end_event = torch.Event(enable_timing=True)
 
@@ -331,6 +335,8 @@ def benchmark_config(
         end_event.record()
         end_event.synchronize()
         latencies.append(start_event.elapsed_time(end_event))
+        # Flush L2 cache again after the iteration
+        cache_flush.zero_()
     avg = sum(latencies) / (num_iters * 10) * 1000  # us
     graph.reset()
     return avg


### PR DESCRIPTION
## Purpose
This PR adds L2 cache flushing before and after each iteration in the MoE kernel benchmark (benchmarks/kernels/benchmark_moe.py).

Currently, back-to-back iterations in the benchmark may benefit from warm cache states, leading to optimistic latency measurements that don't reflect real-world cold-start or interleaved execution scenarios. By allocating and zeroing a 256MB buffer (larger than the L2 cache of standard H100/A100 GPUs), it ensures that the cache is effectively flushed.