### PR TITLE
[Doc] Fix grammatically incorrect comment: "doesn't allow to override" -> "doesn't allow overriding"

### DIFF
--- a/vllm/model_executor/layers/kda.py
+++ b/vllm/model_executor/layers/kda.py
@@ -205,7 +205,7 @@ class KimiDeltaAttention(nn.Module, MambaBase):
         # unsqueeze to fit conv1d weights shape into the linear weights shape.
         # Can't do this in `weight_loader` since it already exists in
         # `ColumnParallelLinear` and `set_weight_attrs`
-        # doesn't allow to override it
+        # doesn't allow overriding it
         self.q_conv1d.weight.data = self.q_conv1d.weight.data.unsqueeze(1)
         self.k_conv1d.weight.data = self.k_conv1d.weight.data.unsqueeze(1)
         self.v_conv1d.weight.data = self.v_conv1d.weight.data.unsqueeze(1)

--- a/vllm/model_executor/layers/mamba/mamba_mixer.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer.py
@@ -91,7 +91,7 @@ class MambaMixer(MambaBase, PluggableLayer):
         # unsqueeze to fit conv1d weights shape into the linear weights shape.
         # Can't do this in `weight_loader` since it already exists in
         # `ColumnParallelLinear` and `set_weight_attrs`
-        # doesn't allow to override it
+        # doesn't allow overriding it
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
 
         self.in_proj = MergedColumnParallelLinear(

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -427,7 +427,7 @@ class MambaMixer2(MambaBase, PluggableLayer):
         # unsqueeze to fit conv1d weights shape into the linear weights shape.
         # Can't do this in `weight_loader` since it already exists in
         # `ColumnParallelLinear` and `MergedColumnParallelLinear`,
-        # and `set_weight_attrs` doesn't allow to override it
+        # and `set_weight_attrs` doesn't allow overriding it
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
         conv_weights = self.conv1d.weight.view(
             self.conv1d.weight.size(0), self.conv1d.weight.size(2)

--- a/vllm/model_executor/layers/mamba/short_conv.py
+++ b/vllm/model_executor/layers/mamba/short_conv.py
@@ -57,7 +57,7 @@ class ShortConv(MambaBase, CustomOp):
         # unsqueeze to fit conv1d weights shape into the linear weights shape.
         # Can't do this in `weight_loader` since it already exists in
         # `ColumnParallelLinear` and `set_weight_attrs`
-        # doesn't allow to override it
+        # doesn't allow overriding it
         self.conv.weight.data = self.conv.weight.data.unsqueeze(1)
 
         self.in_proj = MergedColumnParallelLinear(

--- a/vllm/model_executor/models/plamo2.py
+++ b/vllm/model_executor/models/plamo2.py
@@ -138,7 +138,7 @@ class Plamo2MambaMixer(MambaBase, PluggableLayer):
         # unsqueeze to fit conv1d weights shape into the linear weights shape.
         # Can't do this in `weight_loader` since it already exists in
         # `ColumnParallelLinear` and `set_weight_attrs`
-        # doesn't allow to override it
+        # doesn't allow overriding it
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
 
         self.in_proj = MergedColumnParallelLinear(


### PR DESCRIPTION
…" -> "doesn't allow overriding"

<!-- markdownlint-disable -->

## Purpose
Fix grammatically incorrect comments across 5 files. 

"doesn't allow to override" is incorrect English grammar. 
The correct form is "doesn't allow overriding" (gerund form).

- `vllm/model_executor/layers/kda.py`
- `vllm/model_executor/layers/mamba/short_conv.py`
- `vllm/model_executor/layers/mamba/mamba_mixer.py`
- `vllm/model_executor/layers/mamba/mamba_mixer2.py`
- `vllm/model_executor/models/plamo2.py`

## Test Plan
Comment-only changes, no functional impact. No tests required.

## Test Result
N/A - comment changes only.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

