### PR TITLE
[Bugfix] Fix Mistral-small `--format`

### DIFF
--- a/examples/offline_inference/mistral-small.py
+++ b/examples/offline_inference/mistral-small.py
@@ -62,9 +62,9 @@ def run_simple_demo(args: argparse.Namespace):
 
     llm = LLM(
         model=model_name,
-        tokenizer_mode="mistral" if args.format == "mistral" else "auto",
-        config_format="mistral" if args.format == "mistral" else "auto",
-        load_format="mistral" if args.format == "mistral" else "auto",
+        tokenizer_mode="mistral" if args.format == "mistral" else "hf",
+        config_format="mistral" if args.format == "mistral" else "hf",
+        load_format="mistral" if args.format == "mistral" else "hf",
         limit_mm_per_prompt={"image": 1},
         max_model_len=4096,
         max_num_seqs=2,
@@ -102,9 +102,9 @@ def run_advanced_demo(args: argparse.Namespace):
     sampling_params = SamplingParams(max_tokens=8192, temperature=0.7)
     llm = LLM(
         model=model_name,
-        tokenizer_mode="mistral" if args.format == "mistral" else "auto",
-        config_format="mistral" if args.format == "mistral" else "auto",
-        load_format="mistral" if args.format == "mistral" else "auto",
+        tokenizer_mode="mistral" if args.format == "mistral" else "hf",
+        config_format="mistral" if args.format == "mistral" else "hf",
+        load_format="mistral" if args.format == "mistral" else "hf",
         limit_mm_per_prompt={"image": max_img_per_msg},
         max_model_len=max_img_per_msg * max_tokens_per_img,
         tensor_parallel_size=2,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Update both advanced and simple mistral-small.py example. Why: "auto" is pointing to `mistral` lately, not to `hf`, so regardless the specified `--format`, the choice will be always `mistral`. You could see it from `tekken` being used + the same answer being produced as output. 

## Test Plan
`python examples/offline_inference/mistral-small.py simple --format hf`
`python examples/offline_inference/mistral-small.py simple --format mistral`
`python examples/offline_inference/mistral-small.py advanced--format hf`
`python examples/offline_inference/mistral-small.py advanced--format mistral`

## Test Result
With this PR:
```
python mistral-small.py simple --format hf
 ```
Output:
```
The image captures cherry blossom branches in the foreground with a distinctive tower in the background.
```
```
python mistral-small.py simple --format mistral
 ```
Output:
```
The image captures cherry blossom flowers in full bloom with a distinctive tower in the background on a clear, blue sky day.
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

