### PR TITLE
[Hybrid][GDN] Enable prefix caching 'all' mode for Qwen3.5/Qwen3Next

### DIFF
--- a/vllm/model_executor/layers/fla/ops/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/chunk.py
@@ -32,6 +32,8 @@ def chunk_gated_delta_rule_fwd(
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
+    return_intermediate_states: bool = False,
+    state_dtype: torch.dtype | None = None,
 ):
     g = chunk_local_cumsum(
         g, chunk_size=FLA_CHUNK_SIZE, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices
@@ -67,20 +69,26 @@ def chunk_gated_delta_rule_fwd(
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         chunk_offsets=chunk_offsets,
+        state_dtype=state_dtype,
     )
+    # chunk_fwd_o requires h in the same dtype as q/k (for tl.dot).
+    # When state_dtype is float32, convert h back for the output kernel.
+    h_for_o = h.to(k.dtype) if h.dtype != k.dtype else h
     o = chunk_fwd_o(
         q=q,
         k=k,
         v=v_new,
-        h=h,
+        h=h_for_o,
         g=g,
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
     )
-    if SUPPRESS_LEVEL < 3:
+    if return_intermediate_states:
+        return g, o, A, final_state, w, h, v_new
+    elif SUPPRESS_LEVEL < 3:
         return g, o, A, final_state, None, None, None
-    elif SUPPRESS_LEVEL >= 3:
+    else:
         return g, o, A, final_state, w, h, v_new
 
 
@@ -102,6 +110,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         chunk_indices: torch.Tensor | None = None,
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = False,
+        return_intermediate_states: bool = False,
     ):
         if use_qk_l2norm_in_kernel:
             q = l2norm_fwd(q)
@@ -119,9 +128,13 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
             chunk_offsets=chunk_offsets,
+            return_intermediate_states=return_intermediate_states,
+            state_dtype=torch.float32 if return_intermediate_states else None,
         )
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        if return_intermediate_states:
+            return o.to(q.dtype), h, final_state
         return o.to(q.dtype), final_state
 
 
