### PR TITLE
[ROCm] Fix build issues with cub:: namespace and missing headers

### DIFF
--- a/csrc/moe/moeTopKFuncs.cuh
+++ b/csrc/moe/moeTopKFuncs.cuh
@@ -21,7 +21,7 @@
 
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
-#include <cub/cub.cuh>
+#include "../cub_helpers.h"
 
 namespace vllm {
 namespace moe {

--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -1,7 +1,7 @@
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
-#include <cub/cub.cuh>
+#include "../cub_helpers.h"
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/Atomic.cuh>

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
@@ -5,9 +5,7 @@
 #include <c10/core/ScalarType.h>
 #include <torch/all.h>
 #include "dispatch.h"
-#include <cub/cub.cuh>
-#include <cub/device/device_radix_sort.cuh>
-#include <cub/util_type.cuh>
+#include "../../cub_helpers.h"
 #include "cutlass/numeric_size.h"
 #include "cutlass/array.h"
 

--- a/csrc/sampler.cu
+++ b/csrc/sampler.cu
@@ -4,11 +4,7 @@
 #include <torch/cuda.h>
 #include <c10/cuda/CUDAGuard.h>
 
-#ifndef USE_ROCM
-  #include <cub/cub.cuh>
-#else
-  #include <hipcub/hipcub.hpp>
-#endif
+#include "cub_helpers.h"
 
 namespace vllm {
 


### PR DESCRIPTION
This commit fixes build issues on ROCm platform by replacing manual includes of `cub/cub.cuh` with `cub_helpers.h`. `cub_helpers.h` correctly handles the `hipcub` namespace aliasing and includes necessary headers for HIP.

Affected files:
- `csrc/sampler.cu`: Replaced manual `#ifndef USE_ROCM` block.
- `csrc/moe/moe_align_sum_kernels.cu`: Replaced `#include <cub/cub.cuh>`.
- `csrc/moe/moeTopKFuncs.cuh`: Replaced `#include <cub/cub.cuh>`.
- `csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h`: Replaced `cub` includes.

Fixes #36865

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

