### PR TITLE
Remove unused config field from Gemma2

### DIFF
--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -63,7 +63,6 @@ class Gemma2MLP(nn.Module):
         self,
         hidden_size: int,
         intermediate_size: int,
-        hidden_act: str,
         hidden_activation: str,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
@@ -83,11 +82,10 @@ class Gemma2MLP(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.down_proj",
         )
-        if not (hidden_act == hidden_activation == "gelu_pytorch_tanh"):
+        if not (hidden_activation == "gelu_pytorch_tanh"):
             raise ValueError(
                 "Gemma2 uses `gelu_pytorch_tanh` as the hidden activation "
-                "function. Please set `hidden_act` and `hidden_activation` to "
-                "`gelu_pytorch_tanh`."
+                "function. Please set `hidden_activation` to `gelu_pytorch_tanh`."
             )
         self.act_fn = GeluAndMul(approximate="tanh")
 
@@ -212,7 +210,6 @@ class Gemma2DecoderLayer(nn.Module):
         self.mlp = Gemma2MLP(
             hidden_size=self.hidden_size,
             intermediate_size=config.intermediate_size,
-            hidden_act=config.hidden_act,
             hidden_activation=config.hidden_activation,
             quant_config=quant_config,
             prefix=f"{prefix}.mlp",


### PR DESCRIPTION
Supersedes https://github.com/vllm-project/vllm/pull/30411.

`hidden_act` was only ever used in Gemma 1 but was copied over to Gemma 2.

No version of Transformers supported by vLLM has `hidden_act` in `Gemma2Config`, so we remove it here which should have no effect.

It is only a coincidence that the official Gemma 2 `config.json`s contain `hidden_act` and `hidden_activation`. Any fine-tunes or quants generated with Transformers would not have `hidden_act` and would therefore not be loadable in vLLM prior to this PR.