### PR TITLE
[Metrics] Temporary band-aid for "Counters can only be incremented by non-negative amounts"

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
 from vllm.v1.engine import FinishReason
 from vllm.v1.metrics.stats import IterationStats, PromptTokenStats, RequestStateStats
 
@@ -115,9 +117,10 @@ def test_prompt_token_stats_all_computed():
 
     # Case 1: No caching (All tokens computed locally)
     stats.update_from_output(
+        request_id="test-req-1",
+        prompt_len=1000,
         num_cached_tokens=0,
         num_external_computed_tokens=0,
-        prompt_len=1000,
     )
 
     assert stats.computed == 1000
@@ -132,14 +135,16 @@ def test_prompt_token_stats_partial_local_cache():
 
     # Case 2: Partial local cache
     stats.update_from_output(
+        request_id="test-req-2",
+        prompt_len=1000,
         num_cached_tokens=300,
         num_external_computed_tokens=0,
-        prompt_len=1000,
     )
 
     assert stats.computed == 700
     assert stats.local_cache_hit == 300
     assert stats.external_kv_transfer == 0
+    assert stats.total == 1000
 
 
 def test_prompt_token_stats_partial_external_transfer():
@@ -148,14 +153,16 @@ def test_prompt_token_stats_partial_external_transfer():
 
     # Case 3: Partial external transfer
     stats.update_from_output(
+        request_id="test-req-3",
+        prompt_len=1000,
         num_cached_tokens=500,
         num_external_computed_tokens=500,
-        prompt_len=1000,
     )
 
     assert stats.computed == 500
     assert stats.local_cache_hit == 0
     assert stats.external_kv_transfer == 500
+    assert stats.total == 1000
 
 
 def test_prompt_token_stats_mixed_sources():
@@ -164,14 +171,16 @@ def test_prompt_token_stats_mixed_sources():
 
     # Case 4: Mixed sources
     stats.update_from_output(
+        request_id="test-req-4",
+        prompt_len=1000,
         num_cached_tokens=600,
         num_external_computed_tokens=200,
-        prompt_len=1000,
     )
 
     assert stats.computed == 400
     assert stats.local_cache_hit == 400
     assert stats.external_kv_transfer == 200
+    assert stats.total == 1000
 
 
 def test_prompt_token_stats_full_local_cache_recompute():
@@ -184,14 +193,16 @@ def test_prompt_token_stats_full_local_cache_recompute():
 
     # Case 5: Full local cache (999 cached after reduction, 1 recomputed)
     stats.update_from_output(
+        request_id="test-req-5",
+        prompt_len=1000,
         num_cached_tokens=999,
         num_external_computed_tokens=0,
-        prompt_len=1000,
     )
 
     assert stats.computed == 1
     assert stats.local_cache_hit == 1000
     assert stats.recomputed_tokens == 1
+    assert stats.total == 1000
 
 
 def test_prompt_token_stats_full_external_transfer_recompute():
@@ -200,12 +211,77 @@ def test_prompt_token_stats_full_external_transfer_recompute():
 
     # Case 6: Full external transfer (999 cached after reduction, 1 recomputed)
     stats.update_from_output(
+        request_id="test-req-6",
+        prompt_len=1000,
         num_cached_tokens=999,
         num_external_computed_tokens=1000,
-        prompt_len=1000,
     )
 
     assert stats.computed == 1
     assert stats.local_cache_hit == 0
     assert stats.external_kv_transfer == 1000
     assert stats.recomputed_tokens == 1
+    assert stats.total == 1000
+
+
+@pytest.mark.parametrize(
+    "test_id,prompt_len,num_cached,num_external,description",
+    [
+        (
+            "negative-cached",
+            100,
+            -10,
+            0,
+            "negative num_cached_tokens",
+        ),
+        (
+            "negative-external",
+            100,
+            10,
+            -5,
+            "negative num_external_computed_tokens",
+        ),
+        (
+            "cached-exceeds-prompt",
+            100,
+            150,
+            0,
+            "num_cached_tokens > prompt_len",
+        ),
+        (
+            "external-exceeds-cached",
+            100,
+            10,
+            50,
+            "num_external > num_cached + recomputed (P/D disaggregation)",
+        ),
+        (
+            "multiple-violations",
+            100,
+            -5,
+            -10,
+            "multiple violations (both negative)",
+        ),
+    ],
+)
+def test_prompt_token_stats_invariant_violation(
+    test_id, prompt_len, num_cached, num_external, description, caplog_vllm
+):
+    """Test that invariant violations are caught and handled safely."""
+    stats = PromptTokenStats()
+
+    stats.update_from_output(
+        request_id=f"test-req-{test_id}",
+        prompt_len=prompt_len,
+        num_cached_tokens=num_cached,
+        num_external_computed_tokens=num_external,
+    )
+
+    # Should log a warning
+    assert "METRICS ACCOUNTING BUG DETECTED" in caplog_vllm.text
+
+    # Should not crash, should discard cache metrics
+    assert stats.computed == prompt_len
+    assert stats.local_cache_hit == 0
+    assert stats.external_kv_transfer == 0
+    assert stats.total == prompt_len

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -8,8 +8,11 @@ from typing import TYPE_CHECKING, Any
 
 import vllm.envs as envs
 from vllm.compilation.cuda_graph import CUDAGraphStat
