### PR TITLE
enable flashinfer moe kernel for DP + EP

### DIFF
--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -1,10 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests.kernels.moe.utils import make_dummy_moe_config
+from vllm.model_executor.layers.fused_moe.config import (
+    FUSED_MOE_UNQUANTIZED_CONFIG,
+)
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    FusedMoEActivationFormat,
+)
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoeBackend,
     select_unquantized_moe_backend,
@@ -212,3 +218,43 @@ def test_select_cuda_flashinfer_cutlass_backend_with_dp(
         )
 
         assert selected_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS
+
+
+@pytest.mark.parametrize(
+    "backend,expected_class_name",
+    [
+        (UnquantizedMoeBackend.FLASHINFER_CUTLASS, "FlashInferExperts"),
+        (UnquantizedMoeBackend.TRITON, "TritonExperts"),
+    ],
+)
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
+)
+def test_select_gemm_impl_respects_backend(
+    backend,
+    expected_class_name,
+    default_vllm_config,
+):
+    """Test that select_gemm_impl returns the correct expert implementation
+    matching the selected backend, rather than always falling back to Triton.
+
+    This is needed because select_unquantized_moe_backend (tested above) only
+    controls which backend enum is *logged*. In DP+EP, maybe_init_modular_kernel
+    replaces the quant method with FusedMoEModularMethod, which rebuilds the
+    expert kernel via select_gemm_impl. Without a FlashInfer CUTLASS branch
+    there, the runtime silently falls back to TritonExperts even though the logs
+    say FlashInfer CUTLASS was selected."""
+    from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+        UnquantizedFusedMoEMethod,
+    )
+
+    moe_config = make_dummy_moe_config()
+    method = UnquantizedFusedMoEMethod(moe_config)
+    method.unquantized_backend = backend
+    method.moe_quant_config = FUSED_MOE_UNQUANTIZED_CONFIG
+
+    mock_pf = MagicMock()
+    mock_pf.activation_format = FusedMoEActivationFormat.Standard
+
+    result = method.select_gemm_impl(mock_pf, MagicMock())
+    assert type(result).__name__ == expected_class_name

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -168,7 +168,47 @@ def test_select_cuda_flashinfer_cutlass_backend(
 
         selected_backend = select_unquantized_moe_backend(
             moe_config=moe_config,
-            use_dp=False,  # CUTLASS doesn't support DP
+            use_dp=False,
+        )
+
+        assert selected_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS
+
+
+@patch(
+    "vllm.model_executor.layers.fused_moe.oracle.unquantized.has_flashinfer",
+    return_value=True,
+)
+@patch(
+    "vllm.model_executor.layers.fused_moe.oracle.unquantized.is_supported_config_trtllm_bf16",
+    return_value=(False, None),
+)
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
+)
+def test_select_cuda_flashinfer_cutlass_backend_with_dp(
+    mock_has_flashinfer, mock_is_supported_trtllm, monkeypatch
+):
+    """Test CUDA backend selection picks FlashInfer CUTLASS when both
+    DP and EP are enabled. The runner handles DP communication externally
+    so the kernel works correctly with DP+EP."""
+    with patch(
+        "vllm.model_executor.layers.fused_moe.oracle.unquantized.current_platform"
+    ) as mock_platform:
+        mock_platform.is_cuda.return_value = True
+        mock_platform.is_rocm.return_value = False
+        mock_platform.is_cpu.return_value = False
+        mock_platform.is_xpu.return_value = False
+        mock_platform.is_tpu.return_value = False
+        mock_platform.is_out_of_tree.return_value = False
+        mock_platform.has_device_capability.return_value = True  # SM90+
+
+        monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
+
+        moe_config = make_dummy_moe_config()
+
+        selected_backend = select_unquantized_moe_backend(
+            moe_config=moe_config,
+            use_dp=True,
         )
 
         assert selected_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -95,7 +95,6 @@ def select_unquantized_moe_backend(
     # FlashInfer CUTLASS MoE is only supported on Hopper and later GPUS
     flashinfer_cutlass_available = (
         has_flashinfer_cutlass_fused_moe()
-        and (not use_dp)
         and current_platform.has_device_capability(90)
     )
     flashinfer_trtllm_moe_enabled = (
@@ -159,16 +158,11 @@ def select_unquantized_moe_backend(
                     "to enable it for better performance.",
                     scope="local",
                 )
-            elif not use_dp and flashinfer_cutlass_available:
+            elif flashinfer_cutlass_available:
                 logger.info_once(
                     "FlashInfer CUTLASS MoE is available"
                     " but not enabled, consider setting"
                     " VLLM_USE_FLASHINFER_MOE_FP16=1 to enable it.",
-                    scope="local",
-                )
-            elif use_dp:
-                logger.info_once(
-                    "FlashInfer CUTLASS MoE is currently not available for DP.",
                     scope="local",
                 )
             backend = UnquantizedMoeBackend.TRITON

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -126,6 +126,14 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                 max_num_tokens=self.moe.max_num_tokens,
                 num_dispatchers=prepare_finalize.num_dispatchers(),
             )
+        elif self.unquantized_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS:
+            from .flashinfer_cutlass_moe import FlashInferExperts
+
+            logger.debug("FlashInferExperts %s", self.moe)
+            return FlashInferExperts(
+                moe_config=self.moe,
+                quant_config=self.moe_quant_config,
+            )
         elif (
             self.unquantized_backend == UnquantizedMoeBackend.AITER
             and rocm_aiter_ops.is_fused_moe_enabled()


### PR DESCRIPTION

## Purpose
Previously the BF16 flashinfer moe kernel is disabled when dp > 1. I think the kernel itself should be able to support it, we just need to enable on the vLLM side. Also add test to verify the kernel selection logic works as intended.

## Test Plan
`pytest tests/kernels/moe/test_unquantized_backend_selection.py`
run gsm8k with bf16 qwen 3a30b on 2xB200 DP2 EP2 and compare the result with different moe backend.

server command
```
# triton/default backend
vllm serve Qwen/Qwen3-30B-A3B \
  --data-parallel-size 2 \
  --enable-expert-parallel \
  --trust-remote-code \
  --port 8000

# flashinfer cutlass
VLLM_USE_FLASHINFER_MOE_FP16=1 VLLM_FLASHINFER_MOE_BACKEND=throughput vllm serve Qwen/Qwen3-30B-A3B \
  --data-parallel-size 2 \
  --enable-expert-parallel \
  --trust-remote-code \
  --port 8000

# flashinfer trtllm
VLLM_USE_FLASHINFER_MOE_FP16=1 VLLM_FLASHINFER_MOE_BACKEND=latency vllm serve Qwen/Qwen3-30B-A3B \
  --data-parallel-size 2 \
  --enable-expert-parallel \
  --trust-remote-code \
  --port 8000
```

test command
```
python -m lm_eval \
  --model local-completions \
  --model_args "model=Qwen/Qwen3-30B-A3B,base_url=http://localhost:8000/v1/completions,num_concurrent=128,max_retries=5,tokenized_requests=False,tokenizer=Qwen/Qwen3-30B-A3B" \
  --tasks gsm8k_cot \
  --batch_size auto \
  --log_samples \
  --output_path /tmp/lm_eval_qwen_dp2_ep
```

## Test Result

Backend | flexible-extract | stderr
-- | -- | --
Triton (default) | 0.8870 | ±0.0087
FlashInfer CUTLASS (throughput) | 0.8992 | ±0.0083
FlashInfer TRTLLM (latency) | 0.9007 | ±0.0082

`pytest tests/kernels/moe/test_unquantized_backend_selection.py` pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

