### PR TITLE
[Bugfix] Fix Eagle3 aux_hidden_state_layers indexing with pipeline parallelism

### DIFF
--- a/vllm/model_executor/models/afmoe.py
+++ b/vllm/model_executor/models/afmoe.py
@@ -454,7 +454,8 @@ class AfmoeModel(nn.Module, EagleModelMixin):
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
             self._maybe_add_hidden_state(

--- a/vllm/model_executor/models/apertus.py
+++ b/vllm/model_executor/models/apertus.py
@@ -390,7 +390,8 @@ class ApertusModel(nn.Module, EagleModelMixin):
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
             self._maybe_add_hidden_state(

--- a/vllm/model_executor/models/arcee.py
+++ b/vllm/model_executor/models/arcee.py
@@ -257,7 +257,8 @@ class ArceeModel(nn.Module, EagleModelMixin):
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
             self._maybe_add_hidden_state(

--- a/vllm/model_executor/models/hunyuan_v1.py
+++ b/vllm/model_executor/models/hunyuan_v1.py
@@ -662,7 +662,8 @@ class HunYuanModel(nn.Module, EagleModelMixin):
         prev_kv_states = None
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for i, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual, kv_states = layer(
                 positions,

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -418,7 +418,8 @@ class LlamaModel(nn.Module, EagleModelMixin):
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual = layer(
                 positions, hidden_states, residual, **extra_layer_kwargs

--- a/vllm/model_executor/models/minicpm.py
+++ b/vllm/model_executor/models/minicpm.py
@@ -461,7 +461,8 @@ class MiniCPMModel(nn.Module, EagleModelMixin):
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual = layer(
                 positions,

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -439,7 +439,8 @@ class Qwen2Model(nn.Module, EagleModelMixin):
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
             self._maybe_add_hidden_state(

--- a/vllm/model_executor/models/step1.py
+++ b/vllm/model_executor/models/step1.py
@@ -336,7 +336,10 @@ class StepDecoderModel(nn.Module, EagleModelMixin):
             residual = intermediate_tensors["residual"]
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
-        for idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
+        for idx, layer in enumerate(
+            self.layers[self.start_layer : self.end_layer],
+            start=self.start_layer,
+        ):
             hidden_states, residual = layer(positions, hidden_states, residual)
             self._maybe_add_hidden_state(
                 aux_hidden_states, idx + 1, hidden_states, residual


### PR DESCRIPTION
## Summary
- Fix incorrect layer indexing in Eagle3 auxiliary hidden state collection when using pipeline parallelism (`start_layer > 0`)
- `enumerate(islice(self.layers, start_layer, end_layer))` starts `idx` at 0, but `aux_hidden_state_layers` contains global layer indices, so the check `if idx in self.aux_hidden_state_layers` never matches on non-first PP stages
- Fix: add `start=self.start_layer` to `enumerate()` in all 8 affected model files

## Details

**Affected models:** llama, qwen2, minicpm, afmoe, apertus, arcee, hunyuan_v1, step1

**Already correct (no changes needed):**
- `qwen3_moe` — already uses `start=self.start_layer`
- `qwen3_vl`, `qwen3_vl_moe` — use `islice(enumerate(...))` which preserves global indices
- `gpt_oss` — uses `range(self.start_layer, self.end_layer)` directly

**Root cause:** When `islice` skips the first N layers, `enumerate` still counts from 0. The auxiliary hidden state layers (used by Eagle3 speculative decoding) are specified as global layer indices, so the comparison fails silently.

Fixes #36151

## Test plan
- [ ] Verify with Eagle3 speculative decoding on multi-GPU PP setup
- [ ] Confirm `aux_hidden_states` list is populated correctly on all PP stages
- [ ] Single-GPU (start_layer=0) behavior is unchanged since `enumerate(..., start=0)` is the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)