### PR TITLE
[CI] Fix mypy pre-commit errors on main

### DIFF
--- a/vllm/tokenizers/kimi_audio.py
+++ b/vllm/tokenizers/kimi_audio.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, overload
 
@@ -299,7 +300,9 @@ class KimiAudioTokenizer(TokenizerLike):
             tokens = self._maybe_truncate(tokens, max_length)
         return tokens
 
-    def decode(self, ids: list[int] | int, skip_special_tokens: bool = False) -> str:
+    def decode(
+        self, ids: Sequence[int] | int, skip_special_tokens: bool = False
+    ) -> str:
         """Decode token IDs to text, optionally skipping special tokens."""
         if isinstance(ids, int):
             ids = [ids]
@@ -321,7 +324,7 @@ class KimiAudioTokenizer(TokenizerLike):
         return [self._token_to_id.get(token, self._unk_token_id) for token in tokens]
 
     def convert_ids_to_tokens(
-        self, ids: list[int], skip_special_tokens: bool = False
+        self, ids: Sequence[int], skip_special_tokens: bool = False
     ) -> list[str]:
         tokens = []
         for token_id in ids:

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -68,7 +68,7 @@ class ToolParser:
                 # tool_choice: "Forced Function" or "required" will override
                 # structured output json settings to make tool calling work correctly
                 request.structured_outputs = StructuredOutputsParams(
-                    json=json_schema_from_tool
+                    json=json_schema_from_tool  # type: ignore[call-arg]
                 )
                 request.response_format = None
             if isinstance(request, ResponsesRequest):


### PR DESCRIPTION
## Summary
- Fix 3 mypy errors that surface when running `pre-commit run -a` locally on main
- `abstract_tool_parser.py`: Add `type: ignore[call-arg]` for `StructuredOutputsParams(json=...)` — this is a known limitation of `--follow-imports skip` where mypy resolves the imported class as a builtins stub with no `__init__` kwargs (matches existing pattern in [`responses/protocol.py:349-351`](https://github.com/vllm-project/vllm/blob/7f1f36bf9/vllm/entrypoints/openai/responses/protocol.py#L349-L351), added in #34739)
- `kimi_audio.py`: Widen parameter types from `list[int]` to `Sequence[int]` for `decode()` and `convert_ids_to_tokens()` to satisfy the `TokenizerLike` protocol (Liskov substitution principle)

## Test plan
- [x] `pre-commit run -a` passes all hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
