### PR TITLE
[Bugfix] Fix KV cache offloading for hybrid attention models (e.g. Qwen3.5-27B)

### DIFF
--- a/tests/v1/kv_connector/unit/test_offloading_connector.py
+++ b/tests/v1/kv_connector/unit/test_offloading_connector.py
@@ -783,6 +783,53 @@ def test_abort_loading_requests(request_runner):
     assert req_id not in runner.scheduler.requests
 
 
+class TestOffloadingConnectorHMA:
+    """Tests for OffloadingConnector HMA (hybrid memory allocator) support."""
+
+    def test_supports_hma(self):
+        """OffloadingConnector must declare HMA support."""
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+            SupportsHMA,
+            supports_hma,
+        )
+
+        assert issubclass(OffloadingConnector, SupportsHMA)
+        assert supports_hma(OffloadingConnector)
+
+    def test_request_finished_all_groups_delegates_to_group_0(self):
+        """request_finished_all_groups should delegate to request_finished
+        with block_ids from group 0."""
+        connector = MagicMock(spec=OffloadingConnector)
+        connector.request_finished.return_value = (True, None)
+
+        group0_ids = [1, 2, 3]
+        group1_ids = [4, 5]
+        block_ids = (group0_ids, group1_ids)
+
+        result = OffloadingConnector.request_finished_all_groups(
+            connector, MagicMock(), block_ids
+        )
+
+        connector.request_finished.assert_called_once()
+        args = connector.request_finished.call_args
+        assert args[0][1] == group0_ids
+        assert result == (True, None)
+
+    def test_request_finished_all_groups_empty_block_ids(self):
+        """request_finished_all_groups should handle empty block_ids."""
+        connector = MagicMock(spec=OffloadingConnector)
+        connector.request_finished.return_value = (False, None)
+
+        result = OffloadingConnector.request_finished_all_groups(
+            connector, MagicMock(), ()
+        )
+
+        connector.request_finished.assert_called_once()
+        args = connector.request_finished.call_args
+        assert args[0][1] == []
+        assert result == (False, None)
+
+
 class TestOffloadingConnectorStats:
     """Tests for OffloadingConnector stats reconstruction and operations."""
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1157,18 +1157,32 @@ class VllmConfig:
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
             # Default to disable HMA, but only if the user didn't express a preference.
             if self.kv_transfer_config is not None:
-                # NOTE(Kuntai): turn HMA off for connector unless specifically enabled.
-                need_disable_hybrid_kv_cache_manager = True
-                logger.warning(
-                    "Turning off hybrid kv cache manager because "
-                    "`--kv-transfer-config` is set. This will reduce the "
-                    "performance of vLLM on LLMs with sliding window attention "
-                    "or Mamba attention. If you are a developer of kv connector"
-                    ", please consider supporting hybrid kv cache manager for "
-                    "your connector by making sure your connector is a subclass"
-                    " of `SupportsHMA` defined in kv_connector/v1/base.py and"
-                    " use --no-disable-hybrid-kv-cache-manager to start vLLM."
+                # Check if the connector supports HMA before disabling it.
+                from vllm.distributed.kv_transfer.kv_connector.factory import (
+                    KVConnectorFactory,
                 )
+                from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+                    supports_hma as _supports_hma,
+                )
+
+                connector_cls = KVConnectorFactory.get_connector_class(
+                    self.kv_transfer_config
+                )
+                if not _supports_hma(connector_cls):
+                    need_disable_hybrid_kv_cache_manager = True
+                    logger.warning(
+                        "Turning off hybrid kv cache manager because "
+                        "`--kv-transfer-config` is set and connector %s "
+                        "does not support HMA. This will reduce the "
+                        "performance of vLLM on LLMs with sliding window "
+                        "attention or Mamba attention. If you are a "
+                        "developer of kv connector, please consider "
+                        "supporting hybrid kv cache manager for your "
+                        "connector by making sure your connector is a "
+                        "subclass of `SupportsHMA` defined in "
+                        "kv_connector/v1/base.py.",
+                        connector_cls.__name__,
+                    )
             self.scheduler_config.disable_hybrid_kv_cache_manager = (
                 need_disable_hybrid_kv_cache_manager
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -14,6 +14,7 @@ from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
 from vllm.distributed.kv_transfer.kv_connector.v1 import (
     KVConnectorBase_V1,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -113,7 +114,7 @@ class OffloadingConnectorMetadata(KVConnectorMetadata):
     reqs_to_store: dict[ReqId, TransferSpec]
 
 
-class OffloadingConnector(KVConnectorBase_V1):
+class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
     @property
     def prefer_cross_layer_blocks(self) -> bool:
         return True
@@ -208,6 +209,14 @@ class OffloadingConnector(KVConnectorBase_V1):
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        # Offloading only manages group 0 (attention) blocks.
+        return self.request_finished(request, block_ids[0])
 
     def take_events(self) -> Iterable[KVCacheEvent]:
         assert self.connector_scheduler is not None
@@ -596,11 +605,15 @@ class OffloadingConnectorWorker:
         layers = get_layers_from_vllm_config(
             self.spec.vllm_config, Attention, layer_names
         )
+        # Only register handlers for attention layers. Non-attention layers
+        # (e.g. Mamba/SSM) are not managed by the offloading connector.
+        attn_layer_names = list(layers.keys())
         attn_backends = {
             layer_name: layers[layer_name].get_attn_backend()
-            for layer_name in layer_names
+            for layer_name in attn_layer_names
         }
-        self._register_handlers(kv_caches, attn_backends)
+        attn_kv_caches = {name: kv_caches[name] for name in attn_layer_names}
+        self._register_handlers(attn_kv_caches, attn_backends)
 
     def register_cross_layers_kv_cache(
         self, kv_cache: torch.Tensor, attn_backend: type[AttentionBackend]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -216,6 +216,8 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         # Offloading only manages group 0 (attention) blocks.
+        if not block_ids:
+            return self.request_finished(request, [])
         return self.request_finished(request, block_ids[0])
 
     def take_events(self) -> Iterable[KVCacheEvent]:


### PR DESCRIPTION
## Purpose

Fix #36463: Qwen3.5-27B fails to start with CPU KV cache offloading (`--kv_offloading_backend native`) while Qwen3-32B works fine.

The root cause is that KV offloading auto-disables the Hybrid KV cache Manager (HMA) because `OffloadingConnector` doesn't implement the `SupportsHMA` interface. Without HMA, `unify_hybrid_kv_cache_specs()` tries to force all KV cache specs into one unified type, but fails because Qwen3.5-27B mixes `FullAttentionSpec` (standard attention) and `MambaSpec` (gated delta net / linear attention), which are fundamentally incompatible.

The fix makes `OffloadingConnector` implement `SupportsHMA` so HMA stays enabled for hybrid models. This is minimal and correct because:
- `OffloadingConnector` already only manages group 0 (attention) blocks — it naturally ignores non-attention groups
- `request_finished_all_groups()` simply delegates to existing `request_finished()` with group 0's block IDs
- `register_kv_caches()` is fixed to filter to attention layers only, preventing `KeyError` on Mamba layers
- The config now checks `supports_hma()` on the connector class before auto-disabling HMA, so connectors that support HMA keep it enabled while others are still auto-disabled

## Test Plan

Added 3 unit tests in `tests/v1/kv_connector/unit/test_offloading_connector.py`:
- `test_supports_hma`: verifies `OffloadingConnector` is a `SupportsHMA` subclass
- `test_request_finished_all_groups_delegates_to_group_0`: verifies delegation uses group 0 block IDs
- `test_request_finished_all_groups_empty_block_ids`: verifies empty `block_ids` guard

## Test Result

All 13 tests in `test_offloading_connector.py` pass (10 existing + 3 new):
```
tests/v1/kv_connector/unit/test_offloading_connector.py::test_offloading_connector PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::test_request_preemption PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::test_concurrent_lookups_of_the_same_prefix PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::test_abort_loading_requests PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::TestOffloadingConnectorHMA::test_supports_hma PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::TestOffloadingConnectorHMA::test_request_finished_all_groups_delegates_to_group_0 PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::TestOffloadingConnectorHMA::test_request_finished_all_groups_empty_block_ids PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::TestOffloadingConnectorStats::test_build_kv_connector_stats_with_none PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::TestOffloadingConnectorStats::test_build_kv_connector_stats_with_empty_dict PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::TestOffloadingConnectorStats::test_build_kv_connector_stats_reconstructs_offload_stats PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::TestOffloadingConnectorStats::test_aggregate_same_connector PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::TestOffloadingConnectorStats::test_reduce PASSED
tests/v1/kv_connector/unit/test_offloading_connector.py::TestOffloadingConnectorStats::test_reset PASSED
```

All 47 tests in `test_kv_cache_utils.py` also pass.