### PR TITLE
Vllm add dflash + Optimize draft models (CUDA graph management)

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -193,9 +193,11 @@ class SpeculativeConfig:
         factors: list[Any] = []
         # Eagle3 and extract_hidden_states affect the computation graph because
         # they return intermediate hidden states in addition to the final hidden state.
-        uses_aux_hidden_states = self.method in ("eagle3", 
-                                                 "extract_hidden_states", 
-                                                 "dflash")
+        uses_aux_hidden_states = self.method in (
+            "eagle3", 
+            "extract_hidden_states", 
+            "dflash"
+        )
         factors.append(uses_aux_hidden_states)
 
         # The specific layers used also affect the computation graph

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -196,7 +196,7 @@ class SpeculativeConfig:
         uses_aux_hidden_states = self.method in (
             "eagle3", 
             "extract_hidden_states", 
-            "dflash"
+            "dflash",
         )
         factors.append(uses_aux_hidden_states)
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -194,8 +194,8 @@ class SpeculativeConfig:
         # Eagle3 and extract_hidden_states affect the computation graph because
         # they return intermediate hidden states in addition to the final hidden state.
         uses_aux_hidden_states = self.method in (
-            "eagle3", 
-            "extract_hidden_states", 
+            "eagle3",
+            "extract_hidden_states",
             "dflash",
         )
         factors.append(uses_aux_hidden_states)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -46,7 +46,8 @@ MTPModelTypes = Literal[
     "pangu_ultra_moe_mtp",
     "step3p5_mtp",
 ]
