### PR TITLE
[Core] Skip np.repeat in _prepare_inputs when all requests are decodes

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1688,7 +1688,10 @@ class GPUModelRunner(
 
         # Get request indices.
         # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
-        req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens)
+        if total_num_scheduled_tokens == num_reqs:
+            req_indices = self.arange_np[:num_reqs]
+        else:
+            req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens)
 
         # cu_num_tokens: [2, 5, 3] -> [2, 7, 10]
         # arange: [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Skip the `np.repeat` call for `req_indices` in `_prepare_inputs` when all scheduled requests are single-token decodes (i.e., `total_num_scheduled_tokens == num_reqs`).

In this case, `np.repeat(arange[:N], [1,1,...,1])` is mathematically equivalent to `arange[:N]` but performs an unnecessary heap allocation and memory copy. The fast path returns a zero-copy slice of the pre-allocated `self.arange_np` instead.

This condition is true on every pure-decode step, which is the dominant steady-state of continuous batching.

## Test Plan

Performance was measured with the following microbenchmark:

```python
import numpy as np
import timeit

N = 256  # concurrent decode requests
arange_np = np.arange(4096, dtype=np.int64)
num_scheduled_tokens = np.ones(N, dtype=np.int64)
total_num_scheduled_tokens = N
LOOPS = 100_000

old = timeit.timeit(
    lambda: np.repeat(arange_np[:N], num_scheduled_tokens),
    number=LOOPS,
)

def new_path():
    if total_num_scheduled_tokens == N:
        return arange_np[:N]
    return np.repeat(arange_np[:N], num_scheduled_tokens)

new = timeit.timeit(new_path, number=LOOPS)

print(f"OLD: {old/LOOPS*1e6:.2f} µs")
print(f"NEW: {new/LOOPS*1e6:.2f} µs")
```
---

## Test Result

| Path                        | Time per call      |
|-----------------------------|--------------------|
| Before (always `np.repeat`) | 1.44 µs           |
| After (fast-path slice)     | 0.14 µs           |
| **Saving**                  | **1.30 µs per decode step (~10x for this op)** |

`_prepare_inputs` runs on every decode step, so this directly reduces per-step CPU overhead on the hot path.

The correctness condition `total_num_scheduled_tokens == num_reqs` already existed in the same function


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
