### PR TITLE
Add `AGENTS.md`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,11 +189,9 @@ cython_debug/
 .vscode/
 
 # Claude
-CLAUDE.md
 .claude/
 
 # Codex
-AGENTS.md
 .codex/
 
 # Cursor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
   - id: markdownlint-cli2
     language_version: lts
     args: [--fix]
+    exclude: ^CLAUDE\.md$
 - repo: https://github.com/rhysd/actionlint
   rev: v1.7.7
   hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# Agent Instructions for vLLM
+
+> These instructions apply to **all** AI-assisted contributions to `vllm-project/vllm`.
+> Breaching these guidelines can result in automatic banning.
+
+## 1. Contribution Policy (Mandatory)
+
+### Coordination before coding
+
+- If work maps to an existing issue, coordinate on that issue before opening a PR.
+- Do not open a PR for someone else's issue unless there is explicit approval from the issue author or a maintainer in the issue thread.
+- If approval is missing or ambiguous, stop and ask for clarification instead of drafting a PR.
+
+### Duplicate-work checks
+
+Before proposing a PR, run these checks:
+
+```bash
+gh issue view <issue_number> --repo vllm-project/vllm --comments
+gh pr list --repo vllm-project/vllm --state open --search "<issue_number> in:body"
+gh pr list --repo vllm-project/vllm --state open --search "<short area keywords>"
+```
+
+- If an open PR already addresses the same fix, do not open another.
+- If your approach is materially different, explain the difference in the issue.
+
+### No low-value busywork PRs
+
+Do not open one-off PRs for tiny edits (single typo, isolated lint fix, one mutable default, etc.). Mechanical cleanups are acceptable only when bundled with substantive work.
+
+### Accountability
+
+- Pure code-agent PRs are **not allowed**. A human submitter must understand and defend the change end-to-end.
+- The submitting human must review every changed line and run relevant tests.
+- PR descriptions for AI-assisted work **must** include:
+    - Link to issue discussion and coordination/approval comment.
+    - Why this is not duplicating an existing PR.
+    - Test commands run and results.
+    - Clear statement that AI assistance was used.
+
+### Fail-closed behavior
+
+If coordination evidence is missing, or work is duplicate/trivial busywork, **do not proceed**. Return a short explanation of what is missing.
+
+---
+
+## 2. Development Workflow
+
+### Engironment setup
+
+```bash
+# Always use `uv` for Python environment management:
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv venv
+source .venv/bin/activate
+
+# Always install `pre-commit` and its hooks:
+uv pip install pre-commit
+pre-commit install
+```
+
+### Installing dependencies
+
+```bash
+# If you are only making Python changes:
+VLLM_USE_PRECOMPILED=1 uv pip install -e .
+
+# If you are also making C/C++ changes:
+uv pip install -e .
+```
+
+### Running linters
+
+```bash
+# Run all pre-commit hooks on staged files:
+pre-commit run
+
+# Run on all files:
+pre-commit run --all-files
+
+# Run a specific hook:
+pre-commit run ruff-check --all-files
+
+# Run mypy as it is in CI:
+pre-commit run mypy-3.10 --all-files --hook-stage manual
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,14 +27,13 @@ Do not open one-off PRs for tiny edits (single typo, isolated lint fix, one muta
 - Pure code-agent PRs are **not allowed**. A human submitter must understand and defend the change end-to-end.
 - The submitting human must review every changed line and run relevant tests.
 - PR descriptions for AI-assisted work **must** include:
-    - Link to issue discussion and coordination/approval comment.
     - Why this is not duplicating an existing PR.
     - Test commands run and results.
     - Clear statement that AI assistance was used.
 
 ### Fail-closed behavior
 
-If coordination evidence is missing, or work is duplicate/trivial busywork, **do not proceed**. Return a short explanation of what is missing.
+If work is duplicate/trivial busywork, **do not proceed**. Return a short explanation of what is missing.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,9 @@ VLLM_USE_PRECOMPILED=1 uv pip install -e .
 
 # If you are also making C/C++ changes:
 uv pip install -e .
+
+# If you need to match the CI environment:
+uv pip install -r requirements/text.txt
 ```
 
 ### Running linters

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,17 +62,21 @@ VLLM_USE_PRECOMPILED=1 uv pip install -e .
 
 # If you are also making C/C++ changes:
 uv pip install -e .
-
-# If you need to run tests:
-uv pip install pytest tblib
-
-# If you need to match the CI environment:
-uv pip install -r requirements/text.txt
 ```
 
 ### Running tests
 
+Tests require extra dependencies.
+All versions for test dependencies should be read from `requirements/test.txt`
+
 ```bash