-EagleModelTypes = Literal["eagle", "eagle3", "extract_hidden_states", MTPModelTypes]
+DFlashModelTypes = Literal["dflash"]
+EagleModelTypes = Literal["eagle", "eagle3", "extract_hidden_states", MTPModelTypes, DFlashModelTypes]
 NgramGPUTypes = Literal["ngram_gpu"]
 SpeculativeMethod = Literal[
     "ngram",
@@ -186,7 +187,7 @@ class SpeculativeConfig:
         factors: list[Any] = []
         # Eagle3 and extract_hidden_states affect the computation graph because
         # they return intermediate hidden states in addition to the final hidden state.
-        uses_aux_hidden_states = self.method in ("eagle3", "extract_hidden_states")
+        uses_aux_hidden_states = self.method in ("eagle3", "extract_hidden_states", "dflash")
         factors.append(uses_aux_hidden_states)
 
         # The specific layers used also affect the computation graph
@@ -480,6 +481,8 @@ class SpeculativeConfig:
                     self.method = "eagle"
                 elif "eagle3" in self.draft_model_config.model.lower():
                     self.method = "eagle3"
+                elif "dflash" in self.draft_model_config.model.lower():
+                    self.method = "dflash"
                 elif self.draft_model_config.hf_config.model_type == "medusa":
                     self.method = "medusa"
                 elif self.draft_model_config.hf_config.model_type == "mlp_speculator":
@@ -829,7 +832,7 @@ class SpeculativeConfig:
         return slots_per_req
 
     def use_eagle(self) -> bool:
-        return self.method in ("eagle", "eagle3", "mtp")
+        return self.method in ("eagle", "eagle3", "mtp", "dflash")
 
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -47,7 +47,13 @@ MTPModelTypes = Literal[
     "step3p5_mtp",
 ]
 DFlashModelTypes = Literal["dflash"]
-EagleModelTypes = Literal["eagle", "eagle3", "extract_hidden_states", MTPModelTypes, DFlashModelTypes]
+EagleModelTypes = Literal[
+    "eagle",
+    "eagle3",
+    "extract_hidden_states",
+    MTPModelTypes,
+    DFlashModelTypes,
+]
 NgramGPUTypes = Literal["ngram_gpu"]
 SpeculativeMethod = Literal[
     "ngram",
@@ -187,7 +193,9 @@ class SpeculativeConfig:
         factors: list[Any] = []
         # Eagle3 and extract_hidden_states affect the computation graph because
         # they return intermediate hidden states in addition to the final hidden state.
-        uses_aux_hidden_states = self.method in ("eagle3", "extract_hidden_states", "dflash")
+        uses_aux_hidden_states = self.method in ("eagle3", 
+                                                 "extract_hidden_states", 
+                                                 "dflash")
         factors.append(uses_aux_hidden_states)
 
         # The specific layers used also affect the computation graph

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -9,10 +9,10 @@ from torch import nn
 from transformers import Qwen3Config
 
 from vllm.compilation.decorators import support_torch_compile
-from vllm.model_executor.layers.attention import Attention
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     QKVParallelLinear,

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -326,7 +326,7 @@ class Qwen3Model(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         input_embeds: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         if input_embeds is None:
             input_embeds = self.embed_input_ids(input_ids)
         assert hidden_states.shape[-1] == input_embeds.shape[-1]
@@ -430,7 +430,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         inputs_embeds: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         return self.model(input_ids, positions, hidden_states, inputs_embeds)
 
     def compute_logits(

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -1,0 +1,497 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from torch import nn
+from transformers import Qwen3Config
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.model_executor.layers.attention import Attention
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
+from vllm.multimodal.inputs import NestedTensors
+from vllm.transformers_utils.config import set_default_rope_theta
+from vllm.v1.attention.backend import AttentionType
+
+from .qwen2 import Qwen2MLP as Qwen3MLP
+from .qwen3 import Qwen3ForCausalLM
+from .utils import (
+    AutoWeightsLoader,
+    extract_layer_index,
+    get_draft_quant_config,
+    maybe_prefix,
+    process_eagle_weight,
+)
+
+logger = init_logger(__name__)
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb_safe(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_len = q.size(-2)
+    q_embed = (q * cos[..., -q_len:, :]) + (rotate_half(q) * sin[..., -q_len:, :])
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class Qwen3Attention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_parameters: dict,
+        max_position: int = 4096 * 32,
+        head_dim: int | None = None,
+        rms_norm_eps: float = 1e-06,
+        qkv_bias: bool = False,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        attn_type: str = AttentionType.DECODER,
+        dual_chunk_attention_config: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = head_dim or hidden_size // self.total_num_heads
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.dual_chunk_attention_config = dual_chunk_attention_config
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=qkv_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            max_position=max_position,
+            rope_parameters=rope_parameters,
+            dual_chunk_attention_config=dual_chunk_attention_config,
+        )
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
+            attn_type=attn_type,
+            **{
+                "layer_idx": extract_layer_index(prefix),
+                "dual_chunk_attention_config": dual_chunk_attention_config,
+            }
+            if dual_chunk_attention_config
+            else {},
+        )
+        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        context_states: torch.Tensor,
+    ) -> torch.Tensor:
+        assert context_states is not None
+
+        num_context = context_states.shape[0]
+
+        concat_states = torch.cat([context_states, hidden_states], dim=0)
+        qkv, _ = self.qkv_proj(concat_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+        q = self.q_norm(q_by_head).view(q.shape)
+        k = self.k_norm(k_by_head).view(k.shape)
+
+        q, k = self.rotary_emb(positions, q, k)
+
+        q = q[num_context:]
+
+        attn_output = self.attn(q, k, v)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class Qwen3DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        config: Qwen3Config,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        layer_idx: int = 0,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        set_default_rope_theta(config, default_theta=1000000)
+        dual_chunk_attention_config = getattr(
+            config, "dual_chunk_attention_config", None
+        )
+        attn_type = AttentionType.DECODER
+
+        self.self_attn = Qwen3Attention(
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            max_position=config.max_position_embeddings,
+            num_kv_heads=config.num_key_value_heads,
+            rms_norm_eps=config.rms_norm_eps,
+            qkv_bias=getattr(config, "attention_bias", False),
+            head_dim=getattr(config, "head_dim", None),
+            cache_config=cache_config,
+            quant_config=quant_config,
+            rope_parameters=config.rope_parameters,
+            prefix=f"{prefix}.self_attn",
+            attn_type=attn_type,
+            dual_chunk_attention_config=dual_chunk_attention_config,
+        )
+        self.mlp = Qwen3MLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        context_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is not None:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        else:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            context_states=context_states,
+        )
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "hidden_states": 0,
+        "input_embeds": 0,
+    }
+)
+class Qwen3Model(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int = 0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.vocab_size = self.config.vocab_size
+
+        self.quant_config = get_draft_quant_config(vllm_config)
+
+        drafter_config = getattr(self.config, "eagle_config", {}) or {}
+        drafter_config = dict(drafter_config)
+        drafter_config.update(getattr(self.config, "dflash_config", {}) or {})
+
+        if drafter_config and "use_aux_hidden_state" in drafter_config:
+            self.use_aux_hidden_state = drafter_config["use_aux_hidden_state"]
+        else:
+            self.use_aux_hidden_state = True
+
+        current_vllm_config = get_current_vllm_config()
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                Qwen3DecoderLayer(
+                    current_vllm_config,
+                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
+                    config=self.config,
+                    layer_idx=layer_idx,
+                    quant_config=self.quant_config,
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+        if self.use_aux_hidden_state:
+            num_features_to_use = self.config.num_hidden_layers
+            if "layer_ids" in drafter_config:
+                num_features_to_use = len(drafter_config["layer_ids"])
+            elif "target_layer_ids" in drafter_config:
+                num_features_to_use = len(drafter_config["target_layer_ids"])
+            if hasattr(self.config, "target_hidden_size"):
+                fc_input_size = self.config.target_hidden_size * num_features_to_use
+            else:
+                fc_input_size = self.config.hidden_size * num_features_to_use
+            self.fc = ReplicatedLinear(
+                input_size=fc_input_size,
+                output_size=self.config.hidden_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "fc"),
+                return_bias=False,
+            )
+        self.hidden_norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+        self.norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if input_embeds is None:
+            input_embeds = self.embed_input_ids(input_ids)
+        assert hidden_states.shape[-1] == input_embeds.shape[-1]
+
+        context_states = hidden_states
+        hidden_states = input_embeds
+
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                context_states=context_states,
+                residual=residual,
+            )
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "midlayer." in name:
+                name = name.replace("midlayer.", "layers.0.")
+            if self.quant_config is not None and (
+                scale_name := self.quant_config.get_cache_scale(name)
+            ):
+                param = params_dict[scale_name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                loaded_weight = (
+                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
+                )
+                weight_loader(param, loaded_weight)
+                loaded_params.add(scale_name)
+                continue
+            if "scale" in name:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        nn.Module.__init__(self)
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        if getattr(self.config, "draft_vocab_size", None) is None:
+            base_vocab_size = getattr(self.config, "vocab_size", None)
+            self.config.draft_vocab_size = base_vocab_size
+        target_layer_num = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config
+        )
+
+        self.config.target_layer_count = target_layer_num
+        self.model = Qwen3Model(
+            vllm_config=vllm_config, prefix="model", start_layer_id=target_layer_num
+        )
+
+        logit_scale = getattr(self.config, "logit_scale", 1.0)
+        self.lm_head = ParallelLMHead(
+            self.config.draft_vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(
+            self.config.draft_vocab_size, scale=logit_scale
+        )
+        self.draft_id_to_target_id = None
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: NestedTensors | None = None,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.model(input_ids, positions, hidden_states, inputs_embeds)
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        if self.draft_id_to_target_id is None:
+            assert logits.shape[1] == self.config.vocab_size, (
+                "Expected logits to have shape "
+                f"(*, {self.config.vocab_size}), but got {logits.shape}"
+            )
+            return logits
+
+        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
+        targets = base + self.draft_id_to_target_id
+        logits_new = logits.new_full(
+            (
+                logits.shape[0],
+                self.config.vocab_size,
+            ),
+            float("-inf"),
+        )
+        logits_new[:, targets] = logits
+        return logits_new
+
+    def combine_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if not self.model.use_aux_hidden_state:
+            return hidden_states
+        return self.model.hidden_norm(self.model.fc(hidden_states))
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        model_weights = {}
+        includes_draft_id_mapping = False
+        includes_embed_tokens = False
+        for name, loaded_weight in weights:
+            if "t2d" in name:
+                continue
+            if "d2t" in name:
+                name = name.replace("d2t", "draft_id_to_target_id")
+                includes_draft_id_mapping = True
+            elif "lm_head" not in name:
+                name = "model." + name
+            if "embed_tokens" in name:
+                includes_embed_tokens = True
+            model_weights[name] = loaded_weight
+            process_eagle_weight(self, name)
+
+        skip_substrs = []
+        if not includes_draft_id_mapping:
+            skip_substrs.append("draft_id_to_target_id")
+        if not includes_embed_tokens:
+            skip_substrs.append("embed_tokens")
+        if not self.model.use_aux_hidden_state:
+            skip_substrs.append("fc.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+            skip_substrs=skip_substrs,
+        )
+        loader.load_weights(model_weights.items())

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -543,6 +543,7 @@ _SPECULATIVE_DECODING_MODELS = {
     "EagleLlama4ForCausalLM": ("llama4_eagle", "EagleLlama4ForCausalLM"),
     "EagleMiniCPMForCausalLM": ("minicpm_eagle", "EagleMiniCPMForCausalLM"),
     "Eagle3LlamaForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
+    "DFlashDraftModel": ("qwen3_dflash", "DFlashQwen3ForCausalLM"),
     "LlamaForCausalLMEagle3": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
     "Eagle3Qwen2_5vlForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
     "Eagle3Qwen3vlForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),

--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -62,9 +62,20 @@ class EAGLEConfig(PretrainedConfig):
                 else f"Eagle3{arch}"
                 for arch in self.model.architectures
             ]
+        elif method == "dflash":
+            assert self.model is not None, (
+                "model should not be None when method is dflash"
+            )
+            kwargs["architectures"] = [
+                arch
+                if arch.startswith("DFlash") or arch.endswith("DFlash")
+                else f"DFlash{arch}"
+                for arch in self.model.architectures
+            ]
         else:
             raise ValueError(
-                f"Invalid method {method}. Supported methods are eagle and eagle3."
+                f"Invalid method {method}. "
+                "Supported methods are eagle, eagle3, and dflash."
             )
 
         super().__init__(**kwargs)

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -126,8 +126,8 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
                 positions=self._get_positions(2 * num_input_tokens),
                 hidden_states=self.hidden_states[:num_input_tokens],
                 inputs_embeds=None,
-            )
-            
+            )            
+           
     @override
     def _get_slot_mapping(
         self,

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -3,11 +3,11 @@
 
 from dataclasses import dataclass, replace
 from typing import Any
-from typing_extensions import override
 
 import torch
+from typing_extensions import override
 
-from vllm.config import VllmConfig, CUDAGraphMode
+from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import CommonAttentionMetadata
@@ -93,7 +93,8 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         # One bucket per KV shape
         self._dflash_graph_pool = torch.cuda.graph_pool_handle()
         self._dflash_graph_buckets: dict[tuple[int, int, int], _DFlashGraphBucket] = {}
-# key: (batch_size, num_context_tokens, total_query_tokens)
+
+    # key: (batch_size, num_context_tokens, total_query_tokens)
 
     @override
     @torch.inference_mode()
@@ -104,12 +105,10 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         is_graph_capturing: bool = False,
         slot_mappings: dict[str, torch.Tensor] | None = None,
     ) -> None:
