### PR TITLE
Revert "Fix `hf_override_fn` when it modifies `model_type`" (#35200)

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -162,16 +162,7 @@ class HFConfigParser(ConfigParserBase):
             )
         # Allow hf_overrides to override model_type before checking _CONFIG_REGISTRY
         if (hf_overrides := kwargs.pop("hf_overrides", None)) is not None:
-            if isinstance(hf_overrides, dict) and "model_type" in hf_overrides:
-                model_type = hf_overrides["model_type"]
-            elif callable(hf_overrides):
-                # If hf_overrides doesn't modify model_type, it will be passed straight
-                # through and remain unchanged by this elif block
-                dummy_model_type = f"dummy_{model_type}"
-                dummy_kwargs = dict(architectures=[""], model_type=dummy_model_type)
-                dummy_config = PretrainedConfig(**dummy_kwargs)
-                dummy_model_type = hf_overrides(dummy_config).model_type
-                model_type = dummy_model_type.removeprefix("dummy_")
+            model_type = hf_overrides.get("model_type", model_type)
 
         if model_type in _CONFIG_REGISTRY:
             config_class = _CONFIG_REGISTRY[model_type]
@@ -644,7 +635,7 @@ def get_config(
         trust_remote_code=trust_remote_code,
         revision=revision,
         code_revision=code_revision,
-        hf_overrides=hf_overrides_kw or hf_overrides_fn,
+        hf_overrides=hf_overrides_kw,
         **kwargs,
     )
 

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -79,10 +79,10 @@ class ModelArchConfigConvertorBase:
         if getattr(self.hf_text_config, "hidden_size_per_head", None) is not None:
             return self.hf_text_config.hidden_size_per_head
 
-        if (total_num_attention_heads := self.get_total_num_attention_heads()) == 0:
-            return 0
         # FIXME(woosuk): This may not be true for all models.
-        return self.get_hidden_size() // total_num_attention_heads
+        return (
+            self.hf_text_config.hidden_size // self.hf_text_config.num_attention_heads
+        )
 
     def get_total_num_kv_heads(self) -> int:
         attributes = [
@@ -96,7 +96,7 @@ class ModelArchConfigConvertorBase:
         ]
         # For non-grouped-query attention models, the number of KV heads is
         # equal to the number of attention heads.
-        default_factory = self.get_total_num_attention_heads
+        default_factory = lambda: self.hf_text_config.num_attention_heads
         return getattr_iter(
             self.hf_text_config, attributes, default_factory=default_factory
         )


### PR DESCRIPTION
## Revert of #35200

This reverts commit d88f28da05b12bc7d63ebe3dcedf445ecb274343.

**Original PR:** https://github.com/vllm-project/vllm/pull/35200
**Failure count:** 1 new failure in nightly CI build [#55668](https://buildkite.com/vllm/ci/builds/55668)

### Reason

PR #35200 introduced a code path in `HFConfigParser.parse` that creates a minimal `PretrainedConfig` (with only `architectures` and `model_type`) and passes it to user-provided `hf_overrides` callables. When the callable accesses attributes like `text_config` that exist on real model configs but not on this dummy config, it raises `AttributeError`.

**Failed test:** `test_mm_classifier_conversion.py::test_gemma_multimodal` in "Language Models Test (Extended Pooling)"
**Error:** `AttributeError: 'PretrainedConfig' object has no attribute 'text_config'`

---
*Auto-generated by CI failure analyzer*