### PR TITLE
[BugFix] Scheduler: Only set num_external_computed_tokens once

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1549,6 +1549,12 @@ def test_kv_connector_handles_preemption(is_async, use_ec_connector, ec_role):
 
     # All can be scheduled - 1st token.
     output = scheduler.schedule()
+
+    # verify request-level cache hit stats are set
+    for request in requests:
+        assert request.num_cached_tokens == NUM_MATCHED_NEW_TOKENS
+        assert request.num_external_computed_tokens == NUM_MATCHED_NEW_TOKENS
+
     if is_async:
         assert _num_waiting_requests(scheduler) == 2
         assert scheduler.running == []
@@ -1607,6 +1613,12 @@ def test_kv_connector_handles_preemption(is_async, use_ec_connector, ec_role):
     # Restarts the preempted request - generate 3rd token.
     # This will have a local and remote cache hit.
     output = scheduler.schedule()
+
+    # verify request level hit stats are NOT re-set
+    for request in requests:
+        assert request.num_cached_tokens == NUM_MATCHED_NEW_TOKENS
+        assert request.num_external_computed_tokens == NUM_MATCHED_NEW_TOKENS
+
     if is_async:
         waiting_req_ids = [
             req.request_id
@@ -1648,6 +1660,11 @@ def test_kv_connector_handles_preemption(is_async, use_ec_connector, ec_role):
     assert len(scheduler.running) == 0
     # All memory should be freed since nothing is running.
     assert scheduler.kv_cache_manager.block_pool.get_num_free_blocks() == NUM_BLOCKS - 1
+
+    # final verification request-level cache hit stats are NOT re-set
+    for request in requests:
+        assert request.num_cached_tokens == NUM_MATCHED_NEW_TOKENS
+        assert request.num_external_computed_tokens == NUM_MATCHED_NEW_TOKENS
 
 
 def make_output(scheduler: Scheduler):

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -619,7 +619,6 @@ class Scheduler(SchedulerInterface):
                             step_skipped_waiting.prepend_request(request)
                             continue
 
-                        request.num_external_computed_tokens = ext_tokens
                         num_external_computed_tokens = ext_tokens
 
                         connector_prefix_cache_queries = (
@@ -632,6 +631,16 @@ class Scheduler(SchedulerInterface):
                         num_new_local_computed_tokens + num_external_computed_tokens
                     )
                     assert num_computed_tokens <= request.num_tokens
+
+                    if request.num_preemptions == 0:
+                        # For request-level stats,
+                        # track hits only the first time a request gets scheduled.
+                        # If allocation will later fail, we will get back here
+                        # the next time the request re-tries scheduling
+                        request.num_cached_tokens = num_computed_tokens
+                        request.num_external_computed_tokens = (
+                            num_external_computed_tokens
+                        )
                 else:
                     # KVTransfer: WAITING reqs have num_computed_tokens > 0
                     # after async KV recvs are completed.
@@ -802,9 +811,6 @@ class Scheduler(SchedulerInterface):
                 token_budget -= num_new_tokens
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
-                # Count the number of prefix cached tokens.
-                if request.num_cached_tokens < 0:
-                    request.num_cached_tokens = num_computed_tokens
                 # Encoder-related.
                 if encoder_inputs_to_schedule:
                     scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
@@ -2158,6 +2164,7 @@ class Scheduler(SchedulerInterface):
                 req_num_computed_tokens = request.num_computed_tokens
             else:
                 # Sync loading. num_computed_tokens includes new tokens
+                # TODO(orozery): Bug below! Incorrect for preempted requests!
                 req_num_computed_tokens = request.num_cached_tokens
 
             req_num_computed_blocks = (
@@ -2192,7 +2199,19 @@ class Scheduler(SchedulerInterface):
                     req_num_computed_tokens - request.num_computed_tokens
                 )
                 total_affected_tokens += num_affected_tokens
-                request.num_external_computed_tokens -= num_affected_tokens
+                if request.num_preemptions == 0:
+                    # For request-level stats,
+                    # track hits only the first time a request gets scheduled.
+                    num_local_hit_tokens = (
+                        request.num_cached_tokens - request.num_external_computed_tokens
+                    )
+                    assert num_local_hit_tokens >= 0
+                    request.num_cached_tokens = min(
+                        request.num_cached_tokens, request.num_computed_tokens
+                    )
+                    request.num_external_computed_tokens = max(
+                        0, request.num_cached_tokens - num_local_hit_tokens
+                    )
                 # collect invalid block and all downstream dependent blocks
                 if evict_blocks:
                     blocks_to_evict.update(req_block_ids[idx:])
@@ -2204,6 +2223,8 @@ class Scheduler(SchedulerInterface):
                     # Revert to considering only cached tokens as computed.
                     # Currently this only applies to sync loading; Async
                     # loading does not yet support block sharing
+
+                    # TODO(orozery): Bug! Incorrect computation for preempted requests!
                     total_affected_tokens += (
                         request.num_computed_tokens - request.num_cached_tokens
                     )

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -145,9 +145,6 @@ class Request:
         self.all_token_ids = ConstantList(self._all_token_ids)
         # trace_headers
         self.trace_headers = trace_headers
-        # State
-        # The number of tokens with prefix cache hits.
-        self.num_cached_tokens = -1
 
         # True if this request is scheduled as a non-final prefill chunk.
         self.is_prefill_chunk = False
@@ -159,7 +156,14 @@ class Request:
         # The number of times this request has been preempted by the scheduler.
         self.num_preemptions = 0
 
-        # The number of tokens that have been computed remotely.
+        # Fields used for request-level cache stats
+        # These fields are only set on the first time a request gets scheduled
+        # Cache hits following request preemption are currently not tracked.
+
+        # Total number of KV cache hit tokens:
+        # local prefix cache hits + external (connector-based) hits
+        self.num_cached_tokens = 0
+        # Number of external tokens hit (excluding local prefix cache hits)
         self.num_external_computed_tokens = 0
 
         self.block_hashes: list[BlockHash] = []


### PR DESCRIPTION
`Request.num_cached_tokens` and `Request.num_external_computed_tokens` are two fields used for reporting request level cache hit stats. While `num_cached_tokens` is only set for the first time a request gets schedule, `num_external_computed_tokens` gets re-set whenever a request tries to gets re-scheduled, in case the request is preempted or when initial allocation fails. This creates a possible inconsistency between the two fields, which can yield to wrongful deduction of the derived stat `local_cache_hit`, which can cause vLLM to crash in case the wrong value is negative.
This PR fixes it by properly setting these two fields only after a request gets scheduled for the first time (by checking `Request.num_preemptions == 0`).
This fields may be updated only in the case of an error reported by the connector loading external tokens, We modify a scheduler unit-test for preemptions with KV connector to verify this fields are only set once.