### PR TITLE
Fix Qwen3.5 LoRA packed module mapping

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -547,7 +547,14 @@ class Qwen3_5ForCausalLMBase(
         ],
         "gate_up_proj": ["gate_proj", "up_proj"],
         # GDN fused projections.
-        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        # `in_proj_qkv` spans the first three slices, while `in_proj_z`
+        # occupies the fourth slice in the fused projection.
+        "in_proj_qkvz": [
+            "in_proj_qkv",
+            "in_proj_qkv",
+            "in_proj_qkv",
+            "in_proj_z",
+        ],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 
@@ -650,7 +657,12 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
     supports_multimodal_pruning = False
 
     packed_modules_mapping = Qwen3VLForConditionalGeneration.packed_modules_mapping | {
-        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_qkvz": [
+            "in_proj_qkv",
+            "in_proj_qkv",
+            "in_proj_qkv",
+            "in_proj_z",
+        ],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 


### PR DESCRIPTION
## Purpose

Fix Qwen3.5 LoRA initialization for the fused GatedDeltaNet `in_proj_qkvz` projection.

`Qwen3_5GatedDeltaNet.create_qkvz_proj()` builds a fused `MergedColumnParallelLinear`
with 4 slices, but `packed_modules_mapping["in_proj_qkvz"]` only declared 2 packed
entries (`["in_proj_qkv", "in_proj_z"]`). During LoRA warmup / adapter activation,
vLLM uses this mapping to build packed LoRA tensors, and the shorter mapping causes
an `IndexError: list index out of range` in
`vllm/lora/layers/column_parallel_linear.py`.

This PR updates the packed mapping for Qwen3.5 so it matches the actual fused layout:

- slices `0, 1, 2` map to `in_proj_qkv`
- slice `3` maps to `in_proj_z`

This is a targeted fix for the crash reported in:
- #36478
- #36372

## Test Plan

1. Reproduce the issue with a Qwen3.5 model + LoRA adapter.
   Before this change, engine initialization fails during LoRA warmup / CUDA graph
   capture with:

   ```text
   IndexError: list index out of range
   ...
   vllm/lora/layers/column_parallel_linear.py", line 268, in set_lora
   if (lora_a_i := lora_a[i]) is not None:
   ```

2. Apply this patch and rerun the same Qwen3.5 + LoRA initialization path.

3. Sanity check the edited module:

   ```bash
   python -m compileall vllm/model_executor/models/qwen3_5.py
   ```

## Test Result

- `python -m compileall vllm/model_executor/models/qwen3_5.py` passes.
- Static validation:
  - `create_qkvz_proj()` creates a 4-slice fused projection.
  - the Qwen3.5 weight loader already treats slices `0,1,2` as `in_proj_qkv`
    and slice `3` as `in_proj_z`.
  - after this change, `packed_modules_mapping["in_proj_qkvz"]` matches that
    4-slice layout.

- Runtime behavior before this change:
  - Qwen3.5 + LoRA could fail during engine startup with the `IndexError` above.

- Runtime behavior after this change:
  - [replace this line with your rerun result, e.g. “engine initializes successfully and no longer crashes during LoRA warmup”]

## Notes

- No documentation update needed.
- No release note update planned; this is a targeted bug fix.
