### PR TITLE
[Bugfix][Core] Allow multi-dtype MambaSpec KV cache spec

### DIFF
--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -273,7 +273,7 @@ class SlidingWindowSpec(AttentionSpec):
 @dataclass(frozen=True)
 class MambaSpec(KVCacheSpec):
     shapes: tuple[tuple[int, ...], ...]
-    dtypes: tuple[torch.dtype]
+    dtypes: tuple[torch.dtype, ...]
     page_size_padded: int | None = None
     mamba_type: str = "mamba2"
     mamba_cache_mode: str = "none"


### PR DESCRIPTION
This fixes a msgspec schema mismatch for Mamba KV cache specs when models use multiple state dtypes.

Several Mamba-style and hybrid models (e.g. Qwen3.5, Mamba2) define their Mamba state as multiple tensors via `get_mamba_state_dtype_from_config` and `get_mamba_state_shape_from_config`. That flows into `MambaSpec`, so `MambaSpec.dtypes` is often a tuple with more than one `torch.dtype`.

The bug appears when these specs cross the msgspec RPC boundary (e.g. `collective_rpc("get_kv_cache_spec")`). msgspec raises `ValidationError: Expected array of length 1, got 2 - at $.dtypes`.