### PR TITLE
Update rocm get gpu info capability

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -52,8 +52,8 @@ from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 from vllm.platforms import current_platform
-from vllm.scalar_type import scalar_types
 from vllm.platforms.rocm import on_gfx950
+from vllm.scalar_type import scalar_types
 from vllm.utils.flashinfer import has_flashinfer
 from vllm.utils.import_utils import has_triton_kernels
 from vllm.utils.math_utils import round_up

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -629,7 +629,7 @@ class RocmPlatform(Platform):
 
     @classmethod
     def get_current_memory_usage(
-        cls, device: torch.types.device | none = none
+        cls, device: torch.types.device | None = None
     ) -> float:
         torch.cuda.reset_peak_memory_stats(device)
         free_mem, total_mem = torch.cuda.mem_get_info(device)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -227,7 +227,6 @@ class RocmPlatform(Platform):
     dispatch_key: str = "CUDA"
     ray_device_key: str = "GPU"
     dist_backend: str = "nccl"
-    # rocm shares the same device control env var as CUDA
     device_control_env_var: str = "HIP_VISIBLE_DEVICES"
     ray_noset_device_env_vars: list[str] = [
         "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES",

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -228,7 +228,7 @@ class RocmPlatform(Platform):
     ray_device_key: str = "GPU"
     dist_backend: str = "nccl"
     # rocm shares the same device control env var as CUDA
-    device_control_env_var: str = "CUDA_VISIBLE_DEVICES"
+    device_control_env_var: str = "HIP_VISIBLE_DEVICES"
     ray_noset_device_env_vars: list[str] = [
         "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES",
         "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES",

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -122,16 +122,6 @@ def _get_gcn_arch_via_amdsmi() -> str:
     return torch.cuda.get_device_properties("cuda").gcnArchName
 
 
-@with_amdsmi_context
-def _get_gcn_arch_name(cls, device_id: int = 0) -> str:
-    if torch.cuda.is_available():
-        return torch.cuda.get_device_properties(device_id).gcnArchName
-
-    device = amdsmi_get_processor_handles()[device_id]
-    asic_info = amdsmi_get_gpu_asic_info(device)
-    return asic_info["target_graphics_version"]
-
-
 @cache
 def on_gfx1x() -> bool:
     GPU_ARCH = _get_gcn_arch_via_amdsmi()
@@ -634,11 +624,11 @@ class RocmPlatform(Platform):
 
     @classmethod
     def get_punica_wrapper(cls) -> str:
-        return "vllm.lora.punica_wrapper.punica_gpu.PunicaWrapperGPU"
+        return "vllm.lora.punica_wrapper.punica_gpu.punicawrappergpu"
 
     @classmethod
     def get_current_memory_usage(
-        cls, device: torch.types.Device | None = None
+        cls, device: torch.types.device | none = none
     ) -> float:
         torch.cuda.reset_peak_memory_stats(device)
         free_mem, total_mem = torch.cuda.mem_get_info(device)
@@ -647,23 +637,23 @@ class RocmPlatform(Platform):
     @classmethod
     def get_device_communicator_cls(cls) -> str:
         return (
-            "vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
+            "vllm.distributed.device_communicators.cuda_communicator.cudacommunicator"  # noqa
         )
 
     @classmethod
     def supports_mx(cls) -> bool:
-        gcn_arch = _get_gcn_arch_name(cls, 0)
+        gcn_arch = _get_gcn_arch_via_amdsmi()
         return any(gfx in gcn_arch for gfx in ["gfx95"])
 
     @classmethod
     def supports_fp8(cls) -> bool:
-        gcn_arch = _get_gcn_arch_name(cls, 0)
+        gcn_arch = _get_gcn_arch_via_amdsmi()
         return any(gfx in gcn_arch for gfx in ["gfx94", "gfx95", "gfx12"])
 
     @classmethod
     def is_fp8_fnuz(cls) -> bool:
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
-        return "gfx94" in _get_gcn_arch_name(cls, 0)
+        return "gfx94" in _get_gcn_arch_via_amdsmi()
 
     @classmethod
     def fp8_dtype(cls) -> torch.dtype:
@@ -675,7 +665,7 @@ class RocmPlatform(Platform):
     @classmethod
     def use_custom_allreduce(cls) -> bool:
         # We only enable custom allreduce for MI300 series
-        gcn_arch = _get_gcn_arch_name(cls, 0)
+        gcn_arch = _get_gcn_arch_via_amdsmi()
         supported_archs = ["gfx94", "gfx95"]
         return any(gfx in gcn_arch for gfx in supported_archs)
 
@@ -685,7 +675,7 @@ class RocmPlatform(Platform):
 
     @classmethod
     def is_navi(cls) -> bool:
-        return "gfx1" in _get_gcn_arch_name(cls, 0)
+        return "gfx1" in _get_gcn_arch_via_amdsmi()
 
     @classmethod
     def get_static_graph_wrapper_cls(cls) -> str:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -505,8 +505,8 @@ class RocmPlatform(Platform):
     @classmethod
     @with_amdsmi_context
     def get_device_uuid(cls, device_id: int = 0) -> str:
-            device0 = amdsmi_get_processor_handles()[0]
-            return amdsmi_get_gpu_device_uuid(device0)
+            device = amdsmi_get_processor_handles()[device_id]
+            return amdsmi_get_gpu_device_uuid(device)
         
 
     @classmethod

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -456,16 +456,20 @@ class RocmPlatform(Platform):
         if torch.cuda.is_available():
             major, minor = torch.cuda.get_device_capability(device_id)
         else:
-            device0 = amdsmi_get_processor_handles()[0]
-            asic_info = amdsmi_get_gpu_asic_info(device0)
+            device = amdsmi_get_processor_handles()[device_id]
+            asic_info = amdsmi_get_gpu_asic_info(device)
             target_id = asic_info['target_graphics_version']
             major_minor = target_id[3:]
             if len(major_minor) == 4:
                 major = int(major_minor[0:2])
                 minor = int(major_minor[2:])
             elif len(major_minor) == 3:
-                major = int(major_minor[0])
-                minor = int(major_minor[1])
+                if major_minor[2].isdigit():
+                    major = int(major_minor[0])
+                    minor = int(major_minor[1:])
+                else:
+                    major = int(major_minor[0])
+                    minor = int(major_minor[1])
 
         return DeviceCapability(major=major, minor=minor)
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -451,18 +451,22 @@ class RocmPlatform(Platform):
     @lru_cache(maxsize=8)
     @with_amdsmi_context
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
-        device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi_get_gpu_asic_info(device0)
-        target_id = asic_info['target_graphics_version']
-        major_minor = target_id[3:]
-        if len(major_minor) == 4:
-            major = int(major_minor[0:2])
-            minor = int(major_minor[2:])
-        elif len(major_minor) == 3:
-            major = int(major_minor[0])
-            minor = int(major_minor[1])
+        major = 0
+        minor = 0
+        if torch.cuda.is_available():
+            major, minor = torch.cuda.get_device_capability(device_id)
+        else:
+            device0 = amdsmi_get_processor_handles()[0]
+            asic_info = amdsmi_get_gpu_asic_info(device0)
+            target_id = asic_info['target_graphics_version']
+            major_minor = target_id[3:]
+            if len(major_minor) == 4:
+                major = int(major_minor[0:2])
+                minor = int(major_minor[2:])
+            elif len(major_minor) == 3:
+                major = int(major_minor[0])
+                minor = int(major_minor[1])
 
-        #major, minor = torch.cuda.get_device_capability(device_id)
         return DeviceCapability(major=major, minor=minor)
 
     @classmethod
@@ -629,29 +633,36 @@ class RocmPlatform(Platform):
     @classmethod
     @with_amdsmi_context
     def supports_mx(cls) -> bool:
-        #gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi_get_gpu_asic_info(device0)
-        gcn_arch = asic_info['target_graphics_version']
+        gcn_arch = ""
+        if torch.cuda.is_available():
+            gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        else:
+            device0 = amdsmi_get_processor_handles()[0]
+            asic_info = amdsmi_get_gpu_asic_info(device0)
+            gcn_arch = asic_info['target_graphics_version']
         return any(gfx in gcn_arch for gfx in ["gfx95"])
 
     @classmethod
     @with_amdsmi_context
     def supports_fp8(cls) -> bool:
-        #gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi_get_gpu_asic_info(device0)
-        gcn_arch = asic_info['target_graphics_version']
+        gcn_arch = ""
+        if torch.cuda.is_available():
+            gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        else:
+            device0 = amdsmi_get_processor_handles()[0]
+            asic_info = amdsmi_get_gpu_asic_info(device0)
+            gcn_arch = asic_info['target_graphics_version']
         return any(gfx in gcn_arch for gfx in ["gfx94", "gfx95", "gfx12"])
 
     @classmethod
     @with_amdsmi_context
     def is_fp8_fnuz(cls) -> bool:
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
+        if torch.cuda.is_available():
+            return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
         device0 = amdsmi_get_processor_handles()[0]
         asic_info = amdsmi_get_gpu_asic_info(device0)
         return "gfx94" in asic_info['target_graphics_version']
-        #return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
 
     @classmethod
     def fp8_dtype(cls) -> torch.dtype:
@@ -664,10 +675,13 @@ class RocmPlatform(Platform):
     @with_amdsmi_context
     def use_custom_allreduce(cls) -> bool:
         # We only enable custom allreduce for MI300 series
-        #gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi_get_gpu_asic_info(device0)
-        gcn_arch = asic_info['target_graphics_version']
+        gcn_arch = ""
+        if torch.cuda.is_available():
+            gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        else:
+            device0 = amdsmi_get_processor_handles()[0]
+            asic_info = amdsmi_get_gpu_asic_info(device0)
+            gcn_arch = asic_info['target_graphics_version']
         supported_archs = ["gfx94", "gfx95"]
         return any(gfx in gcn_arch for gfx in supported_archs)
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -452,7 +452,7 @@ class RocmPlatform(Platform):
     @with_amdsmi_context
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
         device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        asic_info = amdsmi_get_gpu_asic_info(device0)
         target_id = asic_info['target_graphics_version']
         major_minor = target_id[3:]
         if len(major_minor) == 4:
@@ -631,7 +631,7 @@ class RocmPlatform(Platform):
     def supports_mx(cls) -> bool:
         #gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
         device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        asic_info = amdsmi_get_gpu_asic_info(device0)
         gcn_arch = asic_info['target_graphics_version']
         return any(gfx in gcn_arch for gfx in ["gfx95"])
 
@@ -640,7 +640,7 @@ class RocmPlatform(Platform):
     def supports_fp8(cls) -> bool:
         #gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
         device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        asic_info = amdsmi_get_gpu_asic_info(device0)
         gcn_arch = asic_info['target_graphics_version']
         return any(gfx in gcn_arch for gfx in ["gfx94", "gfx95", "gfx12"])
 
@@ -649,7 +649,7 @@ class RocmPlatform(Platform):
     def is_fp8_fnuz(cls) -> bool:
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
         device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        asic_info = amdsmi_get_gpu_asic_info(device0)
         return "gfx94" in asic_info['target_graphics_version']
         #return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
 
@@ -666,7 +666,7 @@ class RocmPlatform(Platform):
         # We only enable custom allreduce for MI300 series
         #gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
         device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        asic_info = amdsmi_get_gpu_asic_info(device0)
         gcn_arch = asic_info['target_graphics_version']
         supported_archs = ["gfx94", "gfx95"]
         return any(gfx in gcn_arch for gfx in supported_archs)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -639,37 +639,28 @@ class RocmPlatform(Platform):
 
     @classmethod
     @with_amdsmi_context
-    def supports_mx(cls) -> bool:
-        gcn_arch = ""
+    def _get_gcn_arch_name(cls, device_id: int = 0) -> str:
         if torch.cuda.is_available():
-            gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        else:
-            device0 = amdsmi_get_processor_handles()[0]
-            asic_info = amdsmi_get_gpu_asic_info(device0)
-            gcn_arch = asic_info['target_graphics_version']
+            return torch.cuda.get_device_properties(device_id).gcnArchName
+
+        device = amdsmi_get_processor_handles()[device_id]
+        asic_info = amdsmi_get_gpu_asic_info(device)
+        return asic_info['target_graphics_version']
+
+    @classmethod
+    def supports_mx(cls) -> bool:
+        gcn_arch = _get_gcn_arch_name(cls, 0)
         return any(gfx in gcn_arch for gfx in ["gfx95"])
 
     @classmethod
-    @with_amdsmi_context
     def supports_fp8(cls) -> bool:
-        gcn_arch = ""
-        if torch.cuda.is_available():
-            gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        else:
-            device0 = amdsmi_get_processor_handles()[0]
-            asic_info = amdsmi_get_gpu_asic_info(device0)
-            gcn_arch = asic_info['target_graphics_version']
+        gcn_arch = _get_gcn_arch_name(cls, 0)
         return any(gfx in gcn_arch for gfx in ["gfx94", "gfx95", "gfx12"])
 
     @classmethod
-    @with_amdsmi_context
     def is_fp8_fnuz(cls) -> bool:
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
-        if torch.cuda.is_available():
-            return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
-        device0 = amdsmi_get_processor_handles()[0]
-        asic_info = amdsmi_get_gpu_asic_info(device0)
-        return "gfx94" in asic_info['target_graphics_version']
+        return "gfx94" in _get_gcn_arch_name(cls, 0)
 
     @classmethod
     def fp8_dtype(cls) -> torch.dtype:
@@ -679,16 +670,9 @@ class RocmPlatform(Platform):
             return torch.float8_e4m3fn
 
     @classmethod
-    @with_amdsmi_context
     def use_custom_allreduce(cls) -> bool:
         # We only enable custom allreduce for MI300 series
-        gcn_arch = ""
-        if torch.cuda.is_available():
-            gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        else:
-            device0 = amdsmi_get_processor_handles()[0]
-            asic_info = amdsmi_get_gpu_asic_info(device0)
-            gcn_arch = asic_info['target_graphics_version']
+        gcn_arch = _get_gcn_arch_name(cls, 0)
         supported_archs = ["gfx94", "gfx95"]
         return any(gfx in gcn_arch for gfx in supported_archs)
 
@@ -698,7 +682,7 @@ class RocmPlatform(Platform):
 
     @classmethod
     def is_navi(cls) -> bool:
-        return "gfx1" in torch.cuda.get_device_properties(0).gcnArchName
+        return "gfx1" in _get_gcn_arch_name(cls, 0)
 
     @classmethod
     def get_static_graph_wrapper_cls(cls) -> str:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -449,8 +449,20 @@ class RocmPlatform(Platform):
 
     @classmethod
     @lru_cache(maxsize=8)
+    @with_amdsmi_context
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
-        major, minor = torch.cuda.get_device_capability(device_id)
+        device0 = amdsmi_get_processor_handles()[0]
+        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        target_id = asic_info['target_graphics_version']
+        major_minor = target_id[3:]
+        if len(major_minor) == 4:
+            major = int(major_minor[0:2])
+            minor = int(major_minor[2:])
+        elif len(major_minor) == 3:
+            major = int(major_minor[0])
+            minor = int(major_minor[1])
+
+        #major, minor = torch.cuda.get_device_capability(device_id)
         return DeviceCapability(major=major, minor=minor)
 
     @classmethod
@@ -615,19 +627,31 @@ class RocmPlatform(Platform):
         )
 
     @classmethod
+    @with_amdsmi_context
     def supports_mx(cls) -> bool:
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        #gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        device0 = amdsmi_get_processor_handles()[0]
+        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        gcn_arch = asic_info['target_graphics_version']
         return any(gfx in gcn_arch for gfx in ["gfx95"])
 
     @classmethod
+    @with_amdsmi_context
     def supports_fp8(cls) -> bool:
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        #gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        device0 = amdsmi_get_processor_handles()[0]
+        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        gcn_arch = asic_info['target_graphics_version']
         return any(gfx in gcn_arch for gfx in ["gfx94", "gfx95", "gfx12"])
 
     @classmethod
+    @with_amdsmi_context
     def is_fp8_fnuz(cls) -> bool:
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
-        return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+        device0 = amdsmi_get_processor_handles()[0]
+        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        return "gfx94" in asic_info['target_graphics_version']
+        #return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
 
     @classmethod
     def fp8_dtype(cls) -> torch.dtype:
@@ -637,9 +661,13 @@ class RocmPlatform(Platform):
             return torch.float8_e4m3fn
 
     @classmethod
+    @with_amdsmi_context
     def use_custom_allreduce(cls) -> bool:
         # We only enable custom allreduce for MI300 series
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        #gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        device0 = amdsmi_get_processor_handles()[0]
+        asic_info = amdsmi.amdsmi_get_gpu_asic_info(device0)
+        gcn_arch = asic_info['target_graphics_version']
         supported_archs = ["gfx94", "gfx95"]
         return any(gfx in gcn_arch for gfx in supported_archs)
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -28,6 +28,7 @@ try:
         amdsmi_init,
         amdsmi_shut_down,
         amdsmi_topo_get_link_type,
+        amdsmi_get_gpu_device_uuid,
     )
 except ImportError as e:
     logger.warning("Failed to import from amdsmi with %r", e)
