### PR TITLE
[Bugfix] Fix Qwen3.5 LoRA IndexError in packed_modules_mapping

### DIFF
--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -283,10 +283,9 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         packed_modules_list: list,
         model_config: PretrainedConfig | None = None,
     ) -> bool:
-        return (
-            type(source_layer) is MergedColumnParallelLinear
-            and len(packed_modules_list) == len(source_layer.output_sizes)
-        )
+        return type(source_layer) is MergedColumnParallelLinear and len(
+            packed_modules_list
+        ) == len(source_layer.output_sizes)
 
 
 class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -616,9 +616,8 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         # count. E.g. Qwen3.5 GDN layers have 2 packed modules
         # (in_proj_qkv, in_proj_z) but 4 output_sizes — one HF weight
         # covers multiple output slices.
-        if (
-            hasattr(source_layer, "output_sizes")
-            and len(packed_modules_list) != len(source_layer.output_sizes)
+        if hasattr(source_layer, "output_sizes") and len(packed_modules_list) != len(
+            source_layer.output_sizes
         ):
             return True
 
@@ -705,8 +704,7 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
                         for j in range(start_slice, slice_idx):
                             sz = output_sizes[j]
                             expanded_a.append(a_i)
-                            expanded_b.append(
-                                b_i[split_start:split_start + sz, :])
+                            expanded_b.append(b_i[split_start : split_start + sz, :])
                             split_start += sz
 
             # Pad remaining slices with None (e.g. dummy LoRA warmup

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -285,7 +285,7 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
     ) -> bool:
         return (
             type(source_layer) is MergedColumnParallelLinear
-            and len(packed_modules_list) == 2
+            and len(packed_modules_list) == len(source_layer.output_sizes)
         )
 
 

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -612,8 +612,18 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         if len(packed_modules_list) >= 3:
             return True
 
-        # If packed_modules_list has exactly 2 items, let
-        # MergedColumnParallelLinearWithLoRA handle it
+        # Handle mismatch between packed modules count and output_sizes
+        # count. E.g. Qwen3.5 GDN layers have 2 packed modules
+        # (in_proj_qkv, in_proj_z) but 4 output_sizes — one HF weight
+        # covers multiple output slices.
+        if (
+            hasattr(source_layer, "output_sizes")
+            and len(packed_modules_list) != len(source_layer.output_sizes)
+        ):
+            return True
+
+        # If packed_modules_list has exactly 2 items matching output_sizes,
+        # let MergedColumnParallelLinearWithLoRA handle it
         if len(packed_modules_list) == 2:
             return False
 
@@ -632,9 +642,18 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
     ):
-        """Override to handle single tensor weights
-        that need to be split into slices."""
+        """Override to handle weights that need to be split into slices.
+
+        Handles three cases:
+        1. Single tensor: split lora_b by output_sizes, duplicate lora_a
+        2. List matching n_slices: pass through directly
+        3. List shorter than n_slices: expand by splitting lora_b entries
+           that cover multiple output slices (e.g., 2 packed modules
+           mapping to 4 output_sizes in Qwen3.5 GDN layers)
+        """
         self.reset_lora(index)
+
+        output_sizes = self.base_layer.output_sizes
 
         # Handle case where checkpoint has single tensor weights
         # lora_a shape: (rank, input_size) - same for all slices, duplicate it
@@ -644,7 +663,6 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         # lora_b shape: (total_output_size, rank) -
         # split along dim 0 based on output_sizes
         if isinstance(lora_b, torch.Tensor):
-            output_sizes = self.base_layer.output_sizes
             lora_b_list = []
             start_idx = 0
             for output_size in output_sizes:
@@ -652,6 +670,53 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
                 lora_b_list.append(lora_b[start_idx:end_idx, :])
                 start_idx = end_idx
             lora_b = lora_b_list
+
+        # Handle list shorter than n_slices: one packed module may cover
+        # multiple output slices. Greedily match each lora_b entry to
+        # consecutive output_sizes by dimension, then split accordingly.
+        if isinstance(lora_a, list) and len(lora_a) < self.n_slices:
+            expanded_a: list[torch.Tensor | None] = []
+            expanded_b: list[torch.Tensor | None] = []
+            slice_idx = 0
+            for i, (a_i, b_i) in enumerate(zip(lora_a, lora_b)):
+                if b_i is None:
+                    # Figure out how many slices this None covers
+                    remaining = len(lora_a) - i - 1
+                    remaining_slices = self.n_slices - slice_idx
+                    count = remaining_slices - remaining
+                    expanded_a.extend([None] * count)
+                    expanded_b.extend([None] * count)
+                    slice_idx += count
+                else:
+                    b_dim = b_i.shape[0]
+                    # Greedily consume output_sizes until we match b_dim
+                    consumed = 0
+                    start_slice = slice_idx
+                    while slice_idx < self.n_slices and consumed < b_dim:
+                        consumed += output_sizes[slice_idx]
+                        slice_idx += 1
+                    num_covered = slice_idx - start_slice
+                    if num_covered == 1:
+                        expanded_a.append(a_i)
+                        expanded_b.append(b_i)
+                    else:
+                        # Split lora_b and duplicate lora_a
+                        split_start = 0
+                        for j in range(start_slice, slice_idx):
+                            sz = output_sizes[j]
+                            expanded_a.append(a_i)
+                            expanded_b.append(
+                                b_i[split_start:split_start + sz, :])
+                            split_start += sz
+
+            # Pad remaining slices with None (e.g. dummy LoRA warmup
+            # where per-slice dimensions don't span multiple output_sizes)
+            while len(expanded_a) < self.n_slices:
+                expanded_a.append(None)
+                expanded_b.append(None)
+
+            lora_a = expanded_a
+            lora_b = expanded_b
 
         # Now call parent's set_lora which expects lists
         super().set_lora(index, lora_a, lora_b)

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -694,6 +694,11 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
                     while slice_idx < self.n_slices and consumed < b_dim:
                         consumed += output_sizes[slice_idx]
                         slice_idx += 1
