### PR TITLE
[Doc] Capitalize docstrings in vllm/config/

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -630,7 +630,7 @@ class CompilationConfig:
     """Configuration for dynamic shapes options"""
 
     local_cache_dir: str = field(default=None, init=False)  # type: ignore
-    """local cache dir for each rank"""
+    """Local cache dir for each rank"""
 
     fast_moe_cold_start: bool | None = None
     """Optimization for fast MOE cold start.
@@ -658,13 +658,13 @@ class CompilationConfig:
 
     # keep track of enabled and disabled custom ops
     enabled_custom_ops: Counter[str] = field(default_factory=Counter, init=False)
-    """custom ops that are enabled"""
+    """Custom ops that are enabled"""
     disabled_custom_ops: Counter[str] = field(default_factory=Counter, init=False)
-    """custom ops that are disabled"""
+    """Custom ops that are disabled"""
     traced_files: set[str] = field(default_factory=set, init=False)
-    """files that are traced for compilation"""
+    """Files that are traced for compilation"""
     compilation_time: float = field(default=0.0, init=False)
-    """time taken for compilation"""
+    """Time taken for compilation"""
 
     static_forward_context: dict[str, Any] = field(default_factory=dict, init=False)
     """Per-model forward context

--- a/vllm/config/ec_transfer.py
+++ b/vllm/config/ec_transfer.py
@@ -51,7 +51,7 @@ class ECTransferConfig:
     """The EC connector port, used to build distributed connection."""
 
     ec_connector_extra_config: dict[str, Any] = field(default_factory=dict)
-    """any extra config that the connector may need."""
+    """Any extra config that the connector may need."""
 
     ec_connector_module_path: str | None = None
     """The Python module path to dynamically load the EC connector from.

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -52,7 +52,7 @@ class KVTransferConfig:
     """The KV connector port, used to build distributed connection."""
 
     kv_connector_extra_config: dict[str, Any] = field(default_factory=dict)
-    """any extra config that the connector may need."""
+    """Any extra config that the connector may need."""
 
     kv_connector_module_path: str | None = None
     """The Python module path to dynamically load the KV connector from.

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -199,7 +199,7 @@ class ParallelConfig:
     """Ray runtime environment to pass to distributed workers."""
 
     placement_group: PlacementGroup | None = None
-    """ray distributed model workers placement group."""
+    """Ray distributed model workers placement group."""
 
     distributed_executor_backend: (
         str | DistributedExecutorBackend | type[Executor] | None
@@ -225,16 +225,16 @@ class ParallelConfig:
     new attributes and methods to the worker class for use in collective_rpc
     calls."""
     master_addr: str = "127.0.0.1"
-    """distributed master address for multi-node distributed 
+    """Distributed master address for multi-node distributed 
     inference when distributed_executor_backend is mp."""
     master_port: int = 29501
-    """distributed master port for multi-node distributed 
+    """Distributed master port for multi-node distributed 
     inference when distributed_executor_backend is mp."""
     node_rank: int = 0
-    """distributed node rank for multi-node distributed 
+    """Distributed node rank for multi-node distributed 
     inference when distributed_executor_backend is mp."""
     nnodes: int = 1
-    """num of nodes for multi-node distributed
+    """Number of nodes for multi-node distributed
     inference when distributed_executor_backend is mp."""
 
     distributed_timeout_seconds: int | None = None
@@ -244,7 +244,7 @@ class ParallelConfig:
     Increase this for multi-node setups where model downloads may be slow."""
 
     world_size: int = Field(init=False)
-    """world_size is TPxPP, it affects the number of workers we create."""
+    """World size is TPxPP, it affects the number of workers we create."""
 
     rank: int = 0
     """Global rank in distributed setup."""
@@ -416,7 +416,7 @@ class ParallelConfig:
 
     @property
     def world_size_across_dp(self) -> int:
-        """world_size_across_dp is TPxPPxDP, it is the size of the world
+        """World_size_across_dp is TPxPPxDP, it is the size of the world
         including data parallelism."""
         return self.world_size * self.data_parallel_size
 


### PR DESCRIPTION

## Purpose
Capitalize the first letter of docstrings in vllm/config/ to follow
Python docstring conventions (PEP 257).

- `vllm/config/parallel.py`: capitalize 6 docstrings
- `vllm/config/compilation.py`: capitalize 5 docstrings  
- `vllm/config/ec_transfer.py`: capitalize 1 docstring
- `vllm/config/kv_transfer.py`: capitalize 1 docstring

## Test Plan
Comment/docstring-only changes, no functional impact. No tests required.

## Test Result
N/A - docstring changes only.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