@@ -500,6 +501,13 @@ class RocmPlatform(Platform):
         if device_name in _ROCM_DEVICE_ID_NAME_MAP:
             return _ROCM_DEVICE_ID_NAME_MAP[device_name]
         return asic_info["market_name"]
+
+    @classmethod
+    @with_amdsmi_context
+    def get_device_uuid(cls, device_id: int = 0) -> str:
+            device0 = amdsmi_get_processor_handles()[0]
+            return amdsmi_get_gpu_device_uuid(device0)
+        
 
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -227,7 +227,8 @@ class RocmPlatform(Platform):
     dispatch_key: str = "CUDA"
     ray_device_key: str = "GPU"
     dist_backend: str = "nccl"
-    device_control_env_var: str = "HIP_VISIBLE_DEVICES"
+    # rocm shares the same device control env var as CUDA
+    device_control_env_var: str = "CUDA_VISIBLE_DEVICES"
     ray_noset_device_env_vars: list[str] = [
         "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES",
         "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES",

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -24,11 +24,11 @@ try:
     from amdsmi import (
         AmdSmiException,
         amdsmi_get_gpu_asic_info,
+        amdsmi_get_gpu_device_uuid,
         amdsmi_get_processor_handles,
         amdsmi_init,
         amdsmi_shut_down,
         amdsmi_topo_get_link_type,
-        amdsmi_get_gpu_device_uuid,
     )
 except ImportError as e:
     logger.warning("Failed to import from amdsmi with %r", e)
@@ -120,6 +120,16 @@ def _get_gcn_arch_via_amdsmi() -> str:
         )
     # Ultimate fallback: use torch.cuda (will initialize CUDA)
     return torch.cuda.get_device_properties("cuda").gcnArchName
