### PR TITLE
[Qwen3] Fix truncated reasoning extraction in parser

### DIFF
--- a/tests/reasoning/test_issue_35221.py
+++ b/tests/reasoning/test_issue_35221.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from transformers import AutoTokenizer
+
+from tests.reasoning.utils import run_reasoning_extraction_streaming
+from vllm.reasoning import ReasoningParserManager
+
+# Issue #35221: When max_tokens is hit, the model output is truncated.
+# If this happens inside a reasoning block, the parser should still
+# identify the emitted tokens as reasoning, not content.
+TRUNCATED_REASONING_CASE = [
+    pytest.param(
+        # Simulates a stream where <think> was in the prompt (Qwen3.5 style),
+        # so we just see reasoning text, but it gets cut off without </think>.
+        ["This is some reasoning", " that gets truncated"],
+        "This is some reasoning that gets truncated",
+        None, # Should NOT be content
+        id="truncated_reasoning_no_end_tag",
+    ),
+    pytest.param(
+        # Simulates old style where <think> is generated, then truncated.
+        ["<think>", "This is reasoning", " truncated"],
+        "This is reasoning truncated",
+        None,
+        id="truncated_reasoning_with_start_tag",
+    )
+]
+
+@pytest.mark.parametrize(
+    "deltas, expected_reasoning, expected_content", TRUNCATED_REASONING_CASE
+)
+def test_qwen3_reasoning_truncation(
+    deltas, expected_reasoning, expected_content
+):
+    model_name = "Qwen/Qwen3-0.6B" # Or any Qwen3 model
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+    except Exception:
+        pytest.skip(f"Skipping test, could not load tokenizer for {model_name}")
+
+    parser_cls = ReasoningParserManager.get_reasoning_parser("qwen3")
+    parser = parser_cls(tokenizer)
+
+    reconstructor = run_reasoning_extraction_streaming(parser, deltas)
+
+    assert reconstructor.reasoning == expected_reasoning
+    # This assertion fails if the parser defaults to content when no tags are seen
+    assert (reconstructor.other_content or None) == expected_content

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -114,6 +114,12 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         prompt_is_reasoning_end and routes deltas as content without
         calling this method.
         """
+        # If thinking is disabled, we should treat everything as content.
+        # But per docstring, serving layer might skip this. If we get here
+        # and thinking is disabled, we must return content.
+        if not self.thinking_enabled:
+            return DeltaMessage(content=delta_text)
+
         # Strip <think> from delta if present (old template / edge case
         # where the model generates <think> itself).
         if self.start_token_id in delta_token_ids:


### PR DESCRIPTION
If the model output is truncated (e.g. by max_tokens) while in a reasoning block (i.e. <think> started but no </think> encountered), the parser should treat the truncated content as reasoning instead of falling back to content.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

