### PR TITLE
[Bugfix] Fix unclean shutdown crash with AllReduce Fusion workspace

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import atexit
+
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -29,6 +31,16 @@ _fi_ar_workspace = None
 # Extra workspace for quant fusion patterns (only supported by trtllm backend)
 # Only created if primary workspace is not already trtllm
 _fi_ar_quant_workspace = None
+
+
+def _cleanup_fi_ar_workspaces():
+    """Release workspaces before Python shutdown to avoid __del__ crash."""
+    global _fi_ar_workspace, _fi_ar_quant_workspace
+    _fi_ar_workspace = None
+    _fi_ar_quant_workspace = None
+
+
+atexit.register(_cleanup_fi_ar_workspaces)
 
 
 def get_fi_ar_workspace():

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -36,8 +36,15 @@ _fi_ar_quant_workspace = None
 def _cleanup_fi_ar_workspaces():
     """Release workspaces before Python shutdown to avoid __del__ crash."""
     global _fi_ar_workspace, _fi_ar_quant_workspace
-    _fi_ar_workspace = None
+    if (
+        _fi_ar_quant_workspace is not None
+        and _fi_ar_quant_workspace is not _fi_ar_workspace
+    ):
+        _fi_ar_quant_workspace.destroy()
     _fi_ar_quant_workspace = None
+    if _fi_ar_workspace is not None:
+        _fi_ar_workspace.destroy()
+        _fi_ar_workspace = None
 
 
 atexit.register(_cleanup_fi_ar_workspaces)


### PR DESCRIPTION
## Purpose

Fixes #35686 - On B200 with allreduce fusion enabled, pressing ctrl-c causes FlashInfer `AllReduceFusionWorkspace.__del__` to crash with `ImportError: sys.meta_path is None, Python is likely shutting down`.

The root cause is that global workspace objects (`_fi_ar_workspace`, `_fi_ar_quant_workspace`) rely on garbage collection `__del__` during interpreter shutdown, but Python's module/import system is already torn down by that point.

## Solution

Register an `atexit` handler to release the global workspace references before Python begins interpreter shutdown. This ensures the workspace objects are cleaned up while the import system is still functional, preventing the `ImportError` crash.

This matches the existing pattern already used in `vllm/distributed/device_communicators/pynccl_allocator.py` (lines 115-126) for the same class of shutdown issue.

## Test Plan

- Verified ruff check, ruff format, typos, and SPDX header checks pass
- The fix is a minimal, well-established pattern (atexit cleanup of module-level globals) already proven in the same codebase
- To reproduce the original bug: run vLLM on B200 with `--compilation-config.pass_config.fuse_allreduce_rms=true`, then ctrl-c to stop the server

## Test Result

Pre-commit linting checks pass. The fix adds no new dependencies and cannot affect runtime behavior - `atexit` handlers only run during interpreter shutdown.