### PR TITLE
[Test] Add basic unittests for `split_graph`

### DIFF
--- a/tests/compile/test_graph_partition.py
+++ b/tests/compile/test_graph_partition.py
@@ -16,6 +16,168 @@ from vllm.compilation.passes.fx_utils import find_op_nodes
 from . import silly_attention  # noqa: F401
 
 
+def test_no_split():
+    """
+    Test that passing an empty split_ops list leaves the graph unsplit.
+    """
+
+    def model_fn(x: torch.Tensor) -> torch.Tensor:
+        x = x * 2
+        x = torch.relu(x)
+        x = x - 3
+        return x
+
+    x = torch.randn(6, 4)
+    gm = make_fx(model_fn)(x)
+    split_gm, split_items = split_graph(gm, splitting_ops=[])
+
+    # Check: no split ops, should not split the graph
+    assert len(split_items) == 1, "Graph should not be split"
+
+    # Check: outputs should match
+    new_x = torch.randn(6, 4)
+    output_original = gm(new_x)
+    output_split = split_gm(new_x)
+    assert torch.allclose(output_original, output_split), (
+        "Output mismatch when no split"
+    )
+
+
+def test_single_split_op():
+    """
+    Test splitting on a single op type, verifying submodule count,
+    per-submodule op targets, and is_splitting_graph flags.
+    """
+
+    def model_fn(x: torch.Tensor) -> torch.Tensor:
+        x = x + 1
+        x = torch.relu(x)
+        x = x + 2
+        return x
+
+    x = torch.randn(5, 3)
+    gm = make_fx(model_fn)(x)
+    split_gm, split_items = split_graph(gm, splitting_ops=["aten::relu"])
+
+    # Check: Split on relu, should create 3 submodules
+    assert len(split_items) == 3, "Graph should be split into 3 submodules"
+
+    # Check: Each submodule details
+    expected_targets = [
+        torch.ops.aten.add.Tensor,
+        torch.ops.aten.relu.default,
+        torch.ops.aten.add.Tensor,
+    ]
+    expected_is_splitting = [False, True, False]
+    for split_item, expected_target, expected_splitting in zip(
+        split_items, expected_targets, expected_is_splitting
+    ):
+        call_func_nodes = [
+            n for n in split_item.graph.graph.nodes if n.op == "call_function"
+        ]
+        assert len(call_func_nodes) == 1
+        assert call_func_nodes[0].target == expected_target
+        assert split_item.is_splitting_graph == expected_splitting, (
+            f"Submodule with {expected_target} should have "
+            f"is_splitting_graph={expected_splitting}"
+        )
+
+    # Check: outputs should match
+    new_x = torch.randn(5, 3)
+    output_original = gm(new_x)
+    output_split = split_gm(new_x)
+    assert torch.allclose(output_original, output_split), "Output mismatch after split"
+
+
+def test_split_op_at_boundaries():
+    """
+    Test that split ops at the very start or end of the graph produce correct
+    submodule counts and output values (no empty/degenerate subgraph surprises).
+    """
+
+    def model_leading(x: torch.Tensor) -> torch.Tensor:
+        # relu is the first op — nothing before it
+        x = torch.relu(x)
+        x = x + 1
+        return x
+
+    def model_trailing(x: torch.Tensor) -> torch.Tensor:
+        # relu is the last op — nothing after it
+        x = x + 1
+        x = torch.relu(x)
+        return x
+
+    x = torch.randn(4, 4)
+
+    for model_fn in (model_leading, model_trailing):
+        gm = make_fx(model_fn)(x)
+        split_gm, split_items = split_graph(gm, splitting_ops=["aten::relu"])
+
+        # Check: should split into exactly 2 submodules (one splitting, one not)
+        assert len(split_items) == 2, (
+            f"{model_fn.__name__}: expected 2 submodules, got {len(split_items)}"
+        )
+
+        # Check: exactly one submodule should be the splitting graph containing relu
+        splitting_items = [s for s in split_items if s.is_splitting_graph]
+        assert len(splitting_items) == 1, (
+            f"{model_fn.__name__}: expected exactly 1 splitting subgraph"
+        )
+
+        # Check outputs match
+        new_x = torch.randn(4, 4)
+        output_original = gm(new_x)
+        output_split = split_gm(new_x)
+        assert torch.allclose(output_original, output_split), (
+            f"Output mismatch for {model_fn.__name__}"
+        )
+
+
+def test_repeated_split_op():
+    """
+    Test that each occurrence of the same split op creates its own splitting
+    subgraph, and non-splitting subgraphs in between are correctly identified.
+    """
+
+    def model_fn(x: torch.Tensor) -> torch.Tensor:
+        x = x + 1
+        x = torch.relu(x)  # split point 1
+        x = x + 2
+        x = torch.relu(x)  # split point 2
+        x = x + 3
+        return x
+
+    x = torch.randn(3, 3)
+    gm = make_fx(model_fn)(x)
+    split_gm, split_items = split_graph(gm, splitting_ops=["aten::relu"])
+
+    # Check: should split into 5 submodules: [add, relu, add, relu, add]
+    assert len(split_items) == 5, (
+        f"Expected 5 submodules for two relu splits, got {len(split_items)}"
+    )
+
+    # Check: should have 2 splitting subgraphs, each containing one relu
+    splitting_items = [s for s in split_items if s.is_splitting_graph]
+    assert len(splitting_items) == 2, (
+        f"Expected 2 splitting subgraphs (one per relu), got {len(splitting_items)}"
+    )
+    for item in splitting_items:
+        relu_nodes = [
+            n
+            for n in item.graph.graph.nodes
+            if n.op == "call_function" and n.target == torch.ops.aten.relu.default
+        ]
+        assert len(relu_nodes) == 1, (
+            "Each splitting subgraph should contain exactly one relu"
+        )
+
+    # Check outputs match
+    new_x = torch.randn(3, 3)
+    output_original = gm(new_x)
+    output_split = split_gm(new_x)
+    assert torch.allclose(output_original, output_split), "Output mismatch after split"
+
+
 def test_getitem_moved_to_producer_subgraph():
     """
     Test that getitem operations are moved to the same subgraph as their input,

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -577,24 +577,22 @@ def split_graph(
         graph, None, lambda node: node_to_subgraph_id[node], keep_original_order=True
     )
 
-    outputs = []
-
-    names = [name for (name, module) in split_gm.named_modules()]
-
-    for name in names:
+    # Collect per-subgraph metadata: id, role (splitting vs. non-splitting),
+    # and a reference to the submodule inside split_gm.
+    split_items: list[SplitItem] = []
+    for name, _ in split_gm.named_modules():
         if "." in name or name == "":
             # recursive child module or the root module
             continue
-
         module = getattr(split_gm, name)
-
         graph_id = int(name.replace("submod_", ""))
-        outputs.append(SplitItem(name, graph_id, (graph_id in split_op_graphs), module))
-
+        split_items.append(
+            SplitItem(name, graph_id, (graph_id in split_op_graphs), module)
+        )
     # sort by integer graph_id, rather than string name
-    outputs.sort(key=lambda x: x.graph_id)
+    split_items.sort(key=lambda x: x.graph_id)
 
-    return split_gm, outputs
+    return split_gm, split_items
 
 
 compilation_start_time = 0.0


### PR DESCRIPTION
## Purpose

 
Added basic unit tests for `split_graph` to cover standard scenarios that were missing alongside the existing edge-case tests:
1. `test_no_split`: empty `splitting_ops` leaves the graph intact
2. `test_single_split_op`: single op split, verifies submodule count and `is_splitting_graph` flags
3. `test_split_op_at_boundaries`: split op at graph start/end produces no empty subgraphs
4. `test_repeated_split_op`: repeated op each gets its own splitting subgraph

Also, renamed `outputs` → `split_items` in `split_graph` to match call-site
convention, and removed the intermediate `names` variable.

## Test Plan

`python -m pytest -W ignore -v tests/compile/test_graph_partition.py`

## Test Result

<img width="1901" height="615" alt="image" src="https://github.com/user-attachments/assets/41c34606-9f35-4bdd-8ea9-ff2e4868c967" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