-        (   _, 
-            num_input_tokens, 
-            num_tokens_across_dp
-        ) = self._determine_batch_execution_and_padding(
-            num_tokens, 
-            use_cudagraphs=False
+        (_, num_input_tokens, num_tokens_across_dp) = (
+            self._determine_batch_execution_and_padding(
+                num_tokens, use_cudagraphs=False
+            )
         )
         if num_tokens_across_dp is not None:
             num_tokens_across_dp[self.dp_rank] = num_input_tokens
@@ -143,9 +142,7 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
             sm = num_tokens_or_slot_mapping
         else:
             sm = (
-                slot_mapping 
-                if slot_mapping is not None 
-                else num_tokens_or_slot_mapping
+                slot_mapping if slot_mapping is not None else num_tokens_or_slot_mapping
             )
         return {name: sm for name in self._draft_attn_layer_names}
 
@@ -159,6 +156,7 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         num_query_tokens: int,
         slot_mapping: torch.Tensor,
     ) -> CommonAttentionMetadata:
+        
         """Build non-causal metadata for DFlash 
         from original CommonAttentionMetadata."""
         batch_size = common_attn_metadata.num_reqs
@@ -201,12 +199,10 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         slot_mapping: torch.Tensor,
     ) -> torch.Tensor:
         """Run DFlash draft model forward in eager mode."""
-        (_, 
-         num_query_tokens_dp_padded, 
-         num_tokens_across_dp
-        ) = self._determine_batch_execution_and_padding(
-            total_query_tokens, 
-            use_cudagraphs=False
+        (_, num_query_tokens_dp_padded, num_tokens_across_dp) = (
+            self._determine_batch_execution_and_padding(              
+                total_query_tokens, use_cudagraphs=False
+          )
         )
         self._set_positions(num_kv_tokens, position_ids)
         self.input_ids[:total_query_tokens] = input_ids[:total_query_tokens]
@@ -323,16 +319,19 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
             )
 
         # capture
-        with torch.cuda.graph(
-            graph,
-            self._dflash_graph_pool,
-        ), set_forward_context(
-            per_layer_attn_metadata,
-            self.vllm_config,
-            num_tokens=num_input_tokens,
-            num_tokens_across_dp=num_tokens_across_dp,
-            cudagraph_runtime_mode=CUDAGraphMode.NONE,
-            slot_mapping=self._get_slot_mapping(slot_mapping_static),
+        with (
+            torch.cuda.graph(
+                graph,
+                self._dflash_graph_pool,
+            ),
+            set_forward_context(
+                per_layer_attn_metadata,
+                self.vllm_config,
+                num_tokens=num_input_tokens,
+                num_tokens_across_dp=num_tokens_across_dp,
+                cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                slot_mapping=self._get_slot_mapping(slot_mapping_static),
+            ),
         ):
             output_hidden_states = self.model(
                 input_ids=input_ids_static,
@@ -370,11 +369,13 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         seq_lens: torch.Tensor,
     ) -> torch.Tensor:
         """Replay the captured DFlash graph."""
-        bucket.input_ids[:bucket.total_query_tokens].copy_(
-            input_ids[:bucket.total_query_tokens]
+        bucket.input_ids[: bucket.total_query_tokens].copy_(
+            input_ids[: bucket.total_query_tokens]
         )
         if bucket.num_input_tokens > bucket.total_query_tokens:
-            bucket.input_ids[bucket.total_query_tokens:bucket.num_input_tokens].fill_(0)
+            bucket.input_ids[
+                bucket.total_query_tokens:bucket.num_input_tokens
+            ].fill_(0)
 
         bucket.positions.copy_(position_ids)
         bucket.hidden_states.copy_(target_hidden_states)
@@ -428,7 +429,7 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
             device=device, dtype=torch.long
         )
         ctx_lens = query_start_loc[1:] - query_start_loc[:-1]  # [batch_size]
-        ctx_end_indices = query_start_loc[1:]                  # [batch_size]
+        ctx_end_indices = query_start_loc[1:]  # [batch_size]
 
         # Position of each request's last context token
         last_positions = base_target_positions[ctx_end_indices - 1]  # [batch_size]

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -126,9 +126,8 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
                 positions=self._get_positions(2 * num_input_tokens),
                 hidden_states=self.hidden_states[:num_input_tokens],
                 inputs_embeds=None,
-            )
+            )  
             
-           
     @override
     def _get_slot_mapping(
         self,
@@ -198,8 +197,8 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         slot_mapping: torch.Tensor,
     ) -> torch.Tensor:
         """Run DFlash draft model forward in eager mode."""
-        (_, num_query_tokens_dp_padded, num_tokens_across_dp) = (            
-            self._determine_batch_execution_and_padding(      
+        (_, num_query_tokens_dp_padded, num_tokens_across_dp) = (
+            self._determine_batch_execution_and_padding(
                 total_query_tokens, use_cudagraphs=False
             )
         )

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -126,7 +126,8 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
                 positions=self._get_positions(2 * num_input_tokens),
                 hidden_states=self.hidden_states[:num_input_tokens],
                 inputs_embeds=None,
-            )            
+            )
+            
            
     @override
     def _get_slot_mapping(
@@ -157,8 +158,6 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         num_query_tokens: int,
         slot_mapping: torch.Tensor,
     ) -> CommonAttentionMetadata:
-        """Build non-causal metadata for DFlash 
-        from original CommonAttentionMetadata."""
         batch_size = common_attn_metadata.num_reqs
 
         # For batch_size=1, query_start_loc is always [0, num_query_tokens]
@@ -199,8 +198,8 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         slot_mapping: torch.Tensor,
     ) -> torch.Tensor:
         """Run DFlash draft model forward in eager mode."""
-        (_, num_query_tokens_dp_padded, num_tokens_across_dp) = (
-            self._determine_batch_execution_and_padding(              
+        (_, num_query_tokens_dp_padded, num_tokens_across_dp) = (            
+            self._determine_batch_execution_and_padding(      
                 total_query_tokens, use_cudagraphs=False
             )
         )

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -127,6 +127,7 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
                 hidden_states=self.hidden_states[:num_input_tokens],
                 inputs_embeds=None,
             )
+            
     @override
     def _get_slot_mapping(
         self,
@@ -156,7 +157,6 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         num_query_tokens: int,
         slot_mapping: torch.Tensor,
     ) -> CommonAttentionMetadata:
-        
         """Build non-causal metadata for DFlash 
         from original CommonAttentionMetadata."""
         batch_size = common_attn_metadata.num_reqs
@@ -202,7 +202,7 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         (_, num_query_tokens_dp_padded, num_tokens_across_dp) = (
             self._determine_batch_execution_and_padding(              
                 total_query_tokens, use_cudagraphs=False
-          )
+            )
         )
         self._set_positions(num_kv_tokens, position_ids)
         self.input_ids[:total_query_tokens] = input_ids[:total_query_tokens]
@@ -373,10 +373,9 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
             input_ids[: bucket.total_query_tokens]
         )
         if bucket.num_input_tokens > bucket.total_query_tokens:
-            bucket.input_ids[
-                bucket.total_query_tokens:bucket.num_input_tokens
-            ].fill_(0)
-
+            bucket.input_ids[bucket.total_query_tokens : bucket.num_input_tokens].fill_(
+                0
+            )
         bucket.positions.copy_(position_ids)
         bucket.hidden_states.copy_(target_hidden_states)
         bucket.slot_mapping.copy_(slot_mapping)

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 from dataclasses import dataclass, replace
 from typing import Any
 from typing_extensions import override

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -101,13 +101,12 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         is_graph_capturing: bool = False,
         slot_mappings: dict[str, torch.Tensor] | None = None,
     ) -> None:
-       (
-            _, 
+        (   _, 
             num_input_tokens, 
             num_tokens_across_dp
         ) = self._determine_batch_execution_and_padding(
-            num_tokens,
-            use_cudagraphs=False,
+            num_tokens, 
+            use_cudagraphs=False
         )
         if num_tokens_across_dp is not None:
             num_tokens_across_dp[self.dp_rank] = num_input_tokens

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -101,11 +101,12 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         is_graph_capturing: bool = False,
         slot_mappings: dict[str, torch.Tensor] | None = None,
     ) -> None:
