### PR TITLE
[Frontend] Add SubscribeKvEvents KV cache streaming in gRPC server

### DIFF
--- a/docs/serving/grpc_server.md
+++ b/docs/serving/grpc_server.md
@@ -32,7 +32,14 @@ python -m vllm.entrypoints.grpc_server \
 Notes:
 
 - The RPC request accepts `start_sequence_number` for replay/catch-up.
-- If KV events are disabled, the RPC returns `FAILED_PRECONDITION`.
+- If KV events are disabled, the RPC returns `UNIMPLEMENTED`.
 - For replay support, set `replay_endpoint` in `--kv-events-config`.
+- For security, `SubscribeKvEvents` only allows local peers (`127.0.0.1`,
+  `::1`, or `unix:`) by default. This protects sensitive `token_ids`.
+- To allow remote subscribers, explicitly set
+  `allow_remote_subscribe: true` in `--kv-events-config` and use trusted
+  network controls.
+- The local-peer check is transport-level. If you deploy behind a proxy or
+  sidecar, enforce authentication and authorization at that boundary.
 
 For a KV events example, see [examples/online_serving/disaggregated_serving/kv_events.sh](../../examples/online_serving/disaggregated_serving/kv_events.sh).

--- a/docs/serving/grpc_server.md
+++ b/docs/serving/grpc_server.md
@@ -1,0 +1,38 @@
+# gRPC Server
+
+vLLM provides a gRPC entrypoint at `vllm.entrypoints.grpc_server`.
+
+Install gRPC dependencies:
+
+```bash
+pip install "vllm[grpc]"
+```
+
+Start the gRPC server:
+
+```bash
+python -m vllm.entrypoints.grpc_server \
+  --model meta-llama/Llama-3.1-8B-Instruct \
+  --host 0.0.0.0 \
+  --port 50051
+```
+
+## KV Event Streaming RPC
+
+`VllmEngine.SubscribeKvEvents` streams KV cache events as `KvEventBatch`.
+
+To enable it, start the server with KV events enabled and a ZMQ publisher:
+
+```bash
+python -m vllm.entrypoints.grpc_server \
+  --model meta-llama/Llama-3.1-8B-Instruct \
+  --kv-events-config '{"enable_kv_cache_events": true, "publisher": "zmq", "topic": "kv-events"}'
+```
+
+Notes:
+
+- The RPC request accepts `start_sequence_number` for replay/catch-up.
+- If KV events are disabled, the RPC returns `FAILED_PRECONDITION`.
+- For replay support, set `replay_endpoint` in `--kv-events-config`.
+
+For a KV events example, see [examples/online_serving/disaggregated_serving/kv_events.sh](../../examples/online_serving/disaggregated_serving/kv_events.sh).

--- a/tests/entrypoints/test_grpc_kv_events.py
+++ b/tests/entrypoints/test_grpc_kv_events.py
@@ -58,6 +58,36 @@ class _FakeStreamContext(_FakeAbortContext):
         self.initial_metadata_sent = True
 
 
+def _make_streamer(
+    kv_events_config: KVEventsConfig | None = None,
+) -> GrpcKvEventStreamer:
+    return GrpcKvEventStreamer(
+        kv_events_config=kv_events_config,
+        data_parallel_size=1,
+        pb2_module=vllm_engine_pb2,
+    )
+
+
+def _make_enabled_kv_events_config(
+    topic: str = "",
+    allow_remote_subscribe: bool = False,
+) -> KVEventsConfig:
+    return KVEventsConfig(
+        enable_kv_cache_events=True,
+        publisher="zmq",
+        topic=topic,
+        allow_remote_subscribe=allow_remote_subscribe,
+    )
+
+
+def _make_request(
+    start_sequence_number: int = 0,
+) -> vllm_engine_pb2.SubscribeKvEventsRequest:
+    return vllm_engine_pb2.SubscribeKvEventsRequest(
+        start_sequence_number=start_sequence_number
+    )
+
+
 def test_hash_to_int64_normalizes_unsigned_values():
     assert _hash_to_int64(7) == 7
     assert _hash_to_int64((1 << 63) + 5) == -9223372036854775803
@@ -65,11 +95,7 @@ def test_hash_to_int64_normalizes_unsigned_values():
 
 
 def test_to_proto_batch_maps_all_event_variants():
