### PR TITLE
Extend EPLB support to `CompressedTensorsW4A4Nvfp4MoEMethod` and ML3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,8 @@ markers = [
     "split: run this test as part of a split",
     "distributed: run this test only in distributed GPU tests",
     "optional: optional tests that are automatically skipped, include --optional to run them",
+    "benchmark: marks a test as a benchmark",
+    "forked: marks a test as a fork",
 ]
 
 [tool.ty.src]

--- a/tests/distributed/test_eplb_fused_moe_layer_dep_nvfp4.py
+++ b/tests/distributed/test_eplb_fused_moe_layer_dep_nvfp4.py
@@ -195,6 +195,7 @@ def _test_eplb_fml(env, world_size: int, test_config: TestConfig):
 
         logical_to_physical_map = torch.stack(logical_to_physical_map_list)
 
+        should_record = torch.ones((), dtype=torch.bool, device=device)
         for lidx, fml in enumerate(fml_layers):
             logical_replica_count = torch.ones(
                 (test_config.num_layers, num_global_experts),
@@ -211,6 +212,7 @@ def _test_eplb_fml(env, world_size: int, test_config: TestConfig):
                 ),
                 logical_to_physical_map,
                 logical_replica_count,
+                should_record,
             )
 
         out_after_shuffle = []

--- a/tests/kernels/moe/test_routing.py
+++ b/tests/kernels/moe/test_routing.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 from vllm._aiter_ops import rocm_aiter_ops
-from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.distributed.eplb.eplb_state import EplbLayerState, InitializedEplbLayerState
 from vllm.model_executor.layers.fused_moe.router.base_router import (
     eplb_map_to_physical_and_record,
 )
@@ -36,9 +36,11 @@ TOP_KS = [2, 4, 6]
 NUM_EXPERTS = [8, 16, 64]
 
 
-def setup_eplb_state(enable_eplb: bool, global_num_experts: int) -> EplbLayerState:
+def setup_eplb_state(
+    enable_eplb: bool, global_num_experts: int
+) -> EplbLayerState | None:
     if not enable_eplb:
-        return EplbLayerState()
+        return None
 
     # Initialize EPLB state with proper tensors for testing
     # For testing purposes, we use a simple 1:1 mapping (no redundant experts)
@@ -60,7 +62,7 @@ def setup_eplb_state(enable_eplb: bool, global_num_experts: int) -> EplbLayerSta
     )
     should_record_tensor = torch.ones((), dtype=torch.bool, device="cuda")
 
