### PR TITLE
[ci] Bound nvidia-cudnn-frontend version

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -10,6 +10,9 @@ torchaudio==2.10.0
 torchvision==0.25.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.6.4
+# Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to
+# breaking changes in 1.19.0
+nvidia-cudnn-frontend>=1.13.0,<1.19.0
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
 nvidia-cutlass-dsl>=4.4.0.dev1


### PR DESCRIPTION
`nvidia-cudnn-frontend` seems to only look for CUDA 13 shared object files and it breaks for CUDA 12.9 environment in CI. 