### PR TITLE
[Bugfix] Respect hf-config-path during GGUF speculator detection

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -5,6 +5,7 @@ import json
 from argparse import ArgumentError
 from contextlib import AbstractContextManager, nullcontext
 from typing import Annotated, Literal
+from unittest.mock import patch
 
 import pytest
 from pydantic import Field
@@ -641,3 +642,38 @@ def test_cloud_storage_tokenizer_skips_get_model_path(monkeypatch):
     args = EngineArgs(model="s3://bucket/model", tokenizer="s3://bucket/tokenizer")
     assert args.model == "s3://bucket/model"
     assert args.tokenizer == "s3://bucket/tokenizer"
+
+
+def test_create_engine_config_forwards_hf_config_path_to_speculator_detection():
+    captured_kwargs = {}
+
+    def fake_maybe_override_with_speculators(**kwargs):
+        captured_kwargs.update(kwargs)
+        return kwargs["model"], kwargs["tokenizer"], kwargs["vllm_speculative_config"]
+
+    engine_args = EngineArgs(
+        model="/tmp/model.gguf",
+        tokenizer="/tmp/tokenizer",
+        hf_config_path="/tmp/hf-config",
+    )
+
+    with (
+        patch(
+            "vllm.engine.arg_utils.current_platform.pre_register_and_update",
+            return_value=None,
+        ),
+        patch("vllm.engine.arg_utils.envs.validate_environ", return_value=None),
+        patch(
+            "vllm.engine.arg_utils.maybe_override_with_speculators",
+            side_effect=fake_maybe_override_with_speculators,
+        ),
+        patch.object(
+            EngineArgs,
+            "create_model_config",
+            side_effect=RuntimeError("stop after speculator detection"),
+        ),
+        pytest.raises(RuntimeError, match="stop after speculator detection"),
+    ):
+        engine_args.create_engine_config()
+
+    assert captured_kwargs["hf_config_path"] == "/tmp/hf-config"

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -6,8 +6,14 @@ only get the `eos_token_id` from the tokenizer as defined by
 `BaseRenderer.get_eos_token_id`.
 """
 
+from pathlib import Path
+from unittest.mock import patch
+
 from vllm.tokenizers import get_tokenizer
-from vllm.transformers_utils.config import try_get_generation_config
+from vllm.transformers_utils.config import (
+    maybe_override_with_speculators,
+    try_get_generation_config,
+)
 
 
 def test_get_llama3_eos_token():
@@ -30,3 +36,49 @@ def test_get_blip2_eos_token():
     generation_config = try_get_generation_config(model_name, trust_remote_code=False)
     assert generation_config is not None
     assert generation_config.eos_token_id == 50118
+
+
+@patch("vllm.transformers_utils.config.PretrainedConfig.get_config_dict")
+@patch("vllm.transformers_utils.config.check_gguf_file", return_value=True)
+def test_maybe_override_with_speculators_uses_hf_config_path_for_local_gguf(
+    mock_check_gguf_file,
+    mock_get_config_dict,
+):
+    mock_get_config_dict.return_value = ({}, {})
+    model = "/tmp/model.gguf"
+    tokenizer = "/tmp/tokenizer"
+
+    resolved = maybe_override_with_speculators(
+        model=model,
+        tokenizer=tokenizer,
+        trust_remote_code=False,
+        hf_config_path="/tmp/hf-config",
+    )
+
+    assert resolved == (model, tokenizer, None)
+    mock_check_gguf_file.assert_not_called()
+    mock_get_config_dict.assert_called_once()
+    args, kwargs = mock_get_config_dict.call_args
+    assert args[0] == "/tmp/hf-config"
+    assert "gguf_file" not in kwargs
+
+
+@patch("vllm.transformers_utils.config.PretrainedConfig.get_config_dict")
+@patch("vllm.transformers_utils.config.check_gguf_file", return_value=True)
+def test_maybe_override_with_speculators_keeps_gguf_file_without_hf_config_path(
+    mock_check_gguf_file,
+    mock_get_config_dict,
+):
+    mock_get_config_dict.return_value = ({}, {})
+
+    maybe_override_with_speculators(
+        model="/tmp/model.gguf",
+        tokenizer="/tmp/tokenizer",
+        trust_remote_code=False,
+    )
+
+    mock_check_gguf_file.assert_called_once_with("/tmp/model.gguf")
+    mock_get_config_dict.assert_called_once()
+    args, kwargs = mock_get_config_dict.call_args
+    assert args[0] == Path("/tmp")
+    assert kwargs["gguf_file"] == "model.gguf"

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1729,6 +1729,7 @@ class EngineArgs:
                     trust_remote_code=self.trust_remote_code,
                     vllm_speculative_config=self.speculative_config,
                     hf_token=self.hf_token,
+                    hf_config_path=self.hf_config_path,
                 )
             )
 

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -615,17 +615,21 @@ def maybe_override_with_speculators(
     Returns:
         Tuple of (resolved_model, resolved_tokenizer, speculative_config)
     """
-    if check_gguf_file(model):
+    hf_config_path = kwargs.pop("hf_config_path", None)
+
+    if hf_config_path is not None:
+        config_source: str | Path = hf_config_path
+    elif check_gguf_file(model):
         kwargs["gguf_file"] = Path(model).name
-        gguf_model_repo = Path(model).parent
+        config_source = Path(model).parent
     elif is_remote_gguf(model):
         repo_id, _ = split_remote_gguf(model)
-        gguf_model_repo = Path(repo_id)
+        config_source = Path(repo_id)
     else:
-        gguf_model_repo = None
+        config_source = model
     kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
     config_dict, _ = PretrainedConfig.get_config_dict(
-        model if gguf_model_repo is None else gguf_model_repo,
+        config_source,
         revision=revision,
         token=hf_token,
         **without_trust_remote_code(kwargs),


### PR DESCRIPTION
## Purpose

Fixes #36456 by making speculator detection respect `--hf-config-path` before it tries to parse a local GGUF model.

When `--hf-config-path` is provided, `maybe_override_with_speculators` now loads the config from that path and avoids forwarding `gguf_file` into `PretrainedConfig.get_config_dict()`. This prevents startup from crashing on unsupported GGUF architectures when the user has already supplied a valid Hugging Face config directory.

The PR also forwards `hf_config_path` from `EngineArgs.create_engine_config()` and adds targeted regression tests for both the config helper and the engine-args call site.

## Test Plan

- `python3 -m py_compile vllm/transformers_utils/config.py vllm/engine/arg_utils.py tests/transformers_utils/test_config.py tests/engine/test_arg_utils.py`
- `pytest tests/transformers_utils/test_config.py tests/engine/test_arg_utils.py -k "speculator or hf_config_path"`

## Test Result

- `pytest tests/transformers_utils/test_config.py tests/engine/test_arg_utils.py -k "speculator or hf_config_path"`: passed (3 selected tests)
- verified that local GGUF speculator detection uses `hf_config_path` without `gguf_file` when `--hf-config-path` is set
- verified that the existing local GGUF path still passes `gguf_file` when `--hf-config-path` is not set
- verified that `EngineArgs.create_engine_config()` forwards `hf_config_path` into speculator detection