-    return EplbLayerState(
+    return InitializedEplbLayerState(
         expert_load_view=expert_load_view,
         logical_to_physical_map=logical_to_physical_map,
         logical_replica_count=logical_replica_count,
@@ -349,7 +351,6 @@ def test_fused_topk(
         top_k=top_k,
         global_num_experts=global_num_experts,
         renormalize=renormalize,
-        enable_eplb=enable_eplb,
         eplb_state=eplb_state,
     )
 
@@ -400,7 +401,6 @@ def test_fused_topk_bias(
         top_k=top_k,
         global_num_experts=global_num_experts,
         renormalize=renormalize,
-        enable_eplb=enable_eplb,
         eplb_state=eplb_state,
     )
 
@@ -469,7 +469,6 @@ def test_grouped_topk(
         top_k=top_k,
         global_num_experts=global_num_experts,
         renormalize=renormalize,
-        enable_eplb=enable_eplb,
         eplb_state=eplb_state,
     )
 
@@ -540,7 +539,6 @@ def test_custom(
         global_num_experts=global_num_experts,
         custom_routing_function=custom_routing_function,
         renormalize=renormalize,
-        enable_eplb=enable_eplb,
         eplb_state=eplb_state,
     )
 

--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -5,7 +5,9 @@ import types
 import pytest
 import torch
 
-from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.distributed.eplb.eplb_state import (
+    InitializedEplbLayerState,
+)
 from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
 from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
 
@@ -17,7 +19,9 @@ class DummyRouter(BaseRouter):
     def routing_method_type(self) -> RoutingMethodType:
         return RoutingMethodType.FUSED_TOPK
 
-    def _compute_routing(self, hidden_states, router_logits, indices_type):
+    def _compute_routing(
+        self, hidden_states: torch.Tensor, router_logits: torch.Tensor, indices_type
+    ):
         topk_ids = torch.tensor([[1, 2], [3, 4]], dtype=torch.int64)
         topk_weights = torch.ones_like(topk_ids, dtype=torch.float32)
         return topk_weights, topk_ids
@@ -27,12 +31,11 @@ class DummyRouter(BaseRouter):
         return topk_ids + 10
 
 
-def _make_router() -> DummyRouter:
+def _make_router(eplb_state=None) -> DummyRouter:
     return DummyRouter(
         top_k=2,
         global_num_experts=16,
-        eplb_state=EplbLayerState(),
-        enable_eplb=False,
+        eplb_state=eplb_state,
         indices_type_getter=None,
     )
 
@@ -57,12 +60,13 @@ def test_base_router_capture_pre_eplb_mapping():
 
 
 def test_base_router_capture_with_eplb_enabled():
-    router = _make_router()
-    router.enable_eplb = True
-    router.eplb_state.expert_load_view = torch.zeros(32, dtype=torch.int64)
-    router.eplb_state.logical_to_physical_map = torch.arange(32).view(32, 1)
-    router.eplb_state.logical_replica_count = torch.ones(32, dtype=torch.int64)
-    router.eplb_state.should_record_tensor = torch.ones((), dtype=torch.bool)
+    initialized_eplb_state = InitializedEplbLayerState(
+        expert_load_view=torch.zeros(32, dtype=torch.int64),
+        logical_to_physical_map=torch.arange(32).view(32, 1),
+        logical_replica_count=torch.ones(32, dtype=torch.int64),
+        should_record_tensor=torch.ones((), dtype=torch.bool),
+    )
+    router = _make_router(eplb_state=initialized_eplb_state)
 
     captured = []
 

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -400,8 +400,8 @@ class ElasticEPScalingExecutor:
                 eplb_model_state.expert_load_pass,
                 eplb_model_state.logical_to_physical_map,
                 eplb_model_state.logical_replica_count,
+                eplb_state.should_record_tensor,
             )
-            eplb_state._init_should_record_tensor(model)
             model.update_physical_experts_metadata(
                 num_physical_experts=num_physical_experts,
                 num_local_physical_experts=num_local_experts,

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -6,7 +6,7 @@ Expert parallelism load balancer (EPLB) metrics and states.
 # Glossary
 
 - **Logical Expert**: An expert that is part of the model's logical structure.
-  It holds a set of weights and is replicated across multiple physical
+  It holds a set of weights and might be replicated across multiple physical
   experts.
 - **Redundant Expert**: To achieve load balancing, for some popular logical
   experts, we create additional copies of the expert weights. During inference,
@@ -106,7 +106,10 @@ class EplbModelState:
     [[0, 1, 2, 3, 0, 1],
      [0, 2, 0, 1, 0, 3]]
     ```
+    The two first columns represent physical experts on the first device,
+    the next two on the second device, etc...
     """
+
     logical_to_physical_map: torch.Tensor
     """
     Mapping from logical experts to physical experts.
@@ -130,7 +133,13 @@ class EplbModelState:
       [1, -1, -1],
       [5, -1, -1]]]
     ```
+    In each row, the count of positions that are NOT equal to -1 is
+    the number of times the expert is replicated. In the example above,
+    in the first layer, logical expert 1 (second row) is replicated twice:
+    once as physical expert 1 on device 0 (first column), and once as
+    physical expert 5 on device 1 (second column).
     """
+
     logical_replica_count: torch.Tensor
     """
     Number of replicas for each logical expert.
@@ -150,13 +159,14 @@ class EplbModelState:
     expert_load_pass: torch.Tensor
     """
     Expert load during this forward pass. 
-    We use the token count each expert processes as the load.
+    We use the token count each physical expert processes as the load.
 
     Shape: (num_moe_layers, num_physical_experts)
     """
+
     expert_load_window: torch.Tensor
     """
-    A sliding window of expert load.
+    A sliding window of physical expert load.
 
     Shape: (window_size, num_moe_layers, num_physical_experts)
 
@@ -168,8 +178,14 @@ class EplbModelState:
     See:
     https://github.com/vllm-project/vllm/pull/22167#pullrequestreview-3086143856
     """
+
     model_name: str
+    """
+    Used for observability / logging.
+    """
+
     model: MixtureOfExperts
+
     expert_buffer: list[torch.Tensor]
     """
     The buffer to store the expert weights during transfer.
@@ -282,8 +298,8 @@ class EplbState:
         """
         Shared scalar bool tensor for all layers.  Every
         :class:`EplbLayerState` holds a reference to the **same** object so
-        a single ``.fill_()`` updates all layers at once.  Allocated on the
-        first call to :meth:`_init_should_record_tensor`.
+        a single ``.fill_()`` updates all layers at once.  Allocated during
+        :meth:`initialize`.
         """
         self.is_async: bool = False
         """
@@ -470,12 +486,13 @@ class EplbState:
         self.policy = EPLB_POLICIES[policy_type]
         logger.debug("Selected EPLB policy: %s", policy_type)
 
+        self.should_record_tensor = torch.ones((), dtype=torch.bool, device=self.device)
         model.set_eplb_state(
             expert_load_pass,
             logical_to_physical_map,
             logical_replica_count,
+            self.should_record_tensor,
         )
-        self._init_should_record_tensor(model)
         expert_buffer = [torch.empty_like(w) for w in model.expert_weights[0]]
 
         communicator = create_eplb_communicator(
@@ -632,7 +649,6 @@ class EplbState:
                     self.move_to_workspace(
                         model_state=eplb_model_state,
                         ep_group=ep_group,
-                        is_profile=is_profile,
                     )
 
         if self.expert_rearrangement_step >= self.expert_rearrangement_step_interval:
@@ -678,27 +694,6 @@ class EplbState:
             self.should_record_tensor.fill_(
                 self._should_record_current_step(log_stats=log_stats)
             )
-
-    def _init_should_record_tensor(self, model: "MixtureOfExperts") -> None:  # type: ignore[name-defined]
-        """Allocate (once) and propagate the shared ``should_record_tensor``.
-
-        Must be called after :meth:`model.set_eplb_state` so that each
-        layer's ``eplb_state`` is already populated with the tensor views.
-        """
-        layer_states = [
-            layer.eplb_state
-            for layer in model.moe_layers
-            if hasattr(layer, "eplb_state")
-            and isinstance(layer.eplb_state, EplbLayerState)
-        ]
-
-        if self.should_record_tensor is None and layer_states:
-            self.should_record_tensor = torch.ones(
-                (), dtype=torch.bool, device=self.device
-            )
-
-        for ls in layer_states:
-            ls.should_record_tensor = self.should_record_tensor
 
     def rearrange(
         self,
@@ -862,7 +857,6 @@ class EplbState:
 
     def start_async_loop(
         self,
-        rank_mapping: dict[int, int] | None = None,
         is_profile: bool = False,
     ):
         if not self.is_async:
@@ -900,7 +894,6 @@ class EplbState:
         self,
         model_state: EplbModelState,
         ep_group: ProcessGroup,
-        is_profile: bool = False,
     ):
         # We call move_to_workspace only when ep_buffer_ready is 1.
         # It means we only need to wait for the lock for a short time.
@@ -1069,14 +1062,14 @@ class EplbState:
         return eplb_state
 
 
-@dataclass
-class EplbLayerState:
+@dataclass(frozen=True)
+class InitializedEplbLayerState:
     """Runtime EPLB data stored in the MoE layer."""
 
-    expert_load_view: torch.Tensor | None = None
-    logical_to_physical_map: torch.Tensor | None = None
-    logical_replica_count: torch.Tensor | None = None
-    should_record_tensor: torch.Tensor | None = None
+    expert_load_view: torch.Tensor
+    logical_to_physical_map: torch.Tensor
+    logical_replica_count: torch.Tensor
+    should_record_tensor: torch.Tensor
     """
     Shared scalar bool tensor controlling whether to accumulate expert load
     metrics during this forward pass.  All layers reference the **same**
@@ -1087,6 +1080,14 @@ class EplbLayerState:
     sliding window before the next rearrangement, so recording them wastes
     GPU work.
     """
+
+
+@dataclass(frozen=True)
+class UninitializedEplbLayerState:
+    pass
+
+
+EplbLayerState = InitializedEplbLayerState | UninitializedEplbLayerState
 
 
 def _node_count_with_rank_mapping(

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -17,7 +17,10 @@ from vllm.distributed import (
     get_pcp_group,
     get_tensor_model_parallel_world_size,
 )
-from vllm.distributed.eplb.eplb_state import EplbLayerState, EplbState
+from vllm.distributed.eplb.eplb_state import (
+    EplbState,
+    UninitializedEplbLayerState,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
@@ -36,6 +39,7 @@ from vllm.model_executor.layers.fused_moe.fused_moe_modular_method import (
 from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
     init_aiter_topK_meta_data,
 )
+from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
 from vllm.model_executor.layers.fused_moe.router.router_factory import (
     create_fused_moe_router,
 )
@@ -332,7 +336,6 @@ class FusedMoE(CustomOp):
 
         self.enable_eplb = enable_eplb
         # TODO(bnell): should this be owned by router?
-        self.eplb_state = EplbLayerState()
         self.expert_placement_strategy: ExpertPlacementStrategy = (
             vllm_config.parallel_config.expert_placement_strategy
         )
@@ -446,10 +449,10 @@ class FusedMoE(CustomOp):
 
         # TODO(bnell): we should not have to create a router if the kernel is
         # monolithic.
+        eplb_state = UninitializedEplbLayerState() if self.enable_eplb else None
         self.router = create_fused_moe_router(
             top_k=top_k,
             global_num_experts=self.global_num_experts,
-            eplb_state=self.eplb_state,
             renormalize=renormalize,
             use_grouped_topk=use_grouped_topk,
             num_expert_group=num_expert_group,
@@ -459,7 +462,7 @@ class FusedMoE(CustomOp):
             routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
             num_fused_shared_experts=self.num_fused_shared_experts,
-            enable_eplb=enable_eplb,
+            eplb_state=eplb_state,
             # TODO(bnell): once we can construct the MK at init time, we
             # can make this a value.
             indices_type_getter=lambda: self.quant_method.topk_indices_dtype,
@@ -1475,6 +1478,7 @@ class FusedMoE(CustomOp):
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        should_record_tensor: torch.Tensor,
     ) -> None:
         """
         Register the EPLB state in this layer.
@@ -1482,9 +1486,13 @@ class FusedMoE(CustomOp):
         This is used later in forward pass, where we get the expert mapping
         and record the load metrics in `expert_load_view`.
         """
-        self.eplb_state.expert_load_view = expert_load_view[moe_layer_idx]
-        self.eplb_state.logical_to_physical_map = logical_to_physical_map[moe_layer_idx]
-        self.eplb_state.logical_replica_count = logical_replica_count[moe_layer_idx]
+        if isinstance(self.router, BaseRouter):
+            self.router.initialize_eplb_state(
+                expert_load_view[moe_layer_idx],
+                logical_to_physical_map[moe_layer_idx],
+                logical_replica_count[moe_layer_idx],
+                should_record_tensor,
+            )
 
     def ensure_moe_quant_config_init(self):
         if self.quant_method.moe_quant_config is None:

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -20,7 +20,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     mxfp4_w4a16_moe_quant_config,
     ocp_mx_moe_quant_config,
 )
-from vllm.model_executor.layers.quantization.utils.mxfp4_utils import _swizzle_mxfp4
+from vllm.model_executor.layers.quantization.utils.mxfp4_utils import swizzle_mxfp4
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kMxfp4Static,
@@ -725,11 +725,11 @@ def convert_to_mxfp4_moe_kernel_format(
         w13_bias = w13_bias.to(torch.float32)
         w2_bias = w2_bias.to(torch.float32)
 
-        w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(
+        w13_weight, w13_flex, w13_scale = swizzle_mxfp4(
             w13_weight,
             w13_weight_scale,
         )
-        w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(
+        w2_weight, w2_flex, w2_scale = swizzle_mxfp4(
             w2_weight,
             w2_weight_scale,
         )

--- a/vllm/model_executor/layers/fused_moe/router/base_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/base_router.py
@@ -5,12 +5,15 @@ from collections.abc import Callable
 
 import torch
 
-from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.distributed.eplb.eplb_state import EplbLayerState, InitializedEplbLayerState
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.router.fused_moe_router import (
     FusedMoERouter,
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
 
 if current_platform.is_cuda_alike():
 
@@ -143,8 +146,7 @@ class BaseRouter(FusedMoERouter):
         self,
         top_k: int,
         global_num_experts: int,
-        eplb_state: EplbLayerState,
-        enable_eplb: bool = False,
+        eplb_state: EplbLayerState | None,
         # TODO(bnell): Once the MK is constructed at layer init time, we
         # can make this a plain value instead of a callback.
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
@@ -159,7 +161,6 @@ class BaseRouter(FusedMoERouter):
         self.top_k = top_k
         self.global_num_experts = global_num_experts
         self.eplb_state = eplb_state
-        self.enable_eplb = enable_eplb
         self.indices_type_getter = indices_type_getter
         self.capture_fn: Callable[[torch.Tensor], None] | None = None
 
@@ -167,23 +168,37 @@ class BaseRouter(FusedMoERouter):
         """Set a capture callback for logical routed expert IDs."""
         self.capture_fn = capture_fn
 
+    def _check_eplb_initialized(self) -> InitializedEplbLayerState | None:
+        """Returns initialized EPLB state if EPLB is enabled and initialized,
+        otherwise returns None."""
+        if self.eplb_state is not None and isinstance(
+            self.eplb_state, InitializedEplbLayerState
+        ):
+            return self.eplb_state
+        return None
+
     def _validate_eplb_state(self) -> None:
         """Validate that EPLB state is properly initialized if EPLB is enabled."""
-        if self.enable_eplb:
-            if self.eplb_state.expert_load_view is None:
-                raise ValueError("enable_eplb=True requires expert_load_view != None")
-            if self.eplb_state.logical_to_physical_map is None:
-                raise ValueError(
-                    "enable_eplb=True requires logical_to_physical_map != None"
-                )
-            if self.eplb_state.logical_replica_count is None:
-                raise ValueError(
-                    "enable_eplb=True requires logical_replica_count != None"
-                )
-            if self.eplb_state.should_record_tensor is None:
-                raise ValueError(
-                    "enable_eplb=True requires should_record_tensor != None"
-                )
+        if self._check_eplb_initialized() is None:
+            logger.warning_once(
+                "enable_eplb=True but EPLB state is not yet initialized. "
+                "EPLB mapping will be skipped until set_eplb_state() is "
+                "called. This is expected during compilation/profiling."
+            )
+
+    def initialize_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+        should_record_tensor: torch.Tensor,
+    ) -> None:
+        self.eplb_state = InitializedEplbLayerState(
+            expert_load_view=expert_load_view,
+            logical_to_physical_map=logical_to_physical_map,
+            logical_replica_count=logical_replica_count,
+            should_record_tensor=should_record_tensor,
+        )
 
     def _get_indices_type(self) -> torch.dtype | None:
         """Get the desired indices dtype from the getter function."""
@@ -193,17 +208,14 @@ class BaseRouter(FusedMoERouter):
 
     def _apply_eplb_mapping(self, topk_ids: torch.Tensor) -> torch.Tensor:
         """Apply EPLB mapping to convert logical expert IDs to physical expert IDs."""
-        if self.enable_eplb:
-            assert self.eplb_state.expert_load_view is not None
-            assert self.eplb_state.logical_to_physical_map is not None
-            assert self.eplb_state.logical_replica_count is not None
-            assert self.eplb_state.should_record_tensor is not None
+        if (initialized_eplb_state := self._check_eplb_initialized()) is not None:
+            assert isinstance(initialized_eplb_state, InitializedEplbLayerState)
             return eplb_map_to_physical_and_record(
                 topk_ids=topk_ids,
-                logical_to_physical_map=self.eplb_state.logical_to_physical_map,
-                logical_replica_count=self.eplb_state.logical_replica_count,
-                expert_load_view=self.eplb_state.expert_load_view,
-                record_enabled=self.eplb_state.should_record_tensor,
+                expert_load_view=initialized_eplb_state.expert_load_view,
+                logical_to_physical_map=initialized_eplb_state.logical_to_physical_map,
+                logical_replica_count=initialized_eplb_state.logical_replica_count,
+                record_enabled=initialized_eplb_state.should_record_tensor,
             )
         return topk_ids
 

--- a/vllm/model_executor/layers/fused_moe/router/custom_routing_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/custom_routing_router.py
@@ -16,17 +16,15 @@ class CustomRoutingRouter(BaseRouter):
         self,
         top_k: int,
         global_num_experts: int,
-        eplb_state: EplbLayerState,
+        eplb_state: EplbLayerState | None,
         custom_routing_function: Callable,
         renormalize: bool = True,
-        enable_eplb: bool = False,
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
     ):
         super().__init__(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
-            enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
         )
         self.custom_routing_function = custom_routing_function

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -175,19 +175,17 @@ class FusedTopKBiasRouter(BaseRouter):
         self,
         top_k: int,
         global_num_experts: int,
-        eplb_state: EplbLayerState,
+        eplb_state: EplbLayerState | None,
         e_score_correction_bias: torch.Tensor,
         scoring_func: str,
         renormalize: bool = True,
         routed_scaling_factor: float = 1.0,
-        enable_eplb: bool = False,
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
     ):
         super().__init__(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
-            enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
         )
         self.e_score_correction_bias = e_score_correction_bias

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -120,17 +120,15 @@ class FusedTopKRouter(BaseRouter):
         self,
         top_k: int,
         global_num_experts: int,
-        eplb_state: EplbLayerState,
+        eplb_state: EplbLayerState | None,
         scoring_func: str = "softmax",
         renormalize: bool = True,
-        enable_eplb: bool = False,
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
     ):
         super().__init__(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
-            enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
         )
         self.renormalize = renormalize
@@ -153,7 +151,7 @@ class FusedTopKRouter(BaseRouter):
         indices_type: torch.dtype | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute routing using standard fused top-k."""
-        topk_weights, topk_ids, token_expert_indices = fused_topk(
+        topk_weights, topk_ids, _ = fused_topk(
             hidden_states=hidden_states,
             gating_output=router_logits,
             topk=self.top_k,

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -251,7 +251,7 @@ class GroupedTopKRouter(BaseRouter):
         self,
         top_k: int,
         global_num_experts: int,
-        eplb_state: EplbLayerState,
+        eplb_state: EplbLayerState | None,
         num_expert_group: int,
         topk_group: int,
         renormalize: bool = True,
@@ -259,14 +259,12 @@ class GroupedTopKRouter(BaseRouter):
         routed_scaling_factor: float = 1.0,
         e_score_correction_bias: torch.Tensor | None = None,
         num_fused_shared_experts: int = 0,
-        enable_eplb: bool = False,
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
     ):
         super().__init__(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
-            enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
         )
         self.num_expert_group = num_expert_group
@@ -315,7 +313,7 @@ class GroupedTopKRouter(BaseRouter):
                 if self.routed_scaling_factor != 1.0:
                     topk_weights *= self.routed_scaling_factor
             else:
-                topk_weights, topk_ids, token_expert_indices = fused_topk(
+                topk_weights, topk_ids, _ = fused_topk(
                     hidden_states=hidden_states,
                     gating_output=router_logits,
                     topk=self.top_k,

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 import torch
 
 import vllm.envs as envs
-from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.distributed.eplb.eplb_state import EplbLayerState, UninitializedEplbLayerState
 from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
 from vllm.model_executor.layers.fused_moe.router.custom_routing_router import (
     CustomRoutingRouter,
@@ -26,7 +26,7 @@ from vllm.model_executor.layers.fused_moe.router.routing_simulator_router import
     RoutingSimulatorRouter,
 )
 
-EMPTY_EPLB_STATE: EplbLayerState = EplbLayerState()
+EMPTY_EPLB_STATE: EplbLayerState = UninitializedEplbLayerState()
 
 
 def create_fused_moe_router(
@@ -46,9 +46,7 @@ def create_fused_moe_router(
     e_score_correction_bias: torch.Tensor | None = None,
     # custom routing parameters
     custom_routing_function: Callable | None = None,
-    # eplb parameters
-    enable_eplb: bool = False,
-    eplb_state: EplbLayerState = EMPTY_EPLB_STATE,
+    eplb_state: EplbLayerState | None = None,
 ) -> FusedMoERouter:
     """
     Factory function to create the appropriate FusedMoERouter subclass based on
@@ -96,7 +94,6 @@ def create_fused_moe_router(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
-            enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
         )
 
@@ -118,7 +115,6 @@ def create_fused_moe_router(
             routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
             num_fused_shared_experts=num_fused_shared_experts,
-            enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
         )
         if (
@@ -141,7 +137,6 @@ def create_fused_moe_router(
             eplb_state=eplb_state,
             custom_routing_function=custom_routing_function,
             renormalize=renormalize,
-            enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
         )
 
@@ -154,7 +149,6 @@ def create_fused_moe_router(
             scoring_func=scoring_func,
             renormalize=renormalize,
             routed_scaling_factor=routed_scaling_factor,
-            enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
         )
 
@@ -164,6 +158,5 @@ def create_fused_moe_router(
         eplb_state=eplb_state,
         renormalize=renormalize,
         scoring_func=scoring_func,
-        enable_eplb=enable_eplb,
         indices_type_getter=indices_type_getter,
     )

--- a/vllm/model_executor/layers/fused_moe/router/routing_simulator_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/routing_simulator_router.py
@@ -313,15 +313,13 @@ class RoutingSimulatorRouter(BaseRouter):
         self,
         top_k: int,
         global_num_experts: int,
-        eplb_state: EplbLayerState,
-        enable_eplb: bool = False,
+        eplb_state: EplbLayerState | None,
         indices_type_getter: Callable[[], torch.dtype | None] | None = None,
     ):
         super().__init__(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
-            enable_eplb=enable_eplb,
             indices_type_getter=indices_type_getter,
         )
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -223,10 +223,29 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         replace_parameter(layer, "w13_weight_scale", w13_scale)
         replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w2_weight_scale", w2_scale)
-        layer.w13_weight_scale_2 = w13_scale_2
-        layer.w2_weight_scale_2 = w2_scale_2
-        layer.w13_input_scale = a13_scale
-        layer.w2_input_scale = a2_scale
+        # Ensure contiguity: some backends (e.g. expand() in FlashInfer)
+        # return non-contiguous views.  EPLB's get_expert_weights requires
+        # all nn.Parameters to be contiguous.
+        replace_parameter(
+            layer,
+            "w13_weight_scale_2",
+            w13_scale_2.contiguous() if w13_scale_2 is not None else None,
+        )
+        replace_parameter(
+            layer,
+            "w2_weight_scale_2",
+            w2_scale_2.contiguous() if w2_scale_2 is not None else None,
+        )
+        replace_parameter(
+            layer,
+            "w13_input_scale",
+            a13_scale.contiguous() if a13_scale is not None else None,
+        )
+        replace_parameter(
+            layer,
+            "w2_input_scale",
+            a2_scale.contiguous() if a2_scale is not None else None,
+        )
 
         # Setup modular kernel.
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
@@ -304,3 +323,7 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             shared_experts_input=shared_experts_input,
         )
+
+    @property
+    def supports_eplb(self) -> bool:
+        return True

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -40,7 +40,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
     prepare_fp8_moe_layer_for_marlin,
 )
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
-    _swizzle_mxfp4,
+    swizzle_mxfp4,
 )
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
     OCP_MX_BLOCK_SIZE,
@@ -1226,10 +1226,10 @@ class QuarkOCP_MX_MoEMethod_OSS(QuarkOCP_MX_MoEMethod):
         else:
             num_warps = 8
 
-        w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(
+        w13_weight, w13_flex, w13_scale = swizzle_mxfp4(
             layer.w13_weight, layer.w13_weight_scale, num_warps
         )
-        w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(
+        w2_weight, w2_flex, w2_scale = swizzle_mxfp4(
             layer.w2_weight, layer.w2_weight_scale, num_warps
         )
 

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -19,7 +19,7 @@ logger = init_logger(__name__)
 CK_MXFP4_MOE_DIM_ALIGNMENT = 256
 
 
-def _swizzle_mxfp4(quant_tensor, scale, num_warps=8):
+def swizzle_mxfp4(quant_tensor, scale, num_warps=8):
     """weight swizzle for mxfp4 moe, used for OAI mxfp4 kernel"""
     assert has_triton_kernels()
     import triton_kernels.matmul_ogs_details.opt_flags as opt_flags

--- a/vllm/model_executor/models/afmoe.py
+++ b/vllm/model_executor/models/afmoe.py
@@ -675,6 +675,7 @@ class AfmoeForCausalLM(nn.Module, SupportsPP, SupportsEagle3, SupportsLoRA):
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        should_record_tensor: torch.Tensor,
     ) -> None:
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
@@ -684,6 +685,7 @@ class AfmoeForCausalLM(nn.Module, SupportsPP, SupportsEagle3, SupportsLoRA):
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                should_record_tensor=should_record_tensor,
             )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -886,6 +886,7 @@ class MixtureOfExperts(Protocol):
         expert_load_view: Tensor,
         logical_to_physical_map: Tensor,
         logical_replica_count: Tensor,
+        should_record_tensor: Tensor,
     ) -> None:
         """
         Register the EPLB state in the MoE model.
@@ -902,6 +903,8 @@ class MixtureOfExperts(Protocol):
             expert_load_view: A view of the expert load metrics tensor.
             logical_to_physical_map: Mapping from logical to physical experts.
             logical_replica_count: Count of replicas for each logical expert.
+            should_record_tensor: Shared scalar bool tensor controlling
+                whether to accumulate expert load metrics.
         """
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
@@ -911,6 +914,7 @@ class MixtureOfExperts(Protocol):
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                should_record_tensor=should_record_tensor,
             )
 
     def update_physical_experts_metadata(

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -810,9 +810,13 @@ class Llama4ForConditionalGeneration(
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        should_record_tensor: torch.Tensor,
     ):
         self.language_model.set_eplb_state(
-            expert_load_view, logical_to_physical_map, logical_replica_count
+            expert_load_view,
+            logical_to_physical_map,
+            logical_replica_count,
+            should_record_tensor,
         )
         self.expert_weights = self.language_model.expert_weights
 

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -75,6 +75,7 @@ from .interfaces import (
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
+    is_mixture_of_experts,
     supports_eagle3,
 )
 from .module_mapping import MultiModelKeys
@@ -367,6 +368,121 @@ class PixtralForConditionalGeneration(
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors
+        )
+
+        # Track whether the language model is MoE so we can proxy its
+        # attributes via @property (see below).
+        self._is_moe = is_mixture_of_experts(self.language_model)
+
+    @property
+    def num_moe_layers(self) -> int:  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.num_moe_layers
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute 'num_moe_layers'"
+        )
+
+    @property
+    def num_expert_groups(self) -> int:  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.num_expert_groups
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute "
+            "'num_expert_groups'"
+        )
+
+    @property
+    def num_logical_experts(self) -> int:  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.num_logical_experts
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute "
+            "'num_logical_experts'"
+        )
+
+    @property
+    def num_physical_experts(self) -> int:  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.num_physical_experts
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute "
+            "'num_physical_experts'"
+        )
+
+    @property
+    def num_local_physical_experts(self) -> int:  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.num_local_physical_experts
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute "
+            "'num_local_physical_experts'"
+        )
+
+    @property
+    def num_routed_experts(self) -> int:  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.num_routed_experts
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute "
+            "'num_routed_experts'"
+        )
+
+    @property
+    def num_shared_experts(self) -> int:  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.num_shared_experts
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute "
+            "'num_shared_experts'"
+        )
+
+    @property
+    def num_redundant_experts(self) -> int:  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.num_redundant_experts
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute "
+            "'num_redundant_experts'"
+        )
+
+    @property
+    def moe_layers(self):  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.moe_layers
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute 'moe_layers'"
+        )
+
+    @property
+    def expert_weights(self):  # type: ignore[override]
+        if self._is_moe:
+            return self.language_model.expert_weights
+        raise AttributeError(
+            "'PixtralForConditionalGeneration' object has no attribute 'expert_weights'"
+        )
+
+    def set_eplb_state(
+        self,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+        should_record_tensor: torch.Tensor,
+    ) -> None:
+        self.language_model.set_eplb_state(
+            expert_load_view,
+            logical_to_physical_map,
+            logical_replica_count,
+            should_record_tensor,
+        )
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        self.language_model.update_physical_experts_metadata(
+            num_physical_experts=num_physical_experts,
+            num_local_physical_experts=num_local_physical_experts,
         )
 
     def _parse_and_validate_image_input(

--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -903,6 +903,7 @@ class Step3p5ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        should_record_tensor: torch.Tensor,
     ) -> None:
         for layer_idx, layer in enumerate(self.moe_layers):
             experts = layer.experts
