### PR TITLE
[Bugfix] Fix FlashInfer GDN warmup ValueError on SM90 GPUs

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -135,7 +135,7 @@ def fi_chunk_gated_delta_rule(
     fi_state = initial_state.to(torch.float32)
     fi_g = g.to(torch.float32)
     fi_beta = beta.to(torch.float32)
-    output, final_state = chunk_gated_delta_rule_fi(
+    result = chunk_gated_delta_rule_fi(
         q=q,
         k=k,
         v=v,
@@ -145,8 +145,14 @@ def fi_chunk_gated_delta_rule(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
     )
+    # FlashInfer returns (output, state) when output_final_state=True,
+    # or just output when output_final_state=False.
     # Unsqueeze back to 4D (1, L, H, D) to match fla output format
-    return output.unsqueeze(0), final_state
+    if output_final_state:
+        output, final_state = result
+        return output.unsqueeze(0), final_state
+    else:
+        return result.unsqueeze(0), None
 
 
 @CustomOp.register("chunk_gated_delta_rule")


### PR DESCRIPTION
## Summary
- PR #36599 added Triton autotuner warmup for GDN layers during V1 profiling, which also exercises the FlashInfer path on SM90 GPUs
- FlashInfer's `chunk_gated_delta_rule` returns a single tensor when `output_final_state=False`, but `fi_chunk_gated_delta_rule` always unpacked two values, causing a `ValueError`
- Fix: handle the return value based on `output_final_state` — unpack the tuple when `True`, use the single tensor when `False`

## Error before fix

```
WARNING 03-12 10:34:06 [qwen3_next.py:724] GDN prefill kernel warmup (T=16) failed for layer model.layers.0.linear_attn. First inference may OOM due to autotuner.
WARNING 03-12 10:34:06 [qwen3_next.py:724] Traceback (most recent call last):
WARNING 03-12 10:34:06 [qwen3_next.py:724]   File "/workspace/vllm/vllm/model_executor/models/qwen3_next.py", line 712, in _warmup_prefill_kernels
WARNING 03-12 10:34:06 [qwen3_next.py:724]     self.chunk_gated_delta_rule(
WARNING 03-12 10:34:06 [qwen3_next.py:724]   File "/workspace/vllm/vllm/model_executor/models/qwen3_next.py", line 176, in forward_cuda
WARNING 03-12 10:34:06 [qwen3_next.py:724]     return fi_chunk_gated_delta_rule(
WARNING 03-12 10:34:06 [qwen3_next.py:724]   File "/workspace/vllm/vllm/model_executor/models/qwen3_next.py", line 138, in fi_chunk_gated_delta_rule
WARNING 03-12 10:34:06 [qwen3_next.py:724]     output, final_state = chunk_gated_delta_rule_fi(
WARNING 03-12 10:34:06 [qwen3_next.py:724] ValueError: too many values to unpack (expected 2)
```

This error repeats for T=16, T=32, and T=64 for each GDN layer.

## Test plan
- [x] Ran `tests/v1/e2e/test_mamba_prefix_cache.py::test_mamba_prefix_cache` on H100 (SM90) with all caches cleared — passes without the `ValueError` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