+from vllm.logger import init_logger
 from vllm.v1.metrics.perf import PerfStats
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
+
+logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     from vllm.v1.engine import EngineCoreEvent, EngineCoreOutput, FinishReason
@@ -267,17 +270,77 @@ class PromptTokenStats:
     recomputed_tokens: int = 0
     total: int = 0
 
-    def update_from_output(
+    def _enforce_accounting_invariant(
         self,
+        request_id: str,
+        prompt_len: int,
+        recomputed: int,
         num_cached_tokens: int,
         num_external_computed_tokens: int,
+    ) -> tuple[int, int]:
+        # Temporary defensive check: enforce invariant to catch accounting bugs
+        # Invariant: prompt_len >= num_cached_tokens + recomputed >=
+        # num_external_computed_tokens >= 0
+        error_details = []
+        if num_cached_tokens < 0:
+            error_details.append(f"num_cached_tokens={num_cached_tokens} < 0")
+        if num_external_computed_tokens < 0:
+            error_details.append(
+                f"num_external_computed_tokens={num_external_computed_tokens} < 0"
+            )
+        if num_cached_tokens > prompt_len:
+            error_details.append(
+                f"num_cached_tokens={num_cached_tokens} > prompt_len={prompt_len}"
+            )
+        if num_external_computed_tokens > num_cached_tokens + recomputed:
+            error_details.append(
+                f"num_external_computed_tokens={num_external_computed_tokens} > "
+                f"num_cached_tokens + recomputed ({num_cached_tokens} + {recomputed})"
+            )
+        if error_details:
+            logger.warning_once(
+                "METRICS ACCOUNTING BUG DETECTED - Please file a bug report at "
+                "https://github.com/vllm-project/vllm/issues\n"
+                "Request ID: %s\n"
+                "Invariant violated: prompt_len >= num_cached_tokens + recomputed >= "
+                "num_external_computed_tokens >= 0\n"
+                "Values: prompt_len=%d, num_cached_tokens=%d, "
+                "num_external_computed_tokens=%d, recomputed=%d\n"
+                "Violations: %s\n"
+                "Discarding cache metrics for such requests to prevent crash.",
+                request_id,
+                prompt_len,
+                num_cached_tokens,
+                num_external_computed_tokens,
+                recomputed,
+                ", ".join(error_details),
+            )
+            num_cached_tokens = 0
+            num_external_computed_tokens = 0
+        return num_cached_tokens, num_external_computed_tokens
+
+    def update_from_output(
+        self,
+        request_id: str,
         prompt_len: int,
+        num_cached_tokens: int,
+        num_external_computed_tokens: int,
     ) -> None:
         """Update stats from a prefill output."""
         # When all tokens are cached, the scheduler reduces num_cached_tokens
         # by 1 to force the model to recompute the last token, since the model
         # needs at least one input token to run a forward pass.
         recomputed = 1 if (num_cached_tokens + 1 == prompt_len) else 0
+
+        num_cached_tokens, num_external_computed_tokens = (
+            self._enforce_accounting_invariant(
+                request_id,
+                prompt_len,
+                recomputed,
+                num_cached_tokens,
+                num_external_computed_tokens,
+            )
+        )
 
         self.computed += prompt_len - num_cached_tokens
         self.external_kv_transfer += num_external_computed_tokens
@@ -343,9 +406,10 @@ class IterationStats:
         self.num_generation_tokens += num_new_generation_tokens
         if is_prefilling:
             self.prompt_token_stats.update_from_output(
+                request_id=output.request_id,
+                prompt_len=prompt_len,
                 num_cached_tokens=output.num_cached_tokens,
                 num_external_computed_tokens=output.num_external_computed_tokens,
-                prompt_len=prompt_len,
             )
 
             first_token_latency = self._time_since(req_stats.arrival_time)


### PR DESCRIPTION
Since `num_computed_tokens`, `num_cached_tokens`, and `num_external_computed_tokens` accounting seems quite brittle currently - with preemption reset bugs and P/D disaggregation accounting issues - add a defensive check to detect and prevent instances of Prometheus counter errors:

```
ValueError: Counters can only be incremented by non-negative amounts
```

The invariant check enforces:

```
prompt_len >= num_cached_tokens >= num_external_computed_tokens >= 0
```

with the additional nuance that when all tokens are cached, the scheduler forces recomputation of the last token, so the:

```
num_external_computed_tokens <= num_cached_tokens + recomputed
```

When the invariant is violated, we log a a warning once with diagnostic details, and discard suspect cache metrics.

Obviously, the accounting should be fixed and made more robust and future-proof, at which point we can remove this check (perhaps replacing with a simple assertion).

Related to issues #36533, #36755 and PRs #36638, #36752, #36757.