### PR TITLE
[Bugfix] Fix DeepSeek V3.2 OOM during CG memory profiling

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5551,6 +5551,7 @@ class GPUModelRunner(
         kv_cache_groups = get_kv_cache_groups(self.vllm_config, kv_cache_spec)
         min_blocks = self.compilation_config.max_cudagraph_capture_size or 1
 
+        # Temporarily change num_gpu_blocks_override to allocate a minimal KV cache
         saved_override = self.cache_config.num_gpu_blocks_override
         self.cache_config.num_gpu_blocks_override = min_blocks
         minimal_config = get_kv_cache_config_from_groups(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5550,16 +5550,13 @@ class GPUModelRunner(
         kv_cache_spec = self.get_kv_cache_spec()
         kv_cache_groups = get_kv_cache_groups(self.vllm_config, kv_cache_spec)
         min_blocks = self.compilation_config.max_cudagraph_capture_size or 1
-        if kv_cache_groups:
-            page_size = kv_cache_groups[0].kv_cache_spec.page_size_bytes
-            group_size = max(len(g.layer_names) for g in kv_cache_groups)
-            available_memory = min_blocks * page_size * group_size
-        else:
-            available_memory = 1  # Attention-free model
 
+        saved_override = self.cache_config.num_gpu_blocks_override
+        self.cache_config.num_gpu_blocks_override = min_blocks
         minimal_config = get_kv_cache_config_from_groups(
-            self.vllm_config, kv_cache_groups, available_memory=available_memory
+            self.vllm_config, kv_cache_groups, available_memory=0
         )
+        self.cache_config.num_gpu_blocks_override = saved_override
 
         self.initialize_kv_cache(minimal_config)
         self.cache_config.num_gpu_blocks = minimal_config.num_blocks


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
The cudagraph memory profiler added in #30515 did not account for `UniformTypeKVCacheSpecs` in `init_minimal_kv_cache_for_profiling`, so the `page_size` was being improperly multiplied by the `group_size`, causing an allocation that was 61x too large. This PR fixes this and takes advantage of the existing `num_blocks` override mechanism instead of spoofing the available memory, so it should be more robust.

## Test Plan
```
vllm serve deepseek-ai/DeepSeek-V3.2 -tp 8
```

## Test Result
main: OOM during startup
PR: starts up successfully

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

