### PR TITLE
[LoRA] Add support for PEFT trainable_tokens_delta weights

### DIFF
--- a/tests/lora/test_utils.py
+++ b/tests/lora/test_utils.py
@@ -6,12 +6,17 @@ from typing import NamedTuple
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 from huggingface_hub.utils import HfHubHTTPError
 from torch import nn
 
+from vllm.lora.lora_model import LoRAModel
+from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.utils import (
     get_adapter_absolute_path,
+    is_trainable_tokens_delta,
     parse_fine_tuned_lora_name,
+    parse_trainable_tokens_delta_name,
     replace_submodule,
 )
 from vllm.model_executor.models.utils import WeightsMapper
@@ -199,3 +204,135 @@ def test_get_adapter_absolute_path_huggingface_error(
         response=MagicMock(),
     )
     assert get_adapter_absolute_path(path) == path
+
+
+# ---- Tests for trainable_tokens_delta helpers ----
+
+
+def test_is_trainable_tokens_delta():
+    assert is_trainable_tokens_delta(
+        "base_model.model.language_model.model.embed_tokens"
+        ".token_adapter.trainable_tokens_delta"
+    )
+    assert is_trainable_tokens_delta(
+        "base_model.model.model.embed_tokens.token_adapter.trainable_tokens_delta"
+    )
+    # Should not match standard LoRA weights
+    assert not is_trainable_tokens_delta(
+        "base_model.model.model.embed_tokens.lora_embedding_A"
+    )
+    assert not is_trainable_tokens_delta(
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"
+    )
+
+
+def test_parse_trainable_tokens_delta_name():
+    # With base_model.model. prefix
+    assert (
+        parse_trainable_tokens_delta_name(
+            "base_model.model.model.embed_tokens.token_adapter.trainable_tokens_delta"
+        )
+        == "model.embed_tokens"
+    )
+
+    # VLM-style with language_model prefix
+    assert (
+        parse_trainable_tokens_delta_name(
+            "base_model.model.language_model.model.embed_tokens"
+            ".token_adapter.trainable_tokens_delta"
+        )
+        == "language_model.model.embed_tokens"
+    )
+
+    # Without base_model.model. prefix
+    assert (
+        parse_trainable_tokens_delta_name(
+            "model.embed_tokens.token_adapter.trainable_tokens_delta"
+        )
+        == "model.embed_tokens"
+    )
+
+
+def test_parse_trainable_tokens_delta_name_with_weights_mapper():
+    mapper = WeightsMapper(orig_to_new_prefix={"model.": "language_model.model."})
+    assert (
+        parse_trainable_tokens_delta_name(
+            "base_model.model.model.embed_tokens.token_adapter.trainable_tokens_delta",
+            weights_mapper=mapper,
+        )
+        == "language_model.model.embed_tokens"
+    )
+
+
+def test_from_lora_tensors_trainable_tokens_delta():
+    """Test that trainable_tokens_delta is correctly converted to
+    equivalent LoRA embedding weights."""
+    vocab_size = 1000
+    embedding_dim = 64
+    token_indices = [500, 501, 502]
+    num_tokens = len(token_indices)
+
+    # Simulate the delta tensor from a PEFT checkpoint
+    delta = torch.randn(num_tokens, embedding_dim)
+
+    tensors = {
+        "base_model.model.model.embed_tokens"
+        ".token_adapter.trainable_tokens_delta": delta,
+    }
+
+    peft_helper = PEFTHelper(
+        r=8,
+        lora_alpha=16,
+        target_modules=["q_proj", "v_proj"],
+        trainable_token_indices={"embed_tokens": token_indices},
+    )
+
+    lora_model = LoRAModel.from_lora_tensors(
+        lora_model_id=1,
+        tensors=tensors,
+        peft_helper=peft_helper,
+        device="cpu",
+        dtype=torch.float32,
+        model_vocab_size=vocab_size,
+    )
+
+    lora = lora_model.get_lora("model.embed_tokens")
+    assert lora is not None
+    assert lora.rank == num_tokens
+    assert lora.scaling == 1.0
+
+    # lora_a should be sparse one-hot: [N, vocab_size]
+    assert lora.lora_a.shape == (num_tokens, vocab_size)
+    for i, idx in enumerate(token_indices):
+        assert lora.lora_a[i, idx].item() == 1.0
+    # All other entries should be zero
+    mask = torch.ones(num_tokens, vocab_size, dtype=torch.bool)
+    for i, idx in enumerate(token_indices):
+        mask[i, idx] = False
+    assert (lora.lora_a[mask] == 0).all()
+
+    # lora_b should be delta transposed: [embedding_dim, N]
+    assert lora.lora_b.shape == (embedding_dim, num_tokens)
+    torch.testing.assert_close(lora.lora_b, delta.T)
+
+
+def test_from_lora_tensors_trainable_tokens_delta_missing_config():
+    """Test error when trainable_token_indices is missing from config."""
+    tensors = {
+        "base_model.model.model.embed_tokens"
+        ".token_adapter.trainable_tokens_delta": torch.randn(3, 64),
+    }
+    peft_helper = PEFTHelper(
+        r=8,
+        lora_alpha=16,
+        target_modules=["q_proj"],
+    )
+
+    with pytest.raises(ValueError, match="trainable_token_indices not set"):
+        LoRAModel.from_lora_tensors(
+            lora_model_id=1,
+            tensors=tensors,
+            peft_helper=peft_helper,
+            device="cpu",
+            model_vocab_size=1000,
+        )

