### PR TITLE
[ROCm][Bugfix] Fix NaN corruption

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -1184,6 +1184,8 @@ class AiterFlashAttentionImpl(AttentionImpl):
                         k_descale=layer._k_scale.expand(descale_shape),
                         v_descale=layer._v_scale.expand(descale_shape),
                     )
+
+                    output[:num_decode_tokens].nan_to_num_()
                     return
 
                 # The ll4mi kernel in paged_attention_v1 requires
@@ -1303,7 +1305,8 @@ class AiterFlashAttentionImpl(AttentionImpl):
             raise NotImplementedError(
                 "Cascade attention is not implemented for ROCM AITER"
             )
-
+        
+        output[:num_actual_tokens].nan_to_num_()
         return output
 
     def do_kv_cache_update(


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fix  https://github.com/vllm-project/vllm/issues/35925 
## Purpose
Added nan_to_num_() sanitization to prevent NaN propagation from AITER kernels 

On GSM8K with Qwen3.5-35B-A3B with AITER enabled:
- Corruption drops to 0% (from 2.88% in 1319 samples)

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

