### PR TITLE
Compute MM Pre-processing Timing Metrics in a Non-Blocking Way for Prod (#36685) (#36685) (#36685) (#36685)

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -209,3 +209,52 @@ def test_prompt_token_stats_full_external_transfer_recompute():
     assert stats.local_cache_hit == 0
     assert stats.external_kv_transfer == 1000
     assert stats.recomputed_tokens == 1
+
+
+def test_mm_timing_metrics_propagated_to_finished_request():
+    """Test that MM timing metrics are propagated to FinishedRequestStats."""
+    iteration_stats = IterationStats()
+    req_stats = RequestStateStats(arrival_time=0.0)
+    req_stats.scheduled_ts = 0.1
+    req_stats.first_token_ts = 0.5
+    req_stats.last_token_ts = 2.0
+    req_stats.num_generation_tokens = 10
+    req_stats.mm_preprocess_time_s = 0.123
+    req_stats.mm_cache_time_s = 0.045
+    req_stats.mm_encoder_time_s = 0.678
+
+    iteration_stats.update_from_finished_request(
+        finish_reason=FinishReason.STOP,
+        num_prompt_tokens=1000,
+        max_tokens_param=100,
+        req_stats=req_stats,
+        num_cached_tokens=0,
+    )
+
+    finished_req = iteration_stats.finished_requests[0]
+    assert finished_req.mm_preprocess_time_s == 0.123
+    assert finished_req.mm_cache_time_s == 0.045
+    assert finished_req.mm_encoder_time_s == 0.678
+
+
+def test_mm_timing_metrics_default_zero():
+    """Test that MM timing metrics default to 0 for non-MM requests."""
+    iteration_stats = IterationStats()
+    req_stats = RequestStateStats(arrival_time=0.0)
+    req_stats.scheduled_ts = 0.1
+    req_stats.first_token_ts = 0.5
+    req_stats.last_token_ts = 2.0
+    req_stats.num_generation_tokens = 10
+
+    iteration_stats.update_from_finished_request(
+        finish_reason=FinishReason.STOP,
+        num_prompt_tokens=500,
+        max_tokens_param=50,
+        req_stats=req_stats,
+        num_cached_tokens=0,
+    )
+
+    finished_req = iteration_stats.finished_requests[0]
+    assert finished_req.mm_preprocess_time_s == 0.0
+    assert finished_req.mm_cache_time_s == 0.0
+    assert finished_req.mm_encoder_time_s == 0.0

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -172,6 +172,7 @@ class InputPreprocessor:
                 multi_modal_data,
                 parsed_content.get("mm_processor_kwargs") or {},
                 tokenization_kwargs=tokenization_kwargs,
+                mm_uuids=parsed_content.get("multi_modal_uuids"),
             )
         else:
             prompt_token_ids = self._tokenize_prompt(

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -1062,6 +1062,16 @@ A dictionary containing per-item placeholder ranges for each modality.
 """
 
 
+class MMTimingStats(TypedDict, total=False):
+    """Timing statistics for multimodal preprocessing stages."""
+
+    mm_preprocess_time_s: float
+    """Time in seconds spent in multimodal preprocessing."""
+
+    mm_cache_time_s: float
+    """Time in seconds spent in multimodal cache operations."""
+
+
 class MultiModalInputs(_InputOptions):
     """
     Represents the outputs of
@@ -1089,6 +1099,9 @@ class MultiModalInputs(_InputOptions):
     For each modality, information about the placeholder tokens in
     `prompt_token_ids`.
     """
+
+    mm_timing_stats: NotRequired[MMTimingStats]
+    """Timing statistics for multimodal preprocessing and cache operations."""
 
 
 def mm_inputs(

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1673,12 +1673,30 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             for modality, placeholders in mm_placeholders.items()
         }
 
-        return mm_inputs(
+        result = mm_inputs(
             prompt_token_ids=prompt_ids,
             mm_kwargs=mm_info.kwargs,
             mm_hashes=mm_info.hashes,
             mm_placeholders=mm_placeholder_ranges,
         )
+
+        # Compute cache time from individually recorded stages.
+        # These stages only exist in the cached path.
+        if "get_cache_missing_items" in timing_ctx.stage_secs:
+            cache_time = sum(
+                timing_ctx.stage_secs.get(k, 0.0)
+                for k in (
+                    "get_mm_hashes",
+                    "get_cache_missing_items",
+                    "merge_mm_kwargs",
+                )
+            )
+            if cache_time > 0.0:
+                timing_stats = result.get("mm_timing_stats", {})
+                timing_stats["mm_cache_time_s"] = cache_time
+                result["mm_timing_stats"] = timing_stats
+
+        return result
 
 
 class EncDecMultiModalProcessor(BaseMultiModalProcessor[_I]):

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -620,9 +620,15 @@ class BaseRenderer(ABC, Generic[_T]):
             tokenization_kwargs=tokenization_kwargs or {},
         )
         mm_timing_ctx = self._mm_timing_registry.get(mm_req_id)
+        mm_timing_ctx.enabled = True
 
         with set_default_torch_num_threads():
             mm_inputs = mm_processor.apply(mm_processor_inputs, mm_timing_ctx)
+
+        if mm_timing_ctx.total_secs > 0.0:
+            timing_stats = mm_inputs.get("mm_timing_stats", {})
+            timing_stats["mm_preprocess_time_s"] = mm_timing_ctx.total_secs
+            mm_inputs["mm_timing_stats"] = timing_stats
 
         self.update_mm_cache_stats()
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1285,6 +1285,7 @@ class Scheduler(SchedulerInterface):
         num_nans_in_logits = model_runner_output.num_nans_in_logits
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats = model_runner_output.cudagraph_stats
+        mm_encoder_time_s_map = model_runner_output.mm_encoder_time_s
 
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():
@@ -1418,6 +1419,15 @@ class Scheduler(SchedulerInterface):
             if num_nans_in_logits is not None and req_id in num_nans_in_logits:
                 request.num_nans_in_logits = num_nans_in_logits[req_id]
 
+            # Accumulate MM encoder timing for this request.
+            req_encoder_time_s = 0.0
+            if (
+                mm_encoder_time_s_map is not None
+                and req_id in mm_encoder_time_s_map
+            ):
+                request.mm_encoder_time_s += mm_encoder_time_s_map[req_id]
+                req_encoder_time_s = request.mm_encoder_time_s
+
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
             if (
@@ -1443,6 +1453,7 @@ class Scheduler(SchedulerInterface):
                         num_external_computed_tokens=request.num_external_computed_tokens,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
+                        mm_encoder_time_s=req_encoder_time_s,
                     )
                 )
             else:

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -101,6 +101,9 @@ class EngineCoreRequest(
 
     reasoning_ended: bool | None = None
 
+    mm_preprocess_time_s: float = 0.0
+    mm_cache_time_s: float = 0.0
+
     @property
     def params(self) -> SamplingParams | PoolingParams:
         """Return the processed params (sampling or pooling)."""
@@ -165,6 +168,8 @@ class EngineCoreOutput(
     # The number of NaNs in logits.
     # A value greater than 0 indicates that the output is corrupted.
     num_nans_in_logits: int = 0
+
+    mm_encoder_time_s: float = 0.0
 
     @property
     def finished(self) -> bool:

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -275,6 +275,10 @@ class InputProcessor:
         # Multimodal related.
         mm_features: list[MultiModalFeatureSpec] | None = None
 
+        # MM timing metrics (only present for multimodal requests).
+        mm_preprocess_time_s = 0.0
+        mm_cache_time_s = 0.0
+
         if decoder_inputs["type"] == "multimodal":
             decoder_mm_inputs = decoder_inputs["mm_kwargs"]
             decoder_mm_positions = decoder_inputs["mm_placeholders"]
@@ -310,6 +314,12 @@ class InputProcessor:
                     )
                 )
 
+            # Extract MM timing metrics from processing results.
+            mm_timing_stats = decoder_inputs.get("mm_timing_stats", {})
+            mm_preprocess_time_s = mm_timing_stats.get(
+                "mm_preprocess_time_s", 0.0)
+            mm_cache_time_s = mm_timing_stats.get("mm_cache_time_s", 0.0)
+
         return EngineCoreRequest(
             request_id=request_id,
             prompt_token_ids=prompt_token_ids,
@@ -324,6 +334,8 @@ class InputProcessor:
             data_parallel_rank=data_parallel_rank,
             trace_headers=trace_headers,
             resumable=resumable,
+            mm_preprocess_time_s=mm_preprocess_time_s,
+            mm_cache_time_s=mm_cache_time_s,
         )
 
     def _validate_prompt_len(

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -149,6 +149,8 @@ class RequestState:
         n: int | None = None,
         temperature: float | None = None,
         stream_input: bool = False,
+        mm_preprocess_time_s: float = 0.0,
+        mm_cache_time_s: float = 0.0,
     ):
         self.request_id = request_id
         self.external_req_id = external_req_id
@@ -174,6 +176,13 @@ class RequestState:
         self.num_cached_tokens = 0
 
         self.stats = RequestStateStats(arrival_time=arrival_time) if log_stats else None
+
+        # Multimodal timing metrics.
+        self.mm_preprocess_time_s = mm_preprocess_time_s
+        self.mm_cache_time_s = mm_cache_time_s
+        if self.stats is not None:
+            self.stats.mm_preprocess_time_s = mm_preprocess_time_s
+            self.stats.mm_cache_time_s = mm_cache_time_s
 
         # Stream Interval
         self.stream_interval = stream_interval
@@ -264,6 +273,8 @@ class RequestState:
             log_stats=log_stats,
             stream_interval=stream_interval,
             stream_input=request.resumable,
+            mm_preprocess_time_s=request.mm_preprocess_time_s,
+            mm_cache_time_s=request.mm_cache_time_s,
         )
 
     def make_request_output(

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -132,6 +132,11 @@ class LoggingStatLogger(StatLoggerBase):
         self.num_corrupted_reqs: int = 0
         self.num_preemptions: int = 0
 
+        # Multimodal timing samples collected during this interval.
+        self.mm_preprocess_times: list[float] = []
+        self.mm_cache_times: list[float] = []
+        self.mm_encoder_times: list[float] = []
+
     def _enable_perf_stats(self) -> bool:
         return self.vllm_config.observability_config.enable_mfu_metrics
 
@@ -142,6 +147,19 @@ class LoggingStatLogger(StatLoggerBase):
         self.num_generation_tokens += iteration_stats.num_generation_tokens
         self.num_corrupted_reqs += iteration_stats.num_corrupted_reqs
         self.num_preemptions += iteration_stats.num_preempted_reqs
+
+        # Collect MM timing samples from finished requests.
+        for finished_req in iteration_stats.finished_requests:
+            if finished_req.mm_preprocess_time_s > 0.0:
+                self.mm_preprocess_times.append(
+                    finished_req.mm_preprocess_time_s
+                )
+            if finished_req.mm_cache_time_s > 0.0:
+                self.mm_cache_times.append(finished_req.mm_cache_time_s)
+            if finished_req.mm_encoder_time_s > 0.0:
+                self.mm_encoder_times.append(
+                    finished_req.mm_encoder_time_s
+                )
 
     def _get_throughput(self, tracked_stats: int, now: float) -> float:
         # Compute summary metrics for tracked stats
@@ -193,6 +211,23 @@ class LoggingStatLogger(StatLoggerBase):
         now = time.monotonic()
         prompt_throughput = self._get_throughput(self.num_prompt_tokens, now)
         generation_throughput = self._get_throughput(self.num_generation_tokens, now)
+
+        # Compute MM timing averages before _reset() clears the lists.
+        self.last_mm_preprocess_avg = (
+            sum(self.mm_preprocess_times) / len(self.mm_preprocess_times)
+            if self.mm_preprocess_times
+            else 0.0
+        )
+        self.last_mm_cache_avg = (
+            sum(self.mm_cache_times) / len(self.mm_cache_times)
+            if self.mm_cache_times
+            else 0.0
+        )
+        self.last_mm_encoder_avg = (
+            sum(self.mm_encoder_times) / len(self.mm_encoder_times)
+            if self.mm_encoder_times
+            else 0.0
+        )
 
         self._reset(now)
         self.engine_is_idle = not any(
@@ -267,6 +302,28 @@ class LoggingStatLogger(StatLoggerBase):
             self.cudagraph_logging.log(log_fn=log_fn)
         if self._enable_perf_stats():
             self.perf_metrics_logging.log(log_fn=log_fn, log_prefix=self.log_prefix)
+
+        # Log multimodal timing averages (only when MM requests exist).
+        if (
+            self.last_mm_preprocess_avg > 0.0
+            or self.last_mm_cache_avg > 0.0
+            or self.last_mm_encoder_avg > 0.0
+        ):
+            mm_parts: list[str] = []
+            mm_args: list[float] = []
+            if self.last_mm_preprocess_avg > 0.0:
+                mm_parts.append("Avg MM preprocess: %.3fs")
+                mm_args.append(self.last_mm_preprocess_avg)
+            if self.last_mm_cache_avg > 0.0:
+                mm_parts.append("Avg MM cache: %.3fs")
+                mm_args.append(self.last_mm_cache_avg)
+            if self.last_mm_encoder_avg > 0.0:
+                mm_parts.append("Avg MM encoder: %.3fs")
+                mm_args.append(self.last_mm_encoder_avg)
+            log_fn(
+                self.log_prefix + ", ".join(mm_parts),
+                *mm_args,
+            )
 
     def log_engine_initialized(self):
         if self.vllm_config.cache_config.num_gpu_blocks:
@@ -903,6 +960,69 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
 
         #
+        # Multimodal timing histograms
+        #
+        mm_timing_buckets = [
+            0.001,
+            0.005,
+            0.01,
+            0.02,
+            0.04,
+            0.06,
+            0.08,
+            0.1,
+            0.25,
+            0.5,
+            0.75,
+            1.0,
+            2.5,
+            5.0,
+            7.5,
+            10.0,
+            20.0,
+            40.0,
+            80.0,
+            160.0,
+        ]
+
+        histogram_mm_preprocess_time = self._histogram_cls(
+            name="vllm:request_mm_preprocess_time_seconds",
+            documentation=(
+                "Histogram of multimodal preprocessing time in seconds."
+            ),
+            buckets=mm_timing_buckets,
+            labelnames=labelnames,
+        )
+        self.histogram_mm_preprocess_time = make_per_engine(
+            histogram_mm_preprocess_time, engine_indexes, model_name
+        )
+
+        histogram_mm_cache_time = self._histogram_cls(
+            name="vllm:request_mm_cache_time_seconds",
+            documentation=(
+                "Histogram of multimodal cache operation time in seconds."
+            ),
+            buckets=mm_timing_buckets,
+            labelnames=labelnames,
+        )
+        self.histogram_mm_cache_time = make_per_engine(
+            histogram_mm_cache_time, engine_indexes, model_name
+        )
+
+        histogram_mm_encoder_time = self._histogram_cls(
+            name="vllm:request_mm_encoder_time_seconds",
+            documentation=(
+                "Histogram of multimodal encoder forward pass time "
+                "in seconds."
+            ),
+            buckets=mm_timing_buckets,
+            labelnames=labelnames,
+        )
+        self.histogram_mm_encoder_time = make_per_engine(
+            histogram_mm_encoder_time, engine_indexes, model_name
+        )
+
+        #
         # KV Cache residency metrics
         #
         if self.kv_cache_metrics_enabled:
@@ -1178,6 +1298,20 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             if finished_request.max_tokens_param:
                 self.histogram_max_tokens_request[engine_idx].observe(
                     finished_request.max_tokens_param
+                )
+
+            # Observe MM timing metrics (only for multimodal requests).
+            if finished_request.mm_preprocess_time_s > 0.0:
+                self.histogram_mm_preprocess_time[engine_idx].observe(
+                    finished_request.mm_preprocess_time_s
+                )
+            if finished_request.mm_cache_time_s > 0.0:
+                self.histogram_mm_cache_time[engine_idx].observe(
+                    finished_request.mm_cache_time_s
+                )
+            if finished_request.mm_encoder_time_s > 0.0:
+                self.histogram_mm_encoder_time[engine_idx].observe(
+                    finished_request.mm_encoder_time_s
                 )
 
     def record_sleep_state(self, sleep: int = 0, level: int = 0):

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -218,6 +218,11 @@ class RequestStateStats:
     # Track if this request is corrupted (NaNs in logits)
     is_corrupted: bool = False
 
+    # Multimodal timing metrics (seconds).
+    mm_preprocess_time_s: float = 0.0
+    mm_cache_time_s: float = 0.0
+    mm_encoder_time_s: float = 0.0
+
 
 @dataclass
 class FinishedRequestStats:
@@ -235,6 +240,11 @@ class FinishedRequestStats:
     mean_time_per_output_token: float = 0.0
     is_corrupted: bool = False
     num_cached_tokens: int = 0
+
+    # Multimodal timing metrics (seconds).
+    mm_preprocess_time_s: float = 0.0
+    mm_cache_time_s: float = 0.0
+    mm_encoder_time_s: float = 0.0
 
 
 @dataclass
@@ -363,6 +373,10 @@ class IterationStats:
         ):
             req_stats.is_corrupted = True
 
+        # Propagate MM encoder timing.
+        if output.mm_encoder_time_s > 0.0:
+            req_stats.mm_encoder_time_s = output.mm_encoder_time_s
+
         # Process request-level engine core events
         if output.events is not None:
             self.update_from_events(
@@ -452,6 +466,9 @@ class IterationStats:
             mean_time_per_output_token=mean_time_per_output_token,
             is_corrupted=req_stats.is_corrupted,
             num_cached_tokens=num_cached_tokens,
+            mm_preprocess_time_s=req_stats.mm_preprocess_time_s,
+            mm_cache_time_s=req_stats.mm_cache_time_s,
+            mm_encoder_time_s=req_stats.mm_encoder_time_s,
         )
         self.finished_requests.append(finished_req)
 

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -253,6 +253,10 @@ class ModelRunnerOutput:
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
 
+    # Per-request MM encoder timing (req_id -> seconds).
+    # Populated by gpu_model_runner via CUDA events.
+    mm_encoder_time_s: dict[str, float] | None = None
+
 
 # ModelRunnerOutput wrapper for async scheduling.
 class AsyncModelRunnerOutput(ABC):

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -162,6 +162,9 @@ class Request:
         # The number of tokens that have been computed remotely.
         self.num_external_computed_tokens = 0
 
+        # Multimodal encoder timing (seconds).
+        self.mm_encoder_time_s: float = 0.0
+
         self.block_hashes: list[BlockHash] = []
         # Store the block hasher without binding self to avoid creating a
         # reference cycle (Request -> partial -> Request) that prevents

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -652,6 +652,11 @@ class GPUModelRunner(
         self.encoder_timing_registry: dict[str, EncoderTimingStats] = {}
         self._encoder_timing_lock = threading.Lock()
 
+        # Non-blocking CUDA events for always-on MM encoder timing.
+        self._mm_encoder_events: (
+            tuple[torch.cuda.Event, torch.cuda.Event, set[str]] | None
+        ) = None
+
         # Persistent buffers for CUDA graphs.
         self.input_ids = self._make_buffer(self.max_num_tokens, dtype=torch.int32)
         self.positions = self._make_buffer(self.max_num_tokens, dtype=torch.int64)
@@ -2544,6 +2549,10 @@ class GPUModelRunner(
         if not mm_kwargs:
             return []
 
+        # Non-blocking CUDA event for encoder timing (always-on).
+        mm_start_event = torch.cuda.Event(enable_timing=True)
+        mm_start_event.record()
+
         should_time = bool(
             self.observability_config
             and self.observability_config.enable_mm_processor_stats
@@ -2684,6 +2693,12 @@ class GPUModelRunner(
             self.encoder_cache[mm_hash] = output
             logger.debug("Finish execute for mm hash %s", mm_hash)
             self.maybe_save_ec_to_connector(self.encoder_cache, mm_hash)
+
+        # Store events for deferred readback in sample_tokens().
+        mm_end_event = torch.cuda.Event(enable_timing=True)
+        mm_end_event.record()
+        mm_req_ids = set(scheduler_output.scheduled_encoder_inputs.keys())
+        self._mm_encoder_events = (mm_start_event, mm_end_event, mm_req_ids)
 
         return encoder_outputs
 
@@ -4086,6 +4101,27 @@ class GPUModelRunner(
                 else:
                     logger.error("RoutedExpertsCapturer not initialized.")
 
+            # Read deferred MM encoder timing (CUDA events).
+            # By this point the full model forward pass has completed,
+            # so end_evt.synchronize() returns immediately (no GPU wait).
+            mm_encoder_time_s: dict[str, float] | None = None
+            if self._mm_encoder_events is not None:
+                start_evt, end_evt, encoder_req_ids = self._mm_encoder_events
+                end_evt.synchronize()
+                total_ms = start_evt.elapsed_time(end_evt)
+                num_reqs = len(encoder_req_ids)
+                # NOTE: per_req_s is the total encoder time averaged equally
+                # across all requests in this batch. For batches with varying
+                # numbers of images or resolutions per request, this is an
+                # approximation rather than a true per-request measurement.
+                per_req_s = (
+                    (total_ms / 1000.0 / num_reqs) if num_reqs else 0.0
+                )
+                mm_encoder_time_s = {
+                    req_id: per_req_s for req_id in encoder_req_ids
+                }
+                self._mm_encoder_events = None
+
             output = ModelRunnerOutput(
                 req_ids=req_ids_output_copy,
                 req_id_to_index=req_id_to_index_output_copy,
@@ -4098,6 +4134,7 @@ class GPUModelRunner(
                 else None,
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
+                mm_encoder_time_s=mm_encoder_time_s,
             )
 
         if not self.use_async_scheduling:


### PR DESCRIPTION
Summary:
This PR introduces an always-on, non-blocking timing instrumentation for multimodal (MM) request processing in the vLLM V1 engine: *preprocessing*, *cache operations*, and *vision encoder forward pass*. These per-request metrics are plumbed through the full engine pipeline (renderer → input processor → scheduler → output processor → stats) so they can be consumed by downstream observability.

In particular, we introduce the following three timing metrics:
  - `mm_preprocess_time_s`: CPU wall-clock time for the entire MM preprocessing pass (HF processor apply, image transforms, tokenization). Measured in `renderers/base.py` via `time.monotonic()`.
  - `mm_cache_time_s`: CPU wall-clock time for MM cache hash lookup and merge operations. Measured in `multimodal/processing/processor.py` via `time.monotonic()`.
  - `mm_encoder_time_s`: GPU wall-clock time for the vision encoder forward pass. Measured via non-blocking CUDA timing events in `gpu_model_runner.py`.

**Why non-blocking / why this is necessary:**
The existing vLLM trunk timing infrastructure (`timed_encoder_operation`, gated behind `enable_mm_processor_stats`) uses `torch.cuda.synchronize()` — a full GPU pipeline drain — before and after each encoder group invocation. This can potentially stall the CPU/GPU overlap critical for serving throughput, making it unsuitable for production (it is explicitly documented as "for internal use only, e.g., benchmarks" and defaults to `False`).

This PR  takes a fundamentally different approach using CUDA timing events (`torch.cuda.Event(enable_timing=True)`). Events are recorded directly on the CUDA stream with no CPU-GPUsynchronization at record time. The timing is read back via `start_evt.elapsed_time(end_evt)` only after the full model forward pass and sampling have completed — at which point the GPU has long since passed the encoder event positions, so `end_evt.synchronize()` returns immediately with zero GPU wait.

The CPU-side metrics (`mm_preprocess_time_s`, `mm_cache_time_s`) use `time.monotonic()` to wrap existing operations with no additional synchronization overhead.

Together, these three metrics provide production-safe observability into multimodal processing latency in vLLM, covering the full MM pipeline (download/decode → preprocess → cache → encode) without any performance penalty.


Test Plan: CI Tests

Pulled By:
d-biswa

d-biswa

d-biswa

d-biswa

Differential Revision: D95818911
