### PR TITLE
Protect Download from Object Storage by Multiple Processes with Runai Model Streamer

### DIFF
--- a/tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_s3.py
+++ b/tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_s3.py
@@ -32,7 +32,7 @@ def test_runai_model_loader_download_files_s3_mocked_with_patch(
         patcher.shim_list_safetensors,
     )
     monkeypatch.setattr(
-        "vllm.transformers_utils.runai_utils.runai_pull_files",
+        "runai_model_streamer.safetensors_streamer.safetensors_streamer.pull_files",
         patcher.shim_pull_files,
     )
     monkeypatch.setattr(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -735,8 +735,8 @@ class ModelConfig:
         """Pull model/tokenizer from Object Storage to cache directory when needed.
 
         Args:
-           model: Model name or path
-           tokenizer: Tokenizer name or path
+            model: Model name or path
+            tokenizer: Tokenizer name or path
         """
 
         # Skip if model_weights is already set (model already pulled)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -732,12 +732,11 @@ class ModelConfig:
         return self._architecture
 
     def maybe_pull_model_tokenizer_for_runai(self, model: str, tokenizer: str) -> None:
-        """Pull model/tokenizer from Object Storage to temporary
-        directory when needed.
+        """Pull model/tokenizer from Object Storage to cache directory when needed.
 
         Args:
-            model: Model name or path
-            tokenizer: Tokenizer name or path
+          model: Model name or path
+          tokenizer: Tokenizer name or path
         """
 
         # Skip if model_weights is already set (model already pulled)
@@ -748,16 +747,29 @@ class ModelConfig:
             return
 
         if is_runai_obj_uri(model):
-            object_storage_model = ObjectStorageModel(url=model)
-            object_storage_model.pull_files(
-                model, allow_pattern=["*.model", "*.py", "*.json"]
-            )
-            self.model_weights = model
-            self.model = object_storage_model.dir
+            with ObjectStorageModel(url=model) as obj:
+                obj.pull_files(model, allow_pattern=["*.model", "*.py", "*.json"])
+                self.model_weights = model
+                self.model = obj.dir
 
-            # If tokenizer is same as model, download to same directory
-            if model == tokenizer:
-                object_storage_model.pull_files(
+                if model == tokenizer:
+                    obj.pull_files(
+                        model,
+                        ignore_pattern=[
+                            "*.pt",
+                            "*.safetensors",
+                            "*.bin",
+                            "*.tensors",
+                            "*.pth",
+                        ],
+                    )
+                    self.tokenizer = obj.dir
+                    return
+
+        # Only download tokenizer if needed and not already handled
+        if is_runai_obj_uri(tokenizer):
+            with ObjectStorageModel(url=tokenizer) as obj:
+                obj.pull_files(
                     model,
                     ignore_pattern=[
                         "*.pt",
@@ -767,17 +779,7 @@ class ModelConfig:
                         "*.pth",
                     ],
                 )
-                self.tokenizer = object_storage_model.dir
-                return
-
-        # Only download tokenizer if needed and not already handled
-        if is_runai_obj_uri(tokenizer):
-            object_storage_tokenizer = ObjectStorageModel(url=tokenizer)
-            object_storage_tokenizer.pull_files(
-                model,
-                ignore_pattern=["*.pt", "*.safetensors", "*.bin", "*.tensors", "*.pth"],
-            )
-            self.tokenizer = object_storage_tokenizer.dir
+                self.tokenizer = obj.dir
 
     def _get_encoder_config(self) -> dict[str, Any] | None:
         model = self.model

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -735,8 +735,8 @@ class ModelConfig:
         """Pull model/tokenizer from Object Storage to cache directory when needed.
 
         Args:
-          model: Model name or path
-          tokenizer: Tokenizer name or path
+           model: Model name or path
+           tokenizer: Tokenizer name or path
         """
 
         # Skip if model_weights is already set (model already pulled)

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -16,12 +16,14 @@ logger = init_logger(__name__)
 SUPPORTED_SCHEMES = ["s3://", "gs://", "az://"]
 
 try:
-    from runai_model_streamer import list_safetensors as runai_list_safetensors
     from runai_model_streamer import ObjectStorageModel as RunaiObjectStorageModel
+    from runai_model_streamer import list_safetensors as runai_list_safetensors
 except ImportError:
     runai_model_streamer = PlaceholderModule("runai_model_streamer")  # type: ignore[assignment]
     runai_list_safetensors = runai_model_streamer.placeholder_attr("list_safetensors")
-    RunaiObjectStorageModel = runai_model_streamer.placeholder_attr("ObjectStorageModel")
+    RunaiObjectStorageModel = runai_model_streamer.placeholder_attr(
+        "ObjectStorageModel"
+    )
 
 
 def list_safetensors(path: str = "") -> list[str]:
@@ -56,51 +58,51 @@ class ObjectStorageModel:
     """
 
     def __init__(self, url: str) -> None:
-          if envs.VLLM_ASSETS_CACHE_MODEL_CLEAN:
-              for sig in (signal.SIGINT, signal.SIGTERM):
-                  existing_handler = signal.getsignal(sig)
-                  signal.signal(sig, self._close_by_signal(existing_handler))
+        if envs.VLLM_ASSETS_CACHE_MODEL_CLEAN:
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                existing_handler = signal.getsignal(sig)
+                signal.signal(sig, self._close_by_signal(existing_handler))
 
-          dir_name = os.path.join(
-              get_cache_dir(),
-              "model_streamer",
-              hashlib.sha256(str(url).encode()).hexdigest()[:8],
-          )
-          self._runai_obj = RunaiObjectStorageModel(model_path=url, dst=dir_name)
-          self.dir = self._runai_obj.dir
-          logger.debug("Init object storage, model cache path is: %s", dir_name)
+        dir_name = os.path.join(
+            get_cache_dir(),
+            "model_streamer",
+            hashlib.sha256(str(url).encode()).hexdigest()[:8],
+        )
+        self._runai_obj = RunaiObjectStorageModel(model_path=url, dst=dir_name)
+        self.dir = self._runai_obj.dir
+        logger.debug("Init object storage, model cache path is: %s", dir_name)
 
-      def __enter__(self):
-          return self
+    def __enter__(self):
+        return self
 
-      def __exit__(self, exc_type, exc_val, exc_tb):
-          return self._runai_obj.__exit__(exc_type, exc_val, exc_tb)
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return self._runai_obj.__exit__(exc_type, exc_val, exc_tb)
 
-      def _close(self) -> None:
-          # ignore_errors=True avoids the TOCTOU race when multiple processes
-          # call _close() concurrently on SIGTERM
-          shutil.rmtree(self.dir, ignore_errors=True)
+    def _close(self) -> None:
+        # ignore_errors=True avoids the TOCTOU race when multiple processes
+        # call _close() concurrently on SIGTERM
+        shutil.rmtree(self.dir, ignore_errors=True)
 
-      def _close_by_signal(self, existing_handler=None):
-          def new_handler(signum, frame):
-              self._close()
-              if existing_handler:
-                  existing_handler(signum, frame)
-          return new_handler
+    def _close_by_signal(self, existing_handler=None):
+        def new_handler(signum, frame):
+            self._close()
+            if existing_handler:
+                existing_handler(signum, frame)
 
-      def pull_files(
-          self,
-          model_path: str = "",
-          allow_pattern: list[str] | None = None,
-          ignore_pattern: list[str] | None = None,
-      ) -> None:
-          """Pull files from object storage into the local cache directory.
+        return new_handler
 
-          Args:
-              model_path: The object storage path of the model (unused;
-                  the path is set at construction time).
-              allow_pattern: File patterns to include (e.g. ["*.json"]).
-              ignore_pattern: File patterns to exclude.
-          """
-          self._runai_obj.pull_files(allow_pattern, ignore_pattern)
+    def pull_files(
+        self,
+        model_path: str = "",
+        allow_pattern: list[str] | None = None,
+        ignore_pattern: list[str] | None = None,
+    ) -> None:
+        """Pull files from object storage into the local cache directory.
 
+        Args:
+            model_path: The object storage path of the model (unused;
+                the path is set at construction time).
+            allow_pattern: File patterns to include (e.g. ["*.json"]).
+            ignore_pattern: File patterns to exclude.
+        """
+        self._runai_obj.pull_files(allow_pattern, ignore_pattern)

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -17,11 +17,11 @@ SUPPORTED_SCHEMES = ["s3://", "gs://", "az://"]
 
 try:
     from runai_model_streamer import list_safetensors as runai_list_safetensors
-    from runai_model_streamer import pull_files as runai_pull_files
+    from runai_model_streamer import ObjectStorageModel as RunaiObjectStorageModel
 except ImportError:
     runai_model_streamer = PlaceholderModule("runai_model_streamer")  # type: ignore[assignment]
-    runai_pull_files = runai_model_streamer.placeholder_attr("pull_files")
     runai_list_safetensors = runai_model_streamer.placeholder_attr("list_safetensors")
+    RunaiObjectStorageModel = runai_model_streamer.placeholder_attr("ObjectStorageModel")
 
 
 def list_safetensors(path: str = "") -> list[str]:
@@ -42,59 +42,65 @@ def is_runai_obj_uri(model_or_path: str) -> bool:
 
 
 class ObjectStorageModel:
-    """
-    A class representing an ObjectStorage model mirrored into a
-    temporary directory.
+    """Represents a model hosted in object storage, mirrored into a local
+    cache directory for loading configuration files (e.g. tokenizer, model
+    config). Model weights are not pulled here and are streamed separately.
+
+    Wraps the runai_model_streamer ObjectStorageModel as a context manager,
+    which makes it safe for concurrent use by multiple processes on the same
+    host. When VLLM_ASSETS_CACHE_MODEL_CLEAN is set, the local cache directory
+    is also cleaned up on SIGINT/SIGTERM.
 
     Attributes:
-        dir: The temporary created directory.
-
-    Methods:
-        pull_files(): Pull model from object storage to the temporary directory.
+        dir: Path to the local cache directory where files are pulled to.
     """
 
     def __init__(self, url: str) -> None:
-        if envs.VLLM_ASSETS_CACHE_MODEL_CLEAN:
-            for sig in (signal.SIGINT, signal.SIGTERM):
-                existing_handler = signal.getsignal(sig)
-                signal.signal(sig, self._close_by_signal(existing_handler))
+          if envs.VLLM_ASSETS_CACHE_MODEL_CLEAN:
+              for sig in (signal.SIGINT, signal.SIGTERM):
+                  existing_handler = signal.getsignal(sig)
+                  signal.signal(sig, self._close_by_signal(existing_handler))
 
-        dir_name = os.path.join(
-            get_cache_dir(),
-            "model_streamer",
-            hashlib.sha256(str(url).encode()).hexdigest()[:8],
-        )
-        os.makedirs(dir_name, exist_ok=True)
-        self.dir = dir_name
-        logger.debug("Init object storage, model cache path is: %s", dir_name)
+          dir_name = os.path.join(
+              get_cache_dir(),
+              "model_streamer",
+              hashlib.sha256(str(url).encode()).hexdigest()[:8],
+          )
+          self._runai_obj = RunaiObjectStorageModel(model_path=url, dst=dir_name)
+          self.dir = self._runai_obj.dir
+          logger.debug("Init object storage, model cache path is: %s", dir_name)
 
-    def _close(self) -> None:
-        if os.path.exists(self.dir):
-            shutil.rmtree(self.dir)
+      def __enter__(self):
+          return self
 
-    def _close_by_signal(self, existing_handler=None):
-        def new_handler(signum, frame):
-            self._close()
-            if existing_handler:
-                existing_handler(signum, frame)
+      def __exit__(self, exc_type, exc_val, exc_tb):
+          return self._runai_obj.__exit__(exc_type, exc_val, exc_tb)
 
-        return new_handler
+      def _close(self) -> None:
+          # ignore_errors=True avoids the TOCTOU race when multiple processes
+          # call _close() concurrently on SIGTERM
+          shutil.rmtree(self.dir, ignore_errors=True)
 
-    def pull_files(
-        self,
-        model_path: str = "",
-        allow_pattern: list[str] | None = None,
-        ignore_pattern: list[str] | None = None,
-    ) -> None:
-        """
-        Pull files from object storage into the temporary directory.
+      def _close_by_signal(self, existing_handler=None):
+          def new_handler(signum, frame):
+              self._close()
+              if existing_handler:
+                  existing_handler(signum, frame)
+          return new_handler
 
-        Args:
-            model_path: The object storage path of the model.
-            allow_pattern: A list of patterns of which files to pull.
-            ignore_pattern: A list of patterns of which files not to pull.
+      def pull_files(
+          self,
+          model_path: str = "",
+          allow_pattern: list[str] | None = None,
+          ignore_pattern: list[str] | None = None,
+      ) -> None:
+          """Pull files from object storage into the local cache directory.
 
-        """
-        if not model_path.endswith("/"):
-            model_path = model_path + "/"
-        runai_pull_files(model_path, self.dir, allow_pattern, ignore_pattern)
+          Args:
+              model_path: The object storage path of the model (unused;
+                  the path is set at construction time).
+              allow_pattern: File patterns to include (e.g. ["*.json"]).
+              ignore_pattern: File patterns to exclude.
+          """
+          self._runai_obj.pull_files(allow_pattern, ignore_pattern)
+

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -66,7 +66,7 @@ class ObjectStorageModel:
         dir_name = os.path.join(
             get_cache_dir(),
             "model_streamer",
-            hashlib.sha256(str(url).encode()).hexdigest()[:8],
+            hashlib.sha256(str(url).encode()).hexdigest()[:16],
         )
         self._runai_obj = RunaiObjectStorageModel(model_path=url, dst=dir_name)
         self.dir = self._runai_obj.dir


### PR DESCRIPTION
Fix #36141

### What it fixes

**Race condition with `--api-server-count > 1 --load-format runai_streamer`**

Whenever multiple vLLM API server processes start concurrently, each process downloads the model metadata to the same local path independently. This may lead to corrupted files if not handled by the specific CSP library.

The solution is to download only once in a protected manner, using a context manager from the runai-model-streamer repository as of version 0.15.7.
The context manager is using a sentinel file to insure that the download is completed. If downloading had failed, the next download will clean up the cache and download again.

The library's `ObjectStorageModel` coordinates via a file lock (`dst + ".lock"`):
- The first process to acquire the lock downloads the files and writes a sentinel (`.runai_complete`).
- All other processes wait on the lock, then see the sentinel and skip the download entirely.
- If the download fails, the sentinel is not written and the next process retries.


### What changed

- Import `ObjectStorageModel` from `runai_model_streamer` alongside the existing `pull_files` and `list_safetensors` imports.
- vLLM's `ObjectStorageModel` now delegates to the library class: `__init__` creates a `RunaiObjectStorageModel` instance (which acquires the file lock and sets up the destination directory), `pull_files` delegates to it, and `__enter__`/`__exit__` delegate the context manager protocol.
- `maybe_pull_model_tokenizer_for_runai` wraps each `ObjectStorageModel` usage in a `with` block