--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -12,7 +12,9 @@ from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.utils import (
     get_lora_id,
     is_base_embedding_weights,
+    is_trainable_tokens_delta,
     parse_fine_tuned_lora_name,
+    parse_trainable_tokens_delta_name,
 )
 from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
 from vllm.model_executor.models.utils import WeightsMapper
@@ -91,6 +93,73 @@ class LoRAModel:
             # Skip modules based on model-defined prefixes (e.g., MTP layers)
             if skip_prefixes and cls._should_skip_module(tensor_name, skip_prefixes):
                 continue
+
+            # Handle PEFT trainable_tokens_delta: convert the dense
+            # per-token delta into an equivalent rank-N LoRA embedding
+            # so the existing forward path can be reused unchanged.
+            if is_trainable_tokens_delta(tensor_name):
+                module_name = parse_trainable_tokens_delta_name(
+                    tensor_name, weights_mapper
+                )
+                delta = tensor.to(device=device, dtype=dtype)  # [N, emb_dim]
+                num_tokens = delta.shape[0]
+
+                # Look up the token indices from the PEFT config
+                embed_key = module_name.rsplit(".", 1)[-1]
+                token_indices = (peft_helper.trainable_token_indices or {}).get(
+                    embed_key
+                )
+                if token_indices is None:
+                    raise ValueError(
+                        f"trainable_tokens_delta found for '{embed_key}' "
+                        f"but trainable_token_indices not set in adapter "
+                        f"config"
+                    )
+                if len(token_indices) != num_tokens:
+                    raise ValueError(
+                        f"trainable_tokens_delta has {num_tokens} entries "
+                        f"but trainable_token_indices has "
+                        f"{len(token_indices)} indices"
+                    )
+                if model_vocab_size is None:
+                    raise ValueError(
+                        "model_vocab_size is required to load trainable_tokens_delta"
+                    )
+
+                # Build sparse one-hot lora_a: [N, vocab_size]
+                lora_a = torch.zeros(
+                    num_tokens,
+                    model_vocab_size,
+                    device=device,
+                    dtype=dtype,
+                )
+                idx_tensor = torch.tensor(
+                    token_indices, device=device, dtype=torch.long
+                )
+                lora_a[torch.arange(num_tokens, device=device), idx_tensor] = 1.0
+
+                # lora_b = delta transposed: [embedding_dim, N]
+                lora_b = delta.T.contiguous()
+
+                if module_name in loras:
+                    raise NotImplementedError(
+                        "Combining trainable_token_indices with embedding "
+                        "LoRA on the same module is not yet supported"
+                    )
+
+                loras[module_name] = LoRALayerWeights(
+                    module_name=module_name,
+                    rank=num_tokens,
+                    lora_alpha=num_tokens,
+                    lora_a=lora_a,
+                    lora_b=lora_b,
+                    scaling=1.0,
+                )
+                if pin_memory:
+                    loras[module_name].lora_a = loras[module_name].lora_a.pin_memory()
+                    loras[module_name].lora_b = loras[module_name].lora_b.pin_memory()
+                continue
+
             module_name, is_lora_a = parse_fine_tuned_lora_name(
                 tensor_name, weights_mapper
             )
@@ -167,6 +236,10 @@ class LoRAModel:
                 # Handle PEFT file format where experts.base_layer is the
                 # gate_up_proj and experts is the down_proj
                 if "base_layer" in lora_module:
