### PR TITLE
[Core] Guard mamba prefill split fragmentation

### DIFF
--- a/.buildkite/performance-benchmarks/scripts/compare-json-results.py
+++ b/.buildkite/performance-benchmarks/scripts/compare-json-results.py
@@ -7,12 +7,12 @@ import argparse
 import html as _html
 import json
 import os
-from contextlib import nullcontext
 from dataclasses import dataclass
 from importlib import util
 from pathlib import Path
 
 import pandas as pd
+import regex as re
 
 pd.options.display.float_format = "{:.2f}".format
 plotly_found = util.find_spec("plotly.express") is not None
@@ -34,45 +34,6 @@ pd.set_option("display.float_format", lambda x: f"{x:.2f}")
 
 
 # -----------------------------
-# Concurrency normalization (NEW, small)
-# -----------------------------
-def _find_concurrency_col(df: pd.DataFrame) -> str:
-    for c in [
-        "# of max concurrency.",
-        "# of max concurrency",
-        "Max Concurrency",
-        "max_concurrency",
-        "Concurrency",
-    ]:
-        if c in df.columns:
-            return c
-
-    for c in df.columns:
-        if "concurr" in str(c).lower():
-            s = df[c]
-            if s.dtype.kind in "iu" and s.nunique() > 1 and s.min() >= 1:
-                return c
-
-    raise ValueError(
-        "Cannot infer concurrency column. "
-        "Please rename the column to one of the known names "
-        "or add an explicit override (e.g., --concurrency-col)."
-    )
-
-
-def _normalize_concurrency_in_df(
-    df: pd.DataFrame, canonical: str = "# of max concurrency."
-) -> pd.DataFrame:
-    if canonical in df.columns:
-        return df
-    detected = _find_concurrency_col(df)
-    if detected in df.columns and detected != canonical:
-        return df.rename(columns={detected: canonical})
-    df[canonical] = pd.NA
-    return df
-
-
-# -----------------------------
 # Core data compare
 # -----------------------------
 def compare_data_columns(
@@ -91,25 +52,19 @@ def compare_data_columns(
     - Concat along axis=1 (indexes align), then reset_index so callers can
       group by columns.
     - If --debug, add a <file_label>_name column per file.
-
-    Minimal fix to support different max_concurrency lists across files:
-      - normalize concurrency column naming to "# of max concurrency."
-      - align on UNION of keys (missing points become NaN)
-      - BUGFIX: don't drop throughput rows based on P99/Median presence
     """
     print("\ncompare_data_column:", data_column)
 
     frames = []
     raw_data_cols: list[str] = []
+    compare_frames = []
 
-    # Determine key cols after normalizing concurrency
     cols_per_file: list[set] = []
     for f in files:
         try:
             df_tmp = pd.read_json(f, orient="records")
         except Exception as err:
             raise ValueError(f"Failed to read {f}") from err
-        df_tmp = _normalize_concurrency_in_df(df_tmp, canonical="# of max concurrency.")
         cols_per_file.append(set(df_tmp.columns))
 
     key_cols = [c for c in info_cols if all(c in cset for cset in cols_per_file)]
@@ -120,25 +75,12 @@ def compare_data_columns(
             "No common key columns found from info_cols across the input files."
         )
 
-    union_index = None
-    metas: list[pd.DataFrame] = []
-    staged: list[tuple[str, pd.Series, pd.Series | None]] = []
+    meta_added = False
 
     for file in files:
         df = pd.read_json(file, orient="records")
-        df = _normalize_concurrency_in_df(df, canonical="# of max concurrency.")
 
-        # BUGFIX: only drop rows for latency-like metrics; throughput rows may have
-        # NaN in P99/Median columns even if the column exists in the JSON.
-        metric_lc = str(data_column).lower()
-        is_latency_metric = (
-            "ttft" in metric_lc
-            or "tpot" in metric_lc
-            or "p99" in metric_lc
-            or "median" in metric_lc
-            or metric_lc.strip() in {"p99", "median"}
-        )
-        if is_latency_metric and drop_column in df.columns:
+        if drop_column in df.columns:
             df = df.dropna(subset=[drop_column], ignore_index=True)
 
         for c in (
@@ -163,61 +105,35 @@ def compare_data_columns(
             meta = meta.groupby(level=key_cols, dropna=False).first()
 
         file_label = "/".join(file.split("/")[:-1]) or os.path.basename(file)
-
-        if data_column in df_idx.columns:
-            s = df_idx[data_column]
-            if not s.index.is_unique:
-                s = s.groupby(level=key_cols, dropna=False).mean()
-        else:
-            # keep NA series to preserve meta keys for union_index
-            s = pd.Series(pd.NA, index=meta.index)
+        s = df_idx[data_column]
+        if not s.index.is_unique:
+            s = s.groupby(level=key_cols, dropna=False).mean()
         s.name = file_label
 
-        name_s = None
+        if not meta_added:
+            frames.append(meta)
+            meta_added = True
+
         if debug and name_column in df_idx.columns:
             name_s = df_idx[name_column]
             if not name_s.index.is_unique:
                 name_s = name_s.groupby(level=key_cols, dropna=False).first()
             name_s.name = f"{file_label}_name"
+            frames.append(name_s)
 
-        if union_index is None:
-            union_index = meta.index
-        else:
-            union_index = union_index.union(meta.index)
-        metas.append(meta)
-
-        staged.append((file_label, s, name_s))
-
-    if union_index is None:
-        raise ValueError("No data found after loading inputs.")
-
-    # meta first (union-aligned): build UNION meta across all files
-    if metas:
-        meta_union = pd.concat(metas, axis=0)
-        # Collapse duplicates on the MultiIndex; keep first non-null per column
-        meta_union = meta_union.groupby(level=key_cols, dropna=False).first()
-        frames.append(meta_union.reindex(union_index))
-
-    # values + ratios (union-aligned)
-    metric_series_aligned: list[pd.Series] = []
-    for file_label, s, name_s in staged:
-        s_aligned = s.reindex(union_index)
-        frames.append(s_aligned)
+        frames.append(s)
         raw_data_cols.append(file_label)
-        metric_series_aligned.append(s_aligned)
+        compare_frames.append(s)
 
-        if debug and name_s is not None:
-            frames.append(name_s.reindex(union_index))
-
-        if len(metric_series_aligned) >= 2:
-            base = metric_series_aligned[0]
-            current = metric_series_aligned[-1]
-            if "P99" in str(data_column) or "Median" in str(data_column):
+        if len(compare_frames) >= 2:
+            base = compare_frames[0]
+            current = compare_frames[-1]
+            if "P99" in data_column or "Median" in data_column:
                 ratio = base / current
             else:
                 ratio = current / base
             ratio = ratio.mask(base == 0)
-            ratio.name = f"Ratio 1 vs {len(metric_series_aligned)}"
+            ratio.name = f"Ratio 1 vs {len(compare_frames)}"
             frames.append(ratio)
 
     concat_df = pd.concat(frames, axis=1).reset_index(drop=True)
@@ -288,10 +204,24 @@ def split_json_by_tp_pp(
 # -----------------------------
 # Styling helpers
 # -----------------------------
+def _find_concurrency_col(df: pd.DataFrame) -> str:
+    for c in [
+        "# of max concurrency.",
+        "# of max concurrency",
+        "Max Concurrency",
+        "max_concurrency",
+        "Concurrency",
+    ]:
+        if c in df.columns:
+            return c
+    for c in df.columns:
+        if df[c].dtype.kind in "iu" and df[c].nunique() > 1 and df[c].min() >= 1:
+            return c
+    return "# of max concurrency."
+
+
 def _highlight_threshold(
-    df: pd.DataFrame,
-    threshold: float,
-    slack_pct: float = 0.0,
+    df: pd.DataFrame, threshold: float
 ) -> pd.io.formats.style.Styler:
     conc_col = _find_concurrency_col(df)
     key_cols = [
@@ -304,24 +234,14 @@ def _highlight_threshold(
     ]
     conf_cols = [c for c in conf_cols if pd.api.types.is_numeric_dtype(df[c])]
 
-    try:
-        slack_pct = float(slack_pct or 0.0)
-    except Exception:
-        slack_pct = 0.0
-    slack_limit = threshold * (1.0 + slack_pct / 100.0)
-
-    def _cell(v):
-        if pd.isna(v):
-            return ""
-        if v <= threshold:
-            # Strict SLA
-            return "background-color:#e6ffe6;font-weight:bold;"
-        if v <= slack_limit:
-            # Within slack range
-            return "background-color:#ffe5cc;font-weight:bold;"
-        return ""
-
-    return df.style.map(_cell, subset=conf_cols)
+    return df.style.map(
+        lambda v: (
+            "background-color:#e6ffe6;font-weight:bold;"
+            if pd.notna(v) and v <= threshold
+            else ""
+        ),
+        subset=conf_cols,
+    )
 
 
 def highlight_ratio_columns(styler: pd.io.formats.style.Styler):
@@ -368,30 +288,11 @@ def _sanitize_sheet_name(name: str) -> str:
       - max 31 chars
       - cannot contain: : \ / ? * [ ]
       - cannot be empty
-
-    NOTE: Use fast, non-regex operations here to avoid the third-party `regex`
-    module's compile overhead/edge-cases on some systems.
     """
     name = "sheet" if name is None else str(name)
-
-    # Replace illegal characters with underscore.
-    trans = str.maketrans(
-        {
-            ":": "_",
-            "\\": "_",
-            "/": "_",
-            "?": "_",
-            "*": "_",
-            "[": "_",
-            "]": "_",
-        }
-    )
-    name = name.translate(trans)
-
-    # Strip quotes/spaces and collapse whitespace.
+    name = re.sub(r"[:\\/?*\[\]]", "_", name)
     name = name.strip().strip("'")
-    name = " ".join(name.split())
-
+    name = re.sub(r"\s+", " ", name)
     if not name:
         name = "sheet"
     return name[:31]
@@ -399,57 +300,30 @@ def _sanitize_sheet_name(name: str) -> str:
 
 def _group_to_sheet_base(group_cols: list[str], gkey_tuple) -> str:
     d = dict(zip(group_cols, gkey_tuple))
-
-    # Always keep input/output lengths (these are important).
+    model = d.get("Model", "model")
+    model_short = str(model).split("/")[-1]
     ilen = d.get("Input Len", "")
     olen = d.get("Output Len", "")
     lens = f"_{ilen}x{olen}" if ilen != "" and olen != "" else ""
-
-    # Shorten model name aggressively to make room for lens.
-    model = d.get("Model", "model")
-    leaf = str(model).split("/")[-1]
-
-    max_model_len = max(1, 31 - len(lens))
-    model_short = leaf[:max_model_len]
-
     return _sanitize_sheet_name(f"{model_short}{lens}")
 
 
 def _write_tables_to_excel_sheet(
     writer: pd.ExcelWriter, sheet: str, blocks: list[tuple[str, pd.DataFrame]]
 ):
-    """Write all blocks to a sheet with a single to_excel() call.
-
-    Pandas+openpyxl can be extremely slow when called many times per sheet.
-    We flatten blocks into one table with a 'Section' column to keep structure
-    while making Excel generation fast and deterministic.
-    """
-    if not blocks:
-        pd.DataFrame().to_excel(writer, sheet_name=sheet, index=False)
-        return
-
-    combined_parts: list[pd.DataFrame] = []
+    startrow = 0
     for title, df in blocks:
-        df2 = df.copy()
-        # Put the section label as the first column for readability.
-        df2.insert(0, "Section", title)
-        combined_parts.append(df2)
-
-    combined = pd.concat(combined_parts, axis=0, ignore_index=True, sort=False)
-    combined.to_excel(writer, sheet_name=sheet, index=False)
+        pd.DataFrame([[title]]).to_excel(
+            writer, sheet_name=sheet, index=False, header=False, startrow=startrow
+        )
+        startrow += 1
+        df.to_excel(writer, sheet_name=sheet, index=False, startrow=startrow)
+        startrow += len(df) + 3
 
 
 def _safe_filename(s: str) -> str:
-    # Fast path without the third-party `regex` module.
-    s = " ".join(str(s).strip().split())
-    allowed = []
-    for ch in s:
-        if ch.isalnum() or ch in "._-":
-            allowed.append(ch)
-        else:
-            allowed.append("_")
-    out = "".join(allowed)
-    return out[:180] if len(out) > 180 else out
+    s = re.sub(r"[^\w\-.]+", "_", str(s).strip())
+    return s[:180] if len(s) > 180 else s
 
 
 # -----------------------------
@@ -556,11 +430,7 @@ def _config_value_columns(df: pd.DataFrame, conc_col: str) -> list[str]:
 
 
 def _max_concurrency_ok(
-    df: pd.DataFrame,
-    conc_col: str,
-    cfg_col: str,
-    threshold: float,
-    slack_pct: float = 0.0,
+    df: pd.DataFrame, conc_col: str, cfg_col: str, threshold: float
 ):
     if df is None or conc_col not in df.columns or cfg_col not in df.columns:
         return pd.NA
@@ -573,14 +443,7 @@ def _max_concurrency_ok(
     if d.empty:
         return pd.NA
 
-    # Accept values up to (1 + slack_pct%) above the SLA.
-    try:
-        slack_pct = float(slack_pct or 0.0)
-    except Exception:
-        slack_pct = 0.0
-    effective_limit = float(threshold) * (1.0 + slack_pct / 100.0)
-
-    ok = d[d[cfg_col] <= effective_limit]
+    ok = d[d[cfg_col] <= threshold]
     if ok.empty:
         return pd.NA
 
@@ -646,25 +509,15 @@ def build_valid_max_concurrency_summary_html(
     if not cfg_cols:
         cfg_cols = sorted(set(ttft_cols) | set(tpot_cols) | set(tput_cols), key=str)
 
-    # Display SLA ranges in the table header (SLA .. SLA*(1+slack))
-    ttft_hi = args.ttft_max_ms * (1.0 + args.ttft_slack_pct / 100.0)
-    tpot_hi = args.tpot_max_ms * (1.0 + args.tpot_slack_pct / 100.0)
-    ttft_range = f"{args.ttft_max_ms:g}–{ttft_hi:g} ms (+{args.ttft_slack_pct:g}%)"
-    tpot_range = f"{args.tpot_max_ms:g}–{tpot_hi:g} ms (+{args.tpot_slack_pct:g}%)"
-
     rows = []
     for cfg in cfg_cols:
         ttft_max = (
-            _max_concurrency_ok(
-                ttft_group_df, conc_col, cfg, args.ttft_max_ms, args.ttft_slack_pct
-            )
+            _max_concurrency_ok(ttft_group_df, conc_col, cfg, args.ttft_max_ms)
             if ttft_group_df is not None
             else pd.NA
         )
         tpot_max = (
-            _max_concurrency_ok(
-                tpot_group_df, conc_col, cfg, args.tpot_max_ms, args.tpot_slack_pct
-            )
+            _max_concurrency_ok(tpot_group_df, conc_col, cfg, args.tpot_max_ms)
             if tpot_group_df is not None
             else pd.NA
         )
@@ -693,8 +546,8 @@ def build_valid_max_concurrency_summary_html(
         rows.append(
             {
                 "Configuration": cfg,
-                f"Max {conc_col} (TTFT ≤ {ttft_range})": ttft_max,
-                f"Max {conc_col} (TPOT ≤ {tpot_range})": tpot_max,
+                f"Max {conc_col} (TTFT ≤ {args.ttft_max_ms:g} ms)": ttft_max,
+                f"Max {conc_col} (TPOT ≤ {args.tpot_max_ms:g} ms)": tpot_max,
                 f"Max {conc_col} (Both)": both,
                 "Output Tput @ Both (tok/s)": tput_at_both,
                 "TTFT @ Both (ms)": ttft_at_both,
@@ -769,24 +622,15 @@ def build_valid_max_concurrency_summary_df(
     if not cfg_cols:
         cfg_cols = sorted(set(ttft_cols) | set(tpot_cols) | set(tput_cols), key=str)
 
-    ttft_hi = args.ttft_max_ms * (1.0 + args.ttft_slack_pct / 100.0)
-    tpot_hi = args.tpot_max_ms * (1.0 + args.tpot_slack_pct / 100.0)
-    ttft_range = f"{args.ttft_max_ms:g}–{ttft_hi:g} ms (+{args.ttft_slack_pct:g}%)"
-    tpot_range = f"{args.tpot_max_ms:g}–{tpot_hi:g} ms (+{args.tpot_slack_pct:g}%)"
-
     rows = []
     for cfg in cfg_cols:
         ttft_max = (
-            _max_concurrency_ok(
-                ttft_group_df, conc_col, cfg, args.ttft_max_ms, args.ttft_slack_pct
-            )
+            _max_concurrency_ok(ttft_group_df, conc_col, cfg, args.ttft_max_ms)
             if ttft_group_df is not None
             else pd.NA
         )
         tpot_max = (
-            _max_concurrency_ok(
-                tpot_group_df, conc_col, cfg, args.tpot_max_ms, args.tpot_slack_pct
-            )
+            _max_concurrency_ok(tpot_group_df, conc_col, cfg, args.tpot_max_ms)
             if tpot_group_df is not None
             else pd.NA
         )
@@ -815,8 +659,8 @@ def build_valid_max_concurrency_summary_df(
         rows.append(
             {
                 "Configuration": cfg,
-                f"Max {conc_col} (TTFT ≤ {ttft_range})": ttft_max,
-                f"Max {conc_col} (TPOT ≤ {tpot_range})": tpot_max,
+                f"Max {conc_col} (TTFT ≤ {args.ttft_max_ms:g} ms)": ttft_max,
+                f"Max {conc_col} (TPOT ≤ {args.tpot_max_ms:g} ms)": tpot_max,
                 f"Max {conc_col} (Both)": both,
                 "Output Tput @ Both (tok/s)": tput_at_both,
                 "TTFT @ Both (ms)": ttft_at_both,
@@ -909,21 +753,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Reference limit for TPOT plots (ms)",
     )
 
-    # ---- SLA tolerance (slack) options ----
-    parser.add_argument(
-        "--ttft-slack-pct",
-        type=float,
-        default=5.0,
-        help="Allowed percentage above TTFT SLA (default: 5).",
-    )
-    parser.add_argument(
-        "--tpot-slack-pct",
-        type=float,
-        default=5.0,
-        help="Allowed percentage above TPOT SLA (default: 5).",
-    )
-
-    # ---- export options ----
+    # ---- NEW: export options ----
     parser.add_argument(
         "--excel-out",
         type=str,
@@ -1015,13 +845,9 @@ def render_metric_table_html(
 
     metric_name = metric_label.lower()
     if "ttft" in metric_name:
-        styler = _highlight_threshold(
-            display_group, args.ttft_max_ms, args.ttft_slack_pct
-        )
+        styler = _highlight_threshold(display_group, args.ttft_max_ms)
     elif ("tpot" in metric_name) or ("median" in metric_name) or ("p99" in metric_name):
-        styler = _highlight_threshold(
-            display_group, args.tpot_max_ms, args.tpot_slack_pct
-        )
+        styler = _highlight_threshold(display_group, args.tpot_max_ms)
     else:
         styler = display_group.style
 
@@ -1138,46 +964,22 @@ def write_report_group_first(
         csv_dir.mkdir(parents=True, exist_ok=True)
 
     excel_path = args.excel_out or "perf_comparison.xlsx"
-    disable_excel = os.getenv("VLLM_COMPARE_DISABLE_EXCEL", "0") == "1"
-
-    # Prefer xlsxwriter for speed; fallback to openpyxl if unavailable.
-    excel_engine = (
-        os.getenv("VLLM_COMPARE_EXCEL_ENGINE", "xlsxwriter").strip() or "xlsxwriter"
-    )
-    if excel_engine == "xlsxwriter" and util.find_spec("xlsxwriter") is None:
-        excel_engine = "openpyxl"
-
-    excel_engine_kwargs = {}
-    if excel_engine == "xlsxwriter":
-        # Reduce memory pressure & usually faster writes.
-        excel_engine_kwargs = {"options": {"constant_memory": True}}
-
-    xw_ctx = (
-        nullcontext(None)
-        if disable_excel
-        else pd.ExcelWriter(
-            excel_path, engine=excel_engine, engine_kwargs=excel_engine_kwargs
-        )
-    )
-    with xw_ctx as xw:
-        used_sheets: set[str] = set()
+    with pd.ExcelWriter(excel_path, engine="openpyxl") as xw:
         # ---- Environment sheet (first) ----
         env_sheet = _sanitize_sheet_name("Environment")
         env_df = _load_env_df_for_inputs(args, files)
-        if xw is not None:
-            if env_df is None or env_df.empty:
-                pd.DataFrame(
-                    [
-                        {
-                            "Section": "Environment",
-                            "Key": "vllm_env.txt",
-                            "Value": "NOT FOUND (or empty)",
-                        }
-                    ]
-                ).to_excel(xw, sheet_name=env_sheet, index=False)
-            else:
-                env_df.to_excel(xw, sheet_name=env_sheet, index=False)
-            used_sheets.add(env_sheet)
+        if env_df is None or env_df.empty:
+            pd.DataFrame(
+                [
+                    {
+                        "Section": "Environment",
+                        "Key": "vllm_env.txt",
+                        "Value": "NOT FOUND (or empty)",
+                    }
+                ]
+            ).to_excel(xw, sheet_name=env_sheet, index=False)
+        else:
+            env_df.to_excel(xw, sheet_name=env_sheet, index=False)
         with open("perf_comparison.html", "w", encoding="utf-8") as main_fh:
             main_fh.write('<meta charset="utf-8">\n')
             for gkey in group_keys:
@@ -1193,19 +995,12 @@ def write_report_group_first(
 
                 main_fh.write(group_header)
 
-                do_excel = xw is not None
                 sheet = _group_to_sheet_base(group_cols_canonical, gkey_tuple)
                 sheet_base = sheet
-                if do_excel:
-                    dedup_i = 1
-                    while sheet in used_sheets:
-                        dedup_i += 1
-                        suffix = f"_{dedup_i}"
-                        # Ensure uniqueness even when sheet names are truncated.
-                        base = str(sheet_base)
-                        keep = max(1, 31 - len(suffix))
-                        sheet = _sanitize_sheet_name(base[:keep] + suffix)
-                    used_sheets.add(sheet)
+                dedup_i = 1
+                while sheet in xw.sheets:
+                    dedup_i += 1
+                    sheet = _sanitize_sheet_name(f"{sheet_base}_{dedup_i}")
 
                 excel_blocks: list[tuple[str, pd.DataFrame]] = []
 
@@ -1266,7 +1061,7 @@ def write_report_group_first(
                         )
 
                         excel_blocks.append(
-                            (metric_label, group_df.reset_index(drop=True))
+                            (metric_label, display_group.reset_index(drop=True))
                         )
                         if csv_dir:
                             fn = _safe_filename(
@@ -1274,7 +1069,7 @@ def write_report_group_first(
                                     "/", "_"
                                 )
                             )
-                            group_df.to_csv(csv_dir / f"{fn}.csv", index=False)
+                            display_group.to_csv(csv_dir / f"{fn}.csv", index=False)
 
                     summary_html = build_valid_max_concurrency_summary_html(
                         tput_group_df=tput_group_df,
@@ -1304,13 +1099,9 @@ def write_report_group_first(
                             )
                             summary_df.to_csv(csv_dir / f"{fn}.csv", index=False)
 
-                if do_excel:
-                    _write_tables_to_excel_sheet(xw, sheet, excel_blocks)
+                _write_tables_to_excel_sheet(xw, sheet, excel_blocks)
 
-    if disable_excel:
-        print("Skipped Excel generation (VLLM_COMPARE_DISABLE_EXCEL=1).")
-    else:
-        print(f"Wrote Excel: {excel_path}")
+    print(f"Wrote Excel: {excel_path}")
     if csv_dir:
         print(f"Wrote CSVs under: {csv_dir}")
 

--- a/benchmarks/mamba_prefill_fragmentation.py
+++ b/benchmarks/mamba_prefill_fragmentation.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import dataclasses
+import random
+import time
+
+from transformers import PreTrainedTokenizerBase
+
+from vllm import LLM, SamplingParams
+from vllm.engine.arg_utils import EngineArgs
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+try:
+    from vllm.tokenizers import get_tokenizer
+except ImportError:
+    from backend_request_func import get_tokenizer
+
+
+def _sample_tokens(tokenizer: PreTrainedTokenizerBase, length: int) -> list[int]:
+    vocab = tokenizer.get_vocab()
+    all_special_ids = set(tokenizer.all_special_ids)
+    return random.choices(
+        [v for v in vocab.values() if v not in all_special_ids],
+        k=length,
+    )
+
+
+def _get_scheduler(llm: LLM):
+    engine_core_client = getattr(llm.llm_engine, "engine_core", None)
+    if engine_core_client is None:
+        return None
+    engine_core = getattr(engine_core_client, "engine_core", None)
+    if engine_core is None:
+        return None
+    return getattr(engine_core, "scheduler", None)
+
+
+def _run_once(llm: LLM, prompt_token_ids: list[int], max_tokens: int):
+    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+    start = time.perf_counter()
+    outputs = llm.generate([prompt_token_ids], sampling_params, use_tqdm=False)
+    end = time.perf_counter()
+    output = outputs[0]
+    metrics = output.metrics
+    ttft = None
+    if metrics is not None and metrics.first_token_latency:
+        ttft = metrics.first_token_latency
+    output_tokens = len(output.outputs[0].token_ids)
+    return ttft, end - start, output_tokens
+
+
+def main(args):
+    random.seed(args.seed)
+    tokenizer = get_tokenizer(args.model, trust_remote_code=True)
+    prompt_token_ids = _sample_tokens(tokenizer, args.prompt_length)
+
+    engine_args = EngineArgs.from_cli_args(args)
+    llm = LLM(**dataclasses.asdict(engine_args))
+
+    scheduler = _get_scheduler(llm)
+    if scheduler is None:
+        print("Warning: scheduler not available; fragmentation counters disabled.")
+
+    if args.warmup_steps > 0:
+        for _ in range(args.warmup_steps):
+            _run_once(llm, prompt_token_ids, args.max_tokens)
+
+    ttft_list: list[float] = []
+    latency_list: list[float] = []
+    tok_per_s_list: list[float] = []
+    frag_deltas: list[int] = []
+    zero_deltas: list[int] = []
+    round_deltas: list[int] = []
+
+    for _ in range(args.repeat_count):
+        frag_before = getattr(scheduler, "mamba_fragmentation_count", 0)
+        zero_before = getattr(scheduler, "mamba_zero_collapse_count", 0)
+        round_before = getattr(scheduler, "_scheduler_iteration", 0)
+
+        ttft, latency, output_tokens = _run_once(
+            llm, prompt_token_ids, args.max_tokens
+        )
+
+        frag_after = getattr(scheduler, "mamba_fragmentation_count", 0)
+        zero_after = getattr(scheduler, "mamba_zero_collapse_count", 0)
+        round_after = getattr(scheduler, "_scheduler_iteration", 0)
+
+        if ttft is not None:
+            ttft_list.append(ttft)
+        latency_list.append(latency)
+        tok_per_s_list.append(output_tokens / latency if latency > 0 else 0.0)
+        frag_deltas.append(frag_after - frag_before)
+        zero_deltas.append(zero_after - zero_before)
+        round_deltas.append(round_after - round_before)
+
+    def _avg(values: list[float]) -> float:
+        return sum(values) / len(values) if values else 0.0
+
+    print("=== Mamba Prefill Fragmentation Benchmark ===")
+    print(f"model={args.model}")
+    print(f"prompt_length={args.prompt_length} max_tokens={args.max_tokens}")
+    print(f"repeat_count={args.repeat_count}")
+    if ttft_list:
+        print(f"ttft_avg_s={_avg(ttft_list):.6f}")
+    else:
+        print("ttft_avg_s=NA (metrics unavailable)")
+    print(f"tokens_per_s_avg={_avg(tok_per_s_list):.2f}")
+    print(f"latency_avg_s={_avg(latency_list):.6f}")
+    print(f"scheduler_rounds_avg={_avg([float(x) for x in round_deltas]):.2f}")
+    print(f"fragmentation_events_avg={_avg([float(x) for x in frag_deltas]):.2f}")
+    print(f"zero_collapse_events_avg={_avg([float(x) for x in zero_deltas]):.2f}")
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser(
+        description="Benchmark Mamba prefill fragmentation."
+    )
+    parser.add_argument(
+        "--prompt-length",
+        type=int,
+        default=2000,
+        help="Prompt length in tokens.",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=32,
+        help="Max output tokens.",
+    )
+    parser.add_argument(
+        "--repeat-count",
+        type=int,
+        default=5,
+        help="Number of measured iterations.",
+    )
+    parser.add_argument(
+        "--warmup-steps",
+        type=int,
+        default=1,
+        help="Warmup iterations.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed.",
+    )
+    EngineArgs.add_cli_args(parser)
+    parser.set_defaults(model="Qwen3-5.2B")
+    args = parser.parse_args()
+    main(args)

--- a/benchmarks/mamba_prefill_fragmentation.py
+++ b/benchmarks/mamba_prefill_fragmentation.py
@@ -77,9 +77,7 @@ def main(args):
         zero_before = getattr(scheduler, "mamba_zero_collapse_count", 0)
         round_before = getattr(scheduler, "_scheduler_iteration", 0)
 
-        ttft, latency, output_tokens = _run_once(
-            llm, prompt_token_ids, args.max_tokens
-        )
+        ttft, latency, output_tokens = _run_once(llm, prompt_token_ids, args.max_tokens)
 
         frag_after = getattr(scheduler, "mamba_fragmentation_count", 0)
         zero_after = getattr(scheduler, "mamba_zero_collapse_count", 0)

--- a/tests/config/test_config_utils.py
+++ b/tests/config/test_config_utils.py
@@ -112,7 +112,7 @@ def test_normalize_value_uuid_and_to_json():
     [
         (lambda x: x),
         (type("CallableInstance", (), {"__call__": lambda self: 0}))(),
-        (lambda: (lambda: 0))(),  # nested function instance
+        (lambda: lambda: 0)(),  # nested function instance
     ],
 )
 def test_error_cases(bad):

--- a/tests/cuda/test_cuda_compatibility_path.py
+++ b/tests/cuda/test_cuda_compatibility_path.py
@@ -105,8 +105,9 @@ class TestCudaCompatibilityPathDetection:
             patch("vllm.env_override._get_torch_cuda_version", return_value="12.8"),
             patch(
                 "vllm.env_override.os.path.isdir",
-                side_effect=lambda p: p == "/usr/local/cuda-12.8/compat"
-                or os.path.isdir(p),
+                side_effect=lambda p: (
+                    p == "/usr/local/cuda-12.8/compat" or os.path.isdir(p)
+                ),
             ),
         ):
             _maybe_set_cuda_compatibility_path()

--- a/tests/models/language/generation/test_gemma.py
+++ b/tests/models/language/generation/test_gemma.py
@@ -16,7 +16,9 @@ def test_dummy_loader(vllm_runner, monkeypatch, model: str) -> None:
         ) as llm:
             if model == "google/gemma-3-4b-it":
                 normalizers = llm.llm.collective_rpc(
-                    lambda self: self.model_runner.model.language_model.model.normalizer.cpu().item()  # noqa: E501
+                    lambda self: (
+                        self.model_runner.model.language_model.model.normalizer.cpu().item()
+                    )  # noqa: E501
                 )
                 config = llm.llm.llm_engine.model_config.hf_config.text_config
             else:

--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -125,7 +125,9 @@ VLM_TEST_SETTINGS = {
     "qwen2_5_vl": VLMTestInfo(
         models=["Qwen/Qwen2.5-VL-3B-Instruct"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE, VLMTestType.VIDEO),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<|vision_start|><|image_pad|><|vision_end|>",
         video_idx_to_prompt=lambda idx: "<|vision_start|><|video_pad|><|vision_end|>",
         enforce_eager=False,
@@ -139,7 +141,9 @@ VLM_TEST_SETTINGS = {
     "qwen2_5_omni": VLMTestInfo(
         models=["Qwen/Qwen2.5-Omni-3B"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE, VLMTestType.VIDEO),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<|vision_bos|><|IMAGE|><|vision_eos|>",
         video_idx_to_prompt=lambda idx: "<|vision_bos|><|VIDEO|><|vision_eos|>",
         max_model_len=4096,
@@ -160,7 +164,9 @@ VLM_TEST_SETTINGS = {
         ),
         enforce_eager=False,
         needs_video_metadata=True,
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<|vision_start|><|image_pad|><|vision_end|>",  # noqa: E501
         video_idx_to_prompt=lambda idx: "<|vision_start|><|video_pad|><|vision_end|>",  # noqa: E501
         max_model_len=4096,
@@ -180,7 +186,9 @@ VLM_TEST_SETTINGS = {
     "ultravox": VLMTestInfo(
         models=["fixie-ai/ultravox-v0_5-llama-3_2-1b"],
         test_type=VLMTestType.AUDIO,
-        prompt_formatter=lambda audio_prompt: f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{audio_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n",  # noqa: E501
+        prompt_formatter=lambda audio_prompt: (
+            f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{audio_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        ),  # noqa: E501
         audio_idx_to_prompt=lambda idx: "<|audio|>",
         max_model_len=4096,
         max_num_seqs=2,
@@ -194,7 +202,9 @@ VLM_TEST_SETTINGS = {
     "llava-onevision-transformers": VLMTestInfo(
         models=["llava-hf/llava-onevision-qwen2-0.5b-ov-hf"],
         test_type=VLMTestType.IMAGE,
-        prompt_formatter=lambda vid_prompt: f"<|im_start|>user\n{vid_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda vid_prompt: (
+            f"<|im_start|>user\n{vid_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         max_model_len=16384,
         hf_model_kwargs=model_utils.llava_onevision_hf_model_kwargs(
             "llava-hf/llava-onevision-qwen2-0.5b-ov-hf"
@@ -214,7 +224,9 @@ VLM_TEST_SETTINGS = {
     "gemma3-transformers": VLMTestInfo(
         models=["google/gemma-3-4b-it"],
         test_type=VLMTestType.IMAGE,
-        prompt_formatter=lambda vid_prompt: f"<'<bos><start_of_turn>user\n{vid_prompt}<start_of_image><end_of_turn>\n<start_of_turn>model\n",  # noqa: E501
+        prompt_formatter=lambda vid_prompt: (
+            f"<'<bos><start_of_turn>user\n{vid_prompt}<start_of_image><end_of_turn>\n<start_of_turn>model\n"
+        ),  # noqa: E501
         max_model_len=4096,
         auto_cls=AutoModelForImageTextToText,
         vllm_output_post_proc=model_utils.gemma3_vllm_to_hf_output,
@@ -227,7 +239,9 @@ VLM_TEST_SETTINGS = {
     "idefics3-transformers": VLMTestInfo(
         models=["HuggingFaceTB/SmolVLM-256M-Instruct"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|begin_of_text|>User:{img_prompt}<end_of_utterance>\nAssistant:",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|begin_of_text|>User:{img_prompt}<end_of_utterance>\nAssistant:"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<image>",
         max_model_len=8192,
         max_num_seqs=2,
@@ -243,7 +257,9 @@ VLM_TEST_SETTINGS = {
     "qwen2_5_vl-transformers": VLMTestInfo(
         models=["Qwen/Qwen2.5-VL-3B-Instruct"],
         test_type=VLMTestType.IMAGE,
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<|vision_start|><|image_pad|><|vision_end|>",
         max_model_len=4096,
         max_num_seqs=2,
@@ -270,7 +286,9 @@ VLM_TEST_SETTINGS = {
     "aria": VLMTestInfo(
         models=["rhymes-ai/Aria"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>user\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n ",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>user\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n "
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<fim_prefix><|img|><fim_suffix>\n",
         max_model_len=4096,
         max_num_seqs=2,
@@ -290,7 +308,9 @@ VLM_TEST_SETTINGS = {
     "aya_vision": VLMTestInfo(
         models=["CohereLabs/aya-vision-8b"],
         test_type=(VLMTestType.IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|START_OF_TURN_TOKEN|><|USER_TOKEN|>{img_prompt}<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|START_OF_TURN_TOKEN|><|USER_TOKEN|>{img_prompt}<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>"
+        ),  # noqa: E501
         single_image_prompts=IMAGE_ASSETS.prompts(
             {
                 "stop_sign": "<image>What's the content in the center of the image?",
@@ -306,7 +326,9 @@ VLM_TEST_SETTINGS = {
     "aya_vision-multi_image": VLMTestInfo(
         models=["CohereLabs/aya-vision-8b"],
         test_type=(VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|START_OF_TURN_TOKEN|><|USER_TOKEN|>{img_prompt}<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|START_OF_TURN_TOKEN|><|USER_TOKEN|>{img_prompt}<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>"
+        ),  # noqa: E501
         single_image_prompts=IMAGE_ASSETS.prompts(
             {
                 "stop_sign": "<image>What's the content in the center of the image?",
@@ -347,7 +369,9 @@ VLM_TEST_SETTINGS = {
     "deepseek_vl_v2": VLMTestInfo(
         models=["Isotr0py/deepseek-vl2-tiny"],  # model repo using dynamic module
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|User|>: {img_prompt}\n\n<|Assistant|>: ",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|User|>: {img_prompt}\n\n<|Assistant|>: "
+        ),  # noqa: E501
         max_model_len=4096,
         max_num_seqs=2,
         single_image_prompts=IMAGE_ASSETS.prompts(
@@ -379,7 +403,9 @@ VLM_TEST_SETTINGS = {
     "gemma3": VLMTestInfo(
         models=["google/gemma-3-4b-it"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<bos><start_of_turn>user\n{img_prompt}<end_of_turn>\n<start_of_turn>model\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<bos><start_of_turn>user\n{img_prompt}<end_of_turn>\n<start_of_turn>model\n"
+        ),  # noqa: E501
         single_image_prompts=IMAGE_ASSETS.prompts(
             {
                 "stop_sign": "<start_of_image>What's the content in the center of the image?",  # noqa: E501
@@ -426,7 +452,9 @@ VLM_TEST_SETTINGS = {
     "glm4_1v": VLMTestInfo(
         models=["zai-org/GLM-4.1V-9B-Thinking"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"[gMASK]<|user|>\n{img_prompt}<|assistant|>\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"[gMASK]<|user|>\n{img_prompt}<|assistant|>\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<|begin_of_image|><|image|><|end_of_image|>",
         video_idx_to_prompt=lambda idx: "<|begin_of_video|><|video|><|end_of_video|>",
         max_model_len=2048,
@@ -441,7 +469,9 @@ VLM_TEST_SETTINGS = {
         models=["zai-org/GLM-4.1V-9B-Thinking"],
         # GLM4.1V require include video metadata for input
         test_type=VLMTestType.CUSTOM_INPUTS,
-        prompt_formatter=lambda vid_prompt: f"[gMASK]<|user|>\n{vid_prompt}<|assistant|>\n",  # noqa: E501
+        prompt_formatter=lambda vid_prompt: (
+            f"[gMASK]<|user|>\n{vid_prompt}<|assistant|>\n"
+        ),  # noqa: E501
         max_model_len=4096,
         max_num_seqs=2,
         auto_cls=AutoModelForImageTextToText,
@@ -457,7 +487,9 @@ VLM_TEST_SETTINGS = {
     "glm_ocr": VLMTestInfo(
         models=["zai-org/GLM-OCR"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"[gMASK]<|user|>\n{img_prompt}<|assistant|>\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"[gMASK]<|user|>\n{img_prompt}<|assistant|>\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<|begin_of_image|><|image|><|end_of_image|>",
         video_idx_to_prompt=lambda idx: "<|begin_of_video|><|video|><|end_of_video|>",
         max_model_len=2048,
@@ -490,7 +522,9 @@ VLM_TEST_SETTINGS = {
     "idefics3": VLMTestInfo(
         models=["HuggingFaceTB/SmolVLM-256M-Instruct"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|begin_of_text|>User:{img_prompt}<end_of_utterance>\nAssistant:",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|begin_of_text|>User:{img_prompt}<end_of_utterance>\nAssistant:"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<image>",
         max_model_len=8192,
         max_num_seqs=2,
@@ -505,7 +539,9 @@ VLM_TEST_SETTINGS = {
             # "OpenGVLab/Mono-InternVL-2B",
         ],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n"
+        ),  # noqa: E501
         single_image_prompts=IMAGE_ASSETS.prompts(
             {
                 "stop_sign": "<image>\nWhat's the content in the center of the image?",
@@ -522,7 +558,9 @@ VLM_TEST_SETTINGS = {
             "OpenGVLab/InternVL3-1B",
         ],
         test_type=VLMTestType.VIDEO,
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n"
+        ),  # noqa: E501
         video_idx_to_prompt=lambda idx: "<video>",
         max_model_len=8192,
         use_tokenizer_eos=True,
@@ -536,7 +574,9 @@ VLM_TEST_SETTINGS = {
             VLMTestType.MULTI_IMAGE,
             VLMTestType.VIDEO,
         ),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<IMG_CONTEXT>",
         video_idx_to_prompt=lambda idx: "<video>",
         max_model_len=8192,
@@ -574,8 +614,12 @@ VLM_TEST_SETTINGS = {
     "kimi_vl": VLMTestInfo(
         models=["moonshotai/Kimi-VL-A3B-Instruct"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|im_user|>user<|im_middle|>{img_prompt}<|im_end|><|im_assistant|>assistant<|im_middle|>",  # noqa: E501
-        img_idx_to_prompt=lambda _: "<|media_start|>image<|media_content|><|media_pad|><|media_end|>",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_user|>user<|im_middle|>{img_prompt}<|im_end|><|im_assistant|>assistant<|im_middle|>"
+        ),  # noqa: E501
+        img_idx_to_prompt=lambda _: (
+            "<|media_start|>image<|media_content|><|media_pad|><|media_end|>"
+        ),  # noqa: E501
         max_model_len=8192,
         max_num_seqs=2,
         dtype="bfloat16",
@@ -585,7 +629,9 @@ VLM_TEST_SETTINGS = {
     ),
     "llama4": VLMTestInfo(
         models=["meta-llama/Llama-4-Scout-17B-16E-Instruct"],
-        prompt_formatter=lambda img_prompt: f"<|begin_of_text|><|header_start|>user<|header_end|>\n\n{img_prompt}<|eot|><|header_start|>assistant<|header_end|>\n\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|begin_of_text|><|header_start|>user<|header_end|>\n\n{img_prompt}<|eot|><|header_start|>assistant<|header_end|>\n\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda _: "<|image|>",
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
         distributed_executor_backend="mp",
@@ -617,7 +663,9 @@ VLM_TEST_SETTINGS = {
     "llava_onevision": VLMTestInfo(
         models=["llava-hf/llava-onevision-qwen2-0.5b-ov-hf"],
         test_type=VLMTestType.CUSTOM_INPUTS,
-        prompt_formatter=lambda vid_prompt: f"<|im_start|>user\n{vid_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda vid_prompt: (
+            f"<|im_start|>user\n{vid_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         num_video_frames=16,
         max_model_len=16384,
         hf_model_kwargs=model_utils.llava_onevision_hf_model_kwargs(
@@ -628,7 +676,9 @@ VLM_TEST_SETTINGS = {
         custom_test_opts=[
             CustomTestOptions(
                 inputs=custom_inputs.multi_video_multi_aspect_ratio_inputs(
-                    formatter=lambda vid_prompt: f"<|im_start|>user\n{vid_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+                    formatter=lambda vid_prompt: (
+                        f"<|im_start|>user\n{vid_prompt}<|im_end|>\n<|im_start|>assistant\n"
+                    ),  # noqa: E501
                 ),
                 limit_mm_per_prompt={"video": 4},
             )
@@ -647,7 +697,9 @@ VLM_TEST_SETTINGS = {
     "mantis": VLMTestInfo(
         models=["TIGER-Lab/Mantis-8B-siglip-llama3"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|start_header_id|>user<|end_header_id|>\n\n{img_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|start_header_id|>user<|end_header_id|>\n\n{img_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        ),  # noqa: E501
         max_model_len=4096,
         get_stop_token_ids=lambda tok: [128009],
         auto_cls=AutoModelForImageTextToText,
@@ -657,7 +709,9 @@ VLM_TEST_SETTINGS = {
     "minicpmv_25": VLMTestInfo(
         models=["openbmb/MiniCPM-Llama3-V-2_5"],
         test_type=VLMTestType.IMAGE,
-        prompt_formatter=lambda img_prompt: f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{img_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{img_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "(<image>./</image>)\n",
         max_model_len=4096,
         max_num_seqs=2,
@@ -670,7 +724,9 @@ VLM_TEST_SETTINGS = {
     "minicpmo_26": VLMTestInfo(
         models=["openbmb/MiniCPM-o-2_6"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{img_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{img_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "(<image>./</image>)\n",
         max_model_len=4096,
         max_num_seqs=2,
@@ -685,7 +741,9 @@ VLM_TEST_SETTINGS = {
     "minicpmv_26": VLMTestInfo(
         models=["openbmb/MiniCPM-V-2_6"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{img_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{img_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "(<image>./</image>)\n",
         max_model_len=4096,
         max_num_seqs=2,
@@ -697,7 +755,9 @@ VLM_TEST_SETTINGS = {
     ),
     "minimax_vl_01": VLMTestInfo(
         models=["MiniMaxAI/MiniMax-VL-01"],
-        prompt_formatter=lambda img_prompt: f"<beginning_of_sentence>user: {img_prompt} assistant:<end_of_sentence>",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<beginning_of_sentence>user: {img_prompt} assistant:<end_of_sentence>"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda _: "<image>",
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
         max_model_len=8192,
@@ -729,7 +789,9 @@ VLM_TEST_SETTINGS = {
     "ovis1_6-gemma2": VLMTestInfo(
         models=["AIDC-AI/Ovis1.6-Gemma2-9B"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<bos><start_of_turn>user\n{img_prompt}<end_of_turn>\n<start_of_turn>model\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<bos><start_of_turn>user\n{img_prompt}<end_of_turn>\n<start_of_turn>model\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<image>\n",
         max_model_len=4096,
         max_num_seqs=2,
@@ -742,7 +804,9 @@ VLM_TEST_SETTINGS = {
     "ovis2": VLMTestInfo(
         models=["AIDC-AI/Ovis2-1B"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<image>\n",
         max_model_len=4096,
         max_num_seqs=2,
@@ -754,7 +818,9 @@ VLM_TEST_SETTINGS = {
     "ovis2_5": VLMTestInfo(
         models=["AIDC-AI/Ovis2.5-2B"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE, VLMTestType.VIDEO),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<image>\n",
         video_idx_to_prompt=lambda idx: "<video>\n",
         max_model_len=4096,
@@ -790,7 +856,9 @@ VLM_TEST_SETTINGS = {
     "phi3v": VLMTestInfo(
         models=["microsoft/Phi-3.5-vision-instruct"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|user|>\n{img_prompt}<|end|>\n<|assistant|>\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|user|>\n{img_prompt}<|end|>\n<|assistant|>\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: f"<|image_{idx}|>\n",
         max_model_len=4096,
         max_num_seqs=2,
@@ -830,7 +898,9 @@ VLM_TEST_SETTINGS = {
     "qwen2_vl": VLMTestInfo(
         models=["Qwen/Qwen2-VL-2B-Instruct"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE, VLMTestType.VIDEO),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<|vision_start|><|image_pad|><|vision_end|>",
         video_idx_to_prompt=lambda idx: "<|vision_start|><|video_pad|><|vision_end|>",
         multi_image_prompt="Picture 1: <vlm_image>\nPicture 2: <vlm_image>\nDescribe these two images with one paragraph respectively.",  # noqa: E501
@@ -844,7 +914,9 @@ VLM_TEST_SETTINGS = {
     "skywork_r1v": VLMTestInfo(
         models=["Skywork/Skywork-R1V-38B"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<｜begin▁of▁sentence｜><｜User｜>\n{img_prompt}<｜Assistant｜><think>\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<｜begin▁of▁sentence｜><｜User｜>\n{img_prompt}<｜Assistant｜><think>\n"
+        ),  # noqa: E501
         single_image_prompts=IMAGE_ASSETS.prompts(
             {
                 "stop_sign": "<image>\nWhat's the content in the center of the image?",
@@ -860,7 +932,9 @@ VLM_TEST_SETTINGS = {
     "smolvlm": VLMTestInfo(
         models=["HuggingFaceTB/SmolVLM2-2.2B-Instruct"],
         test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User:{img_prompt}<end_of_utterance>\nAssistant:",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User:{img_prompt}<end_of_utterance>\nAssistant:"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<image>",
         max_model_len=8192,
         max_num_seqs=2,
@@ -884,7 +958,9 @@ VLM_TEST_SETTINGS = {
             VLMTestType.MULTI_IMAGE,
             VLMTestType.VIDEO,
         ),
-        prompt_formatter=lambda img_prompt: f"<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n{img_prompt}<|im_end|>\n<|im_start|>assistant\n"
+        ),  # noqa: E501
         img_idx_to_prompt=lambda idx: "<|vision_start|><|image_pad|><|vision_end|>",
         video_idx_to_prompt=lambda idx: "<|vision_start|><|video_pad|><|vision_end|>",
         max_model_len=4096,
@@ -926,7 +1002,9 @@ VLM_TEST_SETTINGS = {
     ### Custom input edge-cases for specific models
     "intern_vl-diff-patches": VLMTestInfo(
         models=["OpenGVLab/InternVL2-2B"],
-        prompt_formatter=lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n",  # noqa: E501
+        prompt_formatter=lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n"
+        ),  # noqa: E501
         test_type=VLMTestType.CUSTOM_INPUTS,
         max_model_len=4096,
         use_tokenizer_eos=True,
@@ -952,7 +1030,9 @@ VLM_TEST_SETTINGS = {
         custom_test_opts=[
             CustomTestOptions(
                 inputs=custom_inputs.multi_image_multi_aspect_ratio_inputs(
-                    formatter=lambda vid_prompt: f"<|im_start|>user\n{vid_prompt}<|im_end|>\n<|im_start|>assistant\n",  # noqa: E501
+                    formatter=lambda vid_prompt: (
+                        f"<|im_start|>user\n{vid_prompt}<|im_end|>\n<|im_start|>assistant\n"
+                    ),  # noqa: E501
                 ),
                 limit_mm_per_prompt={"image": 4},
             )

--- a/tests/models/multimodal/generation/vlm_utils/custom_inputs.py
+++ b/tests/models/multimodal/generation/vlm_utils/custom_inputs.py
@@ -102,7 +102,9 @@ def multi_video_multi_aspect_ratio_inputs(
 def different_patch_input_cases_internvl():
     images = [asset.pil_image.resize((896, 896)) for asset in IMAGE_ASSETS]
     formatter = (
-        lambda img_prompt: f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n"  # noqa: E501
+        lambda img_prompt: (
+            f"<|im_start|>User\n{img_prompt}<|im_end|>\n<|im_start|>Assistant\n"
+        )  # noqa: E501
     )
     single_img_prompts = [
         "<image>\nWhat's the content in the center of the image?",

--- a/tests/models/multimodal/generation/vlm_utils/model_utils.py
+++ b/tests/models/multimodal/generation/vlm_utils/model_utils.py
@@ -320,8 +320,8 @@ def deepseekvl2_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
         return BatchFeature(data=inputs, tensor_type="pt")
 
     hf_model.processor = processor
-    hf_model.model.get_output_embeddings = (
-        lambda: hf_model.model.language.model.embed_tokens
+    hf_model.model.get_output_embeddings = lambda: (
+        hf_model.model.language.model.embed_tokens
     )
     return hf_model
 
@@ -433,8 +433,8 @@ def glm4v_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
         )
 
     hf_model.processor = processor
-    hf_model.model.get_output_embeddings = (
-        lambda: hf_model.model.transformer.output_layer
+    hf_model.model.get_output_embeddings = lambda: (
+        hf_model.model.transformer.output_layer
     )
     return hf_model
 
@@ -521,8 +521,8 @@ def h2ovl_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
     img_context_token_id = hf_model.tokenizer.convert_tokens_to_ids("<IMG_CONTEXT>")
     hf_model.model.img_context_token_id = img_context_token_id
     hf_model.processor = H2OVLProcessor(hf_model)
-    hf_model.model.get_output_embeddings = (
-        lambda: hf_model.model.language_model.get_output_embeddings()
+    hf_model.model.get_output_embeddings = lambda: (
+        hf_model.model.language_model.get_output_embeddings()
     )
     hf_model.model.generate = types.MethodType(_internvl_generate, hf_model.model)
     return hf_model
@@ -782,8 +782,8 @@ def skyworkr1v_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
     img_context_token_id = hf_model.tokenizer.convert_tokens_to_ids("<IMG_CONTEXT>")
     hf_model.model.img_context_token_id = img_context_token_id
     hf_model.processor = SkyworkR1VProcessor(hf_model)
-    hf_model.model.get_output_embeddings = (
-        lambda: hf_model.model.language_model.get_output_embeddings()
+    hf_model.model.get_output_embeddings = lambda: (
+        hf_model.model.language_model.get_output_embeddings()
     )
     hf_model.model.generate = types.MethodType(_internvl_generate, hf_model.model)
     return hf_model
@@ -890,8 +890,8 @@ def internvl_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
     img_context_token_id = hf_model.tokenizer.convert_tokens_to_ids("<IMG_CONTEXT>")
     hf_model.model.img_context_token_id = img_context_token_id
     hf_model.processor = InternVLProcessor(hf_model)
-    hf_model.model.get_output_embeddings = (
-        lambda: hf_model.model.language_model.get_output_embeddings()
+    hf_model.model.get_output_embeddings = lambda: (
+        hf_model.model.language_model.get_output_embeddings()
     )
     hf_model.model.generate = types.MethodType(_internvl_generate, hf_model.model)
     return hf_model
@@ -1060,8 +1060,8 @@ def molmo_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
 
 def ovis_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
     """Patches and returns an instance of the HfRunner to use for Ovis2."""
-    hf_model.model.get_output_embeddings = (
-        lambda: hf_model.model.llm.get_output_embeddings()
+    hf_model.model.get_output_embeddings = lambda: (
+        hf_model.model.llm.get_output_embeddings()
     )
 
     def processor(*args, text="", images=None, **kwargs):
@@ -1096,8 +1096,8 @@ def ovis_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
 
 def ovis2_5_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
     """Patches and returns an instance of the HfRunner to use for Ovis2."""
-    hf_model.model.get_output_embeddings = (
-        lambda: hf_model.model.llm.get_output_embeddings()
+    hf_model.model.get_output_embeddings = lambda: (
+        hf_model.model.llm.get_output_embeddings()
     )
 
     def processor(*args, text="", images=None, videos=None, **kwargs):

--- a/tests/models/multimodal/processing/test_qwen2_5_omni_embed.py
+++ b/tests/models/multimodal/processing/test_qwen2_5_omni_embed.py
@@ -179,8 +179,8 @@ def make_mock_model(hidden: int = 8):
     # _embed_text_input_ids: delegate to SupportsMultiModal's implementation
     from vllm.model_executor.models.interfaces import SupportsMultiModal
 
-    model._embed_text_input_ids = (
-        lambda *a, **kw: SupportsMultiModal._embed_text_input_ids(model, *a, **kw)
+    model._embed_text_input_ids = lambda *a, **kw: (
+        SupportsMultiModal._embed_text_input_ids(model, *a, **kw)
     )
 
     # super().embed_input_ids → use SupportsMultiModal.embed_input_ids
@@ -196,10 +196,8 @@ def make_mock_model(hidden: int = 8):
         )
 
     # Bind embed_input_ids as the real method
-    model.embed_input_ids = (
-        lambda *a, **kw: Qwen2_5OmniThinkerForConditionalGeneration.embed_input_ids(
-            model, *a, **kw
-        )
+    model.embed_input_ids = lambda *a, **kw: (
+        Qwen2_5OmniThinkerForConditionalGeneration.embed_input_ids(model, *a, **kw)
     )
 
     # Store super-embed for use inside the method

--- a/tests/test_mamba_scheduler_split.py
+++ b/tests/test_mamba_scheduler_split.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from tests.v1.core.utils import create_scheduler
+from vllm.sampling_params import SamplingParams
+from vllm.v1.request import Request
+
+
+def _make_request(prompt_len: int) -> Request:
+    prompt_token_ids = list(range(prompt_len))
+    sampling_params = SamplingParams(max_tokens=1)
+    return Request(
+        request_id="req",
+        prompt_token_ids=prompt_token_ids,
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+
+
+def test_mamba_split_zero_collapse_guard():
+    scheduler = create_scheduler(block_size=128, skip_tokenizer_init=True)
+    request = _make_request(prompt_len=256)
+    request.num_computed_tokens = 0
+    aligned = scheduler._mamba_block_aligned_split(request, 2)
+    assert aligned > 0
+
+
+def test_mamba_split_block_alignment():
+    scheduler = create_scheduler(block_size=16, skip_tokenizer_init=True)
+    request = _make_request(prompt_len=64)
+    request.num_computed_tokens = 0
+    aligned = scheduler._mamba_block_aligned_split(request, 40)
+    assert aligned == 32
+    assert aligned % 16 == 0
+
+
+def test_mamba_split_cache_boundary_cut():
+    scheduler = create_scheduler(block_size=16, skip_tokenizer_init=True)
+    request = _make_request(prompt_len=34)
+    request.num_computed_tokens = 20
+    aligned = scheduler._mamba_block_aligned_split(request, 20)
+    assert aligned == 12

--- a/tests/v1/kv_connector/unit/test_offloading_connector.py
+++ b/tests/v1/kv_connector/unit/test_offloading_connector.py
@@ -107,9 +107,7 @@ class MockOffloadingSpec(OffloadingSpec):
 
         self.manager = MagicMock(spec=OffloadingManager)
         self.manager.lookup.return_value = 0
-        self.manager.prepare_load = lambda block_hashes: (
-            MockLoadStoreSpec(block_hashes)
-        )
+        self.manager.prepare_load = lambda block_hashes: MockLoadStoreSpec(block_hashes)
         self.handler = MockOffloadingHandler()
 
     def get_manager(self) -> OffloadingManager:
@@ -508,8 +506,8 @@ def test_offloading_connector(request_runner, async_scheduling: bool):
     # 3 blocks, store just the middle block (skip first and last)
     # blocks = [0, 1, 2], [3, 4, 5], [6, 7, 8]
     runner.new_request(token_ids=[0] * offloaded_block_size * 3)
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output(list(block_hashes)[1:2])
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output(list(block_hashes)[1:2])
     )
     runner.run(decoded_tokens=[0])
 
@@ -527,15 +525,15 @@ def test_offloading_connector(request_runner, async_scheduling: bool):
 
     # 1 more block (+ token for async scheduling)
     # now set block_hashes_to_store = []
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output([])
     )
     runner.run(decoded_tokens=[0] * (offloaded_block_size + 1))
 
     # 1 more block (+ token for kicking off offloading)
     # now check touch was called with all 6 blocks
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output(block_hashes)
     )
     runner.run(
         decoded_tokens=[0] * (offloaded_block_size + 1),
@@ -569,16 +567,16 @@ def test_offloading_connector(request_runner, async_scheduling: bool):
     runner.new_request(
         token_ids=[0] * gpu_block_size + [1] * (offloaded_block_size - gpu_block_size)
     )
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output([])
     )
     runner.run(decoded_tokens=[EOS_TOKEN_ID])
     runner.manager.lookup.assert_not_called()
 
     # single block lookup with no hits
     runner.new_request(token_ids=[1] * offloaded_block_size)
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output([])
     )
     runner.run(decoded_tokens=[EOS_TOKEN_ID])
     runner.manager.lookup.assert_called()
@@ -587,8 +585,8 @@ def test_offloading_connector(request_runner, async_scheduling: bool):
     # single block lookup with a hit
     runner.scheduler.reset_prefix_cache()
     runner.new_request(token_ids=[0] * offloaded_block_size)
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output([])
     )
     runner.manager.lookup.return_value = 1
     runner.run(
@@ -599,8 +597,8 @@ def test_offloading_connector(request_runner, async_scheduling: bool):
     runner.new_request(
         token_ids=[0] * offloaded_block_size * 2 + [1] * offloaded_block_size
     )
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output([])
     )
     runner.manager.lookup.return_value = 1
     runner.run(
@@ -656,8 +654,8 @@ def test_request_preemption(request_runner, async_scheduling: bool):
     # 2 blocks, store all, without flushing
     # blocks = [0, 1, 2], [3, 4, 5]
     runner.new_request(token_ids=[0] * offloaded_block_size * 2)
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output(block_hashes)
     )
     runner.run(
         decoded_tokens=[0],
@@ -665,8 +663,8 @@ def test_request_preemption(request_runner, async_scheduling: bool):
     )
 
     # decode 2 more blocks - 1 gpu block, storing [6, 7, 8] (no flush)
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output(block_hashes)
     )
     runner.run(
         decoded_tokens=[0] * (2 * offloaded_block_size - gpu_block_size),
@@ -691,8 +689,8 @@ def test_request_preemption(request_runner, async_scheduling: bool):
     # request should now return from preemption
     # re-load [0, ..., 8] from the CPU and store [9, 10, 11]
     runner.manager.lookup.return_value = 3
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output(block_hashes)
     )
     runner.run(
         decoded_tokens=[0] * gpu_block_size,
@@ -720,8 +718,8 @@ def test_concurrent_lookups_of_the_same_prefix(request_runner, async_scheduling:
 
     # store 1 blocks
     runner.new_request(token_ids=[0] * offloaded_block_size)
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output(block_hashes)
     )
     runner.run(
         decoded_tokens=[EOS_TOKEN_ID],
@@ -753,8 +751,8 @@ def test_concurrent_lookups_of_the_same_prefix(request_runner, async_scheduling:
     assert transfer_jobs == list(runner.offloading_spec.handler.transfer_specs)
 
     # complete transfers
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output([])
     )
     runner.run(
         decoded_tokens=[EOS_TOKEN_ID],
@@ -780,8 +778,8 @@ def test_abort_loading_requests(request_runner, async_scheduling: bool):
 
     # store 1 blocks
     runner.new_request(token_ids=[0] * offloaded_block_size)
-    runner.manager.prepare_store.side_effect = (
-        lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = lambda block_hashes: (
+        generate_store_output(block_hashes)
     )
     runner.run(
         decoded_tokens=[EOS_TOKEN_ID],

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2676,9 +2676,11 @@ class MMVUDataset(HuggingFaceDataset):
 
     DEFAULT_OUTPUT_LEN = 128
     SUPPORTED_DATASET_PATHS = {
-        "yale-nlp/MMVU": lambda x: x["question"]
-        + " "
-        + (" ".join(f"{k}.{v}" for k, v in x["choices"].items())),
+        "yale-nlp/MMVU": lambda x: (
+            x["question"]
+            + " "
+            + (" ".join(f"{k}.{v}" for k, v in x["choices"].items()))
+        ),
     }
 
     def __init__(self, **kwargs) -> None:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -476,8 +476,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # rocm, cpu]
     "VLLM_TARGET_DEVICE": lambda: os.getenv("VLLM_TARGET_DEVICE", "cuda").lower(),
     # Main CUDA version of vLLM. This follows PyTorch but can be overridden.
-    "VLLM_MAIN_CUDA_VERSION": lambda: os.getenv("VLLM_MAIN_CUDA_VERSION", "").lower()
-    or "12.9",
+    "VLLM_MAIN_CUDA_VERSION": lambda: (
+        os.getenv("VLLM_MAIN_CUDA_VERSION", "").lower() or "12.9"
+    ),
     # Controls PyTorch float32 matmul precision mode within vLLM workers.
     # Valid options mirror torch.set_float32_matmul_precision
     "VLLM_FLOAT32_MATMUL_PRECISION": env_with_choices(
@@ -494,21 +495,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, `MAX_JOBS` will be reduced to avoid oversubscribing the CPU.
     "NVCC_THREADS": lambda: os.getenv("NVCC_THREADS", None),
     # If set, vllm will use precompiled binaries (*.so)
-    "VLLM_USE_PRECOMPILED": lambda: os.environ.get("VLLM_USE_PRECOMPILED", "")
-    .strip()
-    .lower()
-    in ("1", "true")
-    or bool(os.environ.get("VLLM_PRECOMPILED_WHEEL_LOCATION")),
+    "VLLM_USE_PRECOMPILED": lambda: (
+        os.environ.get("VLLM_USE_PRECOMPILED", "").strip().lower() in ("1", "true")
+        or bool(os.environ.get("VLLM_PRECOMPILED_WHEEL_LOCATION"))
+    ),
     # If set, skip adding +precompiled suffix to version string
     "VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX": lambda: bool(
         int(os.environ.get("VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX", "0"))
     ),
     # Used to mark that setup.py is running in a Docker build context,
     # in order to force the use of precompiled binaries.
-    "VLLM_DOCKER_BUILD_CONTEXT": lambda: os.environ.get("VLLM_DOCKER_BUILD_CONTEXT", "")
-    .strip()
-    .lower()
-    in ("1", "true"),
+    "VLLM_DOCKER_BUILD_CONTEXT": lambda: (
+        os.environ.get("VLLM_DOCKER_BUILD_CONTEXT", "").strip().lower() in ("1", "true")
+    ),
     # CMake build type
     # If not set, defaults to "Debug" or "RelWithDebInfo"
     # Available options: "Debug", "Release", "RelWithDebInfo"
@@ -554,10 +553,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If true, will load models from ModelScope instead of Hugging Face Hub.
     # note that the value is true or false, not numbers
-    "VLLM_USE_MODELSCOPE": lambda: os.environ.get(
-        "VLLM_USE_MODELSCOPE", "False"
-    ).lower()
-    == "true",
+    "VLLM_USE_MODELSCOPE": lambda: (
+        os.environ.get("VLLM_USE_MODELSCOPE", "False").lower() == "true"
+    ),
     # Interval in seconds to log a warning message when the ring buffer is full
     "VLLM_RINGBUFFER_WARNING_INTERVAL": lambda: int(
         os.environ.get("VLLM_RINGBUFFER_WARNING_INTERVAL", "60")
@@ -578,19 +576,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Feature flag to enable/disable Inductor standalone compile.
     # In torch <= 2.7 we ignore this flag; in torch >= 2.9 this is
     # enabled by default.
-    "VLLM_USE_STANDALONE_COMPILE": lambda: os.environ.get(
-        "VLLM_USE_STANDALONE_COMPILE", "1"
-    )
-    == "1",
+    "VLLM_USE_STANDALONE_COMPILE": lambda: (
+        os.environ.get("VLLM_USE_STANDALONE_COMPILE", "1") == "1"
+    ),
     # Inductor's pre-grad passes don't do anything for vLLM.
     # The pre-grad passes get run even on cache-hit and negatively impact
     # vllm cold compile times by O(1s)
     # Can remove this after the following issue gets fixed
     # https://github.com/pytorch/pytorch/issues/174502
-    "VLLM_ENABLE_PREGRAD_PASSES": lambda: os.environ.get(
-        "VLLM_ENABLE_PREGRAD_PASSES", "0"
-    )
-    == "1",
+    "VLLM_ENABLE_PREGRAD_PASSES": lambda: (
+        os.environ.get("VLLM_ENABLE_PREGRAD_PASSES", "0") == "1"
+    ),
     # Debug pattern matching inside custom passes.
     # Should be set to the fx.Node name (e.g. 'getitem_34' or 'scaled_mm_3').
     "VLLM_PATTERN_MATCH_DEBUG": lambda: os.environ.get(
@@ -615,10 +611,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable loading compiled models directly from cached standalone compile artifacts
     # without re-splitting graph modules. This reduces overhead during model
     # loading by using reconstruct_serializable_fn_from_mega_artifact.
-    "VLLM_USE_MEGA_AOT_ARTIFACT": lambda: os.environ.get(
-        "VLLM_USE_MEGA_AOT_ARTIFACT", "0"
-    )
-    == "1",
+    "VLLM_USE_MEGA_AOT_ARTIFACT": lambda: (
+        os.environ.get("VLLM_USE_MEGA_AOT_ARTIFACT", "0") == "1"
+    ),
     # local rank of the process in the distributed setting, used to determine
     # the GPU device id
     "LOCAL_RANK": lambda: int(os.environ.get("LOCAL_RANK", "0")),
@@ -636,10 +631,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # API key for vLLM API server
     "VLLM_API_KEY": lambda: os.environ.get("VLLM_API_KEY", None),
     # Whether to log responses from API Server for debugging
-    "VLLM_DEBUG_LOG_API_SERVER_RESPONSE": lambda: os.environ.get(
-        "VLLM_DEBUG_LOG_API_SERVER_RESPONSE", "False"
-    ).lower()
-    == "true",
+    "VLLM_DEBUG_LOG_API_SERVER_RESPONSE": lambda: (
+        os.environ.get("VLLM_DEBUG_LOG_API_SERVER_RESPONSE", "False").lower() == "true"
+    ),
     # S3 access information, used for tensorizer to load model from S3
     "S3_ACCESS_KEY_ID": lambda: os.environ.get("S3_ACCESS_KEY_ID", None),
     "S3_SECRET_ACCESS_KEY": lambda: os.environ.get("S3_SECRET_ACCESS_KEY", None),
@@ -650,11 +644,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_NO_USAGE_STATS": lambda: os.environ.get("VLLM_NO_USAGE_STATS", "0") == "1",
     "VLLM_DO_NOT_TRACK": lambda: (
-        os.environ.get("VLLM_DO_NOT_TRACK", None)
-        or os.environ.get("DO_NOT_TRACK", None)
-        or "0"
-    )
-    == "1",
+        (
+            os.environ.get("VLLM_DO_NOT_TRACK", None)
+            or os.environ.get("DO_NOT_TRACK", None)
+            or "0"
+        )
+        == "1"
+    ),
     "VLLM_USAGE_SOURCE": lambda: os.environ.get("VLLM_USAGE_SOURCE", "production"),
     # Logging configuration
     # If set to 0, vllm will not configure logging
@@ -677,36 +673,40 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "NO_COLOR": lambda: os.getenv("NO_COLOR", "0") != "0",
     # If set, vllm will log stats at this interval in seconds
     # If not set, vllm will log stats every 10 seconds.
-    "VLLM_LOG_STATS_INTERVAL": lambda: val
-    if (val := float(os.getenv("VLLM_LOG_STATS_INTERVAL", "10."))) > 0.0
-    else 10.0,
+    "VLLM_LOG_STATS_INTERVAL": lambda: (
+        val
+        if (val := float(os.getenv("VLLM_LOG_STATS_INTERVAL", "10."))) > 0.0
+        else 10.0
+    ),
     # Trace function calls
     # If set to 1, vllm will trace function calls
     # Useful for debugging
     "VLLM_TRACE_FUNCTION": lambda: int(os.getenv("VLLM_TRACE_FUNCTION", "0")),
     # If set, vllm will use flashinfer sampler
-    "VLLM_USE_FLASHINFER_SAMPLER": lambda: bool(
-        int(os.environ["VLLM_USE_FLASHINFER_SAMPLER"])
-    )
-    if "VLLM_USE_FLASHINFER_SAMPLER" in os.environ
-    else None,
+    "VLLM_USE_FLASHINFER_SAMPLER": lambda: (
+        bool(int(os.environ["VLLM_USE_FLASHINFER_SAMPLER"]))
+        if "VLLM_USE_FLASHINFER_SAMPLER" in os.environ
+        else None
+    ),
     # Pipeline stage partition strategy
     "VLLM_PP_LAYER_PARTITION": lambda: os.getenv("VLLM_PP_LAYER_PARTITION", None),
     # (CPU backend only) CPU key-value cache space.
     # default is None and will be set as 4 GB
-    "VLLM_CPU_KVCACHE_SPACE": lambda: int(os.getenv("VLLM_CPU_KVCACHE_SPACE", "0"))
-    if "VLLM_CPU_KVCACHE_SPACE" in os.environ
-    else None,
+    "VLLM_CPU_KVCACHE_SPACE": lambda: (
+        int(os.getenv("VLLM_CPU_KVCACHE_SPACE", "0"))
+        if "VLLM_CPU_KVCACHE_SPACE" in os.environ
+        else None
+    ),
     # (CPU backend only) CPU core ids bound by OpenMP threads, e.g., "0-31",
     # "0,1,2", "0-31,33". CPU cores of different ranks are separated by '|'.
     "VLLM_CPU_OMP_THREADS_BIND": lambda: os.getenv("VLLM_CPU_OMP_THREADS_BIND", "auto"),
     # (CPU backend only) CPU cores not used by OMP threads .
     # Those CPU cores will not be used by OMP threads of a rank.
-    "VLLM_CPU_NUM_OF_RESERVED_CPU": lambda: int(
-        os.getenv("VLLM_CPU_NUM_OF_RESERVED_CPU", "0")
-    )
-    if "VLLM_CPU_NUM_OF_RESERVED_CPU" in os.environ
-    else None,
+    "VLLM_CPU_NUM_OF_RESERVED_CPU": lambda: (
+        int(os.getenv("VLLM_CPU_NUM_OF_RESERVED_CPU", "0"))
+        if "VLLM_CPU_NUM_OF_RESERVED_CPU" in os.environ
+        else None
+    ),
     # (CPU backend only) whether to use SGL kernels, optimized for small batch.
     "VLLM_CPU_SGL_KERNEL": lambda: bool(int(os.getenv("VLLM_CPU_SGL_KERNEL", "0"))),
     # If the env var is set, Ray Compiled Graph uses the specified
@@ -862,9 +862,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # a list of plugin names to load, separated by commas.
     # if this is not set, it means all plugins will be loaded
     # if this is set to an empty string, no plugins will be loaded
-    "VLLM_PLUGINS": lambda: None
-    if "VLLM_PLUGINS" not in os.environ
-    else os.environ["VLLM_PLUGINS"].split(","),
+    "VLLM_PLUGINS": lambda: (
+        None
+        if "VLLM_PLUGINS" not in os.environ
+        else os.environ["VLLM_PLUGINS"].split(",")
+    ),
     # a local directory to look in for unrecognized LoRA adapters.
     # only works if plugins are enabled and
     # VLLM_ALLOW_RUNTIME_LORA_UPDATING is enabled.
@@ -896,9 +898,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # and performance comparisons. Currently only affects MPLinearKernel
     # selection
     # (kernels: MacheteLinearKernel, MarlinLinearKernel, ExllamaLinearKernel)
-    "VLLM_DISABLED_KERNELS": lambda: []
-    if "VLLM_DISABLED_KERNELS" not in os.environ
-    else os.environ["VLLM_DISABLED_KERNELS"].split(","),
+    "VLLM_DISABLED_KERNELS": lambda: (
+        []
+        if "VLLM_DISABLED_KERNELS" not in os.environ
+        else os.environ["VLLM_DISABLED_KERNELS"].split(",")
+    ),
     # Disable pynccl (using torch.distributed instead)
     "VLLM_DISABLE_PYNCCL": lambda: (
         os.getenv("VLLM_DISABLE_PYNCCL", "False").lower() in ("true", "1")
@@ -1087,10 +1091,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_ENABLE_MOE_DP_CHUNK", "1"))
     ),
     # Randomize inputs during dummy runs when using Data Parallel
-    "VLLM_RANDOMIZE_DP_DUMMY_INPUTS": lambda: os.environ.get(
-        "VLLM_RANDOMIZE_DP_DUMMY_INPUTS", "0"
-    )
-    == "1",
+    "VLLM_RANDOMIZE_DP_DUMMY_INPUTS": lambda: (
+        os.environ.get("VLLM_RANDOMIZE_DP_DUMMY_INPUTS", "0") == "1"
+    ),
     # Strategy to pack the data parallel ranks for Ray.
     # Available options:
     # - "fill":
@@ -1130,10 +1133,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "VLLM_MODEL_REDIRECT_PATH", None
     ),
     # Whether to use atomicAdd reduce in gptq/awq marlin kernel.
-    "VLLM_MARLIN_USE_ATOMIC_ADD": lambda: os.environ.get(
-        "VLLM_MARLIN_USE_ATOMIC_ADD", "0"
-    )
-    == "1",
+    "VLLM_MARLIN_USE_ATOMIC_ADD": lambda: (
+        os.environ.get("VLLM_MARLIN_USE_ATOMIC_ADD", "0") == "1"
+    ),
     # Whether to use marlin kernel in mxfp4 quantization method
     "VLLM_MXFP4_USE_MARLIN": lambda: maybe_convert_bool(
         os.environ.get("VLLM_MXFP4_USE_MARLIN", None)
@@ -1151,17 +1153,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to turn on the outlines cache for V1
     # This cache is unbounded and on disk, so it's not safe to use in
     # an environment with potentially malicious users.
-    "VLLM_V1_USE_OUTLINES_CACHE": lambda: os.environ.get(
-        "VLLM_V1_USE_OUTLINES_CACHE", "0"
-    )
-    == "1",
+    "VLLM_V1_USE_OUTLINES_CACHE": lambda: (
+        os.environ.get("VLLM_V1_USE_OUTLINES_CACHE", "0") == "1"
+    ),
     # Gap between padding buckets for the forward pass. So we have
     # 8, we will run forward pass with [16, 24, 32, ...].
-    "VLLM_TPU_BUCKET_PADDING_GAP": lambda: int(
-        os.environ["VLLM_TPU_BUCKET_PADDING_GAP"]
-    )
-    if "VLLM_TPU_BUCKET_PADDING_GAP" in os.environ
-    else 0,
+    "VLLM_TPU_BUCKET_PADDING_GAP": lambda: (
+        int(os.environ["VLLM_TPU_BUCKET_PADDING_GAP"])
+        if "VLLM_TPU_BUCKET_PADDING_GAP" in os.environ
+        else 0
+    ),
     "VLLM_TPU_MOST_MODEL_LEN": lambda: maybe_convert_int(
         os.environ.get("VLLM_TPU_MOST_MODEL_LEN", None)
     ),

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -639,15 +639,17 @@ _ACTIVATION_REGISTRY = LazyDict(
         "gelu_fast": lambda: FastGELU(),
         "gelu_new": lambda: NewGELU(),
         "gelu_pytorch_tanh": lambda: (
-            # TODO:[ROCm] PyTorch native GELU with tanh is unstable with torch.compile
-            logger.warning_once(
-                "[ROCm] PyTorch's native GELU with tanh approximation is unstable. "
-                "Falling back to GELU(approximate='none')."
-            ),
-            nn.GELU(approximate="none"),
-        )[1]
-        if current_platform.is_rocm()
-        else nn.GELU(approximate="tanh"),
+            (
+                # TODO:[ROCm] PyTorch native GELU with tanh is unstable with torch.compile
+                logger.warning_once(
+                    "[ROCm] PyTorch's native GELU with tanh approximation is unstable. "
+                    "Falling back to GELU(approximate='none')."
+                ),
+                nn.GELU(approximate="none"),
+            )[1]
+            if current_platform.is_rocm()
+            else nn.GELU(approximate="tanh")
+        ),
         "relu": lambda: nn.ReLU(),
         "relu2": lambda: ReLUSquaredActivation(),
         "silu": lambda: nn.SiLU(),

--- a/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
+++ b/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
@@ -33,8 +33,9 @@ else:
 @triton.heuristics({"HAS_Z": lambda args: args["z_ptr"] is not None})
 @triton.heuristics(
     {
-        "HAS_STATE_BATCH_INDICES": lambda args: args["state_batch_indices_ptr"]
-        is not None
+        "HAS_STATE_BATCH_INDICES": lambda args: (
+            args["state_batch_indices_ptr"] is not None
+        )
     }
 )
 @triton.heuristics(

--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -125,8 +125,8 @@ class BaseKVCacheMethod(QuantizeMethodBase):
         else:
             prob_scale = 1.0
 
-        is_singleton_float = (
-            lambda x: isinstance(x, float)
+        is_singleton_float = lambda x: (
+            isinstance(x, float)
             or isinstance(x, torch.Tensor)
             and x.numel() == 1
             and x.is_floating_point()

--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -337,9 +337,8 @@ class BitsAndBytesModelLoader(BaseModelLoader):
 
         global_tp_size = get_tensor_model_parallel_world_size()
         global_tp_rank = get_tensor_model_parallel_rank()
-        check_match = (
-            lambda weight_name, module_name: weight_name.removesuffix(".weight")
-            == module_name
+        check_match = lambda weight_name, module_name: (
+            weight_name.removesuffix(".weight") == module_name
         )
         for (
             org_weight_name,

--- a/vllm/model_executor/models/whisper_causal.py
+++ b/vllm/model_executor/models/whisper_causal.py
@@ -249,13 +249,15 @@ def create_whisper_attention_backend_with_block_pooling(
             block_size,
             num_kv_heads,
             head_size,
-            cache_dtype_str: underlying_attn_backend.get_kv_cache_shape(
-                num_blocks,
-                # we stretch each block by `block_pool_size`
-                block_size * block_pool_size,
-                num_kv_heads // block_pool_size,
-                head_size,
-                cache_dtype_str,
+            cache_dtype_str: (
+                underlying_attn_backend.get_kv_cache_shape(
+                    num_blocks,
+                    # we stretch each block by `block_pool_size`
+                    block_size * block_pool_size,
+                    num_kv_heads // block_pool_size,
+                    head_size,
+                    cache_dtype_str,
+                )
             ),
             "forward_includes_kv_cache_update": True,
         },

--- a/vllm/model_executor/models/whisper_causal.py
+++ b/vllm/model_executor/models/whisper_causal.py
@@ -245,11 +245,7 @@ def create_whisper_attention_backend_with_block_pooling(
         overrides={
             "get_builder_cls": lambda: WhisperCausalAttentionWithBlockPoolingBuilder,
             "get_impl_cls": lambda: WhisperCausalAttentionWithBlockPoolingImpl,
-            "get_kv_cache_shape": lambda num_blocks,
-            block_size,
-            num_kv_heads,
-            head_size,
-            cache_dtype_str: (
+            "get_kv_cache_shape": lambda num_blocks, block_size, num_kv_heads, head_size, cache_dtype_str: (
                 underlying_attn_backend.get_kv_cache_shape(
                     num_blocks,
                     # we stretch each block by `block_pool_size`

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -310,9 +310,11 @@ def _nested_tensors_h2d(
 
     return json_map_leaves(
         (
-            lambda x: x.to(device=device, non_blocking=True)
-            if isinstance(x, torch.Tensor)
-            else x
+            lambda x: (
+                x.to(device=device, non_blocking=True)
+                if isinstance(x, torch.Tensor)
+                else x
+            )
         ),
         tensors,
     )

--- a/vllm/third_party/pynvml.py
+++ b/vllm/third_party/pynvml.py
@@ -45,52 +45,54 @@ import string
 ## C Type mappings ##
 ## Enums
 _nvmlEnableState_t = c_uint
-NVML_FEATURE_DISABLED    = 0
-NVML_FEATURE_ENABLED     = 1
+NVML_FEATURE_DISABLED = 0
+NVML_FEATURE_ENABLED = 1
 
 _nvmlBrandType_t = c_uint
-NVML_BRAND_UNKNOWN             = 0
-NVML_BRAND_QUADRO              = 1
-NVML_BRAND_TESLA               = 2
-NVML_BRAND_NVS                 = 3
-NVML_BRAND_GRID                = 4   # Deprecated from API reporting. Keeping definition for backward compatibility.
-NVML_BRAND_GEFORCE             = 5
-NVML_BRAND_TITAN               = 6
-NVML_BRAND_NVIDIA_VAPPS        = 7   # NVIDIA Virtual Applications
-NVML_BRAND_NVIDIA_VPC          = 8   # NVIDIA Virtual PC
-NVML_BRAND_NVIDIA_VCS          = 9   # NVIDIA Virtual Compute Server
-NVML_BRAND_NVIDIA_VWS          = 10  # NVIDIA RTX Virtual Workstation
+NVML_BRAND_UNKNOWN = 0
+NVML_BRAND_QUADRO = 1
+NVML_BRAND_TESLA = 2
+NVML_BRAND_NVS = 3
+NVML_BRAND_GRID = (
+    4  # Deprecated from API reporting. Keeping definition for backward compatibility.
+)
+NVML_BRAND_GEFORCE = 5
+NVML_BRAND_TITAN = 6
+NVML_BRAND_NVIDIA_VAPPS = 7  # NVIDIA Virtual Applications
+NVML_BRAND_NVIDIA_VPC = 8  # NVIDIA Virtual PC
+NVML_BRAND_NVIDIA_VCS = 9  # NVIDIA Virtual Compute Server
+NVML_BRAND_NVIDIA_VWS = 10  # NVIDIA RTX Virtual Workstation
 NVML_BRAND_NVIDIA_CLOUD_GAMING = 11  # NVIDIA Cloud Gaming
-NVML_BRAND_NVIDIA_VGAMING      = NVML_BRAND_NVIDIA_CLOUD_GAMING # Deprecated from API reporting. Keeping definition for backward compatibility.
-NVML_BRAND_QUADRO_RTX          = 12
-NVML_BRAND_NVIDIA_RTX          = 13
-NVML_BRAND_NVIDIA              = 14
-NVML_BRAND_GEFORCE_RTX         = 15  # Unused
-NVML_BRAND_TITAN_RTX           = 16  # Unused
-NVML_BRAND_COUNT               = 17
+NVML_BRAND_NVIDIA_VGAMING = NVML_BRAND_NVIDIA_CLOUD_GAMING  # Deprecated from API reporting. Keeping definition for backward compatibility.
+NVML_BRAND_QUADRO_RTX = 12
+NVML_BRAND_NVIDIA_RTX = 13
+NVML_BRAND_NVIDIA = 14
+NVML_BRAND_GEFORCE_RTX = 15  # Unused
+NVML_BRAND_TITAN_RTX = 16  # Unused
+NVML_BRAND_COUNT = 17
 
 _nvmlTemperatureThresholds_t = c_uint
-NVML_TEMPERATURE_THRESHOLD_SHUTDOWN      = 0
-NVML_TEMPERATURE_THRESHOLD_SLOWDOWN      = 1
-NVML_TEMPERATURE_THRESHOLD_MEM_MAX       = 2
-NVML_TEMPERATURE_THRESHOLD_GPU_MAX       = 3
-NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MIN  = 4
+NVML_TEMPERATURE_THRESHOLD_SHUTDOWN = 0
+NVML_TEMPERATURE_THRESHOLD_SLOWDOWN = 1
+NVML_TEMPERATURE_THRESHOLD_MEM_MAX = 2
+NVML_TEMPERATURE_THRESHOLD_GPU_MAX = 3
+NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MIN = 4
 NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_CURR = 5
-NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MAX  = 6
-NVML_TEMPERATURE_THRESHOLD_GPS_CURR      = 7
-NVML_TEMPERATURE_THRESHOLD_COUNT         = 8
+NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MAX = 6
+NVML_TEMPERATURE_THRESHOLD_GPS_CURR = 7
+NVML_TEMPERATURE_THRESHOLD_COUNT = 8
 
 _nvmlTemperatureSensors_t = c_uint
-NVML_TEMPERATURE_GPU     = 0
-NVML_TEMPERATURE_COUNT   = 1
+NVML_TEMPERATURE_GPU = 0
+NVML_TEMPERATURE_COUNT = 1
 
 
 _nvmlComputeMode_t = c_uint
-NVML_COMPUTEMODE_DEFAULT           = 0
-NVML_COMPUTEMODE_EXCLUSIVE_THREAD  = 1  ## Support Removed
-NVML_COMPUTEMODE_PROHIBITED        = 2
+NVML_COMPUTEMODE_DEFAULT = 0
+NVML_COMPUTEMODE_EXCLUSIVE_THREAD = 1  ## Support Removed
+NVML_COMPUTEMODE_PROHIBITED = 2
 NVML_COMPUTEMODE_EXCLUSIVE_PROCESS = 3
-NVML_COMPUTEMODE_COUNT             = 4
+NVML_COMPUTEMODE_COUNT = 4
 
 _nvmlMemoryLocation_t = c_uint
 NVML_MEMORY_LOCATION_L1_CACHE = 0
@@ -127,158 +129,158 @@ NVML_NVLINK_ERROR_DL_ECC_COUNT = 5
 _nvmlNvLinkCapability_t = c_uint
 NVML_NVLINK_CAP_P2P_SUPPORTED = 0
 NVML_NVLINK_CAP_SYSMEM_ACCESS = 1
-NVML_NVLINK_CAP_P2P_ATOMICS   = 2
-NVML_NVLINK_CAP_SYSMEM_ATOMICS= 3
-NVML_NVLINK_CAP_SLI_BRIDGE    = 4
-NVML_NVLINK_CAP_VALID         = 5
-NVML_NVLINK_CAP_COUNT         = 6
+NVML_NVLINK_CAP_P2P_ATOMICS = 2
+NVML_NVLINK_CAP_SYSMEM_ATOMICS = 3
+NVML_NVLINK_CAP_SLI_BRIDGE = 4
+NVML_NVLINK_CAP_VALID = 5
+NVML_NVLINK_CAP_COUNT = 6
 
 _nvmlNvLinkUtilizationCountPktTypes_t = c_uint
-NVML_NVLINK_COUNTER_PKTFILTER_NOP        = 0x1
-NVML_NVLINK_COUNTER_PKTFILTER_READ       = 0x2
-NVML_NVLINK_COUNTER_PKTFILTER_WRITE      = 0x4
-NVML_NVLINK_COUNTER_PKTFILTER_RATOM      = 0x8
-NVML_NVLINK_COUNTER_PKTFILTER_NRATOM     = 0x10
-NVML_NVLINK_COUNTER_PKTFILTER_FLUSH      = 0x20
-NVML_NVLINK_COUNTER_PKTFILTER_RESPDATA   = 0x40
+NVML_NVLINK_COUNTER_PKTFILTER_NOP = 0x1
+NVML_NVLINK_COUNTER_PKTFILTER_READ = 0x2
+NVML_NVLINK_COUNTER_PKTFILTER_WRITE = 0x4
+NVML_NVLINK_COUNTER_PKTFILTER_RATOM = 0x8
+NVML_NVLINK_COUNTER_PKTFILTER_NRATOM = 0x10
+NVML_NVLINK_COUNTER_PKTFILTER_FLUSH = 0x20
+NVML_NVLINK_COUNTER_PKTFILTER_RESPDATA = 0x40
 NVML_NVLINK_COUNTER_PKTFILTER_RESPNODATA = 0x80
-NVML_NVLINK_COUNTER_PKTFILTER_ALL        = 0xFF
+NVML_NVLINK_COUNTER_PKTFILTER_ALL = 0xFF
 
 _nvmlNvLinkUtilizationCountUnits_t = c_uint
-NVML_NVLINK_COUNTER_UNIT_CYCLES   = 0
-NVML_NVLINK_COUNTER_UNIT_PACKETS  = 1
-NVML_NVLINK_COUNTER_UNIT_BYTES    = 2
+NVML_NVLINK_COUNTER_UNIT_CYCLES = 0
+NVML_NVLINK_COUNTER_UNIT_PACKETS = 1
+NVML_NVLINK_COUNTER_UNIT_BYTES = 2
 NVML_NVLINK_COUNTER_UNIT_RESERVED = 3
-NVML_NVLINK_COUNTER_UNIT_COUNT    = 4
+NVML_NVLINK_COUNTER_UNIT_COUNT = 4
 
 _nvmlNvLinkDeviceType_t = c_uint
-NVML_NVLINK_DEVICE_TYPE_GPU     = 0x00
-NVML_NVLINK_DEVICE_TYPE_IBMNPU  = 0x01
-NVML_NVLINK_DEVICE_TYPE_SWITCH  = 0x02
+NVML_NVLINK_DEVICE_TYPE_GPU = 0x00
+NVML_NVLINK_DEVICE_TYPE_IBMNPU = 0x01
+NVML_NVLINK_DEVICE_TYPE_SWITCH = 0x02
 NVML_NVLINK_DEVICE_TYPE_UNKNOWN = 0xFF
 
 # These are deprecated, instead use _nvmlMemoryErrorType_t
 _nvmlEccBitType_t = c_uint
-NVML_SINGLE_BIT_ECC    = 0
-NVML_DOUBLE_BIT_ECC    = 1
+NVML_SINGLE_BIT_ECC = 0
+NVML_DOUBLE_BIT_ECC = 1
 NVML_ECC_ERROR_TYPE_COUNT = 2
 
 _nvmlEccCounterType_t = c_uint
-NVML_VOLATILE_ECC      = 0
-NVML_AGGREGATE_ECC     = 1
+NVML_VOLATILE_ECC = 0
+NVML_AGGREGATE_ECC = 1
 NVML_ECC_COUNTER_TYPE_COUNT = 2
 
 _nvmlMemoryErrorType_t = c_uint
-NVML_MEMORY_ERROR_TYPE_CORRECTED   = 0
+NVML_MEMORY_ERROR_TYPE_CORRECTED = 0
 NVML_MEMORY_ERROR_TYPE_UNCORRECTED = 1
-NVML_MEMORY_ERROR_TYPE_COUNT       = 2
+NVML_MEMORY_ERROR_TYPE_COUNT = 2
 
 _nvmlClockType_t = c_uint
-NVML_CLOCK_GRAPHICS  = 0
-NVML_CLOCK_SM        = 1
-NVML_CLOCK_MEM       = 2
-NVML_CLOCK_VIDEO     = 3
-NVML_CLOCK_COUNT     = 4
+NVML_CLOCK_GRAPHICS = 0
+NVML_CLOCK_SM = 1
+NVML_CLOCK_MEM = 2
+NVML_CLOCK_VIDEO = 3
+NVML_CLOCK_COUNT = 4
 
 _nvmlClockId_t = c_uint
-NVML_CLOCK_ID_CURRENT            = 0
-NVML_CLOCK_ID_APP_CLOCK_TARGET   = 1
-NVML_CLOCK_ID_APP_CLOCK_DEFAULT  = 2
+NVML_CLOCK_ID_CURRENT = 0
+NVML_CLOCK_ID_APP_CLOCK_TARGET = 1
+NVML_CLOCK_ID_APP_CLOCK_DEFAULT = 2
 NVML_CLOCK_ID_CUSTOMER_BOOST_MAX = 3
-NVML_CLOCK_ID_COUNT              = 4
+NVML_CLOCK_ID_COUNT = 4
 
 _nvmlDriverModel_t = c_uint
-NVML_DRIVER_WDDM       = 0
-NVML_DRIVER_WDM        = 1
-NVML_DRIVER_MCDM       = 2
+NVML_DRIVER_WDDM = 0
+NVML_DRIVER_WDM = 1
+NVML_DRIVER_MCDM = 2
 
 NVML_MAX_GPU_PERF_PSTATES = 16
 
 _nvmlPstates_t = c_uint
-NVML_PSTATE_0               = 0
-NVML_PSTATE_1               = 1
-NVML_PSTATE_2               = 2
-NVML_PSTATE_3               = 3
-NVML_PSTATE_4               = 4
-NVML_PSTATE_5               = 5
-NVML_PSTATE_6               = 6
-NVML_PSTATE_7               = 7
-NVML_PSTATE_8               = 8
-NVML_PSTATE_9               = 9
-NVML_PSTATE_10              = 10
-NVML_PSTATE_11              = 11
-NVML_PSTATE_12              = 12
-NVML_PSTATE_13              = 13
-NVML_PSTATE_14              = 14
-NVML_PSTATE_15              = 15
-NVML_PSTATE_UNKNOWN         = 32
+NVML_PSTATE_0 = 0
+NVML_PSTATE_1 = 1
+NVML_PSTATE_2 = 2
+NVML_PSTATE_3 = 3
+NVML_PSTATE_4 = 4
+NVML_PSTATE_5 = 5
+NVML_PSTATE_6 = 6
+NVML_PSTATE_7 = 7
+NVML_PSTATE_8 = 8
+NVML_PSTATE_9 = 9
+NVML_PSTATE_10 = 10
+NVML_PSTATE_11 = 11
+NVML_PSTATE_12 = 12
+NVML_PSTATE_13 = 13
+NVML_PSTATE_14 = 14
+NVML_PSTATE_15 = 15
+NVML_PSTATE_UNKNOWN = 32
 
 _nvmlInforomObject_t = c_uint
-NVML_INFOROM_OEM            = 0
-NVML_INFOROM_ECC            = 1
-NVML_INFOROM_POWER          = 2
-NVML_INFOROM_DEN            = 3
-NVML_INFOROM_COUNT          = 4
+NVML_INFOROM_OEM = 0
+NVML_INFOROM_ECC = 1
+NVML_INFOROM_POWER = 2
+NVML_INFOROM_DEN = 3
+NVML_INFOROM_COUNT = 4
 
 _nvmlReturn_t = c_uint
-NVML_SUCCESS                         = 0
-NVML_ERROR_UNINITIALIZED             = 1
-NVML_ERROR_INVALID_ARGUMENT          = 2
-NVML_ERROR_NOT_SUPPORTED             = 3
-NVML_ERROR_NO_PERMISSION             = 4
-NVML_ERROR_ALREADY_INITIALIZED       = 5
-NVML_ERROR_NOT_FOUND                 = 6
-NVML_ERROR_INSUFFICIENT_SIZE         = 7
-NVML_ERROR_INSUFFICIENT_POWER        = 8
-NVML_ERROR_DRIVER_NOT_LOADED         = 9
-NVML_ERROR_TIMEOUT                   = 10
-NVML_ERROR_IRQ_ISSUE                 = 11
-NVML_ERROR_LIBRARY_NOT_FOUND         = 12
-NVML_ERROR_FUNCTION_NOT_FOUND        = 13
-NVML_ERROR_CORRUPTED_INFOROM         = 14
-NVML_ERROR_GPU_IS_LOST               = 15
-NVML_ERROR_RESET_REQUIRED            = 16
-NVML_ERROR_OPERATING_SYSTEM          = 17
-NVML_ERROR_LIB_RM_VERSION_MISMATCH   = 18
-NVML_ERROR_IN_USE                    = 19
-NVML_ERROR_MEMORY                    = 20
-NVML_ERROR_NO_DATA                   = 21
-NVML_ERROR_VGPU_ECC_NOT_SUPPORTED    = 22
-NVML_ERROR_INSUFFICIENT_RESOURCES    = 23
-NVML_ERROR_FREQ_NOT_SUPPORTED        = 24
+NVML_SUCCESS = 0
+NVML_ERROR_UNINITIALIZED = 1
+NVML_ERROR_INVALID_ARGUMENT = 2
+NVML_ERROR_NOT_SUPPORTED = 3
+NVML_ERROR_NO_PERMISSION = 4
+NVML_ERROR_ALREADY_INITIALIZED = 5
+NVML_ERROR_NOT_FOUND = 6
+NVML_ERROR_INSUFFICIENT_SIZE = 7
+NVML_ERROR_INSUFFICIENT_POWER = 8
+NVML_ERROR_DRIVER_NOT_LOADED = 9
+NVML_ERROR_TIMEOUT = 10
+NVML_ERROR_IRQ_ISSUE = 11
+NVML_ERROR_LIBRARY_NOT_FOUND = 12
+NVML_ERROR_FUNCTION_NOT_FOUND = 13
+NVML_ERROR_CORRUPTED_INFOROM = 14
+NVML_ERROR_GPU_IS_LOST = 15
+NVML_ERROR_RESET_REQUIRED = 16
+NVML_ERROR_OPERATING_SYSTEM = 17
+NVML_ERROR_LIB_RM_VERSION_MISMATCH = 18
+NVML_ERROR_IN_USE = 19
+NVML_ERROR_MEMORY = 20
+NVML_ERROR_NO_DATA = 21
+NVML_ERROR_VGPU_ECC_NOT_SUPPORTED = 22
+NVML_ERROR_INSUFFICIENT_RESOURCES = 23
+NVML_ERROR_FREQ_NOT_SUPPORTED = 24
 NVML_ERROR_ARGUMENT_VERSION_MISMATCH = 25
-NVML_ERROR_DEPRECATED                = 26
-NVML_ERROR_NOT_READY                 = 27
-NVML_ERROR_GPU_NOT_FOUND             = 28
-NVML_ERROR_INVALID_STATE             = 29
-NVML_ERROR_UNKNOWN                   = 999
+NVML_ERROR_DEPRECATED = 26
+NVML_ERROR_NOT_READY = 27
+NVML_ERROR_GPU_NOT_FOUND = 28
+NVML_ERROR_INVALID_STATE = 29
+NVML_ERROR_UNKNOWN = 999
 
 _nvmlFanState_t = c_uint
-NVML_FAN_NORMAL             = 0
-NVML_FAN_FAILED             = 1
+NVML_FAN_NORMAL = 0
+NVML_FAN_FAILED = 1
 
 _nvmlFanControlPolicy_t = c_uint
 NVML_FAN_POLICY_TEMPERATURE_CONTINOUS_SW = 0
-NVML_FAN_POLICY_MANUAL                   = 1
+NVML_FAN_POLICY_MANUAL = 1
 
 _nvmlLedColor_t = c_uint
-NVML_LED_COLOR_GREEN        = 0
-NVML_LED_COLOR_AMBER        = 1
+NVML_LED_COLOR_GREEN = 0
+NVML_LED_COLOR_AMBER = 1
 
 _nvmlGpuOperationMode_t = c_uint
-NVML_GOM_ALL_ON                 = 0
-NVML_GOM_COMPUTE                = 1
-NVML_GOM_LOW_DP                 = 2
+NVML_GOM_ALL_ON = 0
+NVML_GOM_COMPUTE = 1
+NVML_GOM_LOW_DP = 2
 
 _nvmlPageRetirementCause_t = c_uint
 NVML_PAGE_RETIREMENT_CAUSE_MULTIPLE_SINGLE_BIT_ECC_ERRORS = 0
-NVML_PAGE_RETIREMENT_CAUSE_DOUBLE_BIT_ECC_ERROR           = 1
-NVML_PAGE_RETIREMENT_CAUSE_COUNT                          = 2
+NVML_PAGE_RETIREMENT_CAUSE_DOUBLE_BIT_ECC_ERROR = 1
+NVML_PAGE_RETIREMENT_CAUSE_COUNT = 2
 
 _nvmlRestrictedAPI_t = c_uint
-NVML_RESTRICTED_API_SET_APPLICATION_CLOCKS                = 0
-NVML_RESTRICTED_API_SET_AUTO_BOOSTED_CLOCKS               = 1
-NVML_RESTRICTED_API_COUNT                                 = 2
+NVML_RESTRICTED_API_SET_APPLICATION_CLOCKS = 0
+NVML_RESTRICTED_API_SET_AUTO_BOOSTED_CLOCKS = 1
+NVML_RESTRICTED_API_COUNT = 2
 
 _nvmlBridgeChipType_t = c_uint
 NVML_BRIDGE_CHIP_PLX = 0
@@ -365,9 +367,9 @@ NVML_TOPOLOGY_CPU = NVML_TOPOLOGY_NODE
 NVML_TOPOLOGY_SYSTEM = 50
 
 _nvmlGpuP2PCapsIndex_t = c_uint
-NVML_P2P_CAPS_INDEX_READ = 0,
+NVML_P2P_CAPS_INDEX_READ = (0,)
 NVML_P2P_CAPS_INDEX_WRITE = 1
-NVML_P2P_CAPS_INDEX_NVLINK =2
+NVML_P2P_CAPS_INDEX_NVLINK = 2
 NVML_P2P_CAPS_INDEX_ATOMICS = 3
 #
 # NVML_P2P_CAPS_INDEX_PROP is deprecated.
@@ -378,39 +380,39 @@ NVML_P2P_CAPS_INDEX_PCI = 4
 NVML_P2P_CAPS_INDEX_UNKNOWN = 5
 
 _nvmlGpuP2PStatus_t = c_uint
-NVML_P2P_STATUS_OK     = 0
+NVML_P2P_STATUS_OK = 0
 NVML_P2P_STATUS_CHIPSET_NOT_SUPPORED = 1
 NVML_P2P_STATUS_CHIPSET_NOT_SUPPORTED = NVML_P2P_STATUS_CHIPSET_NOT_SUPPORED
 NVML_P2P_STATUS_GPU_NOT_SUPPORTED = 2
-NVML_P2P_STATUS_IOH_TOPOLOGY_NOT_SUPPORTED =3
-NVML_P2P_STATUS_DISABLED_BY_REGKEY =4
-NVML_P2P_STATUS_NOT_SUPPORTED =5
-NVML_P2P_STATUS_UNKNOWN =6
+NVML_P2P_STATUS_IOH_TOPOLOGY_NOT_SUPPORTED = 3
+NVML_P2P_STATUS_DISABLED_BY_REGKEY = 4
+NVML_P2P_STATUS_NOT_SUPPORTED = 5
+NVML_P2P_STATUS_UNKNOWN = 6
 
 _nvmlDeviceArchitecture_t = c_uint
-NVML_DEVICE_ARCH_KEPLER   = 2
-NVML_DEVICE_ARCH_MAXWELL  = 3
-NVML_DEVICE_ARCH_PASCAL   = 4
-NVML_DEVICE_ARCH_VOLTA    = 5
-NVML_DEVICE_ARCH_TURING   = 6
-NVML_DEVICE_ARCH_AMPERE   = 7
-NVML_DEVICE_ARCH_ADA      = 8
-NVML_DEVICE_ARCH_HOPPER   = 9
-NVML_DEVICE_ARCH_BLACKWELL   = 10
-NVML_DEVICE_ARCH_T23X     = 11
-NVML_DEVICE_ARCH_UNKNOWN  = 0xffffffff
+NVML_DEVICE_ARCH_KEPLER = 2
+NVML_DEVICE_ARCH_MAXWELL = 3
+NVML_DEVICE_ARCH_PASCAL = 4
+NVML_DEVICE_ARCH_VOLTA = 5
+NVML_DEVICE_ARCH_TURING = 6
+NVML_DEVICE_ARCH_AMPERE = 7
+NVML_DEVICE_ARCH_ADA = 8
+NVML_DEVICE_ARCH_HOPPER = 9
+NVML_DEVICE_ARCH_BLACKWELL = 10
+NVML_DEVICE_ARCH_T23X = 11
+NVML_DEVICE_ARCH_UNKNOWN = 0xFFFFFFFF
 
 # PCI bus Types
 _nvmlBusType_t = c_uint
 NVML_BUS_TYPE_UNKNOWN = 0
-NVML_BUS_TYPE_PCI     = 1
-NVML_BUS_TYPE_PCIE    = 2
-NVML_BUS_TYPE_FPCI    = 3
-NVML_BUS_TYPE_AGP     = 4
+NVML_BUS_TYPE_PCI = 1
+NVML_BUS_TYPE_PCIE = 2
+NVML_BUS_TYPE_FPCI = 3
+NVML_BUS_TYPE_AGP = 4
 
 _nvmlPowerSource_t = c_uint
-NVML_POWER_SOURCE_AC         = 0x00000000
-NVML_POWER_SOURCE_BATTERY    = 0x00000001
+NVML_POWER_SOURCE_AC = 0x00000000
+NVML_POWER_SOURCE_BATTERY = 0x00000001
 NVML_POWER_SOURCE_UNDERSIZED = 0x00000002
 
 _nvmlAdaptiveClockInfoStatus_t = c_uint
@@ -418,196 +420,290 @@ NVML_ADAPTIVE_CLOCKING_INFO_STATUS_DISABLED = 0x00000000
 NVML_ADAPTIVE_CLOCKING_INFO_STATUS_ENABLED = 0x00000001
 
 _nvmlClockLimitId_t = c_uint
-NVML_CLOCK_LIMIT_ID_RANGE_START = 0xffffff00
-NVML_CLOCK_LIMIT_ID_TDP         = 0xffffff01
-NVML_CLOCK_LIMIT_ID_UNLIMITED   = 0xffffff02
+NVML_CLOCK_LIMIT_ID_RANGE_START = 0xFFFFFF00
+NVML_CLOCK_LIMIT_ID_TDP = 0xFFFFFF01
+NVML_CLOCK_LIMIT_ID_UNLIMITED = 0xFFFFFF02
 
 _nvmlPcieLinkMaxSpeed_t = c_uint
-NVML_PCIE_LINK_MAX_SPEED_INVALID   = 0x00000000
-NVML_PCIE_LINK_MAX_SPEED_2500MBPS  = 0x00000001
-NVML_PCIE_LINK_MAX_SPEED_5000MBPS  = 0x00000002
-NVML_PCIE_LINK_MAX_SPEED_8000MBPS  = 0x00000003
+NVML_PCIE_LINK_MAX_SPEED_INVALID = 0x00000000
+NVML_PCIE_LINK_MAX_SPEED_2500MBPS = 0x00000001
+NVML_PCIE_LINK_MAX_SPEED_5000MBPS = 0x00000002
+NVML_PCIE_LINK_MAX_SPEED_8000MBPS = 0x00000003
 NVML_PCIE_LINK_MAX_SPEED_16000MBPS = 0x00000004
 NVML_PCIE_LINK_MAX_SPEED_32000MBPS = 0x00000005
 NVML_PCIE_LINK_MAX_SPEED_64000MBPS = 0x00000006
 
 _nvmlPcieAtomicsCapability_t = c_uint
-NVML_PCIE_ATOMICS_CAP_FETCHADD32  = 0x01
-NVML_PCIE_ATOMICS_CAP_FETCHADD64  = 0x02
-NVML_PCIE_ATOMICS_CAP_SWAP32      = 0x04
-NVML_PCIE_ATOMICS_CAP_SWAP64      = 0x08
-NVML_PCIE_ATOMICS_CAP_CAS32       = 0x10
-NVML_PCIE_ATOMICS_CAP_CAS64       = 0x20
-NVML_PCIE_ATOMICS_CAP_CAS128      = 0x40
-NVML_PCIE_ATOMICS_OPS_MAX         = 7
+NVML_PCIE_ATOMICS_CAP_FETCHADD32 = 0x01
+NVML_PCIE_ATOMICS_CAP_FETCHADD64 = 0x02
+NVML_PCIE_ATOMICS_CAP_SWAP32 = 0x04
+NVML_PCIE_ATOMICS_CAP_SWAP64 = 0x08
+NVML_PCIE_ATOMICS_CAP_CAS32 = 0x10
+NVML_PCIE_ATOMICS_CAP_CAS64 = 0x20
+NVML_PCIE_ATOMICS_CAP_CAS128 = 0x40
+NVML_PCIE_ATOMICS_OPS_MAX = 7
 
 _nvmlAffinityScope_t = c_uint
-NVML_AFFINITY_SCOPE_NODE   = 0
+NVML_AFFINITY_SCOPE_NODE = 0
 NVML_AFFINITY_SCOPE_SOCKET = 1
 
 _nvmlDeviceGpuRecoveryAction_t = c_uint
-NVML_GPU_RECOVERY_ACTION_NONE        = 0
-NVML_GPU_RECOVERY_ACTION_GPU_RESET   = 1
+NVML_GPU_RECOVERY_ACTION_NONE = 0
+NVML_GPU_RECOVERY_ACTION_GPU_RESET = 1
 NVML_GPU_RECOVERY_ACTION_NODE_REBOOT = 2
-NVML_GPU_RECOVERY_ACTION_DRAIN_P2P   = 3
+NVML_GPU_RECOVERY_ACTION_DRAIN_P2P = 3
 NVML_GPU_RECOVERY_ACTION_DRAIN_AND_RESET = 4
 
 # C preprocessor defined values
-nvmlFlagDefault             = 0
-nvmlFlagForce               = 1
-NVML_INIT_FLAG_NO_GPUS      = 1
-NVML_INIT_FLAG_NO_ATTACH    = 2
+nvmlFlagDefault = 0
+nvmlFlagForce = 1
+NVML_INIT_FLAG_NO_GPUS = 1
+NVML_INIT_FLAG_NO_ATTACH = 2
 
-NVML_MAX_GPC_COUNT          = 32
+NVML_MAX_GPC_COUNT = 32
 
 # buffer size
-NVML_DEVICE_INFOROM_VERSION_BUFFER_SIZE      = 16
-NVML_DEVICE_UUID_BUFFER_SIZE                 = 80
-NVML_DEVICE_UUID_V2_BUFFER_SIZE              = 96
-NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE       = 80
-NVML_SYSTEM_NVML_VERSION_BUFFER_SIZE         = 80
-NVML_DEVICE_NAME_BUFFER_SIZE                 = 64
-NVML_DEVICE_NAME_V2_BUFFER_SIZE              = 96
-NVML_DEVICE_SERIAL_BUFFER_SIZE               = 30
-NVML_DEVICE_PART_NUMBER_BUFFER_SIZE          = 80
-NVML_DEVICE_GPU_PART_NUMBER_BUFFER_SIZE      = 80
-NVML_DEVICE_VBIOS_VERSION_BUFFER_SIZE        = 32
-NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE           = 32
-NVML_DEVICE_PCI_BUS_ID_BUFFER_V2_SIZE        = 16
-NVML_GRID_LICENSE_BUFFER_SIZE                = 128
-NVML_VGPU_NAME_BUFFER_SIZE                   = 64
-NVML_GRID_LICENSE_FEATURE_MAX_COUNT          = 3
-NVML_VGPU_METADATA_OPAQUE_DATA_SIZE          = sizeof(c_uint) + 256
-NVML_VGPU_PGPU_METADATA_OPAQUE_DATA_SIZE     = 256
-NVML_DEVICE_GPU_FRU_PART_NUMBER_BUFFER_SIZE  = 0x14 # NV2080_GPU_MAX_PRODUCT_PART_NUMBER_LENGTH
-NVML_PERF_MODES_BUFFER_SIZE                  = 2048
+NVML_DEVICE_INFOROM_VERSION_BUFFER_SIZE = 16
+NVML_DEVICE_UUID_BUFFER_SIZE = 80
+NVML_DEVICE_UUID_V2_BUFFER_SIZE = 96
+NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE = 80
+NVML_SYSTEM_NVML_VERSION_BUFFER_SIZE = 80
+NVML_DEVICE_NAME_BUFFER_SIZE = 64
+NVML_DEVICE_NAME_V2_BUFFER_SIZE = 96
+NVML_DEVICE_SERIAL_BUFFER_SIZE = 30
+NVML_DEVICE_PART_NUMBER_BUFFER_SIZE = 80
+NVML_DEVICE_GPU_PART_NUMBER_BUFFER_SIZE = 80
+NVML_DEVICE_VBIOS_VERSION_BUFFER_SIZE = 32
+NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE = 32
+NVML_DEVICE_PCI_BUS_ID_BUFFER_V2_SIZE = 16
+NVML_GRID_LICENSE_BUFFER_SIZE = 128
+NVML_VGPU_NAME_BUFFER_SIZE = 64
+NVML_GRID_LICENSE_FEATURE_MAX_COUNT = 3
+NVML_VGPU_METADATA_OPAQUE_DATA_SIZE = sizeof(c_uint) + 256
+NVML_VGPU_PGPU_METADATA_OPAQUE_DATA_SIZE = 256
+NVML_DEVICE_GPU_FRU_PART_NUMBER_BUFFER_SIZE = (
+    0x14  # NV2080_GPU_MAX_PRODUCT_PART_NUMBER_LENGTH
+)
+NVML_PERF_MODES_BUFFER_SIZE = 2048
 
 # Format strings
-NVML_DEVICE_PCI_BUS_ID_LEGACY_FMT   = "%04X:%02X:%02X.0"
-NVML_DEVICE_PCI_BUS_ID_FMT          = "%08X:%02X:%02X.0"
+NVML_DEVICE_PCI_BUS_ID_LEGACY_FMT = "%04X:%02X:%02X.0"
+NVML_DEVICE_PCI_BUS_ID_FMT = "%08X:%02X:%02X.0"
 
 NVML_VALUE_NOT_AVAILABLE_ulonglong = c_ulonglong(-1)
 NVML_VALUE_NOT_AVAILABLE_uint = c_uint(-1)
 
-'''
+"""
  Field Identifiers.
 
  All Identifiers pertain to a device. Each ID is only used once and is guaranteed never to change.
-'''
-NVML_FI_DEV_ECC_CURRENT          = 1   # Current ECC mode. 1=Active. 0=Inactive
-NVML_FI_DEV_ECC_PENDING          = 2   # Pending ECC mode. 1=Active. 0=Inactive
+"""
+NVML_FI_DEV_ECC_CURRENT = 1  # Current ECC mode. 1=Active. 0=Inactive
+NVML_FI_DEV_ECC_PENDING = 2  # Pending ECC mode. 1=Active. 0=Inactive
 
-#ECC Count Totals
-NVML_FI_DEV_ECC_SBE_VOL_TOTAL    = 3   # Total single bit volatile ECC errors
-NVML_FI_DEV_ECC_DBE_VOL_TOTAL    = 4   # Total double bit volatile ECC errors
-NVML_FI_DEV_ECC_SBE_AGG_TOTAL    = 5   # Total single bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_DBE_AGG_TOTAL    = 6   # Total double bit aggregate (persistent) ECC errors
-#Individual ECC locations
-NVML_FI_DEV_ECC_SBE_VOL_L1       = 7   # L1 cache single bit volatile ECC errors
-NVML_FI_DEV_ECC_DBE_VOL_L1       = 8   # L1 cache double bit volatile ECC errors
-NVML_FI_DEV_ECC_SBE_VOL_L2       = 9   # L2 cache single bit volatile ECC errors
-NVML_FI_DEV_ECC_DBE_VOL_L2       = 10  # L2 cache double bit volatile ECC errors
-NVML_FI_DEV_ECC_SBE_VOL_DEV      = 11  # Device memory single bit volatile ECC errors
-NVML_FI_DEV_ECC_DBE_VOL_DEV      = 12  # Device memory double bit volatile ECC errors
-NVML_FI_DEV_ECC_SBE_VOL_REG      = 13  # Register file single bit volatile ECC errors
-NVML_FI_DEV_ECC_DBE_VOL_REG      = 14  # Register file double bit volatile ECC errors
-NVML_FI_DEV_ECC_SBE_VOL_TEX      = 15  # Texture memory single bit volatile ECC errors
-NVML_FI_DEV_ECC_DBE_VOL_TEX      = 16  # Texture memory double bit volatile ECC errors
-NVML_FI_DEV_ECC_DBE_VOL_CBU      = 17  # CBU double bit volatile ECC errors
-NVML_FI_DEV_ECC_SBE_AGG_L1       = 18  # L1 cache single bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_DBE_AGG_L1       = 19  # L1 cache double bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_SBE_AGG_L2       = 20  # L2 cache single bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_DBE_AGG_L2       = 21  # L2 cache double bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_SBE_AGG_DEV      = 22  # Device memory single bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_DBE_AGG_DEV      = 23  # Device memory double bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_SBE_AGG_REG      = 24  # Register File single bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_DBE_AGG_REG      = 25  # Register File double bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_SBE_AGG_TEX      = 26  # Texture memory single bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_DBE_AGG_TEX      = 27  # Texture memory double bit aggregate (persistent) ECC errors
-NVML_FI_DEV_ECC_DBE_AGG_CBU      = 28  # CBU double bit aggregate ECC errors
+# ECC Count Totals
+NVML_FI_DEV_ECC_SBE_VOL_TOTAL = 3  # Total single bit volatile ECC errors
+NVML_FI_DEV_ECC_DBE_VOL_TOTAL = 4  # Total double bit volatile ECC errors
+NVML_FI_DEV_ECC_SBE_AGG_TOTAL = 5  # Total single bit aggregate (persistent) ECC errors
+NVML_FI_DEV_ECC_DBE_AGG_TOTAL = 6  # Total double bit aggregate (persistent) ECC errors
+# Individual ECC locations
+NVML_FI_DEV_ECC_SBE_VOL_L1 = 7  # L1 cache single bit volatile ECC errors
+NVML_FI_DEV_ECC_DBE_VOL_L1 = 8  # L1 cache double bit volatile ECC errors
+NVML_FI_DEV_ECC_SBE_VOL_L2 = 9  # L2 cache single bit volatile ECC errors
+NVML_FI_DEV_ECC_DBE_VOL_L2 = 10  # L2 cache double bit volatile ECC errors
+NVML_FI_DEV_ECC_SBE_VOL_DEV = 11  # Device memory single bit volatile ECC errors
+NVML_FI_DEV_ECC_DBE_VOL_DEV = 12  # Device memory double bit volatile ECC errors
+NVML_FI_DEV_ECC_SBE_VOL_REG = 13  # Register file single bit volatile ECC errors
+NVML_FI_DEV_ECC_DBE_VOL_REG = 14  # Register file double bit volatile ECC errors
+NVML_FI_DEV_ECC_SBE_VOL_TEX = 15  # Texture memory single bit volatile ECC errors
+NVML_FI_DEV_ECC_DBE_VOL_TEX = 16  # Texture memory double bit volatile ECC errors
+NVML_FI_DEV_ECC_DBE_VOL_CBU = 17  # CBU double bit volatile ECC errors
+NVML_FI_DEV_ECC_SBE_AGG_L1 = 18  # L1 cache single bit aggregate (persistent) ECC errors
+NVML_FI_DEV_ECC_DBE_AGG_L1 = 19  # L1 cache double bit aggregate (persistent) ECC errors
+NVML_FI_DEV_ECC_SBE_AGG_L2 = 20  # L2 cache single bit aggregate (persistent) ECC errors
+NVML_FI_DEV_ECC_DBE_AGG_L2 = 21  # L2 cache double bit aggregate (persistent) ECC errors
+NVML_FI_DEV_ECC_SBE_AGG_DEV = (
+    22  # Device memory single bit aggregate (persistent) ECC errors
+)
+NVML_FI_DEV_ECC_DBE_AGG_DEV = (
+    23  # Device memory double bit aggregate (persistent) ECC errors
+)
+NVML_FI_DEV_ECC_SBE_AGG_REG = (
+    24  # Register File single bit aggregate (persistent) ECC errors
+)
+NVML_FI_DEV_ECC_DBE_AGG_REG = (
+    25  # Register File double bit aggregate (persistent) ECC errors
+)
+NVML_FI_DEV_ECC_SBE_AGG_TEX = (
+    26  # Texture memory single bit aggregate (persistent) ECC errors
+)
+NVML_FI_DEV_ECC_DBE_AGG_TEX = (
+    27  # Texture memory double bit aggregate (persistent) ECC errors
+)
+NVML_FI_DEV_ECC_DBE_AGG_CBU = 28  # CBU double bit aggregate ECC errors
 
 # Page Retirement
-NVML_FI_DEV_RETIRED_SBE          = 29  # Number of retired pages because of single bit errors
-NVML_FI_DEV_RETIRED_DBE          = 30  # Number of retired pages because of double bit errors
-NVML_FI_DEV_RETIRED_PENDING      = 31  # If any pages are pending retirement. 1=yes. 0=no.
+NVML_FI_DEV_RETIRED_SBE = 29  # Number of retired pages because of single bit errors
+NVML_FI_DEV_RETIRED_DBE = 30  # Number of retired pages because of double bit errors
+NVML_FI_DEV_RETIRED_PENDING = 31  # If any pages are pending retirement. 1=yes. 0=no.
 
 # NvLink Flit Error Counters
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L0   = 32 # NVLink flow control CRC  Error Counter for Lane 0
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L1   = 33 # NVLink flow control CRC  Error Counter for Lane 1
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L2   = 34 # NVLink flow control CRC  Error Counter for Lane 2
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L3   = 35 # NVLink flow control CRC  Error Counter for Lane 3
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L4   = 36 # NVLink flow control CRC  Error Counter for Lane 4
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L5   = 37 # NVLink flow control CRC  Error Counter for Lane 5
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL = 38 # NVLink flow control CRC  Error Counter total for all Lanes
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L0 = (
+    32  # NVLink flow control CRC  Error Counter for Lane 0
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L1 = (
+    33  # NVLink flow control CRC  Error Counter for Lane 1
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L2 = (
+    34  # NVLink flow control CRC  Error Counter for Lane 2
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L3 = (
+    35  # NVLink flow control CRC  Error Counter for Lane 3
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L4 = (
+    36  # NVLink flow control CRC  Error Counter for Lane 4
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L5 = (
+    37  # NVLink flow control CRC  Error Counter for Lane 5
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL = (
+    38  # NVLink flow control CRC  Error Counter total for all Lanes
+)
 
 # NvLink CRC Data Error Counters
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L0   = 39 # NVLink data CRC Error Counter for Lane 0
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L1   = 40 # NVLink data CRC Error Counter for Lane 1
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L2   = 41 # NVLink data CRC Error Counter for Lane 2
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L3   = 42 # NVLink data CRC Error Counter for Lane 3
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L4   = 43 # NVLink data CRC Error Counter for Lane 4
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L5   = 44 # NVLink data CRC Error Counter for Lane 5
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL = 45 # NvLink data CRC Error Counter total for all Lanes
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L0 = (
+    39  # NVLink data CRC Error Counter for Lane 0
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L1 = (
+    40  # NVLink data CRC Error Counter for Lane 1
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L2 = (
+    41  # NVLink data CRC Error Counter for Lane 2
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L3 = (
+    42  # NVLink data CRC Error Counter for Lane 3
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L4 = (
+    43  # NVLink data CRC Error Counter for Lane 4
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L5 = (
+    44  # NVLink data CRC Error Counter for Lane 5
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL = (
+    45  # NvLink data CRC Error Counter total for all Lanes
+)
 
 # NvLink Replay Error Counters
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L0     = 46 # NVLink Replay Error Counter for Lane 0
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L1     = 47 # NVLink Replay Error Counter for Lane 1
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L2     = 48 # NVLink Replay Error Counter for Lane 2
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L3     = 49 # NVLink Replay Error Counter for Lane 3
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L4     = 50 # NVLink Replay Error Counter for Lane 4
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L5     = 51 # NVLink Replay Error Counter for Lane 5
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL  = 52 # NVLink Replay Error Counter total for all Lanes
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L0 = 46  # NVLink Replay Error Counter for Lane 0
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L1 = 47  # NVLink Replay Error Counter for Lane 1
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L2 = 48  # NVLink Replay Error Counter for Lane 2
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L3 = 49  # NVLink Replay Error Counter for Lane 3
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L4 = 50  # NVLink Replay Error Counter for Lane 4
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L5 = 51  # NVLink Replay Error Counter for Lane 5
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL = (
+    52  # NVLink Replay Error Counter total for all Lanes
+)
 
 # NvLink Recovery Error Counters
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L0   = 53 # NVLink Recovery Error Counter for Lane 0
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L1   = 54 # NVLink Recovery Error Counter for Lane 1
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L2   = 55 # NVLink Recovery Error Counter for Lane 2
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L3   = 56 # NVLink Recovery Error Counter for Lane 3
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L4   = 57 # NVLink Recovery Error Counter for Lane 4
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L5   = 58 # NVLink Recovery Error Counter for Lane 5
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL = 59 # NVLink Recovery Error Counter total for all Lanes
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L0 = (
+    53  # NVLink Recovery Error Counter for Lane 0
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L1 = (
+    54  # NVLink Recovery Error Counter for Lane 1
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L2 = (
+    55  # NVLink Recovery Error Counter for Lane 2
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L3 = (
+    56  # NVLink Recovery Error Counter for Lane 3
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L4 = (
+    57  # NVLink Recovery Error Counter for Lane 4
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L5 = (
+    58  # NVLink Recovery Error Counter for Lane 5
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL = (
+    59  # NVLink Recovery Error Counter total for all Lanes
+)
 
 # NvLink Bandwidth Counters
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L0    = 60 # NVLink Bandwidth Counter for Counter Set 0, Lane 0
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L1    = 61 # NVLink Bandwidth Counter for Counter Set 0, Lane 1
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L2    = 62 # NVLink Bandwidth Counter for Counter Set 0, Lane 2
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L3    = 63 # NVLink Bandwidth Counter for Counter Set 0, Lane 3
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L4    = 64 # NVLink Bandwidth Counter for Counter Set 0, Lane 4
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L5    = 65 # NVLink Bandwidth Counter for Counter Set 0, Lane 5
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_TOTAL = 66 # NVLink Bandwidth Counter Total for Counter Set 0, All Lanes
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L0 = (
+    60  # NVLink Bandwidth Counter for Counter Set 0, Lane 0
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L1 = (
+    61  # NVLink Bandwidth Counter for Counter Set 0, Lane 1
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L2 = (
+    62  # NVLink Bandwidth Counter for Counter Set 0, Lane 2
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L3 = (
+    63  # NVLink Bandwidth Counter for Counter Set 0, Lane 3
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L4 = (
+    64  # NVLink Bandwidth Counter for Counter Set 0, Lane 4
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L5 = (
+    65  # NVLink Bandwidth Counter for Counter Set 0, Lane 5
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_TOTAL = (
+    66  # NVLink Bandwidth Counter Total for Counter Set 0, All Lanes
+)
 
 # NvLink Bandwidth Counters
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L0    = 67 # NVLink Bandwidth Counter for Counter Set 1, Lane 0
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L1    = 68 # NVLink Bandwidth Counter for Counter Set 1, Lane 1
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L2    = 69 # NVLink Bandwidth Counter for Counter Set 1, Lane 2
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L3    = 70 # NVLink Bandwidth Counter for Counter Set 1, Lane 3
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L4    = 71 # NVLink Bandwidth Counter for Counter Set 1, Lane 4
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L5    = 72 # NVLink Bandwidth Counter for Counter Set 1, Lane 5
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_TOTAL = 73 # NVLink Bandwidth Counter Total for Counter Set 1, All Lanes
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L0 = (
+    67  # NVLink Bandwidth Counter for Counter Set 1, Lane 0
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L1 = (
+    68  # NVLink Bandwidth Counter for Counter Set 1, Lane 1
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L2 = (
+    69  # NVLink Bandwidth Counter for Counter Set 1, Lane 2
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L3 = (
+    70  # NVLink Bandwidth Counter for Counter Set 1, Lane 3
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L4 = (
+    71  # NVLink Bandwidth Counter for Counter Set 1, Lane 4
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L5 = (
+    72  # NVLink Bandwidth Counter for Counter Set 1, Lane 5
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_TOTAL = (
+    73  # NVLink Bandwidth Counter Total for Counter Set 1, All Lanes
+)
 
 # Perf Policy Counters
-NVML_FI_DEV_PERF_POLICY_POWER             = 74   # Perf Policy Counter for Power Policy
-NVML_FI_DEV_PERF_POLICY_THERMAL           = 75   # Perf Policy Counter for Thermal Policy
-NVML_FI_DEV_PERF_POLICY_SYNC_BOOST        = 76   # Perf Policy Counter for Sync boost Policy
-NVML_FI_DEV_PERF_POLICY_BOARD_LIMIT       = 77   # Perf Policy Counter for Board Limit
-NVML_FI_DEV_PERF_POLICY_LOW_UTILIZATION   = 78   # Perf Policy Counter for Low GPU Utilization Policy
-NVML_FI_DEV_PERF_POLICY_RELIABILITY       = 79   # Perf Policy Counter for Reliability Policy
-NVML_FI_DEV_PERF_POLICY_TOTAL_APP_CLOCKS  = 80   # Perf Policy Counter for Total App Clock Policy
-NVML_FI_DEV_PERF_POLICY_TOTAL_BASE_CLOCKS = 81   # Perf Policy Counter for Total Base Clocks Policy
+NVML_FI_DEV_PERF_POLICY_POWER = 74  # Perf Policy Counter for Power Policy
+NVML_FI_DEV_PERF_POLICY_THERMAL = 75  # Perf Policy Counter for Thermal Policy
+NVML_FI_DEV_PERF_POLICY_SYNC_BOOST = 76  # Perf Policy Counter for Sync boost Policy
+NVML_FI_DEV_PERF_POLICY_BOARD_LIMIT = 77  # Perf Policy Counter for Board Limit
+NVML_FI_DEV_PERF_POLICY_LOW_UTILIZATION = (
+    78  # Perf Policy Counter for Low GPU Utilization Policy
+)
+NVML_FI_DEV_PERF_POLICY_RELIABILITY = 79  # Perf Policy Counter for Reliability Policy
+NVML_FI_DEV_PERF_POLICY_TOTAL_APP_CLOCKS = (
+    80  # Perf Policy Counter for Total App Clock Policy
+)
+NVML_FI_DEV_PERF_POLICY_TOTAL_BASE_CLOCKS = (
+    81  # Perf Policy Counter for Total Base Clocks Policy
+)
 
 # Memory temperatures
-NVML_FI_DEV_MEMORY_TEMP  = 82 # Memory temperature for the device
+NVML_FI_DEV_MEMORY_TEMP = 82  # Memory temperature for the device
 
 # Energy Counter
-NVML_FI_DEV_TOTAL_ENERGY_CONSUMPTION = 83 # Total energy consumption for the GPU in mJ since the driver was last reloaded
+NVML_FI_DEV_TOTAL_ENERGY_CONSUMPTION = (
+    83  # Total energy consumption for the GPU in mJ since the driver was last reloaded
+)
 
 # NVLink Speed
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L0     = 84
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L1     = 85
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L2     = 86
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L3     = 87
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L4     = 88
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L5     = 89
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L0 = 84
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L1 = 85
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L2 = 86
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L3 = 87
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L4 = 88
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L5 = 89
 NVML_FI_DEV_NVLINK_SPEED_MBPS_COMMON = 90
 
 # NVLink Link Count
@@ -622,307 +718,451 @@ NVML_FI_DEV_PCIE_REPLAY_COUNTER = 94
 NVML_FI_DEV_PCIE_REPLAY_ROLLOVER_COUNTER = 95
 
 # NvLink Flit Error Counters
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L6   = 96 # NVLink flow control CRC  Error Counter for Lane 6
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L7   = 97 # NVLink flow control CRC  Error Counter for Lane 7
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L8   = 98 # NVLink flow control CRC  Error Counter for Lane 8
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L9   = 99 # NVLink flow control CRC  Error Counter for Lane 9
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L10  = 100 # NVLink flow control CRC  Error Counter for Lane 10
-NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L11  = 101 # NVLink flow control CRC  Error Counter for Lane 11
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L6 = (
+    96  # NVLink flow control CRC  Error Counter for Lane 6
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L7 = (
+    97  # NVLink flow control CRC  Error Counter for Lane 7
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L8 = (
+    98  # NVLink flow control CRC  Error Counter for Lane 8
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L9 = (
+    99  # NVLink flow control CRC  Error Counter for Lane 9
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L10 = (
+    100  # NVLink flow control CRC  Error Counter for Lane 10
+)
+NVML_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L11 = (
+    101  # NVLink flow control CRC  Error Counter for Lane 11
+)
 
 # NvLink CRC Data Error Counters
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L6   = 102 # NVLink data CRC Error Counter for Lane 6
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L7   = 103 # NVLink data CRC Error Counter for Lane 7
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L8   = 104 # NVLink data CRC Error Counter for Lane 8
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L9   = 105 # NVLink data CRC Error Counter for Lane 9
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L10  = 106 # NVLink data CRC Error Counter for Lane 10
-NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L11  = 107 # NVLink data CRC Error Counter for Lane 11
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L6 = (
+    102  # NVLink data CRC Error Counter for Lane 6
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L7 = (
+    103  # NVLink data CRC Error Counter for Lane 7
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L8 = (
+    104  # NVLink data CRC Error Counter for Lane 8
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L9 = (
+    105  # NVLink data CRC Error Counter for Lane 9
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L10 = (
+    106  # NVLink data CRC Error Counter for Lane 10
+)
+NVML_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L11 = (
+    107  # NVLink data CRC Error Counter for Lane 11
+)
 
 # NvLink Replay Error Counters
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L6     = 108 # NVLink Replay Error Counter for Lane 6
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L7     = 109 # NVLink Replay Error Counter for Lane 7
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L8     = 110 # NVLink Replay Error Counter for Lane 8
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L9     = 111 # NVLink Replay Error Counter for Lane 9
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L10    = 112 # NVLink Replay Error Counter for Lane 10
-NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L11    = 113 # NVLink Replay Error Counter for Lane 11
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L6 = 108  # NVLink Replay Error Counter for Lane 6
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L7 = 109  # NVLink Replay Error Counter for Lane 7
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L8 = 110  # NVLink Replay Error Counter for Lane 8
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L9 = 111  # NVLink Replay Error Counter for Lane 9
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L10 = (
+    112  # NVLink Replay Error Counter for Lane 10
+)
+NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L11 = (
+    113  # NVLink Replay Error Counter for Lane 11
+)
 
 # NvLink Recovery Error Counters
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L6   = 114 # NVLink Recovery Error Counter for Lane 6
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L7   = 115 # NVLink Recovery Error Counter for Lane 7
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L8   = 116 # NVLink Recovery Error Counter for Lane 8
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L9   = 117 # NVLink Recovery Error Counter for Lane 9
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L10  = 118 # NVLink Recovery Error Counter for Lane 10
-NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L11  = 119 # NVLink Recovery Error Counter for Lane 11
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L6 = (
+    114  # NVLink Recovery Error Counter for Lane 6
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L7 = (
+    115  # NVLink Recovery Error Counter for Lane 7
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L8 = (
+    116  # NVLink Recovery Error Counter for Lane 8
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L9 = (
+    117  # NVLink Recovery Error Counter for Lane 9
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L10 = (
+    118  # NVLink Recovery Error Counter for Lane 10
+)
+NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L11 = (
+    119  # NVLink Recovery Error Counter for Lane 11
+)
 
 # NvLink Bandwidth Counters
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L6    = 120 # NVLink Bandwidth Counter for Counter Set 0, Lane 6
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L7    = 121 # NVLink Bandwidth Counter for Counter Set 0, Lane 7
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L8    = 122 # NVLink Bandwidth Counter for Counter Set 0, Lane 8
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L9    = 123 # NVLink Bandwidth Counter for Counter Set 0, Lane 9
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L10   = 124 # NVLink Bandwidth Counter for Counter Set 0, Lane 10
-NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L11   = 125 # NVLink Bandwidth Counter for Counter Set 0, Lane 11
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L6 = (
+    120  # NVLink Bandwidth Counter for Counter Set 0, Lane 6
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L7 = (
+    121  # NVLink Bandwidth Counter for Counter Set 0, Lane 7
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L8 = (
+    122  # NVLink Bandwidth Counter for Counter Set 0, Lane 8
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L9 = (
+    123  # NVLink Bandwidth Counter for Counter Set 0, Lane 9
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L10 = (
+    124  # NVLink Bandwidth Counter for Counter Set 0, Lane 10
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C0_L11 = (
+    125  # NVLink Bandwidth Counter for Counter Set 0, Lane 11
+)
 
 # NvLink Bandwidth Counters
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L6    = 126 # NVLink Bandwidth Counter for Counter Set 1, Lane 6
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L7    = 127 # NVLink Bandwidth Counter for Counter Set 1, Lane 7
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L8    = 128 # NVLink Bandwidth Counter for Counter Set 1, Lane 8
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L9    = 129 # NVLink Bandwidth Counter for Counter Set 1, Lane 9
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L10   = 130 # NVLink Bandwidth Counter for Counter Set 1, Lane 10
-NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L11   = 131 # NVLink Bandwidth Counter for Counter Set 1, Lane 11
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L6 = (
+    126  # NVLink Bandwidth Counter for Counter Set 1, Lane 6
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L7 = (
+    127  # NVLink Bandwidth Counter for Counter Set 1, Lane 7
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L8 = (
+    128  # NVLink Bandwidth Counter for Counter Set 1, Lane 8
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L9 = (
+    129  # NVLink Bandwidth Counter for Counter Set 1, Lane 9
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L10 = (
+    130  # NVLink Bandwidth Counter for Counter Set 1, Lane 10
+)
+NVML_FI_DEV_NVLINK_BANDWIDTH_C1_L11 = (
+    131  # NVLink Bandwidth Counter for Counter Set 1, Lane 11
+)
 
 # NVLink Speed
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L6     = 132
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L7     = 133
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L8     = 134
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L9     = 135
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L10    = 136
-NVML_FI_DEV_NVLINK_SPEED_MBPS_L11    = 137
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L6 = 132
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L7 = 133
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L8 = 134
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L9 = 135
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L10 = 136
+NVML_FI_DEV_NVLINK_SPEED_MBPS_L11 = 137
 
 # NVLink Throughput Counters
-NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_TX = 138 # NVLink TX Data throughput in KiB
-NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_RX = 139 # NVLink RX Data throughput in KiB
-NVML_FI_DEV_NVLINK_THROUGHPUT_RAW_TX  = 140 # NVLink TX Data + protocol overhead in KiB
-NVML_FI_DEV_NVLINK_THROUGHPUT_RAW_RX  = 141 # NVLink RX Data + protocol overhead in KiB
+NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_TX = 138  # NVLink TX Data throughput in KiB
+NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_RX = 139  # NVLink RX Data throughput in KiB
+NVML_FI_DEV_NVLINK_THROUGHPUT_RAW_TX = 140  # NVLink TX Data + protocol overhead in KiB
+NVML_FI_DEV_NVLINK_THROUGHPUT_RAW_RX = 141  # NVLink RX Data + protocol overhead in KiB
 
 # Row Remapper
-NVML_FI_DEV_REMAPPED_COR        = 142
-NVML_FI_DEV_REMAPPED_UNC        = 143
-NVML_FI_DEV_REMAPPED_PENDING    = 144
-NVML_FI_DEV_REMAPPED_FAILURE    = 145
+NVML_FI_DEV_REMAPPED_COR = 142
+NVML_FI_DEV_REMAPPED_UNC = 143
+NVML_FI_DEV_REMAPPED_PENDING = 144
+NVML_FI_DEV_REMAPPED_FAILURE = 145
 
-#Remote device NVLink ID
+# Remote device NVLink ID
 NVML_FI_DEV_NVLINK_REMOTE_NVLINK_ID = 146
 
 # Number of NVLinks connected to NVSwitch
 NVML_FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT = 147
 
 # NvLink ECC Data Error Counters
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L0    = 148 #< NVLink data ECC Error Counter for Link 0
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L1    = 149 #< NVLink data ECC Error Counter for Link 1
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L2    = 150 #< NVLink data ECC Error Counter for Link 2
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L3    = 151 #< NVLink data ECC Error Counter for Link 3
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L4    = 152 #< NVLink data ECC Error Counter for Link 4
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L5    = 153 #< NVLink data ECC Error Counter for Link 5
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L6    = 154 #< NVLink data ECC Error Counter for Link 6
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L7    = 155 #< NVLink data ECC Error Counter for Link 7
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L8    = 156 #< NVLink data ECC Error Counter for Link 8
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L9    = 157 #< NVLink data ECC Error Counter for Link 9
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L10   = 158 #< NVLink data ECC Error Counter for Link 10
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L11   = 159 #< NVLink data ECC Error Counter for Link 11
-NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL = 160 #< NvLink data ECC Error Counter total for all Links
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L0 = (
+    148  # < NVLink data ECC Error Counter for Link 0
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L1 = (
+    149  # < NVLink data ECC Error Counter for Link 1
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L2 = (
+    150  # < NVLink data ECC Error Counter for Link 2
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L3 = (
+    151  # < NVLink data ECC Error Counter for Link 3
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L4 = (
+    152  # < NVLink data ECC Error Counter for Link 4
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L5 = (
+    153  # < NVLink data ECC Error Counter for Link 5
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L6 = (
+    154  # < NVLink data ECC Error Counter for Link 6
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L7 = (
+    155  # < NVLink data ECC Error Counter for Link 7
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L8 = (
+    156  # < NVLink data ECC Error Counter for Link 8
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L9 = (
+    157  # < NVLink data ECC Error Counter for Link 9
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L10 = (
+    158  # < NVLink data ECC Error Counter for Link 10
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L11 = (
+    159  # < NVLink data ECC Error Counter for Link 11
+)
+NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL = (
+    160  # < NvLink data ECC Error Counter total for all Links
+)
 
-NVML_FI_DEV_NVLINK_ERROR_DL_REPLAY            = 161
-NVML_FI_DEV_NVLINK_ERROR_DL_RECOVERY          = 162
-NVML_FI_DEV_NVLINK_ERROR_DL_CRC               = 163
-NVML_FI_DEV_NVLINK_GET_SPEED                  = 164
-NVML_FI_DEV_NVLINK_GET_STATE                  = 165
-NVML_FI_DEV_NVLINK_GET_VERSION                = 166
+NVML_FI_DEV_NVLINK_ERROR_DL_REPLAY = 161
+NVML_FI_DEV_NVLINK_ERROR_DL_RECOVERY = 162
+NVML_FI_DEV_NVLINK_ERROR_DL_CRC = 163
+NVML_FI_DEV_NVLINK_GET_SPEED = 164
+NVML_FI_DEV_NVLINK_GET_STATE = 165
+NVML_FI_DEV_NVLINK_GET_VERSION = 166
 
-NVML_FI_DEV_NVLINK_GET_POWER_STATE            = 167
-NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD        = 168
+NVML_FI_DEV_NVLINK_GET_POWER_STATE = 167
+NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD = 168
 
-NVML_FI_DEV_PCIE_L0_TO_RECOVERY_COUNTER       = 169
+NVML_FI_DEV_PCIE_L0_TO_RECOVERY_COUNTER = 169
 
-NVML_FI_DEV_C2C_LINK_COUNT                    = 170
-NVML_FI_DEV_C2C_LINK_GET_STATUS               = 171
-NVML_FI_DEV_C2C_LINK_GET_MAX_BW               = 172
+NVML_FI_DEV_C2C_LINK_COUNT = 170
+NVML_FI_DEV_C2C_LINK_GET_STATUS = 171
+NVML_FI_DEV_C2C_LINK_GET_MAX_BW = 172
 
-NVML_FI_DEV_PCIE_COUNT_CORRECTABLE_ERRORS     = 173
-NVML_FI_DEV_PCIE_COUNT_NAKS_RECEIVED          = 174
-NVML_FI_DEV_PCIE_COUNT_RECEIVER_ERROR         = 175
-NVML_FI_DEV_PCIE_COUNT_BAD_TLP                = 176
-NVML_FI_DEV_PCIE_COUNT_NAKS_SENT              = 177
-NVML_FI_DEV_PCIE_COUNT_BAD_DLLP               = 178
-NVML_FI_DEV_PCIE_COUNT_NON_FATAL_ERROR        = 179
-NVML_FI_DEV_PCIE_COUNT_FATAL_ERROR            = 180
-NVML_FI_DEV_PCIE_COUNT_UNSUPPORTED_REQ        = 181
-NVML_FI_DEV_PCIE_COUNT_LCRC_ERROR             = 182
-NVML_FI_DEV_PCIE_COUNT_LANE_ERROR             = 183
+NVML_FI_DEV_PCIE_COUNT_CORRECTABLE_ERRORS = 173
+NVML_FI_DEV_PCIE_COUNT_NAKS_RECEIVED = 174
+NVML_FI_DEV_PCIE_COUNT_RECEIVER_ERROR = 175
+NVML_FI_DEV_PCIE_COUNT_BAD_TLP = 176
+NVML_FI_DEV_PCIE_COUNT_NAKS_SENT = 177
+NVML_FI_DEV_PCIE_COUNT_BAD_DLLP = 178
+NVML_FI_DEV_PCIE_COUNT_NON_FATAL_ERROR = 179
+NVML_FI_DEV_PCIE_COUNT_FATAL_ERROR = 180
+NVML_FI_DEV_PCIE_COUNT_UNSUPPORTED_REQ = 181
+NVML_FI_DEV_PCIE_COUNT_LCRC_ERROR = 182
+NVML_FI_DEV_PCIE_COUNT_LANE_ERROR = 183
 
-NVML_FI_DEV_IS_RESETLESS_MIG_SUPPORTED        = 184
+NVML_FI_DEV_IS_RESETLESS_MIG_SUPPORTED = 184
 
-NVML_FI_DEV_POWER_AVERAGE                     = 185
-NVML_FI_DEV_POWER_INSTANT                     = 186
-NVML_FI_DEV_POWER_MIN_LIMIT                   = 187
-NVML_FI_DEV_POWER_MAX_LIMIT                   = 188
-NVML_FI_DEV_POWER_DEFAULT_LIMIT               = 189
-NVML_FI_DEV_POWER_CURRENT_LIMIT               = 190
-NVML_FI_DEV_ENERGY                            = 191
-NVML_FI_DEV_POWER_REQUESTED_LIMIT             = 192
+NVML_FI_DEV_POWER_AVERAGE = 185
+NVML_FI_DEV_POWER_INSTANT = 186
+NVML_FI_DEV_POWER_MIN_LIMIT = 187
+NVML_FI_DEV_POWER_MAX_LIMIT = 188
+NVML_FI_DEV_POWER_DEFAULT_LIMIT = 189
+NVML_FI_DEV_POWER_CURRENT_LIMIT = 190
+NVML_FI_DEV_ENERGY = 191
+NVML_FI_DEV_POWER_REQUESTED_LIMIT = 192
 
-NVML_FI_DEV_TEMPERATURE_SHUTDOWN_TLIMIT       = 193
-NVML_FI_DEV_TEMPERATURE_SLOWDOWN_TLIMIT       = 194
-NVML_FI_DEV_TEMPERATURE_MEM_MAX_TLIMIT        = 195
-NVML_FI_DEV_TEMPERATURE_GPU_MAX_TLIMIT        = 196
+NVML_FI_DEV_TEMPERATURE_SHUTDOWN_TLIMIT = 193
+NVML_FI_DEV_TEMPERATURE_SLOWDOWN_TLIMIT = 194
+NVML_FI_DEV_TEMPERATURE_MEM_MAX_TLIMIT = 195
+NVML_FI_DEV_TEMPERATURE_GPU_MAX_TLIMIT = 196
 
-NVML_FI_DEV_PCIE_COUNT_TX_BYTES               = 197
-NVML_FI_DEV_PCIE_COUNT_RX_BYTES               = 198
+NVML_FI_DEV_PCIE_COUNT_TX_BYTES = 197
+NVML_FI_DEV_PCIE_COUNT_RX_BYTES = 198
 
-NVML_FI_DEV_IS_MIG_MODE_INDEPENDENT_MIG_QUERY_CAPABLE   = 199
+NVML_FI_DEV_IS_MIG_MODE_INDEPENDENT_MIG_QUERY_CAPABLE = 199
 
-NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_MAX              = 200
+NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_MAX = 200
 
-NVML_FI_DEV_NVLINK_COUNT_XMIT_PACKETS                    = 201
-NVML_FI_DEV_NVLINK_COUNT_XMIT_BYTES                      = 202
-NVML_FI_DEV_NVLINK_COUNT_RCV_PACKETS                     = 203
-NVML_FI_DEV_NVLINK_COUNT_RCV_BYTES                       = 204
-NVML_FI_DEV_NVLINK_COUNT_VL15_DROPPED                    = 205 # Deprecated, do not use
-NVML_FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS         = 206
-NVML_FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS           = 207
-NVML_FI_DEV_NVLINK_COUNT_RCV_ERRORS                      = 208
-NVML_FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS               = 209
-NVML_FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS              = 210
-NVML_FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS     = 211
-NVML_FI_DEV_NVLINK_COUNT_XMIT_DISCARDS                   = 212
+NVML_FI_DEV_NVLINK_COUNT_XMIT_PACKETS = 201
+NVML_FI_DEV_NVLINK_COUNT_XMIT_BYTES = 202
+NVML_FI_DEV_NVLINK_COUNT_RCV_PACKETS = 203
+NVML_FI_DEV_NVLINK_COUNT_RCV_BYTES = 204
+NVML_FI_DEV_NVLINK_COUNT_VL15_DROPPED = 205  # Deprecated, do not use
+NVML_FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS = 206
+NVML_FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS = 207
+NVML_FI_DEV_NVLINK_COUNT_RCV_ERRORS = 208
+NVML_FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS = 209
+NVML_FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS = 210
+NVML_FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS = 211
+NVML_FI_DEV_NVLINK_COUNT_XMIT_DISCARDS = 212
 
 NVML_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS = 213
-NVML_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS     = 214
-NVML_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS            = 215
+NVML_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS = 214
+NVML_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS = 215
 
-NVML_FI_DEV_NVLINK_COUNT_RAW_BER_LANE0                   = 216  # Deprecated, do not use
-NVML_FI_DEV_NVLINK_COUNT_RAW_BER_LANE1                   = 217  # Deprecated, do not use
-NVML_FI_DEV_NVLINK_COUNT_RAW_BER                         = 218  # Deprecated, do not use
-NVML_FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS                = 219
-NVML_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER                   = 220
-NVML_FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS                   = 221
-NVML_FI_DEV_NVLINK_COUNT_SYMBOL_BER                      = 222
+NVML_FI_DEV_NVLINK_COUNT_RAW_BER_LANE0 = 216  # Deprecated, do not use
+NVML_FI_DEV_NVLINK_COUNT_RAW_BER_LANE1 = 217  # Deprecated, do not use
+NVML_FI_DEV_NVLINK_COUNT_RAW_BER = 218  # Deprecated, do not use
+NVML_FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS = 219
+NVML_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER = 220
+NVML_FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS = 221
+NVML_FI_DEV_NVLINK_COUNT_SYMBOL_BER = 222
 
-NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_MIN               = 223
-NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_UNITS             = 224 # Values are in the form NVML_NVLINK_LOW_POWER_THRESHOLD_UNIT_*
-NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_SUPPORTED         = 225
+NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_MIN = 223
+NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_UNITS = (
+    224  # Values are in the form NVML_NVLINK_LOW_POWER_THRESHOLD_UNIT_*
+)
+NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_SUPPORTED = 225
 
-NVML_FI_DEV_RESET_STATUS                                 = 226 # Deprecated use NVML_FI_DEV_GET_GPU_RECOVERY_ACTION instead 
-NVML_FI_DEV_DRAIN_AND_RESET_STATUS                       = 227 # Deprecated use NVML_FI_DEV_GET_GPU_RECOVERY_ACTION instead
-NVML_FI_DEV_PCIE_OUTBOUND_ATOMICS_MASK                   = 228
-NVML_FI_DEV_PCIE_INBOUND_ATOMICS_MASK                    = 229
-NVML_FI_DEV_GET_GPU_RECOVERY_ACTION                      = 230
+NVML_FI_DEV_RESET_STATUS = (
+    226  # Deprecated use NVML_FI_DEV_GET_GPU_RECOVERY_ACTION instead
+)
+NVML_FI_DEV_DRAIN_AND_RESET_STATUS = (
+    227  # Deprecated use NVML_FI_DEV_GET_GPU_RECOVERY_ACTION instead
+)
+NVML_FI_DEV_PCIE_OUTBOUND_ATOMICS_MASK = 228
+NVML_FI_DEV_PCIE_INBOUND_ATOMICS_MASK = 229
+NVML_FI_DEV_GET_GPU_RECOVERY_ACTION = 230
 
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_0                   = 235
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_1                   = 236
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_2                   = 237
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_3                   = 238
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_4                   = 239
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_5                   = 240
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_6                   = 241
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_7                   = 242
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_8                   = 243
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_9                   = 244
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_10                  = 245
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_11                  = 246
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_12                  = 247
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_13                  = 248
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_14                  = 249
-NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_15                  = 250
-NVML_FI_PWR_SMOOTHING_ENABLED                                   = 251 # Enablement (0/DISABLED or 1/ENABLED)
-NVML_FI_PWR_SMOOTHING_PRIV_LVL                                  = 252 # Current privilege level
-NVML_FI_PWR_SMOOTHING_IMM_RAMP_DOWN_ENABLED                     = 253 # Immediate ramp down enablement (0/DISABLED or 1/ENABLED)
-NVML_FI_PWR_SMOOTHING_APPLIED_TMP_CEIL                          = 254 # Applied TMP ceiling value
-NVML_FI_PWR_SMOOTHING_APPLIED_TMP_FLOOR                         = 255 # Applied TMP floor value
-NVML_FI_PWR_SMOOTHING_MAX_PERCENT_TMP_FLOOR_SETTING             = 256 # Max % TMP Floor value
-NVML_FI_PWR_SMOOTHING_MIN_PERCENT_TMP_FLOOR_SETTING             = 257 # Min % TMP Floor value
-NVML_FI_PWR_SMOOTHING_HW_CIRCUITRY_PERCENT_LIFETIME_REMAINING   = 258 # HW Circuitry % lifetime remaining
-NVML_FI_PWR_SMOOTHING_MAX_NUM_PRESET_PROFILES                   = 259 # Max number of preset profiles
-NVML_FI_PWR_SMOOTHING_PROFILE_PERCENT_TMP_FLOOR                 = 260 # % TMP floor for a given profile
-NVML_FI_PWR_SMOOTHING_PROFILE_RAMP_UP_RATE                      = 261 # Ramp up rate in mW/s for a given profile
-NVML_FI_PWR_SMOOTHING_PROFILE_RAMP_DOWN_RATE                    = 262 # Ramp down rate in mW/s for a given profile
-NVML_FI_PWR_SMOOTHING_PROFILE_RAMP_DOWN_HYST_VAL                = 263 # Ramp down hysteresis value in ms for a given profile
-NVML_FI_PWR_SMOOTHING_ACTIVE_PRESET_PROFILE                     = 264 # Active preset profile number
-NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_PERCENT_TMP_FLOOR          = 265 # % TMP floor for a given profile
-NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_UP_RATE               = 266 # Ramp up rate in mW/s for a given profile
-NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_RATE             = 267 # Ramp down rate in mW/s for a given profile
-NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL         = 268 # Ramp down hysteresis value in ms for a given profile
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_0 = 235
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_1 = 236
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_2 = 237
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_3 = 238
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_4 = 239
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_5 = 240
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_6 = 241
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_7 = 242
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_8 = 243
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_9 = 244
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_10 = 245
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_11 = 246
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_12 = 247
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_13 = 248
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_14 = 249
+NVML_FI_DEV_NVLINK_COUNT_FEC_HISTORY_15 = 250
+NVML_FI_PWR_SMOOTHING_ENABLED = 251  # Enablement (0/DISABLED or 1/ENABLED)
+NVML_FI_PWR_SMOOTHING_PRIV_LVL = 252  # Current privilege level
+NVML_FI_PWR_SMOOTHING_IMM_RAMP_DOWN_ENABLED = (
+    253  # Immediate ramp down enablement (0/DISABLED or 1/ENABLED)
+)
+NVML_FI_PWR_SMOOTHING_APPLIED_TMP_CEIL = 254  # Applied TMP ceiling value
+NVML_FI_PWR_SMOOTHING_APPLIED_TMP_FLOOR = 255  # Applied TMP floor value
+NVML_FI_PWR_SMOOTHING_MAX_PERCENT_TMP_FLOOR_SETTING = 256  # Max % TMP Floor value
+NVML_FI_PWR_SMOOTHING_MIN_PERCENT_TMP_FLOOR_SETTING = 257  # Min % TMP Floor value
+NVML_FI_PWR_SMOOTHING_HW_CIRCUITRY_PERCENT_LIFETIME_REMAINING = (
+    258  # HW Circuitry % lifetime remaining
+)
+NVML_FI_PWR_SMOOTHING_MAX_NUM_PRESET_PROFILES = 259  # Max number of preset profiles
+NVML_FI_PWR_SMOOTHING_PROFILE_PERCENT_TMP_FLOOR = 260  # % TMP floor for a given profile
+NVML_FI_PWR_SMOOTHING_PROFILE_RAMP_UP_RATE = (
+    261  # Ramp up rate in mW/s for a given profile
+)
+NVML_FI_PWR_SMOOTHING_PROFILE_RAMP_DOWN_RATE = (
+    262  # Ramp down rate in mW/s for a given profile
+)
+NVML_FI_PWR_SMOOTHING_PROFILE_RAMP_DOWN_HYST_VAL = (
+    263  # Ramp down hysteresis value in ms for a given profile
+)
+NVML_FI_PWR_SMOOTHING_ACTIVE_PRESET_PROFILE = 264  # Active preset profile number
+NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_PERCENT_TMP_FLOOR = (
+    265  # % TMP floor for a given profile
+)
+NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_UP_RATE = (
+    266  # Ramp up rate in mW/s for a given profile
+)
+NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_RATE = (
+    267  # Ramp down rate in mW/s for a given profile
+)
+NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL = (
+    268  # Ramp down hysteresis value in ms for a given profile
+)
 
-NVML_FI_MAX = 269 # One greater than the largest field ID defined above
+NVML_FI_MAX = 269  # One greater than the largest field ID defined above
 
 # NVML_FI_DEV_NVLINK_GET_STATE state enums
 NVML_NVLINK_STATE_INACTIVE = 0x0
-NVML_NVLINK_STATE_ACTIVE   = 0x1
-NVML_NVLINK_STATE_SLEEP    = 0x2
+NVML_NVLINK_STATE_ACTIVE = 0x1
+NVML_NVLINK_STATE_SLEEP = 0x2
 
-NVML_NVLINK_LOW_POWER_THRESHOLD_UNIT_100US = 0 # NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_UNITS
-NVML_NVLINK_LOW_POWER_THRESHOLD_UNIT_50US  = 1 # NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_UNITS
+NVML_NVLINK_LOW_POWER_THRESHOLD_UNIT_100US = (
+    0  # NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_UNITS
+)
+NVML_NVLINK_LOW_POWER_THRESHOLD_UNIT_50US = (
+    1  # NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_UNITS
+)
 
 ## Enums needed for the method nvmlDeviceGetVirtualizationMode and nvmlDeviceSetVirtualizationMode
-NVML_GPU_VIRTUALIZATION_MODE_NONE        = 0  # Represents Bare Metal GPU
-NVML_GPU_VIRTUALIZATION_MODE_PASSTHROUGH = 1  # Device is associated with GPU-Passthorugh
-NVML_GPU_VIRTUALIZATION_MODE_VGPU        = 2  # Device is associated with vGPU inside virtual machine.
-NVML_GPU_VIRTUALIZATION_MODE_HOST_VGPU   = 3  # Device is associated with VGX hypervisor in vGPU mode
-NVML_GPU_VIRTUALIZATION_MODE_HOST_VSGA   = 4  # Device is associated with VGX hypervisor in vSGA mode
+NVML_GPU_VIRTUALIZATION_MODE_NONE = 0  # Represents Bare Metal GPU
+NVML_GPU_VIRTUALIZATION_MODE_PASSTHROUGH = (
+    1  # Device is associated with GPU-Passthorugh
+)
+NVML_GPU_VIRTUALIZATION_MODE_VGPU = (
+    2  # Device is associated with vGPU inside virtual machine.
+)
+NVML_GPU_VIRTUALIZATION_MODE_HOST_VGPU = (
+    3  # Device is associated with VGX hypervisor in vGPU mode
+)
+NVML_GPU_VIRTUALIZATION_MODE_HOST_VSGA = (
+    4  # Device is associated with VGX hypervisor in vSGA mode
+)
 
 ## Lib loading ##
 nvmlLib = None
 libLoadLock = threading.Lock()
-_nvmlLib_refcount = 0 # Incremented on each nvmlInit and decremented on nvmlShutdown
+_nvmlLib_refcount = 0  # Incremented on each nvmlInit and decremented on nvmlShutdown
 
 ## vGPU Management
-_nvmlVgpuTypeId_t   = c_uint
+_nvmlVgpuTypeId_t = c_uint
 _nvmlVgpuInstance_t = c_uint
 
 _nvmlVgpuVmIdType_t = c_uint
-NVML_VGPU_VM_ID_DOMAIN_ID    = 0
-NVML_VGPU_VM_ID_UUID         = 1
+NVML_VGPU_VM_ID_DOMAIN_ID = 0
+NVML_VGPU_VM_ID_UUID = 1
 
 _nvmlGridLicenseFeatureCode_t = c_uint
-NVML_GRID_LICENSE_FEATURE_CODE_UNKNOWN      = 0
-NVML_GRID_LICENSE_FEATURE_CODE_VGPU         = 1
-NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX   = 2
-NVML_GRID_LICENSE_FEATURE_CODE_VWORKSTATION = 2 # deprecated, use NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX.
-NVML_GRID_LICENSE_FEATURE_CODE_GAMING       = 3
-NVML_GRID_LICENSE_FEATURE_CODE_COMPUTE      = 4
+NVML_GRID_LICENSE_FEATURE_CODE_UNKNOWN = 0
+NVML_GRID_LICENSE_FEATURE_CODE_VGPU = 1
+NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX = 2
+NVML_GRID_LICENSE_FEATURE_CODE_VWORKSTATION = (
+    2  # deprecated, use NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX.
+)
+NVML_GRID_LICENSE_FEATURE_CODE_GAMING = 3
+NVML_GRID_LICENSE_FEATURE_CODE_COMPUTE = 4
 
 _nvmlGridLicenseExpiryStatus_t = c_uint8
-NVML_GRID_LICENSE_EXPIRY_NOT_AVAILABLE    = 0,   # Expiry information not available
-NVML_GRID_LICENSE_EXPIRY_INVALID          = 1,   # Invalid expiry or error fetching expiry
-NVML_GRID_LICENSE_EXPIRY_VALID            = 2,   # Valid expiry
-NVML_GRID_LICENSE_EXPIRY_NOT_APPLICABLE   = 3,   # Expiry not applicable
-NVML_GRID_LICENSE_EXPIRY_PERMANENT        = 4,   # Permanent expiry
+NVML_GRID_LICENSE_EXPIRY_NOT_AVAILABLE = (0,)  # Expiry information not available
+NVML_GRID_LICENSE_EXPIRY_INVALID = (1,)  # Invalid expiry or error fetching expiry
+NVML_GRID_LICENSE_EXPIRY_VALID = (2,)  # Valid expiry
+NVML_GRID_LICENSE_EXPIRY_NOT_APPLICABLE = (3,)  # Expiry not applicable
+NVML_GRID_LICENSE_EXPIRY_PERMANENT = (4,)  # Permanent expiry
 
 _nvmlVgpuCapability_t = c_uint
-NVML_VGPU_CAP_NVLINK_P2P                    = 0  # vGPU P2P over NVLink is supported
-NVML_VGPU_CAP_GPUDIRECT                     = 1  # GPUDirect capability is supported
-NVML_VGPU_CAP_MULTI_VGPU_EXCLUSIVE          = 2  # vGPU profile cannot be mixed with other vGPU profiles in same VM
-NVML_VGPU_CAP_EXCLUSIVE_TYPE                = 3  # vGPU profile cannot run on a GPU alongside other profiles of different type
-NVML_VGPU_CAP_EXCLUSIVE_SIZE                = 4  # vGPU profile cannot run on a GPU alongside other profiles of different size
-NVML_VGPU_CAP_COUNT                         = 5
+NVML_VGPU_CAP_NVLINK_P2P = 0  # vGPU P2P over NVLink is supported
+NVML_VGPU_CAP_GPUDIRECT = 1  # GPUDirect capability is supported
+NVML_VGPU_CAP_MULTI_VGPU_EXCLUSIVE = (
+    2  # vGPU profile cannot be mixed with other vGPU profiles in same VM
+)
+NVML_VGPU_CAP_EXCLUSIVE_TYPE = (
+    3  # vGPU profile cannot run on a GPU alongside other profiles of different type
+)
+NVML_VGPU_CAP_EXCLUSIVE_SIZE = (
+    4  # vGPU profile cannot run on a GPU alongside other profiles of different size
+)
+NVML_VGPU_CAP_COUNT = 5
 
 _nvmlVgpuDriverCapability_t = c_uint
-NVML_VGPU_DRIVER_CAP_HETEROGENEOUS_MULTI_VGPU   = 0  # Supports mixing of different vGPU profiles within one guest VM
-NVML_VGPU_DRIVER_CAP_WARM_UPDATE                = 1  # Supports FSR and warm update of vGPU host driver without terminating the running guest VM
-NVML_VGPU_DRIVER_CAP_COUNT                      = 2
+NVML_VGPU_DRIVER_CAP_HETEROGENEOUS_MULTI_VGPU = (
+    0  # Supports mixing of different vGPU profiles within one guest VM
+)
+NVML_VGPU_DRIVER_CAP_WARM_UPDATE = 1  # Supports FSR and warm update of vGPU host driver without terminating the running guest VM
+NVML_VGPU_DRIVER_CAP_COUNT = 2
 
 _nvmlDeviceVgpuCapability_t = c_uint
-NVML_DEVICE_VGPU_CAP_FRACTIONAL_MULTI_VGPU             = 0  # Query whether the fractional vGPU profiles on this GPU can be used in multi-vGPU configurations
-NVML_DEVICE_VGPU_CAP_HETEROGENEOUS_TIMESLICE_PROFILES  = 1  # Query whether the GPU supports concurrent execution of timesliced vGPU profiles of differing types
-NVML_DEVICE_VGPU_CAP_HETEROGENEOUS_TIMESLICE_SIZES     = 2  # Query whether the GPU supports concurrent execution of timesliced vGPU profiles of differing framebuffer sizes
-NVML_DEVICE_VGPU_CAP_READ_DEVICE_BUFFER_BW             = 3  # Query the GPU's read_device_buffer expected bandwidth capacity in megabytes per second
-NVML_DEVICE_VGPU_CAP_WRITE_DEVICE_BUFFER_BW            = 4  # Query the GPU's write_device_buffer expected bandwidth capacity in megabytes per second
-NVML_DEVICE_VGPU_CAP_DEVICE_STREAMING                  = 5  # Query whether the vGPU profiles on the GPU supports migration data streaming
-NVML_DEVICE_VGPU_CAP_MINI_QUARTER_GPU                  = 6  # Set/Get support of mini-quarter vGPU profiles
-NVML_DEVICE_VGPU_CAP_COMPUTE_MEDIA_ENGINE_GPU          = 7  # Set/Get support for compute media engine vGPU profiles
-NVML_DEVICE_VGPU_CAP_WARM_UPDATE                       = 8  # Query whether the GPU supports FSR and warm update
-NVML_DEVICE_VGPU_CAP_HOMOGENEOUS_PLACEMENTS            = 9  # Query whether the GPU supports reporting of placements of timesliced vGPU profiles with identical framebuffer sizes
-NVML_DEVICE_VGPU_CAP_COUNT                             = 10
+NVML_DEVICE_VGPU_CAP_FRACTIONAL_MULTI_VGPU = 0  # Query whether the fractional vGPU profiles on this GPU can be used in multi-vGPU configurations
+NVML_DEVICE_VGPU_CAP_HETEROGENEOUS_TIMESLICE_PROFILES = 1  # Query whether the GPU supports concurrent execution of timesliced vGPU profiles of differing types
+NVML_DEVICE_VGPU_CAP_HETEROGENEOUS_TIMESLICE_SIZES = 2  # Query whether the GPU supports concurrent execution of timesliced vGPU profiles of differing framebuffer sizes
+NVML_DEVICE_VGPU_CAP_READ_DEVICE_BUFFER_BW = 3  # Query the GPU's read_device_buffer expected bandwidth capacity in megabytes per second
+NVML_DEVICE_VGPU_CAP_WRITE_DEVICE_BUFFER_BW = 4  # Query the GPU's write_device_buffer expected bandwidth capacity in megabytes per second
+NVML_DEVICE_VGPU_CAP_DEVICE_STREAMING = (
+    5  # Query whether the vGPU profiles on the GPU supports migration data streaming
+)
+NVML_DEVICE_VGPU_CAP_MINI_QUARTER_GPU = (
+    6  # Set/Get support of mini-quarter vGPU profiles
+)
+NVML_DEVICE_VGPU_CAP_COMPUTE_MEDIA_ENGINE_GPU = (
+    7  # Set/Get support for compute media engine vGPU profiles
+)
+NVML_DEVICE_VGPU_CAP_WARM_UPDATE = (
+    8  # Query whether the GPU supports FSR and warm update
+)
+NVML_DEVICE_VGPU_CAP_HOMOGENEOUS_PLACEMENTS = 9  # Query whether the GPU supports reporting of placements of timesliced vGPU profiles with identical framebuffer sizes
+NVML_DEVICE_VGPU_CAP_COUNT = 10
 
 _nvmlVgpuGuestInfoState_t = c_uint
 NVML_VGPU_INSTANCE_GUEST_INFO_STATE_UNINITIALIZED = 0
-NVML_VGPU_INSTANCE_GUEST_INFO_STATE_INITIALIZED   = 1
+NVML_VGPU_INSTANCE_GUEST_INFO_STATE_INITIALIZED = 1
 
 _nvmlVgpuVmCompatibility_t = c_uint
-NVML_VGPU_VM_COMPATIBILITY_NONE         = 0x0
-NVML_VGPU_VM_COMPATIBILITY_COLD         = 0x1
-NVML_VGPU_VM_COMPATIBILITY_HIBERNATE    = 0x2
-NVML_VGPU_VM_COMPATIBILITY_SLEEP        = 0x4
-NVML_VGPU_VM_COMPATIBILITY_LIVE         = 0x8
+NVML_VGPU_VM_COMPATIBILITY_NONE = 0x0
+NVML_VGPU_VM_COMPATIBILITY_COLD = 0x1
+NVML_VGPU_VM_COMPATIBILITY_HIBERNATE = 0x2
+NVML_VGPU_VM_COMPATIBILITY_SLEEP = 0x4
+NVML_VGPU_VM_COMPATIBILITY_LIVE = 0x8
 
 _nvmlVgpuPgpuCompatibilityLimitCode_t = c_uint
-NVML_VGPU_COMPATIBILITY_LIMIT_NONE          = 0x0
-NVML_VGPU_COMPATIBILITY_LIMIT_HOST_DRIVER   = 0x1
-NVML_VGPU_COMPATIBILITY_LIMIT_GUEST_DRIVER  = 0x2
-NVML_VGPU_COMPATIBILITY_LIMIT_GPU           = 0x4
-NVML_VGPU_COMPATIBILITY_LIMIT_OTHER         = 0x80000000
+NVML_VGPU_COMPATIBILITY_LIMIT_NONE = 0x0
+NVML_VGPU_COMPATIBILITY_LIMIT_HOST_DRIVER = 0x1
+NVML_VGPU_COMPATIBILITY_LIMIT_GUEST_DRIVER = 0x2
+NVML_VGPU_COMPATIBILITY_LIMIT_GPU = 0x4
+NVML_VGPU_COMPATIBILITY_LIMIT_OTHER = 0x80000000
 
 _nvmlHostVgpuMode_t = c_uint
-NVML_HOST_VGPU_MODE_NON_SRIOV   = 0
-NVML_HOST_VGPU_MODE_SRIOV       = 1
+NVML_HOST_VGPU_MODE_NON_SRIOV = 0
+NVML_HOST_VGPU_MODE_SRIOV = 1
 
 _nvmlConfComputeGpusReadyState_t = c_uint
 NVML_CC_ACCEPTING_CLIENT_REQUESTS_FALSE = 0
@@ -945,11 +1185,11 @@ NVML_CC_SYSTEM_DEVTOOLS_MODE_ON = 1
 
 NVML_CC_SYSTEM_MULTIGPU_NONE = 0
 NVML_CC_SYSTEM_MULTIGPU_PROTECTED_PCIE = 1
- 
+
 NVML_CC_SYSTEM_ENVIRONMENT_UNAVAILABLE = 0
 NVML_CC_SYSTEM_ENVIRONMENT_SIM = 1
 NVML_CC_SYSTEM_ENVIRONMENT_PROD = 2
- 
+
 _nvmlConfComputeCcFeature_t = c_uint
 NVML_CC_SYSTEM_FEATURE_DISABLED = 0
 NVML_CC_SYSTEM_FEATURE_ENABLED = 1
@@ -961,62 +1201,71 @@ NVML_CC_KEY_ROTATION_THRESH_ATTACKER_ADVANTAGE_MAX = 65
 # GSP firmware
 NVML_GSP_FIRMWARE_VERSION_BUF_SIZE = 0x40
 
+
 class NVMLLibraryMismatchError(Exception):
     pass
+
 
 ## Error Checking ##
 class NVMLError(Exception):
     _valClassMapping = dict()
     # List of currently known error codes
     _errcode_to_string = {
-        NVML_ERROR_UNINITIALIZED:       "Uninitialized",
-        NVML_ERROR_INVALID_ARGUMENT:    "Invalid Argument",
-        NVML_ERROR_NOT_SUPPORTED:       "Not Supported",
-        NVML_ERROR_NO_PERMISSION:       "Insufficient Permissions",
+        NVML_ERROR_UNINITIALIZED: "Uninitialized",
+        NVML_ERROR_INVALID_ARGUMENT: "Invalid Argument",
+        NVML_ERROR_NOT_SUPPORTED: "Not Supported",
+        NVML_ERROR_NO_PERMISSION: "Insufficient Permissions",
         NVML_ERROR_ALREADY_INITIALIZED: "Already Initialized",
-        NVML_ERROR_NOT_FOUND:           "Not Found",
-        NVML_ERROR_INSUFFICIENT_SIZE:   "Insufficient Size",
-        NVML_ERROR_INSUFFICIENT_POWER:  "Insufficient External Power",
-        NVML_ERROR_DRIVER_NOT_LOADED:   "Driver Not Loaded",
-        NVML_ERROR_TIMEOUT:             "Timeout",
-        NVML_ERROR_IRQ_ISSUE:           "Interrupt Request Issue",
-        NVML_ERROR_LIBRARY_NOT_FOUND:   "NVML Shared Library Not Found",
-        NVML_ERROR_FUNCTION_NOT_FOUND:  "Function Not Found",
-        NVML_ERROR_CORRUPTED_INFOROM:   "Corrupted infoROM",
-        NVML_ERROR_GPU_IS_LOST:         "GPU is lost",
-        NVML_ERROR_RESET_REQUIRED:      "GPU requires restart",
-        NVML_ERROR_OPERATING_SYSTEM:    "The operating system has blocked the request.",
+        NVML_ERROR_NOT_FOUND: "Not Found",
+        NVML_ERROR_INSUFFICIENT_SIZE: "Insufficient Size",
+        NVML_ERROR_INSUFFICIENT_POWER: "Insufficient External Power",
+        NVML_ERROR_DRIVER_NOT_LOADED: "Driver Not Loaded",
+        NVML_ERROR_TIMEOUT: "Timeout",
+        NVML_ERROR_IRQ_ISSUE: "Interrupt Request Issue",
+        NVML_ERROR_LIBRARY_NOT_FOUND: "NVML Shared Library Not Found",
+        NVML_ERROR_FUNCTION_NOT_FOUND: "Function Not Found",
+        NVML_ERROR_CORRUPTED_INFOROM: "Corrupted infoROM",
+        NVML_ERROR_GPU_IS_LOST: "GPU is lost",
+        NVML_ERROR_RESET_REQUIRED: "GPU requires restart",
+        NVML_ERROR_OPERATING_SYSTEM: "The operating system has blocked the request.",
         NVML_ERROR_LIB_RM_VERSION_MISMATCH: "RM has detected an NVML/RM version mismatch.",
-        NVML_ERROR_MEMORY:              "Insufficient Memory",
-        NVML_ERROR_UNKNOWN:             "Unknown Error",
-        }
+        NVML_ERROR_MEMORY: "Insufficient Memory",
+        NVML_ERROR_UNKNOWN: "Unknown Error",
+    }
+
     def __new__(typ, value):
-        '''
+        """
         Maps value to a proper subclass of NVMLError.
         See _extractNVMLErrorsAsClasses function for more details
-        '''
+        """
         if typ == NVMLError:
             typ = NVMLError._valClassMapping.get(value, typ)
         obj = Exception.__new__(typ)
         obj.value = value
         return obj
+
     def __str__(self):
         try:
             if self.value not in NVMLError._errcode_to_string:
-                NVMLError._errcode_to_string[self.value] = str(nvmlErrorString(self.value))
+                NVMLError._errcode_to_string[self.value] = str(
+                    nvmlErrorString(self.value)
+                )
             return NVMLError._errcode_to_string[self.value]
         except NVMLError:
             return "NVML Error with code %d" % self.value
+
     def __eq__(self, other):
         return self.value == other.value
 
+
 def nvmlExceptionClass(nvmlErrorCode):
     if nvmlErrorCode not in NVMLError._valClassMapping:
-        raise ValueError('nvmlErrorCode %s is not valid' % nvmlErrorCode)
+        raise ValueError("nvmlErrorCode %s is not valid" % nvmlErrorCode)
     return NVMLError._valClassMapping[nvmlErrorCode]
 
+
 def _extractNVMLErrorsAsClasses():
-    '''
+    """
     Generates a hierarchy of classes on top of NVMLError class.
 
     Each NVML Error gets a new NVMLError subclass. This way try,except blocks can filter appropriate
@@ -1024,31 +1273,44 @@ def _extractNVMLErrorsAsClasses():
 
     NVMLError is a parent class. Each NVML_ERROR_* gets its own subclass.
     e.g. NVML_ERROR_ALREADY_INITIALIZED will be turned into NVMLError_AlreadyInitialized
-    '''
+    """
     this_module = sys.modules[__name__]
     nvmlErrorsNames = [x for x in dir(this_module) if x.startswith("NVML_ERROR_")]
     for err_name in nvmlErrorsNames:
         # e.g. Turn NVML_ERROR_ALREADY_INITIALIZED into NVMLError_AlreadyInitialized
-        class_name = "NVMLError_" + string.capwords(err_name.replace("NVML_ERROR_", ""), "_").replace("_", "")
+        class_name = "NVMLError_" + string.capwords(
+            err_name.replace("NVML_ERROR_", ""), "_"
+        ).replace("_", "")
         err_val = getattr(this_module, err_name)
+
         def gen_new(val):
             def new(typ):
                 obj = NVMLError.__new__(typ, val)
                 return obj
+
             return new
-        new_error_class = type(class_name, (NVMLError,), {'__new__': gen_new(err_val)})
+
+        new_error_class = type(class_name, (NVMLError,), {"__new__": gen_new(err_val)})
         new_error_class.__module__ = __name__
         setattr(this_module, class_name, new_error_class)
         NVMLError._valClassMapping[err_val] = new_error_class
+
+
 _extractNVMLErrorsAsClasses()
 
+
 def _nvmlCheckReturn(ret):
-    if (ret != NVML_SUCCESS):
+    if ret != NVML_SUCCESS:
         raise NVMLError(ret)
     return ret
 
+
 ## Function access ##
-_nvmlGetFunctionPointer_cache = dict() # function pointers are cached to prevent unnecessary libLoadLock locking
+_nvmlGetFunctionPointer_cache = (
+    dict()
+)  # function pointers are cached to prevent unnecessary libLoadLock locking
+
+
 def _nvmlGetFunctionPointer(name):
     global nvmlLib
 
@@ -1058,7 +1320,7 @@ def _nvmlGetFunctionPointer(name):
     libLoadLock.acquire()
     try:
         # ensure library was loaded
-        if (nvmlLib == None):
+        if nvmlLib == None:
             raise NVMLError(NVML_ERROR_UNINITIALIZED)
         try:
             _nvmlGetFunctionPointer_cache[name] = getattr(nvmlLib, name)
@@ -1069,6 +1331,7 @@ def _nvmlGetFunctionPointer(name):
         # lock is always freed
         libLoadLock.release()
 
+
 ## Alternative object
 # Allows the object to be printed
 # Allows mismatched types to be assigned
@@ -1077,8 +1340,10 @@ class nvmlFriendlyObject(object):
     def __init__(self, dictionary):
         for x in dictionary:
             setattr(self, x, dictionary[x])
+
     def __str__(self):
         return self.__dict__.__str__()
+
 
 def nvmlStructToFriendlyObject(struct):
     d = {}
@@ -1089,6 +1354,7 @@ def nvmlStructToFriendlyObject(struct):
         d[key] = value.decode() if isinstance(value, bytes) else value
     obj = nvmlFriendlyObject(d)
     return obj
+
 
 # pack the object so it can be passed to the NVML library
 def nvmlFriendlyObjectToStruct(obj, model):
@@ -1102,10 +1368,14 @@ def nvmlFriendlyObjectToStruct(obj, model):
             setattr(model, key, value)
     return model
 
+
 ## Unit structures
 class struct_c_nvmlUnit_t(Structure):
-    pass # opaque handle
+    pass  # opaque handle
+
+
 c_nvmlUnit_t = POINTER(struct_c_nvmlUnit_t)
+
 
 class _PrintableStructure(Structure):
     """
@@ -1126,7 +1396,9 @@ class _PrintableStructure(Structure):
 
     Exact format of returned str from this class is subject to change in the future.
     """
+
     _fmt_ = {}
+
     def __str__(self):
         result = []
         for x in self._fields_:
@@ -1138,7 +1410,7 @@ class _PrintableStructure(Structure):
             elif "<default>" in self._fmt_:
                 fmt = self._fmt_["<default>"]
             result.append(("%s: " + fmt) % (key, value))
-        return self.__class__.__name__ + "(" +  ", ".join(result) + ")"
+        return self.__class__.__name__ + "(" + ", ".join(result) + ")"
 
     def __getattribute__(self, name):
         res = super(_PrintableStructure, self).__getattribute__(name)
@@ -1159,184 +1431,199 @@ class _PrintableStructure(Structure):
             value = value.encode()
         super(_PrintableStructure, self).__setattr__(name, value)
 
+
 class c_nvmlUnitInfo_t(_PrintableStructure):
     _fields_ = [
-        ('name', c_char * 96),
-        ('id', c_char * 96),
-        ('serial', c_char * 96),
-        ('firmwareVersion', c_char * 96),
+        ("name", c_char * 96),
+        ("id", c_char * 96),
+        ("serial", c_char * 96),
+        ("firmwareVersion", c_char * 96),
     ]
+
 
 class c_nvmlC2cModeInfo_v1_t(_PrintableStructure):
-    _fields_ = [
-        ('isC2cEnabled', c_uint)
-    ]
+    _fields_ = [("isC2cEnabled", c_uint)]
 
-nvmlC2cModeInfo_v1 = 0x1000008;
+
+nvmlC2cModeInfo_v1 = 0x1000008
+
 
 class c_nvmlLedState_t(_PrintableStructure):
     _fields_ = [
-        ('cause', c_char * 256),
-        ('color', _nvmlLedColor_t),
+        ("cause", c_char * 256),
+        ("color", _nvmlLedColor_t),
     ]
+
 
 class c_nvmlPSUInfo_t(_PrintableStructure):
     _fields_ = [
-        ('state', c_char * 256),
-        ('current', c_uint),
-        ('voltage', c_uint),
-        ('power', c_uint),
+        ("state", c_char * 256),
+        ("current", c_uint),
+        ("voltage", c_uint),
+        ("power", c_uint),
     ]
+
 
 class c_nvmlUnitFanInfo_t(_PrintableStructure):
     _fields_ = [
-        ('speed', c_uint),
-        ('state', _nvmlFanState_t),
+        ("speed", c_uint),
+        ("state", _nvmlFanState_t),
     ]
 
+
 class c_nvmlUnitFanSpeeds_t(_PrintableStructure):
-    _fields_ = [
-        ('fans', c_nvmlUnitFanInfo_t * 24),
-        ('count', c_uint)
-    ]
+    _fields_ = [("fans", c_nvmlUnitFanInfo_t * 24), ("count", c_uint)]
+
 
 ## Device structures
 class struct_c_nvmlDevice_t(Structure):
-    pass # opaque handle
+    pass  # opaque handle
+
+
 c_nvmlDevice_t = POINTER(struct_c_nvmlDevice_t)
+
 
 class nvmlPciInfoExt_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('domain', c_uint),
-        ('bus', c_uint),
-        ('device', c_uint),
-        ('pciDeviceId', c_uint),
-        ('pciSubSystemId', c_uint),
-        ('baseClass', c_uint),
-        ('subClass', c_uint),
-        ('busId', c_char * NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE),
+        ("version", c_uint),
+        ("domain", c_uint),
+        ("bus", c_uint),
+        ("device", c_uint),
+        ("pciDeviceId", c_uint),
+        ("pciSubSystemId", c_uint),
+        ("baseClass", c_uint),
+        ("subClass", c_uint),
+        ("busId", c_char * NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE),
     ]
     _fmt_ = {
-            'version'        : "0x%04X",
-            'domain'         : "0x%04X",
-            'bus'            : "0x%02X",
-            'device'         : "0x%02X",
-            'pciDeviceId'    : "0x%08X",
-            'pciSubSystemId' : "0x%08X",
-            'baseClass'      : "0x%01X",
-            'subClass'       : "0x%01X",
-            }
+        "version": "0x%04X",
+        "domain": "0x%04X",
+        "bus": "0x%02X",
+        "device": "0x%02X",
+        "pciDeviceId": "0x%08X",
+        "pciSubSystemId": "0x%08X",
+        "baseClass": "0x%01X",
+        "subClass": "0x%01X",
+    }
+
 
 nvmlPciInfoExt_v1 = 0x1000040
+
 
 # Legacy pciInfo used for _v1 and _v2
 class nvmlPciInfo_v2_t(_PrintableStructure):
     _fields_ = [
-        ('busId', c_char * NVML_DEVICE_PCI_BUS_ID_BUFFER_V2_SIZE),
-        ('domain', c_uint),
-        ('bus', c_uint),
-        ('device', c_uint),
-        ('pciDeviceId', c_uint),
-
+        ("busId", c_char * NVML_DEVICE_PCI_BUS_ID_BUFFER_V2_SIZE),
+        ("domain", c_uint),
+        ("bus", c_uint),
+        ("device", c_uint),
+        ("pciDeviceId", c_uint),
         # Added in 2.285
-        ('pciSubSystemId', c_uint),
-        ('reserved0', c_uint),
-        ('reserved1', c_uint),
-        ('reserved2', c_uint),
-        ('reserved3', c_uint),
+        ("pciSubSystemId", c_uint),
+        ("reserved0", c_uint),
+        ("reserved1", c_uint),
+        ("reserved2", c_uint),
+        ("reserved3", c_uint),
     ]
     _fmt_ = {
-            'domain'         : "0x%04X",
-            'bus'            : "0x%02X",
-            'device'         : "0x%02X",
-            'pciDeviceId'    : "0x%08X",
-            'pciSubSystemId' : "0x%08X",
-            }
+        "domain": "0x%04X",
+        "bus": "0x%02X",
+        "device": "0x%02X",
+        "pciDeviceId": "0x%08X",
+        "pciSubSystemId": "0x%08X",
+    }
+
 
 class nvmlPciInfo_t(_PrintableStructure):
     _fields_ = [
         # Moved to the new busId location below
-        ('busIdLegacy', c_char * NVML_DEVICE_PCI_BUS_ID_BUFFER_V2_SIZE),
-        ('domain', c_uint),
-        ('bus', c_uint),
-        ('device', c_uint),
-        ('pciDeviceId', c_uint),
-
+        ("busIdLegacy", c_char * NVML_DEVICE_PCI_BUS_ID_BUFFER_V2_SIZE),
+        ("domain", c_uint),
+        ("bus", c_uint),
+        ("device", c_uint),
+        ("pciDeviceId", c_uint),
         # Added in 2.285
-        ('pciSubSystemId', c_uint),
+        ("pciSubSystemId", c_uint),
         # New busId replaced the long deprecated and reserved fields with a
         # field of the same size in 9.0
-        ('busId', c_char * NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE),
+        ("busId", c_char * NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE),
     ]
     _fmt_ = {
-            'domain'         : "0x%08X",
-            'bus'            : "0x%02X",
-            'device'         : "0x%02X",
-            'pciDeviceId'    : "0x%08X",
-            'pciSubSystemId' : "0x%08X",
-            }
+        "domain": "0x%08X",
+        "bus": "0x%02X",
+        "device": "0x%02X",
+        "pciDeviceId": "0x%08X",
+        "pciSubSystemId": "0x%08X",
+    }
+
 
 class c_nvmlSystemDriverBranchInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
+        ("version", c_uint),
         ("branch", c_char * NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE),
     ]
 
+
 SystemDriverBranchInfo_v1 = 0x1000054
 
+
 class c_nvmlExcludedDeviceInfo_t(_PrintableStructure):
-    _fields_ = [
-        ('pci', nvmlPciInfo_t),
-        ('uuid', c_char * NVML_DEVICE_UUID_BUFFER_SIZE)
-    ]
+    _fields_ = [("pci", nvmlPciInfo_t), ("uuid", c_char * NVML_DEVICE_UUID_BUFFER_SIZE)]
+
 
 class nvmlNvLinkUtilizationControl_t(_PrintableStructure):
     _fields_ = [
-        ('units', _nvmlNvLinkUtilizationCountUnits_t),
-        ('pktfilter', _nvmlNvLinkUtilizationCountPktTypes_t),
+        ("units", _nvmlNvLinkUtilizationCountUnits_t),
+        ("pktfilter", _nvmlNvLinkUtilizationCountPktTypes_t),
     ]
+
 
 class c_nvmlMemory_t(_PrintableStructure):
     _fields_ = [
-        ('total', c_ulonglong),
-        ('free', c_ulonglong),
-        ('used', c_ulonglong),
+        ("total", c_ulonglong),
+        ("free", c_ulonglong),
+        ("used", c_ulonglong),
     ]
-    _fmt_ = {'<default>': "%d B"}
+    _fmt_ = {"<default>": "%d B"}
+
 
 class c_nvmlMemory_v2_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('total', c_ulonglong),
-        ('reserved', c_ulonglong),
-        ('free', c_ulonglong),
-        ('used', c_ulonglong),
+        ("version", c_uint),
+        ("total", c_ulonglong),
+        ("reserved", c_ulonglong),
+        ("free", c_ulonglong),
+        ("used", c_ulonglong),
     ]
-    _fmt_ = {'<default>': "%d B"}
+    _fmt_ = {"<default>": "%d B"}
+
 
 nvmlMemory_v2 = 0x02000028
 
+
 class c_nvmlBAR1Memory_t(_PrintableStructure):
     _fields_ = [
-        ('bar1Total', c_ulonglong),
-        ('bar1Free', c_ulonglong),
-        ('bar1Used', c_ulonglong),
+        ("bar1Total", c_ulonglong),
+        ("bar1Free", c_ulonglong),
+        ("bar1Used", c_ulonglong),
     ]
-    _fmt_ = {'<default>': "%d B"}
+    _fmt_ = {"<default>": "%d B"}
+
 
 class nvmlClkMonFaultInfo_t(Structure):
-    _fields_ = [("clkApiDomain", c_uint),
-                ("clkDomainFaultMask", c_uint)
-    ]
+    _fields_ = [("clkApiDomain", c_uint), ("clkDomainFaultMask", c_uint)]
+
 
 MAX_CLK_DOMAINS = 32
 
+
 class nvmlClkMonStatus_t(Structure):
-    _fields_ = [("bGlobalStatus", c_uint),
-                ("clkMonListSize", c_uint),
-                ("clkMonList", nvmlClkMonFaultInfo_t * MAX_CLK_DOMAINS)
+    _fields_ = [
+        ("bGlobalStatus", c_uint),
+        ("clkMonListSize", c_uint),
+        ("clkMonList", nvmlClkMonFaultInfo_t * MAX_CLK_DOMAINS),
     ]
+
 
 # On Windows with the WDDM driver, usedGpuMemory is reported as None
 # Code that processes this structure should check for None, I.E.
@@ -1351,886 +1638,1030 @@ class nvmlClkMonStatus_t(Structure):
 # See NVML documentation for more information
 class c_nvmlProcessInfo_v2_t(_PrintableStructure):
     _fields_ = [
-        ('pid', c_uint),
-        ('usedGpuMemory', c_ulonglong),
-        ('gpuInstanceId', c_uint),
-        ('computeInstanceId', c_uint),
+        ("pid", c_uint),
+        ("usedGpuMemory", c_ulonglong),
+        ("gpuInstanceId", c_uint),
+        ("computeInstanceId", c_uint),
     ]
-    _fmt_ = {'usedGpuMemory': "%d B"}
+    _fmt_ = {"usedGpuMemory": "%d B"}
+
 
 c_nvmlProcessInfo_v3_t = c_nvmlProcessInfo_v2_t
 
 c_nvmlProcessInfo_t = c_nvmlProcessInfo_v3_t
 
 _nvmlProcessMode_t = c_uint
-NVML_PROCESS_MODE_COMPUTE  = 0
+NVML_PROCESS_MODE_COMPUTE = 0
 NVML_PROCESS_MODE_GRAPHICS = 1
-NVML_PROCESS_MODE_MPS      = 2
+NVML_PROCESS_MODE_MPS = 2
+
 
 class c_nvmlProcessDetail_v1_t(Structure):
     _fields_ = [
-        ('pid', c_uint),
-        ('usedGpuMemory', c_ulonglong),
-        ('gpuInstanceId', c_uint),
-        ('computeInstanceId', c_uint),
-        ('usedGpuCcProtectedMemory', c_ulonglong),
+        ("pid", c_uint),
+        ("usedGpuMemory", c_ulonglong),
+        ("gpuInstanceId", c_uint),
+        ("computeInstanceId", c_uint),
+        ("usedGpuCcProtectedMemory", c_ulonglong),
     ]
+
 
 class c_nvmlProcessDetailList_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('mode', _nvmlProcessMode_t),
-        ('numProcArrayEntries', c_uint),
-        ('procArray', POINTER(c_nvmlProcessDetail_v1_t)),
+        ("version", c_uint),
+        ("mode", _nvmlProcessMode_t),
+        ("numProcArrayEntries", c_uint),
+        ("procArray", POINTER(c_nvmlProcessDetail_v1_t)),
     ]
-    _fmt_ = {'numProcArrayEntries': "%d B"}
+    _fmt_ = {"numProcArrayEntries": "%d B"}
+
 
 c_nvmlProcessDetailList_t = c_nvmlProcessDetailList_v1_t
 
 nvmlProcessDetailList_v1 = 0x1000018
 
+
 class c_nvmlBridgeChipInfo_t(_PrintableStructure):
     _fields_ = [
-        ('type', _nvmlBridgeChipType_t),
-        ('fwVersion', c_uint),
+        ("type", _nvmlBridgeChipType_t),
+        ("fwVersion", c_uint),
     ]
+
 
 class c_nvmlBridgeChipHierarchy_t(_PrintableStructure):
     _fields_ = [
-        ('bridgeCount', c_uint),
-        ('bridgeChipInfo', c_nvmlBridgeChipInfo_t * 128),
+        ("bridgeCount", c_uint),
+        ("bridgeChipInfo", c_nvmlBridgeChipInfo_t * 128),
     ]
+
 
 class c_nvmlEccErrorCounts_t(_PrintableStructure):
     _fields_ = [
-        ('l1Cache', c_ulonglong),
-        ('l2Cache', c_ulonglong),
-        ('deviceMemory', c_ulonglong),
-        ('registerFile', c_ulonglong),
+        ("l1Cache", c_ulonglong),
+        ("l2Cache", c_ulonglong),
+        ("deviceMemory", c_ulonglong),
+        ("registerFile", c_ulonglong),
     ]
+
 
 class c_nvmlUtilization_t(_PrintableStructure):
     _fields_ = [
-        ('gpu', c_uint),
-        ('memory', c_uint),
+        ("gpu", c_uint),
+        ("memory", c_uint),
     ]
-    _fmt_ = {'<default>': "%d %%"}
+    _fmt_ = {"<default>": "%d %%"}
+
 
 # Added in 2.285
 class c_nvmlHwbcEntry_t(_PrintableStructure):
     _fields_ = [
-        ('hwbcId', c_uint),
-        ('firmwareVersion', c_char * 32),
+        ("hwbcId", c_uint),
+        ("firmwareVersion", c_char * 32),
     ]
+
 
 class c_nvmlValue_t(Union):
     _fields_ = [
-        ('dVal', c_double),
-        ('uiVal', c_uint),
-        ('ulVal', c_ulong),
-        ('ullVal', c_ulonglong),
-        ('sllVal', c_longlong),
-        ('siVal', c_int),
-        ('usVal', c_ushort),
+        ("dVal", c_double),
+        ("uiVal", c_uint),
+        ("ulVal", c_ulong),
+        ("ullVal", c_ulonglong),
+        ("sllVal", c_longlong),
+        ("siVal", c_int),
+        ("usVal", c_ushort),
     ]
+
 
 class c_nvmlSample_t(_PrintableStructure):
     _fields_ = [
-        ('timeStamp', c_ulonglong),
-        ('sampleValue', c_nvmlValue_t),
+        ("timeStamp", c_ulonglong),
+        ("sampleValue", c_nvmlValue_t),
     ]
+
 
 class c_nvmlViolationTime_t(_PrintableStructure):
     _fields_ = [
-        ('referenceTime', c_ulonglong),
-        ('violationTime', c_ulonglong),
+        ("referenceTime", c_ulonglong),
+        ("violationTime", c_ulonglong),
     ]
+
 
 class c_nvmlFieldValue_t(_PrintableStructure):
     _fields_ = [
-        ('fieldId', c_uint32),
-        ('scopeId', c_uint32),
-        ('timestamp', c_int64),
-        ('latencyUsec', c_int64),
-        ('valueType', _nvmlValueType_t),
-        ('nvmlReturn', _nvmlReturn_t),
-        ('value', c_nvmlValue_t)
+        ("fieldId", c_uint32),
+        ("scopeId", c_uint32),
+        ("timestamp", c_int64),
+        ("latencyUsec", c_int64),
+        ("valueType", _nvmlValueType_t),
+        ("nvmlReturn", _nvmlReturn_t),
+        ("value", c_nvmlValue_t),
     ]
+
 
 NVML_NVLINK_TOTAL_SUPPORTED_BW_MODES = 23
 
-nvmlNvlinkSupportedBwModes_v1 = 0x100001c
+nvmlNvlinkSupportedBwModes_v1 = 0x100001C
+
+
 class c_nvmlNvlinkSupportedBwModes_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('bwModes', c_uint8 * NVML_NVLINK_TOTAL_SUPPORTED_BW_MODES),
-        ('totalBwModes', c_uint8)
+        ("version", c_uint),
+        ("bwModes", c_uint8 * NVML_NVLINK_TOTAL_SUPPORTED_BW_MODES),
+        ("totalBwModes", c_uint8),
     ]
 
     def __init__(self):
-        super(c_nvmlNvlinkSupportedBwModes_v1_t, self).__init__(version=nvmlNvlinkSupportedBwModes_v1)
+        super(c_nvmlNvlinkSupportedBwModes_v1_t, self).__init__(
+            version=nvmlNvlinkSupportedBwModes_v1
+        )
 
-nvmlNvlinkGetBwMode_v1 = 0x100000c
+
+nvmlNvlinkGetBwMode_v1 = 0x100000C
+
+
 class c_nvmlNvlinkGetBwMode_v1_t(_PrintableStructure):
-    _fields_ = [
-        ('version', c_uint),
-        ('bIsBest', c_uint),
-        ('bwMode', c_uint8)
-    ]
+    _fields_ = [("version", c_uint), ("bIsBest", c_uint), ("bwMode", c_uint8)]
 
     def __init__(self):
         super(c_nvmlNvlinkGetBwMode_v1_t, self).__init__(version=nvmlNvlinkGetBwMode_v1)
 
-nvmlNvlinkSetBwMode_v1 = 0x100000c
+
+nvmlNvlinkSetBwMode_v1 = 0x100000C
+
+
 class c_nvmlNvlinkSetBwMode_v1_t(_PrintableStructure):
-    _fields_ = [
-        ('version', c_uint),
-        ('bSetBest', c_uint),
-        ('bwMode', c_uint8)
-    ]
+    _fields_ = [("version", c_uint), ("bSetBest", c_uint), ("bwMode", c_uint8)]
 
     def __init__(self):
         super(c_nvmlNvlinkSetBwMode_v1_t, self).__init__(version=nvmlNvlinkSetBwMode_v1)
 
+
 class c_nvmlVgpuHeterogeneousMode_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('mode', c_uint),
+        ("version", c_uint),
+        ("mode", c_uint),
     ]
+
 
 VgpuHeterogeneousMode_v1 = 0x1000008
 
+
 class c_nvmlVgpuPlacementId_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('placementId', c_uint),
+        ("version", c_uint),
+        ("placementId", c_uint),
     ]
+
 
 VgpuPlacementId_v1 = 0x1000008
 
+
 class c_nvmlVgpuPlacementList_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('count', c_uint),
-        ('placementSize', c_uint),
-        ('placementIds', POINTER(c_uint)),
+        ("version", c_uint),
+        ("count", c_uint),
+        ("placementSize", c_uint),
+        ("placementIds", POINTER(c_uint)),
     ]
+
 
 VgpuPlacementList_v1 = 0x1000018
 
-NVML_VGPU_PGPU_HETEROGENEOUS_MODE   = 0
-NVML_VGPU_PGPU_HOMOGENEOUS_MODE     = 1
+NVML_VGPU_PGPU_HETEROGENEOUS_MODE = 0
+NVML_VGPU_PGPU_HOMOGENEOUS_MODE = 1
+
 
 class c_nvmlVgpuPlacementList_v2_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('placementSize', c_uint),
-        ('count', c_uint),
-        ('placementIds', POINTER(c_uint)),
-        ('mode', c_uint),
+        ("version", c_uint),
+        ("placementSize", c_uint),
+        ("count", c_uint),
+        ("placementIds", POINTER(c_uint)),
+        ("mode", c_uint),
     ]
+
 
 VgpuPlacementList_v2 = 0x2000020
 
+
 class c_nvmlVgpuTypeBar1Info_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('bar1Size', c_ulonglong),
+        ("version", c_uint),
+        ("bar1Size", c_ulonglong),
     ]
+
 
 VgpuTypeBar1Info_v1 = 0x1000010
 
+
 class c_nvmlVgpuInstanceUtilizationSample_t(_PrintableStructure):
     _fields_ = [
-        ('vgpuInstance', _nvmlVgpuInstance_t),
-        ('timeStamp', c_ulonglong),
-        ('smUtil', c_nvmlValue_t),
-        ('memUtil', c_nvmlValue_t),
-        ('encUtil', c_nvmlValue_t),
-        ('decUtil', c_nvmlValue_t),
+        ("vgpuInstance", _nvmlVgpuInstance_t),
+        ("timeStamp", c_ulonglong),
+        ("smUtil", c_nvmlValue_t),
+        ("memUtil", c_nvmlValue_t),
+        ("encUtil", c_nvmlValue_t),
+        ("decUtil", c_nvmlValue_t),
     ]
+
 
 class c_nvmlVgpuInstanceUtilizationInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('timeStamp', c_ulonglong),
-        ('vgpuInstance', _nvmlVgpuInstance_t),
-        ('smUtil', c_nvmlValue_t),
-        ('memUtil', c_nvmlValue_t),
-        ('encUtil', c_nvmlValue_t),
-        ('decUtil', c_nvmlValue_t),
-        ('jpgUtil', c_nvmlValue_t),
-        ('ofaUtil', c_nvmlValue_t),
+        ("timeStamp", c_ulonglong),
+        ("vgpuInstance", _nvmlVgpuInstance_t),
+        ("smUtil", c_nvmlValue_t),
+        ("memUtil", c_nvmlValue_t),
+        ("encUtil", c_nvmlValue_t),
+        ("decUtil", c_nvmlValue_t),
+        ("jpgUtil", c_nvmlValue_t),
+        ("ofaUtil", c_nvmlValue_t),
     ]
+
 
 class c_nvmlVgpuInstancesUtilizationInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('sampleValType', _nvmlValueType_t),
-        ('vgpuInstanceCount', c_uint),
-        ('lastSeenTimeStamp', c_ulonglong),
-        ('vgpuUtilArray', POINTER(c_nvmlVgpuInstanceUtilizationInfo_v1_t)),
+        ("version", c_uint),
+        ("sampleValType", _nvmlValueType_t),
+        ("vgpuInstanceCount", c_uint),
+        ("lastSeenTimeStamp", c_ulonglong),
+        ("vgpuUtilArray", POINTER(c_nvmlVgpuInstanceUtilizationInfo_v1_t)),
     ]
+
 
 VgpuInstancesUtilizationInfo_v1 = 0x01000020
 
+
 class c_nvmlVgpuProcessUtilizationSample_t(_PrintableStructure):
     _fields_ = [
-        ('vgpuInstance', _nvmlVgpuInstance_t),
-        ('pid', c_uint),
-        ('processName', c_char * NVML_VGPU_NAME_BUFFER_SIZE),
-        ('timeStamp', c_ulonglong),
-        ('smUtil', c_uint),
-        ('memUtil', c_uint),
-        ('encUtil', c_uint),
-        ('decUtil', c_uint),
+        ("vgpuInstance", _nvmlVgpuInstance_t),
+        ("pid", c_uint),
+        ("processName", c_char * NVML_VGPU_NAME_BUFFER_SIZE),
+        ("timeStamp", c_ulonglong),
+        ("smUtil", c_uint),
+        ("memUtil", c_uint),
+        ("encUtil", c_uint),
+        ("decUtil", c_uint),
     ]
+
 
 class c_nvmlVgpuProcessUtilizationInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('processName', c_char * NVML_VGPU_NAME_BUFFER_SIZE),
-        ('timeStamp', c_ulonglong),
-        ('vgpuInstance', _nvmlVgpuInstance_t),
-        ('pid', c_uint),
-        ('smUtil', c_uint),
-        ('memUtil', c_uint),
-        ('encUtil', c_uint),
-        ('decUtil', c_uint),
-        ('jpgUtil', c_uint),
-        ('ofaUtil', c_uint),
+        ("processName", c_char * NVML_VGPU_NAME_BUFFER_SIZE),
+        ("timeStamp", c_ulonglong),
+        ("vgpuInstance", _nvmlVgpuInstance_t),
+        ("pid", c_uint),
+        ("smUtil", c_uint),
+        ("memUtil", c_uint),
+        ("encUtil", c_uint),
+        ("decUtil", c_uint),
+        ("jpgUtil", c_uint),
+        ("ofaUtil", c_uint),
     ]
+
 
 class c_nvmlVgpuProcessesUtilizationInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('vgpuProcessCount', c_uint),
-        ('lastSeenTimeStamp', c_ulonglong),
-        ('vgpuProcUtilArray', POINTER(c_nvmlVgpuProcessUtilizationInfo_v1_t)),
+        ("version", c_uint),
+        ("vgpuProcessCount", c_uint),
+        ("lastSeenTimeStamp", c_ulonglong),
+        ("vgpuProcUtilArray", POINTER(c_nvmlVgpuProcessUtilizationInfo_v1_t)),
     ]
+
 
 VgpuProcessesUtilizationInfo_v1 = 0x01000018
 
+
 class nvmlVgpuRuntimeState_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('size', c_ulonglong),
+        ("version", c_uint),
+        ("size", c_ulonglong),
     ]
+
 
 VgpuRuntimeState_v1 = 0x1000010
 
+
 class c_nvmlVgpuLicenseExpiry_t(_PrintableStructure):
     _fields_ = [
-        ('year',    c_uint32),
-        ('month',   c_uint16),
-        ('day',     c_uint16),
-        ('hour',    c_uint16),
-        ('min',     c_uint16),
-        ('sec',     c_uint16),
-        ('status',  c_uint8),
+        ("year", c_uint32),
+        ("month", c_uint16),
+        ("day", c_uint16),
+        ("hour", c_uint16),
+        ("min", c_uint16),
+        ("sec", c_uint16),
+        ("status", c_uint8),
     ]
 
-NVML_GRID_LICENSE_STATE_UNKNOWN                 = 0
-NVML_GRID_LICENSE_STATE_UNINITIALIZED           = 1
+
+NVML_GRID_LICENSE_STATE_UNKNOWN = 0
+NVML_GRID_LICENSE_STATE_UNINITIALIZED = 1
 NVML_GRID_LICENSE_STATE_UNLICENSED_UNRESTRICTED = 2
-NVML_GRID_LICENSE_STATE_UNLICENSED_RESTRICTED   = 3
-NVML_GRID_LICENSE_STATE_UNLICENSED              = 4
-NVML_GRID_LICENSE_STATE_LICENSED                = 5
+NVML_GRID_LICENSE_STATE_UNLICENSED_RESTRICTED = 3
+NVML_GRID_LICENSE_STATE_UNLICENSED = 4
+NVML_GRID_LICENSE_STATE_LICENSED = 5
+
 
 class c_nvmlVgpuLicenseInfo_t(_PrintableStructure):
     _fields_ = [
-        ('isLicensed',      c_uint8),
-        ('licenseExpiry',   c_nvmlVgpuLicenseExpiry_t),
-        ('currentState',    c_uint),
+        ("isLicensed", c_uint8),
+        ("licenseExpiry", c_nvmlVgpuLicenseExpiry_t),
+        ("currentState", c_uint),
     ]
+
 
 class c_nvmlEncoderSession_t(_PrintableStructure):
     _fields_ = [
-        ('sessionId', c_uint),
-        ('pid', c_uint),
-        ('vgpuInstance', _nvmlVgpuInstance_t),
-        ('codecType', c_uint),
-        ('hResolution', c_uint),
-        ('vResolution', c_uint),
-        ('averageFps', c_uint),
-        ('encodeLatency', c_uint),
+        ("sessionId", c_uint),
+        ("pid", c_uint),
+        ("vgpuInstance", _nvmlVgpuInstance_t),
+        ("codecType", c_uint),
+        ("hResolution", c_uint),
+        ("vResolution", c_uint),
+        ("averageFps", c_uint),
+        ("encodeLatency", c_uint),
     ]
+
 
 class c_nvmlProcessUtilizationSample_t(_PrintableStructure):
     _fields_ = [
-        ('pid', c_uint),
-        ('timeStamp', c_ulonglong),
-        ('smUtil', c_uint),
-        ('memUtil', c_uint),
-        ('encUtil', c_uint),
-        ('decUtil', c_uint),
+        ("pid", c_uint),
+        ("timeStamp", c_ulonglong),
+        ("smUtil", c_uint),
+        ("memUtil", c_uint),
+        ("encUtil", c_uint),
+        ("decUtil", c_uint),
     ]
+
 
 class c_nvmlProcessUtilizationInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('timeStamp', c_ulonglong),
-        ('pid', c_uint),
-        ('smUtil', c_uint),
-        ('memUtil', c_uint),
-        ('encUtil', c_uint),
-        ('decUtil', c_uint),
-        ('jpgUtil', c_uint),
-        ('ofaUtil', c_uint),
+        ("timeStamp", c_ulonglong),
+        ("pid", c_uint),
+        ("smUtil", c_uint),
+        ("memUtil", c_uint),
+        ("encUtil", c_uint),
+        ("decUtil", c_uint),
+        ("jpgUtil", c_uint),
+        ("ofaUtil", c_uint),
     ]
+
 
 class c_nvmlProcessesUtilizationInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('processSamplesCount', c_uint),
-        ('lastSeenTimeStamp', c_ulonglong),
-        ('procUtilArray', POINTER(c_nvmlProcessUtilizationInfo_v1_t)),
+        ("version", c_uint),
+        ("processSamplesCount", c_uint),
+        ("lastSeenTimeStamp", c_ulonglong),
+        ("procUtilArray", POINTER(c_nvmlProcessUtilizationInfo_v1_t)),
     ]
+
 
 ProcessesUtilizationInfo_v1 = 0x01000018
 
+
 class c_nvmlGridLicenseExpiry_t(_PrintableStructure):
     _fields_ = [
-        ('year',    c_uint32),
-        ('month',   c_uint16),
-        ('day',     c_uint16),
-        ('hour',    c_uint16),
-        ('min',     c_uint16),
-        ('sec',     c_uint16),
-        ('status',  c_uint8),
+        ("year", c_uint32),
+        ("month", c_uint16),
+        ("day", c_uint16),
+        ("hour", c_uint16),
+        ("min", c_uint16),
+        ("sec", c_uint16),
+        ("status", c_uint8),
     ]
+
 
 class c_nvmlGridLicensableFeature_v4_t(_PrintableStructure):
     _fields_ = [
-        ('featureCode',    _nvmlGridLicenseFeatureCode_t),
-        ('featureState',   c_uint),
-        ('licenseInfo',    c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
-        ('productName',    c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
-        ('featureEnabled', c_uint),
-        ('licenseExpiry',  c_nvmlGridLicenseExpiry_t),
+        ("featureCode", _nvmlGridLicenseFeatureCode_t),
+        ("featureState", c_uint),
+        ("licenseInfo", c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
+        ("productName", c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
+        ("featureEnabled", c_uint),
+        ("licenseExpiry", c_nvmlGridLicenseExpiry_t),
     ]
+
 
 class c_nvmlGridLicensableFeatures_v4_t(_PrintableStructure):
     _fields_ = [
-        ('isGridLicenseSupported',  c_int),
-        ('licensableFeaturesCount', c_uint),
-        ('gridLicensableFeatures',  c_nvmlGridLicensableFeature_v4_t * NVML_GRID_LICENSE_FEATURE_MAX_COUNT),
+        ("isGridLicenseSupported", c_int),
+        ("licensableFeaturesCount", c_uint),
+        (
+            "gridLicensableFeatures",
+            c_nvmlGridLicensableFeature_v4_t * NVML_GRID_LICENSE_FEATURE_MAX_COUNT,
+        ),
     ]
+
 
 class c_nvmlGridLicensableFeature_v3_t(_PrintableStructure):
     _fields_ = [
-        ('featureCode', _nvmlGridLicenseFeatureCode_t),
-        ('featureState', c_uint),
-        ('licenseInfo', c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
-        ('productName', c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
-        ('featureEnabled', c_uint),
+        ("featureCode", _nvmlGridLicenseFeatureCode_t),
+        ("featureState", c_uint),
+        ("licenseInfo", c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
+        ("productName", c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
+        ("featureEnabled", c_uint),
     ]
+
 
 class c_nvmlGridLicensableFeatures_v3_t(_PrintableStructure):
     _fields_ = [
-        ('isGridLicenseSupported', c_int),
-        ('licensableFeaturesCount', c_uint),
-        ('gridLicensableFeatures', c_nvmlGridLicensableFeature_v3_t * NVML_GRID_LICENSE_FEATURE_MAX_COUNT),
+        ("isGridLicenseSupported", c_int),
+        ("licensableFeaturesCount", c_uint),
+        (
+            "gridLicensableFeatures",
+            c_nvmlGridLicensableFeature_v3_t * NVML_GRID_LICENSE_FEATURE_MAX_COUNT,
+        ),
     ]
+
 
 class c_nvmlGridLicensableFeature_v2_t(_PrintableStructure):
     _fields_ = [
-        ('featureCode', _nvmlGridLicenseFeatureCode_t),
-        ('featureState', c_uint),
-        ('licenseInfo', c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
-        ('productName', c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
+        ("featureCode", _nvmlGridLicenseFeatureCode_t),
+        ("featureState", c_uint),
+        ("licenseInfo", c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
+        ("productName", c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
     ]
+
 
 class c_nvmlGridLicensableFeatures_v2_t(_PrintableStructure):
     _fields_ = [
-        ('isGridLicenseSupported', c_int),
-        ('licensableFeaturesCount', c_uint),
-        ('gridLicensableFeatures', c_nvmlGridLicensableFeature_v2_t * NVML_GRID_LICENSE_FEATURE_MAX_COUNT),
+        ("isGridLicenseSupported", c_int),
+        ("licensableFeaturesCount", c_uint),
+        (
+            "gridLicensableFeatures",
+            c_nvmlGridLicensableFeature_v2_t * NVML_GRID_LICENSE_FEATURE_MAX_COUNT,
+        ),
     ]
+
 
 class c_nvmlGridLicensableFeature_t(_PrintableStructure):
     _fields_ = [
-        ('featureCode', _nvmlGridLicenseFeatureCode_t),
-        ('featureState', c_uint),
-        ('licenseInfo', c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
+        ("featureCode", _nvmlGridLicenseFeatureCode_t),
+        ("featureState", c_uint),
+        ("licenseInfo", c_char * NVML_GRID_LICENSE_BUFFER_SIZE),
     ]
+
 
 class c_nvmlGridLicensableFeatures_t(_PrintableStructure):
     _fields_ = [
-        ('isGridLicenseSupported', c_int),
-        ('licensableFeaturesCount', c_uint),
-        ('gridLicensableFeatures', c_nvmlGridLicensableFeature_t * NVML_GRID_LICENSE_FEATURE_MAX_COUNT),
+        ("isGridLicenseSupported", c_int),
+        ("licensableFeaturesCount", c_uint),
+        (
+            "gridLicensableFeatures",
+            c_nvmlGridLicensableFeature_t * NVML_GRID_LICENSE_FEATURE_MAX_COUNT,
+        ),
     ]
+
 
 class c_nvmlMarginTemperature_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('marginTemperature', c_int),
+        ("version", c_uint),
+        ("marginTemperature", c_int),
     ]
+
 
 nvmlMarginTemperature_v1 = 0x1000008
 
+
 ## Event structures
 class struct_c_nvmlEventSet_t(Structure):
-    pass # opaque handle
+    pass  # opaque handle
+
+
 c_nvmlEventSet_t = POINTER(struct_c_nvmlEventSet_t)
 
-nvmlEventTypeSingleBitEccError      = 0x0000000000000001
-nvmlEventTypeDoubleBitEccError      = 0x0000000000000002
-nvmlEventTypePState                 = 0x0000000000000004
-nvmlEventTypeXidCriticalError       = 0x0000000000000008
-nvmlEventTypeClock                  = 0x0000000000000010
-nvmlEventTypePowerSourceChange      = 0x0000000000000080
-nvmlEventMigConfigChange            = 0x0000000000000100
+nvmlEventTypeSingleBitEccError = 0x0000000000000001
+nvmlEventTypeDoubleBitEccError = 0x0000000000000002
+nvmlEventTypePState = 0x0000000000000004
+nvmlEventTypeXidCriticalError = 0x0000000000000008
+nvmlEventTypeClock = 0x0000000000000010
+nvmlEventTypePowerSourceChange = 0x0000000000000080
+nvmlEventMigConfigChange = 0x0000000000000100
 nvmlEventTypeSingleBitEccErrorStorm = 0x0000000000000200
-nvmlEventTypeDramRetirementEvent    = 0x0000000000000400
-nvmlEventTypeDramRetirementFailure  = 0x0000000000000800
-nvmlEventTypeNonFatalPoisonError    = 0x0000000000001000
-nvmlEventTypeFatalPoisonError       = 0x0000000000002000
-nvmlEventTypeGpuUnavailableError    = 0x0000000000004000
-nvmlEventTypeGpuRecoveryAction      = 0x0000000000008000
-nvmlEventTypeNone                   = 0x0000000000000000
-nvmlEventTypeAll                    = (
-                                        nvmlEventTypeNone
-                                        | nvmlEventTypeSingleBitEccError
-                                        | nvmlEventTypeDoubleBitEccError
-                                        | nvmlEventTypePState
-                                        | nvmlEventTypeClock
-                                        | nvmlEventTypePowerSourceChange
-                                        | nvmlEventTypeXidCriticalError
-                                        | nvmlEventMigConfigChange
-                                        | nvmlEventTypeSingleBitEccErrorStorm
-                                        | nvmlEventTypeDramRetirementEvent
-                                        | nvmlEventTypeDramRetirementFailure
-                                        | nvmlEventTypeNonFatalPoisonError
-                                        | nvmlEventTypeFatalPoisonError
-                                        | nvmlEventTypeGpuUnavailableError
-                                        | nvmlEventTypeGpuRecoveryAction
-                                        )
+nvmlEventTypeDramRetirementEvent = 0x0000000000000400
+nvmlEventTypeDramRetirementFailure = 0x0000000000000800
+nvmlEventTypeNonFatalPoisonError = 0x0000000000001000
+nvmlEventTypeFatalPoisonError = 0x0000000000002000
+nvmlEventTypeGpuUnavailableError = 0x0000000000004000
+nvmlEventTypeGpuRecoveryAction = 0x0000000000008000
+nvmlEventTypeNone = 0x0000000000000000
+nvmlEventTypeAll = (
+    nvmlEventTypeNone
+    | nvmlEventTypeSingleBitEccError
+    | nvmlEventTypeDoubleBitEccError
+    | nvmlEventTypePState
+    | nvmlEventTypeClock
+    | nvmlEventTypePowerSourceChange
+    | nvmlEventTypeXidCriticalError
+    | nvmlEventMigConfigChange
+    | nvmlEventTypeSingleBitEccErrorStorm
+    | nvmlEventTypeDramRetirementEvent
+    | nvmlEventTypeDramRetirementFailure
+    | nvmlEventTypeNonFatalPoisonError
+    | nvmlEventTypeFatalPoisonError
+    | nvmlEventTypeGpuUnavailableError
+    | nvmlEventTypeGpuRecoveryAction
+)
 
 ## Clock Event Reasons defines
-nvmlClocksEventReasonGpuIdle              = 0x0000000000000001
+nvmlClocksEventReasonGpuIdle = 0x0000000000000001
 nvmlClocksEventReasonApplicationsClocksSetting = 0x0000000000000002
-nvmlClocksEventReasonUserDefinedClocks         = nvmlClocksEventReasonApplicationsClocksSetting # deprecated, use nvmlClocksEventReasonApplicationsClocksSetting
-nvmlClocksEventReasonSwPowerCap           = 0x0000000000000004
-nvmlClocksEventReasonHwSlowdown           = 0x0000000000000008
-nvmlClocksEventReasonSyncBoost            = 0x0000000000000010
-nvmlClocksEventReasonSwThermalSlowdown    = 0x0000000000000020
-nvmlClocksEventReasonHwThermalSlowdown    = 0x0000000000000040
+nvmlClocksEventReasonUserDefinedClocks = nvmlClocksEventReasonApplicationsClocksSetting  # deprecated, use nvmlClocksEventReasonApplicationsClocksSetting
+nvmlClocksEventReasonSwPowerCap = 0x0000000000000004
+nvmlClocksEventReasonHwSlowdown = 0x0000000000000008
+nvmlClocksEventReasonSyncBoost = 0x0000000000000010
+nvmlClocksEventReasonSwThermalSlowdown = 0x0000000000000020
+nvmlClocksEventReasonHwThermalSlowdown = 0x0000000000000040
 nvmlClocksEventReasonHwPowerBrakeSlowdown = 0x0000000000000080
-nvmlClocksEventReasonDisplayClockSetting  = 0x0000000000000100
-nvmlClocksEventReasonNone                 = 0x0000000000000000
-nvmlClocksEventReasonAll                  = (
-                                                  nvmlClocksEventReasonNone |
-                                                  nvmlClocksEventReasonGpuIdle |
-                                                  nvmlClocksEventReasonApplicationsClocksSetting |
-                                                  nvmlClocksEventReasonSwPowerCap |
-                                                  nvmlClocksEventReasonHwSlowdown |
-                                                  nvmlClocksEventReasonSyncBoost |
-                                                  nvmlClocksEventReasonSwThermalSlowdown |
-                                                  nvmlClocksEventReasonHwThermalSlowdown |
-                                                  nvmlClocksEventReasonHwPowerBrakeSlowdown |
-                                                  nvmlClocksEventReasonDisplayClockSetting
-                                               )
+nvmlClocksEventReasonDisplayClockSetting = 0x0000000000000100
+nvmlClocksEventReasonNone = 0x0000000000000000
+nvmlClocksEventReasonAll = (
+    nvmlClocksEventReasonNone
+    | nvmlClocksEventReasonGpuIdle
+    | nvmlClocksEventReasonApplicationsClocksSetting
+    | nvmlClocksEventReasonSwPowerCap
+    | nvmlClocksEventReasonHwSlowdown
+    | nvmlClocksEventReasonSyncBoost
+    | nvmlClocksEventReasonSwThermalSlowdown
+    | nvmlClocksEventReasonHwThermalSlowdown
+    | nvmlClocksEventReasonHwPowerBrakeSlowdown
+    | nvmlClocksEventReasonDisplayClockSetting
+)
 
 ## Following have been deprecated
-nvmlClocksThrottleReasonGpuIdle              = 0x0000000000000001
+nvmlClocksThrottleReasonGpuIdle = 0x0000000000000001
 nvmlClocksThrottleReasonApplicationsClocksSetting = 0x0000000000000002
-nvmlClocksThrottleReasonUserDefinedClocks         = nvmlClocksThrottleReasonApplicationsClocksSetting # deprecated, use nvmlClocksThrottleReasonApplicationsClocksSetting
-nvmlClocksThrottleReasonSwPowerCap           = 0x0000000000000004
-nvmlClocksThrottleReasonHwSlowdown           = 0x0000000000000008
-nvmlClocksThrottleReasonSyncBoost            = 0x0000000000000010
-nvmlClocksThrottleReasonSwThermalSlowdown    = 0x0000000000000020
-nvmlClocksThrottleReasonHwThermalSlowdown    = 0x0000000000000040
+nvmlClocksThrottleReasonUserDefinedClocks = nvmlClocksThrottleReasonApplicationsClocksSetting  # deprecated, use nvmlClocksThrottleReasonApplicationsClocksSetting
+nvmlClocksThrottleReasonSwPowerCap = 0x0000000000000004
+nvmlClocksThrottleReasonHwSlowdown = 0x0000000000000008
+nvmlClocksThrottleReasonSyncBoost = 0x0000000000000010
+nvmlClocksThrottleReasonSwThermalSlowdown = 0x0000000000000020
+nvmlClocksThrottleReasonHwThermalSlowdown = 0x0000000000000040
 nvmlClocksThrottleReasonHwPowerBrakeSlowdown = 0x0000000000000080
-nvmlClocksThrottleReasonDisplayClockSetting  = 0x0000000000000100
-nvmlClocksThrottleReasonNone                 = 0x0000000000000000
-nvmlClocksThrottleReasonAll                  = (
-                                                  nvmlClocksThrottleReasonNone |
-                                                  nvmlClocksThrottleReasonGpuIdle |
-                                                  nvmlClocksThrottleReasonApplicationsClocksSetting |
-                                                  nvmlClocksThrottleReasonSwPowerCap |
-                                                  nvmlClocksThrottleReasonHwSlowdown |
-                                                  nvmlClocksThrottleReasonSyncBoost |
-                                                  nvmlClocksThrottleReasonSwThermalSlowdown |
-                                                  nvmlClocksThrottleReasonHwThermalSlowdown |
-                                                  nvmlClocksThrottleReasonHwPowerBrakeSlowdown |
-                                                  nvmlClocksThrottleReasonDisplayClockSetting
-                                               )
+nvmlClocksThrottleReasonDisplayClockSetting = 0x0000000000000100
+nvmlClocksThrottleReasonNone = 0x0000000000000000
+nvmlClocksThrottleReasonAll = (
+    nvmlClocksThrottleReasonNone
+    | nvmlClocksThrottleReasonGpuIdle
+    | nvmlClocksThrottleReasonApplicationsClocksSetting
+    | nvmlClocksThrottleReasonSwPowerCap
+    | nvmlClocksThrottleReasonHwSlowdown
+    | nvmlClocksThrottleReasonSyncBoost
+    | nvmlClocksThrottleReasonSwThermalSlowdown
+    | nvmlClocksThrottleReasonHwThermalSlowdown
+    | nvmlClocksThrottleReasonHwPowerBrakeSlowdown
+    | nvmlClocksThrottleReasonDisplayClockSetting
+)
+
 
 class c_nvmlEventData_t(_PrintableStructure):
     _fields_ = [
-        ('device', c_nvmlDevice_t),
-        ('eventType', c_ulonglong),
-        ('eventData', c_ulonglong),
-        ('gpuInstanceId', c_uint),
-        ('computeInstanceId', c_uint)
+        ("device", c_nvmlDevice_t),
+        ("eventType", c_ulonglong),
+        ("eventData", c_ulonglong),
+        ("gpuInstanceId", c_uint),
+        ("computeInstanceId", c_uint),
     ]
-    _fmt_ = {'eventType': "0x%08X"}
+    _fmt_ = {"eventType": "0x%08X"}
+
 
 class c_nvmlAccountingStats_t(_PrintableStructure):
     _fields_ = [
-        ('gpuUtilization', c_uint),
-        ('memoryUtilization', c_uint),
-        ('maxMemoryUsage', c_ulonglong),
-        ('time', c_ulonglong),
-        ('startTime', c_ulonglong),
-        ('isRunning', c_uint),
-        ('reserved', c_uint * 5)
+        ("gpuUtilization", c_uint),
+        ("memoryUtilization", c_uint),
+        ("maxMemoryUsage", c_ulonglong),
+        ("time", c_ulonglong),
+        ("startTime", c_ulonglong),
+        ("isRunning", c_uint),
+        ("reserved", c_uint * 5),
     ]
 
+
 class c_nvmlVgpuVersion_t(Structure):
-    _fields_ = [("minVersion", c_uint),
-                ("maxVersion", c_uint)
-               ]
+    _fields_ = [("minVersion", c_uint), ("maxVersion", c_uint)]
+
 
 class c_nvmlVgpuMetadata_t(_PrintableStructure):
-    _fields_ = [("version", c_uint),
-                ("revision", c_uint),
-                ("guestInfoState", _nvmlVgpuGuestInfoState_t),
-                ("guestDriverVersion", c_char * NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE),
-                ("hostDriverVersion", c_char * NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE),
-                ("reserved", c_uint * 6),
-                ("vgpuVirtualizationCaps", c_uint),
-                ("guestVgpuVersion", c_uint),
-                ("opaqueDataSize", c_uint),
-                ("opaqueData", c_char * NVML_VGPU_METADATA_OPAQUE_DATA_SIZE)
-               ]
+    _fields_ = [
+        ("version", c_uint),
+        ("revision", c_uint),
+        ("guestInfoState", _nvmlVgpuGuestInfoState_t),
+        ("guestDriverVersion", c_char * NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE),
+        ("hostDriverVersion", c_char * NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE),
+        ("reserved", c_uint * 6),
+        ("vgpuVirtualizationCaps", c_uint),
+        ("guestVgpuVersion", c_uint),
+        ("opaqueDataSize", c_uint),
+        ("opaqueData", c_char * NVML_VGPU_METADATA_OPAQUE_DATA_SIZE),
+    ]
+
 
 class c_nvmlVgpuPgpuMetadata_t(_PrintableStructure):
-    _fields_ = [("version", c_uint),
-                ("revision", c_uint),
-                ("hostDriverVersion", c_char * NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE),
-                ("pgpuVirtualizationCaps", c_uint),
-                ("reserved", c_uint * 5),
-                ("hostSupportedVgpuRange", c_nvmlVgpuVersion_t),
-                ("opaqueDataSize", c_uint),
-                ("opaqueData", c_char * NVML_VGPU_PGPU_METADATA_OPAQUE_DATA_SIZE)
-               ]
+    _fields_ = [
+        ("version", c_uint),
+        ("revision", c_uint),
+        ("hostDriverVersion", c_char * NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE),
+        ("pgpuVirtualizationCaps", c_uint),
+        ("reserved", c_uint * 5),
+        ("hostSupportedVgpuRange", c_nvmlVgpuVersion_t),
+        ("opaqueDataSize", c_uint),
+        ("opaqueData", c_char * NVML_VGPU_PGPU_METADATA_OPAQUE_DATA_SIZE),
+    ]
+
 
 class c_nvmlVgpuPgpuCompatibility_t(Structure):
-    _fields_ = [("vgpuVmCompatibility", _nvmlVgpuVmCompatibility_t),
-                ("compatibilityLimitCode", _nvmlVgpuPgpuCompatibilityLimitCode_t)
-               ]
+    _fields_ = [
+        ("vgpuVmCompatibility", _nvmlVgpuVmCompatibility_t),
+        ("compatibilityLimitCode", _nvmlVgpuPgpuCompatibilityLimitCode_t),
+    ]
+
 
 ## vGPU scheduler policy defines
-NVML_VGPU_SCHEDULER_POLICY_UNKNOWN      = 0
-NVML_VGPU_SCHEDULER_POLICY_BEST_EFFORT  = 1
-NVML_VGPU_SCHEDULER_POLICY_EQUAL_SHARE  = 2
-NVML_VGPU_SCHEDULER_POLICY_FIXED_SHARE  = 3
+NVML_VGPU_SCHEDULER_POLICY_UNKNOWN = 0
+NVML_VGPU_SCHEDULER_POLICY_BEST_EFFORT = 1
+NVML_VGPU_SCHEDULER_POLICY_EQUAL_SHARE = 2
+NVML_VGPU_SCHEDULER_POLICY_FIXED_SHARE = 3
 
 ## Supported vGPU scheduler policy count
-NVML_SUPPORTED_VGPU_SCHEDULER_POLICY_COUNT  = 3
+NVML_SUPPORTED_VGPU_SCHEDULER_POLICY_COUNT = 3
 
-NVML_SCHEDULER_SW_MAX_LOG_ENTRIES           = 200
+NVML_SCHEDULER_SW_MAX_LOG_ENTRIES = 200
 
-NVML_VGPU_SCHEDULER_ARR_DEFAULT   = 0
-NVML_VGPU_SCHEDULER_ARR_DISABLE   = 1
-NVML_VGPU_SCHEDULER_ARR_ENABLE    = 2
+NVML_VGPU_SCHEDULER_ARR_DEFAULT = 0
+NVML_VGPU_SCHEDULER_ARR_DISABLE = 1
+NVML_VGPU_SCHEDULER_ARR_ENABLE = 2
+
 
 class c_nvmlVgpuSchedDataWithARR_t(_PrintableStructure):
     _fields_ = [
-        ('avgFactor',   c_uint),
-        ('timeslice',   c_uint),
+        ("avgFactor", c_uint),
+        ("timeslice", c_uint),
     ]
+
 
 class c_nvmlVgpuSchedData_t(_PrintableStructure):
     _fields_ = [
-        ('timeslice',   c_uint),
+        ("timeslice", c_uint),
     ]
+
 
 class c_nvmlVgpuSchedulerParams_t(Union):
     _fields_ = [
-        ('vgpuSchedDataWithARR', c_nvmlVgpuSchedDataWithARR_t),
-        ('vgpuSchedData',        c_nvmlVgpuSchedData_t),
+        ("vgpuSchedDataWithARR", c_nvmlVgpuSchedDataWithARR_t),
+        ("vgpuSchedData", c_nvmlVgpuSchedData_t),
     ]
+
 
 class c_nvmlVgpuSchedulerLogEntry_t(_PrintableStructure):
     _fields_ = [
-        ('timestamp',                   c_ulonglong),
-        ('timeRunTotal',                c_ulonglong),
-        ('timeRun',                     c_ulonglong),
-        ('swRunlistId',                 c_uint),
-        ('targetTimeSlice',             c_ulonglong),
-        ('cumulativePreemptionTime',    c_ulonglong),
+        ("timestamp", c_ulonglong),
+        ("timeRunTotal", c_ulonglong),
+        ("timeRun", c_ulonglong),
+        ("swRunlistId", c_uint),
+        ("targetTimeSlice", c_ulonglong),
+        ("cumulativePreemptionTime", c_ulonglong),
     ]
+
 
 class c_nvmlVgpuSchedulerLog_t(_PrintableStructure):
     _fields_ = [
-        ('engineId',        c_uint),
-        ('schedulerPolicy', c_uint),
-        ('arrMode',         c_uint),
-        ('schedulerParams', c_nvmlVgpuSchedulerParams_t),
-        ('entriesCount',    c_uint),
-        ('logEntries',      c_nvmlVgpuSchedulerLogEntry_t * NVML_SCHEDULER_SW_MAX_LOG_ENTRIES),
+        ("engineId", c_uint),
+        ("schedulerPolicy", c_uint),
+        ("arrMode", c_uint),
+        ("schedulerParams", c_nvmlVgpuSchedulerParams_t),
+        ("entriesCount", c_uint),
+        (
+            "logEntries",
+            c_nvmlVgpuSchedulerLogEntry_t * NVML_SCHEDULER_SW_MAX_LOG_ENTRIES,
+        ),
     ]
+
 
 class c_nvmlVgpuSchedulerGetState_t(_PrintableStructure):
     _fields_ = [
-        ('schedulerPolicy', c_uint),
-        ('arrMode',         c_uint),
-        ('schedulerParams', c_nvmlVgpuSchedulerParams_t),
+        ("schedulerPolicy", c_uint),
+        ("arrMode", c_uint),
+        ("schedulerParams", c_nvmlVgpuSchedulerParams_t),
     ]
+
 
 class c_nvmlVgpuSchedSetDataWithARR_t(_PrintableStructure):
     _fields_ = [
-        ('avgFactor',   c_uint),
-        ('frequency',   c_uint),
+        ("avgFactor", c_uint),
+        ("frequency", c_uint),
     ]
+
 
 class c_nvmlVgpuSchedSetData_t(_PrintableStructure):
     _fields_ = [
-        ('timeslice',   c_uint),
+        ("timeslice", c_uint),
     ]
+
 
 class c_nvmlVgpuSchedulerSetParams_t(Union):
     _fields_ = [
-        ('vgpuSchedDataWithARR', c_nvmlVgpuSchedSetDataWithARR_t),
-        ('vgpuSchedData',        c_nvmlVgpuSchedSetData_t),
+        ("vgpuSchedDataWithARR", c_nvmlVgpuSchedSetDataWithARR_t),
+        ("vgpuSchedData", c_nvmlVgpuSchedSetData_t),
     ]
+
 
 class c_nvmlVgpuSchedulerSetState_t(_PrintableStructure):
     _fields_ = [
-        ('schedulerPolicy', c_uint),
-        ('enableARRMode',   c_uint),
-        ('schedulerParams', c_nvmlVgpuSchedulerSetParams_t),
+        ("schedulerPolicy", c_uint),
+        ("enableARRMode", c_uint),
+        ("schedulerParams", c_nvmlVgpuSchedulerSetParams_t),
     ]
+
 
 class c_nvmlVgpuSchedulerCapabilities_t(_PrintableStructure):
     _fields_ = [
-        ('supportedSchedulers', c_uint * NVML_SUPPORTED_VGPU_SCHEDULER_POLICY_COUNT),
-        ('maxTimeslice',        c_uint),
-        ('minTimeslice',        c_uint),
-        ('isArrModeSupported',  c_uint),
-        ('maxFrequencyForARR',  c_uint),
-        ('minFrequencyForARR',  c_uint),
-        ('maxAvgFactorForARR',  c_uint),
-        ('minAvgFactorForARR',  c_uint),
+        ("supportedSchedulers", c_uint * NVML_SUPPORTED_VGPU_SCHEDULER_POLICY_COUNT),
+        ("maxTimeslice", c_uint),
+        ("minTimeslice", c_uint),
+        ("isArrModeSupported", c_uint),
+        ("maxFrequencyForARR", c_uint),
+        ("minFrequencyForARR", c_uint),
+        ("maxAvgFactorForARR", c_uint),
+        ("minAvgFactorForARR", c_uint),
     ]
 
+
 class c_nvmlFBCStats_t(Structure):
-    _fields_ = [("sessionsCount", c_uint),
-                ("averageFPS", c_uint),
-                ("averageLatency", c_uint)
-               ]
+    _fields_ = [
+        ("sessionsCount", c_uint),
+        ("averageFPS", c_uint),
+        ("averageLatency", c_uint),
+    ]
+
 
 class c_nvmlFBCSession_t(_PrintableStructure):
     _fields_ = [
-        ('sessionId', c_uint),
-        ('pid', c_uint),
-        ('vgpuInstance', _nvmlVgpuInstance_t),
-        ('displayOrdinal', c_uint),
-        ('sessionType', c_uint),
-        ('sessionFlags', c_uint),
-        ('hMaxResolution', c_uint),
-        ('vMaxResolution', c_uint),
-        ('hResolution', c_uint),
-        ('vResolution', c_uint),
-        ('averageFPS', c_uint),
-        ('averageLatency', c_uint),
+        ("sessionId", c_uint),
+        ("pid", c_uint),
+        ("vgpuInstance", _nvmlVgpuInstance_t),
+        ("displayOrdinal", c_uint),
+        ("sessionType", c_uint),
+        ("sessionFlags", c_uint),
+        ("hMaxResolution", c_uint),
+        ("vMaxResolution", c_uint),
+        ("hResolution", c_uint),
+        ("vResolution", c_uint),
+        ("averageFPS", c_uint),
+        ("averageLatency", c_uint),
     ]
 
-NVML_DEVICE_MIG_DISABLE = 0x0
-NVML_DEVICE_MIG_ENABLE  = 0x1
 
-NVML_GPU_INSTANCE_PROFILE_1_SLICE      = 0x0
-NVML_GPU_INSTANCE_PROFILE_2_SLICE      = 0x1
-NVML_GPU_INSTANCE_PROFILE_3_SLICE      = 0x2
-NVML_GPU_INSTANCE_PROFILE_4_SLICE      = 0x3
-NVML_GPU_INSTANCE_PROFILE_7_SLICE      = 0x4
-NVML_GPU_INSTANCE_PROFILE_8_SLICE      = 0x5
-NVML_GPU_INSTANCE_PROFILE_6_SLICE      = 0x6
+NVML_DEVICE_MIG_DISABLE = 0x0
+NVML_DEVICE_MIG_ENABLE = 0x1
+
+NVML_GPU_INSTANCE_PROFILE_1_SLICE = 0x0
+NVML_GPU_INSTANCE_PROFILE_2_SLICE = 0x1
+NVML_GPU_INSTANCE_PROFILE_3_SLICE = 0x2
+NVML_GPU_INSTANCE_PROFILE_4_SLICE = 0x3
+NVML_GPU_INSTANCE_PROFILE_7_SLICE = 0x4
+NVML_GPU_INSTANCE_PROFILE_8_SLICE = 0x5
+NVML_GPU_INSTANCE_PROFILE_6_SLICE = 0x6
 NVML_GPU_INSTANCE_PROFILE_1_SLICE_REV1 = 0x7
 NVML_GPU_INSTANCE_PROFILE_2_SLICE_REV1 = 0x8
 NVML_GPU_INSTANCE_PROFILE_1_SLICE_REV2 = 0x9
-NVML_GPU_INSTANCE_PROFILE_1_SLICE_GFX  = 0xA
-NVML_GPU_INSTANCE_PROFILE_2_SLICE_GFX  = 0xB
-NVML_GPU_INSTANCE_PROFILE_4_SLICE_GFX  = 0xC
-NVML_GPU_INSTANCE_PROFILE_COUNT        = 0xD
+NVML_GPU_INSTANCE_PROFILE_1_SLICE_GFX = 0xA
+NVML_GPU_INSTANCE_PROFILE_2_SLICE_GFX = 0xB
+NVML_GPU_INSTANCE_PROFILE_4_SLICE_GFX = 0xC
+NVML_GPU_INSTANCE_PROFILE_COUNT = 0xD
+
 
 class c_nvmlGpuInstancePlacement_t(Structure):
-    _fields_ = [("start", c_uint),
-                ("size", c_uint)
-               ]
+    _fields_ = [("start", c_uint), ("size", c_uint)]
+
 
 class c_nvmlGpuInstanceProfileInfo_t(Structure):
-    _fields_ = [("id", c_uint),
-                ("isP2pSupported", c_uint),
-                ("sliceCount", c_uint),
-                ("instanceCount", c_uint),
-                ("multiprocessorCount", c_uint),
-                ("copyEngineCount", c_uint),
-                ("decoderCount", c_uint),
-                ("encoderCount", c_uint),
-                ("jpegCount", c_uint),
-                ("ofaCount", c_uint),
-                ("memorySizeMB", c_ulonglong),
-               ]
+    _fields_ = [
+        ("id", c_uint),
+        ("isP2pSupported", c_uint),
+        ("sliceCount", c_uint),
+        ("instanceCount", c_uint),
+        ("multiprocessorCount", c_uint),
+        ("copyEngineCount", c_uint),
+        ("decoderCount", c_uint),
+        ("encoderCount", c_uint),
+        ("jpegCount", c_uint),
+        ("ofaCount", c_uint),
+        ("memorySizeMB", c_ulonglong),
+    ]
+
 
 nvmlGpuInstanceProfileInfo_v2 = 0x02000098
 
+
 class c_nvmlGpuInstanceProfileInfo_v2_t(_PrintableStructure):
-    _fields_ = [("version", c_uint),
-                ("id", c_uint),
-                ("isP2pSupported", c_uint),
-                ("sliceCount", c_uint),
-                ("instanceCount", c_uint),
-                ("multiprocessorCount", c_uint),
-                ("copyEngineCount", c_uint),
-                ("decoderCount", c_uint),
-                ("encoderCount", c_uint),
-                ("jpegCount", c_uint),
-                ("ofaCount", c_uint),
-                ("memorySizeMB", c_ulonglong),
-                ("name", c_char * NVML_DEVICE_NAME_V2_BUFFER_SIZE)
-               ]
-    
+    _fields_ = [
+        ("version", c_uint),
+        ("id", c_uint),
+        ("isP2pSupported", c_uint),
+        ("sliceCount", c_uint),
+        ("instanceCount", c_uint),
+        ("multiprocessorCount", c_uint),
+        ("copyEngineCount", c_uint),
+        ("decoderCount", c_uint),
+        ("encoderCount", c_uint),
+        ("jpegCount", c_uint),
+        ("ofaCount", c_uint),
+        ("memorySizeMB", c_ulonglong),
+        ("name", c_char * NVML_DEVICE_NAME_V2_BUFFER_SIZE),
+    ]
+
     def __init__(self):
-        super(c_nvmlGpuInstanceProfileInfo_v2_t, self).__init__(version=nvmlGpuInstanceProfileInfo_v2)
+        super(c_nvmlGpuInstanceProfileInfo_v2_t, self).__init__(
+            version=nvmlGpuInstanceProfileInfo_v2
+        )
+
 
 class c_nvmlGpuInstanceInfo_t(Structure):
-    _fields_ = [("device", c_nvmlDevice_t),
-                ("id", c_uint),
-                ("profileId", c_uint),
-                ("placement", c_nvmlGpuInstancePlacement_t)
-               ]
+    _fields_ = [
+        ("device", c_nvmlDevice_t),
+        ("id", c_uint),
+        ("profileId", c_uint),
+        ("placement", c_nvmlGpuInstancePlacement_t),
+    ]
+
 
 class struct_c_nvmlGpuInstance_t(Structure):
-    pass # opaque handle
+    pass  # opaque handle
+
+
 c_nvmlGpuInstance_t = POINTER(struct_c_nvmlGpuInstance_t)
 
-NVML_COMPUTE_INSTANCE_PROFILE_1_SLICE      = 0x0
-NVML_COMPUTE_INSTANCE_PROFILE_2_SLICE      = 0x1
-NVML_COMPUTE_INSTANCE_PROFILE_3_SLICE      = 0x2
-NVML_COMPUTE_INSTANCE_PROFILE_4_SLICE      = 0x3
-NVML_COMPUTE_INSTANCE_PROFILE_7_SLICE      = 0x4
-NVML_COMPUTE_INSTANCE_PROFILE_8_SLICE      = 0x5
-NVML_COMPUTE_INSTANCE_PROFILE_6_SLICE      = 0x6
+NVML_COMPUTE_INSTANCE_PROFILE_1_SLICE = 0x0
+NVML_COMPUTE_INSTANCE_PROFILE_2_SLICE = 0x1
+NVML_COMPUTE_INSTANCE_PROFILE_3_SLICE = 0x2
+NVML_COMPUTE_INSTANCE_PROFILE_4_SLICE = 0x3
+NVML_COMPUTE_INSTANCE_PROFILE_7_SLICE = 0x4
+NVML_COMPUTE_INSTANCE_PROFILE_8_SLICE = 0x5
+NVML_COMPUTE_INSTANCE_PROFILE_6_SLICE = 0x6
 NVML_COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1 = 0x7
-NVML_COMPUTE_INSTANCE_PROFILE_COUNT        = 0x8
+NVML_COMPUTE_INSTANCE_PROFILE_COUNT = 0x8
 
 NVML_COMPUTE_INSTANCE_ENGINE_PROFILE_SHARED = 0x0
 NVML_COMPUTE_INSTANCE_ENGINE_PROFILE_COUNT = 0x1
 
+
 class c_nvmlComputeInstancePlacement_t(Structure):
-    _fields_ = [("start", c_uint),
-                ("size", c_uint)
-               ]
+    _fields_ = [("start", c_uint), ("size", c_uint)]
+
 
 class c_nvmlComputeInstanceProfileInfo_t(Structure):
-    _fields_ = [("id", c_uint),
-                ("sliceCount", c_uint),
-                ("instanceCount", c_uint),
-                ("multiprocessorCount", c_uint),
-                ("sharedCopyEngineCount", c_uint),
-                ("sharedDecoderCount", c_uint),
-                ("sharedEncoderCount", c_uint),
-                ("sharedJpegCount", c_uint),
-                ("sharedOfaCount", c_uint)
-               ]
+    _fields_ = [
+        ("id", c_uint),
+        ("sliceCount", c_uint),
+        ("instanceCount", c_uint),
+        ("multiprocessorCount", c_uint),
+        ("sharedCopyEngineCount", c_uint),
+        ("sharedDecoderCount", c_uint),
+        ("sharedEncoderCount", c_uint),
+        ("sharedJpegCount", c_uint),
+        ("sharedOfaCount", c_uint),
+    ]
+
 
 nvmlComputeInstanceProfileInfo_v2 = 0x02000088
 
+
 class c_nvmlComputeInstanceProfileInfo_v2_t(_PrintableStructure):
-    _fields_ = [("version", c_uint),
-                ("id", c_uint),
-                ("sliceCount", c_uint),
-                ("instanceCount", c_uint),
-                ("multiprocessorCount", c_uint),
-                ("sharedCopyEngineCount", c_uint),
-                ("sharedDecoderCount", c_uint),
-                ("sharedEncoderCount", c_uint),
-                ("sharedJpegCount", c_uint),
-                ("sharedOfaCount", c_uint),
-                ("name", c_char * NVML_DEVICE_NAME_V2_BUFFER_SIZE)
-               ]
+    _fields_ = [
+        ("version", c_uint),
+        ("id", c_uint),
+        ("sliceCount", c_uint),
+        ("instanceCount", c_uint),
+        ("multiprocessorCount", c_uint),
+        ("sharedCopyEngineCount", c_uint),
+        ("sharedDecoderCount", c_uint),
+        ("sharedEncoderCount", c_uint),
+        ("sharedJpegCount", c_uint),
+        ("sharedOfaCount", c_uint),
+        ("name", c_char * NVML_DEVICE_NAME_V2_BUFFER_SIZE),
+    ]
 
     def __init__(self):
-        super(c_nvmlComputeInstanceProfileInfo_v2_t, self).__init__(version=nvmlComputeInstanceProfileInfo_v2)
+        super(c_nvmlComputeInstanceProfileInfo_v2_t, self).__init__(
+            version=nvmlComputeInstanceProfileInfo_v2
+        )
+
 
 class c_nvmlComputeInstanceInfo_t(Structure):
-    _fields_ = [("device", c_nvmlDevice_t),
-                ("gpuInstance", c_nvmlGpuInstance_t),
-                ("id", c_uint),
-                ("profileId", c_uint),
-                ("placement", c_nvmlComputeInstancePlacement_t)
-               ]
+    _fields_ = [
+        ("device", c_nvmlDevice_t),
+        ("gpuInstance", c_nvmlGpuInstance_t),
+        ("id", c_uint),
+        ("profileId", c_uint),
+        ("placement", c_nvmlComputeInstancePlacement_t),
+    ]
+
 
 NVML_MAX_GPU_UTILIZATIONS = 8
-NVML_GPU_UTILIZATION_DOMAIN_GPU    = 0
-NVML_GPU_UTILIZATION_DOMAIN_FB     = 1
-NVML_GPU_UTILIZATION_DOMAIN_VID    = 2
-NVML_GPU_UTILIZATION_DOMAIN_BUS    = 3
+NVML_GPU_UTILIZATION_DOMAIN_GPU = 0
+NVML_GPU_UTILIZATION_DOMAIN_FB = 1
+NVML_GPU_UTILIZATION_DOMAIN_VID = 2
+NVML_GPU_UTILIZATION_DOMAIN_BUS = 3
+
+
 class c_nvmlGpuDynamicPstatesUtilization_t(Structure):
-    _fields_ = [("bIsPresent", c_uint, 1),
-                ("percentage", c_uint),
-                ("incThreshold", c_uint),
-                ("decThreshold", c_uint)]
+    _fields_ = [
+        ("bIsPresent", c_uint, 1),
+        ("percentage", c_uint),
+        ("incThreshold", c_uint),
+        ("decThreshold", c_uint),
+    ]
+
+
 class c_nvmlGpuDynamicPstatesInfo_t(Structure):
-    _fields_ = [("flags", c_uint),
-                ("utilization", c_nvmlGpuDynamicPstatesUtilization_t * NVML_MAX_GPU_UTILIZATIONS)]
+    _fields_ = [
+        ("flags", c_uint),
+        (
+            "utilization",
+            c_nvmlGpuDynamicPstatesUtilization_t * NVML_MAX_GPU_UTILIZATIONS,
+        ),
+    ]
+
 
 NVML_MAX_THERMAL_SENSORS_PER_GPU = 3
 
-NVML_THERMAL_TARGET_NONE          = 0
-NVML_THERMAL_TARGET_GPU           = 1
-NVML_THERMAL_TARGET_MEMORY        = 2
-NVML_THERMAL_TARGET_POWER_SUPPLY  = 4
-NVML_THERMAL_TARGET_BOARD         = 8
-NVML_THERMAL_TARGET_VCD_BOARD     = 9
-NVML_THERMAL_TARGET_VCD_INLET     = 10
-NVML_THERMAL_TARGET_VCD_OUTLET    = 11
-NVML_THERMAL_TARGET_ALL           = 15
-NVML_THERMAL_TARGET_UNKNOWN       = -1
+NVML_THERMAL_TARGET_NONE = 0
+NVML_THERMAL_TARGET_GPU = 1
+NVML_THERMAL_TARGET_MEMORY = 2
+NVML_THERMAL_TARGET_POWER_SUPPLY = 4
+NVML_THERMAL_TARGET_BOARD = 8
+NVML_THERMAL_TARGET_VCD_BOARD = 9
+NVML_THERMAL_TARGET_VCD_INLET = 10
+NVML_THERMAL_TARGET_VCD_OUTLET = 11
+NVML_THERMAL_TARGET_ALL = 15
+NVML_THERMAL_TARGET_UNKNOWN = -1
 
-NVML_THERMAL_CONTROLLER_NONE            = 0
-NVML_THERMAL_CONTROLLER_GPU_INTERNAL    = 1
-NVML_THERMAL_CONTROLLER_ADM1032         = 2
-NVML_THERMAL_CONTROLLER_ADT7461         = 3
-NVML_THERMAL_CONTROLLER_MAX6649         = 4
-NVML_THERMAL_CONTROLLER_MAX1617         = 5
-NVML_THERMAL_CONTROLLER_LM99            = 6
-NVML_THERMAL_CONTROLLER_LM89            = 7
-NVML_THERMAL_CONTROLLER_LM64            = 8
-NVML_THERMAL_CONTROLLER_G781            = 9
-NVML_THERMAL_CONTROLLER_ADT7473         = 10
-NVML_THERMAL_CONTROLLER_SBMAX6649       = 11
-NVML_THERMAL_CONTROLLER_VBIOSEVT        = 12
-NVML_THERMAL_CONTROLLER_OS              = 13
+NVML_THERMAL_CONTROLLER_NONE = 0
+NVML_THERMAL_CONTROLLER_GPU_INTERNAL = 1
+NVML_THERMAL_CONTROLLER_ADM1032 = 2
+NVML_THERMAL_CONTROLLER_ADT7461 = 3
+NVML_THERMAL_CONTROLLER_MAX6649 = 4
+NVML_THERMAL_CONTROLLER_MAX1617 = 5
+NVML_THERMAL_CONTROLLER_LM99 = 6
+NVML_THERMAL_CONTROLLER_LM89 = 7
+NVML_THERMAL_CONTROLLER_LM64 = 8
+NVML_THERMAL_CONTROLLER_G781 = 9
+NVML_THERMAL_CONTROLLER_ADT7473 = 10
+NVML_THERMAL_CONTROLLER_SBMAX6649 = 11
+NVML_THERMAL_CONTROLLER_VBIOSEVT = 12
+NVML_THERMAL_CONTROLLER_OS = 13
 NVML_THERMAL_CONTROLLER_NVSYSCON_CANOAS = 14
-NVML_THERMAL_CONTROLLER_NVSYSCON_E551   = 15
-NVML_THERMAL_CONTROLLER_MAX6649R        = 16
-NVML_THERMAL_CONTROLLER_ADT7473S        = 17
-NVML_THERMAL_CONTROLLER_UNKNOWN         = -1
+NVML_THERMAL_CONTROLLER_NVSYSCON_E551 = 15
+NVML_THERMAL_CONTROLLER_MAX6649R = 16
+NVML_THERMAL_CONTROLLER_ADT7473S = 17
+NVML_THERMAL_CONTROLLER_UNKNOWN = -1
+
 
 class c_nvmlGpuThermalSensor_t(Structure):
-    _fields_ = [("controller", c_int),
-                ("defaultMinTemp", c_int),
-                ("defaultMaxTemp", c_int),
-                ("currentTemp", c_int),
-                ("target", c_int)]
+    _fields_ = [
+        ("controller", c_int),
+        ("defaultMinTemp", c_int),
+        ("defaultMaxTemp", c_int),
+        ("currentTemp", c_int),
+        ("target", c_int),
+    ]
+
+
 class c_nvmlGpuThermalSettings_t(Structure):
-    _fields_ = [("count", c_uint),
-                ("sensor", c_nvmlGpuThermalSensor_t * NVML_MAX_THERMAL_SENSORS_PER_GPU)]
+    _fields_ = [
+        ("count", c_uint),
+        ("sensor", c_nvmlGpuThermalSensor_t * NVML_MAX_THERMAL_SENSORS_PER_GPU),
+    ]
+
 
 _nvmlCoolerControl_t = c_uint
-NVML_THERMAL_COOLER_SIGNAL_NONE        = 0
-NVML_THERMAL_COOLER_SIGNAL_TOGGLE      = 1
-NVML_THERMAL_COOLER_SIGNAL_VARIABLE    = 2
-NVML_THERMAL_COOLER_SIGNAL_COUNT       = 3
+NVML_THERMAL_COOLER_SIGNAL_NONE = 0
+NVML_THERMAL_COOLER_SIGNAL_TOGGLE = 1
+NVML_THERMAL_COOLER_SIGNAL_VARIABLE = 2
+NVML_THERMAL_COOLER_SIGNAL_COUNT = 3
 
 _nvmlCoolerTarget_t = c_uint
-NVML_THERMAL_COOLER_TARGET_NONE          = (1 << 0)
-NVML_THERMAL_COOLER_TARGET_GPU           = (1 << 1)
-NVML_THERMAL_COOLER_TARGET_MEMORY        = (1 << 2)
-NVML_THERMAL_COOLER_TARGET_POWER_SUPPLY  = (1 << 3)
-NVML_THERMAL_COOLER_TARGET_GPU_RELATED   = (NVML_THERMAL_COOLER_TARGET_GPU | NVML_THERMAL_COOLER_TARGET_MEMORY | NVML_THERMAL_COOLER_TARGET_POWER_SUPPLY)
+NVML_THERMAL_COOLER_TARGET_NONE = 1 << 0
+NVML_THERMAL_COOLER_TARGET_GPU = 1 << 1
+NVML_THERMAL_COOLER_TARGET_MEMORY = 1 << 2
+NVML_THERMAL_COOLER_TARGET_POWER_SUPPLY = 1 << 3
+NVML_THERMAL_COOLER_TARGET_GPU_RELATED = (
+    NVML_THERMAL_COOLER_TARGET_GPU
+    | NVML_THERMAL_COOLER_TARGET_MEMORY
+    | NVML_THERMAL_COOLER_TARGET_POWER_SUPPLY
+)
+
 
 class c_nvmlCoolerInfo_t(_PrintableStructure):
-    _fields_ = [("version", c_uint),
-                ("index", c_uint),
-                ("coolerControlType", _nvmlCoolerControl_t),
-                ("coolerTarget", _nvmlCoolerTarget_t)
-               ]
+    _fields_ = [
+        ("version", c_uint),
+        ("index", c_uint),
+        ("coolerControlType", _nvmlCoolerControl_t),
+        ("coolerTarget", _nvmlCoolerTarget_t),
+    ]
+
 
 nvmlCoolerInfo_v1 = 0x1000010
+
 
 def nvmlDeviceGetCoolerInfo(handle):
     c_coolerInfo = c_nvmlCoolerInfo_t()
@@ -2241,105 +2672,138 @@ def nvmlDeviceGetCoolerInfo(handle):
     _nvmlCheckReturn(ret)
     return [c_coolerInfo.coolerControlType, c_coolerInfo.coolerTarget]
 
+
 class struct_c_nvmlComputeInstance_t(Structure):
-    pass # opaque handle
+    pass  # opaque handle
+
+
 c_nvmlComputeInstance_t = POINTER(struct_c_nvmlComputeInstance_t)
 
+
 class c_nvmlDeviceAttributes(Structure):
-    _fields_ = [("multiprocessorCount", c_uint),
-                ("sharedCopyEngineCount", c_uint),
-                ("sharedDecoderCount", c_uint),
-                ("sharedEncoderCount", c_uint),
-                ("sharedJpegCount", c_uint),
-                ("sharedOfaCount", c_uint),
-                ("gpuInstanceSliceCount", c_uint),
-                ("computeInstanceSliceCount", c_uint),
-                ("memorySizeMB", c_ulonglong),
-               ]
+    _fields_ = [
+        ("multiprocessorCount", c_uint),
+        ("sharedCopyEngineCount", c_uint),
+        ("sharedDecoderCount", c_uint),
+        ("sharedEncoderCount", c_uint),
+        ("sharedJpegCount", c_uint),
+        ("sharedOfaCount", c_uint),
+        ("gpuInstanceSliceCount", c_uint),
+        ("computeInstanceSliceCount", c_uint),
+        ("memorySizeMB", c_ulonglong),
+    ]
+
 
 class c_nvmlRowRemapperHistogramValues(Structure):
-    _fields_ = [("max", c_uint),
-                ("high", c_uint),
-                ("partial", c_uint),
-                ("low", c_uint),
-                ("none", c_uint)
-               ]
+    _fields_ = [
+        ("max", c_uint),
+        ("high", c_uint),
+        ("partial", c_uint),
+        ("low", c_uint),
+        ("none", c_uint),
+    ]
 
-NVML_GPU_CERT_CHAIN_SIZE                = 0x1000
-NVML_GPU_ATTESTATION_CERT_CHAIN_SIZE    = 0x1400
-NVML_CC_GPU_CEC_NONCE_SIZE              = 0x20
-NVML_CC_GPU_ATTESTATION_REPORT_SIZE     = 0x2000
+
+NVML_GPU_CERT_CHAIN_SIZE = 0x1000
+NVML_GPU_ATTESTATION_CERT_CHAIN_SIZE = 0x1400
+NVML_CC_GPU_CEC_NONCE_SIZE = 0x20
+NVML_CC_GPU_ATTESTATION_REPORT_SIZE = 0x2000
 NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE = 0x1000
 NVML_CC_CEC_ATTESTATION_REPORT_NOT_PRESENT = 0
-NVML_CC_CEC_ATTESTATION_REPORT_PRESENT     = 1
+NVML_CC_CEC_ATTESTATION_REPORT_PRESENT = 1
+
 
 class c_nvmlConfComputeSystemState_t(Structure):
-    _fields_ = [('environment', c_uint),
-                ('ccFeature', c_uint),
-                ('devToolsMode', c_uint),
-               ]
+    _fields_ = [
+        ("environment", c_uint),
+        ("ccFeature", c_uint),
+        ("devToolsMode", c_uint),
+    ]
+
 
 nvmlSystemConfComputeSettings_v1 = 0x1000014
 
+
 class c_nvmlSystemConfComputeSettings_v1_t(Structure):
-    _fields_ = [('version', c_uint),
-                ('environment', c_uint),
-                ('ccFeature', c_uint),
-                ('devToolsMode', c_uint),
-                ('multiGpuMode', c_uint),
-               ]
+    _fields_ = [
+        ("version", c_uint),
+        ("environment", c_uint),
+        ("ccFeature", c_uint),
+        ("devToolsMode", c_uint),
+        ("multiGpuMode", c_uint),
+    ]
+
     def __init__(self):
-        super(c_nvmlSystemConfComputeSettings_v1_t, self).__init__(version=nvmlSystemConfComputeSettings_v1)
+        super(c_nvmlSystemConfComputeSettings_v1_t, self).__init__(
+            version=nvmlSystemConfComputeSettings_v1
+        )
+
 
 class c_nvmlConfComputeSystemCaps_t(Structure):
-    _fields_ = [('cpuCaps', c_uint),
-                ('gpusCaps', c_uint),
-               ]
+    _fields_ = [
+        ("cpuCaps", c_uint),
+        ("gpusCaps", c_uint),
+    ]
+
 
 class c_nvmlConfComputeMemSizeInfo_t(Structure):
-    _fields_ = [('protectedMemSizeKib', c_ulonglong),
-                ('unprotectedMemSizeKib', c_ulonglong),
-               ]
+    _fields_ = [
+        ("protectedMemSizeKib", c_ulonglong),
+        ("unprotectedMemSizeKib", c_ulonglong),
+    ]
+
 
 class c_nvmlConfComputeGpuCertificate_t(Structure):
-    _fields_ = [('certChainSize', c_uint),
-                ('attestationCertChainSize', c_uint),
-                ('certChain', c_uint8 * NVML_GPU_CERT_CHAIN_SIZE),
-                ('attestationCertChain', c_uint8 * NVML_GPU_ATTESTATION_CERT_CHAIN_SIZE),
-               ]
+    _fields_ = [
+        ("certChainSize", c_uint),
+        ("attestationCertChainSize", c_uint),
+        ("certChain", c_uint8 * NVML_GPU_CERT_CHAIN_SIZE),
+        ("attestationCertChain", c_uint8 * NVML_GPU_ATTESTATION_CERT_CHAIN_SIZE),
+    ]
+
 
 class c_nvmlConfComputeGpuAttestationReport_t(Structure):
-    _fields_ = [('isCecAttestationReportPresent', c_uint),
-                ('attestationReportSize', c_uint),
-                ('cecAttestationReportSize', c_uint),
-                ('nonce', c_uint8 * NVML_CC_GPU_CEC_NONCE_SIZE),
-                ('attestationReport', c_uint8 * NVML_CC_GPU_ATTESTATION_REPORT_SIZE),
-                ('cecAttestationReport', c_uint8 * NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE),
-               ]
+    _fields_ = [
+        ("isCecAttestationReportPresent", c_uint),
+        ("attestationReportSize", c_uint),
+        ("cecAttestationReportSize", c_uint),
+        ("nonce", c_uint8 * NVML_CC_GPU_CEC_NONCE_SIZE),
+        ("attestationReport", c_uint8 * NVML_CC_GPU_ATTESTATION_REPORT_SIZE),
+        ("cecAttestationReport", c_uint8 * NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE),
+    ]
+
 
 class c_nvmlConfComputeSetKeyRotationThresholdInfo_t(Structure):
-    _fields_ = [('version', c_uint),
-                ('maxAttackerAdvantage', c_ulong),
-               ]
+    _fields_ = [
+        ("version", c_uint),
+        ("maxAttackerAdvantage", c_ulong),
+    ]
+
+
 ConfComputeSetKeyRotationThresholdInfo_v1 = 0x1000010
 
+
 class c_nvmlConfComputeGetKeyRotationThresholdInfo_t(Structure):
-    _fields_ = [('version', c_uint),
-                ('attackerAdvantage', c_ulong),
-               ]
+    _fields_ = [
+        ("version", c_uint),
+        ("attackerAdvantage", c_ulong),
+    ]
+
+
 ConfComputeGetKeyRotationThresholdInfo_v1 = 0x1000010
 
 
 ## string/bytes conversion for ease of use
 def convertStrBytes(func):
-    '''
+    """
     In python 3, strings are unicode instead of bytes, and need to be converted for ctypes
     Args from caller: (1, 'string', <__main__.c_nvmlDevice_t at 0xFFFFFFFF>)
     Args passed to function: (1, b'string', <__main__.c_nvmlDevice_t at 0xFFFFFFFF)>
     ----
     Returned from function: b'returned string'
     Returned to caller: 'returned string'
-    '''
+    """
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         # encoding a str returns bytes in python 2 and 3
@@ -2358,17 +2822,22 @@ def convertStrBytes(func):
         return wrapper
     return func
 
+
 def throwOnVersionMismatch(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
         except NVMLError_FunctionNotFound:
-            raise NVMLLibraryMismatchError("Unversioned function called and the "
-                                           "pyNVML version does not match the NVML lib version. "
-                                           "Either use matching pyNVML and NVML lib versions or "
-                                           "use a versioned function such as " + func.__name__ + "_v2")
+            raise NVMLLibraryMismatchError(
+                "Unversioned function called and the "
+                "pyNVML version does not match the NVML lib version. "
+                "Either use matching pyNVML and NVML lib versions or "
+                "use a versioned function such as " + func.__name__ + "_v2"
+            )
+
     return wrapper
+
 
 ## C function wrappers ##
 def nvmlInitWithFlags(flags):
@@ -2388,43 +2857,56 @@ def nvmlInitWithFlags(flags):
     libLoadLock.release()
     return None
 
+
 def nvmlInit():
     nvmlInitWithFlags(0)
     return None
 
+
 def _LoadNvmlLibrary():
-    '''
+    """
     Load the library if it isn't loaded already
-    '''
+    """
     global nvmlLib
 
-    if (nvmlLib == None):
+    if nvmlLib == None:
         # lock to ensure only one caller loads the library
         libLoadLock.acquire()
 
         try:
             # ensure the library still isn't loaded
-            if (nvmlLib == None):
+            if nvmlLib == None:
                 try:
-                    if (sys.platform[:3] == "win"):
+                    if sys.platform[:3] == "win":
                         # cdecl calling convention
                         try:
                             # Check for nvml.dll in System32 first for DCH drivers
-                            nvmlLib = CDLL(os.path.join(os.getenv("WINDIR", "C:/Windows"), "System32/nvml.dll"))
+                            nvmlLib = CDLL(
+                                os.path.join(
+                                    os.getenv("WINDIR", "C:/Windows"),
+                                    "System32/nvml.dll",
+                                )
+                            )
                         except OSError as ose:
                             # If nvml.dll is not found in System32, it should be in ProgramFiles
                             # load nvml.dll from %ProgramFiles%/NVIDIA Corporation/NVSMI/nvml.dll
-                            nvmlLib = CDLL(os.path.join(os.getenv("ProgramFiles", "C:/Program Files"), "NVIDIA Corporation/NVSMI/nvml.dll"))
+                            nvmlLib = CDLL(
+                                os.path.join(
+                                    os.getenv("ProgramFiles", "C:/Program Files"),
+                                    "NVIDIA Corporation/NVSMI/nvml.dll",
+                                )
+                            )
                     else:
                         # assume linux
                         nvmlLib = CDLL("libnvidia-ml.so.1")
                 except OSError as ose:
                     _nvmlCheckReturn(NVML_ERROR_LIBRARY_NOT_FOUND)
-                if (nvmlLib == None):
+                if nvmlLib == None:
                     _nvmlCheckReturn(NVML_ERROR_LIBRARY_NOT_FOUND)
         finally:
             # lock is always freed
             libLoadLock.release()
+
 
 def nvmlShutdown():
     #
@@ -2437,18 +2919,20 @@ def nvmlShutdown():
     # Atomically update refcount
     global _nvmlLib_refcount
     libLoadLock.acquire()
-    if (0 < _nvmlLib_refcount):
+    if 0 < _nvmlLib_refcount:
         _nvmlLib_refcount -= 1
     libLoadLock.release()
     return None
+
 
 # Added in 2.285
 @convertStrBytes
 def nvmlErrorString(result):
     fn = _nvmlGetFunctionPointer("nvmlErrorString")
-    fn.restype = c_char_p # otherwise return is an int
+    fn.restype = c_char_p  # otherwise return is an int
     ret = fn(result)
     return ret
+
 
 # Added in 2.285
 @convertStrBytes
@@ -2459,6 +2943,7 @@ def nvmlSystemGetNVMLVersion():
     _nvmlCheckReturn(ret)
     return c_version.value
 
+
 def nvmlSystemGetCudaDriverVersion():
     c_cuda_version = c_int()
     fn = _nvmlGetFunctionPointer("nvmlSystemGetCudaDriverVersion")
@@ -2466,12 +2951,14 @@ def nvmlSystemGetCudaDriverVersion():
     _nvmlCheckReturn(ret)
     return c_cuda_version.value
 
+
 def nvmlSystemGetCudaDriverVersion_v2():
     c_cuda_version = c_int()
     fn = _nvmlGetFunctionPointer("nvmlSystemGetCudaDriverVersion_v2")
     ret = fn(byref(c_cuda_version))
     _nvmlCheckReturn(ret)
     return c_cuda_version.value
+
 
 # Added in 2.285
 @convertStrBytes
@@ -2482,6 +2969,7 @@ def nvmlSystemGetProcessName(pid):
     _nvmlCheckReturn(ret)
     return c_name.value
 
+
 @convertStrBytes
 def nvmlSystemGetDriverVersion():
     c_version = create_string_buffer(NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE)
@@ -2489,6 +2977,7 @@ def nvmlSystemGetDriverVersion():
     ret = fn(c_version, c_uint(NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE))
     _nvmlCheckReturn(ret)
     return c_version.value
+
 
 # Added in 2.285
 def nvmlSystemGetHicVersion():
@@ -2500,12 +2989,11 @@ def nvmlSystemGetHicVersion():
     ret = fn(byref(c_count), None)
 
     # this should only fail with insufficient size
-    if ((ret != NVML_SUCCESS) and
-        (ret != NVML_ERROR_INSUFFICIENT_SIZE)):
+    if (ret != NVML_SUCCESS) and (ret != NVML_ERROR_INSUFFICIENT_SIZE):
         raise NVMLError(ret)
 
     # If there are no hics
-    if (c_count.value == 0):
+    if c_count.value == 0:
         return []
 
     hic_array = c_nvmlHwbcEntry_t * c_count.value
@@ -2514,13 +3002,15 @@ def nvmlSystemGetHicVersion():
     _nvmlCheckReturn(ret)
     return hics
 
+
 def nvmlSystemGetDriverBranch():
     c_branchInfo = c_nvmlSystemDriverBranchInfo_v1_t(0)
     c_branchInfo.version = SystemDriverBranchInfo_v1
-    fn  = _nvmlGetFunctionPointer("nvmlSystemGetDriverBranch")
+    fn = _nvmlGetFunctionPointer("nvmlSystemGetDriverBranch")
     ret = fn(byref(c_branchInfo), c_uint(NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE))
     _nvmlCheckReturn(ret)
     return c_branchInfo
+
 
 ## Unit get functions
 def nvmlUnitGetCount():
@@ -2530,6 +3020,7 @@ def nvmlUnitGetCount():
     _nvmlCheckReturn(ret)
     return c_count.value
 
+
 def nvmlUnitGetHandleByIndex(index):
     c_index = c_uint(index)
     unit = c_nvmlUnit_t()
@@ -2538,6 +3029,7 @@ def nvmlUnitGetHandleByIndex(index):
     _nvmlCheckReturn(ret)
     return unit
 
+
 def nvmlUnitGetUnitInfo(unit):
     c_info = c_nvmlUnitInfo_t()
     fn = _nvmlGetFunctionPointer("nvmlUnitGetUnitInfo")
@@ -2545,12 +3037,14 @@ def nvmlUnitGetUnitInfo(unit):
     _nvmlCheckReturn(ret)
     return c_info
 
+
 def nvmlUnitGetLedState(unit):
-    c_state =  c_nvmlLedState_t()
+    c_state = c_nvmlLedState_t()
     fn = _nvmlGetFunctionPointer("nvmlUnitGetLedState")
     ret = fn(unit, byref(c_state))
     _nvmlCheckReturn(ret)
     return c_state
+
 
 def nvmlUnitGetPsuInfo(unit):
     c_info = c_nvmlPSUInfo_t()
@@ -2559,12 +3053,14 @@ def nvmlUnitGetPsuInfo(unit):
     _nvmlCheckReturn(ret)
     return c_info
 
+
 def nvmlUnitGetTemperature(unit, type):
     c_temp = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlUnitGetTemperature")
     ret = fn(unit, c_uint(type), byref(c_temp))
     _nvmlCheckReturn(ret)
     return c_temp.value
+
 
 def nvmlUnitGetFanSpeedInfo(unit):
     c_speeds = c_nvmlUnitFanSpeeds_t()
@@ -2573,16 +3069,18 @@ def nvmlUnitGetFanSpeedInfo(unit):
     _nvmlCheckReturn(ret)
     return c_speeds
 
+
 # added to API
 def nvmlUnitGetDeviceCount(unit):
     c_count = c_uint(0)
     # query the unit to determine device count
     fn = _nvmlGetFunctionPointer("nvmlUnitGetDevices")
     ret = fn(unit, byref(c_count), None)
-    if (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    if ret == NVML_ERROR_INSUFFICIENT_SIZE:
         ret = NVML_SUCCESS
     _nvmlCheckReturn(ret)
     return c_count.value
+
 
 def nvmlUnitGetDevices(unit):
     c_count = c_uint(nvmlUnitGetDeviceCount(unit))
@@ -2593,6 +3091,7 @@ def nvmlUnitGetDevices(unit):
     _nvmlCheckReturn(ret)
     return c_devices
 
+
 ## Device get functions
 def nvmlDeviceGetCount():
     c_count = c_uint()
@@ -2601,6 +3100,7 @@ def nvmlDeviceGetCount():
     _nvmlCheckReturn(ret)
     return c_count.value
 
+
 def nvmlDeviceGetHandleByIndex(index):
     c_index = c_uint(index)
     device = c_nvmlDevice_t()
@@ -2608,6 +3108,7 @@ def nvmlDeviceGetHandleByIndex(index):
     ret = fn(c_index, byref(device))
     _nvmlCheckReturn(ret)
     return device
+
 
 @convertStrBytes
 def nvmlDeviceGetHandleBySerial(serial):
@@ -2618,6 +3119,7 @@ def nvmlDeviceGetHandleBySerial(serial):
     _nvmlCheckReturn(ret)
     return device
 
+
 @convertStrBytes
 def nvmlDeviceGetHandleByUUID(uuid):
     c_uuid = c_char_p(uuid)
@@ -2626,6 +3128,7 @@ def nvmlDeviceGetHandleByUUID(uuid):
     ret = fn(c_uuid, byref(device))
     _nvmlCheckReturn(ret)
     return device
+
 
 @convertStrBytes
 def nvmlDeviceGetHandleByPciBusId(pciBusId):
@@ -2636,6 +3139,7 @@ def nvmlDeviceGetHandleByPciBusId(pciBusId):
     _nvmlCheckReturn(ret)
     return device
 
+
 @convertStrBytes
 def nvmlDeviceGetName(handle):
     c_name = create_string_buffer(NVML_DEVICE_NAME_V2_BUFFER_SIZE)
@@ -2644,13 +3148,16 @@ def nvmlDeviceGetName(handle):
     _nvmlCheckReturn(ret)
     return c_name.value
 
+
 class c_nvmlDevicePerfModes_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('str', c_char * NVML_PERF_MODES_BUFFER_SIZE),
+        ("version", c_uint),
+        ("str", c_char * NVML_PERF_MODES_BUFFER_SIZE),
     ]
 
+
 nvmlDevicePerfModes_v1 = 0x1000804
+
 
 @convertStrBytes
 def nvmlDeviceGetPerformanceModes(handle):
@@ -2661,13 +3168,16 @@ def nvmlDeviceGetPerformanceModes(handle):
     _nvmlCheckReturn(ret)
     return perfModes.str
 
+
 class c_nvmlDeviceCurrentClockFreqs_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('str', c_char * NVML_PERF_MODES_BUFFER_SIZE),
+        ("version", c_uint),
+        ("str", c_char * NVML_PERF_MODES_BUFFER_SIZE),
     ]
 
+
 nvmlDeviceCurrentClockFreqs_v1 = 0x1000804
+
 
 @convertStrBytes
 def nvmlDeviceGetCurrentClockFreqs(handle):
@@ -2678,19 +3188,22 @@ def nvmlDeviceGetCurrentClockFreqs(handle):
     _nvmlCheckReturn(ret)
     return currentClockFreqs.str
 
+
 def nvmlDeviceGetBoardId(handle):
-    c_id = c_uint();
+    c_id = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetBoardId")
     ret = fn(handle, byref(c_id))
     _nvmlCheckReturn(ret)
     return c_id.value
 
+
 def nvmlDeviceGetMultiGpuBoard(handle):
-    c_multiGpu = c_uint();
+    c_multiGpu = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMultiGpuBoard")
     ret = fn(handle, byref(c_multiGpu))
     _nvmlCheckReturn(ret)
     return c_multiGpu.value
+
 
 def nvmlDeviceGetBrand(handle):
     c_type = _nvmlBrandType_t()
@@ -2699,6 +3212,7 @@ def nvmlDeviceGetBrand(handle):
     _nvmlCheckReturn(ret)
     return c_type.value
 
+
 def nvmlDeviceGetC2cModeInfoV1(handle):
     c_info = c_nvmlC2cModeInfo_v1_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetC2cModeInfoV")
@@ -2706,8 +3220,10 @@ def nvmlDeviceGetC2cModeInfoV1(handle):
     _nvmlCheckReturn(ret)
     return c_info
 
+
 def nvmlDeviceGetC2cModeInfoV(handle):
     return nvmlDeviceGetC2cModeInfoV1(handle)
+
 
 @convertStrBytes
 def nvmlDeviceGetBoardPartNumber(handle):
@@ -2717,6 +3233,7 @@ def nvmlDeviceGetBoardPartNumber(handle):
     _nvmlCheckReturn(ret)
     return c_part_number.value
 
+
 @convertStrBytes
 def nvmlDeviceGetSerial(handle):
     c_serial = create_string_buffer(NVML_DEVICE_SERIAL_BUFFER_SIZE)
@@ -2724,6 +3241,7 @@ def nvmlDeviceGetSerial(handle):
     ret = fn(handle, c_serial, c_uint(NVML_DEVICE_SERIAL_BUFFER_SIZE))
     _nvmlCheckReturn(ret)
     return c_serial.value
+
 
 def nvmlDeviceGetModuleId(handle, moduleId=c_uint()):
     isReference = type(moduleId) is not c_uint
@@ -2736,6 +3254,7 @@ def nvmlDeviceGetModuleId(handle, moduleId=c_uint()):
         _nvmlCheckReturn(ret)
         return moduleId.value
 
+
 def nvmlDeviceGetMemoryAffinity(handle, nodeSetSize, scope):
     affinity_array = c_ulonglong * nodeSetSize
     c_affinity = affinity_array()
@@ -2743,6 +3262,7 @@ def nvmlDeviceGetMemoryAffinity(handle, nodeSetSize, scope):
     ret = fn(handle, nodeSetSize, byref(c_affinity), _nvmlAffinityScope_t(scope))
     _nvmlCheckReturn(ret)
     return c_affinity
+
 
 def nvmlDeviceGetCpuAffinityWithinScope(handle, cpuSetSize, scope):
     affinity_array = c_ulonglong * cpuSetSize
@@ -2752,6 +3272,7 @@ def nvmlDeviceGetCpuAffinityWithinScope(handle, cpuSetSize, scope):
     _nvmlCheckReturn(ret)
     return c_affinity
 
+
 def nvmlDeviceGetCpuAffinity(handle, cpuSetSize):
     affinity_array = c_ulonglong * cpuSetSize
     c_affinity = affinity_array()
@@ -2760,17 +3281,20 @@ def nvmlDeviceGetCpuAffinity(handle, cpuSetSize):
     _nvmlCheckReturn(ret)
     return c_affinity
 
+
 def nvmlDeviceSetCpuAffinity(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetCpuAffinity")
     ret = fn(handle)
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceClearCpuAffinity(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceClearCpuAffinity")
     ret = fn(handle)
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceGetNumaNodeId(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetNumaNodeId")
@@ -2779,12 +3303,14 @@ def nvmlDeviceGetNumaNodeId(handle):
     _nvmlCheckReturn(ret)
     return node.value
 
+
 def nvmlDeviceGetMinorNumber(handle):
     c_minor_number = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMinorNumber")
     ret = fn(handle, byref(c_minor_number))
     _nvmlCheckReturn(ret)
     return c_minor_number.value
+
 
 @convertStrBytes
 def nvmlDeviceGetUUID(handle):
@@ -2794,14 +3320,20 @@ def nvmlDeviceGetUUID(handle):
     _nvmlCheckReturn(ret)
     return c_uuid.value
 
+
 @convertStrBytes
 def nvmlDeviceGetInforomVersion(handle, infoRomObject):
     c_version = create_string_buffer(NVML_DEVICE_INFOROM_VERSION_BUFFER_SIZE)
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetInforomVersion")
-    ret = fn(handle, _nvmlInforomObject_t(infoRomObject),
-                 c_version, c_uint(NVML_DEVICE_INFOROM_VERSION_BUFFER_SIZE))
+    ret = fn(
+        handle,
+        _nvmlInforomObject_t(infoRomObject),
+        c_version,
+        c_uint(NVML_DEVICE_INFOROM_VERSION_BUFFER_SIZE),
+    )
     _nvmlCheckReturn(ret)
     return c_version.value
+
 
 # Added in 4.304
 @convertStrBytes
@@ -2812,6 +3344,7 @@ def nvmlDeviceGetInforomImageVersion(handle):
     _nvmlCheckReturn(ret)
     return c_version.value
 
+
 # Added in 4.304
 def nvmlDeviceGetInforomConfigurationChecksum(handle):
     c_checksum = c_uint()
@@ -2820,12 +3353,14 @@ def nvmlDeviceGetInforomConfigurationChecksum(handle):
     _nvmlCheckReturn(ret)
     return c_checksum.value
 
+
 # Added in 4.304
 def nvmlDeviceValidateInforom(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceValidateInforom")
     ret = fn(handle)
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceGetLastBBXFlushTime(handle):
     c_timestamp = c_ulonglong()
@@ -2835,12 +3370,14 @@ def nvmlDeviceGetLastBBXFlushTime(handle):
     _nvmlCheckReturn(ret)
     return [c_timestamp.value, c_durationUs.value]
 
+
 def nvmlDeviceGetDisplayMode(handle):
     c_mode = _nvmlEnableState_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetDisplayMode")
     ret = fn(handle, byref(c_mode))
     _nvmlCheckReturn(ret)
     return c_mode.value
+
 
 def nvmlDeviceGetDisplayActive(handle):
     c_mode = _nvmlEnableState_t()
@@ -2857,11 +3394,13 @@ def nvmlDeviceGetPersistenceMode(handle):
     _nvmlCheckReturn(ret)
     return c_state.value
 
+
 def nvmlDeviceGetPciInfoExt(handle, c_info):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetPciInfoExt")
     ret = fn(handle, c_info)
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceGetPciInfo_v3(handle):
     c_info = nvmlPciInfo_t()
@@ -2870,8 +3409,10 @@ def nvmlDeviceGetPciInfo_v3(handle):
     _nvmlCheckReturn(ret)
     return c_info
 
+
 def nvmlDeviceGetPciInfo(handle):
     return nvmlDeviceGetPciInfo_v3(handle)
+
 
 def nvmlDeviceGetClockInfo(handle, type):
     c_clock = c_uint()
@@ -2879,6 +3420,7 @@ def nvmlDeviceGetClockInfo(handle, type):
     ret = fn(handle, _nvmlClockType_t(type), byref(c_clock))
     _nvmlCheckReturn(ret)
     return c_clock.value
+
 
 # Added in 2.285
 def nvmlDeviceGetMaxClockInfo(handle, type):
@@ -2888,6 +3430,7 @@ def nvmlDeviceGetMaxClockInfo(handle, type):
     _nvmlCheckReturn(ret)
     return c_clock.value
 
+
 # Added in 4.304
 def nvmlDeviceGetApplicationsClock(handle, type):
     c_clock = c_uint()
@@ -2896,6 +3439,7 @@ def nvmlDeviceGetApplicationsClock(handle, type):
     _nvmlCheckReturn(ret)
     return c_clock.value
 
+
 def nvmlDeviceGetMaxCustomerBoostClock(handle, type):
     c_clock = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMaxCustomerBoostClock")
@@ -2903,12 +3447,14 @@ def nvmlDeviceGetMaxCustomerBoostClock(handle, type):
     _nvmlCheckReturn(ret)
     return c_clock.value
 
+
 def nvmlDeviceGetClock(handle, type, id):
     c_clock = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetClock")
     ret = fn(handle, _nvmlClockType_t(type), _nvmlClockId_t(id), byref(c_clock))
     _nvmlCheckReturn(ret)
     return c_clock.value
+
 
 # Added in 5.319
 def nvmlDeviceGetDefaultApplicationsClock(handle, type):
@@ -2918,6 +3464,7 @@ def nvmlDeviceGetDefaultApplicationsClock(handle, type):
     _nvmlCheckReturn(ret)
     return c_clock.value
 
+
 # Added in 4.304
 def nvmlDeviceGetSupportedMemoryClocks(handle):
     # first call to get the size
@@ -2925,10 +3472,10 @@ def nvmlDeviceGetSupportedMemoryClocks(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetSupportedMemoryClocks")
     ret = fn(handle, byref(c_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no clocks
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         clocks_array = c_uint * c_count.value
         c_clocks = clocks_array()
@@ -2946,6 +3493,7 @@ def nvmlDeviceGetSupportedMemoryClocks(handle):
         # error case
         raise NVMLError(ret)
 
+
 # Added in 4.304
 def nvmlDeviceGetSupportedGraphicsClocks(handle, memoryClockMHz):
     # first call to get the size
@@ -2953,10 +3501,10 @@ def nvmlDeviceGetSupportedGraphicsClocks(handle, memoryClockMHz):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetSupportedGraphicsClocks")
     ret = fn(handle, c_uint(memoryClockMHz), byref(c_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no clocks
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         clocks_array = c_uint * c_count.value
         c_clocks = clocks_array()
@@ -2974,12 +3522,14 @@ def nvmlDeviceGetSupportedGraphicsClocks(handle, memoryClockMHz):
         # error case
         raise NVMLError(ret)
 
+
 def nvmlDeviceGetFanSpeed(handle):
     c_speed = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetFanSpeed")
     ret = fn(handle, byref(c_speed))
     _nvmlCheckReturn(ret)
     return c_speed.value
+
 
 def nvmlDeviceGetFanSpeed_v2(handle, fan):
     c_speed = c_uint()
@@ -2988,14 +3538,17 @@ def nvmlDeviceGetFanSpeed_v2(handle, fan):
     _nvmlCheckReturn(ret)
     return c_speed.value
 
+
 class c_nvmlFanSpeedInfo_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('fan', c_uint),
-        ('speed', c_uint),
+        ("version", c_uint),
+        ("fan", c_uint),
+        ("speed", c_uint),
     ]
 
+
 nvmlFanSpeedInfo_v1 = 0x100000C
+
 
 def nvmlDeviceGetFanSpeedRPM(handle):
     c_fanSpeed = c_nvmlFanSpeedInfo_t()
@@ -3006,12 +3559,14 @@ def nvmlDeviceGetFanSpeedRPM(handle):
     _nvmlCheckReturn(ret)
     return c_fanSpeed.speed
 
+
 def nvmlDeviceGetTargetFanSpeed(handle, fan):
     c_speed = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetTargetFanSpeed")
     ret = fn(handle, fan, byref(c_speed))
     _nvmlCheckReturn(ret)
     return c_speed.value
+
 
 def nvmlDeviceGetNumFans(device):
     c_numFans = c_uint()
@@ -3020,11 +3575,13 @@ def nvmlDeviceGetNumFans(device):
     _nvmlCheckReturn(ret)
     return c_numFans.value
 
+
 def nvmlDeviceSetDefaultFanSpeed_v2(handle, index):
-    fn = _nvmlGetFunctionPointer("nvmlDeviceSetDefaultFanSpeed_v2");
+    fn = _nvmlGetFunctionPointer("nvmlDeviceSetDefaultFanSpeed_v2")
     ret = fn(handle, index)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlDeviceGetMinMaxFanSpeed(handle, minSpeed=c_uint(), maxSpeed=c_uint()):
     isReference = (type(minSpeed) is not c_uint) or (type(maxSpeed) is not c_uint)
@@ -3035,6 +3592,7 @@ def nvmlDeviceGetMinMaxFanSpeed(handle, minSpeed=c_uint(), maxSpeed=c_uint()):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isReference else [minSpeed.value, maxSpeed.value]
 
+
 def nvmlDeviceGetFanControlPolicy_v2(handle, fan, fanControlPolicy=c_uint()):
     isReference = type(fanControlPolicy) is not c_uint
     fanControlPolicyRef = fanControlPolicy if isReference else byref(fanControlPolicy)
@@ -3043,34 +3601,41 @@ def nvmlDeviceGetFanControlPolicy_v2(handle, fan, fanControlPolicy=c_uint()):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isReference else fanControlPolicy.value
 
+
 def nvmlDeviceSetFanControlPolicy(handle, fan, fanControlPolicy):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetFanControlPolicy")
     ret = fn(handle, fan, _nvmlFanControlPolicy_t(fanControlPolicy))
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 class c_nvmlTemperature_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('sensorType', _nvmlTemperatureSensors_t),
-        ('temperature', c_int),
+        ("version", c_uint),
+        ("sensorType", _nvmlTemperatureSensors_t),
+        ("temperature", c_int),
     ]
+
+
 nvmlTemperature_v1 = 0x100000C
+
 
 def nvmlDeviceGetTemperatureV1(handle, sensor):
     c_temp = c_nvmlTemperature_v1_t()
     c_temp.version = nvmlTemperature_v1
-    c_temp.sensorType = _nvmlTemperatureSensors_t(sensor) 
+    c_temp.sensorType = _nvmlTemperatureSensors_t(sensor)
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetTemperatureV")
     ret = fn(handle, byref(c_temp))
     _nvmlCheckReturn(ret)
     return c_temp.temperature
+
 
 def nvmlDeviceGetTemperatureV(handle, sensor, version=nvmlTemperature_v1):
     if version == nvmlTemperature_v1:
         return nvmlDeviceGetTemperatureV1(handle, sensor)
     else:
         raise NVMLError(NVML_ERROR_ARGUMENT_VERSION_MISMATCH)
+
 
 # DEPRECATED use nvmlDeviceGetTemperatureV instead
 def nvmlDeviceGetTemperature(handle, sensor):
@@ -3080,12 +3645,14 @@ def nvmlDeviceGetTemperature(handle, sensor):
     _nvmlCheckReturn(ret)
     return c_temp.value
 
+
 def nvmlDeviceGetTemperatureThreshold(handle, threshold):
     c_temp = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetTemperatureThreshold")
     ret = fn(handle, _nvmlTemperatureThresholds_t(threshold), byref(c_temp))
     _nvmlCheckReturn(ret)
     return c_temp.value
+
 
 def nvmlDeviceSetTemperatureThreshold(handle, threshold, temp):
     c_temp = c_uint()
@@ -3095,6 +3662,7 @@ def nvmlDeviceSetTemperatureThreshold(handle, threshold, temp):
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceGetMarginTemperature(handle):
     c_marginTempInfo = c_nvmlMarginTemperature_v1_t()
     c_marginTempInfo.version = nvmlMarginTemperature_v1
@@ -3102,6 +3670,7 @@ def nvmlDeviceGetMarginTemperature(handle):
     ret = fn(handle, byref(c_marginTempInfo))
     _nvmlCheckReturn(ret)
     return c_marginTempInfo.marginTemperature
+
 
 # DEPRECATED use nvmlDeviceGetPerformanceState
 def nvmlDeviceGetPowerState(handle):
@@ -3111,12 +3680,14 @@ def nvmlDeviceGetPowerState(handle):
     _nvmlCheckReturn(ret)
     return c_pstate.value
 
+
 def nvmlDeviceGetPerformanceState(handle):
     c_pstate = _nvmlPstates_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetPerformanceState")
     ret = fn(handle, byref(c_pstate))
     _nvmlCheckReturn(ret)
     return c_pstate.value
+
 
 def nvmlDeviceGetPowerManagementMode(handle):
     c_pcapMode = _nvmlEnableState_t()
@@ -3125,12 +3696,14 @@ def nvmlDeviceGetPowerManagementMode(handle):
     _nvmlCheckReturn(ret)
     return c_pcapMode.value
 
+
 def nvmlDeviceGetPowerManagementLimit(handle):
     c_limit = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetPowerManagementLimit")
     ret = fn(handle, byref(c_limit))
     _nvmlCheckReturn(ret)
     return c_limit.value
+
 
 # Added in 4.304
 def nvmlDeviceGetPowerManagementLimitConstraints(handle):
@@ -3140,6 +3713,7 @@ def nvmlDeviceGetPowerManagementLimitConstraints(handle):
     ret = fn(handle, byref(c_minLimit), byref(c_maxLimit))
     _nvmlCheckReturn(ret)
     return [c_minLimit.value, c_maxLimit.value]
+
 
 # Added in 4.304
 def nvmlDeviceGetPowerManagementDefaultLimit(handle):
@@ -3158,6 +3732,7 @@ def nvmlDeviceGetEnforcedPowerLimit(handle):
     _nvmlCheckReturn(ret)
     return c_limit.value
 
+
 def nvmlDeviceGetPowerUsage(handle):
     c_watts = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetPowerUsage")
@@ -3165,12 +3740,14 @@ def nvmlDeviceGetPowerUsage(handle):
     _nvmlCheckReturn(ret)
     return c_watts.value
 
+
 def nvmlDeviceGetTotalEnergyConsumption(handle):
     c_millijoules = c_uint64()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetTotalEnergyConsumption")
     ret = fn(handle, byref(c_millijoules))
     _nvmlCheckReturn(ret)
     return c_millijoules.value
+
 
 # Added in 4.304
 def nvmlDeviceGetGpuOperationMode(handle):
@@ -3181,13 +3758,16 @@ def nvmlDeviceGetGpuOperationMode(handle):
     _nvmlCheckReturn(ret)
     return [c_currState.value, c_pendingState.value]
 
+
 # Added in 4.304
 def nvmlDeviceGetCurrentGpuOperationMode(handle):
     return nvmlDeviceGetGpuOperationMode(handle)[0]
 
+
 # Added in 4.304
 def nvmlDeviceGetPendingGpuOperationMode(handle):
     return nvmlDeviceGetGpuOperationMode(handle)[1]
+
 
 def nvmlDeviceGetMemoryInfo(handle, version=None):
     if not version:
@@ -3201,6 +3781,7 @@ def nvmlDeviceGetMemoryInfo(handle, version=None):
     _nvmlCheckReturn(ret)
     return c_memory
 
+
 def nvmlDeviceGetBAR1MemoryInfo(handle):
     c_bar1_memory = c_nvmlBAR1Memory_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetBAR1MemoryInfo")
@@ -3208,12 +3789,14 @@ def nvmlDeviceGetBAR1MemoryInfo(handle):
     _nvmlCheckReturn(ret)
     return c_bar1_memory
 
+
 def nvmlDeviceGetComputeMode(handle):
     c_mode = _nvmlComputeMode_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetComputeMode")
     ret = fn(handle, byref(c_mode))
     _nvmlCheckReturn(ret)
     return c_mode.value
+
 
 def nvmlDeviceGetCudaComputeCapability(handle):
     c_major = c_int()
@@ -3223,6 +3806,7 @@ def nvmlDeviceGetCudaComputeCapability(handle):
     _nvmlCheckReturn(ret)
     return (c_major.value, c_minor.value)
 
+
 def nvmlDeviceGetEccMode(handle):
     c_currState = _nvmlEnableState_t()
     c_pendingState = _nvmlEnableState_t()
@@ -3231,13 +3815,16 @@ def nvmlDeviceGetEccMode(handle):
     _nvmlCheckReturn(ret)
     return [c_currState.value, c_pendingState.value]
 
+
 # added to API
 def nvmlDeviceGetCurrentEccMode(handle):
     return nvmlDeviceGetEccMode(handle)[0]
 
+
 # added to API
 def nvmlDeviceGetPendingEccMode(handle):
     return nvmlDeviceGetEccMode(handle)[1]
+
 
 def nvmlDeviceGetDefaultEccMode(handle):
     c_defaultState = _nvmlEnableState_t()
@@ -3246,34 +3833,48 @@ def nvmlDeviceGetDefaultEccMode(handle):
     _nvmlCheckReturn(ret)
     return [c_defaultState.value]
 
+
 def nvmlDeviceGetTotalEccErrors(handle, errorType, counterType):
     c_count = c_ulonglong()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetTotalEccErrors")
-    ret = fn(handle, _nvmlMemoryErrorType_t(errorType),
-                 _nvmlEccCounterType_t(counterType), byref(c_count))
+    ret = fn(
+        handle,
+        _nvmlMemoryErrorType_t(errorType),
+        _nvmlEccCounterType_t(counterType),
+        byref(c_count),
+    )
     _nvmlCheckReturn(ret)
     return c_count.value
+
 
 # This is deprecated, instead use nvmlDeviceGetMemoryErrorCounter
 def nvmlDeviceGetDetailedEccErrors(handle, errorType, counterType):
     c_counts = c_nvmlEccErrorCounts_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetDetailedEccErrors")
-    ret = fn(handle, _nvmlMemoryErrorType_t(errorType),
-                 _nvmlEccCounterType_t(counterType), byref(c_counts))
+    ret = fn(
+        handle,
+        _nvmlMemoryErrorType_t(errorType),
+        _nvmlEccCounterType_t(counterType),
+        byref(c_counts),
+    )
     _nvmlCheckReturn(ret)
     return c_counts
+
 
 # Added in 4.304
 def nvmlDeviceGetMemoryErrorCounter(handle, errorType, counterType, locationType):
     c_count = c_ulonglong()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMemoryErrorCounter")
-    ret = fn(handle,
-             _nvmlMemoryErrorType_t(errorType),
-             _nvmlEccCounterType_t(counterType),
-             _nvmlMemoryLocation_t(locationType),
-             byref(c_count))
+    ret = fn(
+        handle,
+        _nvmlMemoryErrorType_t(errorType),
+        _nvmlEccCounterType_t(counterType),
+        _nvmlMemoryLocation_t(locationType),
+        byref(c_count),
+    )
     _nvmlCheckReturn(ret)
     return c_count.value
+
 
 def nvmlDeviceGetUtilizationRates(handle):
     c_util = c_nvmlUtilization_t()
@@ -3281,6 +3882,7 @@ def nvmlDeviceGetUtilizationRates(handle):
     ret = fn(handle, byref(c_util))
     _nvmlCheckReturn(ret)
     return c_util
+
 
 def nvmlDeviceGetEncoderUtilization(handle):
     c_util = c_uint()
@@ -3290,6 +3892,7 @@ def nvmlDeviceGetEncoderUtilization(handle):
     _nvmlCheckReturn(ret)
     return [c_util.value, c_samplingPeriod.value]
 
+
 def nvmlDeviceGetDecoderUtilization(handle):
     c_util = c_uint()
     c_samplingPeriod = c_uint()
@@ -3297,6 +3900,7 @@ def nvmlDeviceGetDecoderUtilization(handle):
     ret = fn(handle, byref(c_util), byref(c_samplingPeriod))
     _nvmlCheckReturn(ret)
     return [c_util.value, c_samplingPeriod.value]
+
 
 def nvmlDeviceGetJpgUtilization(handle):
     c_util = c_uint()
@@ -3306,6 +3910,7 @@ def nvmlDeviceGetJpgUtilization(handle):
     _nvmlCheckReturn(ret)
     return [c_util.value, c_samplingPeriod.value]
 
+
 def nvmlDeviceGetOfaUtilization(handle):
     c_util = c_uint()
     c_samplingPeriod = c_uint()
@@ -3314,12 +3919,14 @@ def nvmlDeviceGetOfaUtilization(handle):
     _nvmlCheckReturn(ret)
     return [c_util.value, c_samplingPeriod.value]
 
+
 def nvmlDeviceGetPcieReplayCounter(handle):
     c_replay = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetPcieReplayCounter")
     ret = fn(handle, byref(c_replay))
     _nvmlCheckReturn(ret)
     return c_replay.value
+
 
 def nvmlDeviceGetDriverModel(handle):
     c_currModel = _nvmlDriverModel_t()
@@ -3329,13 +3936,16 @@ def nvmlDeviceGetDriverModel(handle):
     _nvmlCheckReturn(ret)
     return [c_currModel.value, c_pendingModel.value]
 
+
 # added to API
 def nvmlDeviceGetCurrentDriverModel(handle):
     return nvmlDeviceGetDriverModel(handle)[0]
 
+
 # added to API
 def nvmlDeviceGetPendingDriverModel(handle):
     return nvmlDeviceGetDriverModel(handle)[1]
+
 
 # Added in 2.285
 @convertStrBytes
@@ -3346,16 +3956,17 @@ def nvmlDeviceGetVbiosVersion(handle):
     _nvmlCheckReturn(ret)
     return c_version.value
 
+
 # Added in 2.285
 def nvmlDeviceGetComputeRunningProcesses_v2(handle):
     # first call to get the size
     c_count = c_uint(0)
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetComputeRunningProcesses_v2")
     ret = fn(handle, byref(c_count), None)
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no running processes
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         # oversize the array incase more processes are created
         c_count.value = c_count.value * 2 + 5
@@ -3368,7 +3979,7 @@ def nvmlDeviceGetComputeRunningProcesses_v2(handle):
         for i in range(c_count.value):
             # use an alternative struct for this object
             obj = nvmlStructToFriendlyObject(c_procs[i])
-            if (obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value):
+            if obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value:
                 # special case for WDDM on Windows, see comment above
                 obj.usedGpuMemory = None
             procs.append(obj)
@@ -3376,6 +3987,7 @@ def nvmlDeviceGetComputeRunningProcesses_v2(handle):
     else:
         # error case
         raise NVMLError(ret)
+
 
 # Added in 2.285
 def nvmlDeviceGetComputeRunningProcesses_v3(handle):
@@ -3384,10 +3996,10 @@ def nvmlDeviceGetComputeRunningProcesses_v3(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetComputeRunningProcesses_v3")
     ret = fn(handle, byref(c_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no running processes
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         # oversize the array incase more processes are created
         c_count.value = c_count.value * 2 + 5
@@ -3402,7 +4014,7 @@ def nvmlDeviceGetComputeRunningProcesses_v3(handle):
         for i in range(c_count.value):
             # use an alternative struct for this object
             obj = nvmlStructToFriendlyObject(c_procs[i])
-            if (obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value):
+            if obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value:
                 # special case for WDDM on Windows, see comment above
                 obj.usedGpuMemory = None
             procs.append(obj)
@@ -3412,19 +4024,21 @@ def nvmlDeviceGetComputeRunningProcesses_v3(handle):
         # error case
         raise NVMLError(ret)
 
+
 @throwOnVersionMismatch
 def nvmlDeviceGetComputeRunningProcesses(handle):
     return nvmlDeviceGetComputeRunningProcesses_v3(handle)
+
 
 def nvmlDeviceGetGraphicsRunningProcesses_v2(handle):
     # first call to get the size
     c_count = c_uint(0)
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetGraphicsRunningProcesses_v2")
     ret = fn(handle, byref(c_count), None)
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no running processes
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         # oversize the array incase more processes are created
         c_count.value = c_count.value * 2 + 5
@@ -3437,7 +4051,7 @@ def nvmlDeviceGetGraphicsRunningProcesses_v2(handle):
         for i in range(c_count.value):
             # use an alternative struct for this object
             obj = nvmlStructToFriendlyObject(c_procs[i])
-            if (obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value):
+            if obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value:
                 # special case for WDDM on Windows, see comment above
                 obj.usedGpuMemory = None
             procs.append(obj)
@@ -3445,6 +4059,7 @@ def nvmlDeviceGetGraphicsRunningProcesses_v2(handle):
     else:
         # error case
         raise NVMLError(ret)
+
 
 def nvmlDeviceGetGraphicsRunningProcesses_v3(handle):
     # first call to get the size
@@ -3452,10 +4067,10 @@ def nvmlDeviceGetGraphicsRunningProcesses_v3(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetGraphicsRunningProcesses_v3")
     ret = fn(handle, byref(c_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no running processes
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         # oversize the array incase more processes are created
         c_count.value = c_count.value * 2 + 5
@@ -3470,7 +4085,7 @@ def nvmlDeviceGetGraphicsRunningProcesses_v3(handle):
         for i in range(c_count.value):
             # use an alternative struct for this object
             obj = nvmlStructToFriendlyObject(c_procs[i])
-            if (obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value):
+            if obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value:
                 # special case for WDDM on Windows, see comment above
                 obj.usedGpuMemory = None
             procs.append(obj)
@@ -3480,13 +4095,16 @@ def nvmlDeviceGetGraphicsRunningProcesses_v3(handle):
         # error case
         raise NVMLError(ret)
 
+
 @throwOnVersionMismatch
 def nvmlDeviceGetGraphicsRunningProcesses(handle):
     return nvmlDeviceGetGraphicsRunningProcesses_v3(handle)
 
+
 @throwOnVersionMismatch
 def nvmlDeviceGetMPSComputeRunningProcesses(handle):
     return nvmlDeviceGetMPSComputeRunningProcesses_v3(handle)
+
 
 def nvmlDeviceGetMPSComputeRunningProcesses_v2(handle):
     # first call to get the size
@@ -3494,10 +4112,10 @@ def nvmlDeviceGetMPSComputeRunningProcesses_v2(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMPSComputeRunningProcesses_v2")
     ret = fn(handle, byref(c_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no running processes
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         # oversize the array incase more processes are created
         c_count.value = c_count.value * 2 + 5
@@ -3512,7 +4130,7 @@ def nvmlDeviceGetMPSComputeRunningProcesses_v2(handle):
         for i in range(c_count.value):
             # use an alternative struct for this object
             obj = nvmlStructToFriendlyObject(c_procs[i])
-            if (obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value):
+            if obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value:
                 # special case for WDDM on Windows, see comment above
                 obj.usedGpuMemory = None
             procs.append(obj)
@@ -3522,16 +4140,17 @@ def nvmlDeviceGetMPSComputeRunningProcesses_v2(handle):
         # error case
         raise NVMLError(ret)
 
+
 def nvmlDeviceGetMPSComputeRunningProcesses_v3(handle):
     # first call to get the size
     c_count = c_uint(0)
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMPSComputeRunningProcesses_v3")
     ret = fn(handle, byref(c_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no running processes
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         # oversize the array in case more processes are created
         c_count.value = c_count.value * 2 + 5
@@ -3546,7 +4165,7 @@ def nvmlDeviceGetMPSComputeRunningProcesses_v3(handle):
         for i in range(c_count.value):
             # use an alternative struct for this object
             obj = nvmlStructToFriendlyObject(c_procs[i])
-            if (obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value):
+            if obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value:
                 # special case for WDDM on Windows, see comment above
                 obj.usedGpuMemory = None
             procs.append(obj)
@@ -3555,6 +4174,7 @@ def nvmlDeviceGetMPSComputeRunningProcesses_v3(handle):
     else:
         # error case
         raise NVMLError(ret)
+
 
 def nvmlDeviceGetRunningProcessDetailList(handle, version, mode):
     c_processDetailList = c_nvmlProcessDetailList_t()
@@ -3565,12 +4185,14 @@ def nvmlDeviceGetRunningProcessDetailList(handle, version, mode):
 
     # first call to get the size
     ret = fn(handle, byref(c_processDetailList))
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no running processes
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         c_procs = c_nvmlProcessDetail_v1_t * c_processDetailList.numProcArrayEntries
-        c_processDetailList.procArray = cast((c_procs)(), POINTER(c_nvmlProcessDetail_v1_t))
+        c_processDetailList.procArray = cast(
+            (c_procs)(), POINTER(c_nvmlProcessDetail_v1_t)
+        )
 
         # make the call again
         ret = fn(handle, byref(c_processDetailList))
@@ -3580,9 +4202,9 @@ def nvmlDeviceGetRunningProcessDetailList(handle, version, mode):
         for i in range(c_processDetailList.numProcArrayEntries):
             # use an alternative struct for this object
             obj = c_processDetailList.procArray[i]
-            if (obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value):
+            if obj.usedGpuMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value:
                 obj.usedGpuMemory = None
-            if (obj.usedGpuCcProtectedMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value):
+            if obj.usedGpuCcProtectedMemory == NVML_VALUE_NOT_AVAILABLE_ulonglong.value:
                 obj.usedGpuCcProtectedMemory = None
             procs.append(obj)
 
@@ -3591,6 +4213,7 @@ def nvmlDeviceGetRunningProcessDetailList(handle, version, mode):
         # error case
         raise NVMLError(ret)
 
+
 def nvmlDeviceGetAutoBoostedClocksEnabled(handle):
     c_isEnabled = _nvmlEnableState_t()
     c_defaultIsEnabled = _nvmlEnableState_t()
@@ -3598,7 +4221,8 @@ def nvmlDeviceGetAutoBoostedClocksEnabled(handle):
     ret = fn(handle, byref(c_isEnabled), byref(c_defaultIsEnabled))
     _nvmlCheckReturn(ret)
     return [c_isEnabled.value, c_defaultIsEnabled.value]
-    #Throws NVML_ERROR_NOT_SUPPORTED if hardware doesn't support setting auto boosted clocks
+    # Throws NVML_ERROR_NOT_SUPPORTED if hardware doesn't support setting auto boosted clocks
+
 
 ## Set functions
 def nvmlUnitSetLedState(unit, color):
@@ -3607,11 +4231,13 @@ def nvmlUnitSetLedState(unit, color):
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceSetPersistenceMode(handle, mode):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetPersistenceMode")
     ret = fn(handle, _nvmlEnableState_t(mode))
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceSetComputeMode(handle, mode):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetComputeMode")
@@ -3619,11 +4245,13 @@ def nvmlDeviceSetComputeMode(handle, mode):
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceSetEccMode(handle, mode):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetEccMode")
     ret = fn(handle, _nvmlEnableState_t(mode))
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceClearEccErrorCounts(handle, counterType):
     fn = _nvmlGetFunctionPointer("nvmlDeviceClearEccErrorCounts")
@@ -3631,25 +4259,29 @@ def nvmlDeviceClearEccErrorCounts(handle, counterType):
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceSetDriverModel(handle, model):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetDriverModel")
     ret = fn(handle, _nvmlDriverModel_t(model))
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceSetAutoBoostedClocksEnabled(handle, enabled):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetAutoBoostedClocksEnabled")
     ret = fn(handle, _nvmlEnableState_t(enabled))
     _nvmlCheckReturn(ret)
     return None
-    #Throws NVML_ERROR_NOT_SUPPORTED if hardware doesn't support setting auto boosted clocks
+    # Throws NVML_ERROR_NOT_SUPPORTED if hardware doesn't support setting auto boosted clocks
+
 
 def nvmlDeviceSetDefaultAutoBoostedClocksEnabled(handle, enabled, flags):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetDefaultAutoBoostedClocksEnabled")
     ret = fn(handle, _nvmlEnableState_t(enabled), c_uint(flags))
     _nvmlCheckReturn(ret)
     return None
-    #Throws NVML_ERROR_NOT_SUPPORTED if hardware doesn't support setting auto boosted clocks
+    # Throws NVML_ERROR_NOT_SUPPORTED if hardware doesn't support setting auto boosted clocks
+
 
 def nvmlDeviceSetGpuLockedClocks(handle, minGpuClockMHz, maxGpuClockMHz):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetGpuLockedClocks")
@@ -3657,11 +4289,13 @@ def nvmlDeviceSetGpuLockedClocks(handle, minGpuClockMHz, maxGpuClockMHz):
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceResetGpuLockedClocks(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceResetGpuLockedClocks")
     ret = fn(handle)
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceSetMemoryLockedClocks(handle, minMemClockMHz, maxMemClockMHz):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetMemoryLockedClocks")
@@ -3669,11 +4303,13 @@ def nvmlDeviceSetMemoryLockedClocks(handle, minMemClockMHz, maxMemClockMHz):
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceResetMemoryLockedClocks(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceResetMemoryLockedClocks")
     ret = fn(handle)
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceGetClkMonStatus(handle, c_clkMonInfo=nvmlClkMonStatus_t()):
     isReference = type(c_clkMonInfo) is not nvmlClkMonStatus_t
@@ -3683,12 +4319,14 @@ def nvmlDeviceGetClkMonStatus(handle, c_clkMonInfo=nvmlClkMonStatus_t()):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isReference else c_clkMonInfo
 
+
 # Added in 4.304
 def nvmlDeviceSetApplicationsClocks(handle, maxMemClockMHz, maxGraphicsClockMHz):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetApplicationsClocks")
     ret = fn(handle, c_uint(maxMemClockMHz), c_uint(maxGraphicsClockMHz))
     _nvmlCheckReturn(ret)
     return None
+
 
 # Added in 4.304
 def nvmlDeviceResetApplicationsClocks(handle):
@@ -3697,6 +4335,7 @@ def nvmlDeviceResetApplicationsClocks(handle):
     _nvmlCheckReturn(ret)
     return None
 
+
 # Added in 4.304
 def nvmlDeviceSetPowerManagementLimit(handle, limit):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetPowerManagementLimit")
@@ -3704,12 +4343,14 @@ def nvmlDeviceSetPowerManagementLimit(handle, limit):
     _nvmlCheckReturn(ret)
     return None
 
+
 # Added in 4.304
 def nvmlDeviceSetGpuOperationMode(handle, mode):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetGpuOperationMode")
     ret = fn(handle, _nvmlGpuOperationMode_t(mode))
     _nvmlCheckReturn(ret)
     return None
+
 
 # Added in 2.285
 def nvmlEventSetCreate():
@@ -3719,12 +4360,14 @@ def nvmlEventSetCreate():
     _nvmlCheckReturn(ret)
     return eventSet
 
+
 # Added in 2.285
 def nvmlDeviceRegisterEvents(handle, eventTypes, eventSet):
     fn = _nvmlGetFunctionPointer("nvmlDeviceRegisterEvents")
     ret = fn(handle, c_ulonglong(eventTypes), eventSet)
     _nvmlCheckReturn(ret)
     return None
+
 
 # Added in 2.285
 def nvmlDeviceGetSupportedEventTypes(handle):
@@ -3734,6 +4377,7 @@ def nvmlDeviceGetSupportedEventTypes(handle):
     _nvmlCheckReturn(ret)
     return c_eventTypes.value
 
+
 # raises NVML_ERROR_TIMEOUT exception on timeout
 def nvmlEventSetWait_v2(eventSet, timeoutms):
     fn = _nvmlGetFunctionPointer("nvmlEventSetWait_v2")
@@ -3742,8 +4386,10 @@ def nvmlEventSetWait_v2(eventSet, timeoutms):
     _nvmlCheckReturn(ret)
     return data
 
+
 def nvmlEventSetWait(eventSet, timeoutms):
     return nvmlEventSetWait_v2(eventSet, timeoutms)
+
 
 # Added in 2.285
 def nvmlEventSetFree(eventSet):
@@ -3752,13 +4398,15 @@ def nvmlEventSetFree(eventSet):
     _nvmlCheckReturn(ret)
     return None
 
+
 # Added in 3.295
 def nvmlDeviceOnSameBoard(handle1, handle2):
     fn = _nvmlGetFunctionPointer("nvmlDeviceOnSameBoard")
     onSameBoard = c_int()
     ret = fn(handle1, handle2, byref(onSameBoard))
     _nvmlCheckReturn(ret)
-    return (onSameBoard.value != 0)
+    return onSameBoard.value != 0
+
 
 # Added in 3.295
 def nvmlDeviceGetCurrPcieLinkGeneration(handle):
@@ -3768,6 +4416,7 @@ def nvmlDeviceGetCurrPcieLinkGeneration(handle):
     _nvmlCheckReturn(ret)
     return gen.value
 
+
 # Added in 3.295
 def nvmlDeviceGetMaxPcieLinkGeneration(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMaxPcieLinkGeneration")
@@ -3775,6 +4424,7 @@ def nvmlDeviceGetMaxPcieLinkGeneration(handle):
     ret = fn(handle, byref(gen))
     _nvmlCheckReturn(ret)
     return gen.value
+
 
 # Added in 3.295
 def nvmlDeviceGetCurrPcieLinkWidth(handle):
@@ -3784,6 +4434,7 @@ def nvmlDeviceGetCurrPcieLinkWidth(handle):
     _nvmlCheckReturn(ret)
     return width.value
 
+
 # Added in 3.295
 def nvmlDeviceGetMaxPcieLinkWidth(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMaxPcieLinkWidth")
@@ -3792,6 +4443,7 @@ def nvmlDeviceGetMaxPcieLinkWidth(handle):
     _nvmlCheckReturn(ret)
     return width.value
 
+
 def nvmlDeviceGetGpuMaxPcieLinkGeneration(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetGpuMaxPcieLinkGeneration")
     gen = c_uint()
@@ -3799,35 +4451,40 @@ def nvmlDeviceGetGpuMaxPcieLinkGeneration(handle):
     _nvmlCheckReturn(ret)
     return gen.value
 
+
 # Added in 4.304
 def nvmlDeviceGetSupportedClocksThrottleReasons(handle):
-    c_reasons= c_ulonglong()
+    c_reasons = c_ulonglong()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetSupportedClocksThrottleReasons")
     ret = fn(handle, byref(c_reasons))
     _nvmlCheckReturn(ret)
     return c_reasons.value
 
+
 def nvmlDeviceGetSupportedClocksEventReasons(handle):
-    c_reasons= c_ulonglong()
+    c_reasons = c_ulonglong()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetSupportedClocksEventReasons")
     ret = fn(handle, byref(c_reasons))
     _nvmlCheckReturn(ret)
     return c_reasons.value
 
+
 # Added in 4.304
 def nvmlDeviceGetCurrentClocksThrottleReasons(handle):
-    c_reasons= c_ulonglong()
+    c_reasons = c_ulonglong()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetCurrentClocksThrottleReasons")
     ret = fn(handle, byref(c_reasons))
     _nvmlCheckReturn(ret)
     return c_reasons.value
 
+
 def nvmlDeviceGetCurrentClocksEventReasons(handle):
-    c_reasons= c_ulonglong()
+    c_reasons = c_ulonglong()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetCurrentClocksEventReasons")
     ret = fn(handle, byref(c_reasons))
     _nvmlCheckReturn(ret)
     return c_reasons.value
+
 
 # Added in 5.319
 def nvmlDeviceGetIndex(handle):
@@ -3837,6 +4494,7 @@ def nvmlDeviceGetIndex(handle):
     _nvmlCheckReturn(ret)
     return c_index.value
 
+
 # Added in 5.319
 def nvmlDeviceGetAccountingMode(handle):
     c_mode = _nvmlEnableState_t()
@@ -3845,11 +4503,13 @@ def nvmlDeviceGetAccountingMode(handle):
     _nvmlCheckReturn(ret)
     return c_mode.value
 
+
 def nvmlDeviceSetAccountingMode(handle, mode):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetAccountingMode")
     ret = fn(handle, _nvmlEnableState_t(mode))
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceClearAccountingPids(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceClearAccountingPids")
@@ -3857,15 +4517,17 @@ def nvmlDeviceClearAccountingPids(handle):
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceGetAccountingStats(handle, pid):
     stats = c_nvmlAccountingStats_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetAccountingStats")
     ret = fn(handle, c_uint(pid), byref(stats))
     _nvmlCheckReturn(ret)
-    if (stats.maxMemoryUsage == NVML_VALUE_NOT_AVAILABLE_ulonglong.value):
+    if stats.maxMemoryUsage == NVML_VALUE_NOT_AVAILABLE_ulonglong.value:
         # special case for WDDM on Windows, see comment above
         stats.maxMemoryUsage = None
     return stats
+
 
 def nvmlDeviceGetAccountingPids(handle):
     count = c_uint(nvmlDeviceGetAccountingBufferSize(handle))
@@ -3873,7 +4535,8 @@ def nvmlDeviceGetAccountingPids(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetAccountingPids")
     ret = fn(handle, byref(count), pids)
     _nvmlCheckReturn(ret)
-    return list(map(int, pids[0:count.value]))
+    return list(map(int, pids[0 : count.value]))
+
 
 def nvmlDeviceGetAccountingBufferSize(handle):
     bufferSize = c_uint()
@@ -3881,6 +4544,7 @@ def nvmlDeviceGetAccountingBufferSize(handle):
     ret = fn(handle, byref(bufferSize))
     _nvmlCheckReturn(ret)
     return int(bufferSize.value)
+
 
 def nvmlDeviceGetRetiredPages(device, sourceFilter):
     c_source = _nvmlPageRetirementCause_t(sourceFilter)
@@ -3891,8 +4555,7 @@ def nvmlDeviceGetRetiredPages(device, sourceFilter):
     ret = fn(device, c_source, byref(c_count), None)
 
     # this should only fail with insufficient size
-    if ((ret != NVML_SUCCESS) and
-        (ret != NVML_ERROR_INSUFFICIENT_SIZE)):
+    if (ret != NVML_SUCCESS) and (ret != NVML_ERROR_INSUFFICIENT_SIZE):
         raise NVMLError(ret)
 
     # call again with a buffer
@@ -3903,7 +4566,8 @@ def nvmlDeviceGetRetiredPages(device, sourceFilter):
     c_pages = page_array()
     ret = fn(device, c_source, byref(c_count), c_pages)
     _nvmlCheckReturn(ret)
-    return list(map(int, c_pages[0:c_count.value]))
+    return list(map(int, c_pages[0 : c_count.value]))
+
 
 def nvmlDeviceGetRetiredPages_v2(device, sourceFilter):
     c_source = _nvmlPageRetirementCause_t(sourceFilter)
@@ -3914,8 +4578,7 @@ def nvmlDeviceGetRetiredPages_v2(device, sourceFilter):
     ret = fn(device, c_source, byref(c_count), None)
 
     # this should only fail with insufficient size
-    if ((ret != NVML_SUCCESS) and
-        (ret != NVML_ERROR_INSUFFICIENT_SIZE)):
+    if (ret != NVML_SUCCESS) and (ret != NVML_ERROR_INSUFFICIENT_SIZE):
         raise NVMLError(ret)
 
     # call again with a buffer
@@ -3928,7 +4591,11 @@ def nvmlDeviceGetRetiredPages_v2(device, sourceFilter):
     c_times = times_array()
     ret = fn(device, c_source, byref(c_count), c_pages, c_times)
     _nvmlCheckReturn(ret)
-    return [ { 'address': int(c_pages[i]), 'timestamp': int(c_times[i]) } for i in range(c_count.value) ];
+    return [
+        {"address": int(c_pages[i]), "timestamp": int(c_times[i])}
+        for i in range(c_count.value)
+    ]
+
 
 def nvmlDeviceGetRetiredPagesPendingStatus(device):
     c_pending = _nvmlEnableState_t()
@@ -3937,6 +4604,7 @@ def nvmlDeviceGetRetiredPagesPendingStatus(device):
     _nvmlCheckReturn(ret)
     return int(c_pending.value)
 
+
 def nvmlDeviceGetAPIRestriction(device, apiType):
     c_permission = _nvmlEnableState_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetAPIRestriction")
@@ -3944,11 +4612,13 @@ def nvmlDeviceGetAPIRestriction(device, apiType):
     _nvmlCheckReturn(ret)
     return int(c_permission.value)
 
+
 def nvmlDeviceSetAPIRestriction(handle, apiType, isRestricted):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetAPIRestriction")
     ret = fn(handle, _nvmlRestrictedAPI_t(apiType), _nvmlEnableState_t(isRestricted))
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceGetBridgeChipInfo(handle):
     bridgeHierarchy = c_nvmlBridgeChipHierarchy_t()
@@ -3956,6 +4626,7 @@ def nvmlDeviceGetBridgeChipInfo(handle):
     ret = fn(handle, byref(bridgeHierarchy))
     _nvmlCheckReturn(ret)
     return bridgeHierarchy
+
 
 def nvmlDeviceGetSamples(device, sampling_type, timeStamp):
     c_sampling_type = _nvmlSamplingType_t(sampling_type)
@@ -3965,17 +4636,32 @@ def nvmlDeviceGetSamples(device, sampling_type, timeStamp):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetSamples")
 
     ## First Call gets the size
-    ret = fn(device, c_sampling_type, c_time_stamp, byref(c_sample_value_type), byref(c_sample_count), None)
+    ret = fn(
+        device,
+        c_sampling_type,
+        c_time_stamp,
+        byref(c_sample_value_type),
+        byref(c_sample_count),
+        None,
+    )
 
     # Stop if this fails
-    if (ret != NVML_SUCCESS):
+    if ret != NVML_SUCCESS:
         raise NVMLError(ret)
 
     sampleArray = c_sample_count.value * c_nvmlSample_t
     c_samples = sampleArray()
-    ret = fn(device, c_sampling_type, c_time_stamp,  byref(c_sample_value_type), byref(c_sample_count), c_samples)
+    ret = fn(
+        device,
+        c_sampling_type,
+        c_time_stamp,
+        byref(c_sample_value_type),
+        byref(c_sample_count),
+        c_samples,
+    )
     _nvmlCheckReturn(ret)
-    return (c_sample_value_type.value, c_samples[0:c_sample_count.value])
+    return (c_sample_value_type.value, c_samples[0 : c_sample_count.value])
+
 
 def nvmlDeviceGetViolationStatus(device, perfPolicyType):
     c_perfPolicy_type = _nvmlPerfPolicyType_t(perfPolicyType)
@@ -3987,12 +4673,14 @@ def nvmlDeviceGetViolationStatus(device, perfPolicyType):
     _nvmlCheckReturn(ret)
     return c_violTime
 
+
 def nvmlDeviceGetPcieThroughput(device, counter):
     c_util = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetPcieThroughput")
     ret = fn(device, _nvmlPcieUtilCounter_t(counter), byref(c_util))
     _nvmlCheckReturn(ret)
     return c_util.value
+
 
 def nvmlSystemGetTopologyGpuSet(cpuNumber):
     c_count = c_uint(0)
@@ -4008,7 +4696,8 @@ def nvmlSystemGetTopologyGpuSet(cpuNumber):
     c_devices = device_array()
     ret = fn(cpuNumber, byref(c_count), c_devices)
     _nvmlCheckReturn(ret)
-    return list(c_devices[0:c_count.value])
+    return list(c_devices[0 : c_count.value])
+
 
 def nvmlDeviceGetTopologyNearestGpus(device, level):
     c_count = c_uint(0)
@@ -4025,7 +4714,8 @@ def nvmlDeviceGetTopologyNearestGpus(device, level):
     c_devices = device_array()
     ret = fn(device, level, byref(c_count), c_devices)
     _nvmlCheckReturn(ret)
-    return list(c_devices[0:c_count.value])
+    return list(c_devices[0 : c_count.value])
+
 
 def nvmlDeviceGetTopologyCommonAncestor(device1, device2):
     c_level = _nvmlGpuTopologyLevel_t()
@@ -4033,6 +4723,7 @@ def nvmlDeviceGetTopologyCommonAncestor(device1, device2):
     ret = fn(device1, device2, byref(c_level))
     _nvmlCheckReturn(ret)
     return c_level.value
+
 
 def nvmlDeviceGetNvLinkUtilizationCounter(device, link, counter):
     c_rxcounter = c_ulonglong()
@@ -4042,11 +4733,13 @@ def nvmlDeviceGetNvLinkUtilizationCounter(device, link, counter):
     _nvmlCheckReturn(ret)
     return (c_rxcounter.value, c_txcounter.value)
 
+
 def nvmlDeviceFreezeNvLinkUtilizationCounter(device, link, counter, freeze):
     fn = _nvmlGetFunctionPointer("nvmlDeviceFreezeNvLinkUtilizationCounter")
     ret = fn(device, link, counter, freeze)
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceResetNvLinkUtilizationCounter(device, link, counter):
     fn = _nvmlGetFunctionPointer("nvmlDeviceResetNvLinkUtilizationCounter")
@@ -4054,11 +4747,13 @@ def nvmlDeviceResetNvLinkUtilizationCounter(device, link, counter):
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceSetNvLinkUtilizationControl(device, link, counter, control, reset):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetNvLinkUtilizationControl")
     ret = fn(device, link, counter, byref(control), reset)
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceGetNvLinkUtilizationControl(device, link, counter):
     c_control = nvmlNvLinkUtilizationControl_t()
@@ -4067,12 +4762,14 @@ def nvmlDeviceGetNvLinkUtilizationControl(device, link, counter):
     _nvmlCheckReturn(ret)
     return c_control
 
+
 def nvmlDeviceGetNvLinkCapability(device, link, capability):
     c_capResult = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetNvLinkCapability")
     ret = fn(device, link, capability, byref(c_capResult))
     _nvmlCheckReturn(ret)
     return c_capResult.value
+
 
 def nvmlDeviceGetNvLinkErrorCounter(device, link, counter):
     c_result = c_ulonglong()
@@ -4081,11 +4778,13 @@ def nvmlDeviceGetNvLinkErrorCounter(device, link, counter):
     _nvmlCheckReturn(ret)
     return c_result.value
 
+
 def nvmlDeviceResetNvLinkErrorCounters(device, link):
     fn = _nvmlGetFunctionPointer("nvmlDeviceResetNvLinkErrorCounters")
     ret = fn(device, link)
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceGetNvLinkRemotePciInfo(device, link):
     c_pci = nvmlPciInfo_t()
@@ -4094,12 +4793,14 @@ def nvmlDeviceGetNvLinkRemotePciInfo(device, link):
     _nvmlCheckReturn(ret)
     return c_pci
 
+
 def nvmlDeviceGetNvLinkRemoteDeviceType(handle, link):
     c_type = _nvmlNvLinkDeviceType_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetNvLinkRemoteDeviceType")
     ret = fn(handle, link, byref(c_type))
     _nvmlCheckReturn(ret)
     return c_type.value
+
 
 def nvmlDeviceGetNvLinkState(device, link):
     c_isActive = c_uint()
@@ -4108,6 +4809,7 @@ def nvmlDeviceGetNvLinkState(device, link):
     _nvmlCheckReturn(ret)
     return c_isActive.value
 
+
 def nvmlDeviceGetNvLinkVersion(device, link):
     c_version = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetNvLinkVersion")
@@ -4115,11 +4817,13 @@ def nvmlDeviceGetNvLinkVersion(device, link):
     _nvmlCheckReturn(ret)
     return c_version.value
 
+
 def nvmlDeviceModifyDrainState(pciInfo, newState):
     fn = _nvmlGetFunctionPointer("nvmlDeviceModifyDrainState")
     ret = fn(pointer(pciInfo), newState)
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceQueryDrainState(pciInfo):
     c_newState = c_uint()
@@ -4128,17 +4832,20 @@ def nvmlDeviceQueryDrainState(pciInfo):
     _nvmlCheckReturn(ret)
     return c_newState.value
 
+
 def nvmlDeviceRemoveGpu(pciInfo):
     fn = _nvmlGetFunctionPointer("nvmlDeviceRemoveGpu")
     ret = fn(pointer(pciInfo))
     _nvmlCheckReturn(ret)
     return None
 
+
 def nvmlDeviceDiscoverGpus(pciInfo):
     fn = _nvmlGetFunctionPointer("nvmlDeviceDiscoverGpus")
     ret = fn(pointer(pciInfo))
     _nvmlCheckReturn(ret)
     return None
+
 
 def nvmlDeviceGetFieldValues(handle, fieldIds):
     values_arr = c_nvmlFieldValue_t * len(fieldIds)
@@ -4155,6 +4862,7 @@ def nvmlDeviceGetFieldValues(handle, fieldIds):
     _nvmlCheckReturn(ret)
     return values
 
+
 def nvmlDeviceClearFieldValues(handle, fieldIds):
     values_arr = c_nvmlFieldValue_t * len(fieldIds)
     values = values_arr()
@@ -4170,6 +4878,7 @@ def nvmlDeviceClearFieldValues(handle, fieldIds):
     _nvmlCheckReturn(ret)
     return values
 
+
 def nvmlDeviceGetVirtualizationMode(handle):
     c_virtualization_mode = c_ulonglong()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetVirtualizationMode")
@@ -4177,9 +4886,11 @@ def nvmlDeviceGetVirtualizationMode(handle):
     _nvmlCheckReturn(ret)
     return c_virtualization_mode.value
 
+
 def nvmlDeviceSetVirtualizationMode(handle, virtualization_mode):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetVirtualizationMode")
     return fn(handle, virtualization_mode)
+
 
 def nvmlDeviceGetVgpuHeterogeneousMode(handle):
     c_vgpuHeterogeneousMode = c_nvmlVgpuHeterogeneousMode_v1_t(0)
@@ -4188,6 +4899,7 @@ def nvmlDeviceGetVgpuHeterogeneousMode(handle):
     ret = fn(handle, byref(c_vgpuHeterogeneousMode))
     _nvmlCheckReturn(ret)
     return c_vgpuHeterogeneousMode.mode
+
 
 def nvmlDeviceSetVgpuHeterogeneousMode(handle, heterogeneous_mode):
     c_vgpuHeterogeneousMode = c_nvmlVgpuHeterogeneousMode_v1_t(0)
@@ -4198,6 +4910,7 @@ def nvmlDeviceSetVgpuHeterogeneousMode(handle, heterogeneous_mode):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 def nvmlVgpuInstanceGetPlacementId(vgpuInstance):
     c_placement = c_nvmlVgpuPlacementId_v1_t(0)
     c_placement.version = VgpuPlacementId_v1
@@ -4206,9 +4919,10 @@ def nvmlVgpuInstanceGetPlacementId(vgpuInstance):
     _nvmlCheckReturn(ret)
     return c_placement.placementId
 
+
 def nvmlDeviceGetVgpuTypeSupportedPlacements(handle, vgpuTypeId, mode=0, version=1):
     c_max_instances = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetMaxInstances")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetMaxInstances")
     ret = fn(handle, vgpuTypeId, byref(c_max_instances))
     _nvmlCheckReturn(ret)
 
@@ -4225,14 +4939,15 @@ def nvmlDeviceGetVgpuTypeSupportedPlacements(handle, vgpuTypeId, mode=0, version
 
     c_placements = c_uint * c_max_instances.value
     c_vgpu_placements.placementIds = c_placements()
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuTypeSupportedPlacements")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuTypeSupportedPlacements")
     ret = fn(handle, vgpuTypeId, byref(c_vgpu_placements))
     _nvmlCheckReturn(ret)
     return c_vgpu_placements
 
+
 def nvmlDeviceGetVgpuTypeCreatablePlacements(handle, vgpuTypeId, version=1):
     c_max_instances = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetMaxInstances")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetMaxInstances")
     ret = fn(handle, vgpuTypeId, byref(c_max_instances))
     _nvmlCheckReturn(ret)
 
@@ -4246,10 +4961,11 @@ def nvmlDeviceGetVgpuTypeCreatablePlacements(handle, vgpuTypeId, version=1):
 
     c_placements = c_uint * c_max_instances.value
     c_vgpu_placements.placementIds = c_placements()
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuTypeCreatablePlacements")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuTypeCreatablePlacements")
     ret = fn(handle, vgpuTypeId, byref(c_vgpu_placements))
     _nvmlCheckReturn(ret)
     return c_vgpu_placements
+
 
 def nvmlGetVgpuDriverCapabilities(capability):
     c_capResult = c_uint()
@@ -4258,6 +4974,7 @@ def nvmlGetVgpuDriverCapabilities(capability):
     _nvmlCheckReturn(ret)
     return c_capResult.value
 
+
 def nvmlDeviceGetVgpuCapabilities(handle, capability):
     c_capResult = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuCapabilities")
@@ -4265,23 +4982,25 @@ def nvmlDeviceGetVgpuCapabilities(handle, capability):
     _nvmlCheckReturn(ret)
     return c_capResult.value
 
+
 def nvmlDeviceSetVgpuCapabilities(handle, capability, state):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetVgpuCapabilities")
     ret = fn(handle, _nvmlDeviceVgpuCapability_t(capability), state)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 def nvmlDeviceGetSupportedVgpus(handle):
     # first call to get the size
     c_vgpu_count = c_uint(0)
 
-    fn =  _nvmlGetFunctionPointer("nvmlDeviceGetSupportedVgpus")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetSupportedVgpus")
     ret = fn(handle, byref(c_vgpu_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no supported vGPUs
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         vgpu_type_ids_array = _nvmlVgpuTypeId_t * c_vgpu_count.value
         c_vgpu_type_ids = vgpu_type_ids_array()
@@ -4296,18 +5015,19 @@ def nvmlDeviceGetSupportedVgpus(handle):
     else:
         # error case
         raise NVMLError(ret)
+
 
 def nvmlDeviceGetCreatableVgpus(handle):
     # first call to get the size
     c_vgpu_count = c_uint(0)
 
-    fn =  _nvmlGetFunctionPointer("nvmlDeviceGetCreatableVgpus")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetCreatableVgpus")
     ret = fn(handle, byref(c_vgpu_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no supported vGPUs
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         vgpu_type_ids_array = _nvmlVgpuTypeId_t * c_vgpu_count.value
         c_vgpu_type_ids = vgpu_type_ids_array()
@@ -4323,132 +5043,148 @@ def nvmlDeviceGetCreatableVgpus(handle):
         # error case
         raise NVMLError(ret)
 
+
 def nvmlVgpuTypeGetGpuInstanceProfileId(vgpuTypeId):
     c_profile_id = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetGpuInstanceProfileId")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetGpuInstanceProfileId")
     ret = fn(vgpuTypeId, byref(c_profile_id))
     _nvmlCheckReturn(ret)
-    return (c_profile_id.value)
+    return c_profile_id.value
+
 
 @convertStrBytes
 def nvmlVgpuTypeGetClass(vgpuTypeId):
     c_class = create_string_buffer(NVML_DEVICE_NAME_BUFFER_SIZE)
     c_buffer_size = c_uint(NVML_DEVICE_NAME_BUFFER_SIZE)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetClass")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetClass")
     ret = fn(vgpuTypeId, c_class, byref(c_buffer_size))
     _nvmlCheckReturn(ret)
     return c_class.value
+
 
 @convertStrBytes
 def nvmlVgpuTypeGetName(vgpuTypeId):
     c_name = create_string_buffer(NVML_DEVICE_NAME_BUFFER_SIZE)
     c_buffer_size = c_uint(NVML_DEVICE_NAME_BUFFER_SIZE)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetName")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetName")
     ret = fn(vgpuTypeId, c_name, byref(c_buffer_size))
     _nvmlCheckReturn(ret)
     return c_name.value
 
+
 def nvmlVgpuTypeGetDeviceID(vgpuTypeId):
-    c_device_id    = c_ulonglong(0)
+    c_device_id = c_ulonglong(0)
     c_subsystem_id = c_ulonglong(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetDeviceID")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetDeviceID")
     ret = fn(vgpuTypeId, byref(c_device_id), byref(c_subsystem_id))
     _nvmlCheckReturn(ret)
     return (c_device_id.value, c_subsystem_id.value)
 
+
 def nvmlVgpuTypeGetFramebufferSize(vgpuTypeId):
     c_fb_size = c_ulonglong(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetFramebufferSize")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetFramebufferSize")
     ret = fn(vgpuTypeId, byref(c_fb_size))
     _nvmlCheckReturn(ret)
     return c_fb_size.value
 
+
 def nvmlVgpuTypeGetNumDisplayHeads(vgpuTypeId):
     c_num_heads = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetNumDisplayHeads")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetNumDisplayHeads")
     ret = fn(vgpuTypeId, byref(c_num_heads))
     _nvmlCheckReturn(ret)
     return c_num_heads.value
 
+
 def nvmlVgpuTypeGetResolution(vgpuTypeId):
     c_xdim = c_uint(0)
     c_ydim = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetResolution")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetResolution")
     ret = fn(vgpuTypeId, 0, byref(c_xdim), byref(c_ydim))
     _nvmlCheckReturn(ret)
     return (c_xdim.value, c_ydim.value)
+
 
 @convertStrBytes
 def nvmlVgpuTypeGetLicense(vgpuTypeId):
     c_license = create_string_buffer(NVML_GRID_LICENSE_BUFFER_SIZE)
     c_buffer_size = c_uint(NVML_GRID_LICENSE_BUFFER_SIZE)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetLicense")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetLicense")
     ret = fn(vgpuTypeId, c_license, c_buffer_size)
     _nvmlCheckReturn(ret)
     return c_license.value
 
+
 def nvmlVgpuTypeGetFrameRateLimit(vgpuTypeId):
     c_frl_config = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetFrameRateLimit")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetFrameRateLimit")
     ret = fn(vgpuTypeId, byref(c_frl_config))
     _nvmlCheckReturn(ret)
     return c_frl_config.value
 
+
 def nvmlVgpuTypeGetGspHeapSize(vgpuTypeId):
     c_gsp_heap = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetGspHeapSize")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetGspHeapSize")
     ret = fn(vgpuTypeId, byref(c_gsp_heap))
     _nvmlCheckReturn(ret)
     return c_gsp_heap.value
 
+
 def nvmlVgpuTypeGetFbReservation(vgpuTypeId):
     c_fb_reservation = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetFbReservation")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetFbReservation")
     ret = fn(vgpuTypeId, byref(c_fb_reservation))
     _nvmlCheckReturn(ret)
     return c_fb_reservation.value
 
+
 def nvmlVgpuInstanceGetRuntimeStateSize(vgpuInstance):
     c_runtime_state = nvmlVgpuRuntimeState_v1_t()
     c_runtime_state.version = VgpuRuntimeState_v1
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetRuntimeStateSize")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetRuntimeStateSize")
     ret = fn(vgpuInstance, byref(c_runtime_state))
     _nvmlCheckReturn(ret)
     return c_runtime_state
 
+
 def nvmlVgpuTypeGetMaxInstances(handle, vgpuTypeId):
     c_max_instances = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetMaxInstances")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetMaxInstances")
     ret = fn(handle, vgpuTypeId, byref(c_max_instances))
     _nvmlCheckReturn(ret)
     return c_max_instances.value
 
+
 def nvmlVgpuTypeGetMaxInstancesPerVm(vgpuTypeId):
     c_max_instances_per_vm = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetMaxInstancesPerVm")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetMaxInstancesPerVm")
     ret = fn(vgpuTypeId, byref(c_max_instances_per_vm))
     _nvmlCheckReturn(ret)
     return c_max_instances_per_vm.value
 
+
 def nvmlVgpuTypeGetBAR1Info(vgpuTypeId):
     c_bar1Info = c_nvmlVgpuTypeBar1Info_v1_t(0)
     c_bar1Info.version = VgpuTypeBar1Info_v1
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetBAR1Info")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetBAR1Info")
     ret = fn(vgpuTypeId, byref(c_bar1Info))
     _nvmlCheckReturn(ret)
     return c_bar1Info
+
 
 def nvmlDeviceGetActiveVgpus(handle):
     # first call to get the size
     c_vgpu_count = c_uint(0)
 
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetActiveVgpus")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetActiveVgpus")
     ret = fn(handle, byref(c_vgpu_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no active vGPUs
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         vgpu_instance_array = _nvmlVgpuInstance_t * c_vgpu_count.value
         c_vgpu_instances = vgpu_instance_array()
@@ -4464,66 +5200,75 @@ def nvmlDeviceGetActiveVgpus(handle):
         # error case
         raise NVMLError(ret)
 
+
 @convertStrBytes
 def nvmlVgpuInstanceGetVmID(vgpuInstance):
     c_vm_id = create_string_buffer(NVML_DEVICE_UUID_BUFFER_SIZE)
     c_buffer_size = c_uint(NVML_GRID_LICENSE_BUFFER_SIZE)
-    c_vm_id_type  = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetVmID")
+    c_vm_id_type = c_uint(0)
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetVmID")
     ret = fn(vgpuInstance, byref(c_vm_id), c_buffer_size, byref(c_vm_id_type))
     _nvmlCheckReturn(ret)
     return (c_vm_id.value, c_vm_id_type.value)
+
 
 @convertStrBytes
 def nvmlVgpuInstanceGetUUID(vgpuInstance):
     c_uuid = create_string_buffer(NVML_DEVICE_UUID_BUFFER_SIZE)
     c_buffer_size = c_uint(NVML_DEVICE_UUID_BUFFER_SIZE)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetUUID")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetUUID")
     ret = fn(vgpuInstance, byref(c_uuid), c_buffer_size)
     _nvmlCheckReturn(ret)
     return c_uuid.value
+
 
 @convertStrBytes
 def nvmlVgpuInstanceGetMdevUUID(vgpuInstance):
     c_uuid = create_string_buffer(NVML_DEVICE_UUID_BUFFER_SIZE)
     c_buffer_size = c_uint(NVML_DEVICE_UUID_BUFFER_SIZE)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetMdevUUID")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetMdevUUID")
     ret = fn(vgpuInstance, byref(c_uuid), c_buffer_size)
     _nvmlCheckReturn(ret)
     return c_uuid.value
+
 
 @convertStrBytes
 def nvmlVgpuInstanceGetVmDriverVersion(vgpuInstance):
     c_driver_version = create_string_buffer(NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE)
     c_buffer_size = c_uint(NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetVmDriverVersion")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetVmDriverVersion")
     ret = fn(vgpuInstance, byref(c_driver_version), c_buffer_size)
     _nvmlCheckReturn(ret)
     return c_driver_version.value
 
+
 def nvmlVgpuInstanceGetLicenseStatus(vgpuInstance):
     c_license_status = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetLicenseStatus")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetLicenseStatus")
     ret = fn(vgpuInstance, byref(c_license_status))
     _nvmlCheckReturn(ret)
     return c_license_status.value
 
+
 def nvmlVgpuInstanceGetLicenseInfo_v2(vgpuInstance):
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetLicenseInfo_v2")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetLicenseInfo_v2")
     c_license_info = c_nvmlVgpuLicenseInfo_t()
     ret = fn(vgpuInstance, byref(c_license_info))
     _nvmlCheckReturn(ret)
     return c_license_info
 
+
 def nvmlVgpuInstanceGetLicenseInfo(vgpuInstance):
     return nvmlVgpuInstanceGetLicenseInfo_v2(vgpuInstance)
 
+
 def nvmlVgpuInstanceGetFrameRateLimit(vgpuInstance):
     c_frl = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetFrameRateLimit")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetFrameRateLimit")
     ret = fn(vgpuInstance, byref(c_frl))
     _nvmlCheckReturn(ret)
     return c_frl.value
+
 
 def nvmlVgpuInstanceGetEccMode(vgpuInstance):
     c_mode = _nvmlEnableState_t()
@@ -4532,52 +5277,62 @@ def nvmlVgpuInstanceGetEccMode(vgpuInstance):
     _nvmlCheckReturn(ret)
     return c_mode.value
 
+
 def nvmlVgpuInstanceGetType(vgpuInstance):
     c_vgpu_type = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetType")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetType")
     ret = fn(vgpuInstance, byref(c_vgpu_type))
     _nvmlCheckReturn(ret)
     return c_vgpu_type.value
 
+
 def nvmlVgpuInstanceGetEncoderCapacity(vgpuInstance):
     c_encoder_capacity = c_ulonglong(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetEncoderCapacity")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetEncoderCapacity")
     ret = fn(vgpuInstance, byref(c_encoder_capacity))
     _nvmlCheckReturn(ret)
     return c_encoder_capacity.value
 
+
 def nvmlVgpuInstanceSetEncoderCapacity(vgpuInstance, encoder_capacity):
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceSetEncoderCapacity")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceSetEncoderCapacity")
     return fn(vgpuInstance, encoder_capacity)
+
 
 def nvmlVgpuInstanceGetFbUsage(vgpuInstance):
     c_fb_usage = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetFbUsage")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetFbUsage")
     ret = fn(vgpuInstance, byref(c_fb_usage))
     _nvmlCheckReturn(ret)
     return c_fb_usage.value
 
+
 def nvmlVgpuTypeGetCapabilities(vgpuTypeId, capability):
     c_cap_result = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuTypeGetCapabilities")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuTypeGetCapabilities")
     ret = fn(vgpuTypeId, _nvmlVgpuCapability_t(capability), byref(c_cap_result))
     _nvmlCheckReturn(ret)
-    return (c_cap_result.value)
+    return c_cap_result.value
+
 
 def nvmlVgpuInstanceGetGpuInstanceId(vgpuInstance):
     c_id = c_uint(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetGpuInstanceId")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetGpuInstanceId")
     ret = fn(vgpuInstance, byref(c_id))
     _nvmlCheckReturn(ret)
-    return (c_id.value)
+    return c_id.value
+
 
 @convertStrBytes
 def nvmlVgpuInstanceGetGpuPciId(vgpuInstance):
     c_vgpuPciId = create_string_buffer(NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE)
     fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetGpuPciId")
-    ret = fn(vgpuInstance, c_vgpuPciId, byref(c_uint(NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE)))
+    ret = fn(
+        vgpuInstance, c_vgpuPciId, byref(c_uint(NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE))
+    )
     _nvmlCheckReturn(ret)
     return c_vgpuPciId.value
+
 
 def nvmlDeviceGetVgpuUtilization(handle, timeStamp):
     # first call to get the size
@@ -4585,25 +5340,34 @@ def nvmlDeviceGetVgpuUtilization(handle, timeStamp):
     c_time_stamp = c_ulonglong(timeStamp)
     c_sample_value_type = _nvmlValueType_t()
 
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuUtilization")
-    ret = fn(handle, c_time_stamp, byref(c_sample_value_type), byref(c_vgpu_count), None)
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuUtilization")
+    ret = fn(
+        handle, c_time_stamp, byref(c_sample_value_type), byref(c_vgpu_count), None
+    )
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no active vGPUs
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         sampleArray = c_vgpu_count.value * c_nvmlVgpuInstanceUtilizationSample_t
         c_samples = sampleArray()
 
         # make the call again
-        ret = fn(handle, c_time_stamp, byref(c_sample_value_type), byref(c_vgpu_count), c_samples)
+        ret = fn(
+            handle,
+            c_time_stamp,
+            byref(c_sample_value_type),
+            byref(c_vgpu_count),
+            c_samples,
+        )
         _nvmlCheckReturn(ret)
 
-        return c_samples[0:c_vgpu_count.value]
+        return c_samples[0 : c_vgpu_count.value]
     else:
         # error case
         raise NVMLError(ret)
+
 
 def nvmlDeviceGetVgpuInstancesUtilizationInfo(handle, timeStamp):
     # first call to get the size
@@ -4614,15 +5378,17 @@ def nvmlDeviceGetVgpuInstancesUtilizationInfo(handle, timeStamp):
     c_vgpuUtilInfo.vgpuInstanceCount = c_uint(0)
     c_vgpuUtilInfo.lastSeenTimeStamp = c_time_stamp
 
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuInstancesUtilizationInfo")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuInstancesUtilizationInfo")
     ret = fn(handle, byref(c_vgpuUtilInfo))
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no active vGPUs
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
-        sampleArray = c_vgpuUtilInfo.vgpuInstanceCount * c_nvmlVgpuInstanceUtilizationInfo_v1_t
+        sampleArray = (
+            c_vgpuUtilInfo.vgpuInstanceCount * c_nvmlVgpuInstanceUtilizationInfo_v1_t
+        )
         c_samples = sampleArray()
         c_vgpuUtilInfo.vgpuUtilArray = c_samples
 
@@ -4630,17 +5396,19 @@ def nvmlDeviceGetVgpuInstancesUtilizationInfo(handle, timeStamp):
         ret = fn(handle, byref(c_vgpuUtilInfo))
         _nvmlCheckReturn(ret)
 
-        return c_samples[0:c_vgpuUtilInfo.vgpuInstanceCount]
+        return c_samples[0 : c_vgpuUtilInfo.vgpuInstanceCount]
     else:
         # error case
         raise NVMLError(ret)
 
+
 def nvmlDeviceGetP2PStatus(device1, device2, p2pIndex):
     c_p2pstatus = _nvmlGpuP2PStatus_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetP2PStatus")
-    ret = fn(device1, device2,p2pIndex, byref(c_p2pstatus))
+    ret = fn(device1, device2, p2pIndex, byref(c_p2pstatus))
     _nvmlCheckReturn(ret)
     return c_p2pstatus.value
+
 
 def nvmlDeviceGetGridLicensableFeatures_v4(handle):
     c_get_grid_licensable_features = c_nvmlGridLicensableFeatures_v4_t()
@@ -4648,10 +5416,12 @@ def nvmlDeviceGetGridLicensableFeatures_v4(handle):
     ret = fn(handle, byref(c_get_grid_licensable_features))
     _nvmlCheckReturn(ret)
 
-    return (c_get_grid_licensable_features)
+    return c_get_grid_licensable_features
+
 
 def nvmlDeviceGetGridLicensableFeatures(handle):
     return nvmlDeviceGetGridLicensableFeatures_v4(handle)
+
 
 def nvmlDeviceGetGspFirmwareVersion(handle, version=None):
     isUserDefined = version is not None
@@ -4662,6 +5432,7 @@ def nvmlDeviceGetGspFirmwareVersion(handle, version=None):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isUserDefined else version.value
 
+
 def nvmlDeviceGetGspFirmwareMode(handle, isEnabled=c_uint(), defaultMode=c_uint()):
     isReference = type(isEnabled) is not c_uint
     isEnabledRef = isEnabled if isReference else byref(isEnabled)
@@ -4670,6 +5441,7 @@ def nvmlDeviceGetGspFirmwareMode(handle, isEnabled=c_uint(), defaultMode=c_uint(
     ret = fn(handle, isEnabledRef, defaultModeRef)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isReference else [isEnabled.value, defaultMode.value]
+
 
 def nvmlDeviceGetEncoderCapacity(handle, encoderQueryType):
     c_encoder_capacity = c_ulonglong(0)
@@ -4680,18 +5452,19 @@ def nvmlDeviceGetEncoderCapacity(handle, encoderQueryType):
     _nvmlCheckReturn(ret)
     return c_encoder_capacity.value
 
+
 def nvmlDeviceGetVgpuProcessUtilization(handle, timeStamp):
     # first call to get the size
     c_vgpu_count = c_uint(0)
     c_time_stamp = c_ulonglong(timeStamp)
 
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuProcessUtilization")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuProcessUtilization")
     ret = fn(handle, c_time_stamp, byref(c_vgpu_count), None)
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no active vGPUs
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         sampleArray = c_vgpu_count.value * c_nvmlVgpuProcessUtilizationSample_t
         c_samples = sampleArray()
@@ -4700,10 +5473,11 @@ def nvmlDeviceGetVgpuProcessUtilization(handle, timeStamp):
         ret = fn(handle, c_time_stamp, byref(c_vgpu_count), c_samples)
         _nvmlCheckReturn(ret)
 
-        return c_samples[0:c_vgpu_count.value]
+        return c_samples[0 : c_vgpu_count.value]
     else:
         # error case
         raise NVMLError(ret)
+
 
 def nvmlDeviceGetVgpuProcessesUtilizationInfo(handle, timeStamp):
     # first call to get the size
@@ -4713,15 +5487,17 @@ def nvmlDeviceGetVgpuProcessesUtilizationInfo(handle, timeStamp):
     c_vgpuProcUtilInfo.vgpuProcessCount = c_uint(0)
     c_vgpuProcUtilInfo.lastSeenTimeStamp = c_time_stamp
 
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuProcessesUtilizationInfo")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuProcessesUtilizationInfo")
     ret = fn(handle, byref(c_vgpuProcUtilInfo))
 
-    if (ret == NVML_SUCCESS):
+    if ret == NVML_SUCCESS:
         # special case, no active vGPUs
         return []
-    elif (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    elif ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
-        sampleArray = c_vgpuProcUtilInfo.vgpuProcessCount * c_nvmlVgpuProcessUtilizationInfo_v1_t
+        sampleArray = (
+            c_vgpuProcUtilInfo.vgpuProcessCount * c_nvmlVgpuProcessUtilizationInfo_v1_t
+        )
         c_samples = sampleArray()
         c_vgpuProcUtilInfo.vgpuProcUtilArray = c_samples
 
@@ -4729,10 +5505,11 @@ def nvmlDeviceGetVgpuProcessesUtilizationInfo(handle, timeStamp):
         ret = fn(handle, byref(c_vgpuProcUtilInfo))
         _nvmlCheckReturn(ret)
 
-        return c_samples[0:c_vgpuProcUtilInfo.vgpuProcessCount]
+        return c_samples[0 : c_vgpuProcUtilInfo.vgpuProcessCount]
     else:
         # error case
         raise NVMLError(ret)
+
 
 def nvmlDeviceGetEncoderStats(handle):
     c_encoderCount = c_ulonglong(0)
@@ -4743,15 +5520,16 @@ def nvmlDeviceGetEncoderStats(handle):
     _nvmlCheckReturn(ret)
     return (c_encoderCount.value, c_encodeFps.value, c_encoderLatency.value)
 
+
 def nvmlDeviceGetEncoderSessions(handle):
     # first call to get the size
     c_session_count = c_uint(0)
 
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetEncoderSessions")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetEncoderSessions")
     ret = fn(handle, byref(c_session_count), None)
 
-    if (ret == NVML_SUCCESS):
-        if (c_session_count.value != 0):
+    if ret == NVML_SUCCESS:
+        if c_session_count.value != 0:
             # typical case
             session_array = c_nvmlEncoderSession_t * c_session_count.value
             c_sessions = session_array()
@@ -4768,6 +5546,7 @@ def nvmlDeviceGetEncoderSessions(handle):
     else:
         # error case
         raise NVMLError(ret)
+
 
 def nvmlDeviceGetFBCStats(handle):
     c_fbcStats = c_nvmlFBCStats_t()
@@ -4776,15 +5555,16 @@ def nvmlDeviceGetFBCStats(handle):
     _nvmlCheckReturn(ret)
     return c_fbcStats
 
+
 def nvmlDeviceGetFBCSessions(handle):
     # first call to get the size
     c_session_count = c_uint(0)
 
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetFBCSessions")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetFBCSessions")
     ret = fn(handle, byref(c_session_count), None)
 
-    if (ret == NVML_SUCCESS):
-        if (c_session_count.value != 0):
+    if ret == NVML_SUCCESS:
+        if c_session_count.value != 0:
             # typical case
             session_array = c_nvmlFBCSession_t * c_session_count.value
             c_sessions = session_array()
@@ -4802,24 +5582,28 @@ def nvmlDeviceGetFBCSessions(handle):
         # error case
         raise NVMLError(ret)
 
+
 def nvmlVgpuInstanceGetEncoderStats(vgpuInstance):
-    c_encoderCount    = c_ulonglong(0)
-    c_encodeFps       = c_ulonglong(0)
-    c_encoderLatency  = c_ulonglong(0)
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetEncoderStats")
-    ret = fn(vgpuInstance, byref(c_encoderCount), byref(c_encodeFps), byref(c_encoderLatency))
+    c_encoderCount = c_ulonglong(0)
+    c_encodeFps = c_ulonglong(0)
+    c_encoderLatency = c_ulonglong(0)
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetEncoderStats")
+    ret = fn(
+        vgpuInstance, byref(c_encoderCount), byref(c_encodeFps), byref(c_encoderLatency)
+    )
     _nvmlCheckReturn(ret)
     return (c_encoderCount.value, c_encodeFps.value, c_encoderLatency.value)
+
 
 def nvmlVgpuInstanceGetEncoderSessions(vgpuInstance):
     # first call to get the size
     c_session_count = c_uint(0)
 
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetEncoderSessions")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetEncoderSessions")
     ret = fn(vgpuInstance, byref(c_session_count), None)
 
-    if (ret == NVML_SUCCESS):
-        if (c_session_count.value != 0):
+    if ret == NVML_SUCCESS:
+        if c_session_count.value != 0:
             # typical case
             session_array = c_nvmlEncoderSession_t * c_session_count.value
             c_sessions = session_array()
@@ -4837,6 +5621,7 @@ def nvmlVgpuInstanceGetEncoderSessions(vgpuInstance):
         # error case
         raise NVMLError(ret)
 
+
 def nvmlVgpuInstanceGetFBCStats(vgpuInstance):
     c_fbcStats = c_nvmlFBCStats_t()
     fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetFBCStats")
@@ -4844,15 +5629,16 @@ def nvmlVgpuInstanceGetFBCStats(vgpuInstance):
     _nvmlCheckReturn(ret)
     return c_fbcStats
 
+
 def nvmlVgpuInstanceGetFBCSessions(vgpuInstance):
     # first call to get the size
     c_session_count = c_uint(0)
 
-    fn  = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetFBCSessions")
+    fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetFBCSessions")
     ret = fn(vgpuInstance, byref(c_session_count), None)
 
-    if (ret == NVML_SUCCESS):
-        if (c_session_count.value != 0):
+    if ret == NVML_SUCCESS:
+        if c_session_count.value != 0:
             # typical case
             session_array = c_nvmlFBCSession_t * c_session_count.value
             c_sessions = session_array()
@@ -4870,15 +5656,16 @@ def nvmlVgpuInstanceGetFBCSessions(vgpuInstance):
         # error case
         raise NVMLError(ret)
 
+
 def nvmlDeviceGetProcessUtilization(handle, timeStamp):
     # first call to get the size
     c_count = c_uint(0)
     c_time_stamp = c_ulonglong(timeStamp)
 
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetProcessUtilization")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetProcessUtilization")
     ret = fn(handle, None, byref(c_count), c_time_stamp)
 
-    if (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    if ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
         sampleArray = c_count.value * c_nvmlProcessUtilizationSample_t
         c_samples = sampleArray()
@@ -4887,10 +5674,11 @@ def nvmlDeviceGetProcessUtilization(handle, timeStamp):
         ret = fn(handle, c_samples, byref(c_count), c_time_stamp)
         _nvmlCheckReturn(ret)
 
-        return c_samples[0:c_count.value]
+        return c_samples[0 : c_count.value]
     else:
         # error case
         raise NVMLError(ret)
+
 
 def nvmlDeviceGetProcessesUtilizationInfo(handle, timeStamp):
     # first call to get the size
@@ -4900,12 +5688,14 @@ def nvmlDeviceGetProcessesUtilizationInfo(handle, timeStamp):
     c_processesUtilInfo.processSamplesCount = c_uint(0)
     c_processesUtilInfo.lastSeenTimeStamp = c_time_stamp
 
-    fn  = _nvmlGetFunctionPointer("nvmlDeviceGetProcessesUtilizationInfo")
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetProcessesUtilizationInfo")
     ret = fn(handle, byref(c_processesUtilInfo))
 
-    if (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    if ret == NVML_ERROR_INSUFFICIENT_SIZE:
         # typical case
-        sampleArray = c_processesUtilInfo.processSamplesCount * c_nvmlProcessUtilizationInfo_v1_t
+        sampleArray = (
+            c_processesUtilInfo.processSamplesCount * c_nvmlProcessUtilizationInfo_v1_t
+        )
         c_samples = sampleArray()
         c_processesUtilInfo.procUtilArray = c_samples
 
@@ -4913,10 +5703,11 @@ def nvmlDeviceGetProcessesUtilizationInfo(handle, timeStamp):
         ret = fn(handle, byref(c_processesUtilInfo))
         _nvmlCheckReturn(ret)
 
-        return c_samples[0:c_processesUtilInfo.processSamplesCount]
+        return c_samples[0 : c_processesUtilInfo.processSamplesCount]
     else:
         # error case
         raise NVMLError(ret)
+
 
 def nvmlVgpuInstanceGetMetadata(vgpuInstance):
     fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetMetadata")
@@ -4925,12 +5716,13 @@ def nvmlVgpuInstanceGetMetadata(vgpuInstance):
     # Make the first NVML API call to get the c_bufferSize value.
     # We have already allocated required buffer above.
     ret = fn(vgpuInstance, byref(c_vgpuMetadata), byref(c_bufferSize))
-    if (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    if ret == NVML_ERROR_INSUFFICIENT_SIZE:
         ret = fn(vgpuInstance, byref(c_vgpuMetadata), byref(c_bufferSize))
         _nvmlCheckReturn(ret)
     else:
         raise NVMLError(ret)
     return c_vgpuMetadata
+
 
 def nvmlDeviceGetVgpuMetadata(handle):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuMetadata")
@@ -4939,12 +5731,13 @@ def nvmlDeviceGetVgpuMetadata(handle):
     # Make the first NVML API call to get the c_bufferSize value.
     # We have already allocated required buffer above.
     ret = fn(handle, byref(c_vgpuPgpuMetadata), byref(c_bufferSize))
-    if (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    if ret == NVML_ERROR_INSUFFICIENT_SIZE:
         ret = fn(handle, byref(c_vgpuPgpuMetadata), byref(c_bufferSize))
         _nvmlCheckReturn(ret)
     else:
         raise NVMLError(ret)
     return c_vgpuPgpuMetadata
+
 
 def nvmlGetVgpuCompatibility(vgpuMetadata, pgpuMetadata):
     fn = _nvmlGetFunctionPointer("nvmlGetVgpuCompatibility")
@@ -4952,6 +5745,7 @@ def nvmlGetVgpuCompatibility(vgpuMetadata, pgpuMetadata):
     ret = fn(byref(vgpuMetadata), byref(pgpuMetadata), byref(c_vgpuPgpuCompatibility))
     _nvmlCheckReturn(ret)
     return c_vgpuPgpuCompatibility
+
 
 @convertStrBytes
 def nvmlDeviceGetPgpuMetadataString(handle):
@@ -4961,12 +5755,13 @@ def nvmlDeviceGetPgpuMetadataString(handle):
     # Make the first NVML API call to get the c_bufferSize value.
     # We have already allocated required buffer above.
     ret = fn(handle, byref(c_pgpuMetadata), byref(c_bufferSize))
-    if (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    if ret == NVML_ERROR_INSUFFICIENT_SIZE:
         ret = fn(handle, byref(c_pgpuMetadata), byref(c_bufferSize))
         _nvmlCheckReturn(ret)
     else:
         raise NVMLError(ret)
     return (c_pgpuMetadata.value, c_bufferSize.value)
+
 
 def nvmlDeviceGetVgpuSchedulerLog(handle):
     c_vgpu_sched_log = c_nvmlVgpuSchedulerLog_t()
@@ -4975,12 +5770,14 @@ def nvmlDeviceGetVgpuSchedulerLog(handle):
     _nvmlCheckReturn(ret)
     return c_vgpu_sched_log
 
+
 def nvmlDeviceGetVgpuSchedulerState(handle):
     c_vgpu_sched_state = c_nvmlVgpuSchedulerGetState_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetVgpuSchedulerState")
     ret = fn(handle, byref(c_vgpu_sched_state))
     _nvmlCheckReturn(ret)
     return c_vgpu_sched_state
+
 
 def nvmlDeviceGetVgpuSchedulerCapabilities(handle):
     c_vgpu_sched_caps = c_nvmlVgpuSchedulerCapabilities_t()
@@ -4989,17 +5786,20 @@ def nvmlDeviceGetVgpuSchedulerCapabilities(handle):
     _nvmlCheckReturn(ret)
     return c_vgpu_sched_caps
 
+
 def nvmlDeviceSetVgpuSchedulerState(handle, sched_state):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetVgpuSchedulerState")
     ret = fn(handle, byref(sched_state))
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 def nvmlSetVgpuVersion(vgpuVersion):
     fn = _nvmlGetFunctionPointer("nvmlSetVgpuVersion")
     ret = fn(byref(vgpuVersion))
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlGetVgpuVersion(supported=None, current=None):
     isUserDefined = (supported is not None) or (current is not None)
@@ -5009,10 +5809,15 @@ def nvmlGetVgpuVersion(supported=None, current=None):
     fn = _nvmlGetFunctionPointer("nvmlGetVgpuVersion")
     ret = fn(byref(supported), byref(current))
     _nvmlCheckReturn(ret)
-    return NVML_SUCCESS if isUserDefined else [(supported.minVersion,
-                                                supported.maxVersion),
-                                               (current.minVersion,
-                                                current.maxVersion)]
+    return (
+        NVML_SUCCESS
+        if isUserDefined
+        else [
+            (supported.minVersion, supported.maxVersion),
+            (current.minVersion, current.maxVersion),
+        ]
+    )
+
 
 def nvmlVgpuInstanceGetAccountingMode(vgpuInstance):
     c_mode = _nvmlEnableState_t()
@@ -5021,11 +5826,12 @@ def nvmlVgpuInstanceGetAccountingMode(vgpuInstance):
     _nvmlCheckReturn(ret)
     return c_mode.value
 
+
 def nvmlVgpuInstanceGetAccountingPids(vgpuInstance):
     c_pidCount = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetAccountingPids")
     ret = fn(vgpuInstance, byref(c_pidCount), None)
-    if (ret == NVML_ERROR_INSUFFICIENT_SIZE):
+    if ret == NVML_ERROR_INSUFFICIENT_SIZE:
         sampleArray = c_pidCount.value * c_uint
         c_pidArray = sampleArray()
         ret = fn(vgpuInstance, byref(c_pidCount), byref(c_pidArray))
@@ -5034,6 +5840,7 @@ def nvmlVgpuInstanceGetAccountingPids(vgpuInstance):
         raise NVMLError(ret)
     return (c_pidCount, c_pidArray)
 
+
 def nvmlVgpuInstanceGetAccountingStats(vgpuInstance, pid):
     c_accountingStats = c_nvmlAccountingStats_t()
     fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceGetAccountingStats")
@@ -5041,11 +5848,13 @@ def nvmlVgpuInstanceGetAccountingStats(vgpuInstance, pid):
     _nvmlCheckReturn(ret)
     return c_accountingStats
 
+
 def nvmlVgpuInstanceClearAccountingPids(vgpuInstance):
     fn = _nvmlGetFunctionPointer("nvmlVgpuInstanceClearAccountingPids")
     ret = fn(vgpuInstance)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlGetExcludedDeviceCount():
     c_count = c_uint()
@@ -5053,6 +5862,7 @@ def nvmlGetExcludedDeviceCount():
     ret = fn(byref(c_count))
     _nvmlCheckReturn(ret)
     return c_count.value
+
 
 def nvmlGetExcludedDeviceInfoByIndex(index):
     c_index = c_uint(index)
@@ -5062,12 +5872,14 @@ def nvmlGetExcludedDeviceInfoByIndex(index):
     _nvmlCheckReturn(ret)
     return info
 
+
 def nvmlDeviceGetHostVgpuMode(handle):
     c_host_vgpu_mode = _nvmlHostVgpuMode_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetHostVgpuMode")
     ret = fn(handle, byref(c_host_vgpu_mode))
     _nvmlCheckReturn(ret)
     return c_host_vgpu_mode.value
+
 
 def nvmlDeviceSetMigMode(device, mode):
     c_activationStatus = c_uint()
@@ -5076,6 +5888,7 @@ def nvmlDeviceSetMigMode(device, mode):
     _nvmlCheckReturn(ret)
     return c_activationStatus.value
 
+
 def nvmlDeviceGetMigMode(device):
     c_currentMode = c_uint()
     c_pendingMode = c_uint()
@@ -5083,6 +5896,7 @@ def nvmlDeviceGetMigMode(device):
     ret = fn(device, byref(c_currentMode), byref(c_pendingMode))
     _nvmlCheckReturn(ret)
     return [c_currentMode.value, c_pendingMode.value]
+
 
 def nvmlDeviceGetGpuInstanceProfileInfo(device, profile, version=2):
     if version == 2:
@@ -5097,8 +5911,10 @@ def nvmlDeviceGetGpuInstanceProfileInfo(device, profile, version=2):
     _nvmlCheckReturn(ret)
     return c_info
 
+
 # Define function alias for the API exposed by NVML
 nvmlDeviceGetGpuInstanceProfileInfoV = nvmlDeviceGetGpuInstanceProfileInfo
+
 
 def nvmlDeviceGetGpuInstanceRemainingCapacity(device, profileId):
     c_count = c_uint()
@@ -5107,11 +5923,15 @@ def nvmlDeviceGetGpuInstanceRemainingCapacity(device, profileId):
     _nvmlCheckReturn(ret)
     return c_count.value
 
-def nvmlDeviceGetGpuInstancePossiblePlacements(device, profileId, placementsRef, countRef):
+
+def nvmlDeviceGetGpuInstancePossiblePlacements(
+    device, profileId, placementsRef, countRef
+):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetGpuInstancePossiblePlacements_v2")
     ret = fn(device, profileId, placementsRef, countRef)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlDeviceCreateGpuInstance(device, profileId):
     c_instance = c_nvmlGpuInstance_t()
@@ -5120,6 +5940,7 @@ def nvmlDeviceCreateGpuInstance(device, profileId):
     _nvmlCheckReturn(ret)
     return c_instance
 
+
 def nvmlDeviceCreateGpuInstanceWithPlacement(device, profileId, placement):
     c_instance = c_nvmlGpuInstance_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceCreateGpuInstanceWithPlacement")
@@ -5127,17 +5948,20 @@ def nvmlDeviceCreateGpuInstanceWithPlacement(device, profileId, placement):
     _nvmlCheckReturn(ret)
     return c_instance
 
+
 def nvmlGpuInstanceDestroy(gpuInstance):
     fn = _nvmlGetFunctionPointer("nvmlGpuInstanceDestroy")
     ret = fn(gpuInstance)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 def nvmlDeviceGetGpuInstances(device, profileId, gpuInstancesRef, countRef):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetGpuInstances")
     ret = fn(device, profileId, gpuInstancesRef, countRef)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlDeviceGetGpuInstanceById(device, gpuInstanceId):
     c_instance = c_nvmlGpuInstance_t()
@@ -5146,6 +5970,7 @@ def nvmlDeviceGetGpuInstanceById(device, gpuInstanceId):
     _nvmlCheckReturn(ret)
     return c_instance
 
+
 def nvmlGpuInstanceGetInfo(gpuInstance):
     c_info = c_nvmlGpuInstanceInfo_t()
     fn = _nvmlGetFunctionPointer("nvmlGpuInstanceGetInfo")
@@ -5153,7 +5978,10 @@ def nvmlGpuInstanceGetInfo(gpuInstance):
     _nvmlCheckReturn(ret)
     return c_info
 
-def nvmlGpuInstanceGetComputeInstanceProfileInfo(device, profile, engProfile, version=2):
+
+def nvmlGpuInstanceGetComputeInstanceProfileInfo(
+    device, profile, engProfile, version=2
+):
     if version == 2:
         c_info = c_nvmlComputeInstanceProfileInfo_v2_t()
         fn = _nvmlGetFunctionPointer("nvmlGpuInstanceGetComputeInstanceProfileInfoV")
@@ -5161,13 +5989,17 @@ def nvmlGpuInstanceGetComputeInstanceProfileInfo(device, profile, engProfile, ve
         c_info = c_nvmlComputeInstanceProfileInfo_t()
         fn = _nvmlGetFunctionPointer("nvmlGpuInstanceGetComputeInstanceProfileInfo")
     else:
-        raise NVMLError(NVML_ERROR_FUNCTION_NOT_FOUND) 
+        raise NVMLError(NVML_ERROR_FUNCTION_NOT_FOUND)
     ret = fn(device, profile, engProfile, byref(c_info))
     _nvmlCheckReturn(ret)
     return c_info
 
+
 # Define function alias for the API exposed by NVML
-nvmlGpuInstanceGetComputeInstanceProfileInfoV = nvmlGpuInstanceGetComputeInstanceProfileInfo
+nvmlGpuInstanceGetComputeInstanceProfileInfoV = (
+    nvmlGpuInstanceGetComputeInstanceProfileInfo
+)
+
 
 def nvmlGpuInstanceGetComputeInstanceRemainingCapacity(gpuInstance, profileId):
     c_count = c_uint()
@@ -5176,11 +6008,15 @@ def nvmlGpuInstanceGetComputeInstanceRemainingCapacity(gpuInstance, profileId):
     _nvmlCheckReturn(ret)
     return c_count.value
 
-def nvmlGpuInstanceGetComputeInstancePossiblePlacements(gpuInstance, profileId, placementsRef, countRef):
+
+def nvmlGpuInstanceGetComputeInstancePossiblePlacements(
+    gpuInstance, profileId, placementsRef, countRef
+):
     fn = _nvmlGetFunctionPointer("nvmlGpuInstanceGetComputeInstancePossiblePlacements")
     ret = fn(gpuInstance, profileId, placementsRef, countRef)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlGpuInstanceCreateComputeInstance(gpuInstance, profileId):
     c_instance = c_nvmlComputeInstance_t()
@@ -5189,12 +6025,16 @@ def nvmlGpuInstanceCreateComputeInstance(gpuInstance, profileId):
     _nvmlCheckReturn(ret)
     return c_instance
 
-def nvmlGpuInstanceCreateComputeInstanceWithPlacement(gpuInstance, profileId, placement):
+
+def nvmlGpuInstanceCreateComputeInstanceWithPlacement(
+    gpuInstance, profileId, placement
+):
     c_instance = c_nvmlComputeInstance_t()
     fn = _nvmlGetFunctionPointer("nvmlGpuInstanceCreateComputeInstanceWithPlacement")
     ret = fn(gpuInstance, profileId, placement, byref(c_instance))
     _nvmlCheckReturn(ret)
     return c_instance
+
 
 def nvmlComputeInstanceDestroy(computeInstance):
     fn = _nvmlGetFunctionPointer("nvmlComputeInstanceDestroy")
@@ -5202,11 +6042,15 @@ def nvmlComputeInstanceDestroy(computeInstance):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
-def nvmlGpuInstanceGetComputeInstances(gpuInstance, profileId, computeInstancesRef, countRef):
+
+def nvmlGpuInstanceGetComputeInstances(
+    gpuInstance, profileId, computeInstancesRef, countRef
+):
     fn = _nvmlGetFunctionPointer("nvmlGpuInstanceGetComputeInstances")
     ret = fn(gpuInstance, profileId, computeInstancesRef, countRef)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlGpuInstanceGetComputeInstanceById(gpuInstance, computeInstanceId):
     c_instance = c_nvmlComputeInstance_t()
@@ -5215,6 +6059,7 @@ def nvmlGpuInstanceGetComputeInstanceById(gpuInstance, computeInstanceId):
     _nvmlCheckReturn(ret)
     return c_instance
 
+
 def nvmlComputeInstanceGetInfo_v2(computeInstance):
     c_info = c_nvmlComputeInstanceInfo_t()
     fn = _nvmlGetFunctionPointer("nvmlComputeInstanceGetInfo_v2")
@@ -5222,8 +6067,10 @@ def nvmlComputeInstanceGetInfo_v2(computeInstance):
     _nvmlCheckReturn(ret)
     return c_info
 
+
 def nvmlComputeInstanceGetInfo(computeInstance):
     return nvmlComputeInstanceGetInfo_v2(computeInstance)
+
 
 def nvmlDeviceIsMigDeviceHandle(device):
     c_isMigDevice = c_uint()
@@ -5232,12 +6079,14 @@ def nvmlDeviceIsMigDeviceHandle(device):
     _nvmlCheckReturn(ret)
     return c_isMigDevice
 
+
 def nvmlDeviceGetGpuInstanceId(device):
     c_gpuInstanceId = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetGpuInstanceId")
     ret = fn(device, byref(c_gpuInstanceId))
     _nvmlCheckReturn(ret)
     return c_gpuInstanceId.value
+
 
 def nvmlDeviceGetComputeInstanceId(device):
     c_computeInstanceId = c_uint()
@@ -5246,12 +6095,14 @@ def nvmlDeviceGetComputeInstanceId(device):
     _nvmlCheckReturn(ret)
     return c_computeInstanceId.value
 
+
 def nvmlDeviceGetMaxMigDeviceCount(device):
     c_count = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMaxMigDeviceCount")
     ret = fn(device, byref(c_count))
     _nvmlCheckReturn(ret)
     return c_count.value
+
 
 def nvmlDeviceGetMigDeviceHandleByIndex(device, index):
     c_index = c_uint(index)
@@ -5261,12 +6112,14 @@ def nvmlDeviceGetMigDeviceHandleByIndex(device, index):
     _nvmlCheckReturn(ret)
     return migDevice
 
+
 def nvmlDeviceGetDeviceHandleFromMigDeviceHandle(migDevice):
     device = c_nvmlDevice_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetDeviceHandleFromMigDeviceHandle")
     ret = fn(migDevice, byref(device))
     _nvmlCheckReturn(ret)
     return device
+
 
 def nvmlDeviceGetAttributes_v2(device):
     c_attrs = c_nvmlDeviceAttributes()
@@ -5275,8 +6128,10 @@ def nvmlDeviceGetAttributes_v2(device):
     _nvmlCheckReturn(ret)
     return c_attrs
 
+
 def nvmlDeviceGetAttributes(device):
     return nvmlDeviceGetAttributes_v2(device)
+
 
 def nvmlDeviceGetRemappedRows(device):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetRemappedRows")
@@ -5288,12 +6143,14 @@ def nvmlDeviceGetRemappedRows(device):
     _nvmlCheckReturn(ret)
     return (c_corr.value, c_unc.value, c_bpending.value, c_bfailure.value)
 
+
 def nvmlDeviceGetRowRemapperHistogram(device):
     c_vals = c_nvmlRowRemapperHistogramValues()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetRowRemapperHistogram")
     ret = fn(device, byref(c_vals))
     _nvmlCheckReturn(ret)
     return c_vals
+
 
 def nvmlDeviceGetArchitecture(device):
     arch = _nvmlDeviceArchitecture_t()
@@ -5302,12 +6159,14 @@ def nvmlDeviceGetArchitecture(device):
     _nvmlCheckReturn(ret)
     return arch.value
 
+
 def nvmlDeviceGetBusType(device):
     c_busType = _nvmlBusType_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetBusType")
     ret = fn(device, byref(c_busType))
     _nvmlCheckReturn(ret)
     return c_busType.value
+
 
 def nvmlDeviceGetIrqNum(device):
     c_irqNum = c_uint()
@@ -5316,12 +6175,14 @@ def nvmlDeviceGetIrqNum(device):
     _nvmlCheckReturn(ret)
     return c_irqNum.value
 
+
 def nvmlDeviceGetNumGpuCores(device):
     c_numCores = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetNumGpuCores")
     ret = fn(device, byref(c_numCores))
     _nvmlCheckReturn(ret)
     return c_numCores.value
+
 
 def nvmlDeviceGetPowerSource(device):
     c_powerSource = _nvmlPowerSource_t()
@@ -5330,12 +6191,14 @@ def nvmlDeviceGetPowerSource(device):
     _nvmlCheckReturn(ret)
     return c_powerSource.value
 
+
 def nvmlDeviceGetMemoryBusWidth(device):
     c_memBusWidth = c_uint()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMemoryBusWidth")
     ret = fn(device, byref(c_memBusWidth))
     _nvmlCheckReturn(ret)
     return c_memBusWidth.value
+
 
 def nvmlDeviceGetPcieLinkMaxSpeed(device):
     c_speed = _nvmlPcieLinkMaxSpeed_t()
@@ -5344,12 +6207,14 @@ def nvmlDeviceGetPcieLinkMaxSpeed(device):
     _nvmlCheckReturn(ret)
     return c_speed.value
 
+
 def nvmlDeviceGetAdaptiveClockInfoStatus(device):
     c_adaptiveClockInfoStatus = _nvmlAdaptiveClockInfoStatus_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetAdaptiveClockInfoStatus")
     ret = fn(device, byref(c_adaptiveClockInfoStatus))
     _nvmlCheckReturn(ret)
     return c_adaptiveClockInfoStatus.value
+
 
 def nvmlDeviceGetPcieSpeed(device):
     c_speed = c_uint()
@@ -5358,64 +6223,87 @@ def nvmlDeviceGetPcieSpeed(device):
     _nvmlCheckReturn(ret)
     return c_speed.value
 
-def nvmlDeviceGetDynamicPstatesInfo(device, c_dynamicpstatesinfo=c_nvmlGpuDynamicPstatesInfo_t()):
-    isReference = type(c_dynamicpstatesinfo) is not c_nvmlGpuDynamicPstatesInfo_t
-    dynamicpstatesinfoRef = c_dynamicpstatesinfo if isReference else byref(c_dynamicpstatesinfo)
 
-    fn = _nvmlGetFunctionPointer("nvmlDeviceGetDynamicPstatesInfo");
+def nvmlDeviceGetDynamicPstatesInfo(
+    device, c_dynamicpstatesinfo=c_nvmlGpuDynamicPstatesInfo_t()
+):
+    isReference = type(c_dynamicpstatesinfo) is not c_nvmlGpuDynamicPstatesInfo_t
+    dynamicpstatesinfoRef = (
+        c_dynamicpstatesinfo if isReference else byref(c_dynamicpstatesinfo)
+    )
+
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetDynamicPstatesInfo")
     ret = fn(device, dynamicpstatesinfoRef)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isReference else c_dynamicpstatesinfo
 
+
 def nvmlDeviceSetFanSpeed_v2(handle, index, speed):
-    fn = _nvmlGetFunctionPointer("nvmlDeviceSetFanSpeed_v2");
+    fn = _nvmlGetFunctionPointer("nvmlDeviceSetFanSpeed_v2")
     ret = fn(handle, index, speed)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
-def nvmlDeviceGetThermalSettings(device, sensorindex, c_thermalsettings=c_nvmlGpuThermalSettings_t()):
+
+def nvmlDeviceGetThermalSettings(
+    device, sensorindex, c_thermalsettings=c_nvmlGpuThermalSettings_t()
+):
     isReference = type(c_thermalsettings) is not c_nvmlGpuThermalSettings_t
     thermalsettingsRef = c_thermalsettings if isReference else byref(c_thermalsettings)
-    fn = _nvmlGetFunctionPointer("nvmlDeviceGetThermalSettings");
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetThermalSettings")
     ret = fn(device, sensorindex, thermalsettingsRef)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isReference else c_thermalsettings.sensor[:]
 
-def nvmlDeviceGetMinMaxClockOfPState(device, clockType, pstate, minClockMHz=c_uint(), maxClockMHz=c_uint()):
+
+def nvmlDeviceGetMinMaxClockOfPState(
+    device, clockType, pstate, minClockMHz=c_uint(), maxClockMHz=c_uint()
+):
     isReference = (type(minClockMHz) is not c_uint) or (type(maxClockMHz) is not c_uint)
     minClockMHzRef = minClockMHz if isReference else byref(minClockMHz)
     maxClockMHzRef = maxClockMHz if isReference else byref(maxClockMHz)
-    fn = _nvmlGetFunctionPointer("nvmlDeviceGetMinMaxClockOfPState");
-    ret = fn(device, _nvmlClockType_t(clockType), _nvmlClockType_t(pstate), minClockMHzRef, maxClockMHzRef)
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetMinMaxClockOfPState")
+    ret = fn(
+        device,
+        _nvmlClockType_t(clockType),
+        _nvmlClockType_t(pstate),
+        minClockMHzRef,
+        maxClockMHzRef,
+    )
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isReference else (minClockMHz.value, maxClockMHz.value)
 
+
 class c_nvmlClockOffset_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('type', _nvmlClockType_t),
-        ('pstate', _nvmlPstates_t),
-        ('clockOffsetMHz', c_int),
-        ('minClockOffsetMHz', c_int),
-        ('maxClockOffsetMHz', c_int),
+        ("version", c_uint),
+        ("type", _nvmlClockType_t),
+        ("pstate", _nvmlPstates_t),
+        ("clockOffsetMHz", c_int),
+        ("minClockOffsetMHz", c_int),
+        ("maxClockOffsetMHz", c_int),
     ]
+
 
 nvmlClockOffset_v1 = 0x1000018
 
+
 def nvmlDeviceGetClockOffsets(device, info):
-    fn = _nvmlGetFunctionPointer("nvmlDeviceGetClockOffsets");
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetClockOffsets")
     ret = fn(device, info)
     return NVML_SUCCESS
 
+
 def nvmlDeviceSetClockOffsets(device, info):
-    fn = _nvmlGetFunctionPointer("nvmlDeviceSetClockOffsets");
+    fn = _nvmlGetFunctionPointer("nvmlDeviceSetClockOffsets")
     ret = fn(device, info)
     return NVML_SUCCESS
+
 
 def nvmlDeviceGetSupportedPerformanceStates(device):
     pstates = []
     c_count = c_uint(NVML_MAX_GPU_PERF_PSTATES)
-    c_size = sizeof(c_uint)*c_count.value
+    c_size = sizeof(c_uint) * c_count.value
 
     # NOTE: use 'c_uint' to represent the size of the nvmlPstate_t enumeration.
     pstates_array = _nvmlPstates_t * c_count.value
@@ -5431,6 +6319,7 @@ def nvmlDeviceGetSupportedPerformanceStates(device):
 
     return pstates
 
+
 def nvmlDeviceGetGpcClkVfOffset(device):
     offset = c_int32()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetGpcClkVfOffset")
@@ -5438,12 +6327,14 @@ def nvmlDeviceGetGpcClkVfOffset(device):
     _nvmlCheckReturn(ret)
     return offset.value
 
+
 def nvmlDeviceSetGpcClkVfOffset(device, offset):
     c_offset = c_int32(offset)
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetGpcClkVfOffset")
     ret = fn(device, c_offset)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlDeviceGetGpcClkMinMaxVfOffset(device, minOffset=c_int(), maxOffset=c_int()):
     isReference = (type(minOffset) is not c_int) or (type(maxOffset) is not c_int)
@@ -5454,6 +6345,7 @@ def nvmlDeviceGetGpcClkMinMaxVfOffset(device, minOffset=c_int(), maxOffset=c_int
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isReference else (minOffset.value, maxOffset.value)
 
+
 def nvmlDeviceGetMemClkVfOffset(device):
     offset = c_int32()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetMemClkVfOffset")
@@ -5461,12 +6353,14 @@ def nvmlDeviceGetMemClkVfOffset(device):
     _nvmlCheckReturn(ret)
     return offset.value
 
+
 def nvmlDeviceSetMemClkVfOffset(device, offset):
     c_offset = c_int32(offset)
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetMemClkVfOffset")
     ret = fn(device, c_offset)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlDeviceGetMemClkMinMaxVfOffset(device, minOffset=c_int(), maxOffset=c_int()):
     isReference = (type(minOffset) is not c_int) or (type(maxOffset) is not c_int)
@@ -5478,12 +6372,14 @@ def nvmlDeviceGetMemClkMinMaxVfOffset(device, minOffset=c_int(), maxOffset=c_int
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS if isReference else (minOffset.value, maxOffset.value)
 
+
 def nvmlSystemSetConfComputeGpusReadyState(state):
     c_state = c_uint(state)
     fn = _nvmlGetFunctionPointer("nvmlSystemSetConfComputeGpusReadyState")
     ret = fn(c_state)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlSystemGetConfComputeGpusReadyState():
     c_state = c_uint()
@@ -5492,12 +6388,14 @@ def nvmlSystemGetConfComputeGpusReadyState():
     _nvmlCheckReturn(ret)
     return c_state.value
 
+
 def nvmlSystemGetConfComputeCapabilities():
     c_ccSysCaps = c_nvmlConfComputeSystemCaps_t()
     fn = _nvmlGetFunctionPointer("nvmlSystemGetConfComputeCapabilities")
     ret = fn(byref(c_ccSysCaps))
     _nvmlCheckReturn(ret)
     return c_ccSysCaps
+
 
 def nvmlSystemGetConfComputeState():
     c_state = c_nvmlConfComputeSystemState_t()
@@ -5506,15 +6404,18 @@ def nvmlSystemGetConfComputeState():
     _nvmlCheckReturn(ret)
     return c_state
 
+
 def nvmlSystemGetConfComputeSettings(settings):
     fn = _nvmlGetFunctionPointer("nvmlSystemGetConfComputeSettings")
     return fn(settings)
+
 
 def nvmlDeviceSetConfComputeUnprotectedMemSize(device, c_ccMemSize):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetConfComputeUnprotectedMemSize")
     ret = fn(device, c_ccMemSize)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlDeviceGetConfComputeMemSizeInfo(device):
     c_ccMemSize = c_nvmlConfComputeMemSizeInfo_t()
@@ -5523,12 +6424,14 @@ def nvmlDeviceGetConfComputeMemSizeInfo(device):
     _nvmlCheckReturn(ret)
     return c_ccMemSize
 
+
 def nvmlDeviceGetConfComputeProtectedMemoryUsage(device):
     c_memory = c_nvmlMemory_t()
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetConfComputeProtectedMemoryUsage")
     ret = fn(device, byref(c_memory))
     _nvmlCheckReturn(ret)
     return c_memory
+
 
 def nvmlDeviceGetConfComputeGpuCertificate(device):
     c_cert = c_nvmlConfComputeGpuCertificate_t()
@@ -5537,14 +6440,16 @@ def nvmlDeviceGetConfComputeGpuCertificate(device):
     _nvmlCheckReturn(ret)
     return c_cert
 
+
 def nvmlDeviceGetConfComputeGpuAttestationReport(device, c_nonce):
     c_attestReport = c_nvmlConfComputeGpuAttestationReport_t()
     c_nonce_arr = (c_uint8 * len(c_nonce))(*(c_nonce))
-    setattr(c_attestReport, 'nonce', c_nonce_arr)
+    setattr(c_attestReport, "nonce", c_nonce_arr)
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetConfComputeGpuAttestationReport")
     ret = fn(device, byref(c_attestReport))
     _nvmlCheckReturn(ret)
     return c_attestReport
+
 
 def nvmlSystemSetConfComputeKeyRotationThresholdInfo(max_atk_adv):
     c_keyRotationThrInfo = c_nvmlConfComputeSetKeyRotationThresholdInfo_t(0)
@@ -5555,6 +6460,7 @@ def nvmlSystemSetConfComputeKeyRotationThresholdInfo(max_atk_adv):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 def nvmlSystemGetConfComputeKeyRotationThresholdInfo():
     c_keyRotationThrInfo = c_nvmlConfComputeGetKeyRotationThresholdInfo_t(0)
     c_keyRotationThrInfo.version = ConfComputeGetKeyRotationThresholdInfo_v1
@@ -5563,97 +6469,181 @@ def nvmlSystemGetConfComputeKeyRotationThresholdInfo():
     _nvmlCheckReturn(ret)
     return c_keyRotationThrInfo
 
+
 ## GPM ##
 #########
 
 ## Enums/defines
 
 #### GPM Metric Identifiers
-NVML_GPM_METRIC_GRAPHICS_UTIL               = 1 # Percentage of time any compute/graphics app was active on the GPU. 0.0 - 100.0
-NVML_GPM_METRIC_SM_UTIL                     = 2 # Percentage of SMs that were busy. 0.0 - 100.0
-NVML_GPM_METRIC_SM_OCCUPANCY                = 3 # Percentage of warps that were active vs theoretical maximum. 0.0 - 100.0
-NVML_GPM_METRIC_INTEGER_UTIL                = 4 # Percentage of time the GPU's SMs were doing integer operations. 0.0 - 100.0
-NVML_GPM_METRIC_ANY_TENSOR_UTIL             = 5 # Percentage of time the GPU's SMs were doing ANY tensor operations. 0.0 - 100.0
-NVML_GPM_METRIC_DFMA_TENSOR_UTIL            = 6 # Percentage of time the GPU's SMs were doing DFMA tensor operations. 0.0 - 100.0
-NVML_GPM_METRIC_HMMA_TENSOR_UTIL            = 7 # Percentage of time the GPU's SMs were doing HMMA tensor operations. 0.0 - 100.0
-NVML_GPM_METRIC_IMMA_TENSOR_UTIL            = 9 # Percentage of time the GPU's SMs were doing IMMA tensor operations. 0.0 - 100.0
-NVML_GPM_METRIC_DRAM_BW_UTIL                = 10 # Percentage of DRAM bw used vs theoretical maximum. 0.0 - 100.0
-NVML_GPM_METRIC_FP64_UTIL                   = 11 # Percentage of time the GPU's SMs were doing non-tensor FP64 math. 0.0 - 100.0
-NVML_GPM_METRIC_FP32_UTIL                   = 12 # Percentage of time the GPU's SMs were doing non-tensor FP32 math. 0.0 - 100.0
-NVML_GPM_METRIC_FP16_UTIL                   = 13 # Percentage of time the GPU's SMs were doing non-tensor FP16 math. 0.0 - 100.0
-NVML_GPM_METRIC_PCIE_TX_PER_SEC             = 20 # PCIe traffic from this GPU in MiB/sec
-NVML_GPM_METRIC_PCIE_RX_PER_SEC             = 21 # PCIe traffic to this GPU in MiB/sec
-NVML_GPM_METRIC_NVDEC_0_UTIL                = 30 # Percent utilization of NVDEC 0. 0.0 - 100.0
-NVML_GPM_METRIC_NVDEC_1_UTIL                = 31 # Percent utilization of NVDEC 1. 0.0 - 100.0
-NVML_GPM_METRIC_NVDEC_2_UTIL                = 32 # Percent utilization of NVDEC 2. 0.0 - 100.0
-NVML_GPM_METRIC_NVDEC_3_UTIL                = 33 # Percent utilization of NVDEC 3. 0.0 - 100.0
-NVML_GPM_METRIC_NVDEC_4_UTIL                = 34 # Percent utilization of NVDEC 4. 0.0 - 100.0
-NVML_GPM_METRIC_NVDEC_5_UTIL                = 35 # Percent utilization of NVDEC 5. 0.0 - 100.0
-NVML_GPM_METRIC_NVDEC_6_UTIL                = 36 # Percent utilization of NVDEC 6. 0.0 - 100.0
-NVML_GPM_METRIC_NVDEC_7_UTIL                = 37 # Percent utilization of NVDEC 7. 0.0 - 100.0
-NVML_GPM_METRIC_NVJPG_0_UTIL                = 40 # Percent utilization of NVJPG 0. 0.0 - 100.0
-NVML_GPM_METRIC_NVJPG_1_UTIL                = 41 # Percent utilization of NVJPG 1. 0.0 - 100.0
-NVML_GPM_METRIC_NVJPG_2_UTIL                = 42 # Percent utilization of NVJPG 2. 0.0 - 100.0
-NVML_GPM_METRIC_NVJPG_3_UTIL                = 43 # Percent utilization of NVJPG 3. 0.0 - 100.0
-NVML_GPM_METRIC_NVJPG_4_UTIL                = 44 # Percent utilization of NVJPG 4. 0.0 - 100.0
-NVML_GPM_METRIC_NVJPG_5_UTIL                = 45 # Percent utilization of NVJPG 5. 0.0 - 100.0
-NVML_GPM_METRIC_NVJPG_6_UTIL                = 46 # Percent utilization of NVJPG 6. 0.0 - 100.0
-NVML_GPM_METRIC_NVJPG_7_UTIL                = 47 # Percent utilization of NVJPG 7. 0.0 - 100.0
-NVML_GPM_METRIC_NVOFA_0_UTIL                = 50 # Percent utilization of NVOFA 0. 0.0 - 100.0
-NVML_GPM_METRIC_NVOFA_1_UTIL                = 51 # Percent utilization of NVOFA 1. 0.0 - 100.0
-NVML_GPM_METRIC_NVLINK_TOTAL_RX_PER_SEC     = 60 # NvLink read bandwidth for all links in MiB/sec
-NVML_GPM_METRIC_NVLINK_TOTAL_TX_PER_SEC     = 61 # NvLink write bandwidth for all links in MiB/sec
-NVML_GPM_METRIC_NVLINK_L0_RX_PER_SEC        = 62 # NvLink read bandwidth for link 0 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L0_TX_PER_SEC        = 63 # NvLink write bandwidth for link 0 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L1_RX_PER_SEC        = 64 # NvLink read bandwidth for link 1 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L1_TX_PER_SEC        = 65 # NvLink write bandwidth for link 1 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L2_RX_PER_SEC        = 66 # NvLink read bandwidth for link 2 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L2_TX_PER_SEC        = 67 # NvLink write bandwidth for link 2 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L3_RX_PER_SEC        = 68 # NvLink read bandwidth for link 3 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L3_TX_PER_SEC        = 69 # NvLink write bandwidth for link 3 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L4_RX_PER_SEC        = 70 # NvLink read bandwidth for link 4 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L4_TX_PER_SEC        = 71 # NvLink write bandwidth for link 4 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L5_RX_PER_SEC        = 72 # NvLink read bandwidth for link 5 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L5_TX_PER_SEC        = 73 # NvLink write bandwidth for link 5 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L6_RX_PER_SEC        = 74 # NvLink read bandwidth for link 6 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L6_TX_PER_SEC        = 75 # NvLink write bandwidth for link 6 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L7_RX_PER_SEC        = 76 # NvLink read bandwidth for link 7 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L7_TX_PER_SEC        = 77 # NvLink write bandwidth for link 7 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L8_RX_PER_SEC        = 78 # NvLink read bandwidth for link 8 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L8_TX_PER_SEC        = 79 # NvLink write bandwidth for link 8 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L9_RX_PER_SEC        = 80 # NvLink read bandwidth for link 9 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L9_TX_PER_SEC        = 81 # NvLink write bandwidth for link 9 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L10_RX_PER_SEC       = 82 # NvLink read bandwidth for link 10 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L10_TX_PER_SEC       = 83 # NvLink write bandwidth for link 10 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L11_RX_PER_SEC       = 84 # NvLink read bandwidth for link 11 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L11_TX_PER_SEC       = 85 # NvLink write bandwidth for link 11 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L12_RX_PER_SEC       = 86 # NvLink read bandwidth for link 12 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L12_TX_PER_SEC       = 87 # NvLink write bandwidth for link 12 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L13_RX_PER_SEC       = 88 # NvLink read bandwidth for link 13 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L13_TX_PER_SEC       = 89 # NvLink write bandwidth for link 13 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L14_RX_PER_SEC       = 90 # NvLink read bandwidth for link 14 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L14_TX_PER_SEC       = 91 # NvLink write bandwidth for link 14 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L15_RX_PER_SEC       = 92 # NvLink read bandwidth for link 15 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L15_TX_PER_SEC       = 93 # NvLink write bandwidth for link 15 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L16_RX_PER_SEC       = 94 # NvLink read bandwidth for link 16 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L16_TX_PER_SEC       = 95 # NvLink write bandwidth for link 16 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L17_RX_PER_SEC       = 96 # NvLink read bandwidth for link 17 in MiB/sec
-NVML_GPM_METRIC_NVLINK_L17_TX_PER_SEC       = 97 # NvLink write bandwidth for link 17 in MiB/sec
-NVML_GPM_METRIC_MAX                         = 98
+NVML_GPM_METRIC_GRAPHICS_UTIL = (
+    1  # Percentage of time any compute/graphics app was active on the GPU. 0.0 - 100.0
+)
+NVML_GPM_METRIC_SM_UTIL = 2  # Percentage of SMs that were busy. 0.0 - 100.0
+NVML_GPM_METRIC_SM_OCCUPANCY = (
+    3  # Percentage of warps that were active vs theoretical maximum. 0.0 - 100.0
+)
+NVML_GPM_METRIC_INTEGER_UTIL = (
+    4  # Percentage of time the GPU's SMs were doing integer operations. 0.0 - 100.0
+)
+NVML_GPM_METRIC_ANY_TENSOR_UTIL = (
+    5  # Percentage of time the GPU's SMs were doing ANY tensor operations. 0.0 - 100.0
+)
+NVML_GPM_METRIC_DFMA_TENSOR_UTIL = (
+    6  # Percentage of time the GPU's SMs were doing DFMA tensor operations. 0.0 - 100.0
+)
+NVML_GPM_METRIC_HMMA_TENSOR_UTIL = (
+    7  # Percentage of time the GPU's SMs were doing HMMA tensor operations. 0.0 - 100.0
+)
+NVML_GPM_METRIC_IMMA_TENSOR_UTIL = (
+    9  # Percentage of time the GPU's SMs were doing IMMA tensor operations. 0.0 - 100.0
+)
+NVML_GPM_METRIC_DRAM_BW_UTIL = (
+    10  # Percentage of DRAM bw used vs theoretical maximum. 0.0 - 100.0
+)
+NVML_GPM_METRIC_FP64_UTIL = (
+    11  # Percentage of time the GPU's SMs were doing non-tensor FP64 math. 0.0 - 100.0
+)
+NVML_GPM_METRIC_FP32_UTIL = (
+    12  # Percentage of time the GPU's SMs were doing non-tensor FP32 math. 0.0 - 100.0
+)
+NVML_GPM_METRIC_FP16_UTIL = (
+    13  # Percentage of time the GPU's SMs were doing non-tensor FP16 math. 0.0 - 100.0
+)
+NVML_GPM_METRIC_PCIE_TX_PER_SEC = 20  # PCIe traffic from this GPU in MiB/sec
+NVML_GPM_METRIC_PCIE_RX_PER_SEC = 21  # PCIe traffic to this GPU in MiB/sec
+NVML_GPM_METRIC_NVDEC_0_UTIL = 30  # Percent utilization of NVDEC 0. 0.0 - 100.0
+NVML_GPM_METRIC_NVDEC_1_UTIL = 31  # Percent utilization of NVDEC 1. 0.0 - 100.0
+NVML_GPM_METRIC_NVDEC_2_UTIL = 32  # Percent utilization of NVDEC 2. 0.0 - 100.0
+NVML_GPM_METRIC_NVDEC_3_UTIL = 33  # Percent utilization of NVDEC 3. 0.0 - 100.0
+NVML_GPM_METRIC_NVDEC_4_UTIL = 34  # Percent utilization of NVDEC 4. 0.0 - 100.0
+NVML_GPM_METRIC_NVDEC_5_UTIL = 35  # Percent utilization of NVDEC 5. 0.0 - 100.0
+NVML_GPM_METRIC_NVDEC_6_UTIL = 36  # Percent utilization of NVDEC 6. 0.0 - 100.0
+NVML_GPM_METRIC_NVDEC_7_UTIL = 37  # Percent utilization of NVDEC 7. 0.0 - 100.0
+NVML_GPM_METRIC_NVJPG_0_UTIL = 40  # Percent utilization of NVJPG 0. 0.0 - 100.0
+NVML_GPM_METRIC_NVJPG_1_UTIL = 41  # Percent utilization of NVJPG 1. 0.0 - 100.0
+NVML_GPM_METRIC_NVJPG_2_UTIL = 42  # Percent utilization of NVJPG 2. 0.0 - 100.0
+NVML_GPM_METRIC_NVJPG_3_UTIL = 43  # Percent utilization of NVJPG 3. 0.0 - 100.0
+NVML_GPM_METRIC_NVJPG_4_UTIL = 44  # Percent utilization of NVJPG 4. 0.0 - 100.0
+NVML_GPM_METRIC_NVJPG_5_UTIL = 45  # Percent utilization of NVJPG 5. 0.0 - 100.0
+NVML_GPM_METRIC_NVJPG_6_UTIL = 46  # Percent utilization of NVJPG 6. 0.0 - 100.0
+NVML_GPM_METRIC_NVJPG_7_UTIL = 47  # Percent utilization of NVJPG 7. 0.0 - 100.0
+NVML_GPM_METRIC_NVOFA_0_UTIL = 50  # Percent utilization of NVOFA 0. 0.0 - 100.0
+NVML_GPM_METRIC_NVOFA_1_UTIL = 51  # Percent utilization of NVOFA 1. 0.0 - 100.0
+NVML_GPM_METRIC_NVLINK_TOTAL_RX_PER_SEC = (
+    60  # NvLink read bandwidth for all links in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_TOTAL_TX_PER_SEC = (
+    61  # NvLink write bandwidth for all links in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L0_RX_PER_SEC = 62  # NvLink read bandwidth for link 0 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L0_TX_PER_SEC = (
+    63  # NvLink write bandwidth for link 0 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L1_RX_PER_SEC = 64  # NvLink read bandwidth for link 1 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L1_TX_PER_SEC = (
+    65  # NvLink write bandwidth for link 1 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L2_RX_PER_SEC = 66  # NvLink read bandwidth for link 2 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L2_TX_PER_SEC = (
+    67  # NvLink write bandwidth for link 2 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L3_RX_PER_SEC = 68  # NvLink read bandwidth for link 3 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L3_TX_PER_SEC = (
+    69  # NvLink write bandwidth for link 3 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L4_RX_PER_SEC = 70  # NvLink read bandwidth for link 4 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L4_TX_PER_SEC = (
+    71  # NvLink write bandwidth for link 4 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L5_RX_PER_SEC = 72  # NvLink read bandwidth for link 5 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L5_TX_PER_SEC = (
+    73  # NvLink write bandwidth for link 5 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L6_RX_PER_SEC = 74  # NvLink read bandwidth for link 6 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L6_TX_PER_SEC = (
+    75  # NvLink write bandwidth for link 6 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L7_RX_PER_SEC = 76  # NvLink read bandwidth for link 7 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L7_TX_PER_SEC = (
+    77  # NvLink write bandwidth for link 7 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L8_RX_PER_SEC = 78  # NvLink read bandwidth for link 8 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L8_TX_PER_SEC = (
+    79  # NvLink write bandwidth for link 8 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L9_RX_PER_SEC = 80  # NvLink read bandwidth for link 9 in MiB/sec
+NVML_GPM_METRIC_NVLINK_L9_TX_PER_SEC = (
+    81  # NvLink write bandwidth for link 9 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L10_RX_PER_SEC = (
+    82  # NvLink read bandwidth for link 10 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L10_TX_PER_SEC = (
+    83  # NvLink write bandwidth for link 10 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L11_RX_PER_SEC = (
+    84  # NvLink read bandwidth for link 11 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L11_TX_PER_SEC = (
+    85  # NvLink write bandwidth for link 11 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L12_RX_PER_SEC = (
+    86  # NvLink read bandwidth for link 12 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L12_TX_PER_SEC = (
+    87  # NvLink write bandwidth for link 12 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L13_RX_PER_SEC = (
+    88  # NvLink read bandwidth for link 13 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L13_TX_PER_SEC = (
+    89  # NvLink write bandwidth for link 13 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L14_RX_PER_SEC = (
+    90  # NvLink read bandwidth for link 14 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L14_TX_PER_SEC = (
+    91  # NvLink write bandwidth for link 14 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L15_RX_PER_SEC = (
+    92  # NvLink read bandwidth for link 15 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L15_TX_PER_SEC = (
+    93  # NvLink write bandwidth for link 15 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L16_RX_PER_SEC = (
+    94  # NvLink read bandwidth for link 16 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L16_TX_PER_SEC = (
+    95  # NvLink write bandwidth for link 16 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L17_RX_PER_SEC = (
+    96  # NvLink read bandwidth for link 17 in MiB/sec
+)
+NVML_GPM_METRIC_NVLINK_L17_TX_PER_SEC = (
+    97  # NvLink write bandwidth for link 17 in MiB/sec
+)
+NVML_GPM_METRIC_MAX = 98
 
 ## Structs
 
+
 class c_nvmlUnitInfo_t(_PrintableStructure):
     _fields_ = [
-        ('name', c_char * 96),
-        ('id', c_char * 96),
-        ('serial', c_char * 96),
-        ('firmwareVersion', c_char * 96),
+        ("name", c_char * 96),
+        ("id", c_char * 96),
+        ("serial", c_char * 96),
+        ("firmwareVersion", c_char * 96),
     ]
 
+
 class struct_c_nvmlGpmSample_t(Structure):
-    pass # opaque handle
+    pass  # opaque handle
+
+
 c_nvmlGpmSample_t = POINTER(struct_c_nvmlGpmSample_t)
+
 
 class c_metricInfo_t(Structure):
     _fields_ = [
@@ -5662,34 +6652,40 @@ class c_metricInfo_t(Structure):
         ("unit", c_char_p),
     ]
 
+
 class c_nvmlGpmMetric_t(_PrintableStructure):
     _fields_ = [
-        ('metricId', c_uint),
-        ('nvmlReturn', _nvmlReturn_t),
-        ('value', c_double),
-        ('metricInfo', c_metricInfo_t)
+        ("metricId", c_uint),
+        ("nvmlReturn", _nvmlReturn_t),
+        ("value", c_double),
+        ("metricInfo", c_metricInfo_t),
     ]
+
 
 class c_nvmlGpmMetricsGet_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('numMetrics', c_uint),
-        ('sample1', c_nvmlGpmSample_t),
-        ('sample2', c_nvmlGpmSample_t),
-        ('metrics', c_nvmlGpmMetric_t * NVML_GPM_METRIC_MAX)
+        ("version", c_uint),
+        ("numMetrics", c_uint),
+        ("sample1", c_nvmlGpmSample_t),
+        ("sample2", c_nvmlGpmSample_t),
+        ("metrics", c_nvmlGpmMetric_t * NVML_GPM_METRIC_MAX),
     ]
+
 
 NVML_GPM_METRICS_GET_VERSION = 1
 
+
 class c_nvmlGpmSupport_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('isSupportedDevice', c_uint),
+        ("version", c_uint),
+        ("isSupportedDevice", c_uint),
     ]
+
 
 NVML_GPM_SUPPORT_VERSION = 1
 
 ## Functions
+
 
 def nvmlGpmMetricsGet(metricsGet):
     fn = _nvmlGetFunctionPointer("nvmlGpmMetricsGet")
@@ -5697,11 +6693,13 @@ def nvmlGpmMetricsGet(metricsGet):
     _nvmlCheckReturn(ret)
     return metricsGet
 
+
 def nvmlGpmSampleFree(gpmSample):
     fn = _nvmlGetFunctionPointer("nvmlGpmSampleFree")
     ret = fn(gpmSample)
     _nvmlCheckReturn(ret)
     return
+
 
 def nvmlGpmSampleAlloc():
     gpmSample = c_nvmlGpmSample_t()
@@ -5710,17 +6708,20 @@ def nvmlGpmSampleAlloc():
     _nvmlCheckReturn(ret)
     return gpmSample
 
+
 def nvmlGpmSampleGet(device, gpmSample):
     fn = _nvmlGetFunctionPointer("nvmlGpmSampleGet")
     ret = fn(device, gpmSample)
     _nvmlCheckReturn(ret)
     return gpmSample
 
+
 def nvmlGpmMigSampleGet(device, gpuInstanceId, gpmSample):
     fn = _nvmlGetFunctionPointer("nvmlGpmMigSampleGet")
     ret = fn(device, gpuInstanceId, gpmSample)
     _nvmlCheckReturn(ret)
     return gpmSample
+
 
 def nvmlGpmQueryDeviceSupport(device):
     gpmSupport = c_nvmlGpmSupport_t()
@@ -5730,12 +6731,14 @@ def nvmlGpmQueryDeviceSupport(device):
     _nvmlCheckReturn(ret)
     return gpmSupport
 
+
 def nvmlGpmSetStreamingEnabled(device, state):
     c_state = c_uint(state)
     fn = _nvmlGetFunctionPointer("nvmlGpmSetStreamingEnabled")
     ret = fn(device, c_state)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlGpmQueryIfStreamingEnabled(device):
     c_state = c_uint()
@@ -5744,20 +6747,23 @@ def nvmlGpmQueryIfStreamingEnabled(device):
     _nvmlCheckReturn(ret)
     return c_state.value
 
+
 # Low Power Structure and Function
 
-NVML_NVLINK_POWER_STATE_HIGH_SPEED    = 0x0
-NVML_NVLINK_POWER_STATE_LOW           = 0x1
+NVML_NVLINK_POWER_STATE_HIGH_SPEED = 0x0
+NVML_NVLINK_POWER_STATE_LOW = 0x1
 
-NVML_NVLINK_LOW_POWER_THRESHOLD_MIN     = 0x1
-NVML_NVLINK_LOW_POWER_THRESHOLD_MAX     = 0x1FFF
-NVML_NVLINK_LOW_POWER_THRESHOLD_RESET   = 0xFFFFFFFF
+NVML_NVLINK_LOW_POWER_THRESHOLD_MIN = 0x1
+NVML_NVLINK_LOW_POWER_THRESHOLD_MAX = 0x1FFF
+NVML_NVLINK_LOW_POWER_THRESHOLD_RESET = 0xFFFFFFFF
 NVML_NVLINK_LOW_POWER_THRESHOLD_DEFAULT = NVML_NVLINK_LOW_POWER_THRESHOLD_RESET
+
 
 class c_nvmlNvLinkPowerThres_t(Structure):
     _fields_ = [
         ("lowPwrThreshold", c_uint),
     ]
+
 
 def nvmlDeviceSetNvLinkDeviceLowPowerThreshold(device, l1threshold):
     c_info = c_nvmlNvLinkPowerThres_t()
@@ -5767,47 +6773,51 @@ def nvmlDeviceSetNvLinkDeviceLowPowerThreshold(device, l1threshold):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 NVML_GPU_FABRIC_UUID_LEN = 16
 
 _nvmlGpuFabricState_t = c_uint
 NVML_GPU_FABRIC_STATE_NOT_SUPPORTED = 0
-NVML_GPU_FABRIC_STATE_NOT_STARTED   = 1
-NVML_GPU_FABRIC_STATE_IN_PROGRESS   = 2
-NVML_GPU_FABRIC_STATE_COMPLETED     = 3
+NVML_GPU_FABRIC_STATE_NOT_STARTED = 1
+NVML_GPU_FABRIC_STATE_IN_PROGRESS = 2
+NVML_GPU_FABRIC_STATE_COMPLETED = 3
+
 
 class c_nvmlGpuFabricInfo_t(_PrintableStructure):
     _fields_ = [
         ("clusterUuid", c_char * NVML_DEVICE_UUID_BUFFER_SIZE),
         ("status", _nvmlReturn_t),
         ("cliqueId", c_uint32),
-        ("state", _nvmlGpuFabricState_t)
+        ("state", _nvmlGpuFabricState_t),
     ]
 
+
 NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_NOT_SUPPORTED = 0
-NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_TRUE          = 1
-NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_FALSE         = 2
-NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_DEGRADED_BW         = 0
-NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_DEGRADED_BW         = 0x11
+NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_TRUE = 1
+NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_FALSE = 2
+NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_DEGRADED_BW = 0
+NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_DEGRADED_BW = 0x11
 
-NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_RECOVERY_NOT_SUPPORTED   = 0
-NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_RECOVERY_TRUE            = 1
-NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_RECOVERY_FALSE           = 2
-NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_ROUTE_RECOVERY           = 2
-NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_ROUTE_RECOVERY           = 0x11
+NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_RECOVERY_NOT_SUPPORTED = 0
+NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_RECOVERY_TRUE = 1
+NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_RECOVERY_FALSE = 2
+NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_ROUTE_RECOVERY = 2
+NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_ROUTE_RECOVERY = 0x11
 
-NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_UNHEALTHY_NOT_SUPPORTED  = 0
-NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_UNHEALTHY_TRUE           = 1
-NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_UNHEALTHY_FALSE          = 2
-NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_ROUTE_UNHEALTHY          = 4
-NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_ROUTE_UNHEALTHY          = 0x11
+NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_UNHEALTHY_NOT_SUPPORTED = 0
+NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_UNHEALTHY_TRUE = 1
+NVML_GPU_FABRIC_HEALTH_MASK_ROUTE_UNHEALTHY_FALSE = 2
+NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_ROUTE_UNHEALTHY = 4
+NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_ROUTE_UNHEALTHY = 0x11
 
 NVML_GPU_FABRIC_HEALTH_MASK_ACCESS_TIMEOUT_RECOVERY_NOT_SUPPORTED = 0
-NVML_GPU_FABRIC_HEALTH_MASK_ACCESS_TIMEOUT_RECOVERY_TRUE          = 1
-NVML_GPU_FABRIC_HEALTH_MASK_ACCESS_TIMEOUT_RECOVERY_FALSE         = 2
-NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_ACCESS_TIMEOUT_RECOVERY         = 6
-NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_ACCESS_TIMEOUT_RECOVERY         = 0x11
+NVML_GPU_FABRIC_HEALTH_MASK_ACCESS_TIMEOUT_RECOVERY_TRUE = 1
+NVML_GPU_FABRIC_HEALTH_MASK_ACCESS_TIMEOUT_RECOVERY_FALSE = 2
+NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_ACCESS_TIMEOUT_RECOVERY = 6
+NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_ACCESS_TIMEOUT_RECOVERY = 0x11
 
 nvmlGpuFabricInfo_v2 = 0x02000024
+
 
 class c_nvmlGpuFabricInfoV_t(_PrintableStructure):
     _fields_ = [
@@ -5816,39 +6826,44 @@ class c_nvmlGpuFabricInfoV_t(_PrintableStructure):
         ("status", _nvmlReturn_t),
         ("cliqueId", c_uint32),
         ("state", _nvmlGpuFabricState_t),
-        ("healthMask", c_uint32)
+        ("healthMask", c_uint32),
     ]
 
     def __init__(self):
         super(c_nvmlGpuFabricInfoV_t, self).__init__(version=nvmlGpuFabricInfo_v2)
 
+
 def nvmlDeviceGetGpuFabricInfo(device, gpuFabricInfo):
-    fn = _nvmlGetFunctionPointer("nvmlDeviceGetGpuFabricInfo");
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetGpuFabricInfo")
     ret = fn(device, gpuFabricInfo)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 def nvmlDeviceGetGpuFabricInfoV(device, gpuFabricInfo):
-    fn = _nvmlGetFunctionPointer("nvmlDeviceGetGpuFabricInfoV");
+    fn = _nvmlGetFunctionPointer("nvmlDeviceGetGpuFabricInfoV")
     ret = fn(device, gpuFabricInfo)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 ######################
 ## Enums/defines
 #### NVML GPU NVLINK BW MODE
-NVML_GPU_NVLINK_BW_MODE_FULL      = 0x0
-NVML_GPU_NVLINK_BW_MODE_OFF       = 0x1
-NVML_GPU_NVLINK_BW_MODE_MIN       = 0x2
-NVML_GPU_NVLINK_BW_MODE_HALF      = 0x3
-NVML_GPU_NVLINK_BW_MODE_3QUARTER  = 0x4
-NVML_GPU_NVLINK_BW_MODE_COUNT     = 0x5
+NVML_GPU_NVLINK_BW_MODE_FULL = 0x0
+NVML_GPU_NVLINK_BW_MODE_OFF = 0x1
+NVML_GPU_NVLINK_BW_MODE_MIN = 0x2
+NVML_GPU_NVLINK_BW_MODE_HALF = 0x3
+NVML_GPU_NVLINK_BW_MODE_3QUARTER = 0x4
+NVML_GPU_NVLINK_BW_MODE_COUNT = 0x5
+
 
 def nvmlSystemSetNvlinkBwMode(mode):
     fn = _nvmlGetFunctionPointer("nvmlSystemSetNvlinkBwMode")
     ret = fn(mode)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlSystemGetNvlinkBwMode():
     mode = c_uint()
@@ -5857,22 +6872,28 @@ def nvmlSystemGetNvlinkBwMode():
     _nvmlCheckReturn(ret)
     return mode.value
 
+
 _nvmlPowerScopeType_t = c_uint
-NVML_POWER_SCOPE_GPU     = 0
-NVML_POWER_SCOPE_MODULE  = 1
-NVML_POWER_SCOPE_MEMORY  = 2
+NVML_POWER_SCOPE_GPU = 0
+NVML_POWER_SCOPE_MODULE = 1
+NVML_POWER_SCOPE_MEMORY = 2
+
 
 class c_nvmlPowerValue_v2_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('powerScope', _nvmlPowerScopeType_t),
-        ('powerValueMw', c_uint),
+        ("version", c_uint),
+        ("powerScope", _nvmlPowerScopeType_t),
+        ("powerValueMw", c_uint),
     ]
-    _fmt_ = {'<default>': "%d B"}
+    _fmt_ = {"<default>": "%d B"}
+
 
 nvmlPowerValue_v2 = 0x0200000C
 
-def nvmlDeviceSetPowerManagementLimit_v2(device, powerScope, powerLimit, version=nvmlPowerValue_v2):
+
+def nvmlDeviceSetPowerManagementLimit_v2(
+    device, powerScope, powerLimit, version=nvmlPowerValue_v2
+):
     c_powerScope = _nvmlPowerScopeType_t(powerScope)
     c_powerValue = c_nvmlPowerValue_v2_t()
     c_powerValue.version = c_uint(version)
@@ -5882,139 +6903,178 @@ def nvmlDeviceSetPowerManagementLimit_v2(device, powerScope, powerLimit, version
     ret = fn(device, byref(c_powerValue))
     return NVML_SUCCESS
 
+
 class c_nvmlEccSramErrorStatus_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('aggregateUncParity', c_ulonglong),
-        ('aggregateUncSecDed', c_ulonglong),
-        ('aggregateCor', c_ulonglong),
-        ('volatileUncParity', c_ulonglong),
-        ('volatileUncSecDed', c_ulonglong),
-        ('volatileCor', c_ulonglong),
-        ('aggregateUncBucketL2', c_ulonglong),
-        ('aggregateUncBucketSm', c_ulonglong),
-        ('aggregateUncBucketPcie', c_ulonglong),
-        ('aggregateUncBucketMcu', c_ulonglong),
-        ('aggregateUncBucketOther', c_ulonglong),
-        ('bThresholdExceeded', c_uint)
+        ("version", c_uint),
+        ("aggregateUncParity", c_ulonglong),
+        ("aggregateUncSecDed", c_ulonglong),
+        ("aggregateCor", c_ulonglong),
+        ("volatileUncParity", c_ulonglong),
+        ("volatileUncSecDed", c_ulonglong),
+        ("volatileCor", c_ulonglong),
+        ("aggregateUncBucketL2", c_ulonglong),
+        ("aggregateUncBucketSm", c_ulonglong),
+        ("aggregateUncBucketPcie", c_ulonglong),
+        ("aggregateUncBucketMcu", c_ulonglong),
+        ("aggregateUncBucketOther", c_ulonglong),
+        ("bThresholdExceeded", c_uint),
     ]
 
     def __init__(self):
-        super(c_nvmlEccSramErrorStatus_v1_t, self).__init__(version=nvmlEccSramErrorStatus_v1)
+        super(c_nvmlEccSramErrorStatus_v1_t, self).__init__(
+            version=nvmlEccSramErrorStatus_v1
+        )
+
 
 nvmlEccSramErrorStatus_v1 = 0x1000068
+
+
 def nvmlDeviceGetSramEccErrorStatus(device, status):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetSramEccErrorStatus")
     ret = fn(device, status)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
-NVML_DEV_CAP_EGM = (1 << 0)
+
+NVML_DEV_CAP_EGM = 1 << 0
 nvmlDeviceCapabilities_v1 = 0x1000008
+
 
 class c_nvmlDeviceCapabilities_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('capMask', c_uint),
+        ("version", c_uint),
+        ("capMask", c_uint),
     ]
 
     def __init__(self):
-        super(c_nvmlDeviceCapabilities_v1_t, self).__init__(version=nvmlDeviceCapabilities_v1)
+        super(c_nvmlDeviceCapabilities_v1_t, self).__init__(
+            version=nvmlDeviceCapabilities_v1
+        )
 
 
 def nvmlDeviceGetCapabilities(device, caps):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetCapabilities")
     return fn(device, caps)
 
+
 class c_nvmlPlatformInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('ibGuid', c_char * 16),
-        ('rackGuid', c_char * 16),
-        ('chassisPhysicalSlotNumber', c_char),
-        ('computeSlotIndex', c_char),
-        ('nodeIndex', c_char),
-        ('peerType', c_char),
-        ('moduleId', c_char)
+        ("version", c_uint),
+        ("ibGuid", c_char * 16),
+        ("rackGuid", c_char * 16),
+        ("chassisPhysicalSlotNumber", c_char),
+        ("computeSlotIndex", c_char),
+        ("nodeIndex", c_char),
+        ("peerType", c_char),
+        ("moduleId", c_char),
     ]
 
     def __init__(self):
         super(c_nvmlPlatformInfo_v1_t, self).__init__(version=nvmlPlatformInfo_v1)
 
-nvmlPlatformInfo_v1 = 0x100002c
+
+nvmlPlatformInfo_v1 = 0x100002C
+
+
 def nvmlDeviceGetPlatformInfo(device, platformInfo):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetPlatformInfo")
     ret = fn(device, platformInfo)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 class c_nvmlMask255_t(_PrintableStructure):
     _fields_ = [
-        ('mask', c_uint * 8),
+        ("mask", c_uint * 8),
     ]
 
-NVML_WORKLOAD_POWER_MAX_PROFILES    = 255
-NVML_POWER_PROFILE_MAX_P            = 0
-NVML_POWER_PROFILE_MAX_Q            = 1
-NVML_POWER_PROFILE_COMPUTE          = 2
-NVML_POWER_PROFILE_MEMORY_BOUND     = 3
-NVML_POWER_PROFILE_NETWORK          = 4
-NVML_POWER_PROFILE_BALANCED         = 5
-NVML_POWER_PROFILE_LLM_INFERENCE    = 6
-NVML_POWER_PROFILE_LLM_TRAINING     = 7
-NVML_POWER_PROFILE_RBM              = 8
-NVML_POWER_PROFILE_DCPCIE           = 9
-NVML_POWER_PROFILE_HMMA_SPARSE      = 10
-NVML_POWER_PROFILE_HMMA_DENSE       = 11
-NVML_POWER_PROFILE_SYNC_BALANCED    = 12
-NVML_POWER_PROFILE_HPC              = 13
-NVML_POWER_PROFILE_MIG              = 14
-NVML_POWER_PROFILE_MAX              = 15
 
-nvmlWorkloadPowerProfileInfo_v1 = 0x100002c
+NVML_WORKLOAD_POWER_MAX_PROFILES = 255
+NVML_POWER_PROFILE_MAX_P = 0
+NVML_POWER_PROFILE_MAX_Q = 1
+NVML_POWER_PROFILE_COMPUTE = 2
+NVML_POWER_PROFILE_MEMORY_BOUND = 3
+NVML_POWER_PROFILE_NETWORK = 4
+NVML_POWER_PROFILE_BALANCED = 5
+NVML_POWER_PROFILE_LLM_INFERENCE = 6
+NVML_POWER_PROFILE_LLM_TRAINING = 7
+NVML_POWER_PROFILE_RBM = 8
+NVML_POWER_PROFILE_DCPCIE = 9
+NVML_POWER_PROFILE_HMMA_SPARSE = 10
+NVML_POWER_PROFILE_HMMA_DENSE = 11
+NVML_POWER_PROFILE_SYNC_BALANCED = 12
+NVML_POWER_PROFILE_HPC = 13
+NVML_POWER_PROFILE_MIG = 14
+NVML_POWER_PROFILE_MAX = 15
+
+nvmlWorkloadPowerProfileInfo_v1 = 0x100002C
+
+
 class c_nvmlWorkloadPowerProfileInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('profileId', c_uint),
-        ('priority', c_uint),
-        ('conflictingmask', c_nvmlMask255_t)
+        ("version", c_uint),
+        ("profileId", c_uint),
+        ("priority", c_uint),
+        ("conflictingmask", c_nvmlMask255_t),
     ]
 
     def __init__(self):
-        super(c_nvmlWorkloadPowerProfileInfo_v1_t, self).__init__(version=nvmlWorkloadPowerProfileInfo_v1)
+        super(c_nvmlWorkloadPowerProfileInfo_v1_t, self).__init__(
+            version=nvmlWorkloadPowerProfileInfo_v1
+        )
 
-nvmlWorkloadPowerProfileProfilesInfo_v1 = 0x1002bf8
+
+nvmlWorkloadPowerProfileProfilesInfo_v1 = 0x1002BF8
+
+
 class c_nvmlWorkloadPowerProfileProfilesInfo_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('perfProfilesMask', c_nvmlMask255_t),
-        ('perfProfile', c_nvmlWorkloadPowerProfileInfo_v1_t * NVML_WORKLOAD_POWER_MAX_PROFILES)
+        ("version", c_uint),
+        ("perfProfilesMask", c_nvmlMask255_t),
+        (
+            "perfProfile",
+            c_nvmlWorkloadPowerProfileInfo_v1_t * NVML_WORKLOAD_POWER_MAX_PROFILES,
+        ),
     ]
 
     def __init__(self):
-        super(c_nvmlWorkloadPowerProfileProfilesInfo_v1_t, self).__init__(version=nvmlWorkloadPowerProfileProfilesInfo_v1)
+        super(c_nvmlWorkloadPowerProfileProfilesInfo_v1_t, self).__init__(
+            version=nvmlWorkloadPowerProfileProfilesInfo_v1
+        )
+
 
 nvmlWorkloadPowerProfileCurrentProfiles_v1 = 0x1000064
+
+
 class c_nvmlWorkloadPowerProfileCurrentProfiles_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('perfProfilesMask', c_nvmlMask255_t),
-        ('requestedProfilesMask', c_nvmlMask255_t),
-        ('enforcedProfilesMask', c_nvmlMask255_t)
+        ("version", c_uint),
+        ("perfProfilesMask", c_nvmlMask255_t),
+        ("requestedProfilesMask", c_nvmlMask255_t),
+        ("enforcedProfilesMask", c_nvmlMask255_t),
     ]
 
     def __init__(self):
-        super(c_nvmlWorkloadPowerProfileCurrentProfiles_v1_t, self).__init__(version=nvmlWorkloadPowerProfileCurrentProfiles_v1)
+        super(c_nvmlWorkloadPowerProfileCurrentProfiles_v1_t, self).__init__(
+            version=nvmlWorkloadPowerProfileCurrentProfiles_v1
+        )
+
 
 nvmlWorkloadPowerProfileRequestedProfiles_v1 = 0x1000024
+
+
 class c_nvmlWorkloadPowerProfileRequestedProfiles_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('requestedProfilesMask', c_nvmlMask255_t),
+        ("version", c_uint),
+        ("requestedProfilesMask", c_nvmlMask255_t),
     ]
 
     def __init__(self):
-        super(c_nvmlWorkloadPowerProfileRequestedProfiles_v1_t, self).__init__(version=nvmlWorkloadPowerProfileRequestedProfiles_v1)
+        super(c_nvmlWorkloadPowerProfileRequestedProfiles_v1_t, self).__init__(
+            version=nvmlWorkloadPowerProfileRequestedProfiles_v1
+        )
+
 
 def nvmlDeviceWorkloadPowerProfileGetProfilesInfo(device, profilesInfo):
     fn = _nvmlGetFunctionPointer("nvmlDeviceWorkloadPowerProfileGetProfilesInfo")
@@ -6022,11 +7082,13 @@ def nvmlDeviceWorkloadPowerProfileGetProfilesInfo(device, profilesInfo):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 def nvmlDeviceWorkloadPowerProfileGetCurrentProfiles(device, currentProfiles):
     fn = _nvmlGetFunctionPointer("nvmlDeviceWorkloadPowerProfileGetCurrentProfiles")
     ret = fn(device, currentProfiles)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlDeviceWorkloadPowerProfileSetRequestedProfiles(device, requestedProfiles):
     fn = _nvmlGetFunctionPointer("nvmlDeviceWorkloadPowerProfileSetRequestedProfiles")
@@ -6034,11 +7096,13 @@ def nvmlDeviceWorkloadPowerProfileSetRequestedProfiles(device, requestedProfiles
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 def nvmlDeviceWorkloadPowerProfileClearRequestedProfiles(device, requestedProfiles):
     fn = _nvmlGetFunctionPointer("nvmlDeviceWorkloadPowerProfileClearRequestedProfiles")
     ret = fn(device, requestedProfiles)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlDeviceGetNvlinkSupportedBwModes(device, supportedBwModes):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetNvlinkSupportedBwModes")
@@ -6046,11 +7110,13 @@ def nvmlDeviceGetNvlinkSupportedBwModes(device, supportedBwModes):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 def nvmlDeviceGetNvlinkBwMode(device, getBwMode):
     fn = _nvmlGetFunctionPointer("nvmlDeviceGetNvlinkBwMode")
     ret = fn(device, getBwMode)
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
+
 
 def nvmlDeviceSetNvlinkBwMode(device, setBwMode):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetNvlinkBwMode")
@@ -6058,16 +7124,21 @@ def nvmlDeviceSetNvlinkBwMode(device, setBwMode):
     _nvmlCheckReturn(ret)
     return NVML_SUCCESS
 
+
 nvmlDramEncryptionInfo_v1 = 0x01000008
+
 
 class c_nvmlDramEncryptionInfo_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('encryptionState',  _nvmlEnableState_t),
+        ("version", c_uint),
+        ("encryptionState", _nvmlEnableState_t),
     ]
 
     def __init__(self):
-        super(c_nvmlDramEncryptionInfo_t, self).__init__(version=nvmlDramEncryptionInfo_v1)
+        super(c_nvmlDramEncryptionInfo_t, self).__init__(
+            version=nvmlDramEncryptionInfo_v1
+        )
+
 
 def nvmlDeviceGetDramEncryptionMode(handle):
     c_currState = c_nvmlDramEncryptionInfo_t()
@@ -6077,64 +7148,79 @@ def nvmlDeviceGetDramEncryptionMode(handle):
     _nvmlCheckReturn(ret)
     return [c_currState.encryptionState, c_pendingState.encryptionState]
 
+
 # added to API
 def nvmlDeviceGetCurrentDramEncryptionMode(handle):
     return nvmlDeviceGetDramEncryptionMode(handle)[0]
+
 
 # added to API
 def nvmlDeviceGetPendingDramEncryptionMode(handle):
     return nvmlDeviceGetDramEncryptionMode(handle)[1]
 
+
 def nvmlDeviceSetDramEncryptionMode(handle, mode):
     fn = _nvmlGetFunctionPointer("nvmlDeviceSetDramEncryptionMode")
     c_dramEncryptionMode = c_nvmlDramEncryptionInfo_t()
-    c_dramEncryptionMode.encryptionState = mode;
+    c_dramEncryptionMode.encryptionState = mode
     ret = fn(handle, byref(c_dramEncryptionMode))
     _nvmlCheckReturn(ret)
     return None
 
+
 # Power Smoothing defines
-NVML_POWER_SMOOTHING_MAX_NUM_PROFILES                   = 5
-NVML_POWER_SMOOTHING_ADMIN_OVERRIDE_NOT_SET             = 0xFFFFFFFF
-NVML_POWER_SMOOTHING_PROFILE_PARAM_PERCENT_TMP_FLOOR    = 0
-NVML_POWER_SMOOTHING_PROFILE_PARAM_RAMP_UP_RATE         = 1
-NVML_POWER_SMOOTHING_PROFILE_PARAM_RAMP_DOWN_RATE       = 2
+NVML_POWER_SMOOTHING_MAX_NUM_PROFILES = 5
+NVML_POWER_SMOOTHING_ADMIN_OVERRIDE_NOT_SET = 0xFFFFFFFF
+NVML_POWER_SMOOTHING_PROFILE_PARAM_PERCENT_TMP_FLOOR = 0
+NVML_POWER_SMOOTHING_PROFILE_PARAM_RAMP_UP_RATE = 1
+NVML_POWER_SMOOTHING_PROFILE_PARAM_RAMP_DOWN_RATE = 2
 NVML_POWER_SMOOTHING_PROFILE_PARAM_RAMP_DOWN_HYSTERESIS = 3
 
-nvmlPowerSmoothingState_v1=0x1000008
+nvmlPowerSmoothingState_v1 = 0x1000008
+
+
 class c_nvmlPowerSmoothingState_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('state', c_uint),
+        ("version", c_uint),
+        ("state", c_uint),
     ]
 
     def __init__(self):
-        super(c_nvmlPowerSmoothingState_v1_t, self).__init__(version=nvmlPowerSmoothingState_v1)
+        super(c_nvmlPowerSmoothingState_v1_t, self).__init__(
+            version=nvmlPowerSmoothingState_v1
+        )
 
-nvmlPowerSmoothingProfile_v1=0x1000018
+
+nvmlPowerSmoothingProfile_v1 = 0x1000018
+
+
 class c_nvmlPowerSmoothingProfile_v1_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('profileId', c_uint),
-        ('paramId', c_uint),
-        ('value', c_double),
+        ("version", c_uint),
+        ("profileId", c_uint),
+        ("paramId", c_uint),
+        ("value", c_double),
     ]
 
     def __init__(self):
-        super(c_nvmlPowerSmoothingProfile_v1_t, self).__init__(version=nvmlPowerSmoothingProfile_v1)
+        super(c_nvmlPowerSmoothingProfile_v1_t, self).__init__(
+            version=nvmlPowerSmoothingProfile_v1
+        )
+
 
 def nvmlDevicePowerSmoothingActivatePresetProfile(device, profile):
     fn = _nvmlGetFunctionPointer("nvmlDevicePowerSmoothingActivatePresetProfile")
     ret = fn(device, profile)
     _nvmlCheckReturn(ret)
 
+
 def nvmlDevicePowerSmoothingUpdatePresetProfileParam(device, profile):
     fn = _nvmlGetFunctionPointer("nvmlDevicePowerSmoothingUpdatePresetProfileParam")
     ret = fn(device, profile)
     _nvmlCheckReturn(ret)
 
+
 def nvmlDevicePowerSmoothingSetState(device, state):
     fn = _nvmlGetFunctionPointer("nvmlDevicePowerSmoothingSetState")
     ret = fn(device, state)
     _nvmlCheckReturn(ret)
-

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import logging
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -242,6 +243,10 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        self.mamba_fragmentation_count = 0
+        self.mamba_zero_collapse_count = 0
+        # Number of schedule() iterations executed.
+        self._scheduler_iteration = 0
         self.perf_metrics: ModelMetrics | None = None
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
             self.perf_metrics = ModelMetrics(vllm_config)
@@ -292,6 +297,7 @@ class Scheduler(SchedulerInterface):
         num_new_local_computed_tokens: int = 0,
         num_external_computed_tokens: int = 0,
     ) -> int:
+        requested_tokens = num_new_tokens
         assert num_external_computed_tokens == 0, (
             "External KV connector is not verified yet"
         )
@@ -333,6 +339,30 @@ class Scheduler(SchedulerInterface):
             else:
                 # prefill the last few tokens
                 pass
+        aligned_tokens = num_new_tokens
+        fragmentation_event = aligned_tokens < requested_tokens
+        zero_collapse_event = requested_tokens > 0 and aligned_tokens == 0
+        if zero_collapse_event:
+            # Allow forward progress for sub-block requests.
+            num_new_tokens = max(1, requested_tokens)
+        if fragmentation_event:
+            self.mamba_fragmentation_count += 1
+        if zero_collapse_event:
+            self.mamba_zero_collapse_count += 1
+        if (fragmentation_event or zero_collapse_event) and logger.isEnabledFor(
+            logging.DEBUG
+        ):
+            logger.debug(
+                "[mamba_split] requested=%d aligned=%d round=%d "
+                "fragmentation_event=%d mamba_fragmentation_count=%d "
+                "mamba_zero_collapse_count=%d",
+                requested_tokens,
+                aligned_tokens,
+                self._scheduler_iteration,
+                int(fragmentation_event),
+                self.mamba_fragmentation_count,
+                self.mamba_zero_collapse_count,
+            )
         return num_new_tokens
 
     def schedule(self) -> SchedulerOutput:
@@ -369,6 +399,7 @@ class Scheduler(SchedulerInterface):
         scheduled_timestamp = time.monotonic()
 
         self.kv_cache_manager.new_step_starts()
+        self._scheduler_iteration += 1
 
         # First, schedule the RUNNING requests.
         req_index = 0

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1185,8 +1185,9 @@ class EngineCoreProc(EngineCore):
             client_idx, call_id, method_name, args = request
             output = UtilityOutput(call_id)
             # Lazily look-up utility method so that failure will be handled/returned.
-            get_result = lambda: (method := getattr(self, method_name)) and method(
-                *self._convert_msgspec_args(method, args)
+            get_result = lambda: (
+                (method := getattr(self, method_name))
+                and method(*self._convert_msgspec_args(method, args))
             )
             enqueue_output = lambda out: self.output_queue.put_nowait(
                 (client_idx, EngineCoreOutputs(utility_output=out))


### PR DESCRIPTION
## Summary
Prefill fragmentation in `_mamba_block_aligned_split()` may amplify TTFT when hybrid (Mamba / DeltaNet) layers are used.

## What this PR does
1. Add scheduler instrumentation
2. Add fragmentation counters
3. Add minimal zero-collapse safeguard
4. Add benchmark script
5. Add unit tests

## Instrumentation
The following counters are introduced to observe scheduling behavior:

- `mamba_fragmentation_count`
- `mamba_zero_collapse_count`
- `_scheduler_iteration`

These metrics help track:

- how often prefill chunks are fragmented
- whether alignment collapses to zero
- how many scheduler rounds occur during prefill

## Benchmark

Benchmark script included: `benchmarks/mamba_prefill_fragmentation.py`

Default configuration:
```
model = Qwen3-5.2B
prompt length ≈ 2000 tokens
batch size = 1
```

Metrics reported:

- TTFT
- tokens/sec
- scheduler rounds
- fragmentation events

## Safety

The safeguard only triggers when alignment collapses to zero while the scheduler requested tokens.
It prevents no-progress scheduling rounds without changing normal block alignment behavior.

## Motivation

Related discussion: https://github.com/vllm-project/vllm/issues/36627

## Notes
I currently do not have access to an A10/A100 GPU, so the patch is based on source analysis and local instrumentation.
Benchmark validation from others with production GPUs would be appreciated.