### PR TITLE
[Bugfix] Fix off-by-one in multimodal prefix cache hash boundary check

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -413,7 +413,9 @@ def _gen_mm_extra_hash_keys(
     # We do not need to check all mm inputs if the start token index is out of
     # range. This usually happens in the late prefill phase and decoding phase.
     last_pos = mm_features[-1].mm_position
-    if last_pos.offset + last_pos.length < start_token_idx:
+    # MM range is [offset, offset+length), so offset+length is the exclusive
+    # end. A block starting at exactly offset+length does not overlap.
+    if last_pos.offset + last_pos.length <= start_token_idx:
         return extra_keys, start_mm_idx
 
     # Support start_mm_idx == -1 to indicate the last mm input.
@@ -428,8 +430,9 @@ def _gen_mm_extra_hash_keys(
         offset = mm_feature.mm_position.offset
         length = mm_feature.mm_position.length
         if end_token_idx > offset:
-            if start_token_idx > offset + length:
-                # This block has passed the current mm input.
+            if start_token_idx >= offset + length:
+                # This block has passed the current mm input (MM range
+                # is [offset, offset+length), exclusive end).
                 curr_mm_idx += 1
                 continue
 


### PR DESCRIPTION
Fix exclusive-end boundary comparisons in _gen_mm_extra_hash_keys causing incorrect block hashes at mm input boundaries.

Closes #20261