+                    if consumed != b_dim:
+                        raise ValueError(
+                            f"Packed LoRA B dimension {b_dim} does not match "
+                            f"the sum of output sizes {consumed} for LoRA {i}."
+                        )
                     num_covered = slice_idx - start_slice
                     if num_covered == 1:
                         expanded_a.append(a_i)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -528,8 +528,9 @@ class Qwen3_5ForCausalLMBase(
             "v_proj",
         ],
         "gate_up_proj": ["gate_proj", "up_proj"],
-        # GDN fused projections.
-        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        # GDN fused projections — 4 packed modules to match 4 output_sizes
+        # in create_qkvz_proj for correct per-slice TP sharding with LoRA.
+        "in_proj_qkvz": ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 
@@ -632,7 +633,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
     supports_multimodal_pruning = False
 
     packed_modules_mapping = Qwen3VLForConditionalGeneration.packed_modules_mapping | {
-        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_qkvz": ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -528,9 +528,8 @@ class Qwen3_5ForCausalLMBase(
             "v_proj",
         ],
         "gate_up_proj": ["gate_proj", "up_proj"],
-        # GDN fused projections — 4 packed modules to match 4 output_sizes
-        # in create_qkvz_proj for correct per-slice TP sharding with LoRA.
-        "in_proj_qkvz": ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"],
+        # GDN fused projections.
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 
@@ -633,7 +632,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
     supports_multimodal_pruning = False
 
     packed_modules_mapping = Qwen3VLForConditionalGeneration.packed_modules_mapping | {
-        "in_proj_qkvz": ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 


### PR DESCRIPTION
## Summary

Fixes `IndexError: list index out of range` when enabling LoRA with Qwen3.5 models (`Qwen3_5ForCausalLMBase` and `Qwen3_5ForConditionalGeneration`).

**Root cause:** Qwen3.5's `create_qkvz_proj` overrides the parent (Qwen3Next) to use 4 `output_sizes` `[key_dim, key_dim, value_dim, value_dim]` for correct per-slice TP sharding. However, `packed_modules_mapping` only lists 2 entries `["in_proj_qkv", "in_proj_z"]`. During LoRA initialization, `MergedColumnParallelLinearWithLoRA` sets `n_slices = len(output_sizes)` (4) but only creates `len(packed_modules)` (2) adapters, so accessing `lora_a[2]`/`lora_a[3]` crashes.

**Fix:**
1. Expand `packed_modules_mapping` for `in_proj_qkvz` from 2 to 4 entries: `["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"]` — matching the 4 output_sizes
2. Generalize `MergedColumnParallelLinearWithLoRA.can_replace_layer` from `len(packed_modules_list) == 2` to `len(packed_modules_list) == len(source_layer.output_sizes)` — so it works for any N-way merged column parallel linear, not just 2-way

This works for any TP size because each of the 4 packed modules maps to one output_size, preserving correct per-slice sharding.

**Note:** The parent class `Qwen3Next` doesn't have this issue because it uses `output_sizes=[sum(key_dim, key_dim, value_dim, value_dim)]` (1 entry) with `packed_modules=["in_proj_qkvz"]` (1 entry) — they match.

**Note:** This may not be the globally optimal solution. The 4 packed module names (`in_proj_q`, `in_proj_k`, `in_proj_v`, `in_proj_z`) are synthetic — the actual HF weight names are `in_proj_qkv` (fused Q+K+V) and `in_proj_z`. This means LoRA adapter weights targeting the GDN projections by their real HF names wouldn't be found during loading. In practice this isn't an issue today because nobody LoRAs the GDN layers — only standard attention and MLP layers are targeted. A more complete fix would be to support M packed modules mapping to N output sizes (2 weights → 4 sharding slices) in `MergedColumnParallelLinearWithLoRA`, but that's a larger refactor.

Related: #36372, #36478

## Test plan

- [x] Verified LoRA training (TP=1) completes successfully with Qwen3.5-9B on 2x RTX PRO 6000 Blackwell GPUs using [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl)
- [x] Test with TP=2 and TP=4