### PR TITLE
[XPU][Doc] Remove manual OneAPI install step, now handled by torch-xpu

### DIFF
--- a/docs/getting_started/installation/gpu.xpu.inc.md
+++ b/docs/getting_started/installation/gpu.xpu.inc.md
@@ -7,7 +7,6 @@ vLLM initially supports basic model inference and serving on Intel GPU platform.
 --8<-- [start:requirements]
 
 - Supported Hardware: Intel Data Center GPU, Intel ARC GPU
-- OneAPI requirements: oneAPI 2025.3
 - Dependency: [vllm-xpu-kernels](https://github.com/vllm-project/vllm-xpu-kernels): a package provide all necessary vllm custom kernel when running vLLM on Intel GPU platform,
 - Python: 3.12
 !!! warning
@@ -26,8 +25,8 @@ Currently, there are no pre-built XPU wheels.
 --8<-- [end:pre-built-wheels]
 --8<-- [start:build-wheel-from-source]
 
-- First, install required [driver](https://dgpu-docs.intel.com/driver/installation.html#installing-gpu-drivers) and [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html) 2025.3 or later.
-- Second, install Python packages for vLLM XPU backend building:
+- First, install required [driver](https://dgpu-docs.intel.com/driver/installation.html#installing-gpu-drivers).
+- Second, install Python packages for vLLM XPU backend building (Intel OneAPI dependencies are installed automatically as part of `torch-xpu`, see [PyTorch XPU get started](https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html)):
 
 ```bash
 git clone https://github.com/vllm-project/vllm.git


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Intel OneAPI no longer needs to be installed separately — it is pulled in automatically as a dependency of torch-xpu. Manual installation is redundant and potentially confusing.

Changes
Requirements section: Removed OneAPI requirements: oneAPI 2025.3 bullet
Build from source: Replaced the "install driver + Intel OneAPI" step with driver-only, adding a note that OneAPI dependencies come automatically via torch-xpu with a link to the [PyTorch XPU get started guide](https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html)

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

