### PR TITLE
`nano-nemotron-vl` dummy video: Respect `media_io_kwargs.num_frames` if set to budget encoder cache correctly

### DIFF
--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -1741,6 +1741,12 @@ class NanoNemotronVLDummyInputsBuilder(
             target_num_frames = self.info.get_num_frames_with_most_features(
                 seq_len, mm_counts
             )
+            mm_config = self.info.ctx.get_mm_config()
+            if num_frames := mm_config.media_io_kwargs.get("video", {}).get(
+                "num_frames"
+            ):
+                assert num_frames > 0
+                target_num_frames = num_frames
             num_videos = mm_counts.get("video", 0)
             video_overrides = mm_options.get("video")
             dummy_video = {


### PR DESCRIPTION
Set num_frames to `512`:
```shell
python -m vllm.entrypoints.cli.main serve --model model --trust-remote-code -tp=8 --gpu-memory-utilization 0.8 --max-model-len 80000 --video-pruning-rate 0.5 --limit-mm-per-prompt '{"video": 1, "image": 0, "audio": 0}' \
  --media-io-kwargs '{"video": {"num_frames": 512, "fps": -1}}' 
```

Request [(video contains well over 512 frames)](https://upload.wikimedia.org/wikipedia/commons/2/2a/Mp4_webm_test.webm):
```json
{"role": "user", "content": [{ "type": "video_url", "video_url": 
  { "url": "https://upload.wikimedia.org/wikipedia/commons/2/2a/Mp4_webm_test.webm" }}]}
```

Before change:
```shell
Encoder cache will be initialized with a budget of 45536 tokens
"POST /v1/chat/completions HTTP/1.1" 400 Bad Request
Traceback (most recent call last):
ValueError: The decoder prompt contains a(n) video item with length 74717, which exceeds the pre-allocated encoder cache size 45536. Please reduce the input size or increase the encoder cache size by setting --limit-mm-per-prompt at startup.
```

After change:
```shell
Encoder cache will be initialized with a budget of 74936 tokens
"POST /v1/chat/completions HTTP/1.1" 200 OK
```