### PR TITLE
Use client-provided UUIDs directly as cache keys (#36692) 

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -309,6 +309,7 @@ class ModelConfig:
     mm_encoder_attn_backend: InitVar[AttentionBackendEnum | str | None] = None
     interleave_mm_strings: InitVar[bool | None] = None
     skip_mm_profiling: InitVar[bool | None] = None
+    enable_client_mm_cache_keys: InitVar[bool | None] = None
     video_pruning_rate: InitVar[float | None] = None
 
     def compute_hash(self) -> str:
@@ -355,6 +356,7 @@ class ModelConfig:
             "mm_encoder_tp_mode",
             "interleave_mm_strings",
             "skip_mm_profiling",
+            "enable_client_mm_cache_keys",
         }
 
         from vllm.config.utils import get_hash_factors, hash_factors
@@ -429,6 +431,7 @@ class ModelConfig:
         mm_encoder_attn_backend: AttentionBackendEnum | str | None,
         interleave_mm_strings: bool | None,
         skip_mm_profiling: bool | None,
+        enable_client_mm_cache_keys: bool | None,
         video_pruning_rate: float | None,
     ) -> None:
         # Keep set served_model_name before maybe_model_redirect(self.model)
@@ -611,6 +614,7 @@ class ModelConfig:
                 mm_encoder_attn_backend=mm_encoder_attn_backend,
                 interleave_mm_strings=interleave_mm_strings,
                 skip_mm_profiling=skip_mm_profiling,
+                enable_client_mm_cache_keys=enable_client_mm_cache_keys,
                 video_pruning_rate=video_pruning_rate,
             )
 

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -167,6 +167,14 @@ class MultiModalConfig:
     This reduces engine startup time but shifts the responsibility to users for
     estimating the peak memory usage of the activation of multimodal encoder and
     embedding cache."""
+    enable_client_mm_cache_keys: bool = False
+    """When enabled, client-provided multimodal UUIDs are used directly as
+    cache keys instead of computing content-based (BLAKE3) hashes.
+
+    WARNING: Only enable this in trusted, single-tenant deployments (e.g.,
+    LiveAI) where UUIDs are server-generated and clients never reach vLLM
+    directly. In multi-tenant environments, malicious clients can craft
+    duplicate UUIDs to poison the cache or leak data across tenants."""
     video_pruning_rate: float | None = Field(default=None, ge=0.0, lt=1.0)
     """Sets pruning rate for video pruning via Efficient Video Sampling.
     Value sits in range [0;1) and determines fraction of media tokens

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1093,6 +1093,10 @@ class EngineArgs:
         multimodal_group.add_argument(
             "--skip-mm-profiling", **multimodal_kwargs["skip_mm_profiling"]
         )
+        multimodal_group.add_argument(
+            "--enable-client-mm-cache-keys",
+            **multimodal_kwargs["enable_client_mm_cache_keys"],
+        )
 
         multimodal_group.add_argument(
             "--video-pruning-rate", **multimodal_kwargs["video_pruning_rate"]

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -172,6 +172,7 @@ class InputPreprocessor:
                 multi_modal_data,
                 parsed_content.get("mm_processor_kwargs") or {},
                 tokenization_kwargs=tokenization_kwargs,
+                mm_uuids=parsed_content.get("multi_modal_uuids"),
             )
         else:
             prompt_token_ids = self._tokenize_prompt(

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -572,17 +572,30 @@ class BaseRenderer(ABC, Generic[_T]):
         # reused across requests, therefore identifying multimodal data items
         # by their content is no longer necessary, and we create uuids with
         # `<mm_req_id>-<modality>-<index>`, overriding even user-provided ones.
-        if (
+        both_caches_disabled = (
             model_config.multimodal_config
             and model_config.multimodal_config.mm_processor_cache_gb == 0
             and not self.config.cache_config.enable_prefix_caching
-        ):
+        )
+        if both_caches_disabled:
             mm_uuid_items = {
                 modality: [f"{mm_req_id}-{modality}-{i}" for i in range(data_count)]
                 for modality, data_count in mm_data_items.get_all_counts().items()
             }
 
         self._validate_mm_uuids(mm_data, mm_data_items, mm_uuid_items)
+
+        # Strip client-provided UUIDs when the flag is off to prevent
+        # cache poisoning in multi-tenant environments. Downstream
+        # processors will fall back to content-based (BLAKE3) hashing.
+        # Synthetic UUIDs (generated above when both caches are disabled)
+        # are preserved since they serve request-level uniqueness.
+        if (
+            not both_caches_disabled
+            and model_config.multimodal_config
+            and not model_config.multimodal_config.enable_client_mm_cache_keys
+        ):
+            mm_uuid_items = {}
 
         return mm_uuid_items
 


### PR DESCRIPTION
Summary:
Enable client-controlled media caching by using client-provided UUIDs directly as cache keys.

Previously, vLLM computed SHA256 content hashes for media items, which meant identical media sent across requests would only cache-hit if the binary content matched exactly. This change allows clients to provide UUIDs (via MediaMetadata.hash_key) that are used directly as cache keys for both P0 (processor) and P1 (encoder) caches.

Key changes:
- Pass mm_uuids through the full processing pipeline (preprocess.py → processor.py → input_processor.py)
- Use client UUIDs directly as cache keys instead of computing content hashes
- Add client_uuid field to MultiModalFeatureSpec for P1 cache tracking
- Improve error messages for cache miss scenarios


Test Plan: Ran end-to-end testing with multi-image internal tool to verify client-provided UUIDs are used as cache keys for both P0 and P1 caches. Verified cache hits on second request with overlapping images.

Pulled By: tensorAI