-       (   _,
-            num_query_tokens_dp_padded,
-            num_tokens_across_dp,
+       (
+            _, 
+            num_input_tokens, 
+            num_tokens_across_dp
         ) = self._determine_batch_execution_and_padding(
-            total_query_tokens,
+            num_tokens,
             use_cudagraphs=False,
         )
         if num_tokens_across_dp is not None:

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -101,8 +101,7 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         is_graph_capturing: bool = False,
         slot_mappings: dict[str, torch.Tensor] | None = None,
     ) -> None:
-       (
-            _,
+       (   _,
             num_query_tokens_dp_padded,
             num_tokens_across_dp,
         ) = self._determine_batch_execution_and_padding(
@@ -140,7 +139,11 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         ):
             sm = num_tokens_or_slot_mapping
         else:
-            sm = slot_mapping if slot_mapping is not None else num_tokens_or_slot_mapping
+            sm = (
+                slot_mapping 
+                if slot_mapping is not None 
+                else num_tokens_or_slot_mapping
+            )
         return {name: sm for name in self._draft_attn_layer_names}
 
     # ---------------- DFlash-specific internal utilities ----------------
@@ -153,7 +156,8 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         num_query_tokens: int,
         slot_mapping: torch.Tensor,
     ) -> CommonAttentionMetadata:
-        """Build non-causal metadata for DFlash from original CommonAttentionMetadata."""
+        """Build non-causal metadata for DFlash 
+        from original CommonAttentionMetadata."""
         batch_size = common_attn_metadata.num_reqs
 
         # For batch_size=1, query_start_loc is always [0, num_query_tokens]
@@ -194,8 +198,13 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         slot_mapping: torch.Tensor,
     ) -> torch.Tensor:
         """Run DFlash draft model forward in eager mode."""
-        _, num_query_tokens_dp_padded, num_tokens_across_dp = self._determine_batch_execution_and_padding(
-        total_query_tokens, use_cudagraphs=False)
+        (_, 
+         num_query_tokens_dp_padded, 
+         num_tokens_across_dp
+        ) = self._determine_batch_execution_and_padding(
+            total_query_tokens, 
+            use_cudagraphs=False
+        )
         self._set_positions(num_kv_tokens, position_ids)
         self.input_ids[:total_query_tokens] = input_ids[:total_query_tokens]
         if num_query_tokens_dp_padded > total_query_tokens:
@@ -394,7 +403,6 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
         assert target_hidden_states.shape[-1] == self.hidden_size
 