+# Install bare minimum test dependencies:
+uv pip install pytest==<requirements/test.txt version>
+uv pip install tblib==<requirements/test.txt version>
+
+# Install additional required dependencies from `requirements/test.txt` as needed:
+uv pip install <requirements/test.txt dependency>==<requirements/test.txt version>
+
 # Run specific test from specific test file
 pytest tests/path/to/test.py -v -s -k test_name
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,16 @@ pre-commit run ruff-check --all-files
 # Run mypy as it is in CI:
 pre-commit run mypy-3.10 --all-files --hook-stage manual
 ```
+
+### Commit messages
+
+Add attribution using commit trailers such as `Co-authored-by:` (other projects use `Assisted-by:` or `Generated-by:`). For example:
+
+```text
+Your commit message here
+
+Co-authored-by: GitHub Copilot
+Co-authored-by: Claude
+Co-authored-by: gemini-code-assist
+Signed-off-by: Your Name <your.email@example.com>
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ If coordination evidence is missing, or work is duplicate/trivial busywork, **do
 
 ## 2. Development Workflow
 
-### Engironment setup
+### Environment setup
 
 ```bash
 # Always use `uv` for Python environment management:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,16 @@ uv pip install -e .
 uv pip install -r requirements/text.txt
 ```
 
+### Running tests
+
+```bash
+# Run specific test from specific test file
+pytest tests/path/to/test.py -v -s -k test_name
+
+# Run all tests in directory
+pytest tests/path/to/dir -v -s
+```
+
 ### Running linters
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,6 @@
 
 ## 1. Contribution Policy (Mandatory)
 
-### Coordination before coding
-
-- If work maps to an existing issue, coordinate on that issue before opening a PR.
-- Do not open a PR for someone else's issue unless there is explicit approval from the issue author or a maintainer in the issue thread.
-- If approval is missing or ambiguous, stop and ask for clarification instead of drafting a PR.
-
 ### Duplicate-work checks
 
 Before proposing a PR, run these checks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,14 @@ If work is duplicate/trivial busywork, **do not proceed**. Return a short explan
 ### Environment setup
 
 ```bash
-# Always use `uv` for Python environment management:
+# Install uv if you don't have it already:
 curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Always use `uv` for Python environment management:
 uv venv
 source .venv/bin/activate
 
-# Always install `pre-commit` and its hooks:
+# Always make sure `pre-commit` and its hooks are installed:
 uv pip install pre-commit
 pre-commit install
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ If work is duplicate/trivial busywork, **do not proceed**. Return a short explan
 ### Environment setup
 
 ```bash
-# Install uv if you don't have it already:
+# Install `uv` if you don't have it already:
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Always use `uv` for Python environment management:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ gh pr list --repo vllm-project/vllm --state open --search "<short area keywords>
 
 ### No low-value busywork PRs
 
-Do not open one-off PRs for tiny edits (single typo, isolated lint fix, one mutable default, etc.). Mechanical cleanups are acceptable only when bundled with substantive work.
+Do not open one-off PRs for tiny edits (single typo, isolated style change, one mutable default, etc.). Mechanical cleanups are acceptable only when bundled with substantive work.
 
 ### Accountability
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,9 @@ VLLM_USE_PRECOMPILED=1 uv pip install -e .
 # If you are also making C/C++ changes:
 uv pip install -e .
 
+# If you need to run tests:
+uv pip install pytest tblib
+
 # If you need to match the CI environment:
 uv pip install -r requirements/text.txt
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-/home/harry/.claude/project-configs/vllm/CLAUDE.md
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/harry/.claude/project-configs/vllm/CLAUDE.md

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -189,6 +189,12 @@ Using `-s` with `git commit` will automatically add this header.
 
 ### AI Assisted Contributions
 
+Before making an AI assisted contribution, you must:
+
+1. **Be involved**: Do not submit "pure agent" PRs. The human submitter is responsible for reviewing all changed lines, validating behavior end-to-end, and running relevant tests.
+2. **Ensure significance**: Avoid one-off "busywork" PRs (single typo, isolated style cleanup, one mutable default fix, etc.). Bundle mechanical cleanups into a clear, systematic scope.
+3. **Get permission**: Coordinate on issues before opening a PRs, review similar PRs, and wait for approval.
+
 When AI tools provide non-trivial assistance in generating or modifying code, you must:
 
 1. **Review thoroughly**: You remain responsible for all code you submit. Review and understand AI-generated code with the same care as code you write manually.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -193,7 +193,7 @@ Before making an AI assisted contribution, you must:
 
 1. **Be involved**: Do not submit "pure agent" PRs. The human submitter is responsible for reviewing all changed lines, validating behavior end-to-end, and running relevant tests.
 2. **Ensure significance**: Avoid one-off "busywork" PRs (single typo, isolated style cleanup, one mutable default fix, etc.). Bundle mechanical cleanups into a clear, systematic scope.
-3. **Get permission**: Coordinate on issues before opening a PRs, review similar PRs, and wait for approval.
+3. **Get permission**: Coordinate on issues before opening PRs, review similar PRs, and wait for approval.
 
 When AI tools provide non-trivial assistance in generating or modifying code, you must:
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -193,7 +193,6 @@ Before making an AI assisted contribution, you must:
 
 1. **Be involved**: Do not submit "pure agent" PRs. The human submitter is responsible for reviewing all changed lines, validating behavior end-to-end, and running relevant tests.
 2. **Ensure significance**: Avoid one-off "busywork" PRs (single typo, isolated style cleanup, one mutable default fix, etc.). Bundle mechanical cleanups into a clear, systematic scope.
