### PR TITLE
Correct link to supported hardware on vllm.ai

### DIFF
--- a/docs/getting_started/installation/README.md
+++ b/docs/getting_started/installation/README.md
@@ -16,4 +16,4 @@ vLLM supports the following hardware platforms:
 
 vLLM supports third-party hardware plugins that live **outside** the main `vllm` repository. These follow the [Hardware-Pluggable RFC](../../design/plugin_system.md).
 
-A list of all supported hardware can be found on the [vllm.ai website](https://vllm.ai/#hardware). If you want to add new hardware, please contact us on [Slack](https://slack.vllm.ai/) or [Email](mailto:collaboration@vllm.ai).
+A list of all supported hardware can be found on the [vllm.ai website](https://vllm.ai/#compatibility). If you want to add new hardware, please contact us on [Slack](https://slack.vllm.ai/) or [Email](mailto:collaboration@vllm.ai).


### PR DESCRIPTION
This anchor doesn't exist anymore, `compatibility` is the next best thing which shows the list of hardware

<img width="1139" height="961" alt="image" src="https://github.com/user-attachments/assets/597c85a5-80ad-4a27-ae3d-fc34423964d4" />
