### PR TITLE
[Perf] recreate torch profiler wrapper for each new profiling session to avoid slow starts

### DIFF
--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -41,6 +41,10 @@ class WorkerProfiler(ABC):
         self._profiling_for_iters = 0
         self._running = False
 
+    @property
+    def active(self) -> bool:
+        return self._active
+
     @abstractmethod
     def _start(self) -> None:
         """Start the profiler."""

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -871,9 +871,19 @@ class Worker(WorkerBase):
             else:
                 trace_name = rank_suffix
 
-            # Create the profiler wrapper only on the first start call
+            profiler_type = self.profiler_config.profiler
+            # For torch profiler, recreate the wrapper when the previous
+            # profiling session has stopped. This keeps repeated start_profile
+            # calls idempotent and can help avoid start latency from reusing
+            # a stale backend profiler object across sessions.
+            if (
+                profiler_type == "torch"
+                and self.profiler is not None
+                and not self.profiler.active
+            ):
+                self.profiler = None
+
             if self.profiler is None:
-                profiler_type = self.profiler_config.profiler
                 if profiler_type == "torch":
                     self.profiler = TorchProfilerWrapper(
                         self.profiler_config,
@@ -884,6 +894,7 @@ class Worker(WorkerBase):
                     logger.debug(
                         "Starting torch profiler with trace name: %s", trace_name
                     )
+                # Create the cuda profiler wrapper only on the first start call
                 elif profiler_type == "cuda":
                     self.profiler = CudaProfilerWrapper(self.profiler_config)
                     logger.debug("Starting CUDA profiler")
@@ -893,8 +904,8 @@ class Worker(WorkerBase):
                         f"Invalid profiler value of {self.profiler_config.profiler}"
                     )
 
-            # If profiler already initialized, restart profiling but keep
-            # the original trace name from the first initialization.
+            # If profiler is already initialized for the current active session,
+            # start() is a no-op and keeps the existing trace name.
             self.profiler.start()
         else:
             if self.profiler is None:


### PR DESCRIPTION
## Purpose
This PR fixes a profiling accuracy issue caused by reusing the same torch profiler wrapper across multiple profiling sessions.

We observed that the first profiling session starts quickly, but subsequent sessions can spend significantly more time in `profiler.start()`. This startup delay makes the collected profiling data inaccurate.

For example, after adding logging around `profiler.start()`, we observed the following startup times for two workers.

For the first profiling session:

```text
Profiler start() took 81.220 ms
Profiler start() took 87.516 ms
```

For the second profiling session:

```text
Profiler start() took 1801.335 ms
Profiler start() took 1920.664 ms
```

This delay leads to two main issues:

1. Inaccurate profiling results

Because different workers enter profiling at noticeably different times, workers that have already started profiling may spend time waiting for the others. As a result, the trace contains many unrelated `acquire_read()` calls.

<img width="1172" height="436" alt="image" src="https://github.com/user-attachments/assets/a48e78a1-e343-4de5-a1ff-0c3ce53c24e9" />


2. Larger profiling files

The repeated `acquire_read()` calls also make the profiling output significantly larger. In our case, a normal profiling file is about 900 MB, while an affected one can grow to about 2 GB. Larger profiling files also increase dump time while the inference engine is paused.

Based on additional logging in the torch profiler code, the delay appears to be related to recreation of the underlying profiling object during profiler.start():

https://github.com/pytorch/pytorch/blob/490b1ddd3c5afa6854a9fb5fee8e4e3076a4dd0e/torch/profiler/profiler.py#L214

More specifically, when a profiling session starts, `profiler.start()` may trigger reclamation of the previous `prof.profile` object, which introduces noticeable latency.

To avoid this issue, this patch stops reusing the torch profiler wrapper. Instead, it creates a new torch profiler wrapper for each profiling session.

After this fix, we no longer observe the profiling startup delay, and the abnormally frequent `acquire_read()` calls in the profiling results also disappear.

Creating a new `TorchProfilerWrapper` can reduce visible startup delay because the old `torch.profiler.profile` object referenced by the previous wrapper is often not reclaimed immediately. After the wrapper reference is dropped, the old `torch.profiler.profile` object may still be kept alive by internal reference cycles (for example, bound methods stored in `action_map`), so its nested `_KinetoProfile.profiler` is reclaimed only when cyclic GC runs, sometimes one or more profiling sessions later. 

In contrast, if the same wrapper is reused, `prepare_trace()` overwrites `_KinetoProfile.profiler` in place; then the previous `_KinetoProfile.profiler` may be reclaimed synchronously on the `profiler.start()` path, and that synchronous reclaim can appear as startup delay.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

