### PR TITLE
fix bugs when token_classify & classify run concurrently

### DIFF
--- a/vllm/model_executor/layers/pooler/tokwise/methods.py
+++ b/vllm/model_executor/layers/pooler/tokwise/methods.py
@@ -47,10 +47,13 @@ class AllPool(TokenPoolingMethod):
         pooling_metadata: PoolingMetadata,
     ) -> list[TokenPoolingMethodOutputItem]:
         pooling_cursor = pooling_metadata.get_pooling_cursor()
-        hidden_states_all = hidden_states.split(
-            pooling_cursor.num_scheduled_tokens_cpu.tolist()
-        )
-        hidden_states_lst = [hidden_states_all[i] for i in pooling_cursor.index]
+        hidden_states_lst = [
+            hidden_states[first : last + 1]
+            for first, last in zip(
+                pooling_cursor.first_token_indices_gpu.tolist(),
+                pooling_cursor.last_token_indices_gpu.tolist(),
+            )
+        ]
 
         if not self.enable_chunked_prefill:
             return hidden_states_lst


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Fix bugs for `*For*Classification, *ClassificationModel` models that runs `token_classify` and `classify` concurrently. 

vllm version 0.17.0
### steps to reproduce

```bash
pip install vllm==0.17.0
python \
  -m vllm.entrypoints.openai.api_server \
  --model Qwen/Qwen3-Reranker-8B \
  --max-num-batched-tokens 65536 \
  --max-num-seqs 64 \
  --port 31001 \
  --tensor-parallel-size 1 \
  --served-model-name auto \
  --runner pooling \
  --enable-prompt-tokens-details \
  --no-enable-prefix-caching \
  --log-error-stack \
  --hf_overrides '{"architectures": ["Qwen3ForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
  --trust-remote-code


# then do loop curl 

for i in {1..200}; do
curl -X POST "http://127.0.0.1:31001/pooling" \
-H "Content-Type: application/json" \
-d '{
  "model": "auto",
  "task": "token_classify",
  "input": [ "why", "ok"]
}' &

curl -X POST "http://127.0.0.1:31001/classify" \
-H "Content-Type: application/json" \
-d '{
  "model": "auto",
  "user": "abc",
  "input": ["why", "ok"]
}' &

done
wait
```

Error log shows that `hidden_states` and `pooling_cursor.num_scheduled_tokens_cpu` mismatched. From `DispatchPooler.forward` passes whole `hidden_states` of a batch to `AllPool`, while `num_scheduled_tokens_cpu` in `pooling_metadat` set in https://github.com/vllm-project/vllm/blob/ddbb0d230a3592106ac9f5f7f4e9a861863fcbee/vllm/v1/pool/metadata.py#L31 and  https://github.com/vllm-project/vllm/blob/ddbb0d230a3592106ac9f5f7f4e9a861863fcbee/vllm/model_executor/layers/pooler/special.py#L103 is a subset for current pooling_task
```
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/vllm/model_executor/layers/pooler/special.py", line 101, in forward
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     group_output: PoolerOutput = pooler(
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/vllm/model_executor/layers/pooler/tokwise/poolers.py", line 91, in forward
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     pooled_data = self.pooling(hidden_states, pooling_metadata)
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/vllm/model_executor/layers/pooler/tokwise/methods.py", line 50, in forward
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     hidden_states_all = hidden_states.split(
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]   File "/opt/conda/envs/os/lib/python3.10/site-packages/torch/_tensor.py", line 1066, in split
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102]     return torch._VF.split_with_sizes(
(EngineCore_DP0 pid=56494) ERROR 03-10 16:43:31 [v1/engine/core.py:1102] RuntimeError: split_with_sizes expects split_sizes to sum exactly to 34 (input tensor's size at dimension 0), but got split_sizes=[1, 1]
```



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

