### PR TITLE
[torch.compile] Let Non-CUDA platforms provide default sp_min_token_num

### DIFF
--- a/tests/compile/conftest.py
+++ b/tests/compile/conftest.py
@@ -24,8 +24,7 @@ def mock_cuda_platform():
     def _mock_platform(is_cuda: bool = True, capability: tuple[int, int] | None = None):
         mock_platform = MagicMock()
         mock_platform.is_cuda.return_value = is_cuda
-        # Non-CUDA platforms use get_sp_min_token_num_default(); base returns None
-        mock_platform.get_sp_min_token_num_default.return_value = None
+
         if capability is not None:
             mock_platform.get_device_capability.return_value = DeviceCapability(
                 *capability

--- a/tests/compile/conftest.py
+++ b/tests/compile/conftest.py
@@ -24,7 +24,6 @@ def mock_cuda_platform():
     def _mock_platform(is_cuda: bool = True, capability: tuple[int, int] | None = None):
         mock_platform = MagicMock()
         mock_platform.is_cuda.return_value = is_cuda
-
         if capability is not None:
             mock_platform.get_device_capability.return_value = DeviceCapability(
                 *capability

--- a/tests/compile/conftest.py
+++ b/tests/compile/conftest.py
@@ -24,6 +24,8 @@ def mock_cuda_platform():
     def _mock_platform(is_cuda: bool = True, capability: tuple[int, int] | None = None):
         mock_platform = MagicMock()
         mock_platform.is_cuda.return_value = is_cuda
+        # Non-CUDA platforms use get_sp_min_token_num_default(); base returns None
+        mock_platform.get_sp_min_token_num_default.return_value = None
         if capability is not None:
             mock_platform.get_device_capability.return_value = DeviceCapability(
                 *capability

--- a/tests/compile/test_sequence_parallelism_threshold.py
+++ b/tests/compile/test_sequence_parallelism_threshold.py
@@ -13,13 +13,15 @@ from vllm.compilation.passes.fusion.sequence_parallelism import (
 class TestGetSequenceParallelismThreshold:
     """Tests for get_sequence_parallelism_threshold function."""
 
-    def test_non_cuda_returns_none(self, mock_cuda_platform):
-        """Non-CUDA platforms should return None."""
-        with mock_cuda_platform(is_cuda=False):
-            result = get_sequence_parallelism_threshold(
+    def test_non_cuda_delegates_to_platform_default(self, mock_cuda_platform):
+        """Non-CUDA platforms delegate to get_sp_min_token_num_default()."""
+        with mock_cuda_platform(is_cuda=False) as mock_platform:
+            get_sequence_parallelism_threshold(
                 hidden_size=8192, tp_size=2, element_size=2
             )
-        assert result is None
+            mock_platform.get_sp_min_token_num_default.assert_called_once_with(
+                8192, 2, 2
+            )
 
     def test_unsupported_device_capability_returns_none(self, mock_cuda_platform):
         """Unsupported device capabilities (e.g., sm80) should return None."""

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -61,7 +61,7 @@ def get_sequence_parallelism_threshold(
     from vllm.platforms import current_platform
 
     if not current_platform.is_cuda():
-        # Non-CUDA platforms: let platform provide default
+        # Non-CUDA platforms: let platform provide default sp_min_token_num
         return current_platform.get_sp_min_token_num_default(
             hidden_size, tp_size, element_size
         )

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -62,7 +62,9 @@ def get_sequence_parallelism_threshold(
 
     if not current_platform.is_cuda():
         # Non-CUDA platforms: let platform provide default
-        return current_platform.get_sp_min_token_num_default(hidden_size, tp_size, element_size)
+        return current_platform.get_sp_min_token_num_default(
+            hidden_size, tp_size, element_size
+        )
 
     capability = current_platform.get_device_capability()
     if capability is None:

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -62,7 +62,7 @@ def get_sequence_parallelism_threshold(
 
     if not current_platform.is_cuda():
         # Non-CUDA platforms: let platform provide default
-        return current_platform.get_sp_min_token_num_default()
+        return current_platform.get_sp_min_token_num_default(hidden_size, tp_size, element_size)
 
     capability = current_platform.get_device_capability()
     if capability is None:

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -61,7 +61,8 @@ def get_sequence_parallelism_threshold(
     from vllm.platforms import current_platform
 
     if not current_platform.is_cuda():
-        return None
+        # Non-CUDA platforms: let platform provide default
+        return current_platform.get_sp_min_token_num_default()
 
     capability = current_platform.get_device_capability()
     if capability is None:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -408,7 +408,7 @@ class Platform:
         pass
 
     @classmethod
-    def get_sp_min_token_num_default(cls) -> int | None:
+    def get_sp_min_token_num_default(cls, hidden_size: int, tp_size: int, element_size: int) -> int | None:
         """
         Return None by default to keep SP disabled.
         """

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -408,7 +408,9 @@ class Platform:
         pass
 
     @classmethod
-    def get_sp_min_token_num_default(cls, hidden_size: int, tp_size: int, element_size: int) -> int | None:
+    def get_sp_min_token_num_default(
+        cls, hidden_size: int, tp_size: int, element_size: int
+    ) -> int | None:
         """
         Return None by default to keep SP disabled.
         """

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -408,6 +408,13 @@ class Platform:
         pass
 
     @classmethod
+    def get_sp_min_token_num_default(cls) -> int | None:
+        """
+        Return None by default to keep SP disabled.
+        """
+        return None
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         """
         Check and update the configuration for the current platform.


### PR DESCRIPTION
## Purpose

Let non-CUDA platforms (NPU, TPU, etc.) provide their own default minimum token number for sequence parallelism via `get_sp_min_token_num_default()` instead of being limited to CUDA-only device capability logic. Previously, non-CUDA platforms would always get `None` from hardcoded CUDA logic. Now they can override `Platform.get_sp_min_token_num_default()` to return a platform-specific threshold. The base class returns `None` by default to keep SP disabled for backward compatibility.

## Test Plan

```bash
pytest tests/compile/test_sequence_parallelism_threshold.py -v
```

## Test Result

- `test_non_cuda_returns_none`: Pass (non-CUDA platforms return `None` via base `get_sp_min_token_num_default()`)
- `test_h100_large_model_returns_threshold`: Pass (CUDA H100 logic unchanged)
- All other existing threshold tests: Pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