-        # If target uses M-RoPE but draft does not, use eagle-style handling: take dim-0 positions.
         if (
             self.uses_xdrope_dim > 0
             and self.draft_uses_xdrope_dim == 0
@@ -487,7 +495,6 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
             for layer_name in attn_group.layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata
 
-        # Query input_ids: first query per request is sampled token, rest are mask tokens
         self.input_ids[:total_query_tokens] = self.mask_token_id
         first_query_indices = torch.arange(
             0, total_query_tokens, num_query_tokens, device=device, dtype=torch.long

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -101,8 +101,13 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
         is_graph_capturing: bool = False,
         slot_mappings: dict[str, torch.Tensor] | None = None,
     ) -> None:
-        _, num_input_tokens, num_tokens_across_dp = self._determine_batch_execution_and_padding(
-            num_tokens, use_cudagraphs=False
+       (
+            _,
+            num_query_tokens_dp_padded,
+            num_tokens_across_dp,
+        ) = self._determine_batch_execution_and_padding(
+            total_query_tokens,
+            use_cudagraphs=False,
         )
         if num_tokens_across_dp is not None:
             num_tokens_across_dp[self.dp_rank] = num_input_tokens
@@ -306,21 +311,23 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
             )
 
         # capture
-        with torch.cuda.graph(graph, self._dflash_graph_pool):
-            with set_forward_context(
-                per_layer_attn_metadata,
-                self.vllm_config,
-                num_tokens=num_input_tokens,
-                num_tokens_across_dp=num_tokens_across_dp,
-                cudagraph_runtime_mode=CUDAGraphMode.NONE,
-                slot_mapping=self._get_slot_mapping(slot_mapping_static),
-            ):
-                output_hidden_states = self.model(
-                    input_ids=input_ids_static,
-                    positions=positions_static,
-                    hidden_states=hidden_states_static,
-                    inputs_embeds=None,
-                )
+        with torch.cuda.graph(
+            graph,
+            self._dflash_graph_pool,
+        ), set_forward_context(
+            per_layer_attn_metadata,
+            self.vllm_config,
+            num_tokens=num_input_tokens,
+            num_tokens_across_dp=num_tokens_across_dp,
+            cudagraph_runtime_mode=CUDAGraphMode.NONE,
+            slot_mapping=self._get_slot_mapping(slot_mapping_static),
+        ):
+            output_hidden_states = self.model(
+                input_ids=input_ids_static,
+                positions=positions_static,
+                hidden_states=hidden_states_static,
+                inputs_embeds=None,
+            )
 
         bucket = _DFlashGraphBucket(
             num_context_tokens=num_context_tokens,

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -1,0 +1,542 @@
+from dataclasses import dataclass, replace
+from typing import Any
+from typing_extensions import override
+
+import torch
+
+from vllm.config import VllmConfig, CUDAGraphMode
+from vllm.forward_context import set_forward_context
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.spec_decode.eagle import SpecDecodeBaseProposer
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class _DFlashGraphBucket:
+    # Bucket shape info
+    num_context_tokens: int
+    total_query_tokens: int
+    num_kv_tokens: int
+    num_input_tokens: int
+
+    # Static tensors used by captured graph
+    input_ids: torch.Tensor
+    positions: torch.Tensor
+    hidden_states: torch.Tensor
+    slot_mapping: torch.Tensor
+    seq_lens: torch.Tensor
+    num_tokens_across_dp: torch.Tensor | None
+
+    # Metadata / context
+    per_layer_attn_metadata: dict[str, Any]
+
+    # Graph output and graph object
+    output_hidden_states: torch.Tensor
+    graph: torch.cuda.CUDAGraph
+
+
+class DFlashModelProposer(SpecDecodeBaseProposer):
+    """DFlash draft model proposer.
+
+    - Uses target hidden states as KV; context length can vary.
+    - Parallel drafting for queries (sampled token + several MASK tokens).
+    - Per-shape CUDA graph bucketing strategy (aligned with dflash 0.13).
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ):
+        # Same as EagleProposer: pass target hidden_states to draft model
+        super().__init__(
+            vllm_config=vllm_config,
+            device=device,
+            pass_hidden_states_to_model=True,
+            runner=runner,
+        )
+
+        # Read mask_token_id from draft model config.json dflash_config
+        draft_hf_config = self.draft_model_config.hf_config
+        dflash_cfg = getattr(draft_hf_config, "dflash_config", {})
+        if "mask_token_id" in dflash_cfg:
+            self.mask_token_id = dflash_cfg["mask_token_id"]
+        else:
+            raise ValueError(
+                "DFlash draft model config must have "
+                "`dflash_config.mask_token_id` in its config.json."
+            )
+
+        # CUDA graph control
+        self.compilation_config = self.vllm_config.compilation_config
+        cudagraph_mode = self.compilation_config.cudagraph_mode
+        if cudagraph_mode != CUDAGraphMode.NONE and not cudagraph_mode.has_mode(
+            CUDAGraphMode.PIECEWISE
+        ):
+            logger.warning(
+                "DFlash draft model only supports PIECEWISE CUDA graphs. "
+                "Please set compilation_config.cudagraph_mode to PIECEWISE "
+                "or FULL_AND_PIECEWISE to enable CUDA graphs for DFlash."
+            )
+
+        self.use_cuda_graph: bool = (
+            cudagraph_mode.has_mode(CUDAGraphMode.PIECEWISE)
+            and not self.speculative_config.enforce_eager
+        )
+        # One bucket per KV shape
+        self._dflash_graph_pool = torch.cuda.graph_pool_handle()
+        self._dflash_graph_buckets: dict[tuple[int, int, int], _DFlashGraphBucket] = {}
+# key: (batch_size, num_context_tokens, total_query_tokens)
+
+    @override
+    @torch.inference_mode()
+    def dummy_run(
+        self,
+        num_tokens: int,
+        use_cudagraphs: bool = True,
+        is_graph_capturing: bool = False,
+        slot_mappings: dict[str, torch.Tensor] | None = None,
+    ) -> None:
+        _, num_input_tokens, num_tokens_across_dp = self._determine_batch_execution_and_padding(
+            num_tokens, use_cudagraphs=False
+        )
+        if num_tokens_across_dp is not None:
+            num_tokens_across_dp[self.dp_rank] = num_input_tokens
+
+        with set_forward_context(
+            None,
+            self.vllm_config,
+            num_tokens=num_input_tokens,
+            num_tokens_across_dp=num_tokens_across_dp,
+            cudagraph_runtime_mode=CUDAGraphMode.NONE,
+            slot_mapping=slot_mappings or {},
+        ):
+            self.model(
+                input_ids=self.input_ids[:num_input_tokens],
+                positions=self._get_positions(2 * num_input_tokens),
+                hidden_states=self.hidden_states[:num_input_tokens],
+                inputs_embeds=None,
+            )
+    @override
+    def _get_slot_mapping(
+        self,
+        num_tokens_or_slot_mapping,
+        slot_mapping: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """DFlash constructs complete slot_mappings externally,
+        so just wrap the tensor in a per-layer dict."""
+        if isinstance(num_tokens_or_slot_mapping, torch.Tensor) and slot_mapping is None:
+            sm = num_tokens_or_slot_mapping
+        else:
+            sm = slot_mapping if slot_mapping is not None else num_tokens_or_slot_mapping
+        return {name: sm for name in self._draft_attn_layer_names}
+
+    # ---------------- DFlash-specific internal utilities ----------------
+
+    def _build_dflash_common_attn_metadata(
+        self,
+        *,
+        common_attn_metadata: CommonAttentionMetadata,
+        position_ids: torch.Tensor,
+        num_query_tokens: int,
+        slot_mapping: torch.Tensor,
+    ) -> CommonAttentionMetadata:
+        """Build non-causal metadata for DFlash from original CommonAttentionMetadata."""
+        batch_size = common_attn_metadata.num_reqs
+
+        # For batch_size=1, query_start_loc is always [0, num_query_tokens]
+        query_start_loc = self.arange[: batch_size + 1] * num_query_tokens
+        query_start_loc_cpu = (
+            torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone()
+            * num_query_tokens
+        )
+
+        # seq_lens adds query length on top of original (kept dynamic)
+        seq_lens = common_attn_metadata.seq_lens + num_query_tokens
+
+        max_seq_len = self.max_model_len
+
+        return replace(
+            common_attn_metadata,
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc_cpu,
+            seq_lens=seq_lens,
+            _seq_lens_cpu=None,
+            num_actual_tokens=batch_size * num_query_tokens,
+            max_query_len=num_query_tokens,
+            max_seq_len=max_seq_len,
+            slot_mapping=slot_mapping,
+            causal=False,
+        )
+
+    def _run_dflash_eager(
+        self,
+        *,
+        total_query_tokens: int,
+        num_kv_tokens: int,
+        num_context_tokens: int,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        per_layer_attn_metadata: dict[str, Any],
+        slot_mapping: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run DFlash draft model forward in eager mode."""
+        _, num_query_tokens_dp_padded, num_tokens_across_dp = self._determine_batch_execution_and_padding(
+        total_query_tokens, use_cudagraphs=False)
+        self._set_positions(num_kv_tokens, position_ids)
+        self.input_ids[:total_query_tokens] = input_ids[:total_query_tokens]
+        if num_query_tokens_dp_padded > total_query_tokens:
+            self.input_ids[total_query_tokens:num_query_tokens_dp_padded].fill_(0)
+
+        self.hidden_states[:num_context_tokens] = target_hidden_states
+
+        with set_forward_context(
+            per_layer_attn_metadata,
+            self.vllm_config,
+            num_tokens=num_query_tokens_dp_padded,
+            num_tokens_across_dp=num_tokens_across_dp,
+            cudagraph_runtime_mode=CUDAGraphMode.NONE,
+            slot_mapping=self._get_slot_mapping(slot_mapping),
+        ):
+            ret_hidden_states = self.model(
+                input_ids=self.input_ids[:num_query_tokens_dp_padded],
+                positions=self._get_positions(num_kv_tokens),
+                hidden_states=self.hidden_states[:num_context_tokens],
+                inputs_embeds=None,
+            )
+        return ret_hidden_states
+
+    def _capture_dflash_bucket(
+        self,
+        *,
+        bucket_key: tuple[int, int, int],
+        total_query_tokens: int,
+        num_query_tokens_per_req: int,
+        num_context_tokens: int,
+        num_kv_tokens: int,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        common_attn_metadata: CommonAttentionMetadata,
+    ) -> _DFlashGraphBucket:
+        """Capture a CUDA graph bucket for the given KV shape."""
+        _, num_input_tokens, num_tokens_across_dp = (
+            self._determine_batch_execution_and_padding(
+                total_query_tokens, use_cudagraphs=False
+            )
+        )
+        if num_tokens_across_dp is not None:
+            num_tokens_across_dp = num_tokens_across_dp.clone()
+            num_tokens_across_dp[self.dp_rank] = num_input_tokens
+
+        input_ids_static = torch.empty(
+            (num_input_tokens,), dtype=self.input_ids.dtype, device=self.device
+        )
+        if self.uses_mrope:
+            positions_static = torch.empty(
+                (3, num_kv_tokens), dtype=position_ids.dtype, device=self.device
+            )
+        else:
+            positions_static = torch.empty(
+                (num_kv_tokens,), dtype=position_ids.dtype, device=self.device
+            )
+
+        hidden_states_static = torch.empty(
+            (num_context_tokens, self.hidden_size), dtype=self.dtype, device=self.device
+        )
+        slot_mapping_static = torch.empty_like(slot_mapping)
+        seq_lens_static = common_attn_metadata.seq_lens.clone()
+
+        common_attn_static = self._build_dflash_common_attn_metadata(
+            common_attn_metadata=common_attn_metadata,
+            position_ids=position_ids,
+            num_query_tokens=num_query_tokens_per_req,
+            slot_mapping=slot_mapping_static,
+        )
+        common_attn_static = replace(common_attn_static, seq_lens=seq_lens_static)
+
+        per_layer_attn_metadata: dict[str, Any] = {}
+        for attn_group in self.draft_attn_groups:
+            attn_metadata = attn_group.get_metadata_builder().build_for_drafting(
+                common_attn_metadata=common_attn_static, draft_index=0
+            )
+            if hasattr(attn_metadata, "causal"):
+                assert not attn_metadata.causal, (
+                    "DFlash proposer requires non-causal attention. "
+                    "Choose a different attention backend."
+                )
+            for layer_name in attn_group.layer_names:
+                per_layer_attn_metadata[layer_name] = attn_metadata
+
+        # Initialize static buffer contents
+        input_ids_static[:total_query_tokens].copy_(input_ids[:total_query_tokens])
+        if num_input_tokens > total_query_tokens:
+            input_ids_static[total_query_tokens:].fill_(0)
+
+        positions_static.copy_(position_ids)
+        hidden_states_static.copy_(target_hidden_states)
+        slot_mapping_static.copy_(slot_mapping)
+        seq_lens_static.copy_(common_attn_static.seq_lens)
+
+        graph = torch.cuda.CUDAGraph()
+
+        # warmup
+        with set_forward_context(
+            per_layer_attn_metadata,
+            self.vllm_config,
+            num_tokens=num_input_tokens,
+            num_tokens_across_dp=num_tokens_across_dp,
+            cudagraph_runtime_mode=CUDAGraphMode.NONE,
+            slot_mapping=self._get_slot_mapping(slot_mapping_static),
+        ):
+            output_hidden_states = self.model(
+                input_ids=input_ids_static,
+                positions=positions_static,
+                hidden_states=hidden_states_static,
+                inputs_embeds=None,
+            )
+
+        # capture
+        with torch.cuda.graph(graph, self._dflash_graph_pool):
+            with set_forward_context(
+                per_layer_attn_metadata,
+                self.vllm_config,
+                num_tokens=num_input_tokens,
+                num_tokens_across_dp=num_tokens_across_dp,
+                cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                slot_mapping=self._get_slot_mapping(slot_mapping_static),
+            ):
+                output_hidden_states = self.model(
+                    input_ids=input_ids_static,
+                    positions=positions_static,
+                    hidden_states=hidden_states_static,
+                    inputs_embeds=None,
+                )
+
+        bucket = _DFlashGraphBucket(
+            num_context_tokens=num_context_tokens,
+            total_query_tokens=total_query_tokens,
+            num_kv_tokens=num_kv_tokens,
+            num_input_tokens=num_input_tokens,
+            input_ids=input_ids_static,
+            positions=positions_static,
+            hidden_states=hidden_states_static,
+            slot_mapping=slot_mapping_static,
+            seq_lens=seq_lens_static,
+            num_tokens_across_dp=num_tokens_across_dp,
+            per_layer_attn_metadata=per_layer_attn_metadata,
+            output_hidden_states=output_hidden_states,
+            graph=graph,
+        )
+        self._dflash_graph_buckets[bucket_key] = bucket
+        return bucket
+
+    def _run_dflash_graph(
+        self,
+        *,
+        bucket: _DFlashGraphBucket,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        """Replay the captured DFlash graph."""
+        bucket.input_ids[:bucket.total_query_tokens].copy_(
+            input_ids[:bucket.total_query_tokens]
+        )
+        if bucket.num_input_tokens > bucket.total_query_tokens:
+            bucket.input_ids[bucket.total_query_tokens:bucket.num_input_tokens].fill_(0)
+
+        bucket.positions.copy_(position_ids)
+        bucket.hidden_states.copy_(target_hidden_states)
+        bucket.slot_mapping.copy_(slot_mapping)
+        bucket.seq_lens.copy_(seq_lens)
+
+        bucket.graph.replay()
+        return bucket.output_hidden_states
+
+    def _propose_dflash_core(
+        self,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        common_attn_metadata: CommonAttentionMetadata,
+        sampling_metadata: SamplingMetadata,
+    ) -> torch.Tensor:
+        batch_size = common_attn_metadata.num_reqs
+        device = self.device
+
+        num_query_tokens = 1 + self.num_speculative_tokens
+        total_query_tokens = batch_size * num_query_tokens
+        num_context_tokens = target_hidden_states.shape[0]
+        num_kv_tokens = num_context_tokens + total_query_tokens
+
+        assert self.runner is not None
+
+        # target_hidden_states: [num_tokens, hidden_size]
+        target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
+        assert target_hidden_states.shape[-1] == self.hidden_size
+
+        # If target uses M-RoPE but draft does not, use eagle-style handling: take dim-0 positions.
+        if (
+            self.uses_xdrope_dim > 0
+            and self.draft_uses_xdrope_dim == 0
+            and target_positions.ndim == 2
+        ):
+            target_positions = target_positions[0]
+
+        # Use 1D base positions for per-request last position and slot computation;
+        # position_ids fed to the model may be 1D or 2D (M-RoPE).
+        if target_positions.ndim == 2:
+            # [3, num_context_tokens]
+            base_target_positions = target_positions[0]
+        else:
+            # [num_context_tokens]
+            base_target_positions = target_positions
+
+        # End index (exclusive) of each request's context
+        # Diff of query_start_loc equals tokens per request
+        query_start_loc = common_attn_metadata.query_start_loc.to(
+            device=device, dtype=torch.long
+        )
+        ctx_lens = query_start_loc[1:] - query_start_loc[:-1]  # [batch_size]
+        ctx_end_indices = query_start_loc[1:]                  # [batch_size]
+
+        # Position of each request's last context token
+        last_positions = base_target_positions[ctx_end_indices - 1]  # [batch_size]
+
+        # Per-request query positions: [last+1, last+2, ..., last+num_query_tokens]
+        query_offsets = torch.arange(
+            1,
+            num_query_tokens + 1,
+            device=device,
+            dtype=base_target_positions.dtype,
+        )
+        query_positions = last_positions.unsqueeze(1) + query_offsets.unsqueeze(0)
+        query_positions_flat = query_positions.reshape(-1)  # [total_query_tokens]
+
+        # Assemble position_ids (fed to draft model)
+        if target_positions.ndim == 2:
+            # M-RoPE: expand to [3, total_query_tokens]
+            query_positions_mrope = query_positions_flat.unsqueeze(0).expand(
+                target_positions.shape[0], -1
+            )
+            position_ids = torch.cat([target_positions, query_positions_mrope], dim=1)
+            # Slot mapping uses 1D base positions
+            flat_position_ids = position_ids[0]
+            assert position_ids.shape[1] == num_kv_tokens
+        else:
+            position_ids = torch.cat([target_positions, query_positions_flat], dim=0)
+            flat_position_ids = position_ids
+            assert position_ids.shape[0] == num_kv_tokens
+
+        # Build req_indices: which request each token belongs to
+        ctx_req_indices = torch.repeat_interleave(
+            torch.arange(batch_size, device=device, dtype=torch.long),
+            ctx_lens.to(torch.long),
+        )
+        query_req_indices = torch.repeat_interleave(
+            torch.arange(batch_size, device=device, dtype=torch.long),
+            num_query_tokens,
+        )
+        req_indices = torch.cat([ctx_req_indices, query_req_indices], dim=0)
+        assert req_indices.shape[0] == num_kv_tokens
+
+        # Build slot_mapping
+        block_size = self.block_size
+        block_numbers = (flat_position_ids // block_size).to(torch.long)
+        block_ids = common_attn_metadata.block_table_tensor[req_indices, block_numbers]
+        slot_mapping = block_ids * block_size + (flat_position_ids % block_size)
+
+        # Build DFlash non-causal metadata from original metadata
+        dflash_common_attn = self._build_dflash_common_attn_metadata(
+            common_attn_metadata=common_attn_metadata,
+            position_ids=position_ids,
+            num_query_tokens=num_query_tokens,
+            slot_mapping=slot_mapping,
+        )
+
+        per_layer_attn_metadata: dict[str, Any] = {}
+        for attn_group in self.draft_attn_groups:
+            attn_metadata = attn_group.get_metadata_builder().build_for_drafting(
+                common_attn_metadata=dflash_common_attn,
+                draft_index=0,
+            )
+            if hasattr(attn_metadata, "causal"):
+                assert not attn_metadata.causal, (
+                    "DFlash proposer requires non-causal attention. "
+                    "Choose a different attention backend."
+                )
+            for layer_name in attn_group.layer_names:
+                per_layer_attn_metadata[layer_name] = attn_metadata
+
+        # Query input_ids: first query per request is sampled token, rest are mask tokens
+        self.input_ids[:total_query_tokens] = self.mask_token_id
+        first_query_indices = torch.arange(
+            0, total_query_tokens, num_query_tokens, device=device, dtype=torch.long
+        )
+        self.input_ids[first_query_indices] = next_token_ids.to(self.input_ids.dtype)
+        dflash_input_ids = self.input_ids[:total_query_tokens]
+
+        # CUDA graph strategy
+        can_use_dflash_graph = (
+            self.use_cuda_graph
+            and total_query_tokens <= self.compilation_config.max_cudagraph_capture_size
+            and num_context_tokens <= total_query_tokens
+        )
+
+        if not can_use_dflash_graph:
+            ret_hidden_states = self._run_dflash_eager(
+                total_query_tokens=total_query_tokens,
+                num_kv_tokens=num_kv_tokens,
+                num_context_tokens=num_context_tokens,
+                input_ids=dflash_input_ids,
+                position_ids=position_ids,
+                target_hidden_states=target_hidden_states,
+                per_layer_attn_metadata=per_layer_attn_metadata,
+                slot_mapping=slot_mapping,
+            )
+        else:
+            bucket_key = (batch_size, num_context_tokens, total_query_tokens)
+            bucket = self._dflash_graph_buckets.get(bucket_key)
+            if bucket is None:
+                bucket = self._capture_dflash_bucket(
+                    bucket_key=bucket_key,
+                    total_query_tokens=total_query_tokens,
+                    num_query_tokens_per_req=num_query_tokens,
+                    num_context_tokens=num_context_tokens,
+                    num_kv_tokens=num_kv_tokens,
+                    input_ids=dflash_input_ids,
+                    position_ids=position_ids,
+                    target_hidden_states=target_hidden_states,
+                    slot_mapping=slot_mapping,
+                    common_attn_metadata=dflash_common_attn,
+                )
+
+            ret_hidden_states = self._run_dflash_graph(
+                bucket=bucket,
+                input_ids=dflash_input_ids,
+                position_ids=position_ids,
+                target_hidden_states=target_hidden_states,
+                slot_mapping=slot_mapping,
+                seq_lens=dflash_common_attn.seq_lens,
+            )
+
+        # ret_hidden_states: [total_query_tokens, hidden_size]
+        # Per-request layout: [sampled, mask1, mask2, ...]
+        ret_hidden_states = ret_hidden_states[:total_query_tokens]
+        ret_hidden_states = ret_hidden_states.view(batch_size, num_query_tokens, -1)
+        valid_hidden_states = ret_hidden_states[:, 1:, :].reshape(
+            batch_size * self.num_speculative_tokens, -1
+        )
+
+        logits = self.model.compute_logits(valid_hidden_states)
+        draft_token_ids = logits.argmax(dim=-1)
+        return draft_token_ids.view(batch_size, self.num_speculative_tokens)

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -129,7 +129,10 @@ class DFlashModelProposer(SpecDecodeBaseProposer):
     ) -> dict[str, torch.Tensor]:
         """DFlash constructs complete slot_mappings externally,
         so just wrap the tensor in a per-layer dict."""
-        if isinstance(num_tokens_or_slot_mapping, torch.Tensor) and slot_mapping is None:
+        if (
+            isinstance(num_tokens_or_slot_mapping, torch.Tensor)
+            and slot_mapping is None
+        ):
             sm = num_tokens_or_slot_mapping
         else:
             sm = slot_mapping if slot_mapping is not None else num_tokens_or_slot_mapping

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -398,12 +398,12 @@ class SpecDecodeBaseProposer:
         batch_size = common_attn_metadata.batch_size()
 
         if self.method == "dflash":
+            dflash_core = getattr(self, "_propose_dflash_core", None)
             if dflash_core is None:
                 raise RuntimeError(
                     "_propose_dflash_core is not initialized ."
                 )
 
-            dflash_core = getattr(self, "_propose_dflash_core", None)
             return dflash_core(
                 target_positions=target_positions,
                 target_hidden_states=target_hidden_states,

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -401,9 +401,7 @@ class SpecDecodeBaseProposer:
         if self.method == "dflash":
             dflash_core = getattr(self, "_propose_dflash_core", None)
             if dflash_core is None:
-                raise RuntimeError(
-                    "_propose_dflash_core is not initialized ."
-                )
+                raise RuntimeError("_propose_dflash_core is not initialized .")
 
             return dflash_core(
                 target_positions=target_positions,

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -398,6 +398,11 @@ class SpecDecodeBaseProposer:
         batch_size = common_attn_metadata.batch_size()
 
         if self.method == "dflash":
+            if dflash_core is None:
+                raise RuntimeError(
+                    "_propose_dflash_core is not initialized ."
+                )
+
             dflash_core = getattr(self, "_propose_dflash_core", None)
             return dflash_core(
                 target_positions=target_positions,

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -397,6 +397,15 @@ class SpecDecodeBaseProposer:
     ) -> torch.Tensor:
         batch_size = common_attn_metadata.batch_size()
 
+        if self.method == "dflash":
+            dflash_core = getattr(self, "_propose_dflash_core", None)
+            return dflash_core(
+                target_positions=target_positions,
+                target_hidden_states=target_hidden_states,
+                next_token_ids=next_token_ids,
+                common_attn_metadata=common_attn_metadata,
+                sampling_metadata=sampling_metadata,
+            )
         if self.method == "eagle3":
             assert isinstance(self.model, Eagle3LlamaForCausalLM)
             target_hidden_states = self.model.combine_hidden_states(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6161,7 +6161,7 @@ class GPUModelRunner(
         ):
             assert isinstance(
                 self.drafter, 
-                EagleProposer | ExtractHiddenStatesProposer | DFlashModelProposer
+                EagleProposer | ExtractHiddenStatesProposer | DFlashModelProposer,
             )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5983,7 +5983,7 @@ class GPUModelRunner(
         ):
             assert isinstance(
                 self.drafter, 
-                EagleProposer | DraftModelProposer | DFlashModelProposer
+                EagleProposer | DraftModelProposer | DFlashModelProposer,
             )
             self.drafter.initialize_attn_backend(kv_cache_config, kernel_block_sizes)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5261,7 +5261,10 @@ class GPUModelRunner(
             ):
                 assert isinstance(
                     self.drafter, 
-                    EagleProposer | DraftModelProposer | ExtractHiddenStatesProposer | DFlashModelProposer,
+                    EagleProposer 
+                    | DraftModelProposer 
+                    | ExtractHiddenStatesProposer 
+                    | DFlashModelProposer,
                 )
                 assert self.speculative_config is not None
                 # Eagle currently only supports PIECEWISE cudagraphs.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5260,7 +5260,8 @@ class GPUModelRunner(
                 or self.speculative_config.uses_extract_hidden_states()
             ):
                 assert isinstance(
-                    self.drafter, EagleProposer | DraftModelProposer | ExtractHiddenStatesProposer,
+                    self.drafter, 
+                    EagleProposer | DraftModelProposer | ExtractHiddenStatesProposer | DFlashModelProposer,
                 )
                 assert self.speculative_config is not None
                 # Eagle currently only supports PIECEWISE cudagraphs.
@@ -6156,7 +6157,8 @@ class GPUModelRunner(
             or self.speculative_config.uses_extract_hidden_states()
         ):
             assert isinstance(
-                self.drafter, EagleProposer | ExtractHiddenStatesProposer | DFlashModelProposer
+                self.drafter, 
+                EagleProposer | ExtractHiddenStatesProposer | DFlashModelProposer
             )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4378,8 +4378,7 @@ class GPUModelRunner(
 
         elif spec_config.use_eagle() or spec_config.uses_draft_model():
             assert isinstance(
-                self.drafter, 
-                EagleProposer | DraftModelProposer | DFlashModelProposer
+                self.drafter, EagleProposer | DraftModelProposer | DFlashModelProposer
             )
 
             if spec_config.disable_padded_drafter_batch:
@@ -5261,8 +5260,7 @@ class GPUModelRunner(
                 or self.speculative_config.uses_extract_hidden_states()
             ):
                 assert isinstance(
-                    self.drafter,
-                    EagleProposer | DraftModelProposer | ExtractHiddenStatesProposer,
+                    self.drafter, EagleProposer | DraftModelProposer | ExtractHiddenStatesProposer,
                 )
                 assert self.speculative_config is not None
                 # Eagle currently only supports PIECEWISE cudagraphs.
@@ -6158,8 +6156,7 @@ class GPUModelRunner(
             or self.speculative_config.uses_extract_hidden_states()
         ):
             assert isinstance(
-                self.drafter, 
-                EagleProposer | ExtractHiddenStatesProposer | DFlashModelProposer
+                self.drafter, EagleProposer | ExtractHiddenStatesProposer | DFlashModelProposer
             )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -160,6 +160,7 @@ from vllm.v1.sample.logits_processor.interface import LogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import RejectionSampler
 from vllm.v1.sample.sampler import Sampler
+from vllm.v1.spec_decode.dflash import DFlashModelProposer
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.extract_hidden_states import ExtractHiddenStatesProposer
@@ -506,6 +507,7 @@ class GPUModelRunner(
                 | NgramProposerGPU
                 | SuffixDecodingProposer
                 | EagleProposer
+                | DFlashModelProposer
                 | DraftModelProposer
                 | MedusaProposer
                 | ExtractHiddenStatesProposer
@@ -539,6 +541,18 @@ class GPUModelRunner(
                 )
             elif self.speculative_config.method == "suffix":
                 self.drafter = SuffixDecodingProposer(self.vllm_config)
+            elif self.speculative_config.method == "dflash":
+                self.drafter = DFlashModelProposer(
+                    vllm_config=self.vllm_config,
+                    device=self.device,
+                    runner=self,
+                )
+                hf_config = self.speculative_config.draft_model_config.hf_config
+                drafter_config = getattr(hf_config, "eagle_config", {}) or {}
+                drafter_config.update(getattr(hf_config, "dflash_config", {}) or {})
+                use_aux = drafter_config.get("use_aux_hidden_state", True)
+                if use_aux:
+                    self.use_aux_hidden_state_outputs = True
             elif self.speculative_config.use_eagle():
                 self.drafter = EagleProposer(self.vllm_config, self.device, self)
                 if self.speculative_config.method == "eagle3":
@@ -2082,7 +2096,7 @@ class GPUModelRunner(
                 cm.slot_mapping = slot_mappings[kv_cache_gid]
 
             if self.speculative_config and spec_decode_common_attn_metadata is None:
-                if isinstance(self.drafter, EagleProposer):
+                if isinstance(self.drafter, EagleProposer | DFlashModelProposer):
                     if self.drafter.kv_cache_gid == kv_cache_gid:
                         spec_decode_common_attn_metadata = cm
                 else:
@@ -4363,7 +4377,7 @@ class GPUModelRunner(
             )
 
         elif spec_config.use_eagle() or spec_config.uses_draft_model():
-            assert isinstance(self.drafter, EagleProposer | DraftModelProposer)
+            assert isinstance(self.drafter, EagleProposer | DraftModelProposer | DFlashModelProposer)
 
             if spec_config.disable_padded_drafter_batch:
                 # When padded-batch is disabled, the sampled_token_ids should be
@@ -4657,12 +4671,17 @@ class GPUModelRunner(
             return None
 
         hf_config = self.speculative_config.draft_model_config.hf_config
-        if not hasattr(hf_config, "eagle_aux_hidden_state_layer_ids"):
-            return None
 
-        layer_ids = hf_config.eagle_aux_hidden_state_layer_ids
-        if layer_ids and isinstance(layer_ids, (list, tuple)):
-            return tuple(layer_ids)
+        if hasattr(hf_config, "eagle_aux_hidden_state_layer_ids"):
+            layer_ids = hf_config.eagle_aux_hidden_state_layer_ids
+            if layer_ids and isinstance(layer_ids, (list, tuple)):
+                return tuple(layer_ids)
+
+        dflash_cfg = getattr(hf_config, "dflash_config", None)
+        if dflash_cfg and isinstance(dflash_cfg, dict):
+            target_layer_ids = dflash_cfg.get("target_layer_ids")
+            if target_layer_ids and isinstance(target_layer_ids, (list, tuple)):
+                return tuple(target_layer_ids)
 
         return None
 
@@ -5959,7 +5978,7 @@ class GPUModelRunner(
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_draft_model()
         ):
-            assert isinstance(self.drafter, EagleProposer | DraftModelProposer)
+            assert isinstance(self.drafter, EagleProposer | DraftModelProposer | DFlashModelProposer)
             self.drafter.initialize_attn_backend(kv_cache_config, kernel_block_sizes)
 
     def _check_and_update_cudagraph_mode(
@@ -6134,7 +6153,7 @@ class GPUModelRunner(
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_extract_hidden_states()
         ):
-            assert isinstance(self.drafter, EagleProposer | ExtractHiddenStatesProposer)
+            assert isinstance(self.drafter, EagleProposer | ExtractHiddenStatesProposer | DFlashModelProposer)
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 
     def calculate_reorder_batch_threshold(self) -> None:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4377,7 +4377,10 @@ class GPUModelRunner(
             )
 
         elif spec_config.use_eagle() or spec_config.uses_draft_model():
-            assert isinstance(self.drafter, EagleProposer | DraftModelProposer | DFlashModelProposer)
+            assert isinstance(
+                self.drafter, 
+                EagleProposer | DraftModelProposer | DFlashModelProposer
+            )
 
             if spec_config.disable_padded_drafter_batch:
                 # When padded-batch is disabled, the sampled_token_ids should be
@@ -5978,7 +5981,10 @@ class GPUModelRunner(
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_draft_model()
         ):
-            assert isinstance(self.drafter, EagleProposer | DraftModelProposer | DFlashModelProposer)
+            assert isinstance(
+                self.drafter, 
+                EagleProposer | DraftModelProposer | DFlashModelProposer
+            )
             self.drafter.initialize_attn_backend(kv_cache_config, kernel_block_sizes)
 
     def _check_and_update_cudagraph_mode(
@@ -6153,7 +6159,10 @@ class GPUModelRunner(
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_extract_hidden_states()
         ):
-            assert isinstance(self.drafter, EagleProposer | ExtractHiddenStatesProposer | DFlashModelProposer)
+            assert isinstance(
+                self.drafter, 
+                EagleProposer | ExtractHiddenStatesProposer | DFlashModelProposer
+            )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 
     def calculate_reorder_batch_threshold(self) -> None:


### PR DESCRIPTION
## Purpose

This PR builds on the DFlash speculative decoding implementation in [#32206](https://github.com/vllm-project/vllm/pull/32206). It optimizes the draft model side by managing CUDA graph to reduce overhead and improve end-to-end speculative decoding performance.

## Test Plan

- **Platform**: H800
- **Config**: draft number = 4
- **Baseline**: EAGLE3 with the same BS=1 and draft number=4
- **Workloads**: math，dialogue and chat tasks

## Test Result

On H800 with BS=1 and draft number=4:

- **Math tasks**: up to **2.0x** speedup
- **Dialogue tasks**: at least **1.4x** speedup
- **vs EAGLE3** (BS=1, draft number=4): **~15%** average speed improvement
```python
vllm serve Qwen3-8B \
    --host 0.0.0.0 \
    --port 8898 \
    --no-enable-prefix-caching \
    --trust-remote-code \
    --max-model-len 20480 \
    --max-model-seqs 5 \
    --gpu-memory-utilization 0.9 \
    --speculative-config '{"method": "dflash", "model": "Qwen3-8B-DFlash", "num_speculative_tokens": 4, "disable_padded_drafter_batch": true}'

vllm bench serve \
    --base-url http://0.0.0.0:8898 \
    --model Qwen3-8B \
    --tokenizer Qwen3-8B \
    --dataset-name hf \
    --dataset-path mt-bench \
    --hf-name philschmid/mt-bench \
    --max-concurrency 1\
    --num-prompts 80\
    --temperature 0\
```
<img width="2224" height="913" alt="h800" src="https://github.com/user-attachments/assets/33a66cbd-ef0c-40af-b194-858d193860c6" />

Under different concurrency conditions:

| method | BS= 1 | BS= 2 | BS= 3 | BS= 4 |
|---|---|---|---|---|
| eagle3 | 222.77 | 413.02 | 597.85 | 739.80 |
| dflash | 307.11 | 568.01 | 804.87 | 962.37 |
