### PR TITLE
platforms: Fix Ray DP startup crash

### DIFF
--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -638,6 +638,11 @@ class Platform:
         """Raises if this request is unsupported on this platform"""
 
     def __getattr__(self, key: str):
+        # Pickle checks dunder methods like __getstate__. If we return None
+        # for them, pickle treats it like a real value and tries to call it.
+        if key.startswith("__") and key.endswith("__"):
+            raise AttributeError(key)
+
         device = getattr(torch, self.device_type, None)
         if device is not None and hasattr(device, key):
             attr = getattr(device, key)


### PR DESCRIPTION
## Purpose
PR #35122 broke Ray DP startup because
`self.collective_rpc(_update_block_size)` pickles the nested callback.

When pickle serializes that callback, it checks dunder methods like
`__getstate__` on `current_platform`. `Platform` was returning `None` for
missing dunder methods, which pickle treats like a valid value, so it tried
to call `None` and crashed with `'NoneType' object is not callable`.

Raise `AttributeError` for missing dunder methods instead so pickle treats
them as missing.

## Test Result
`tests/distributed/test_elastic_ep.py` which uses Ray DP backend passes