-    streamer = GrpcKvEventStreamer(
-        kv_events_config=None,
-        data_parallel_size=1,
-        pb2_module=vllm_engine_pb2,
-    )
+    streamer = _make_streamer()
 
     stored = BlockStored(
         block_hashes=[1, 2],
@@ -118,11 +144,7 @@ def test_to_proto_batch_maps_all_event_variants():
 
 
 def test_unknown_medium_does_not_set_cache_level():
-    streamer = GrpcKvEventStreamer(
-        kv_events_config=None,
-        data_parallel_size=1,
-        pb2_module=vllm_engine_pb2,
-    )
+    streamer = _make_streamer()
 
     removed = BlockRemoved(block_hashes=[1], medium="DISK")
     proto_event = streamer._to_proto_event(event_id=0, event=removed)
@@ -131,11 +153,7 @@ def test_unknown_medium_does_not_set_cache_level():
 
 
 def test_block_stored_token_ids_are_split_per_block():
-    streamer = GrpcKvEventStreamer(
-        kv_events_config=None,
-        data_parallel_size=1,
-        pb2_module=vllm_engine_pb2,
-    )
+    streamer = _make_streamer()
 
     stored = BlockStored(
         block_hashes=[101, 202],
@@ -152,12 +170,10 @@ def test_block_stored_token_ids_are_split_per_block():
     assert proto_event.stored.blocks[1].token_ids == [3, 4]
 
 
-def test_is_cancelled_uses_cancelled_method_false():
-    assert not GrpcKvEventStreamer._is_cancelled(_FakeContext(cancelled=False))
-
-
-def test_is_cancelled_uses_cancelled_method_true():
-    assert GrpcKvEventStreamer._is_cancelled(_FakeContext(cancelled=True))
+@pytest.mark.parametrize("cancelled", [False, True])
+def test_is_cancelled_uses_cancelled_method(cancelled: bool):
+    context = _FakeContext(cancelled=cancelled)
+    assert GrpcKvEventStreamer._is_cancelled(context) is cancelled
 
 
 @pytest.mark.parametrize(
@@ -176,43 +192,36 @@ def test_is_local_peer(peer: str, is_local: bool):
     assert GrpcKvEventStreamer._is_local_peer(peer) is is_local
 
 
+def test_extract_ipv6_host_only_strips_bracketed_port():
+    assert GrpcKvEventStreamer._extract_ipv6_host("[::1]:50051") == "::1"
+    assert GrpcKvEventStreamer._extract_ipv6_host("::1") == "::1"
+    assert GrpcKvEventStreamer._extract_ipv6_host("2001:db8::1") == "2001:db8::1"
+    # Unbracketed inputs are treated as full IPv6 host text.
+    assert GrpcKvEventStreamer._extract_ipv6_host("::1:50051") == "::1:50051"
+
+
 def test_is_subscriber_allowed_respects_allow_remote_subscribe():
-    streamer_default = GrpcKvEventStreamer(
-        kv_events_config=KVEventsConfig(
-            enable_kv_cache_events=True,
-            publisher="zmq",
-        ),
-        data_parallel_size=1,
-        pb2_module=vllm_engine_pb2,
-    )
+    streamer_default = _make_streamer(kv_events_config=_make_enabled_kv_events_config())
     remote_context = _FakePeerContext(cancelled=False, peer="ipv4:10.1.2.3:50051")
     assert not streamer_default._is_subscriber_allowed(remote_context)
 
-    streamer_remote_allowed = GrpcKvEventStreamer(
-        kv_events_config=KVEventsConfig(
-            enable_kv_cache_events=True,
-            publisher="zmq",
+    streamer_remote_allowed = _make_streamer(
+        kv_events_config=_make_enabled_kv_events_config(
             allow_remote_subscribe=True,
-        ),
-        data_parallel_size=1,
-        pb2_module=vllm_engine_pb2,
+        )
     )
     assert streamer_remote_allowed._is_subscriber_allowed(remote_context)
 
 
 @pytest.mark.asyncio
 async def test_subscribe_denies_remote_peer_by_default():
-    streamer = GrpcKvEventStreamer(
-        kv_events_config=KVEventsConfig(
-            enable_kv_cache_events=True,
-            publisher="zmq",
+    streamer = _make_streamer(
+        kv_events_config=_make_enabled_kv_events_config(
             topic="kv-events",
-        ),
-        data_parallel_size=1,
-        pb2_module=vllm_engine_pb2,
+        )
     )
     context = _FakeAbortContext(cancelled=False, peer="ipv4:10.1.2.3:50051")
-    request = vllm_engine_pb2.SubscribeKvEventsRequest(start_sequence_number=0)
+    request = _make_request()
 
     responses = [batch async for batch in streamer.subscribe(request, context)]
 
@@ -225,13 +234,9 @@ async def test_subscribe_denies_remote_peer_by_default():
 
 @pytest.mark.asyncio
 async def test_subscribe_returns_unimplemented_when_disabled():
-    streamer = GrpcKvEventStreamer(
-        kv_events_config=None,
-        data_parallel_size=1,
-        pb2_module=vllm_engine_pb2,
-    )
+    streamer = _make_streamer()
     context = _FakeAbortContext(cancelled=False, peer="")
-    request = vllm_engine_pb2.SubscribeKvEventsRequest(start_sequence_number=0)
+    request = _make_request()
 
     responses = [batch async for batch in streamer.subscribe(request, context)]
 
@@ -244,17 +249,13 @@ async def test_subscribe_returns_unimplemented_when_disabled():
 
 @pytest.mark.asyncio
 async def test_subscribe_sends_initial_metadata_before_stream():
-    streamer = GrpcKvEventStreamer(
-        kv_events_config=KVEventsConfig(
-            enable_kv_cache_events=True,
-            publisher="zmq",
+    streamer = _make_streamer(
+        kv_events_config=_make_enabled_kv_events_config(
             topic="kv-events",
-        ),
-        data_parallel_size=1,
-        pb2_module=vllm_engine_pb2,
+        )
     )
     context = _FakeStreamContext(cancelled=True, peer="ipv4:127.0.0.1:50051")
-    request = vllm_engine_pb2.SubscribeKvEventsRequest(start_sequence_number=0)
+    request = _make_request()
 
     responses = [batch async for batch in streamer.subscribe(request, context)]
 

--- a/tests/entrypoints/test_grpc_kv_events.py
+++ b/tests/entrypoints/test_grpc_kv_events.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+
 import pytest
 
 pytest.importorskip("grpc")
 
 import grpc
+from vllm.grpc import vllm_engine_pb2
 
 from vllm.config.kv_events import KVEventsConfig
 from vllm.distributed.kv_events import (
@@ -15,7 +17,6 @@ from vllm.distributed.kv_events import (
     KVEventBatch,
 )
 from vllm.entrypoints.grpc_kv_events import GrpcKvEventStreamer, _hash_to_int64
-from vllm.grpc import vllm_engine_pb2
 
 
 class _FakeContext:

--- a/tests/entrypoints/test_grpc_kv_events.py
+++ b/tests/entrypoints/test_grpc_kv_events.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+pytest.importorskip("grpc")
+
+from vllm.distributed.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    KVEventBatch,
+)
+from vllm.entrypoints.grpc_kv_events import GrpcKvEventStreamer, _hash_to_int64
+from vllm.grpc import vllm_engine_pb2
+
+
+def test_hash_to_int64_normalizes_unsigned_values():
+    assert _hash_to_int64(7) == 7
+    assert _hash_to_int64((1 << 63) + 5) == -9223372036854775803
+    assert _hash_to_int64(b"\xff" * 32) == -1
+
+
+def test_to_proto_batch_maps_all_event_variants():
+    streamer = GrpcKvEventStreamer(
+        kv_events_config=None,
+        data_parallel_size=1,
+        pb2_module=vllm_engine_pb2,
+    )
+
+    stored = BlockStored(
+        block_hashes=[1, 2],
+        parent_block_hash=3,
+        token_ids=[10, 11, 12],
+        block_size=16,
+        lora_id=5,
+        medium="CPU",
+        lora_name=None,
+    )
+    removed = BlockRemoved(block_hashes=[4, 5], medium="GPU")
+    cleared = AllBlocksCleared()
+    batch = KVEventBatch(
+        ts=123.45,
+        events=[stored, removed, cleared],
+        data_parallel_rank=2,
+    )
+
+    proto_batch = streamer._to_proto_batch(sequence_number=7, batch=batch)
+
+    assert proto_batch.sequence_number == 7
+    assert proto_batch.timestamp == 123.45
+    assert proto_batch.dp_rank == 2
+    assert len(proto_batch.events) == 3
+
+    proto_stored = proto_batch.events[0]
+    assert proto_stored.event_id == (7 << 32)
+    assert proto_stored.HasField("stored")
+    assert proto_stored.stored.parent_block_hash == 3
+    assert len(proto_stored.stored.blocks) == 2
+    assert proto_stored.stored.blocks[0].block_hash == 1
+    assert proto_stored.stored.blocks[0].token_ids == [10, 11, 12]
+    assert proto_stored.stored.blocks[0].block_size == 16
+    assert proto_stored.stored.blocks[0].lora_id == 5
+    assert proto_stored.stored.blocks[0].cache_level == 1
+
+    proto_removed = proto_batch.events[1]
+    assert proto_removed.event_id == (7 << 32) + 1
+    assert proto_removed.HasField("removed")
+    assert proto_removed.removed.block_hashes == [4, 5]
+    assert proto_removed.removed.cache_level == 0
+
+    proto_cleared = proto_batch.events[2]
+    assert proto_cleared.event_id == (7 << 32) + 2
+    assert proto_cleared.HasField("cleared")
+
+
+def test_unknown_medium_does_not_set_cache_level():
+    streamer = GrpcKvEventStreamer(
+        kv_events_config=None,
+        data_parallel_size=1,
+        pb2_module=vllm_engine_pb2,
+    )
+
+    removed = BlockRemoved(block_hashes=[1], medium="DISK")
+    proto_event = streamer._to_proto_event(event_id=0, event=removed)
+    assert proto_event.removed.block_hashes == [1]
+    assert not proto_event.removed.HasField("cache_level")
+
+
+def test_block_stored_token_ids_are_split_per_block():
+    streamer = GrpcKvEventStreamer(
+        kv_events_config=None,
+        data_parallel_size=1,
+        pb2_module=vllm_engine_pb2,
+    )
+
+    stored = BlockStored(
+        block_hashes=[101, 202],
+        parent_block_hash=None,
+        token_ids=[1, 2, 3, 4],
+        block_size=2,
+        lora_id=None,
+        medium="GPU",
+        lora_name=None,
+    )
+    proto_event = streamer._to_proto_event(event_id=0, event=stored)
+
+    assert proto_event.stored.blocks[0].token_ids == [1, 2]
+    assert proto_event.stored.blocks[1].token_ids == [3, 4]

--- a/tests/entrypoints/test_grpc_kv_events.py
+++ b/tests/entrypoints/test_grpc_kv_events.py
@@ -5,6 +5,9 @@ import pytest
 
 pytest.importorskip("grpc")
 
+import grpc
+
+from vllm.config.kv_events import KVEventsConfig
 from vllm.distributed.kv_events import (
     AllBlocksCleared,
     BlockRemoved,
@@ -13,6 +16,46 @@ from vllm.distributed.kv_events import (
 )
 from vllm.entrypoints.grpc_kv_events import GrpcKvEventStreamer, _hash_to_int64
 from vllm.grpc import vllm_engine_pb2
+
+
+class _FakeContext:
+    def __init__(self, cancelled: bool):
+        self._cancelled = cancelled
+
+    def cancelled(self) -> bool:
+        return self._cancelled
+
+    def done(self):
+        # Regression guard: _is_cancelled must not rely on done(),
+        # which may return a truthy future object.
+        return object()
+
+
+class _FakePeerContext(_FakeContext):
+    def __init__(self, cancelled: bool, peer: str):
+        super().__init__(cancelled=cancelled)
+        self._peer = peer
+
+    def peer(self) -> str:
+        return self._peer
+
+
+class _FakeAbortContext(_FakePeerContext):
+    def __init__(self, cancelled: bool, peer: str):
+        super().__init__(cancelled=cancelled, peer=peer)
+        self.aborted: tuple[grpc.StatusCode, str] | None = None
+
+    async def abort(self, code: grpc.StatusCode, details: str):
+        self.aborted = (code, details)
+
+
+class _FakeStreamContext(_FakeAbortContext):
+    def __init__(self, cancelled: bool, peer: str):
+        super().__init__(cancelled=cancelled, peer=peer)
+        self.initial_metadata_sent = False
+
+    async def send_initial_metadata(self, _metadata):
+        self.initial_metadata_sent = True
 
 
 def test_hash_to_int64_normalizes_unsigned_values():
@@ -107,3 +150,114 @@ def test_block_stored_token_ids_are_split_per_block():
 
     assert proto_event.stored.blocks[0].token_ids == [1, 2]
     assert proto_event.stored.blocks[1].token_ids == [3, 4]
+
+
+def test_is_cancelled_uses_cancelled_method_false():
+    assert not GrpcKvEventStreamer._is_cancelled(_FakeContext(cancelled=False))
+
+
+def test_is_cancelled_uses_cancelled_method_true():
+    assert GrpcKvEventStreamer._is_cancelled(_FakeContext(cancelled=True))
+
+
+@pytest.mark.parametrize(
+    ("peer", "is_local"),
+    [
+        ("unix:/tmp/vllm.sock", True),
+        ("ipv4:127.0.0.1:50051", True),
+        ("ipv4:10.1.2.3:50051", False),
+        ("ipv6:[::1]:50051", True),
+        ("ipv6:[2001:db8::1]:50051", False),
+        ("unknown:anything", False),
+        ("", False),
+    ],
+)
+def test_is_local_peer(peer: str, is_local: bool):
+    assert GrpcKvEventStreamer._is_local_peer(peer) is is_local
+
+
+def test_is_subscriber_allowed_respects_allow_remote_subscribe():
+    streamer_default = GrpcKvEventStreamer(
+        kv_events_config=KVEventsConfig(
+            enable_kv_cache_events=True,
+            publisher="zmq",
+        ),
+        data_parallel_size=1,
+        pb2_module=vllm_engine_pb2,
+    )
+    remote_context = _FakePeerContext(cancelled=False, peer="ipv4:10.1.2.3:50051")
+    assert not streamer_default._is_subscriber_allowed(remote_context)
+
+    streamer_remote_allowed = GrpcKvEventStreamer(
+        kv_events_config=KVEventsConfig(
+            enable_kv_cache_events=True,
+            publisher="zmq",
+            allow_remote_subscribe=True,
+        ),
+        data_parallel_size=1,
+        pb2_module=vllm_engine_pb2,
+    )
+    assert streamer_remote_allowed._is_subscriber_allowed(remote_context)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_denies_remote_peer_by_default():
+    streamer = GrpcKvEventStreamer(
+        kv_events_config=KVEventsConfig(
+            enable_kv_cache_events=True,
+            publisher="zmq",
+            topic="kv-events",
+        ),
+        data_parallel_size=1,
+        pb2_module=vllm_engine_pb2,
+    )
+    context = _FakeAbortContext(cancelled=False, peer="ipv4:10.1.2.3:50051")
+    request = vllm_engine_pb2.SubscribeKvEventsRequest(start_sequence_number=0)
+
+    responses = [batch async for batch in streamer.subscribe(request, context)]
+
+    assert responses == []
+    assert context.aborted is not None
+    code, details = context.aborted
+    assert code == grpc.StatusCode.PERMISSION_DENIED
+    assert "allow_remote_subscribe=true" in details
+
+
+@pytest.mark.asyncio
+async def test_subscribe_returns_unimplemented_when_disabled():
+    streamer = GrpcKvEventStreamer(
+        kv_events_config=None,
+        data_parallel_size=1,
+        pb2_module=vllm_engine_pb2,
+    )
+    context = _FakeAbortContext(cancelled=False, peer="")
+    request = vllm_engine_pb2.SubscribeKvEventsRequest(start_sequence_number=0)
+
+    responses = [batch async for batch in streamer.subscribe(request, context)]
+
+    assert responses == []
+    assert context.aborted is not None
+    code, details = context.aborted
+    assert code == grpc.StatusCode.UNIMPLEMENTED
+    assert "KV cache events are not enabled" in details
+
+
+@pytest.mark.asyncio
+async def test_subscribe_sends_initial_metadata_before_stream():
+    streamer = GrpcKvEventStreamer(
+        kv_events_config=KVEventsConfig(
+            enable_kv_cache_events=True,
+            publisher="zmq",
+            topic="kv-events",
+        ),
+        data_parallel_size=1,
+        pb2_module=vllm_engine_pb2,
+    )
+    context = _FakeStreamContext(cancelled=True, peer="ipv4:127.0.0.1:50051")
+    request = vllm_engine_pb2.SubscribeKvEventsRequest(start_sequence_number=0)
+
+    responses = [batch async for batch in streamer.subscribe(request, context)]
+
+    assert responses == []
+    assert context.aborted is None
+    assert context.initial_metadata_sent

--- a/tests/entrypoints/test_grpc_server_kv_registration.py
+++ b/tests/entrypoints/test_grpc_server_kv_registration.py
@@ -118,15 +118,39 @@ def _make_async_llm():
     )
 
 
-def _make_async_llm_with_kv_events_disabled():
+def _make_async_llm_with_kv_events_config(kv_events_config: Any):
     return SimpleNamespace(
         vllm_config=SimpleNamespace(
-            kv_events_config=SimpleNamespace(
-                enable_kv_cache_events=False,
-                publisher="null",
-            ),
+            kv_events_config=kv_events_config,
             parallel_config=SimpleNamespace(data_parallel_size=1),
         )
+    )
+
+
+def _make_async_llm_with_kv_events_disabled():
+    return _make_async_llm_with_kv_events_config(
+        SimpleNamespace(
+            enable_kv_cache_events=False,
+            publisher="null",
+        )
+    )
+
+
+def _make_async_llm_with_kv_events_enabled_local_only():
+    return _make_async_llm_with_kv_events_config(
+        SimpleNamespace(
+            enable_kv_cache_events=True,
+            publisher="zmq",
+            allow_remote_subscribe=False,
+        )
+    )
+
+
+def _subscribe_kv_events_rpc(channel: grpc.aio.Channel):
+    return channel.unary_stream(
+        "/vllm.grpc.engine.VllmEngine/SubscribeKvEvents",
+        request_serializer=local_pb2.SubscribeKvEventsRequest.SerializeToString,
+        response_deserializer=local_pb2.KvEventBatch.FromString,
     )
 
 
@@ -278,11 +302,7 @@ async def test_subscribe_kv_events_round_trip_with_servicer_override(
 
     channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
     try:
-        rpc = channel.unary_stream(
-            "/vllm.grpc.engine.VllmEngine/SubscribeKvEvents",
-            request_serializer=local_pb2.SubscribeKvEventsRequest.SerializeToString,
-            response_deserializer=local_pb2.KvEventBatch.FromString,
-        )
+        rpc = _subscribe_kv_events_rpc(channel)
         call = rpc(local_pb2.SubscribeKvEventsRequest(start_sequence_number=42))
         responses = [msg async for msg in call]
         assert len(responses) == 1
@@ -356,11 +376,7 @@ async def test_subscribe_kv_events_round_trip_with_fallback_handler(
 
     channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
     try:
-        rpc = channel.unary_stream(
-            "/vllm.grpc.engine.VllmEngine/SubscribeKvEvents",
-            request_serializer=local_pb2.SubscribeKvEventsRequest.SerializeToString,
-            response_deserializer=local_pb2.KvEventBatch.FromString,
-        )
+        rpc = _subscribe_kv_events_rpc(channel)
         call = rpc(local_pb2.SubscribeKvEventsRequest(start_sequence_number=7))
         responses = [msg async for msg in call]
         assert len(responses) == 1
@@ -402,17 +418,62 @@ async def test_subscribe_kv_events_returns_unimplemented_when_disabled(
 
     channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
     try:
-        rpc = channel.unary_stream(
-            "/vllm.grpc.engine.VllmEngine/SubscribeKvEvents",
-            request_serializer=local_pb2.SubscribeKvEventsRequest.SerializeToString,
-            response_deserializer=local_pb2.KvEventBatch.FromString,
-        )
+        rpc = _subscribe_kv_events_rpc(channel)
         call = rpc(local_pb2.SubscribeKvEventsRequest(start_sequence_number=0))
         with pytest.raises(grpc.aio.AioRpcError) as exc_info:
             await call.read()
 
         assert exc_info.value.code() == grpc.StatusCode.UNIMPLEMENTED
         assert "KV cache events are not enabled" in exc_info.value.details()
+    finally:
+        await channel.close()
+        await server.stop(None)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_kv_events_returns_permission_denied_for_remote_peer(
+    monkeypatch,
+    grpc_server_module,
+):
+    server = grpc.aio.server()
+    servicer = local_pb2_grpc.VllmEngineServicer()
+    async_llm = _make_async_llm_with_kv_events_enabled_local_only()
+
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_resolve_kv_proto_bindings",
+        lambda _pb2_module: (
+            local_pb2.SubscribeKvEventsRequest,
+            local_pb2.KvEventBatch,
+            local_pb2,
+        ),
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_supports_subscribe_kv_events",
+        lambda _pb2_module: True,
+    )
+    monkeypatch.setattr(
+        grpc_server_module.GrpcKvEventStreamer,
+        "_peer",
+        staticmethod(lambda _context: "ipv4:10.1.2.3:50051"),
+    )
+
+    grpc_server_module._register_subscribe_kv_events(server, servicer, async_llm)
+    local_pb2_grpc.add_VllmEngineServicer_to_server(servicer, server)
+
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+
+    channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
+    try:
+        rpc = _subscribe_kv_events_rpc(channel)
+        call = rpc(local_pb2.SubscribeKvEventsRequest(start_sequence_number=0))
+        with pytest.raises(grpc.aio.AioRpcError) as exc_info:
+            await call.read()
+
+        assert exc_info.value.code() == grpc.StatusCode.PERMISSION_DENIED
+        assert "allow_remote_subscribe=true" in exc_info.value.details()
     finally:
         await channel.close()
         await server.stop(None)

--- a/tests/entrypoints/test_grpc_server_kv_registration.py
+++ b/tests/entrypoints/test_grpc_server_kv_registration.py
@@ -12,7 +12,6 @@ pytest.importorskip("grpc")
 pytest.importorskip("torch")
 
 import grpc
-
 from vllm.grpc import vllm_engine_pb2 as local_pb2
 from vllm.grpc import vllm_engine_pb2_grpc as local_pb2_grpc
 

--- a/tests/entrypoints/test_grpc_server_kv_registration.py
+++ b/tests/entrypoints/test_grpc_server_kv_registration.py
@@ -371,7 +371,7 @@ async def test_subscribe_kv_events_round_trip_with_fallback_handler(
 
 
 @pytest.mark.asyncio
-async def test_subscribe_kv_events_returns_failed_precondition_when_disabled(
+async def test_subscribe_kv_events_returns_unimplemented_when_disabled(
     monkeypatch,
     grpc_server_module,
 ):
@@ -411,7 +411,7 @@ async def test_subscribe_kv_events_returns_failed_precondition_when_disabled(
         with pytest.raises(grpc.aio.AioRpcError) as exc_info:
             await call.read()
 
-        assert exc_info.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+        assert exc_info.value.code() == grpc.StatusCode.UNIMPLEMENTED
         assert "KV cache events are not enabled" in exc_info.value.details()
     finally:
         await channel.close()

--- a/tests/entrypoints/test_grpc_server_kv_registration.py
+++ b/tests/entrypoints/test_grpc_server_kv_registration.py
@@ -4,6 +4,7 @@
 import importlib
 import sys
 from types import ModuleType, SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -17,14 +18,14 @@ from vllm.grpc import vllm_engine_pb2_grpc as local_pb2_grpc
 
 
 def _install_grpc_reflection_stub(monkeypatch: pytest.MonkeyPatch) -> None:
-    reflection_module = ModuleType("grpc_reflection.v1alpha.reflection")
+    reflection_module: Any = ModuleType("grpc_reflection.v1alpha.reflection")
     reflection_module.SERVICE_NAME = "grpc.reflection.v1alpha.ServerReflection"
     reflection_module.enable_server_reflection = lambda *_args, **_kwargs: None
 
-    v1alpha_module = ModuleType("grpc_reflection.v1alpha")
+    v1alpha_module: Any = ModuleType("grpc_reflection.v1alpha")
     v1alpha_module.reflection = reflection_module
 
-    root_module = ModuleType("grpc_reflection")
+    root_module: Any = ModuleType("grpc_reflection")
     root_module.v1alpha = v1alpha_module
 
     monkeypatch.setitem(sys.modules, "grpc_reflection", root_module)
@@ -37,17 +38,17 @@ def _install_grpc_reflection_stub(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _install_smg_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
-    smg_proto_module = ModuleType("smg_grpc_proto")
+    smg_proto_module: Any = ModuleType("smg_grpc_proto")
     smg_proto_module.vllm_engine_pb2 = local_pb2
     smg_proto_module.vllm_engine_pb2_grpc = local_pb2_grpc
 
-    servicer_module = ModuleType("smg_grpc_servicer.vllm.servicer")
+    servicer_module: Any = ModuleType("smg_grpc_servicer.vllm.servicer")
     servicer_module.VllmEngineServicer = local_pb2_grpc.VllmEngineServicer
 
-    vllm_module = ModuleType("smg_grpc_servicer.vllm")
+    vllm_module: Any = ModuleType("smg_grpc_servicer.vllm")
     vllm_module.servicer = servicer_module
 
-    root_module = ModuleType("smg_grpc_servicer")
+    root_module: Any = ModuleType("smg_grpc_servicer")
     root_module.vllm = vllm_module
 
     monkeypatch.setitem(sys.modules, "smg_grpc_proto", smg_proto_module)
@@ -69,30 +70,26 @@ def grpc_server_module(monkeypatch: pytest.MonkeyPatch):
 
 
 class _DummyRequest:
-
     @staticmethod
     def FromString(data):
         return data
 
 
 class _DummyResponse:
-
     @staticmethod
     def SerializeToString(_message):
         return b""
 
 
 class _FakeServer:
-
     def __init__(self) -> None:
-        self.generic_handlers = []
+        self.generic_handlers: list[Any] = []
 
     def add_generic_rpc_handlers(self, handlers):
         self.generic_handlers.extend(handlers)
 
 
 class _DummyStreamer:
-
     def __init__(self, **kwargs):
         self.kwargs = kwargs
 
@@ -102,7 +99,6 @@ class _DummyStreamer:
 
 
 class _ProtoAwareDummyStreamer:
-
     def __init__(self, **kwargs):
         self._pb2 = kwargs["pb2_module"]
 

--- a/tests/entrypoints/test_grpc_server_kv_registration.py
+++ b/tests/entrypoints/test_grpc_server_kv_registration.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+pytest.importorskip("grpc")
+pytest.importorskip("torch")
+
+import grpc
+
+from vllm.grpc import vllm_engine_pb2 as local_pb2
+from vllm.grpc import vllm_engine_pb2_grpc as local_pb2_grpc
+
+
+def _install_grpc_reflection_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    reflection_module = ModuleType("grpc_reflection.v1alpha.reflection")
+    reflection_module.SERVICE_NAME = "grpc.reflection.v1alpha.ServerReflection"
+    reflection_module.enable_server_reflection = lambda *_args, **_kwargs: None
+
+    v1alpha_module = ModuleType("grpc_reflection.v1alpha")
+    v1alpha_module.reflection = reflection_module
+
+    root_module = ModuleType("grpc_reflection")
+    root_module.v1alpha = v1alpha_module
+
+    monkeypatch.setitem(sys.modules, "grpc_reflection", root_module)
+    monkeypatch.setitem(sys.modules, "grpc_reflection.v1alpha", v1alpha_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "grpc_reflection.v1alpha.reflection",
+        reflection_module,
+    )
+
+
+def _install_smg_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    smg_proto_module = ModuleType("smg_grpc_proto")
+    smg_proto_module.vllm_engine_pb2 = local_pb2
+    smg_proto_module.vllm_engine_pb2_grpc = local_pb2_grpc
+
+    servicer_module = ModuleType("smg_grpc_servicer.vllm.servicer")
+    servicer_module.VllmEngineServicer = local_pb2_grpc.VllmEngineServicer
+
+    vllm_module = ModuleType("smg_grpc_servicer.vllm")
+    vllm_module.servicer = servicer_module
+
+    root_module = ModuleType("smg_grpc_servicer")
+    root_module.vllm = vllm_module
+
+    monkeypatch.setitem(sys.modules, "smg_grpc_proto", smg_proto_module)
+    monkeypatch.setitem(sys.modules, "smg_grpc_servicer", root_module)
+    monkeypatch.setitem(sys.modules, "smg_grpc_servicer.vllm", vllm_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "smg_grpc_servicer.vllm.servicer",
+        servicer_module,
+    )
+
+
+@pytest.fixture
+def grpc_server_module(monkeypatch: pytest.MonkeyPatch):
+    _install_grpc_reflection_stub(monkeypatch)
+    _install_smg_stubs(monkeypatch)
+    monkeypatch.delitem(sys.modules, "vllm.entrypoints.grpc_server", raising=False)
+    return importlib.import_module("vllm.entrypoints.grpc_server")
+
+
+class _DummyRequest:
+
+    @staticmethod
+    def FromString(data):
+        return data
+
+
+class _DummyResponse:
+
+    @staticmethod
+    def SerializeToString(_message):
+        return b""
+
+
+class _FakeServer:
+
+    def __init__(self) -> None:
+        self.generic_handlers = []
+
+    def add_generic_rpc_handlers(self, handlers):
+        self.generic_handlers.extend(handlers)
+
+
+class _DummyStreamer:
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    async def subscribe(self, _request, _context):
+        if False:
+            yield None
+
+
+class _ProtoAwareDummyStreamer:
+
+    def __init__(self, **kwargs):
+        self._pb2 = kwargs["pb2_module"]
+
+    async def subscribe(self, request, _context):
+        yield self._pb2.KvEventBatch(
+            sequence_number=max(0, int(request.start_sequence_number)),
+            timestamp=1.0,
+        )
+
+
+def _make_async_llm():
+    return SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            kv_events_config=SimpleNamespace(),
+            parallel_config=SimpleNamespace(data_parallel_size=1),
+        )
+    )
+
+
+def _make_async_llm_with_kv_events_disabled():
+    return SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            kv_events_config=SimpleNamespace(
+                enable_kv_cache_events=False,
+                publisher="null",
+            ),
+            parallel_config=SimpleNamespace(data_parallel_size=1),
+        )
+    )
+
+
+def test_register_subscribe_kv_events_overrides_servicer(
+    monkeypatch,
+    grpc_server_module,
+):
+    server = _FakeServer()
+    servicer = SimpleNamespace()
+    async_llm = _make_async_llm()
+
+    monkeypatch.setattr(grpc_server_module, "GrpcKvEventStreamer", _DummyStreamer)
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_resolve_kv_proto_bindings",
+        lambda _pb2_module: (_DummyRequest, _DummyResponse, SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_supports_subscribe_kv_events",
+        lambda _pb2_module: True,
+    )
+
+    grpc_server_module._register_subscribe_kv_events(server, servicer, async_llm)
+
+    assert callable(servicer.SubscribeKvEvents)
+    assert server.generic_handlers == []
+
+
+def test_register_subscribe_kv_events_fallback_uses_descriptor_full_name(
+    monkeypatch,
+    grpc_server_module,
+):
+    server = _FakeServer()
+    servicer = SimpleNamespace()
+    async_llm = _make_async_llm()
+
+    monkeypatch.setattr(grpc_server_module, "GrpcKvEventStreamer", _DummyStreamer)
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_resolve_kv_proto_bindings",
+        lambda _pb2_module: (_DummyRequest, _DummyResponse, SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_supports_subscribe_kv_events",
+        lambda _pb2_module: False,
+    )
+
+    fake_service = SimpleNamespace(full_name="custom.grpc.engine.VllmEngine")
+    fake_descriptor = SimpleNamespace(services_by_name={"VllmEngine": fake_service})
+    monkeypatch.setattr(
+        grpc_server_module,
+        "vllm_engine_pb2",
+        SimpleNamespace(DESCRIPTOR=fake_descriptor),
+    )
+
+    def _fake_unary_stream_rpc_method_handler(*args, **kwargs):
+        return SimpleNamespace(args=args, kwargs=kwargs)
+
+    def _fake_method_handlers_generic_handler(service_name, method_handlers):
+        return SimpleNamespace(
+            service_name=service_name,
+            method_handlers=method_handlers,
+        )
+
+    monkeypatch.setattr(
+        grpc_server_module,
+        "grpc",
+        SimpleNamespace(
+            unary_stream_rpc_method_handler=_fake_unary_stream_rpc_method_handler,
+            method_handlers_generic_handler=_fake_method_handlers_generic_handler,
+        ),
+    )
+
+    grpc_server_module._register_subscribe_kv_events(server, servicer, async_llm)
+
+    assert len(server.generic_handlers) == 1
+    handler = server.generic_handlers[0]
+    assert handler.service_name == "custom.grpc.engine.VllmEngine"
+    assert "SubscribeKvEvents" in handler.method_handlers
+
+
+def test_register_subscribe_kv_events_fallback_raises_when_service_missing(
+    monkeypatch,
+    grpc_server_module,
+):
+    server = _FakeServer()
+    servicer = SimpleNamespace()
+    async_llm = _make_async_llm()
+
+    monkeypatch.setattr(grpc_server_module, "GrpcKvEventStreamer", _DummyStreamer)
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_resolve_kv_proto_bindings",
+        lambda _pb2_module: (_DummyRequest, _DummyResponse, SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_supports_subscribe_kv_events",
+        lambda _pb2_module: False,
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "vllm_engine_pb2",
+        SimpleNamespace(DESCRIPTOR=SimpleNamespace(services_by_name={})),
+    )
+
+    with pytest.raises(RuntimeError, match="VllmEngine service descriptor is missing"):
+        grpc_server_module._register_subscribe_kv_events(server, servicer, async_llm)
+
+    assert server.generic_handlers == []
+
+
+@pytest.mark.asyncio
+async def test_subscribe_kv_events_round_trip_with_servicer_override(
+    monkeypatch,
+    grpc_server_module,
+):
+    server = grpc.aio.server()
+    servicer = local_pb2_grpc.VllmEngineServicer()
+    async_llm = _make_async_llm()
+
+    monkeypatch.setattr(
+        grpc_server_module,
+        "GrpcKvEventStreamer",
+        _ProtoAwareDummyStreamer,
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_resolve_kv_proto_bindings",
+        lambda _pb2_module: (
+            local_pb2.SubscribeKvEventsRequest,
+            local_pb2.KvEventBatch,
+            local_pb2,
+        ),
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_supports_subscribe_kv_events",
+        lambda _pb2_module: True,
+    )
+
+    grpc_server_module._register_subscribe_kv_events(server, servicer, async_llm)
+    local_pb2_grpc.add_VllmEngineServicer_to_server(servicer, server)
+
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+
+    channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
+    try:
+        rpc = channel.unary_stream(
+            "/vllm.grpc.engine.VllmEngine/SubscribeKvEvents",
+            request_serializer=local_pb2.SubscribeKvEventsRequest.SerializeToString,
+            response_deserializer=local_pb2.KvEventBatch.FromString,
+        )
+        call = rpc(local_pb2.SubscribeKvEventsRequest(start_sequence_number=42))
+        responses = [msg async for msg in call]
+        assert len(responses) == 1
+        assert responses[0].sequence_number == 42
+    finally:
+        await channel.close()
+        await server.stop(None)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_kv_events_round_trip_with_fallback_handler(
+    monkeypatch,
+    grpc_server_module,
+):
+    server = grpc.aio.server()
+    servicer = SimpleNamespace()
+    async_llm = _make_async_llm()
+
+    monkeypatch.setattr(
+        grpc_server_module,
+        "GrpcKvEventStreamer",
+        _ProtoAwareDummyStreamer,
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_resolve_kv_proto_bindings",
+        lambda _pb2_module: (
+            local_pb2.SubscribeKvEventsRequest,
+            local_pb2.KvEventBatch,
+            local_pb2,
+        ),
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_supports_subscribe_kv_events",
+        lambda _pb2_module: False,
+    )
+    monkeypatch.setattr(grpc_server_module, "vllm_engine_pb2", local_pb2)
+
+    def _fake_add_servicer_to_server(_servicer, target_server):
+        health_handler = grpc.unary_unary_rpc_method_handler(
+            lambda _request, _context: local_pb2.HealthCheckResponse(
+                healthy=True,
+                message="ok",
+            ),
+            request_deserializer=local_pb2.HealthCheckRequest.FromString,
+            response_serializer=local_pb2.HealthCheckResponse.SerializeToString,
+        )
+        target_server.add_generic_rpc_handlers(
+            (
+                grpc.method_handlers_generic_handler(
+                    "vllm.grpc.engine.VllmEngine",
+                    {"HealthCheck": health_handler},
+                ),
+            )
+        )
+
+    monkeypatch.setattr(
+        grpc_server_module,
+        "vllm_engine_pb2_grpc",
+        SimpleNamespace(add_VllmEngineServicer_to_server=_fake_add_servicer_to_server),
+    )
+    grpc_server_module._register_subscribe_kv_events(server, servicer, async_llm)
+    grpc_server_module.vllm_engine_pb2_grpc.add_VllmEngineServicer_to_server(
+        servicer,
+        server,
+    )
+
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+
+    channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
+    try:
+        rpc = channel.unary_stream(
+            "/vllm.grpc.engine.VllmEngine/SubscribeKvEvents",
+            request_serializer=local_pb2.SubscribeKvEventsRequest.SerializeToString,
+            response_deserializer=local_pb2.KvEventBatch.FromString,
+        )
+        call = rpc(local_pb2.SubscribeKvEventsRequest(start_sequence_number=7))
+        responses = [msg async for msg in call]
+        assert len(responses) == 1
+        assert responses[0].sequence_number == 7
+    finally:
+        await channel.close()
+        await server.stop(None)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_kv_events_returns_failed_precondition_when_disabled(
+    monkeypatch,
+    grpc_server_module,
+):
+    server = grpc.aio.server()
+    servicer = local_pb2_grpc.VllmEngineServicer()
+    async_llm = _make_async_llm_with_kv_events_disabled()
+
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_resolve_kv_proto_bindings",
+        lambda _pb2_module: (
+            local_pb2.SubscribeKvEventsRequest,
+            local_pb2.KvEventBatch,
+            local_pb2,
+        ),
+    )
+    monkeypatch.setattr(
+        grpc_server_module,
+        "_supports_subscribe_kv_events",
+        lambda _pb2_module: True,
+    )
+
+    grpc_server_module._register_subscribe_kv_events(server, servicer, async_llm)
+    local_pb2_grpc.add_VllmEngineServicer_to_server(servicer, server)
+
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+
+    channel = grpc.aio.insecure_channel(f"127.0.0.1:{port}")
+    try:
+        rpc = channel.unary_stream(
+            "/vllm.grpc.engine.VllmEngine/SubscribeKvEvents",
+            request_serializer=local_pb2.SubscribeKvEventsRequest.SerializeToString,
+            response_deserializer=local_pb2.KvEventBatch.FromString,
+        )
+        call = rpc(local_pb2.SubscribeKvEventsRequest(start_sequence_number=0))
+        with pytest.raises(grpc.aio.AioRpcError) as exc_info:
+            await call.read()
+
+        assert exc_info.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+        assert "KV cache events are not enabled" in exc_info.value.details()
+    finally:
+        await channel.close()
+        await server.stop(None)

--- a/vllm/config/kv_events.py
+++ b/vllm/config/kv_events.py
@@ -49,6 +49,12 @@ class KVEventsConfig:
     this topic to receive events.
     """
 
+    allow_remote_subscribe: bool = False
+    """If False (default), SubscribeKvEvents only allows local loopback or unix
+    peers. Set to True to allow remote gRPC subscribers. KV events include
+    token IDs and may expose sensitive prompt/response content.
+    """
+
     def __post_init__(self):
         if self.publisher is None:
             self.publisher = "zmq" if self.enable_kv_cache_events else "null"

--- a/vllm/entrypoints/grpc_kv_events.py
+++ b/vllm/entrypoints/grpc_kv_events.py
@@ -171,20 +171,15 @@ class GrpcKvEventStreamer:
                 if sequence_number < start_sequence:
                     continue
 
-                try:
-                    decoded_batch = self._decoder.decode(payload)
-                except Exception as exc:
-                    logger.warning(
-                        "Failed to decode KV event batch seq=%d: %s",
-                        sequence_number,
-                        exc,
-                    )
+                message = self._decode_and_maybe_convert(
+                    payload,
+                    sequence_number,
+                    last_seq_by_dp,
+                    source="KV event",
+                )
+                if message is None:
                     continue
-                if not self._should_emit(
-                    decoded_batch, sequence_number, last_seq_by_dp
-                ):
-                    continue
-                yield self._to_proto_batch(sequence_number, decoded_batch)
+                yield message
 
         except asyncio.CancelledError:
             return
@@ -231,27 +226,27 @@ class GrpcKvEventStreamer:
             if sequence_number < start_sequence:
                 continue
 
-            try:
-                decoded_batch = self._decoder.decode(payload)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to decode KV replay batch seq=%d: %s",
-                    sequence_number,
-                    exc,
-                )
+            message = self._decode_and_maybe_convert(
+                payload,
+                sequence_number,
+                last_seq_by_dp,
+                source="KV replay",
+            )
+            if message is None:
                 continue
-            if not self._should_emit(decoded_batch, sequence_number, last_seq_by_dp):
-                continue
-            yield self._to_proto_batch(sequence_number, decoded_batch)
+            yield message
+
+    def _offset_endpoint(self, endpoint: str, dp_rank: int) -> str:
+        maybe_endpoint = ZmqEventPublisher.offset_endpoint_port(endpoint, dp_rank)
+        if maybe_endpoint is None:
+            raise ValueError("KV event endpoint must not be None")
+        return maybe_endpoint
 
     def _offset_endpoints(self, endpoint: str) -> list[str]:
-        endpoints: list[str] = []
-        for dp_rank in range(self._data_parallel_size):
-            maybe_endpoint = ZmqEventPublisher.offset_endpoint_port(endpoint, dp_rank)
-            if maybe_endpoint is None:
-                raise ValueError("KV event endpoint must not be None")
-            endpoints.append(maybe_endpoint)
-        return endpoints
+        return [
+            self._offset_endpoint(endpoint, dp_rank)
+            for dp_rank in range(self._data_parallel_size)
+        ]
 
     def _is_subscriber_allowed(self, context: grpc.aio.ServicerContext) -> bool:
         assert self._config is not None
@@ -275,6 +270,27 @@ class GrpcKvEventStreamer:
             return False
         last_seq_by_dp[dp_rank] = sequence_number
         return True
+
+    def _decode_and_maybe_convert(
+        self,
+        payload: bytes,
+        sequence_number: int,
+        last_seq_by_dp: dict[int, int],
+        source: str,
+    ) -> Any | None:
+        try:
+            decoded_batch = self._decoder.decode(payload)
+        except Exception as exc:
+            logger.warning(
+                "Failed to decode %s batch seq=%d: %s",
+                source,
+                sequence_number,
+                exc,
+            )
+            return None
+        if not self._should_emit(decoded_batch, sequence_number, last_seq_by_dp):
+            return None
+        return self._to_proto_batch(sequence_number, decoded_batch)
 
     def _to_proto_batch(self, sequence_number: int, batch: KVEventBatch) -> Any:
         proto_events = [
@@ -366,20 +382,20 @@ class GrpcKvEventStreamer:
     def _is_local_peer(cls, peer: str) -> bool:
         if not peer:
             return False
-        if peer.startswith("unix:"):
+        family, _, address = peer.partition(":")
+        if family == "unix":
             return True
-        if peer.startswith("ipv4:"):
-            host_port = peer[len("ipv4:") :]
-            if ":" in host_port:
-                host = host_port.rsplit(":", maxsplit=1)[0]
-            else:
-                host = host_port
-            return cls._is_loopback_host(host)
-        if peer.startswith("ipv6:"):
-            host_port = peer[len("ipv6:") :]
-            host = cls._extract_ipv6_host(host_port)
-            return cls._is_loopback_host(host)
+        if family == "ipv4":
+            return cls._is_loopback_host(cls._extract_ipv4_host(address))
+        if family == "ipv6":
+            return cls._is_loopback_host(cls._extract_ipv6_host(address))
         return False
+
+    @staticmethod
+    def _extract_ipv4_host(host_port: str) -> str:
+        if ":" in host_port:
+            return host_port.rsplit(":", maxsplit=1)[0]
+        return host_port
 
     @staticmethod
     def _extract_ipv6_host(host_port: str) -> str:

--- a/vllm/entrypoints/grpc_kv_events.py
+++ b/vllm/entrypoints/grpc_kv_events.py
@@ -390,10 +390,7 @@ class GrpcKvEventStreamer:
             if bracket_end != -1:
                 return host_port[1:bracket_end]
             return host_port.strip("[]")
-        # grpc peer strings for ipv6 are generally bracketed when a port is
-        # present, but keep a best-effort fallback.
-        if ":" in host_port and host_port.count(":") == 1:
-            return host_port.rsplit(":", maxsplit=1)[0]
+        # An unbracketed IPv6 address is assumed to not have a port.
         return host_port
 
     @staticmethod

--- a/vllm/entrypoints/grpc_kv_events.py
+++ b/vllm/entrypoints/grpc_kv_events.py
@@ -227,10 +227,13 @@ class GrpcKvEventStreamer:
             yield self._to_proto_batch(sequence_number, decoded_batch)
 
     def _offset_endpoints(self, endpoint: str) -> list[str]:
-        return [
-            ZmqEventPublisher.offset_endpoint_port(endpoint, dp_rank)
-            for dp_rank in range(self._data_parallel_size)
-        ]
+        endpoints: list[str] = []
+        for dp_rank in range(self._data_parallel_size):
+            maybe_endpoint = ZmqEventPublisher.offset_endpoint_port(endpoint, dp_rank)
+            if maybe_endpoint is None:
+                raise ValueError("KV event endpoint must not be None")
+            endpoints.append(maybe_endpoint)
+        return endpoints
 
     def _should_emit(
         self,

--- a/vllm/entrypoints/grpc_kv_events.py
+++ b/vllm/entrypoints/grpc_kv_events.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 from typing import Any
 
 import grpc
@@ -96,13 +98,29 @@ class GrpcKvEventStreamer:
     ) -> AsyncGenerator[Any, None]:
         if not self.enabled:
             await context.abort(
-                grpc.StatusCode.FAILED_PRECONDITION,
+                grpc.StatusCode.UNIMPLEMENTED,
                 "KV cache events are not enabled. Set --kv-events-config with "
                 "enable_kv_cache_events=true and publisher=zmq.",
             )
             return
 
         assert self._config is not None
+        if not self._is_subscriber_allowed(context):
+            await context.abort(
+                grpc.StatusCode.PERMISSION_DENIED,
+                "SubscribeKvEvents is restricted to local subscribers by "
+                "default. Set kv_events_config.allow_remote_subscribe=true "
+                "only on trusted networks.",
+            )
+            return
+
+        send_initial_metadata = getattr(context, "send_initial_metadata", None)
+        if callable(send_initial_metadata):
+            # Flush response headers immediately so clients can await
+            # stream setup without waiting for the first event.
+            with suppress(Exception):
+                await send_initial_metadata(())
+
         start_sequence = max(0, int(getattr(request, "start_sequence_number", 0)))
 
         ctx = zmq.asyncio.Context.instance()
@@ -235,6 +253,12 @@ class GrpcKvEventStreamer:
             endpoints.append(maybe_endpoint)
         return endpoints
 
+    def _is_subscriber_allowed(self, context: grpc.aio.ServicerContext) -> bool:
+        assert self._config is not None
+        if self._config.allow_remote_subscribe:
+            return True
+        return self._is_local_peer(self._peer(context))
+
     def _should_emit(
         self,
         decoded_batch: KVEventBatch,
@@ -328,13 +352,64 @@ class GrpcKvEventStreamer:
         return (seq_hi << 32) | idx_lo
 
     @staticmethod
-    def _is_cancelled(context: grpc.aio.ServicerContext) -> bool:
-        for method_name in ("done", "cancelled"):
-            method = getattr(context, method_name, None)
-            if callable(method):
-                try:
-                    if bool(method()):
-                        return True
-                except Exception:
-                    continue
+    def _peer(context: grpc.aio.ServicerContext) -> str:
+        peer_method = getattr(context, "peer", None)
+        if callable(peer_method):
+            try:
+                peer_value = peer_method()
+            except Exception:
+                return ""
+            return str(peer_value) if peer_value is not None else ""
+        return ""
+
+    @classmethod
+    def _is_local_peer(cls, peer: str) -> bool:
+        if not peer:
+            return False
+        if peer.startswith("unix:"):
+            return True
+        if peer.startswith("ipv4:"):
+            host_port = peer[len("ipv4:") :]
+            if ":" in host_port:
+                host = host_port.rsplit(":", maxsplit=1)[0]
+            else:
+                host = host_port
+            return cls._is_loopback_host(host)
+        if peer.startswith("ipv6:"):
+            host_port = peer[len("ipv6:") :]
+            host = cls._extract_ipv6_host(host_port)
+            return cls._is_loopback_host(host)
         return False
+
+    @staticmethod
+    def _extract_ipv6_host(host_port: str) -> str:
+        if not host_port:
+            return ""
+        if host_port.startswith("["):
+            bracket_end = host_port.find("]")
+            if bracket_end != -1:
+                return host_port[1:bracket_end]
+            return host_port.strip("[]")
+        # grpc peer strings for ipv6 are generally bracketed when a port is
+        # present, but keep a best-effort fallback.
+        if ":" in host_port and host_port.count(":") == 1:
+            return host_port.rsplit(":", maxsplit=1)[0]
+        return host_port
+
+    @staticmethod
+    def _is_loopback_host(host: str) -> bool:
+        normalized = host.strip().strip("[]")
+        if not normalized:
+            return False
+        if normalized.lower() == "localhost":
+            return True
+        # Strip optional IPv6 zone index (e.g., ::1%lo0).
+        ip_text = normalized.split("%", maxsplit=1)[0]
+        try:
+            return ipaddress.ip_address(ip_text).is_loopback
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _is_cancelled(context: grpc.aio.ServicerContext) -> bool:
+        return context.cancelled()

--- a/vllm/entrypoints/grpc_kv_events.py
+++ b/vllm/entrypoints/grpc_kv_events.py
@@ -251,9 +251,7 @@ class GrpcKvEventStreamer:
 
     def _to_proto_batch(self, sequence_number: int, batch: KVEventBatch) -> Any:
         proto_events = [
-            self._to_proto_event(
-                self._make_event_id(sequence_number, event_idx), event
-            )
+            self._to_proto_event(self._make_event_id(sequence_number, event_idx), event)
             for event_idx, event in enumerate(batch.events)
         ]
         message = self._pb2.KvEventBatch(
@@ -285,9 +283,7 @@ class GrpcKvEventStreamer:
             start = block_idx * token_stride
             end = start + token_stride
             block_token_ids = (
-                event.token_ids[start:end]
-                if token_stride > 0
-                else event.token_ids
+                event.token_ids[start:end] if token_stride > 0 else event.token_ids
             )
             block = self._pb2.KvBlock(
                 block_hash=_hash_to_int64(block_hash),

--- a/vllm/entrypoints/grpc_kv_events.py
+++ b/vllm/entrypoints/grpc_kv_events.py
@@ -1,0 +1,341 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Utilities for streaming KV cache events over gRPC."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import grpc
+import msgspec.msgpack
+import zmq
+import zmq.asyncio
+
+from vllm.config.kv_events import KVEventsConfig
+from vllm.distributed.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    KVEventBatch,
+    ZmqEventPublisher,
+)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_INT64_MAX = (1 << 63) - 1
+_INT64_MIN = -(1 << 63)
+_UINT64_MOD = 1 << 64
+_UINT64_MASK = _UINT64_MOD - 1
+_SEQ_BYTES = 8
+_END_SEQ = -1
+_DEFAULT_POLL_TIMEOUT_MS = 200
+_REPLAY_IDLE_TIMEOUT_S = 5.0
+_EVENT_ID_SEQ_MASK = (1 << 32) - 1
+_CACHE_LEVEL_BY_MEDIUM = {
+    "GPU": 0,
+    "CPU": 1,
+}
+
+
+def _normalize_connect_endpoint(endpoint: str) -> str:
+    if endpoint.startswith("tcp://*"):
+        return endpoint.replace("tcp://*", "tcp://127.0.0.1", 1)
+    if endpoint.startswith("tcp://0.0.0.0"):
+        return endpoint.replace("tcp://0.0.0.0", "tcp://127.0.0.1", 1)
+    return endpoint
+
+
+def _hash_to_int64(block_hash: int | bytes) -> int:
+    if isinstance(block_hash, bytes):
+        value = int.from_bytes(block_hash, byteorder="big", signed=False)
+    else:
+        value = int(block_hash)
+
+    if value < 0:
+        if value < _INT64_MIN:
+            raise OverflowError(f"block hash {value} is smaller than int64 min")
+        return value
+
+    value &= _UINT64_MASK
+    if value > _INT64_MAX:
+        value -= _UINT64_MOD
+    return value
+
+
+class GrpcKvEventStreamer:
+    """Bridge from vLLM KV events (msgpack/zmq) to gRPC protobuf batches."""
+
+    def __init__(
+        self,
+        kv_events_config: KVEventsConfig | None,
+        data_parallel_size: int,
+        pb2_module: Any,
+        poll_timeout_ms: int = _DEFAULT_POLL_TIMEOUT_MS,
+    ) -> None:
+        self._config = kv_events_config
+        self._data_parallel_size = max(1, data_parallel_size)
+        self._pb2 = pb2_module
+        self._decoder = msgspec.msgpack.Decoder(type=KVEventBatch)
+        self._poll_timeout_ms = poll_timeout_ms
+
+    @property
+    def enabled(self) -> bool:
+        return (
+            self._config is not None
+            and self._config.enable_kv_cache_events
+            and self._config.publisher == "zmq"
+        )
+
+    async def subscribe(
+        self,
+        request: Any,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncGenerator[Any, None]:
+        if not self.enabled:
+            await context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "KV cache events are not enabled. Set --kv-events-config with "
+                "enable_kv_cache_events=true and publisher=zmq.",
+            )
+            return
+
+        assert self._config is not None
+        start_sequence = max(0, int(getattr(request, "start_sequence_number", 0)))
+
+        ctx = zmq.asyncio.Context.instance()
+        sub_socket = ctx.socket(zmq.SUB)
+        replay_sockets: list[zmq.asyncio.Socket] = []
+        last_seq_by_dp: dict[int, int] = {}
+        try:
+            sub_socket.setsockopt(zmq.SUBSCRIBE, self._config.topic.encode("utf-8"))
+            for endpoint in self._offset_endpoints(self._config.endpoint):
+                sub_socket.connect(_normalize_connect_endpoint(endpoint))
+
+            if self._config.replay_endpoint:
+                start_seq_bytes = start_sequence.to_bytes(8, "big", signed=False)
+                for endpoint in self._offset_endpoints(self._config.replay_endpoint):
+                    replay = ctx.socket(zmq.REQ)
+                    replay.connect(_normalize_connect_endpoint(endpoint))
+                    replay_sockets.append(replay)
+                    await replay.send(start_seq_bytes)
+
+                for replay in replay_sockets:
+                    async for message in self._drain_replay(
+                        replay, context, start_sequence, last_seq_by_dp
+                    ):
+                        yield message
+
+            topic_bytes = self._config.topic.encode("utf-8")
+            while not self._is_cancelled(context):
+                if not await sub_socket.poll(self._poll_timeout_ms):
+                    continue
+
+                frames = await sub_socket.recv_multipart()
+                if len(frames) != 3:
+                    logger.warning("Invalid KV event frame count=%d", len(frames))
+                    continue
+
+                recv_topic, seq_bytes, payload = frames
+                if recv_topic != topic_bytes:
+                    continue
+                if len(seq_bytes) != _SEQ_BYTES:
+                    logger.warning(
+                        "Invalid KV event sequence length=%d (expected %d)",
+                        len(seq_bytes),
+                        _SEQ_BYTES,
+                    )
+                    continue
+
+                sequence_number = int.from_bytes(seq_bytes, "big", signed=False)
+                if sequence_number < start_sequence:
+                    continue
+
+                try:
+                    decoded_batch = self._decoder.decode(payload)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to decode KV event batch seq=%d: %s",
+                        sequence_number,
+                        exc,
+                    )
+                    continue
+                if not self._should_emit(
+                    decoded_batch, sequence_number, last_seq_by_dp
+                ):
+                    continue
+                yield self._to_proto_batch(sequence_number, decoded_batch)
+
+        except asyncio.CancelledError:
+            return
+        finally:
+            sub_socket.close(linger=0)
+            for replay in replay_sockets:
+                replay.close(linger=0)
+
+    async def _drain_replay(
+        self,
+        replay_socket: zmq.asyncio.Socket,
+        context: grpc.aio.ServicerContext,
+        start_sequence: int,
+        last_seq_by_dp: dict[int, int],
+    ) -> AsyncGenerator[Any, None]:
+        loop = asyncio.get_running_loop()
+        idle_deadline = loop.time() + _REPLAY_IDLE_TIMEOUT_S
+
+        while not self._is_cancelled(context):
+            if not await replay_socket.poll(self._poll_timeout_ms):
+                if loop.time() >= idle_deadline:
+                    logger.warning("Timed out waiting for KV replay response.")
+                    break
+                continue
+
+            frames = await replay_socket.recv_multipart()
+            idle_deadline = loop.time() + _REPLAY_IDLE_TIMEOUT_S
+            if len(frames) != 2:
+                logger.warning("Invalid KV replay frame count=%d", len(frames))
+                continue
+
+            seq_bytes, payload = frames
+            if len(seq_bytes) != _SEQ_BYTES:
+                logger.warning(
+                    "Invalid KV replay sequence length=%d (expected %d)",
+                    len(seq_bytes),
+                    _SEQ_BYTES,
+                )
+                continue
+            sequence_number = int.from_bytes(seq_bytes, "big", signed=True)
+            if sequence_number == _END_SEQ:
+                break
+
+            if sequence_number < start_sequence:
+                continue
+
+            try:
+                decoded_batch = self._decoder.decode(payload)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to decode KV replay batch seq=%d: %s",
+                    sequence_number,
+                    exc,
+                )
+                continue
+            if not self._should_emit(decoded_batch, sequence_number, last_seq_by_dp):
+                continue
+            yield self._to_proto_batch(sequence_number, decoded_batch)
+
+    def _offset_endpoints(self, endpoint: str) -> list[str]:
+        return [
+            ZmqEventPublisher.offset_endpoint_port(endpoint, dp_rank)
+            for dp_rank in range(self._data_parallel_size)
+        ]
+
+    def _should_emit(
+        self,
+        decoded_batch: KVEventBatch,
+        sequence_number: int,
+        last_seq_by_dp: dict[int, int],
+    ) -> bool:
+        dp_rank = (
+            int(decoded_batch.data_parallel_rank)
+            if decoded_batch.data_parallel_rank is not None
+            else -1
+        )
+        prev_seq = last_seq_by_dp.get(dp_rank, -1)
+        if sequence_number <= prev_seq:
+            return False
+        last_seq_by_dp[dp_rank] = sequence_number
+        return True
+
+    def _to_proto_batch(self, sequence_number: int, batch: KVEventBatch) -> Any:
+        proto_events = [
+            self._to_proto_event(
+                self._make_event_id(sequence_number, event_idx), event
+            )
+            for event_idx, event in enumerate(batch.events)
+        ]
+        message = self._pb2.KvEventBatch(
+            sequence_number=sequence_number,
+            timestamp=batch.ts,
+            events=proto_events,
+        )
+        if batch.data_parallel_rank is not None:
+            message.dp_rank = int(batch.data_parallel_rank)
+        return message
+
+    def _to_proto_event(self, event_id: int, event: Any) -> Any:
+        if isinstance(event, BlockStored):
+            return self._to_proto_block_stored(event_id, event)
+        if isinstance(event, BlockRemoved):
+            return self._to_proto_block_removed(event_id, event)
+        if isinstance(event, AllBlocksCleared):
+            return self._pb2.KvCacheEvent(
+                event_id=event_id,
+                cleared=self._pb2.KvCacheCleared(),
+            )
+        raise TypeError(f"Unsupported KV event type: {type(event)}")
+
+    def _to_proto_block_stored(self, event_id: int, event: BlockStored) -> Any:
+        cache_level = self._cache_level(event.medium)
+        blocks = []
+        token_stride = max(int(event.block_size), 0)
+        for block_idx, block_hash in enumerate(event.block_hashes):
+            start = block_idx * token_stride
+            end = start + token_stride
+            block_token_ids = (
+                event.token_ids[start:end]
+                if token_stride > 0
+                else event.token_ids
+            )
+            block = self._pb2.KvBlock(
+                block_hash=_hash_to_int64(block_hash),
+                token_ids=block_token_ids,
+                block_size=event.block_size,
+            )
+            if event.lora_id is not None:
+                block.lora_id = event.lora_id
+            if cache_level is not None:
+                block.cache_level = cache_level
+            blocks.append(block)
+
+        stored = self._pb2.KvBlocksStored(blocks=blocks)
+        if event.parent_block_hash is not None:
+            stored.parent_block_hash = _hash_to_int64(event.parent_block_hash)
+
+        return self._pb2.KvCacheEvent(event_id=event_id, stored=stored)
+
+    def _to_proto_block_removed(self, event_id: int, event: BlockRemoved) -> Any:
+        removed = self._pb2.KvBlocksRemoved(
+            block_hashes=[_hash_to_int64(bh) for bh in event.block_hashes]
+        )
+        cache_level = self._cache_level(event.medium)
+        if cache_level is not None:
+            removed.cache_level = cache_level
+        return self._pb2.KvCacheEvent(event_id=event_id, removed=removed)
+
+    @staticmethod
+    def _cache_level(medium: str | None) -> int | None:
+        if medium is None:
+            return None
+        return _CACHE_LEVEL_BY_MEDIUM.get(medium.upper())
+
+    @staticmethod
+    def _make_event_id(sequence_number: int, event_idx: int) -> int:
+        # Pack 32 bits of sequence and 32 bits of per-batch event index.
+        seq_hi = sequence_number & _EVENT_ID_SEQ_MASK
+        idx_lo = event_idx & _EVENT_ID_SEQ_MASK
+        return (seq_hi << 32) | idx_lo
+
+    @staticmethod
+    def _is_cancelled(context: grpc.aio.ServicerContext) -> bool:
+        for method_name in ("done", "cancelled"):
+            method = getattr(context, method_name, None)
+            if callable(method):
+                try:
+                    if bool(method()):
+                        return True
+                except Exception:
+                    continue
+        return False

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -24,7 +24,6 @@ import importlib
 import signal
 import sys
 import time
-from collections.abc import AsyncGenerator
 from types import SimpleNamespace
 from typing import Any
 
@@ -109,15 +108,6 @@ def _resolve_kv_proto_bindings(default_pb2_module: Any) -> tuple[Any, Any, Any]:
     )
 
 
-async def _stream_kv_events(
-    streamer: GrpcKvEventStreamer,
-    request: Any,
-    context: grpc.aio.ServicerContext,
-) -> AsyncGenerator[Any, None]:
-    async for batch in streamer.subscribe(request, context):
-        yield batch
-
-
 def _register_subscribe_kv_events(
     server: grpc.aio.Server,
     servicer: Any,
@@ -133,7 +123,7 @@ def _register_subscribe_kv_events(
     )
 
     async def subscribe_handler(request, context):
-        async for batch in _stream_kv_events(kv_streamer, request, context):
+        async for batch in kv_streamer.subscribe(request, context):
             yield batch
 
     if _supports_subscribe_kv_events(vllm_engine_pb2):

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -20,12 +20,17 @@ Example:
 
 import argparse
 import asyncio
+import importlib
 import signal
 import sys
 import time
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from typing import Any
 
 try:
     import grpc
+    from google.protobuf.symbol_database import Default as symbol_db_default
     from grpc_reflection.v1alpha import reflection
     from smg_grpc_proto import vllm_engine_pb2, vllm_engine_pb2_grpc
     from smg_grpc_servicer.vllm.servicer import VllmEngineServicer
@@ -38,6 +43,7 @@ except ImportError:
 import uvloop
 
 from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.entrypoints.grpc_kv_events import GrpcKvEventStreamer
 from vllm.entrypoints.utils import log_version_and_model
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext
@@ -46,6 +52,105 @@ from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
+
+
+def _get_vllm_engine_service_descriptor(pb2_module: Any) -> Any | None:
+    return pb2_module.DESCRIPTOR.services_by_name.get("VllmEngine")
+
+
+def _supports_subscribe_kv_events(pb2_module: Any) -> bool:
+    service_descriptor = _get_vllm_engine_service_descriptor(pb2_module)
+    if service_descriptor is None:
+        return False
+    return "SubscribeKvEvents" in service_descriptor.methods_by_name
+
+
+def _resolve_kv_proto_bindings(default_pb2_module: Any) -> tuple[Any, Any, Any]:
+    """Resolve request/response protobuf classes for SubscribeKvEvents.
+
+    Handles both layouts:
+    - vLLM local proto: messages are in `vllm_engine_pb2`.
+    - SMG proto: service is in `vllm_engine_pb2`, messages are in `common_pb2`.
+    """
+    service_descriptor = _get_vllm_engine_service_descriptor(default_pb2_module)
+    if (
+        service_descriptor is not None
+        and "SubscribeKvEvents" in service_descriptor.methods_by_name
+    ):
+        subscribe_desc = service_descriptor.methods_by_name["SubscribeKvEvents"]
+        sym_db = symbol_db_default()
+        request_cls = sym_db.GetSymbol(subscribe_desc.input_type.full_name)
+        response_cls = sym_db.GetSymbol(subscribe_desc.output_type.full_name)
+
+        response_pb2 = importlib.import_module(response_cls.__module__)
+        pb2_bundle = SimpleNamespace(
+            KvEventBatch=response_pb2.KvEventBatch,
+            KvCacheEvent=response_pb2.KvCacheEvent,
+            KvBlocksStored=response_pb2.KvBlocksStored,
+            KvBlock=response_pb2.KvBlock,
+            KvBlocksRemoved=response_pb2.KvBlocksRemoved,
+            KvCacheCleared=response_pb2.KvCacheCleared,
+        )
+        return request_cls, response_cls, pb2_bundle
+
+    from vllm.grpc import vllm_engine_pb2 as local_pb2
+
+    return (
+        local_pb2.SubscribeKvEventsRequest,
+        local_pb2.KvEventBatch,
+        local_pb2,
+    )
+
+
+async def _stream_kv_events(
+    streamer: GrpcKvEventStreamer,
+    request: Any,
+    context: grpc.aio.ServicerContext,
+) -> AsyncGenerator[Any, None]:
+    async for batch in streamer.subscribe(request, context):
+        yield batch
+
+
+def _register_subscribe_kv_events(
+    server: grpc.aio.Server,
+    servicer: Any,
+    async_llm: AsyncLLM,
+) -> None:
+    request_cls, response_cls, kv_pb2_module = _resolve_kv_proto_bindings(
+        vllm_engine_pb2
+    )
+    kv_streamer = GrpcKvEventStreamer(
+        kv_events_config=async_llm.vllm_config.kv_events_config,
+        data_parallel_size=async_llm.vllm_config.parallel_config.data_parallel_size,
+        pb2_module=kv_pb2_module,
+    )
+
+    async def subscribe_handler(request, context):
+        async for batch in _stream_kv_events(kv_streamer, request, context):
+            yield batch
+
+    if _supports_subscribe_kv_events(vllm_engine_pb2):
+        # Override the method on the runtime instance before registration.
+        servicer.SubscribeKvEvents = subscribe_handler
+        logger.info("Registered SubscribeKvEvents using smg_grpc_proto service.")
+        return
+
+    # Fallback: register this single method directly if the imported service
+    # descriptor is older and does not include SubscribeKvEvents yet.
+    method_handler = grpc.unary_stream_rpc_method_handler(
+        subscribe_handler,
+        request_deserializer=request_cls.FromString,
+        response_serializer=response_cls.SerializeToString,
+    )
+    generic_handler = grpc.method_handlers_generic_handler(
+        "vllm.grpc.engine.VllmEngine",
+        {"SubscribeKvEvents": method_handler},
+    )
+    server.add_generic_rpc_handlers((generic_handler,))
+    logger.warning(
+        "Registered SubscribeKvEvents as a fallback generic handler because "
+        "the imported gRPC service descriptor does not include it."
+    )
 
 
 async def serve_grpc(args: argparse.Namespace):
@@ -91,6 +196,10 @@ async def serve_grpc(args: argparse.Namespace):
             ("grpc.keepalive_permit_without_calls", True),
         ],
     )
+
+    # Register SubscribeKvEvents before adding the main servicer so method
+    # overrides are picked up during handler construction.
+    _register_subscribe_kv_events(server, servicer, async_llm)
 
     # Add servicer to server
     vllm_engine_pb2_grpc.add_VllmEngineServicer_to_server(servicer, server)

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -58,6 +58,13 @@ def _get_vllm_engine_service_descriptor(pb2_module: Any) -> Any | None:
     return pb2_module.DESCRIPTOR.services_by_name.get("VllmEngine")
 
 
+def _get_vllm_engine_service_full_name(pb2_module: Any) -> str:
+    service_descriptor = _get_vllm_engine_service_descriptor(pb2_module)
+    if service_descriptor is None:
+        raise RuntimeError("VllmEngine service descriptor is missing")
+    return service_descriptor.full_name
+
+
 def _supports_subscribe_kv_events(pb2_module: Any) -> bool:
     service_descriptor = _get_vllm_engine_service_descriptor(pb2_module)
     if service_descriptor is None:
@@ -142,8 +149,9 @@ def _register_subscribe_kv_events(
         request_deserializer=request_cls.FromString,
         response_serializer=response_cls.SerializeToString,
     )
+    service_full_name = _get_vllm_engine_service_full_name(vllm_engine_pb2)
     generic_handler = grpc.method_handlers_generic_handler(
-        "vllm.grpc.engine.VllmEngine",
+        service_full_name,
         {"SubscribeKvEvents": method_handler},
     )
     server.add_generic_rpc_handlers((generic_handler,))


### PR DESCRIPTION
## Purpose

  Add `SubscribeKvEvents` support for KV cache event streaming in vLLM gRPC server, implemented on the vLLM side.

  ### Scope

  - Add KV event streaming bridge:
    - `vllm/entrypoints/grpc_kv_events.py`
  - Wire `SubscribeKvEvents` registration in gRPC startup:
    - `vllm/entrypoints/grpc_server.py`
  - Handle proto layout compatibility using descriptor-based request/response resolution.
  - Add fallback generic handler registration with descriptor full-name resolution.
  - Fail fast when service descriptor is missing in fallback path.
  - Add tests:
    - `tests/entrypoints/test_grpc_kv_events.py`
    - `tests/entrypoints/test_grpc_server_kv_registration.py`
  - Add user docs:
    - `docs/serving/grpc_server.md`
    - nav update in `docs/.nav.yml`

  Fixes/implements: `SubscribeKvEvents` RPC behavior for KV cache events in gRPC mode.

  ## Test Plan

  ```bash
  ruff check vllm/entrypoints/grpc_server.py \
    vllm/entrypoints/grpc_kv_events.py \
    tests/entrypoints/test_grpc_kv_events.py \
    tests/entrypoints/test_grpc_server_kv_registration.py

  python -m compileall vllm/entrypoints/grpc_server.py \
    vllm/entrypoints/grpc_kv_events.py \
    tests/entrypoints/test_grpc_kv_events.py \
    tests/entrypoints/test_grpc_server_kv_registration.py

  pytest -q tests/entrypoints/test_grpc_kv_events.py \
    tests/entrypoints/test_grpc_server_kv_registration.py

  ## Test Result

  - ruff check on changed Python files: pass
  - python -m compileall on changed Python files: pass
  - pytest in this local environment: not executable due missing torch import in test bootstrap (tests/conftest.py); rely on CI for full test execution.

  ### Added coverage

  - KV event proto mapping and hash normalization.
  - Per-block token slicing for BlockStored.
  - Registration path coverage:
      - servicer override path
      - fallback generic handler path
      - descriptor-missing failure path
  - gRPC round-trip behavior:
      - successful SubscribeKvEvents streaming
      - FAILED_PRECONDITION when KV events are disabled