### PR TITLE
[DO NOT MERGE] Reapply "[BugFix] Fix engine hanging after KV cache initialization failure #35478"

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
 import os
 import queue
 import signal
@@ -119,9 +120,18 @@ class EngineCore:
             self._eep_scale_up_before_kv_init()
 
         # Setup KV Caches and update CacheConfig after profiling.
-        num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
-            vllm_config
-        )
+        try:
+            num_gpu_blocks, num_cpu_blocks, kv_cache_config = (
+                self._initialize_kv_caches(vllm_config)
+            )
+        except Exception:
+            logger.exception(
+                "EngineCore failed during KV cache initialization; "
+                "shutting down executor."
+            )
+            self.model_executor.shutdown()
+            raise
+
         if kv_cache_config.kv_cache_groups:
             vllm_config.cache_config.block_size = min(
                 g.kv_cache_spec.block_size for g in kv_cache_config.kv_cache_groups
@@ -971,29 +981,49 @@ class EngineCoreProc(EngineCore):
             addresses = self.startup_handshake(
                 handshake_socket, local_client, headless, parallel_config_to_update
             )
-            yield addresses
+            exc_during_init = False
+            try:
+                yield addresses
+            except Exception:
+                exc_during_init = True
+                raise
+            finally:
+                if exc_during_init:
+                    # Send FAILED status so the front-end detects init
+                    # failure immediately via ZMQ instead of waiting for
+                    # process sentinel (which may be delayed by cleanup).
+                    with contextlib.suppress(Exception):
+                        handshake_socket.send(
+                            msgspec.msgpack.encode(
+                                {
+                                    "status": "FAILED",
+                                    "local": local_client,
+                                    "headless": headless,
+                                }
+                            )
+                        )
+                else:
+                    # Send ready message.
+                    num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks
+                    # We pass back the coordinator stats update address
+                    # here for the external LB case for our colocated
+                    # front-end to use (coordinator only runs with rank 0).
+                    dp_stats_address = self.frontend_stats_publish_address
 
-            # Send ready message.
-            num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks
-            # We pass back the coordinator stats update address here for the
-            # external LB case for our colocated front-end to use (coordinator
-            # only runs with rank 0).
-            dp_stats_address = self.frontend_stats_publish_address
+                    # Include config hash for DP configuration validation
+                    ready_msg = {
+                        "status": "READY",
+                        "local": local_client,
+                        "headless": headless,
+                        "num_gpu_blocks": num_gpu_blocks,
+                        "dp_stats_address": dp_stats_address,
+                    }
+                    if vllm_config.parallel_config.data_parallel_size > 1:
+                        ready_msg["parallel_config_hash"] = (
+                            vllm_config.parallel_config.compute_hash()
+                        )
 
-            # Include config hash for DP configuration validation
-            ready_msg = {
-                "status": "READY",
-                "local": local_client,
-                "headless": headless,
-                "num_gpu_blocks": num_gpu_blocks,
-                "dp_stats_address": dp_stats_address,
-            }
-            if vllm_config.parallel_config.data_parallel_size > 1:
-                ready_msg["parallel_config_hash"] = (
-                    vllm_config.parallel_config.compute_hash()
-                )
-
-            handshake_socket.send(msgspec.msgpack.encode(ready_msg))
+                    handshake_socket.send(msgspec.msgpack.encode(ready_msg))
 
     @staticmethod
     def startup_handshake(

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1130,6 +1130,11 @@ def wait_for_engine_startup(
 
             start_pending[0 if local else 1] -= 1
             engine.state = CoreEngineState.READY
+        elif status == "FAILED":
+            raise RuntimeError(
+                f"Engine core {eng_index} reported initialization failure. "
+                "See root cause above."
+            )
         else:
             raise RuntimeError(
                 f"Unexpected {status} message for "


### PR DESCRIPTION
`Distributed Test 4 GPUs` is still failing. Testing whether this reverts fixes it

Fixes https://github.com/vllm-project/vllm/issues/36624

See https://github.com/vllm-project/vllm/pull/36628#issuecomment-4030961404

The series of relevant PRs are:

* [Core] Remove busy loop from idle buffer readers (#28053)
  * **Passed** before merging - https://buildkite.com/vllm/ci/builds/54275
* .... (omitting a bunch here)
* [BugFix] Fix engine hanging after KV cache initialization failure (#35478)
* [Frontend][Core] Add shutdown timeout - allowing in-flight requests to finish (#34730)
  * **Failed** - https://buildkite.com/vllm/ci/builds/54863
* [Bugfix] Fix inner_dp_world initialization order for multi-node TP (#35892)
  * **Failed** - https://buildkite.com/vllm/ci/builds/54864
* [Bugfix] Quickfix followups to busy loop removal in #28053 (#36068)
  * **Passed** (on PR branch!) (triggered today) - https://buildkite.com/vllm/ci/builds/54834
  * **Failed** (on main) (triggered today) - https://buildkite.com/vllm/ci/builds/54959
* Revert "[BugFix] Fix engine hanging after KV cache initialization fai… (#36262)
  * **Not tested** on PR branch
  * **Failed** (on main) (triggered after it merged?) - https://buildkite.com/vllm/ci/builds/54961
* [Core] Fix benign error log during normal shutdown (#36270)
  * **Failed** (on PR branch) (triggered today) - https://buildkite.com/vllm/ci/builds/55015
  * **Not tested** (on main) (just triggered now) - https://buildkite.com/vllm/ci/builds/55026

So it appears that reverting #36262 might be sufficient


