### PR TITLE
[Bugfix] Fix tool call streaming JSON separator mismatch

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1218,6 +1218,25 @@ class OpenAIServingChat(OpenAIServing):
 
                             # check to see if there's anything left to stream
                             remaining_call = expected_call.replace(actual_call, "", 1)
+
+                            # If the replace had no effect and args is a dict,
+                            # the mismatch may be caused by json.dumps using
+                            # different separators than the model's output
+                            # (e.g. '{"key": "v"}' vs '{"key":"v"}').
+                            # Retry with compact separators.
+                            if (
+                                remaining_call == expected_call
+                                and actual_call
+                                and not isinstance(args, str)
+                            ):
+                                expected_call = json.dumps(
+                                    args,
+                                    ensure_ascii=False,
+                                    separators=(",", ":"),
+                                )
+                                remaining_call = expected_call.replace(
+                                    actual_call, "", 1
+                                )
                             # set that as a delta message
                             delta_message = self._create_remaining_args_delta(
                                 delta_message, remaining_call, index


### PR DESCRIPTION
## Summary

Fixes #36857

When a tool parser stores arguments as a parsed dict (via `json.loads`), the serving layer re-serializes them with `json.dumps()` using Python's default separators (`', '` and `': '`). If the model streamed compact JSON without spaces (e.g. `{"key":"value"}` instead of `{"key": "value"}`), the `str.replace()` call that computes the remaining unstreamed arguments fails silently — the replacement has no effect and the entire arguments string is dumped in the final streaming chunk.

This adds a fallback: when the default-formatted `expected_call` does not match the actually streamed text (`actual_call`), retry with compact JSON separators (`(',', ':')`).

- Affects models like GLM-5 that stream tool call arguments without spaces after `:` 
- No behavior change for models whose output already matches Python's default `json.dumps` formatting
- The fix is backward-compatible: it only activates when the initial `replace()` has no effect

## Test plan

- [ ] Verify with GLM-5 model that tool call arguments are correctly streamed incrementally (not batched in final chunk)
- [ ] Verify existing tool call streaming tests still pass (no regression for models that use spaced JSON)


🤖 Generated with [Claude Code](https://claude.com/claude-code)