### PR TITLE
Disable docs build skipping until a better solution is found

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
     python: "3.12"
   jobs:
     post_checkout:
-      - bash docs/maybe_skip_pr_build.sh
+      # - bash docs/maybe_skip_pr_build.sh
       - git fetch origin main --unshallow --no-tags --filter=blob:none || true
     pre_create_environment:
       - pip install uv


### PR DESCRIPTION
The issues with this approach were:

- If the docs build skips and exits with `137` (readthedocs special skip exit code) it appears as passed on GitHub which could lead to PRs merging with no docs build run at all
- If the docs build skips and exits with any other non-zero exit code then either:
  - The build must be manually restarted by a docs admin when `ready` is added
  - A new commit must be pushed after `ready` is added

Neither of these issues are acceptable.