@@ -139,6 +152,7 @@ def chunk_gated_delta_rule(
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
+    return_intermediate_states: bool = False,
 ):
     r"""
     Args:
@@ -217,7 +231,7 @@ def chunk_gated_delta_rule(
             )
     if scale is None:
         scale = k.shape[-1] ** -0.5
-    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+    result = ChunkGatedDeltaRuleFunction.apply(
         q,
         k,
         v,
@@ -230,5 +244,8 @@ def chunk_gated_delta_rule(
         chunk_indices,
         chunk_offsets,
         use_qk_l2norm_in_kernel,
+        return_intermediate_states,
     )
-    return o, final_state
+    # Returns (output, intermediate_h, final_state) when
+    # return_intermediate_states=True, else (output, final_state).
+    return result

--- a/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
@@ -311,6 +311,7 @@ def chunk_gated_delta_rule_fwd_h(
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
+    state_dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # This kernel is slightly different from fla to support Q/K with different head numbers.
     # In fla, Q/K always have the same head number, so Hg is always equal to H.
@@ -329,7 +330,7 @@ def chunk_gated_delta_rule_fwd_h(
             chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
     assert K <= 256, "current kernel does not support head dimension larger than 256."
 
-    h = k.new_empty(B, NT, H, V, K)
+    h = k.new_empty(B, NT, H, V, K, dtype=state_dtype or k.dtype)
     final_state = (
         k.new_empty(N, H, V, K, dtype=torch.float32) if output_final_state else None
     )

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -67,6 +67,63 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 logger = init_logger(__name__)
 
 
+def _save_gdn_block_states(
+    h: torch.Tensor,
+    final_state: torch.Tensor,
+    ssm_state: torch.Tensor,
+    state_indices: torch.Tensor,
+    block_idx_first_scheduled: torch.Tensor,
+    block_idx_last_scheduled: torch.Tensor,
+    context_lens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    mamba_block_size: int,
+) -> None:
+    """Save GDN intermediate states at block boundaries for prefix caching.
+
+    h: [1, total_chunks, H, V, K] — state BEFORE each chunk (chunk_size=64).
+    final_state: [N, H, V, K] — state AFTER the last chunk per sequence.
+    state_indices: [num_non_spec, max_blocks] — block table.
+    chunk_offsets: [N+1] cumulative chunk counts (from prepare_chunk_offsets).
+    """
+    chunk_stride = mamba_block_size // FLA_CHUNK_SIZE
+    num_non_spec = state_indices.shape[0]
+    device = h.device
+
+    n_to_fill = (
+        block_idx_last_scheduled[:num_non_spec]
+        - block_idx_first_scheduled[:num_non_spec]
+    )
+
+    seq_idx_flat = torch.repeat_interleave(
+        torch.arange(num_non_spec, device=device), n_to_fill
+    )
+    starts = n_to_fill.cumsum(0) - n_to_fill
+    within_k = torch.arange(
+        seq_idx_flat.numel(), device=device
+    ) - torch.repeat_interleave(starts, n_to_fill)
+
+    # h[i] is the SSM state BEFORE chunk i in the kernel's flat layout.
+    # End-of-block state for relative block k (counting from
+    # block_idx_first_scheduled) lives at chunk
+    # `chunk_offsets[seq] + chunk_stride * (k + 1) - unaligned_chunks`,
+    # where `unaligned_chunks` accounts for context already covered by an
+    # earlier partially-filled block.
+    unaligned_chunks = (
+        context_lens[:num_non_spec] % mamba_block_size
+    ) // FLA_CHUNK_SIZE
+    first_aligned = chunk_offsets[:num_non_spec] + chunk_stride - unaligned_chunks
+
+    src_chunks = first_aligned[seq_idx_flat] + within_k * chunk_stride
+    dst_block_pos = block_idx_first_scheduled[seq_idx_flat] + within_k
+    dst_blocks = state_indices[seq_idx_flat, dst_block_pos]
+    ssm_state[dst_blocks] = h[0, src_chunks].to(ssm_state.dtype)
+
+    last_block_ids = state_indices.gather(
+        1, block_idx_last_scheduled[:num_non_spec].unsqueeze(1)
+    ).squeeze(1)
+    ssm_state[last_block_ids] = final_state[:num_non_spec].to(ssm_state.dtype)
+
+
 def fi_chunk_gated_delta_rule(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -169,7 +226,25 @@ class ChunkGatedDeltaRule(CustomOp):
         chunk_indices: torch.Tensor | None = None,
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = True,
+        return_intermediate_states: bool = False,
     ):
+        if return_intermediate_states:
+            # FlashInfer doesn't support intermediate states;
+            # fall back to the FLA (Triton) implementation.
+            return self.forward_native(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                chunk_offsets=chunk_offsets,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+                return_intermediate_states=True,
+            )
         return fi_chunk_gated_delta_rule(
             q=q,
             k=k,
@@ -195,6 +270,7 @@ class ChunkGatedDeltaRule(CustomOp):
         chunk_indices: torch.Tensor | None = None,
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = True,
+        return_intermediate_states: bool = False,
     ):
         return fla_chunk_gated_delta_rule(
             q=q,
@@ -208,6 +284,7 @@ class ChunkGatedDeltaRule(CustomOp):
             chunk_indices=chunk_indices,
             chunk_offsets=chunk_offsets,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            return_intermediate_states=return_intermediate_states,
         )
 
 
@@ -769,8 +846,11 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         attn_metadata = attn_metadata_raw[self.prefix]  # type: ignore[index]
         assert isinstance(attn_metadata, GDNAttentionMetadata)
 
+        is_cache_all = attn_metadata.is_cache_all
+
         if (
             self.enable_packed_recurrent_decode
+            and not is_cache_all
             and attn_metadata.spec_sequence_masks is None
             and attn_metadata.num_prefills == 0
             and attn_metadata.num_decodes > 0
@@ -848,30 +928,71 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
             # - "cache_indices" updates the conv_state cache in positions
             #   pointed to by "state_indices_tensor"
-            mixed_qkv_non_spec = causal_conv1d_fn(
-                mixed_qkv_non_spec_T,
-                conv_weights,
-                self.conv1d.bias,
-                activation=self.activation,
-                conv_states=conv_state,
-                has_initial_state=has_initial_state,
-                cache_indices=non_spec_state_indices_tensor,
-                query_start_loc=non_spec_query_start_loc,
-                metadata=attn_metadata,
-            ).transpose(0, 1)
+            if is_cache_all:
+                mixed_qkv_non_spec = causal_conv1d_fn(
+                    mixed_qkv_non_spec_T,
+                    conv_weights,
+                    self.conv1d.bias,
+                    activation=self.activation,
+                    conv_states=conv_state,
+                    has_initial_state=has_initial_state,
+                    cache_indices=non_spec_state_indices_tensor,
+                    query_start_loc=non_spec_query_start_loc,
+                    metadata=attn_metadata,
+                    block_idx_first_scheduled_token=(
+                        attn_metadata.block_idx_first_scheduled_token
+                    ),
+                    block_idx_last_scheduled_token=(
+                        attn_metadata.block_idx_last_scheduled_token
+                    ),
+                    initial_state_idx=attn_metadata.block_idx_last_computed_token,
+                    num_computed_tokens=attn_metadata.context_lens_tensor,
+                    block_size_to_align=attn_metadata.mamba_block_size,
+                ).transpose(0, 1)
+            else:
+                mixed_qkv_non_spec = causal_conv1d_fn(
+                    mixed_qkv_non_spec_T,
+                    conv_weights,
+                    self.conv1d.bias,
+                    activation=self.activation,
+                    conv_states=conv_state,
+                    has_initial_state=has_initial_state,
+                    cache_indices=non_spec_state_indices_tensor,
+                    query_start_loc=non_spec_query_start_loc,
+                    metadata=attn_metadata,
+                ).transpose(0, 1)
         elif attn_metadata.num_decodes > 0:
             assert mixed_qkv_non_spec is not None
-            mixed_qkv_non_spec = causal_conv1d_update(
-                mixed_qkv_non_spec,
-                conv_state,
-                conv_weights,
-                self.conv1d.bias,
-                self.activation,
-                conv_state_indices=non_spec_state_indices_tensor[  # type: ignore[index]
-                    : attn_metadata.num_actual_tokens  # type: ignore[attr-defined]
-                ],
-                validate_data=True,
-            )
+            if is_cache_all:
+                num_decodes = attn_metadata.num_decodes
+                assert non_spec_state_indices_tensor is not None
+                last_scheduled_full = attn_metadata.block_idx_last_scheduled_token
+                last_computed_full = attn_metadata.block_idx_last_computed_token
+                assert last_scheduled_full is not None
+                assert last_computed_full is not None
+                mixed_qkv_non_spec = causal_conv1d_update(
+                    mixed_qkv_non_spec,
+                    conv_state,
+                    conv_weights,
+                    self.conv1d.bias,
+                    self.activation,
+                    conv_state_indices=non_spec_state_indices_tensor[:num_decodes],
+                    block_idx_last_scheduled_token=last_scheduled_full[:num_decodes],
+                    initial_state_idx=last_computed_full[:num_decodes],
+                    validate_data=False,
+                )
+            else:
+                mixed_qkv_non_spec = causal_conv1d_update(
+                    mixed_qkv_non_spec,
+                    conv_state,
+                    conv_weights,
+                    self.conv1d.bias,
+                    self.activation,
+                    conv_state_indices=non_spec_state_indices_tensor[  # type: ignore[index]
+                        : attn_metadata.num_actual_tokens  # type: ignore[attr-defined]
+                    ],
+                    validate_data=True,
+                )
         else:
             mixed_qkv_non_spec = None
 
@@ -947,49 +1068,123 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # 2.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
             assert non_spec_state_indices_tensor is not None
-            initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()  # type: ignore[index]
             assert has_initial_state is not None
-            initial_state[~has_initial_state, ...] = 0  # type: ignore[operator]
-            (
-                core_attn_out_non_spec,
-                last_recurrent_state,
-            ) = self.chunk_gated_delta_rule(
-                q=query_non_spec,
-                k=key_non_spec,
-                v=value_non_spec,
-                g=g_non_spec,
-                beta=beta_non_spec,
-                initial_state=initial_state,
-                output_final_state=True,
-                cu_seqlens=non_spec_query_start_loc,
-                chunk_indices=attn_metadata.chunk_indices,
-                chunk_offsets=attn_metadata.chunk_offsets,
-                use_qk_l2norm_in_kernel=False,
-            )
-            # Init cache
-            ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(
-                ssm_state.dtype
-            )
-        elif attn_metadata.num_decodes > 0:
-            core_attn_out_non_spec, last_recurrent_state = (
-                fused_sigmoid_gating_delta_rule_update(
-                    A_log=self.A_log,
-                    a=a,
-                    b=b,
-                    dt_bias=self.dt_bias,
+            if is_cache_all:
+                last_computed = attn_metadata.block_idx_last_computed_token
+                assert last_computed is not None
+                initial_block_ids = non_spec_state_indices_tensor.gather(
+                    1, last_computed.unsqueeze(1)
+                ).squeeze(1)
+                initial_state = ssm_state[initial_block_ids]
+                initial_state[~has_initial_state, ...] = 0
+                (
+                    core_attn_out_non_spec,
+                    intermediate_h,
+                    final_state,
+                ) = self.chunk_gated_delta_rule(
                     q=query_non_spec,
                     k=key_non_spec,
                     v=value_non_spec,
-                    initial_state=ssm_state,
-                    inplace_final_state=True,
-                    cu_seqlens=non_spec_query_start_loc[  # type: ignore[index]
-                        : attn_metadata.num_decodes
-                        + 1  # type: ignore[attr-defined]
-                    ],
-                    ssm_state_indices=non_spec_state_indices_tensor,
-                    use_qk_l2norm_in_kernel=True,
+                    g=g_non_spec,
+                    beta=beta_non_spec,
+                    initial_state=initial_state,
+                    output_final_state=True,
+                    cu_seqlens=non_spec_query_start_loc,
+                    chunk_indices=attn_metadata.chunk_indices,
+                    chunk_offsets=attn_metadata.chunk_offsets,
+                    use_qk_l2norm_in_kernel=False,
+                    return_intermediate_states=True,
                 )
-            )
+                _save_gdn_block_states(
+                    h=intermediate_h,
+                    final_state=final_state,
+                    ssm_state=ssm_state,
+                    state_indices=non_spec_state_indices_tensor,
+                    block_idx_first_scheduled=(
+                        attn_metadata.block_idx_first_scheduled_token
+                    ),
+                    block_idx_last_scheduled=(
+                        attn_metadata.block_idx_last_scheduled_token
+                    ),
+                    context_lens=attn_metadata.context_lens_tensor,
+                    chunk_offsets=attn_metadata.chunk_offsets,
+                    mamba_block_size=attn_metadata.mamba_block_size,
+                )
+            else:
+                initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()  # type: ignore[index]
+                initial_state[~has_initial_state, ...] = 0  # type: ignore[operator]
+                (
+                    core_attn_out_non_spec,
+                    last_recurrent_state,
+                ) = self.chunk_gated_delta_rule(
+                    q=query_non_spec,
+                    k=key_non_spec,
+                    v=value_non_spec,
+                    g=g_non_spec,
+                    beta=beta_non_spec,
+                    initial_state=initial_state,
+                    output_final_state=True,
+                    cu_seqlens=non_spec_query_start_loc,
+                    chunk_indices=attn_metadata.chunk_indices,
+                    chunk_offsets=attn_metadata.chunk_offsets,
+                    use_qk_l2norm_in_kernel=False,
+                )
+                # Init cache
+                ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(
+                    ssm_state.dtype
+                )
+        elif attn_metadata.num_decodes > 0:
+            if is_cache_all:
+                num_decodes = attn_metadata.num_decodes
+                assert non_spec_state_indices_tensor is not None
+                last_computed_full = attn_metadata.block_idx_last_computed_token
+                last_scheduled_full = attn_metadata.block_idx_last_scheduled_token
+                assert last_computed_full is not None
+                assert last_scheduled_full is not None
+                last_computed = last_computed_full[:num_decodes].unsqueeze(1)
+                last_scheduled = last_scheduled_full[:num_decodes].unsqueeze(1)
+                table = non_spec_state_indices_tensor[:num_decodes]
+                input_indices = table.gather(1, last_computed).squeeze(1)
+                output_indices = table.gather(1, last_scheduled).squeeze(1)
+                # Pre-copy initial state into the new block when crossing a
+                # block boundary; same-block decode steps no-op into themselves.
+                ssm_state[output_indices] = ssm_state[input_indices]
+                core_attn_out_non_spec, last_recurrent_state = (
+                    fused_sigmoid_gating_delta_rule_update(
+                        A_log=self.A_log,
+                        a=a,
+                        b=b,
+                        dt_bias=self.dt_bias,
+                        q=query_non_spec,
+                        k=key_non_spec,
+                        v=value_non_spec,
+                        initial_state=ssm_state,
+                        inplace_final_state=True,
+                        cu_seqlens=non_spec_query_start_loc[: num_decodes + 1],  # type: ignore[index]
+                        ssm_state_indices=output_indices,
+                        use_qk_l2norm_in_kernel=True,
+                    )
+                )
+            else:
+                core_attn_out_non_spec, last_recurrent_state = (
+                    fused_sigmoid_gating_delta_rule_update(
+                        A_log=self.A_log,
+                        a=a,
+                        b=b,
+                        dt_bias=self.dt_bias,
+                        q=query_non_spec,
+                        k=key_non_spec,
+                        v=value_non_spec,
+                        initial_state=ssm_state,
+                        inplace_final_state=True,
+                        cu_seqlens=non_spec_query_start_loc[  # type: ignore[index]
+                            : attn_metadata.num_decodes
+                            + 1  # type: ignore[attr-defined]
+                        ],
+                        ssm_state_indices=non_spec_state_indices_tensor,
+                        use_qk_l2norm_in_kernel=True,
+                    )
+                )
         else:
             core_attn_out_non_spec, last_recurrent_state = None, None
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -380,6 +380,20 @@ class MambaModelConfig(VerifyAndUpdateConfig):
                     "for prefix caching with Mamba cache 'all' mode: "
                     "falling back to 'align' mode."
                 )
+            if (
+                cache_config.mamba_cache_mode == "all"
+                and cache_config.mamba_ssm_cache_dtype == "auto"
+            ):
+                # "all" mode stores intermediate SSM states at block
+                # boundaries.  These states are accumulated in float32 inside
+                # the kernel; storing them back in bfloat16/float16 causes
+                # unacceptable precision loss, so the SSM cache must be
+                # float32.
+                cache_config.mamba_ssm_cache_dtype = "float32"
+                logger.info(
+                    "Setting mamba_ssm_cache_dtype to 'float32' for "
+                    "mamba_cache_mode='all' to preserve precision."
+                )
             if cache_config.mamba_cache_mode == "align":
                 assert vllm_config.scheduler_config.enable_chunked_prefill, (
                     "Chunked prefill is required for mamba cache mode 'align'."

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -73,6 +73,7 @@ from .interfaces import (
     MultiModalEmbeddings,
     SupportsEagle3,
     SupportsLoRA,
+    SupportsMambaPrefixCaching,
     SupportsPP,
     _require_is_multimodal,
 )
@@ -450,6 +451,7 @@ class Qwen3_5ForCausalLMBase(
     HasInnerState,
     SupportsEagle3,
     SupportsLoRA,
+    SupportsMambaPrefixCaching,
     SupportsPP,
 ):
     packed_modules_mapping = {
@@ -468,14 +470,7 @@ class Qwen3_5ForCausalLMBase(
         config = vllm_config.model_config.hf_text_config
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
-        cache_config = vllm_config.cache_config
-
         scheduler_config = vllm_config.scheduler_config
-        if cache_config.mamba_cache_mode == "all":
-            raise NotImplementedError(
-                "Qwen3.5 currently does not support 'all' prefix caching, "
-                "please use '--mamba-cache-mode=align' instead"
-            )
         self.quant_config = vllm_config.quant_config
 
         super().__init__()
@@ -574,7 +569,9 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase, QwenNextMixtureOfExperts):
     info=Qwen3_5ProcessingInfo,
     dummy_inputs=Qwen3VLDummyInputsBuilder,
 )
-class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid):
+class Qwen3_5ForConditionalGeneration(
+    Qwen3VLForConditionalGeneration, IsHybrid, SupportsMambaPrefixCaching
+):
     # Qwen3.5 does not support multimodal pruning (EVS).
     supports_multimodal_pruning = False
 

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -64,6 +64,7 @@ from .interfaces import (
     IsHybrid,
     MixtureOfExperts,
     SupportsLoRA,
+    SupportsMambaPrefixCaching,
     SupportsPP,
 )
 from .utils import (
@@ -686,6 +687,7 @@ class Qwen3NextForCausalLM(
     nn.Module,
     HasInnerState,
     SupportsLoRA,
+    SupportsMambaPrefixCaching,
     SupportsPP,
     QwenNextMixtureOfExperts,
     IsHybrid,
@@ -705,14 +707,8 @@ class Qwen3NextForCausalLM(
         config = vllm_config.model_config.hf_text_config
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
-        cache_config = vllm_config.cache_config
 
         scheduler_config = vllm_config.scheduler_config
-        if cache_config.mamba_cache_mode == "all":
-            raise NotImplementedError(
-                "Qwen3Next currently does not support 'all' prefix caching, "
-                "please use '--mamba-cache-mode=align' instead"
-            )
         self.quant_config = vllm_config.quant_config
 
         super().__init__()

--- a/vllm/transformers_utils/configs/qwen3_5.py
+++ b/vllm/transformers_utils/configs/qwen3_5.py
@@ -107,7 +107,8 @@ class Qwen3_5TextConfig(PretrainedConfig):
 
             layer_type_validation(self.layer_types, self.num_hidden_layers)
 
-        # linear attention part
+        # linear attention part (Gated Delta Net with chunk_size=64)
+        self.mamba_chunk_size = 64
         self.linear_conv_kernel_dim = linear_conv_kernel_dim
         self.linear_key_head_dim = linear_key_head_dim
         self.linear_value_head_dim = linear_value_head_dim

--- a/vllm/transformers_utils/configs/qwen3_5_moe.py
+++ b/vllm/transformers_utils/configs/qwen3_5_moe.py
@@ -113,7 +113,8 @@ class Qwen3_5MoeTextConfig(PretrainedConfig):
 
             layer_type_validation(self.layer_types, self.num_hidden_layers)
 
-        # linear attention part
+        # linear attention part (Gated Delta Net with chunk_size=64)
+        self.mamba_chunk_size = 64
         self.linear_conv_kernel_dim = linear_conv_kernel_dim
         self.linear_key_head_dim = linear_key_head_dim
         self.linear_value_head_dim = linear_value_head_dim

--- a/vllm/transformers_utils/configs/qwen3_next.py
+++ b/vllm/transformers_utils/configs/qwen3_next.py
@@ -261,7 +261,8 @@ class Qwen3NextConfig(PretrainedConfig):
 
             layer_type_validation(self.layer_types)
 
-        # linear attention part
+        # linear attention part (Gated Delta Net with chunk_size=64)
+        self.mamba_chunk_size = 64
         self.linear_conv_kernel_dim = linear_conv_kernel_dim
         self.linear_key_head_dim = linear_key_head_dim
         self.linear_value_head_dim = linear_value_head_dim

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import torch
 
 from vllm.config import VllmConfig
+from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -67,6 +68,17 @@ class GDNAttentionMetadata:
     chunk_indices: torch.Tensor | None = None
     chunk_offsets: torch.Tensor | None = None
 
+    # The following fields are used for prefix caching in "all" mode.
+    # When mamba_cache_mode == "all", non_spec_state_indices_tensor is 2D
+    # [num_non_spec, max_num_blocks] instead of 1D [num_non_spec].
+    # All block_idx_* tensors are for ALL non-spec requests (decodes + prefills).
+    is_cache_all: bool = False
+    context_lens_tensor: torch.Tensor | None = None
+    block_idx_first_scheduled_token: torch.Tensor | None = None
+    block_idx_last_scheduled_token: torch.Tensor | None = None
+    block_idx_last_computed_token: torch.Tensor | None = None
+    mamba_block_size: int = 0
+
     # The following attributes are for triton implementation of causal_conv1d
     nums_dict: dict | None = None
     batch_ptr: torch.Tensor | None = None
@@ -99,6 +111,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         self.use_spec_decode: bool = self.num_spec > 0
         self._init_reorder_batch_threshold(1, self.use_spec_decode)
 
+        self.is_cache_all = self.vllm_config.cache_config.mamba_cache_mode == "all"
+
         self.use_full_cuda_graph: bool = (
             self.compilation_config.cudagraph_mode.has_full_cudagraphs()
         )
@@ -110,6 +124,27 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             self.decode_cudagraph_max_bs = min(
                 self.decode_cudagraph_max_bs,
                 self.compilation_config.max_cudagraph_capture_size,
+            )
+
+        if self.is_cache_all:
+            max_num_blocks = cdiv(
+                self.vllm_config.model_config.max_model_len,
+                self.kv_cache_spec.block_size,
+            )
+            self.non_spec_state_indices_tensor_2d = torch.empty(
+                (self.decode_cudagraph_max_bs, max_num_blocks),
+                dtype=torch.int32,
+                device=device,
+            )
+            self.block_idx_last_scheduled_token_buf = torch.empty(
+                (self.decode_cudagraph_max_bs,),
+                dtype=torch.int32,
+                device=device,
+            )
+            self.block_idx_last_computed_token_buf = torch.empty(
+                (self.decode_cudagraph_max_bs,),
+                dtype=torch.int32,
+                device=device,
             )
 
         self.spec_state_indices_tensor: torch.Tensor = torch.empty(
@@ -204,7 +239,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_indx = None
             non_spec_token_indx = None
             spec_state_indices_tensor = None
-            non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            if self.is_cache_all:
+                non_spec_state_indices_tensor = block_table_tensor
+            else:
+                non_spec_state_indices_tensor = block_table_tensor[:, 0]
             spec_query_start_loc = None
             non_spec_query_start_loc = query_start_loc
             non_spec_query_start_loc_cpu = query_start_loc_cpu
@@ -353,6 +391,25 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
         )
 
+        # Compute block indices for prefix caching in "all" mode.
+        # All block_idx_* tensors cover ALL non-spec requests.
+        mamba_block_size = 0
+        block_idx_first_scheduled_token = None
+        block_idx_last_scheduled_token = None
+        block_idx_last_computed_token = None
+
+        if self.is_cache_all and spec_sequence_masks is None:
+            mamba_block_size = self.kv_cache_spec.block_size
+            block_idx_last_computed_token = torch.clamp(
+                cdiv(context_lens_tensor, mamba_block_size) - 1, min=0
+            )
+            block_idx_first_scheduled_token = (
+                cdiv(context_lens_tensor + 1, mamba_block_size) - 1
+            )
+            block_idx_last_scheduled_token = torch.clamp(
+                cdiv(m.seq_lens, mamba_block_size) - 1, min=0
+            )
+
         # Prepare tensors for cudagraph
         # Note: m.num_actual_tokens is already padded by the model runner for CUDAGraph
         batch_size = m.num_actual_tokens
@@ -409,13 +466,43 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             and num_spec_decodes == 0
             and num_decodes <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
-                non_spec_state_indices_tensor, non_blocking=True
-            )
-            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
-                :batch_size
-            ]
-            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
+            if self.is_cache_all:
+                self.non_spec_state_indices_tensor_2d[:num_decodes].copy_(
+                    non_spec_state_indices_tensor[:num_decodes],
+                    non_blocking=True,
+                )
+                non_spec_state_indices_tensor = self.non_spec_state_indices_tensor_2d[
+                    :batch_size
+                ]
+                non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
+
+                assert block_idx_last_scheduled_token is not None
+                assert block_idx_last_computed_token is not None
+                self.block_idx_last_scheduled_token_buf[:num_decodes].copy_(
+                    block_idx_last_scheduled_token[:num_decodes],
+                    non_blocking=True,
+                )
+                block_idx_last_scheduled_token = (
+                    self.block_idx_last_scheduled_token_buf[:batch_size]
+                )
+                block_idx_last_scheduled_token[num_decodes:].fill_(0)
+
+                self.block_idx_last_computed_token_buf[:num_decodes].copy_(
+                    block_idx_last_computed_token[:num_decodes],
+                    non_blocking=True,
+                )
+                block_idx_last_computed_token = self.block_idx_last_computed_token_buf[
+                    :batch_size
+                ]
+                block_idx_last_computed_token[num_decodes:].fill_(0)
+            else:
+                self.non_spec_state_indices_tensor[:num_decodes].copy_(
+                    non_spec_state_indices_tensor, non_blocking=True
+                )
+                non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
+                    :batch_size
+                ]
+                non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
 
             self.non_spec_query_start_loc[: num_decodes + 1].copy_(
                 non_spec_query_start_loc, non_blocking=True
@@ -443,6 +530,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
+            is_cache_all=self.is_cache_all,
+            context_lens_tensor=context_lens_tensor if self.is_cache_all else None,
+            block_idx_first_scheduled_token=block_idx_first_scheduled_token,
+            block_idx_last_scheduled_token=block_idx_last_scheduled_token,
+            block_idx_last_computed_token=block_idx_last_computed_token,
+            mamba_block_size=mamba_block_size,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,


### PR DESCRIPTION
## Purpose

Fixes #36493

Enable block-level GDN (Gated Delta Net) state caching for Qwen3.5 and Qwen3Next hybrid models, fixing near-0% prefix cache hit rates.

Previously, these models fell back to `mamba_cache_mode="align"` (caching only 1-2 tail blocks), causing the `HybridKVCacheCoordinator` to report 0% hits since Mamba/GDN null blocks were never cached. This PR implements full "all" mode support following the Mamba2 pattern:

- Expose per-chunk intermediate states (`h` tensor) from the GDN Triton kernel in float32 via `return_intermediate_states`
- Add "all" mode block-index metadata to `GDNAttentionMetadata` and its builder
- Save GDN SSM + conv1d states at block boundaries during prefill, with correct decode block-boundary handling
- Set `mamba_chunk_size=64` in Qwen3.5/Qwen3Next configs for proper block alignment
- Add `SupportsMambaPrefixCaching` interface to all Qwen3.5/Qwen3Next model classes (CausalLM + ConditionalGeneration)
- Auto-set `mamba_ssm_cache_dtype=float32` when `mamba_cache_mode=all` to prevent precision loss in cached intermediate states

## Test Plan

## Test Result

### E2E: `Qwen/Qwen3.5-35B-A3B`

```
vllm serve Qwen/Qwen3.5-35B-A3B \
  --enable-prefix-caching \
  --mamba-cache-mode all \
  --enable-chunked-prefill \
  --language-model-only \
  --enforce-eager \
  --max-model-len 8192
```

| Run | Prefill time | Cached tokens | Tokens match |
|-----|-------------|---------------|-------------|
| Run 1 (fill cache) | 37s | 0 | - |
| Run 2 (use cache) | **2.6s (14x faster)** | **1088** | Yes |

### Kernel-level: GDN intermediate state split correctness

Verified that processing tokens `[0..3001]` in one pass produces the same output as splitting at token 2880 (block boundary) and resuming from the cached `h` state:

| Test | Result |
|------|--------|
| Kernel split via `final_state` | PASS (max diff = 0.0) |
| Kernel split via `h[chunk_idx]` (float32) | PASS (max diff = 0.0) |
| Kernel split via `h[chunk_idx]` (bfloat16 roundtrip) | FAIL (max diff = 2.0) - motivates the float32 requirement |