-3. **Get permission**: Coordinate on issues before opening PRs, review similar PRs, and wait for approval.
 
 When AI tools provide non-trivial assistance in generating or modifying code, you must:
 

--- a/docs/governance/process.md
+++ b/docs/governance/process.md
@@ -144,7 +144,7 @@ All AI-assisted contributions must meet the same quality, testing, and review st
 - Do not submit "pure agent" PRs. The human submitter is responsible for reviewing all changed lines, validating behavior end-to-end, and running relevant tests.
 - Attribution preserves legal clarity and community trust. Contributors must disclose AI assistance in pull requests and mark commits with appropriate trailers (e.g. `Co-authored-by:`).
 - Avoid one-off "busywork" PRs (single typo, isolated style cleanup, one mutable default fix, etc.). Bundle mechanical cleanups into a clear, systematic scope.
-- Coordinate on issues before opening a PRs, review similar PRs, and wait for approval.
+- Coordinate on issues before opening PRs, review similar PRs, and wait for approval.
 
 !!! warning
     These topics are outlined for agents in `AGENTS.MD` with instruction for how to autonomously implement them.

--- a/docs/governance/process.md
+++ b/docs/governance/process.md
@@ -147,7 +147,7 @@ All AI-assisted contributions must meet the same quality, testing, and review st
 - Coordinate on issues before opening PRs, review similar PRs, and wait for approval.
 
 !!! warning
-    These topics are outlined for agents in `AGENTS.MD` with instruction for how to autonomously implement them.
+    These topics are outlined for agents in [AGENTS.md](../../AGENTS.md) with instructions for how to autonomously implement them.
 
 ### Slack
 

--- a/docs/governance/process.md
+++ b/docs/governance/process.md
@@ -144,7 +144,6 @@ All AI-assisted contributions must meet the same quality, testing, and review st
 - Do not submit "pure agent" PRs. The human submitter is responsible for reviewing all changed lines, validating behavior end-to-end, and running relevant tests.
 - Attribution preserves legal clarity and community trust. Contributors must disclose AI assistance in pull requests and mark commits with appropriate trailers (e.g. `Co-authored-by:`).
 - Avoid one-off "busywork" PRs (single typo, isolated style cleanup, one mutable default fix, etc.). Bundle mechanical cleanups into a clear, systematic scope.
-- Coordinate on issues before opening PRs, review similar PRs, and wait for approval.
 
 !!! warning
     These topics are outlined for agents in [AGENTS.md](../../AGENTS.md) with instructions for how to autonomously implement them.

--- a/docs/governance/process.md
+++ b/docs/governance/process.md
@@ -139,9 +139,15 @@ In case where CI didn't pass due to the failure is not related to the PR, the PR
 
 AI tools can accelerate development, but contributors remain fully responsible for all code they submit. Like the Developer Certificate of Origin, this policy centers on accountability: contributors must believe they have the right to submit their contribution under vLLM's open source license, regardless of how the code was created.
 
-All AI-assisted contributions must meet the same quality, testing, and review standards as any other code. Contributors must review and understand AI-generated code before submission—just make sure it is good code.
+All AI-assisted contributions must meet the same quality, testing, and review standards as any other code. Contributors must review and understand AI-generated code before submission—just make sure it is good code:
 
-Attribution preserves legal clarity and community trust. Contributors must disclose AI assistance in pull requests and mark commits with appropriate trailers (e.g. `Co-authored-by:`).
+- Do not submit "pure agent" PRs. The human submitter is responsible for reviewing all changed lines, validating behavior end-to-end, and running relevant tests.
+- Attribution preserves legal clarity and community trust. Contributors must disclose AI assistance in pull requests and mark commits with appropriate trailers (e.g. `Co-authored-by:`).
+- Avoid one-off "busywork" PRs (single typo, isolated style cleanup, one mutable default fix, etc.). Bundle mechanical cleanups into a clear, systematic scope.
+- Coordinate on issues before opening a PRs, review similar PRs, and wait for approval.
+
+!!! warning
+    These topics are outlined for agents in `AGENTS.MD` with instruction for how to autonomously implement them.
 
 ### Slack
 


### PR DESCRIPTION
This PR adds to the AI-assisted contribution policy and adds an `AGENTS.md` file to help the maintainers manage AI contributions. It was heavily inspired by https://github.com/huggingface/transformers/pull/44411.

The main goals of the changes are:

- Dissuade agent-only contributions. Contributions must have a human in the loop who understands what they are contributing
- Reduce unwanted duplicate PRs created by agents where a PR already exists
- Reduce unwanted low effort PRs which make trivial changes like fixing 1 typo