### PR TITLE
[Bug][MoE] Strengthen _supports_current_device() checks in the TRTLLM FP8, NVFP4, and FlashInfer CuteDSL MoE experts

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_cutedsl_grouped_gemm_nt_masked,
+    has_flashinfer_cutedsl_grouped_gemm_nt_masked,
     scaled_fp4_grouped_quantize,
     silu_and_mul_scaled_nvfp4_experts_quantize,
 )
@@ -60,7 +61,11 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
     @staticmethod
     def _supports_current_device() -> bool:
         p = current_platform
-        return p.is_cuda() and p.is_device_capability_family(100)
+        return (
+            p.is_cuda()
+            and p.is_device_capability_family(100)
+            and has_flashinfer_cutedsl_grouped_gemm_nt_masked()
+        )
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kMxfp8Static,
 )
 from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
 
 logger = init_logger(__name__)
 
@@ -61,8 +62,11 @@ class TrtLlmFp8ExpertsBase:
     def _supports_current_device() -> bool:
         """Supports only Blackwell-family GPUs."""
         p = current_platform
-        # Add check flashinfer trtllm is available
-        return p.is_cuda() and p.is_device_capability_family(100)
+        return (
+            p.is_cuda()
+            and p.is_device_capability_family(100)
+            and has_flashinfer_trtllm_fused_moe()
+        )
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -24,6 +24,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Static,
 )
 from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
 
 
 class TrtLlmNvFp4ExpertsBase:
@@ -80,7 +81,11 @@ class TrtLlmNvFp4ExpertsBase:
     def _supports_current_device() -> bool:
         """Supports only Blackwell-family GPUs."""
         p = current_platform
-        return p.is_cuda() and p.is_device_capability_family(100)
+        return (
+            p.is_cuda()
+            and p.is_device_capability_family(100)
+            and has_flashinfer_trtllm_fused_moe()
+        )
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -244,7 +244,7 @@ def has_flashinfer_cutedsl_grouped_gemm_nt_masked() -> bool:
     required_functions = [
         ("flashinfer.cute_dsl.blockscaled_gemm", "grouped_gemm_nt_masked"),
         ("flashinfer", "scaled_fp4_grouped_quantize"),
-        ("flashinfer", "silu_and_scaled_nvfp4_experts_quantize"),
+        ("flashinfer", "silu_and_mul_scaled_nvfp4_experts_quantize"),
     ]
 
     for module_name, attr_name in required_functions:


### PR DESCRIPTION
Signed-off-by: Yifan Zong <yzong@redhat.com>


## Purpose

Strengthened `_supports_current_device()` checks in TRTLLM FP8/NvFP4/BF16 and FlashInfer CuteDSL MoE experts to verify FlashInfer runtime availability before selecting those backends. This helps preventing crashes on platforms where FlashInfer TRTLLM or CuteDSL kernels are not installed.

## Test Plan

```
pytest -s -v tests/kernels/moe/test_unquantized_backend_selection.py
pytest -s -v tests/kernels/moe/test_cutedsl_moe.py
pytest -s -v tests/kernels/moe/test_flashinfer_moe.py
```

## Test Result

| Test Name | Expected | Measured |
|---|---|---|
| Qwen3-30B-A3B-Fp8-AutoFp8-fi-trtllm | 0.8800 | 0.8946 |
| Qwen3-30B-A3B-NvFp4-CT-fi-trtllm | 0.8800 | 0.8939 |
| Qwen3-30B-A3B-NvFp4-ModelOpt-fi-trtllm | 0.8800 | 0.8757 |
| Mixtral-8x7B-BF16-fi-cutlass | 0.5800 | 0.5648 |
| Qwen3-30B-A3B-NvFp4-CT-fi-cutlass | 0.8800 | 0.8992 |
| Qwen3-30B-A3B-NvFp4-ModelOpt-fi-cutlass | 0.8800 | 0.8787 |
| Nemotron-Nano-30B-NvFp4-ModelOpt-fi-cutlass | 0.2900 | 0.3654 |

cc @robertgshaw2-redhat @bnellnm 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

