### PR TITLE
[Bugfix] Fix DP wave race condition re-arming engine while paused

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1578,7 +1578,7 @@ class DPEngineCoreProc(EngineCoreProc):
                 new_wave >= self.current_wave
             ):
                 self.current_wave = new_wave
-                if not self.engines_running:
+                if not self.engines_running and not self.is_scheduler_paused():
                     logger.debug("EngineCore starting idle loop for wave %d.", new_wave)
                     self.engines_running = True
         else:


### PR DESCRIPTION
Gate START_DP_WAVE on scheduler pause state to prevent race with collective_rpc.

Closes #36594