@@ -914,6 +915,7 @@ class Step3p5ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                should_record_tensor=should_record_tensor,
             )
 
     def update_physical_experts_metadata(

--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -129,6 +129,7 @@ class MoEMixin(MixtureOfExperts):
         expert_load_view: torch.Tensor,
         logical_to_physical_map: torch.Tensor,
         logical_replica_count: torch.Tensor,
+        should_record_tensor: torch.Tensor,
     ):
         for moe_layer_idx, mlp_layer in enumerate(self.mlp_moe_layers):
             mlp_layer.experts.set_eplb_state(
@@ -136,6 +137,7 @@ class MoEMixin(MixtureOfExperts):
                 expert_load_view=expert_load_view,
                 logical_to_physical_map=logical_to_physical_map,
                 logical_replica_count=logical_replica_count,
+                should_record_tensor=should_record_tensor,
             )
 
     def update_physical_experts_metadata(


### PR DESCRIPTION
## Purpose

The NVFP4 compressed tensors MoE implementation does not support EPLB currently. This PR adds this support.

### Key changes

#### 1. EPLB state management redesigned

- **`EplbLayerState` is now a union type** of two frozen dataclasses:
  - `InitializedEplbLayerState` — all tensor fields are required (non-optional).
  - `UninitializedEplbLayerState` — empty marker indicating EPLB is registered but not yet initialized.
- This eliminates the previous pattern of a single mutable dataclass with all-`None` optional fields, making state validity checkable at the type level.
- The `_init_should_record_tensor()` post-hoc propagation method is **removed**. The `should_record_tensor` is now allocated once during `EplbState.initialize()` and passed explicitly through `set_eplb_state()`.

#### 2. `enable_eplb` flag removed from routers

- The redundant `enable_eplb: bool` parameter is **removed from all router constructors** (base_router.py, fused_topk_router.py, grouped_topk_router.py, fused_topk_bias_router.py, custom_routing_router.py, routing_simulator_router.py, and router_factory.py).
- Enablement is now inferred from whether `eplb_state` is `None` vs. a populated instance. A new `_check_eplb_initialized()` helper returns the initialized state or `None`.
- Validation in `_validate_eplb_state()` now logs a **warning** (instead of raising) when EPLB is enabled but not yet initialized — expected during compilation/profiling.

#### 3. EPLB state ownership moved to the router

- `FusedMoE` no longer owns an `eplb_state` attribute. Instead, the `eplb_state` is passed to the router at construction and the router exposes an `initialize_eplb_state()` method.
- `FusedMoE.set_eplb_state()` now delegates to `router.initialize_eplb_state()`, constructing an `InitializedEplbLayerState` inside the router.

#### 4. Compressed tensors NVFP4 EPLB support

- `CompressedTensorsW4A4Nvfp4MoEMethod` gains `supports_eplb = True`, enabling EPLB for NVFP4-quantized MoE models.
- Weight/scale parameter handling is improved:
  - Variables renamed for clarity (`w13_weight_scale_2` → `w13_weight_global_scale`, `w13_input_scale` → `w13_input_global_scale`, etc.).
  - `replace_parameter()` is now used (instead of bare attribute assignment) for global scales and input scales, with `.contiguous()` calls to satisfy EPLB's `get_expert_weights` requirement.
  - Internal constant renamed from `group_size` to `nvfp4_block_size` for accuracy.

#### 5. Pixtral (ML3) MoE proxy support

- `PixtralForConditionalGeneration` now **proxies all `MixtureOfExperts` properties** (`moe_layers`, `expert_weights`, `num_moe_layers`, `num_logical_experts`, `num_physical_experts`, etc.) to its inner `language_model` when it is an MoE model.
- `set_eplb_state()` and `update_physical_experts_metadata()` are forwarded as well, allowing EPLB to work transparently through the vision-language wrapper.

#### 6. `should_record_tensor` plumbed through the interface

- The `MixtureOfExperts` protocol and all its implementations (interfaces.py, afmoe.py, step3p5.py, mllama4.py, transformers/moe.py) now accept `should_record_tensor` as an explicit parameter in `set_eplb_state()`.

#### 7. Minor cleanups

- `_swizzle_mxfp4` renamed to `swizzle_mxfp4` (public API in mxfp4_utils.py), updated at all call sites.
- Unused `is_profile` and `rank_mapping` parameters removed from `EplbState.start_async_loop()` and `move_to_workspace()`.
- Unused `token_expert_indices` variables replaced with `_` in routers.
- New pytest markers (`benchmark`, `forked`) registered in pyproject.toml.
- Tests updated to use the new `InitializedEplbLayerState` / `None` pattern instead of the old mutable `EplbLayerState` + `enable_eplb` flag.

## Test Plan

Testing was done by comparing accuracy on DSR1 and ML3 without EPLB (baseline), with EPLB, with EPLB and redundant experts.

## Test Result

DS Baseline (no EPLB):
Results:
Accuracy: 0.949
Invalid responses: 0.000
Total latency: 366.631 s
Questions per second: 3.598
Total output tokens: 132068
Output tokens per second: 360.220

DS EPLB:
Results:
Accuracy: 0.955
Invalid responses: 0.000
Total latency: 344.953 s
Questions per second: 3.824
Total output tokens: 132169
Output tokens per second: 383.151

DS EPLB + Redundancy
Results:
Accuracy: 0.959
Invalid responses: 0.000
Total latency: 369.150 s
Questions per second: 3.573
Total output tokens: 133503
Output tokens per second: 361.650

ML3 Baseline (no EPLB):
Results:
Accuracy: 0.921
Invalid responses: 0.000
Total latency: 378.327 s
Questions per second: 3.486
Total output tokens: 160501
Output tokens per second: 424.239

ML3 EPLB:
Results:
Accuracy: 0.914
Invalid responses: 0.000
Total latency: 392.951 s
Questions per second: 3.357
Total output tokens: 160152
Output tokens per second: 407.562

ML3 EPLB + Redundancy:
Results:
Accuracy: 0.922
Invalid responses: 0.001
Total latency: 392.763 s
Questions per second: 3.358
Total output tokens: 160390
Output tokens per second: 408.364

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

