### PR TITLE
[Bugfix] Support Qwen3.5 text-only configs

### DIFF
--- a/tests/config/test_model_arch_config.py
+++ b/tests/config/test_model_arch_config.py
@@ -154,3 +154,60 @@ def test_draft_model_arch_config(
     _assert_model_config_methods(
         model_config, expected, check_head_size=check_head_size
     )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "architectures", "expected_architecture"),
+    [
+        (
+            "qwen3_5_text",
+            ["Qwen3_5ForConditionalGeneration"],
+            "Qwen3_5ForCausalLM",
+        ),
+        (
+            "qwen3_5_moe_text",
+            ["Qwen3_5MoeForConditionalGeneration"],
+            "Qwen3_5MoeForCausalLM",
+        ),
+    ],
+)
+def test_qwen3_5_text_model_arch_config(
+    tmp_path: Path,
+    model_type: str,
+    architectures: list[str],
+    expected_architecture: str,
+) -> None:
+    model_dir = tmp_path / model_type
+    model_dir.mkdir()
+
+    config = {
+        "architectures": architectures,
+        "head_dim": 4,
+        "hidden_size": 16,
+        "intermediate_size": 32,
+        "model_type": model_type,
+        "num_attention_heads": 4,
+        "num_hidden_layers": 2,
+        "num_key_value_heads": 4,
+        "torch_dtype": "float16",
+        "vocab_size": 128,
+    }
+    if model_type == "qwen3_5_moe_text":
+        config.update(
+            {
+                "moe_intermediate_size": 8,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "shared_expert_intermediate_size": 8,
+            }
+        )
+
+    with open(model_dir / "config.json", "w") as f:
+        json.dump(config, f)
+
+    model_config = ModelConfig(str(model_dir), tokenizer=str(model_dir))
+
+    assert model_config.hf_config.model_type == model_type
+    assert model_config.architectures == [expected_architecture]
+    assert model_config.architecture == expected_architecture
+    assert not model_config.is_multimodal_model

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -488,6 +488,14 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
     "Qwen2MoeForCausalLM": _HfExamplesInfo("Qwen/Qwen1.5-MoE-A2.7B-Chat"),
     "Qwen3ForCausalLM": _HfExamplesInfo("Qwen/Qwen3-8B"),
     "Qwen3MoeForCausalLM": _HfExamplesInfo("Qwen/Qwen3-30B-A3B"),
