### PR TITLE
[Bugfix] Fix negative max_tokens when input prompt is too long

### DIFF
--- a/tests/entrypoints/test_utils.py
+++ b/tests/entrypoints/test_utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
+
 from vllm.entrypoints.utils import get_max_tokens, sanitize_message
 
 
@@ -80,3 +82,15 @@ class TestGetMaxTokens:
             default_sampling_params={"max_tokens": 2048},
         )
         assert result == 512
+
+    def test_input_length_exceeds_max_model_len(self):
+        with pytest.raises(
+            ValueError,
+            match="Input length .* exceeds model's maximum context length .*",
+        ):
+            get_max_tokens(
+                max_model_len=100,
+                max_tokens=50,
+                input_length=150,
+                default_sampling_params={"max_tokens": 2048},
+            )

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -178,6 +178,11 @@ def get_max_tokens(
     default_sampling_params: dict,
     override_max_tokens: int | None = None,
 ) -> int:
+    if max_model_len < input_length:
+        raise ValueError(
+            f"Input length ({input_length}) exceeds model's maximum "
+            f"context length ({max_model_len})."
+        )
     model_max_tokens = max_model_len - input_length
     platform_max_tokens = current_platform.get_max_output_tokens(input_length)
     fallback_max_tokens = (


### PR DESCRIPTION

## Purpose
- `get_max_tokens` will return negative `max_tokens` when max_model_len too small, which makes error message a bit confusing
```
openai.BadRequestError: Error code: 400 - {'error': {'message': 'max_tokens must be at least 1, got -7584. (parameter=max_tokens, value=-7584)', 'type': 'BadRequestError', 'param': 'max_tokens', 'code': 400}}
```
- Avoid negative max_tokens when `max_model_len` smaller than `input_length`.

## Test Plan
```
vllm serve Qwen/Qwen3.5-0.8B --max-model-len 4096
```
```
python examples/online_serving/openai_chat_completion_client_for_multimodal.py -c video
```

## Test Result
```
openai.BadRequestError: Error code: 400 - {'error': {'message': "Input length (11680) exceeds model's maximum context length (4096).", 'type': 'BadRequestError', 'param': None, 'code': 400}}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

