### PR TITLE
Support Flashinfer rope+quant+cache update fusion kernel for TRTLLM attention

### DIFF
--- a/tests/compile/fusions_e2e/conftest.py
+++ b/tests/compile/fusions_e2e/conftest.py
@@ -151,7 +151,7 @@ def run_e2e_fusion_test(monkeypatch, caplog_mp_spawn):
             match_table = run_model(full_compilation_config, model_name, **model_kwargs)
 
         num_compile_ranges = len(full_compilation_config.get_compile_ranges())
-        assert num_compile_ranges in [1, 2, 3]
+        assert num_compile_ranges in [1, 2, 3, 4]
 
         print(f"Compile ranges: {full_compilation_config.get_compile_ranges()}")
         print("Fusion results:")
@@ -162,31 +162,47 @@ def run_e2e_fusion_test(monkeypatch, caplog_mp_spawn):
             log_matches_dict[match_name] = list(pattern.findall(log_holder.text))
             print(f"- {match_name}={','.join(log_matches_dict[match_name])}")
 
+        # AR+RMS and SP have range-based applicability (AR+RMS runs when
+        # range.end <= threshold, SP when range.start >= threshold). With
+        # multiple range-creating features enabled (rope+kvcache fusion,
+        # SP threshold, AR+RMS threshold), the activation count of each
+        # pass is configuration-dependent. Derive it from log data: the
+        # pass manager emits one "Replaced N patterns" line per (rank,
+        # range) where the pass ran, and one "Skipping X with compile
+        # range" line per (rank, range) where it was skipped.
+        def _num_ranges_activated(match_name: str, pass_class: str) -> int:
+            if match_name not in matches_check:
+                return num_compile_ranges
+            runs = len(log_matches_dict.get(match_name, []))
+            skips = len(
+                re.findall(
+                    rf"pass_manager.py:\d+] Skipping "
+                    rf".*{pass_class}.* with compile range",
+                    log_holder.text,
+                )
+            )
+            assert runs + skips == tp_size * num_compile_ranges, (
+                f"Expected {tp_size * num_compile_ranges} {pass_class} pass "
+                f"invocations (runs + skips), found runs={runs}, skips={skips}"
+            )
+            assert runs % tp_size == 0, (
+                f"Expected multiple of {tp_size} {match_name} log entries, found {runs}"
+            )
+            return runs // tp_size
+
+        num_ranges_ar = _num_ranges_activated("ar_rms_fusion", "AllReduceFusionPass")
+        num_ranges_sp = _num_ranges_activated(
+            "sequence_parallel", "SequenceParallelismPass"
+        )
+
         # Now check the matches
         for match_name in matches_check:
             log_matches = list(int(ms) for ms in log_matches_dict[match_name])
 
-            # AR+RMS skips the largest range; SP skips the smallest.
-            # When both are enabled, AR+RMS activation count is
-            # model-dependent (hidden_size affects threshold), so derive
-            # from log data.
-            if (
-                match_name == "ar_rms_fusion"
-                and "sequence_parallel" in matches_check
-                and num_compile_ranges >= 2
-            ):
-                assert (
-                    len(log_matches) >= tp_size and len(log_matches) % tp_size == 0
-                ), (
-                    f"Expected multiple of {tp_size} ar_rms log entries, "
-                    f"found {len(log_matches)}"
-                )
-                num_ranges_activated = len(log_matches) // tp_size
-            elif (
-                match_name in ("ar_rms_fusion", "sequence_parallel")
-                and num_compile_ranges >= 2
-            ):
-                num_ranges_activated = num_compile_ranges - 1
+            if match_name == "ar_rms_fusion":
+                num_ranges_activated = num_ranges_ar
+            elif match_name == "sequence_parallel":
+                num_ranges_activated = num_ranges_sp
             else:
                 num_ranges_activated = num_compile_ranges
 
@@ -202,12 +218,18 @@ def run_e2e_fusion_test(monkeypatch, caplog_mp_spawn):
             expected_matches = getattr(matches, match_name)
 
             if match_name == "rms_quant_fusion" and "ar_rms_fusion" in matches_check:
-                # AR+rms+quant takes precedence over rms+quant if activated.
-                # That means we get full matching where ar+rms+quant was not
-                # activated, and less where it was (only the smallest range).
-                assert sum(m == expected_matches for m in log_matches) == tp_size * (
-                    num_ranges_activated - 1
-                ), "Expecting full rms+quant fusion where ar+rms+quant not activated"
+                # AR+rms+quant takes precedence over rms+quant on ranges
+                # where AR+RMS is activated, leaving rms+quant with fewer
+                # matches there. On ranges where AR+RMS was not activated,
+                # rms+quant fuses the full set of patterns.
+                n_no_ar_ranges = num_compile_ranges - num_ranges_ar
+                assert sum(m == expected_matches for m in log_matches) == (
+                    tp_size * n_no_ar_ranges
+                ), (
+                    f"Expecting full rms+quant fusion on "
+                    f"{tp_size * n_no_ar_ranges} non-AR+RMS-range entries, "
+                    f"found: {log_matches}"
+                )
 
                 assert all(
                     expected_matches - matches.ar_rms_fusion <= m <= expected_matches
@@ -222,36 +244,46 @@ def run_e2e_fusion_test(monkeypatch, caplog_mp_spawn):
                 and num_compile_ranges >= 2
             ):
                 # AsyncTP only finds patterns on ranges where SP ran.
-                n_sp_ranges = num_compile_ranges - 1
                 assert (
                     sum(m == expected_matches for m in log_matches)
-                    == tp_size * n_sp_ranges
+                    == tp_size * num_ranges_sp
                 ), (
                     f"Expecting {expected_matches} async_tp on "
-                    f"{tp_size * n_sp_ranges} SP-range entries, "
+                    f"{tp_size * num_ranges_sp} SP-range entries, "
                     f"found: {log_matches}"
                 )