+
+
+@with_amdsmi_context
+def _get_gcn_arch_name(cls, device_id: int = 0) -> str:
+    if torch.cuda.is_available():
+        return torch.cuda.get_device_properties(device_id).gcnArchName
+
+    device = amdsmi_get_processor_handles()[device_id]
+    asic_info = amdsmi_get_gpu_asic_info(device)
+    return asic_info["target_graphics_version"]
 
 
 @cache
@@ -458,7 +468,7 @@ class RocmPlatform(Platform):
         else:
             device = amdsmi_get_processor_handles()[device_id]
             asic_info = amdsmi_get_gpu_asic_info(device)
-            target_id = asic_info['target_graphics_version']
+            target_id = asic_info["target_graphics_version"]
             major_minor = target_id[3:]
             if len(major_minor) == 4:
                 major = int(major_minor[0:2])
@@ -508,9 +518,8 @@ class RocmPlatform(Platform):
     @classmethod
     @with_amdsmi_context
     def get_device_uuid(cls, device_id: int = 0) -> str:
-            device = amdsmi_get_processor_handles()[device_id]
-            return amdsmi_get_gpu_device_uuid(device)
-        
+        device = amdsmi_get_processor_handles()[device_id]
+        return amdsmi_get_gpu_device_uuid(device)
 
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:
@@ -640,16 +649,6 @@ class RocmPlatform(Platform):
         return (
             "vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
         )
