### PR TITLE
[Fix] Fix `--headless` mode with openai.api_server

### DIFF
--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -148,7 +148,7 @@ def cmd_init() -> list[CLISubcommand]:
 
 
 def run_headless(args: argparse.Namespace):
-    if args.api_server_count > 1:
+    if args.api_server_count is not None and args.api_server_count > 1:
         raise ValueError("api_server_count can't be set in headless mode")
 
     # Create the EngineConfig.

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -714,9 +714,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     validate_parsed_serve_args(args)
 
-    if args.headless or (
-        args.api_server_count is not None and args.api_server_count < 1
-    ):
+    if args.headless or (args.api_server_count is None or args.api_server_count < 1):
         run_headless(args)
 
     else:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -714,7 +714,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     validate_parsed_serve_args(args)
 
-    if args.headless or args.api_server_count < 1:
+    if args.headless or (
+        args.api_server_count is not None and args.api_server_count < 1
+    ):
         run_headless(args)
 
     else:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -704,6 +704,8 @@ if __name__ == "__main__":
     # NOTE(simon):
     # This section should be in sync with vllm/entrypoints/cli/main.py for CLI
     # entrypoints.
+    from vllm.entrypoints.cli.serve import run_headless
+
     cli_env_setup()
     parser = FlexibleArgumentParser(
         description="vLLM OpenAI-Compatible RESTful API server."
@@ -712,4 +714,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     validate_parsed_serve_args(args)
 
-    uvloop.run(run_server(args))
+    if args.headless or args.api_server_count < 1:
+        run_headless(args)
+
+    else:
+        uvloop.run(run_server(args))


### PR DESCRIPTION
## Purpose
When doing multi-node deployment with the multiprocessing backend (--distributed-executor-backend mp), the follower node fails with:
```
AssertionError: collective_rpc should not be called on follower node
```

Also mentioned in: https://github.com/vllm-project/vllm/issues/33910


When running vLLM via `python -m vllm.entrypoints.openai.api_server` (as in the vllm-openai docker image) with `--headless`, always calls `run_server()` without checking the `--headless` flag.

This is different from `vllm serve`, which properly checks this arg and routes to `run_headless()`.
As a result, the follower node (node_rank > 0) incorrectly:
- Goes through the normal API server initialization path
- Creates a full EngineCore with scheduler
- Tries to call collective_rpc() to initialize KV caches
- Fails because `rpc_broadcast_mq` is `None` on follower nodes (only the leader node initializes it).

## Test Plan
Multi-node PP=2 setup with 2 nodes:

Leader (node 0):
```
python3 -m vllm.entrypoints.openai.api_server \ 
    --distributed-executor-backend mp \
    --pipeline-parallel-size 2 \
    --nnodes 2 \
    --node-rank 0 \
    --master-addr $MASTER_IP_ADDR
```

Worker (node 1):
```
python3 -m vllm.entrypoints.openai.api_server \
    --distributed-executor-backend mp \
    --pipeline-parallel-size 2 \
    --nnodes 2 \
    --node-rank 1 \
    --master-addr $MASTER_IP_ADDR \
    --headless
```

Server starts without error with the fix.