### PR TITLE
[Bugfix] opcheck false mutation error in rms_norm_per_block_quant (#36688)

### DIFF
--- a/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
+++ b/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
@@ -286,6 +286,15 @@ void rms_norm_per_block_quant(torch::Tensor& out, torch::Tensor const& input,
                 "Outer scale stride must be 1 when scales are not transposed");
   }
 
+  int64_t hidden_size = input.size(-1);
+  TORCH_CHECK(hidden_size > 0 && hidden_size % group_size == 0,
+              "hidden_size must be a positive multiple of group_size");
+  int64_t num_tokens = input.numel() / hidden_size;
+  int64_t num_groups = hidden_size / group_size;
+  TORCH_CHECK(scales.numel() >= num_tokens * num_groups,
+              "scales buffer too small: need ", num_tokens * num_groups,
+              " elements, got ", scales.numel());
+
   rms_norm_per_block_quant_dispatch(out, input, weight, scales, group_size,
                                     var_epsilon, scale_ub, residual,
                                     is_scale_transposed);

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -278,21 +278,22 @@ def test_rms_norm(
         assert torch.allclose(ref_residual, ops_residual)
 
     output = torch.empty(x.shape, dtype=quant_dtype, device=x.device)
-    scales = torch.empty(
-        (x.numel() // x.shape[-1], 1), device=x.device, dtype=torch.float32
-    )
-
     if group_size is None:
+        scales = torch.empty(
+            (x.numel() // x.shape[-1], 1), device=x.device, dtype=torch.float32
+        )
         opcheck(
             torch.ops._C.rms_norm_dynamic_per_token_quant,
             (output, x, layer.weight, scales, 1e-5, scale_ub, residual),
         )
     else:
-        # TODO(luka/eliza) opcheck is broken?
-        #  Somehow the cloned args are getting mutated in-place,
-        #  which causes the opcheck to fail.
-        # https://github.com/vllm-project/vllm/issues/36688
-        return
+        assert hidden_size % group_size[1] == 0
+        num_groups = hidden_size // group_size[1]
+        scales = torch.empty(
+            (num_groups, num_tokens),
+            device=x.device,
+            dtype=torch.float32,
+        ).transpose(0, 1)
         opcheck(
             torch.ops._C.rms_norm_per_block_quant,
             (


### PR DESCRIPTION
Fixes #36688.

The `opcheck` call in `test_rms_norm` was allocating `scales` with shape
`(num_tokens, 1)` and passing it to `rms_norm_per_block_quant`. The blockwise
kernel writes `hidden_size / group_size` scale values per token, so with 8
groups the buffer was 8× too small. The out-of-bounds writes landed in the
adjacent cloned `weight` tensor under opcheck's memory layout, which is why
opcheck reported `weight` as mutated even though nothing in the kernel
intentionally touches it.

The schema and C++ declaration are correct - `weight` is and should remain immutable.

**Changes:**
- Allocate `block_scales` with the correct shape `(num_tokens, hidden_size // group_size)` in the test, and add the missing `opcheck` call for the blockwise path
- Add a `TORCH_CHECK` in `rms_norm_per_block_quant` validating `scales.numel() >= num_tokens * num_groups` so callers get a clear error instead of silent OOB writes

**Testing:**
Ran 16 blockwise int8 opcheck cases: group_size 64 and 128, with and without
residual, 1 and 2048 tokens-> all pass. The pre-existing FP8 failures in this
file reproduce identically on upstream main before any edits (unrelated
binary/source API mismatch).
<img width="802" height="264" alt="image" src="https://github.com/user-attachments/assets/b0136b52-11fd-4be8-bda9-f6468f347ee5" />