-
-    @classmethod
-    @with_amdsmi_context
-    def _get_gcn_arch_name(cls, device_id: int = 0) -> str:
-        if torch.cuda.is_available():
-            return torch.cuda.get_device_properties(device_id).gcnArchName
-
-        device = amdsmi_get_processor_handles()[device_id]
-        asic_info = amdsmi_get_gpu_asic_info(device)
-        return asic_info['target_graphics_version']
 
     @classmethod
     def supports_mx(cls) -> bool:


### PR DESCRIPTION
## Purpose
This PR is to allow amdsmi to retrieve gpu info when torch is not available

## Test Plan
Run the command
```bash
vllm serve Qwen/Qwen2-7B-Instruct --tensor-parallel-size 4 --pipeline-parallel-size 2 --distributed-executor-backend ray --gpu-memory-utilization .9 --max-model-len 8192 --max-num-seqs 2000 --max-num-batched-tokens 131072 --cudagraph_capture_sizes 1 2 4
```
This command should execute the modified execution path.

## Test Result
Once the application reaches startup
```bash
(APIServer pid=53) INFO:     Started server process [53]
(APIServer pid=53) INFO:     Waiting for application startup.
(APIServer pid=53) INFO:     Application startup complete.
```
the test is complete and the server can be shutdown using crt-C

