### PR TITLE
[CI] Fix mypy error with json field name

### DIFF
--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -67,7 +67,9 @@ class ToolParser:
             if isinstance(request, ChatCompletionRequest):
                 # tool_choice: "Forced Function" or "required" will override
                 # structured output json settings to make tool calling work correctly
-                request.structured_outputs = StructuredOutputsParams(
+                request.structured_outputs = StructuredOutputsParams(  # type: ignore[call-arg]
+                    # TODO: Look to change field from json to json_schema
+                    # to avoid conflicts
                     json=json_schema_from_tool
                 )
                 request.response_format = None


### PR DESCRIPTION
## Purpose

Error as follows:

```bash
Run mypy locally for lowest supported Python version................................................Failed
- hook id: mypy-local
- exit code: 1

$ mypy --python-version 3.10 --follow-imports skip

vllm/tool_parsers/abstract_tool_parser.py:70: error: Unexpected keyword argument "json" for "StructuredOutputsParams"  [call-arg]

/Users/mhickey/.cache/pre-commit/repo7ba2kc0l/py_env-python3/lib/python3.12/site-packages/mypy/typeshed/stdlib/builtins.pyi:117: note: "StructuredOutputsParams" defined here Found 1 error in 1 file (checked 741 source files)
```