-                assert sum(m == 0 for m in log_matches) == tp_size, (
-                    f"Expecting 0 async_tp on {tp_size} small-range entries "
-                    f"(no SP), found: {log_matches}"
+                assert sum(m == 0 for m in log_matches) == tp_size * (
+                    num_compile_ranges - num_ranges_sp
+                ), (
+                    f"Expecting 0 async_tp on "
+                    f"{tp_size * (num_compile_ranges - num_ranges_sp)} "
+                    f"non-SP-range entries, found: {log_matches}"
                 )
             elif (
                 match_name == "ar_rms_fusion"
                 and "sequence_parallel" in matches_check
                 and num_compile_ranges >= 2
             ):
-                # SP consumes allreduce patterns first, so AR+RMS finds
-                # full matches only on the smallest range (no SP).
-                assert sum(m == expected_matches for m in log_matches) == tp_size, (
-                    f"Expecting {expected_matches} ar_rms on "
-                    f"{tp_size} small-range entries, found: {log_matches}"
-                )
-                assert sum(m == 0 for m in log_matches) == tp_size * (
-                    num_ranges_activated - 1
+                # SP consumes allreduce patterns first. AR+RMS-active set
+                # is the first K ranges (sorted), SP-active set is the
+                # last M ranges; their intersection has size
+                # max(0, K+M - N).
+                # AR+RMS finds full matches on AR-only ranges (size
+                # K - intersection) and 0 on the intersection.
+                n_intersect = max(0, num_ranges_ar + num_ranges_sp - num_compile_ranges)
+                n_ar_only = num_ranges_ar - n_intersect
+                assert (
+                    sum(m == expected_matches for m in log_matches)
+                    == tp_size * n_ar_only
                 ), (
+                    f"Expecting {expected_matches} ar_rms on "
+                    f"{tp_size * n_ar_only} AR-only-range entries, "
+                    f"found: {log_matches}"
+                )
+                assert sum(m == 0 for m in log_matches) == tp_size * n_intersect, (
                     f"Expecting 0 ar_rms on "
-                    f"{tp_size * (num_ranges_activated - 1)} large-range "
-                    f"entries (SP took precedence), found: {log_matches}"
+                    f"{tp_size * n_intersect} AR+SP-range entries "
+                    f"(SP took precedence), found: {log_matches}"
                 )
 
             elif match_name == "act_quant_fusion":
@@ -273,32 +305,6 @@ def run_e2e_fusion_test(monkeypatch, caplog_mp_spawn):
                 assert sorted(log_matches) == expected_matches_list, (
                     f"{match_name} expected: {expected_matches_list}, "
                     f"found: {sorted(log_matches)}"
-                )
-
-            if match_name == "ar_rms_fusion" and num_compile_ranges >= 2:
-                log_matches = re.findall(
-                    r"pass_manager.py:\d+] Skipping "
-                    r".*AllReduceFusionPass.* with compile range",
-                    log_holder.text,
-                )
-
-                n_expected = tp_size * (num_compile_ranges - num_ranges_activated)
-                assert len(log_matches) == n_expected, (
-                    f'Could not find {n_expected} "Skipping AllReduceFusionPass" '
-                    f"(found {len(log_matches)}) in:\n {log_holder.text}"
-                )
-
-            if match_name == "sequence_parallel" and num_compile_ranges >= 2:
-                log_matches = re.findall(
-                    r"pass_manager.py:\d+] Skipping "
-                    r".*SequenceParallelismPass.* with compile range",
-                    log_holder.text,
-                )
-
-                n_expected = tp_size * (num_compile_ranges - num_ranges_activated)
-                assert len(log_matches) == n_expected, (
-                    f'Could not find {n_expected} "Skipping SequenceParallelismPass" '
-                    f"(found {len(log_matches)}) in:\n {log_holder.text}"
                 )
 
     return run

--- a/tests/compile/passes/test_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rope_kvcache_fusion.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import copy
 
 import pytest
 import torch
@@ -8,7 +9,7 @@ import vllm.config
 from tests.compile.backend import TestBackend
 from tests.v1.attention.utils import BatchSpec, create_common_attn_metadata
 from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
-from vllm.compilation.passes.fusion.matcher_utils import ROTARY_OP
+from vllm.compilation.passes.fusion.matcher_utils import QUANT_OPS, ROTARY_OP
 from vllm.compilation.passes.fusion.rope_kvcache_fusion import RopeKVCacheFusionPass
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
 from vllm.compilation.passes.utility.post_cleanup import PostCleanupPass
@@ -17,17 +18,24 @@ from vllm.compilation.passes.utility.scatter_split_replace import (
 )
 from vllm.compilation.passes.utility.split_coalescing import SplitCoalescingPass
 from vllm.config import (
+    AttentionConfig,
     CacheConfig,
     CompilationConfig,
     CompilationMode,
     ModelConfig,
     PassConfig,
+    SchedulerConfig,
     VllmConfig,
+    set_current_vllm_config,
 )
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8StaticTensorSym,
+)
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer
 from vllm.utils.torch_utils import _encode_layer_name
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -40,7 +48,7 @@ VLLM_UNIFIED_KV_CACHE_UPDATE_OP = torch.ops.vllm.unified_kv_cache_update
 FP8_DTYPE = current_platform.fp8_dtype()
 
 
-class QKRoPEKVCacheTestModel(torch.nn.Module):
+class QKRoPEKVCacheTestModelBase(torch.nn.Module):
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -95,11 +103,6 @@ class QKRoPEKVCacheTestModel(torch.nn.Module):
         self.attn._k_scale = self.attn._k_scale.to(device)
         self.attn._v_scale = self.attn._v_scale.to(device)
 
-        kv_cache_dtype_str = vllm_config.cache_config.cache_dtype
-        self.kv_cache_dtype = (
-            FP8_DTYPE if kv_cache_dtype_str.startswith("fp8") else self.dtype
-        )
-
         # Initialize attn MetadataBuilder
         self.builder = self.attn_backend.get_builder_cls()(
             kv_cache_spec=self.attn.get_kv_cache_spec(vllm_config),
@@ -136,7 +139,7 @@ class QKRoPEKVCacheTestModel(torch.nn.Module):
         # Create dummy KV cache
         raw_tensor = torch.zeros(
             2 * num_blocks * self.block_size * self.num_kv_heads * self.head_size,
-            dtype=self.kv_cache_dtype,
+            dtype=self.attn.kv_cache_torch_dtype,
             device=self.device,
         )
         raw_tensor = raw_tensor.view(kv_cache_shape)
@@ -151,6 +154,19 @@ class QKRoPEKVCacheTestModel(torch.nn.Module):
 
         return attn_metadata
 
+    def forward(
+        self, qkv: torch.Tensor, positions: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+    def ops_in_model_before(self) -> list[torch._ops.OpOverload]:
+        raise NotImplementedError
+
+    def ops_in_model_after(self) -> list[torch._ops.OpOverload]:
+        raise NotImplementedError
+
+
+class QKRoPEKVCacheTestModel(QKRoPEKVCacheTestModelBase):
     def forward(
         self, qkv: torch.Tensor, positions: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -177,6 +193,39 @@ class QKRoPEKVCacheTestModel(torch.nn.Module):
                 ops.append(ROTARY_OP)
         else:
             ops.append(INDEX_SELECT_OP)
+        ops.append(torch.ops.vllm.unified_kv_cache_update.default)
+        return ops
+
+    def ops_in_model_after(self) -> list[torch._ops.OpOverload]:
+        return [torch.ops.vllm.fused_rope_and_unified_kv_cache_update.default]
+
+
+class QKRoPEQuantKVCacheTestModel(QKRoPEKVCacheTestModelBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        assert self.attn.query_quant is not None
+
+    def forward(self, qkv: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+        qkv = qkv.clone()
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k = self.rotary_emb(positions, q, k)
+        attn_output = self.attn(q, k, v)
+        return attn_output
+
+    def ops_in_model_before(self) -> list[torch._ops.OpOverload]:
+        ops = []
+        if self.enable_rope_custom_op:
+            if self.rotary_emb.use_flashinfer:
+                ops.append(torch.ops.vllm.flashinfer_rotary_embedding.default)
+            else:
+                ops.append(ROTARY_OP)
+        else:
+            ops.append(INDEX_SELECT_OP)
+        if self.attn.query_quant.enabled():
+            ops.append(QUANT_OPS[kFp8StaticTensorSym])
+        else:
+            ops.append(torch.ops.aten.reciprocal)
         ops.append(torch.ops.vllm.unified_kv_cache_update.default)
         return ops
 
@@ -326,3 +375,158 @@ def test_rope_kvcache_fusion(
             atol=ATOL,
             rtol=RTOL,
         )
+
+
+@pytest.mark.parametrize("attn_backend", [AttentionBackendEnum.FLASHINFER])
+@pytest.mark.parametrize("model_name", ["openai/gpt-oss-20b"])
+@pytest.mark.parametrize("enable_rope_custom_op", [True])
+@pytest.mark.parametrize("enable_quant_custom_op", [True, False])
+@pytest.mark.parametrize("enable_flashinfer_rope", [True, False])
+@pytest.mark.parametrize("batch_size", [7, 64, 533])
+@pytest.mark.parametrize("num_heads", [64])
+@pytest.mark.parametrize("num_kv_heads", [8])
+@pytest.mark.parametrize("head_size", [64])
+@pytest.mark.parametrize("block_size", [16])
+@pytest.mark.parametrize("is_neox", [True, False])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("kv_cache_dtype", ["fp8"])
+@pytest.mark.skipif(
+    not (
+        current_platform.is_cuda()
+        and current_platform.is_device_capability((10, 0))
+        and has_flashinfer()
+    ),
+    reason="Only test on CUDA Blackwell platform with FlashInfer installed",
+)
+def test_rope_quant_kvcache_fusion(
+    attn_backend: AttentionBackendEnum,
+    model_name: str,
+    enable_rope_custom_op: bool,
+    enable_quant_custom_op: bool,
+    enable_flashinfer_rope: bool,
+    batch_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    block_size: int,
+    is_neox: bool,
+    dtype: torch.dtype,
+    kv_cache_dtype: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    if enable_flashinfer_rope:
+        monkeypatch.setenv("VLLM_USE_FLASHINFER_ROPE", "1")
+
+    torch.set_default_device("cuda")
+    torch.set_default_dtype(dtype)
+    torch.manual_seed(42)
+
+    custom_ops: list[str] = []
+    if enable_rope_custom_op:
+        custom_ops.append("+rotary_embedding")
+    if enable_quant_custom_op:
+        custom_ops.append("+quant_fp8")
+
+    model_config = ModelConfig(
+        model=model_name,
+        max_model_len=2048,
+        dtype=dtype,
+    )
+
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=1024,
+            max_model_len=model_config.max_model_len,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        cache_config=CacheConfig(
+            block_size=block_size,
+            cache_dtype=kv_cache_dtype,
+        ),
+        attention_config=AttentionConfig(
+            backend=attn_backend,
+        ),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            custom_ops=custom_ops,
+            pass_config=PassConfig(
+                eliminate_noops=False,
+                fuse_rope_kvcache=False,
+            ),
+        ),
+    )
+
+    hidden_size = head_size * (num_heads + num_kv_heads * 2)
+    qkv = torch.randn(batch_size, hidden_size, dtype=dtype)
+    pos = torch.arange(batch_size, dtype=torch.long)
+
+    # Run model directly without fusion
+    vllm_config_unfused = copy.deepcopy(vllm_config)
+    with (
+        set_current_vllm_config(vllm_config_unfused),
+        set_forward_context(attn_metadata=None, vllm_config=vllm_config_unfused),
+    ):
+        model_unfused = QKRoPEQuantKVCacheTestModel(
+            vllm_config=vllm_config_unfused,
+            attn_backend=attn_backend,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            is_neox=is_neox,
+            dtype=dtype,
+            device=torch.get_default_device(),
+        )
+        forward_ctx = get_forward_context()
+        forward_ctx.attn_metadata = model_unfused.build_attn_metadata(batch_size)
+        forward_ctx.slot_mapping = {
+            model_unfused.layer_name: forward_ctx.attn_metadata.slot_mapping
+        }
+        compiled_unfused = torch.compile(model_unfused, fullgraph=True)
+        result_unfused = compiled_unfused(qkv.clone(), pos.clone())
+
+    # Run model with fusion enabled
+    vllm_config.compilation_config.pass_config = PassConfig(
+        eliminate_noops=True,
+        fuse_rope_kvcache=True,
+    )
+    with (
+        set_current_vllm_config(vllm_config),
+        set_forward_context(attn_metadata=None, vllm_config=vllm_config),
+    ):
+        model_fused = QKRoPEQuantKVCacheTestModel(
+            vllm_config=vllm_config,
+            attn_backend=attn_backend,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            is_neox=is_neox,
+            dtype=dtype,
+            device=torch.get_default_device(),
+        )
+        forward_ctx = get_forward_context()
+        forward_ctx.attn_metadata = model_fused.build_attn_metadata(batch_size)
+        forward_ctx.slot_mapping = {
+            model_fused.layer_name: forward_ctx.attn_metadata.slot_mapping
+        }
+
+        # Create test backend with fusion passes enabled
+        fusion_pass = RopeKVCacheFusionPass(vllm_config)
+        passes = [
+            NoOpEliminationPass(vllm_config),
+            SplitCoalescingPass(vllm_config),
+            ScatterSplitReplacementPass(vllm_config),
+            fusion_pass,
+            PostCleanupPass(vllm_config),
+        ]
+        backend = TestBackend(*passes)
+        compiled_fused = torch.compile(model_fused, backend=backend, fullgraph=True)
+        result_fused = compiled_fused(qkv.clone(), pos.clone())
+
+        assert fusion_pass.matched_count == 1
+
+        backend.check_before_ops(model_fused.ops_in_model_before())
+        backend.check_after_ops(model_fused.ops_in_model_after())
+
+    torch.testing.assert_close(result_unfused, result_fused, atol=1e-2, rtol=1e-2)

--- a/tests/v1/attention/utils.py
+++ b/tests/v1/attention/utils.py
@@ -93,9 +93,15 @@ def create_common_attn_metadata(
         block_table_tensor = torch.arange(
             num_blocks, dtype=torch.int32, device=device
         ).view(batch_spec.batch_size, max_blocks)
-        slot_mapping = torch.arange(num_tokens, dtype=torch.int64, device=device).view(
-            num_tokens
-        )
+        # Compute slot_mapping consistent with block_table:
+        slots = []
+        for i in range(batch_spec.batch_size):
+            context_len = batch_spec.seq_lens[i] - batch_spec.query_lens[i]
+            for j in range(batch_spec.query_lens[i]):
+                global_pos = context_len + j
+                physical_block = block_table_tensor[i, global_pos // block_size].item()
+                slots.append(physical_block * block_size + global_pos % block_size)
+        slot_mapping = torch.tensor(slots, dtype=torch.int64, device=device)
     else:
         block_table_tensor = torch.randint(
             0,

--- a/vllm/compilation/passes/fusion/rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/rope_kvcache_fusion.py
@@ -15,6 +15,11 @@ from vllm.model_executor.layers.attention.attention import (
     Attention,
     get_attention_context,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kStaticTensorScale,
+)
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
     _USE_LAYERNAME,
     LayerNameType,
@@ -25,15 +30,12 @@ from vllm.utils.torch_utils import (
 
 from ..inductor_pass import enable_fake_mode
 from ..vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
-from .matcher_utils import (
-    MatcherRotaryEmbedding,
-)
-from .rms_quant_fusion import (
-    empty_bf16,
-    empty_i64,
-)
+from .matcher_utils import MatcherQuantFP8, MatcherRotaryEmbedding
+from .rms_quant_fusion import empty_bf16, empty_fp32, empty_i64
 
 logger = init_logger(__name__)
+
+FP8_DTYPE = current_platform.fp8_dtype()
 
 
 def fused_rope_and_unified_kv_cache_update_impl(
@@ -44,6 +46,8 @@ def fused_rope_and_unified_kv_cache_update_impl(
     cos_sin_cache: torch.Tensor,
     is_neox: bool,
     layer_name: LayerNameType,
+    query_quant_scale: torch.Tensor | None = None,
+    query_quant_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     This impl fetches the KV cache and slot mapping from the forward context,
@@ -53,7 +57,9 @@ def fused_rope_and_unified_kv_cache_update_impl(
     the data dependency between them to ensure torch.compile preserves ordering.
     """
     layer_name = _resolve_layer_name(layer_name)
-    _, attn_layer, kv_cache, layer_slot_mapping = get_attention_context(layer_name)
+    attn_metadata, attn_layer, kv_cache, layer_slot_mapping = get_attention_context(
+        layer_name
+    )
     if layer_slot_mapping is not None:
         attn_layer.impl.do_rope_and_kv_cache_update(
             attn_layer,
@@ -65,6 +71,9 @@ def fused_rope_and_unified_kv_cache_update_impl(
             is_neox,
             kv_cache,
             layer_slot_mapping,
+            attn_metadata,
+            query_quant_scale,
+            query_quant_out,
         )
 
     return torch.empty(0, device=kv_cache.device, dtype=kv_cache.dtype)
@@ -78,6 +87,8 @@ def fused_rope_and_unified_kv_cache_update_fake(
     cos_sin_cache: torch.Tensor,
     is_neox: bool,
     layer_name: LayerNameType,
+    query_quant_scale: torch.Tensor | None = None,
+    query_quant_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.empty(0, device=query.device, dtype=query.dtype)
 
@@ -85,7 +96,7 @@ def fused_rope_and_unified_kv_cache_update_fake(
 direct_register_custom_op(
     op_name="fused_rope_and_unified_kv_cache_update",
     op_func=fused_rope_and_unified_kv_cache_update_impl,
-    mutates_args=["query", "key"],
+    mutates_args=["query", "key", "query_quant_out"],
     fake_impl=fused_rope_and_unified_kv_cache_update_fake,
 )
 
@@ -223,6 +234,178 @@ class RopeReshapeKVCachePattern:
         )
 
 
+class RopeQuantReshapeKVCachePattern:
+    """
+    This pattern matches the following unfused inplace ops:
+      q, k = rotary_embedding(positions, q, k, head_size, cos_sin_cache, is_neox)
+      q = static_scaled_fp8_quant(q, scale)
+      kv_cache_dummy = unified_kv_cache_update(k, v, layer_name)
+
+    and replaces it with the fused inplace op:
+      kv_cache_dummy = fused_rope_and_unified_kv_cache_update(
+        q, k, v, positions, cos_sin_cache, is_neox, layer_name, scale
+      )
+    """
+
+    FUSED_OP = torch.ops.vllm.fused_rope_and_unified_kv_cache_update.default
+
+    def __init__(
+        self,
+        layer: Attention,
+        quant_key: QuantKey,
+        is_neox: bool,
+        use_flashinfer_rope: bool = False,
+    ) -> None:
+        self.layer_name = layer.layer_name
+        self.num_heads = layer.num_heads
+        self.num_kv_heads = layer.num_kv_heads
+        self.head_size = layer.head_size
+        self.head_size_v = layer.head_size_v
+        self.is_neox = is_neox
+        self.use_flashinfer_rope = use_flashinfer_rope
+
+        self.q_size = self.num_heads * self.head_size
+        self.k_size = self.num_kv_heads * self.head_size
+        self.v_size = self.num_kv_heads * self.head_size_v
+
+        self.rope_matcher = MatcherRotaryEmbedding(
+            is_neox=self.is_neox,
+            head_size=self.head_size,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            use_flashinfer=self.use_flashinfer_rope,
+        )
+        self.quant_key = quant_key
+        self.quant_matcher = MatcherQuantFP8(quant_key)
+
+    def get_inputs(self) -> list:
+        T = 5
+        L = 4096
+        qkv = empty_bf16(T, self.q_size + self.k_size + self.v_size)
+        positions = empty_i64(T)
+        cos_sin_cache = empty_fp32(L, self.head_size)
+        query_quant_scale = empty_fp32(1, 1)
+        inputs: list = [qkv, positions, cos_sin_cache, query_quant_scale]
+        if _USE_LAYERNAME:
+            inputs.append(_encode_layer_name(self.layer_name))
+        return inputs
+
+    def _mk_pattern_with_layer_name_input(self, _ln):
+        """Pattern/replacement with layer_name as an explicit input."""
+
+        def pattern(
+            qkv: torch.Tensor,
+            positions: torch.Tensor,
+            cos_sin_cache: torch.Tensor,
+            query_quant_scale: torch.Tensor,
+            layer_name: LayerNameType,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            q, k, v = qkv.split([self.q_size, self.k_size, self.v_size], dim=-1)
+            q, k = self.rope_matcher(positions, q, k, cos_sin_cache)
+            q, _ = self.quant_matcher(q, query_quant_scale)
+            q = q.view(-1, self.num_heads, self.head_size)
+            k = k.view(-1, self.num_kv_heads, self.head_size)
+            v = v.view(-1, self.num_kv_heads, self.head_size_v)
+            dummy = torch.ops.vllm.unified_kv_cache_update(k, v, layer_name)
+            return dummy, q, k, v
+
+        def replacement(
+            qkv: torch.Tensor,
+            positions: torch.Tensor,
+            cos_sin_cache: torch.Tensor,
+            query_quant_scale: torch.Tensor,
+            layer_name: LayerNameType,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            q, k, v = qkv.split([self.q_size, self.k_size, self.v_size], dim=-1)
+            q = q.view(-1, self.num_heads, self.head_size)
+            k = k.view(-1, self.num_kv_heads, self.head_size)
+            v = v.view(-1, self.num_kv_heads, self.head_size_v)
+            q_quant_out = torch.empty_like(q, dtype=self.quant_key.dtype)
+            results = auto_functionalized(
+                self.FUSED_OP,
+                query=q,
+                key=k,
+                value=v,
+                positions=positions,
+                cos_sin_cache=cos_sin_cache.to(torch.float32),
+                is_neox=self.is_neox,
+                layer_name=layer_name,
+                query_quant_scale=query_quant_scale,
+                query_quant_out=q_quant_out,
+            )
+            return results[0], results[3], results[2], v
+
+        return pattern, replacement
+
+    def _mk_pattern_with_layer_name_closure(self, _ln):
+        """Pattern/replacement with layer_name as a closure constant."""
+
+        def pattern(
+            qkv: torch.Tensor,
+            positions: torch.Tensor,
+            cos_sin_cache: torch.Tensor,
+            query_quant_scale: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            q, k, v = qkv.split([self.q_size, self.k_size, self.v_size], dim=-1)
+            q, k = self.rope_matcher(positions, q, k, cos_sin_cache)
+            q, _ = self.quant_matcher(q, query_quant_scale)
+            q = q.view(-1, self.num_heads, self.head_size)
+            k = k.view(-1, self.num_kv_heads, self.head_size)
+            v = v.view(-1, self.num_kv_heads, self.head_size_v)
+            dummy = torch.ops.vllm.unified_kv_cache_update(k, v, _ln)
+            return dummy, q, k, v
+
+        def replacement(
+            qkv: torch.Tensor,
+            positions: torch.Tensor,
+            cos_sin_cache: torch.Tensor,
+            query_quant_scale: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            q, k, v = qkv.split([self.q_size, self.k_size, self.v_size], dim=-1)
+            q = q.view(-1, self.num_heads, self.head_size)
+            k = k.view(-1, self.num_kv_heads, self.head_size)
+            v = v.view(-1, self.num_kv_heads, self.head_size_v)
+            q_quant_out = torch.empty_like(q, dtype=self.quant_key.dtype)
+            results = auto_functionalized(
+                self.FUSED_OP,
+                query=q,
+                key=k,
+                value=v,
+                positions=positions,
+                cos_sin_cache=cos_sin_cache.to(torch.float32),
+                is_neox=self.is_neox,
+                layer_name=_ln,
+                query_quant_scale=query_quant_scale,
+                query_quant_out=q_quant_out,
+            )
+            return results[0], results[3], results[2], v
+
+        return pattern, replacement
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        _ln = _encode_layer_name(self.layer_name)
+
+        if _USE_LAYERNAME:
+            pattern, replacement = self._mk_pattern_with_layer_name_input(_ln)
+        else:
+            pattern, replacement = self._mk_pattern_with_layer_name_closure(_ln)
+
+        # NOTE: use view_to_reshape to unify view/reshape to simplify
+        # pattern and increase matching opportunities
+        def fwd_and_view_to_reshape(*args, **kwargs) -> fx.GraphModule:
+            gm = pm.fwd_only(*args, **kwargs)
+            view_to_reshape(gm)
+            return gm
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            self.get_inputs(),
+            fwd_and_view_to_reshape,
+            pm_pass,
+        )
+
+
 class RopeKVCacheFusionPass(VllmPatternMatcherPass):
     """
     This pass fuses the rotary embedding and KV cache update operations
@@ -247,18 +430,36 @@ class RopeKVCacheFusionPass(VllmPatternMatcherPass):
         cc = config.compilation_config
         self.max_token_num = cc.pass_config.rope_kvcache_fusion_max_token_num
 
+        quant_key = None
+        # Only CUDA supports RoPE + Query Quant + KV Cache Pattern
+        if current_platform.is_cuda():
+            quant_key = QuantKey(
+                dtype=FP8_DTYPE, scale=kStaticTensorScale, symmetric=True
+            )
+
         attn_layers = get_layers_from_vllm_config(config, Attention)
         # When _USE_LAYERNAME is enabled, layer_name is a wildcard so all
         # layers produce the same pattern — register once then break.
         for _, layer in attn_layers.items():
-            if layer.impl.fused_rope_kvcache_supported():
-                for is_neox in [True, False]:
+            if not layer.impl.fused_rope_kvcache_supported(quant_key):
+                continue
+            for is_neox in [True, False]:
+                if current_platform.is_cuda():
+                    for use_flashinfer_rope in [True, False]:
+                        assert quant_key is not None
+                        RopeQuantReshapeKVCachePattern(
+                            layer=layer,
+                            quant_key=quant_key,
+                            is_neox=is_neox,
+                            use_flashinfer_rope=use_flashinfer_rope,
+                        ).register(self.patterns)
+                elif current_platform.is_rocm():
                     RopeReshapeKVCachePattern(
                         layer=layer,
                         is_neox=is_neox,
                     ).register(self.patterns)
-                if _USE_LAYERNAME:
-                    break
+            if _USE_LAYERNAME:
+                break
 
         self.dump_patterns(config, self.patterns)
 
@@ -274,4 +475,6 @@ class RopeKVCacheFusionPass(VllmPatternMatcherPass):
         return compile_range.end <= self.max_token_num
 
     def uuid(self) -> str:
-        return VllmInductorPass.hash_source(self, RopeReshapeKVCachePattern)
+        return VllmInductorPass.hash_source(
+            self, RopeReshapeKVCachePattern, RopeQuantReshapeKVCachePattern
+        )

--- a/vllm/compilation/passes/utility/fix_functionalization.py
+++ b/vllm/compilation/passes/utility/fix_functionalization.py
@@ -44,6 +44,8 @@ class FixFunctionalizationPass(VllmInductorPass):
             rope_targets.append(
                 torch.ops.vllm.rocm_aiter_triton_rotary_embedding.default
             )
+        if hasattr(torch.ops.vllm, "flashinfer_rotary_embedding"):
+            rope_targets.append(torch.ops.vllm.flashinfer_rotary_embedding.default)
 
         for node in graph.nodes:
             if not is_func(node, auto_functionalized):
@@ -179,6 +181,7 @@ class FixFunctionalizationPass(VllmInductorPass):
                 mutated_args = {
                     1: "query",
                     2: "key",
+                    3: "query_quant_out",
                 }
                 self.defunctionalize(graph, node, mutated_args=mutated_args)
             elif (

--- a/vllm/compilation/passes/utility/scatter_split_replace.py
+++ b/vllm/compilation/passes/utility/scatter_split_replace.py
@@ -63,6 +63,8 @@ class ScatterSplitReplacementPass(VllmInductorPass):
         target_ops = [torch.ops._C.rotary_embedding.default]
         if hasattr(torch.ops.vllm, "rocm_aiter_triton_rotary_embedding"):
             target_ops.append(torch.ops.vllm.rocm_aiter_triton_rotary_embedding.default)
+        if hasattr(torch.ops.vllm, "flashinfer_rotary_embedding"):
+            target_ops.append(torch.ops.vllm.flashinfer_rotary_embedding.default)
 
         for node in graph.nodes:
             if not is_func(node, auto_functionalized):

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -138,6 +138,8 @@ class PassConfig:
     """Enable fused allreduce+RMSNorm for MiniMax QK norm."""
     enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
     """Enable fused Q/K RMSNorm + RoPE pass."""
+    fuse_rope_kvcache: bool = None  # type: ignore[assignment]
+    """Fuse the QK rope (+ Q quant) + KV cache ops."""
     fuse_rope_kvcache_cat_mla: bool = None  # type: ignore[assignment]
     """Enable fused MLA KV cache update with RoPE."""
 
@@ -146,11 +148,9 @@ class PassConfig:
     """Fuse the custom RMSNorm + padding ops."""
     fuse_mla_dual_rms_norm: bool = None  # type: ignore[assignment]
     """Fuse paired q/kv RMS norms in MLA attention."""
-    fuse_rope_kvcache: bool = None  # type: ignore[assignment]
-    """Fuse the QK rope + KV cache ops."""
 
     rope_kvcache_fusion_max_token_num: int = 256
-    """The threshold for ROCm AITER RoPE+KVCache fusion e.g. for small batch decode.
+    """The threshold for RoPE(+Q quant)+KVCache fusion e.g. for small batch decode.
     Larger batch sizes e.g. during prefill will use the unfused kernels.
     """
 
@@ -282,10 +282,10 @@ class PassConfig:
                 "The fusion will be disabled."
             )
             self.fuse_mla_dual_rms_norm = False
-        if self.fuse_rope_kvcache and not current_platform.is_rocm():
+        if self.fuse_rope_kvcache and not current_platform.is_cuda_alike():
             logger.warning_once(
-                "KV cache fusion currently only enabled on ROCm. "
-                "The fusion will be disabled."
+                "KV cache fusion enabled but the current platform is not "
+                "CUDA or ROCm. The fusion will be disabled."
             )
             self.fuse_rope_kvcache = False
         if self.fuse_rope_kvcache_cat_mla and not current_platform.is_cuda_alike():
@@ -1119,6 +1119,20 @@ class CompilationConfig:
                 # for details. Make a copy to avoid mutating the class-level
                 # list via reference.
                 self.splitting_ops = list(self._attention_ops)
+
+                # Flashinfer fuse_rope_kvcache op needs to be a splitting op in
+                # piecewise cudagraph since it needs to access attn_metadata.
+                from vllm.utils.flashinfer import has_flashinfer
+
+                if (
+                    current_platform.is_cuda()
+                    and has_flashinfer()
+                    and self.use_inductor_graph_partition
+                    and self.pass_config.fuse_rope_kvcache
+                ):
+                    self.splitting_ops.append(
+                        "vllm::fused_rope_and_unified_kv_cache_update"
+                    )
 
                 # unified_kv_cache_update has a string param that prevents Inductor
                 # from reusing piecewise graphs. Remove it from the compiled graph.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -147,9 +147,12 @@ def enable_rope_kvcache_fusion(cfg: "VllmConfig") -> bool:
     use_inductor_graph_partition is enabled.
     """
     from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.platforms import current_platform
+    from vllm.utils.flashinfer import has_flashinfer
 
     return (
-        rocm_aiter_ops.is_enabled()
+        current_platform.is_cuda_alike()
+        and (rocm_aiter_ops.is_enabled() or has_flashinfer())
         and cfg.compilation_config.is_custom_op_enabled("rotary_embedding")
         and (
             cfg.compilation_config.use_inductor_graph_partition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -281,6 +281,7 @@ if TYPE_CHECKING:
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
     VLLM_LORA_ENABLE_DUAL_STREAM: bool = False
+    VLLM_USE_FLASHINFER_ROPE: bool = False
 
 
 def get_default_cache_root():
@@ -1974,6 +1975,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, use Python spinloop extension to poll in a more efficient
     # way when using the mp backend.
     "VLLM_USE_SPINLOOP_EXT": lambda: bool(int(os.getenv("VLLM_USE_SPINLOOP_EXT", "0"))),
+    # If set to 1, use the FlashInfer's rotary embedding kernel
+    "VLLM_USE_FLASHINFER_ROPE": lambda: bool(
+        int(os.getenv("VLLM_USE_FLASHINFER_ROPE", "0"))
+    ),
 }
 
 

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -313,6 +313,18 @@ class Attention(nn.Module, AttentionLayerBase):
             )
         else:
             self.attn_backend = attn_backend
+            # Adjust kv cache layout if the selected backend requires a specific one
+            required_layout = attn_backend.get_required_kv_cache_layout()
+            if required_layout is not None:
+                from vllm.v1.attention.backends.utils import set_kv_cache_layout
+
+                set_kv_cache_layout(required_layout)
+                logger.info(
+                    "Using %s KV cache layout for %s backend.",
+                    required_layout,
+                    attn_backend.get_name(),
+                )
+
         backend_supports_alibi_sqrt = self.attn_backend.supports_alibi_sqrt()
         use_alibi_sqrt = use_alibi_sqrt if use_alibi_sqrt else False
         if use_alibi_sqrt and not backend_supports_alibi_sqrt:

--- a/vllm/model_executor/layers/rotary_embedding/base.py
+++ b/vllm/model_executor/layers/rotary_embedding/base.py
@@ -4,8 +4,11 @@
 
 import torch
 
+from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.model_executor.custom_op import CustomOp
+from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer
 
 from .common import ApplyRotaryEmb
 
@@ -34,18 +37,20 @@ class RotaryEmbeddingBase(CustomOp):
         self.base = base
         self.is_neox_style = is_neox_style
         self.dtype = dtype
-        # TODO(mgoin): disabled for now due to failures
-        # Flashinfer only supports head_size=64, 128, 256, 512.
-        # https://github.com/flashinfer-ai/flashinfer/blob/ebfd655efe830048dba5d582aaa61d61d1cf9a87/include/flashinfer/utils.cuh#L174-L202
-        # self.use_flashinfer = (self.enabled()
-        #                        and dtype in (torch.float16, torch.bfloat16)
-        #                        and current_platform.is_cuda()
-        #                        and has_flashinfer()
-        #                        and self.head_size in [64, 128, 256, 512])
 
         # Check if use_flashinfer is already set
         if not hasattr(self, "use_flashinfer"):
-            self.use_flashinfer = False
+            # TODO(mgoin): VLLM_USE_FLASHINFER_ROPE is disabled for now due to failures
+            # Flashinfer only supports head_size=64, 128, 256, 512.
+            # https://github.com/flashinfer-ai/flashinfer/blob/ebfd655efe830048dba5d582aaa61d61d1cf9a87/include/flashinfer/utils.cuh#L174-L202
+            self.use_flashinfer = (
+                self.enabled()
+                and dtype in (torch.float16, torch.bfloat16)
+                and current_platform.is_cuda()
+                and has_flashinfer()
+                and self.head_size in [64, 128, 256, 512]
+                and envs.VLLM_USE_FLASHINFER_ROPE
+            )
 
         self.use_aiter = (
             self.enabled() and rocm_aiter_ops.is_triton_rotary_embed_enabled()

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -86,7 +86,6 @@ class OAIAttention(nn.Module):
         self.rotary_emb = get_rope(
             self.head_dim,
             max_position=config.max_position_embeddings,
-            dtype=torch.float32,
             rope_parameters={
                 "rope_theta": config.rope_parameters["rope_theta"],
                 "rope_type": "yarn",

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -441,7 +441,7 @@ class CommonAttentionMetadata:
     @deprecated(
         """
     Prefer using device seq_lens directly to avoid implicit H<>D sync which breaks full
-    async scheduling. If a CPU copy is needed, it can be derived from 
+    async scheduling. If a CPU copy is needed, it can be derived from
     query_start_loc_cpu and seq_lens.
     Will be removed in a future release, please migrate as soon as possible.
     """
@@ -812,9 +812,9 @@ class AttentionImpl(AttentionImplBase[T], Generic[T]):
         """
         return False
 
-    def fused_rope_kvcache_supported(self):
+    def fused_rope_kvcache_supported(self, query_quant_key: "QuantKey | None" = None):
         """
-        Does this attention implementation support RoPE+KVCache fusion.
+        Does this attention implementation support RoPE(+Quant)+KVCache fusion.
         This is used by the RopeKVCacheFusionPass to only fuse the RoPE ops
         with the KV cache update for implementations that support it.
         """
@@ -831,6 +831,9 @@ class AttentionImpl(AttentionImplBase[T], Generic[T]):
         is_neox: bool,
         kv_cache: torch.Tensor,
         layer_slot_mapping: torch.Tensor,
+        attn_metadata: T | None = None,
+        query_quant_scale: torch.Tensor | None = None,
+        query_quant_out: torch.Tensor | None = None,
     ):
         """
         If `fused_rope_kvcache_supported` returns True, this method will be called

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -15,7 +15,9 @@ from flashinfer import (
     MultiLevelCascadeAttentionWrapper,
 )
 from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
+from flashinfer.page import get_batch_indices_positions
 from flashinfer.prefill import trtllm_batch_context_with_kv_cache
+from flashinfer.rope import rope_quantize_fp8_append_paged_kv_cache
 from flashinfer.utils import FP4Tensor
 from typing_extensions import override
 
@@ -534,6 +536,16 @@ class FlashInferMetadata:
 
     cascade_wrapper: MultiLevelCascadeAttentionWrapper | None
 
+    # --- For RoPE + FP8 Quantize + KV Cache Update Kernel ---
+    paged_kv_indices: torch.Tensor | None = None
+    """Physical page indices for paged KV cache."""
+    paged_kv_indptr: torch.Tensor | None = None
+    """Cumulative page count per request."""
+    batch_indices: torch.Tensor | None = None
+    """Request index for each token."""
+    paged_positions: torch.Tensor | None = None
+    """Position within each request's KV sequence."""
+
 
 class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
     reorder_batch_threshold: int = 1
@@ -689,6 +701,24 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )  # Extra buffer for mutable paged_kv_indptr.cpu in cuda graph mode
         self.paged_kv_indices = self._make_buffer(max_num_pages)
         self.paged_kv_last_page_len = self._make_buffer(max_num_reqs)
+
+        self.enabled_rope_quant_cache_fusion = (
+            self.compilation_config.pass_config.fuse_rope_kvcache
+            and self.cache_dtype.startswith("fp8")
+            and can_use_trtllm
+        )
+        if self.enabled_rope_quant_cache_fusion:
+            max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+            self.batch_indices = torch.empty(
+                max_num_tokens,
+                device=device,
+                dtype=torch.int32,
+            )
+            self.paged_positions = torch.empty(
+                max_num_tokens,
+                device=device,
+                dtype=torch.int32,
+            )
 
     def _make_buffer(
         self, *size: int | torch.SymInt, dtype: torch.dtype = torch.int32
@@ -978,7 +1008,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # When all attention (both prefill and decode) uses TRTLLM,
         # seq_lens_cpu is not needed since TRTLLM paths use GPU tensors
         # (block_tables, seq_lens) directly.
-        needs_seq_lens_cpu = self.use_dcp or use_cascade or not all_uses_trtllm
+        needs_seq_lens_cpu = (
+            self.use_dcp
+            or use_cascade
+            or not all_uses_trtllm
+            or self.enabled_rope_quant_cache_fusion
+        )
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu if needs_seq_lens_cpu else None
         seq_lens_np = seq_lens_cpu.numpy() if seq_lens_cpu is not None else None
         num_blocks_np = (
@@ -1018,7 +1053,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # Compute paged_kv_indices if necessary
         # paged_kv_indices is only needed for FlashInfer native paths;
         # TRTLLM paths use block_tables directly on GPU.
-        needs_paged_kv_indices = use_cascade or not all_uses_trtllm
+        needs_paged_kv_indices = (
+            use_cascade or not all_uses_trtllm or self.enabled_rope_quant_cache_fusion
+        )
         if needs_paged_kv_indices:
             assert num_blocks_np is not None
             assert seq_lens_np is not None
@@ -1243,6 +1280,23 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     disable_split_kv=self.disable_split_kv,
                 )
                 attn_metadata.decode = FIDecode(wrapper=decode_wrapper)
+
+        # Step 4: Pre-compute params for RoPE + FP8 quantize + KV cache update fusion
+        # kernel here to avoid per-layer computation in do_rope_and_kv_cache_update.
+        if self.enabled_rope_quant_cache_fusion:
+            assert paged_kv_indices is not None
+            attn_metadata.paged_kv_indices = paged_kv_indices
+            attn_metadata.paged_kv_indptr = self.paged_kv_indptr.gpu[: num_reqs + 1]
+            attn_metadata.batch_indices = self.batch_indices[:num_actual_tokens]
+            attn_metadata.paged_positions = self.paged_positions[:num_actual_tokens]
+            get_batch_indices_positions(
+                qo_indptr[: num_reqs + 1],
+                seq_lens[:num_reqs],
+                num_actual_tokens,
+                attn_metadata.batch_indices,
+                attn_metadata.paged_positions,
+            )
+
         return attn_metadata
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
@@ -1850,6 +1904,86 @@ class FlashInferImpl(AttentionImpl):
                 layer._k_scale,
                 layer._v_scale,
             )
+
+    def fused_rope_kvcache_supported(self, query_quant_key: QuantKey | None = None):
+        return (
+            self.support_trtllm_attn
+            and self.kv_cache_dtype.startswith("fp8")
+            and query_quant_key == kFp8StaticTensorSym
+        )
+
+    def do_rope_and_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        positions: torch.Tensor,
+        cos_sin_cache: torch.Tensor,
+        is_neox: bool,
+        kv_cache: torch.Tensor,
+        layer_slot_mapping: torch.Tensor,
+        attn_metadata: FlashInferMetadata | None = None,
+        query_quant_scale: torch.Tensor | None = None,
+        query_quant_out: torch.Tensor | None = None,
+    ):
+        if attn_metadata is None:
+            # Skip this in piecewise cudagraph capturing since the kernel requires
+            # access to the attn_metadata
+            return
+
+        assert cos_sin_cache.dtype == torch.float32
+        assert query_quant_scale is not None
+        assert query_quant_out is not None
+
+        quant_dtype = FlashInferBackend.get_dtype_for_flashinfer(self.kv_cache_dtype)
+        kv_cache = kv_cache.view(quant_dtype)
+
+        stride_order = FlashInferBackend.get_kv_cache_stride_order()
+        kv_cache_perm = kv_cache.permute(*stride_order)
+        k_cache = kv_cache_perm[:, 0]
+        v_cache = kv_cache_perm[:, 1]
+
+        kv_layout = get_kv_cache_layout()
+        page_size = k_cache.shape[1] if kv_layout == "NHD" else k_cache.shape[2]
+
+        rotary_dim = cos_sin_cache.shape[-1]
+        head_size = query.shape[-1]
+
+        q_rope = query[..., :rotary_dim]
+        k_rope = key[..., :rotary_dim]
+        q_rope_out = query_quant_out[..., :rotary_dim]
+        if rotary_dim < head_size:
+            q_nope = query[..., rotary_dim:]
+            k_nope = key[..., rotary_dim:]
+            q_nope_out = query_quant_out[..., rotary_dim:]
+        else:
+            q_nope = None
+            k_nope = None
+            q_nope_out = None
+
+        rope_quantize_fp8_append_paged_kv_cache(
+            q_rope=q_rope,
+            k_rope=k_rope,
+            q_nope=q_nope,
+            k_nope=k_nope,
+            v=value,
+            cos_sin_cache=cos_sin_cache,
+            pos_ids=positions,
+            paged_kv_cache=(k_cache, v_cache),
+            kv_indices=attn_metadata.paged_kv_indices,
+            kv_indptr=attn_metadata.paged_kv_indptr,
+            batch_indices=attn_metadata.batch_indices,
+            positions=attn_metadata.paged_positions,
+            is_neox=is_neox,
+            quantize_dtype=quant_dtype,
+            quant_scale_q=layer._q_scale_float,
+            quant_scale_kv=layer._k_scale_float,
+            page_size=page_size,
+            kv_layout=kv_layout,
+            q_rope_out=q_rope_out,
+            q_nope_out=q_nope_out,
+        )
 
 
 def fast_plan_decode(

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -12,6 +12,7 @@ from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.math_utils import cdiv
@@ -1426,7 +1427,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 layer._v_scale,
             )
 
-    def fused_rope_kvcache_supported(self):
+    def fused_rope_kvcache_supported(self, query_quant_key: QuantKey | None = None):
         # Only support fusion when shuffle KV cache layout is not used;
         # shuffle layout uses a different cache update path.
         return (
@@ -1445,6 +1446,9 @@ class AiterFlashAttentionImpl(AttentionImpl):
         is_neox: bool,
         kv_cache: torch.Tensor,
         layer_slot_mapping: torch.Tensor,
+        attn_metadata: AiterFlashAttentionMetadata | None = None,
+        query_quant_scale: torch.Tensor | None = None,
+        query_quant_out: torch.Tensor | None = None,
     ):
         key_cache, value_cache = kv_cache.unbind(0)
         flash_layout = True

--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -260,7 +260,7 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
             layer._v_scale,
         )
 
-    def fused_rope_kvcache_supported(self):
+    def fused_rope_kvcache_supported(self, query_quant_key: QuantKey | None = None):
         return rocm_aiter_ops.is_enabled()
 
     def do_rope_and_kv_cache_update(
@@ -274,6 +274,9 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
         is_neox: bool,
         kv_cache: torch.Tensor,
         layer_slot_mapping: torch.Tensor,
+        attn_metadata: RocmAttentionMetadata | None = None,
+        query_quant_scale: torch.Tensor | None = None,
+        query_quant_out: torch.Tensor | None = None,
     ):
         if self.attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
             # For encoder attention,

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -499,7 +499,7 @@ class RocmAttentionImpl(AttentionImpl):
                 layer._v_scale,
             )
 
-    def fused_rope_kvcache_supported(self):
+    def fused_rope_kvcache_supported(self, query_quant_key: QuantKey | None = None):
         return rocm_aiter_ops.is_enabled()
 
     def do_rope_and_kv_cache_update(
@@ -513,6 +513,9 @@ class RocmAttentionImpl(AttentionImpl):
         is_neox: bool,
         kv_cache: torch.Tensor,
         layer_slot_mapping: torch.Tensor,
+        attn_metadata: RocmAttentionMetadata | None = None,
+        query_quant_scale: torch.Tensor | None = None,
+        query_quant_out: torch.Tensor | None = None,
     ):
         if self.attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
             return

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -758,7 +758,7 @@ class TritonAttentionImpl(AttentionImpl):
             layer._v_scale,
         )
 
-    def fused_rope_kvcache_supported(self):
+    def fused_rope_kvcache_supported(self, query_quant_key: QuantKey | None = None):
         if self._is_per_token_head_quant:
             return False
         return rocm_aiter_ops.is_enabled()
@@ -774,6 +774,9 @@ class TritonAttentionImpl(AttentionImpl):
         is_neox: bool,
         kv_cache: torch.Tensor,
         layer_slot_mapping: torch.Tensor,
+        attn_metadata: TritonAttentionMetadata | None = None,
+        query_quant_scale: torch.Tensor | None = None,
+        query_quant_out: torch.Tensor | None = None,
     ):
         key_cache, value_cache = kv_cache.unbind(1)
         flash_layout = True


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Support Flashinfer RoPE+Quant+KV Cache Update fusion kernel `rope_quantize_fp8_append_paged_kv_cache`.

Depend on https://github.com/flashinfer-ai/flashinfer/pull/2792: Fixed the padding token issue for the kernel when using full cudagraph

## Test Plan && Test Result

### Fusion pass unit test
`pytest -v -s tests/compile/passes/test_rope_kvcache_fusion.py::test_rope_quant_kvcache_fusion`
```
===== 24 passed, 41 warnings in 93.37s (0:01:33) ========
```

### Model e2e accuracy
Server cmd:
```
VLLM_USE_FLASHINFER_ROPE=1 \
VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1 \
\
vllm serve \
openai/gpt-oss-120b \
--tensor-parallel-size 8 \
-cc.use_inductor_graph_partition=True \
-cc.pass_config.fuse_allreduce_rms=True \
-cc.pass_config.eliminate_noops=True \
-cc.pass_config.fuse_rope_kvcache=True \
--async-scheduling \
--no-enable-prefix-caching \
--kv-cache-dtype fp8 \
--stream-interval 20 \
--max-num-seqs 1024 \
--max-model-len 131072 \
--max-num-batched-tokens 8192 \
--max-cudagraph-capture-size 2048
```
Fused:
```
[{'eval_name': 'gpqa', 'model_name': 'gpt-oss-120b-high_temp1.0_20260315_204508', 'metric': 0.7922979797979798}]
```
Infused:
```
[{'eval_name': 'gpqa', 'model_name': 'gpt-oss-120b-high_temp1.0_20260315_210654', 'metric': 0.7891414141414141}]
```

### Model e2e perf
Fused: **about 5% perf gain for GPT-OSS-120b TP8 con8**
```
============ Serving Benchmark Result ============
Successful requests:                     80
Failed requests:                         0
Maximum request concurrency:             8
Benchmark duration (s):                  29.01
Total input tokens:                      81920
Total generated tokens:                  81920
Request throughput (req/s):              2.76
Output token throughput (tok/s):         2824.22
Peak output token throughput (tok/s):    152.00
Peak concurrent requests:                16.00
Total token throughput (tok/s):          5648.44
---------------Time to First Token----------------
Mean TTFT (ms):                          53.85
Median TTFT (ms):                        55.84
P99 TTFT (ms):                           86.79
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          2.78
Median TPOT (ms):                        2.78
P99 TPOT (ms):                           2.84
---------------Inter-token Latency----------------
Mean ITL (ms):                           54.73
Median ITL (ms):                         55.41
P99 ITL (ms):                            57.44
==================================================
```
Infused:
```
============ Serving Benchmark Result ============
Successful requests:                     80
Failed requests:                         0
Maximum request concurrency:             8
Benchmark duration (s):                  30.50
Total input tokens:                      81920
Total generated tokens:                  81920
Request throughput (req/s):              2.62
Output token throughput (tok/s):         2686.20
Peak output token throughput (tok/s):    145.00
Peak concurrent requests:                16.00
Total token throughput (tok/s):          5372.41
---------------Time to First Token----------------
Mean TTFT (ms):                          58.81
Median TTFT (ms):                        63.80
P99 TTFT (ms):                           85.12
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          2.92
Median TPOT (ms):                        2.92
P99 TPOT (ms):                           2.99
---------------Inter-token Latency----------------
Mean ITL (ms):                           57.49
Median ITL (ms):                         58.44
P99 ITL (ms):                            59.91
==================================================
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