+                    continue
+                # Skip PEFT trainable_tokens_delta weights (handled
+                # separately during loading)
+                if is_trainable_tokens_delta(lora_module):
                     continue
                 # Skip modules based on model-defined prefixes
                 if skip_prefixes and cls._should_skip_module(

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -35,6 +35,9 @@ class PEFTHelper:
     use_rslora: bool = field(default=False)
     # True to use Weight-Decomposed Low-Rank Adaptation (DoRA, see: https://arxiv.org/abs/2402.09353)
     use_dora: bool = field(default=False)
+    # Maps embedding module names to lists of token indices for trainable
+    # token embeddings (PEFT's trainable_token_indices feature)
+    trainable_token_indices: dict[str, list[int]] | None = field(default=None)
     # Extra vllm field, start with 'vllm_' to avoid conflict
     vllm_lora_scaling_factor: float = field(default=1.0)
     vllm_max_position_embeddings: int | None = field(default=False)

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -193,6 +193,40 @@ def parse_fine_tuned_lora_name(
     raise ValueError(f"{name} is unsupported LoRA weight")
 
 
+_TRAINABLE_TOKENS_DELTA_SUFFIX = ".token_adapter.trainable_tokens_delta"
+
+
+def is_trainable_tokens_delta(name: str) -> bool:
+    """Check if a weight name is a PEFT trainable_tokens_delta weight."""
+    return name.endswith(_TRAINABLE_TOKENS_DELTA_SUFFIX)
+
+
+def parse_trainable_tokens_delta_name(
+    name: str, weights_mapper: "WeightsMapper | None" = None
+) -> str:
+    """Extract module name from a trainable_tokens_delta weight name.
+
+    e.g. 'base_model.model.language_model.model.embed_tokens
+          .token_adapter.trainable_tokens_delta'
+       -> 'language_model.model.embed_tokens'
+    """
+    # Apply same prefix stripping + weights_mapper logic as
+    # parse_fine_tuned_lora_name
+    if name.startswith("base_model.model."):
+        name = name.replace("base_model.model.", "")
+        name = weights_mapper._map_name(name) if weights_mapper else name
+        name = "base_model.model." + name
+    else:
+        name = weights_mapper._map_name(name) if weights_mapper else name
+
+    start_index = 2 if name.startswith("base_model.model.") else 0
+
+    # Strip the token_adapter.trainable_tokens_delta suffix
+    core = name.removesuffix(_TRAINABLE_TOKENS_DELTA_SUFFIX)
+    parts = core.split(".")
+    return ".".join(parts[start_index:])
+
+
 def is_base_embedding_weights(name: str) -> bool:
     # hardcoded subfixes for input & output embedding weights
     embedding_suffixes = (


### PR DESCRIPTION
## Purpose

Adds support for PEFT's `trainable_token_indices` feature (see [PEFT docs](https://huggingface.co/docs/peft/developer_guides/lora#efficiently-train-tokens-alongside-lora)), which allows efficient training of embedding deltas for specific token indices alongside standard LoRA adapters.

Previously, loading an adapter with `trainable_tokens_delta` weights would fail with:
```
ValueError: Call to add_lora method failed: base_model.model.language_model.model.embed_tokens.token_adapter.trainable_tokens_delta is unsupported LoRA weight
```

The fix converts the dense per-token delta tensor into equivalent sparse LoRA embedding weights (`lora_embedding_A` / `lora_embedding_B`) at load time, so the existing forward path handles them without any kernel or layer changes.

Fixes #36501

## Test Plan

Added 5 new unit tests in `tests/lora/test_utils.py`:
- `test_is_trainable_tokens_delta` — verifies weight name detection
- `test_parse_trainable_tokens_delta_name` — verifies module name extraction (with/without `base_model.model.` prefix, VLM-style paths)
- `test_parse_trainable_tokens_delta_name_with_weights_mapper` — verifies `WeightsMapper` integration
- `test_from_lora_tensors_trainable_tokens_delta` — end-to-end test that the delta tensor is correctly converted to sparse one-hot `lora_a` + transposed `lora_b` with `scaling=1.0`
- `test_from_lora_tensors_trainable_tokens_delta_missing_config` — verifies error when `trainable_token_indices` is missing from adapter config

## Test Result

```
tests/lora/test_utils.py::test_is_trainable_tokens_delta PASSED
tests/lora/test_utils.py::test_parse_trainable_tokens_delta_name PASSED
tests/lora/test_utils.py::test_parse_trainable_tokens_delta_name_with_weights_mapper PASSED
tests/lora/test_utils.py::test_from_lora_tensors_trainable_tokens_delta PASSED
tests/lora/test_utils.py::test_from_lora_tensors_trainable_tokens_delta_missing_config PASSED

======================= 13 passed in 2.11s =======================
```