+    "Qwen3_5ForCausalLM": _HfExamplesInfo(
+        "local/qwen3_5_text_config_example",
+        is_available_online=False,
+    ),
+    "Qwen3_5MoeForCausalLM": _HfExamplesInfo(
+        "local/qwen3_5_moe_text_config_example",
+        is_available_online=False,
+    ),
     "Qwen3NextForCausalLM": _HfExamplesInfo(
         "Qwen/Qwen3-Next-80B-A3B-Instruct",
         extras={"tiny-random": "tiny-random/qwen3-next-moe"},

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -683,6 +683,8 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "Qwen2ForRewardModel": Qwen2ForRewardModelConfig,
     "Qwen3ForSequenceClassification": Qwen3ForSequenceClassificationConfig,
     "Qwen3VLForSequenceClassification": Qwen3VLForSequenceClassificationConfig,
+    "Qwen3_5ForCausalLM": Qwen3_5ForConditionalGenerationConfig,
+    "Qwen3_5MoeForCausalLM": Qwen3_5ForConditionalGenerationConfig,
     "Qwen3_5ForConditionalGeneration": Qwen3_5ForConditionalGenerationConfig,
     "Qwen3_5MoeForConditionalGeneration": Qwen3_5ForConditionalGenerationConfig,
     "VoyageQwen3BidirectionalEmbedModel": VoyageQwen3BidirectionalEmbedModelConfig,

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -192,6 +192,8 @@ _TEXT_GENERATION_MODELS = {
     "Qwen2MoeForCausalLM": ("qwen2_moe", "Qwen2MoeForCausalLM"),
     "Qwen3ForCausalLM": ("qwen3", "Qwen3ForCausalLM"),
     "Qwen3MoeForCausalLM": ("qwen3_moe", "Qwen3MoeForCausalLM"),
+    "Qwen3_5ForCausalLM": ("qwen3_5", "Qwen3_5ForCausalLM"),
+    "Qwen3_5MoeForCausalLM": ("qwen3_5", "Qwen3_5MoeForCausalLM"),
     "RWForCausalLM": ("falcon", "FalconForCausalLM"),
     "SarvamMoEForCausalLM": ("sarvam", "SarvamMoEForCausalLM"),
     "SarvamMLAForCausalLM": ("sarvam", "SarvamMLAForCausalLM"),

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -110,7 +110,9 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     qwen3_asr="Qwen3ASRConfig",
     qwen3_next="Qwen3NextConfig",
     qwen3_5="Qwen3_5Config",
+    qwen3_5_text="Qwen3_5TextConfig",
     qwen3_5_moe="Qwen3_5MoeConfig",
+    qwen3_5_moe_text="Qwen3_5MoeTextConfig",
     lfm2_moe="Lfm2MoeConfig",
     tarsier2="Tarsier2Config",
 )

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -24,6 +24,16 @@ from vllm.utils.torch_utils import common_broadcastable_dtype
 
 logger = init_logger(__name__)
 
+_QWEN3_5_TEXT_ARCHITECTURES = {
+    "Qwen3_5ForConditionalGeneration": "Qwen3_5ForCausalLM",
+    "Qwen3_5MoeForConditionalGeneration": "Qwen3_5MoeForCausalLM",
+}
+
+_QWEN3_5_TEXT_DEFAULT_ARCHITECTURES = {
+    "qwen3_5_text": "Qwen3_5ForCausalLM",
+    "qwen3_5_moe_text": "Qwen3_5MoeForCausalLM",
+}
+
 
 @contextmanager
 def _maybe_patch_hf_hub_constants(config_format: ConfigFormat) -> Iterator[None]:
@@ -344,6 +354,22 @@ class MedusaModelArchConfigConvertor(ModelArchConfigConvertorBase):
         return 0
 
 
+class Qwen3_5TextModelArchConfigConvertor(ModelArchConfigConvertorBase):
+    def get_architectures(self) -> list[str]:
+        architectures = super().get_architectures()
+
+        if not architectures:
+            if (
+                default_arch := _QWEN3_5_TEXT_DEFAULT_ARCHITECTURES.get(
+                    self.hf_config.model_type
+                )
+            ) is not None:
+                return [default_arch]
+            return architectures
+
+        return [_QWEN3_5_TEXT_ARCHITECTURES.get(arch, arch) for arch in architectures]
+
+
 class Zamba2ModelArchConfigConvertor(ModelArchConfigConvertorBase):
     def get_head_size(self) -> int:
         return getattr(self.hf_text_config, "attention_head_dim", 0)
@@ -449,6 +475,8 @@ MODEL_ARCH_CONFIG_CONVERTORS = {
     "falcon_mamba": MambaModelArchConfigConvertor,
     "timm_wrapper": TerratorchModelArchConfigConvertor,
     "medusa": MedusaModelArchConfigConvertor,
+    "qwen3_5_text": Qwen3_5TextModelArchConfigConvertor,
+    "qwen3_5_moe_text": Qwen3_5TextModelArchConfigConvertor,
     "zamba2": Zamba2ModelArchConfigConvertor,
     "mpt": MPTModelArchConfigConvertor,
     "dbrx": DbrxModelArchConfigConvertor,


### PR DESCRIPTION
Fixes #36585

## Summary
- register `qwen3_5_text` and `qwen3_5_moe_text` with vLLM's config loader
- remap text-only Qwen3.5 checkpoints that still advertise conditional-generation architectures onto the text-only CausalLM implementations
- add regression coverage for Qwen3.5 text-only config parsing and model registry resolution

## Testing
- `pytest tests/config/test_model_arch_config.py -k qwen3_5_text_model_arch_config`
- `pytest tests/models/test_registry.py -k 'Qwen3_5ForCausalLM or Qwen3_5MoeForCausalLM or test_hf_registry_coverage'`
