### PR TITLE
[Doc] Fix typos in comments: i.e./e.g. punctuation and "archive" -> "achieve"

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1521,8 +1521,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_DEEPEP_BUFFER_SIZE_MB", "1024")
     ),
     # Force DeepEP to use intranode kernel for inter-node communication in
-    # high throughput mode. This is useful archive higher prefill throughput
-    # on system supports multi-node nvlink (e.g GB200).
+    # high throughput mode. This is useful to achieve higher prefill throughput
+    # on system supports multi-node nvlink (e.g., GB200).
     "VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE": lambda: bool(
         int(os.getenv("VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE", "0"))
     ),

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -63,7 +63,7 @@ logger = init_logger(__name__)
 #   finalize method, informed by the FusedMoEExpertsModular method,
 #   may apply weights and/or do the final reduction of the output.
 # * FusedMoEExpertsModular - an abstract base class for the main fused
-#   MoE operation, i.e matmul + act_mul + optionally quant + matmul.
+#   MoE operation, i.e., matmul + act_mul + optionally quant + matmul.
 #   Some FusedMoEExpertsModular implementations may choose to do
 #   the weight application and/or reduction. The class communicates this
 #   to [Finalize] via a TopKWeightAndReduce object.
@@ -220,7 +220,7 @@ class FusedMoEPrepareAndFinalize(ABC):
         """
         Some PrepareFinalize All2All implementations are batched. Meaning,
         they can process only as set of tokens at a time. This
-        function returns the batch size i.e the maximum number of tokens
+        function returns the batch size i.e., the maximum number of tokens
         the implementation can process at a time.
         Return None if there are no such restrictions.
         """


### PR DESCRIPTION
…hieve'

<!-- markdownlint-disable -->

## Purpose
Fix minor typos in inline comments to improve readability and correctness.

- `vllm/model_executor/layers/fused_moe/modular_kernel.py`: fix `i.e ` → `i.e.,` (lines 66, 223)
- `vllm/envs.py`: fix `e.g ` → `e.g.,` (line 1525), fix `archive` → `achieve` (line 1524)

## Test Plan
Comment-only changes, no functional impact. No tests required.

## Test Result
N/A - documentation/comment changes only.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

