### PR TITLE
[Frontend] Improve error message when tool_choice=required hits max_tokens

### DIFF
--- a/tests/tool_use/test_tool_choice_required.py
+++ b/tests/tool_use/test_tool_choice_required.py
@@ -361,3 +361,23 @@ def test_streaming_output_valid_with_trailing_extra_data():
         previous_text = current_text
 
     assert len(messages) > 0
+
+
+def test_parse_tool_calls_incomplete_json_gives_clear_error():
+    """When tool_choice='required' and content is incomplete JSON
+    (e.g. model hit max_tokens), the error message should be
+    actionable rather than a cryptic JSON parse error."""
+    from vllm.entrypoints.openai.engine.serving import OpenAIServing
+
+    incomplete_json = '[{"name": "get_current_weather", "parameters": {"city":'
+    request = MagicMock()
+    request.tool_choice = "required"
+
+    with pytest.raises(ValueError, match="max token limit"):
+        OpenAIServing._parse_tool_calls_from_content(
+            request=request,
+            tokenizer=None,
+            content=incomplete_json,
+            enable_auto_tools=False,
+            tool_parser_cls=None,
+        )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1451,6 +1451,21 @@ class OpenAIServingChat(OpenAIServing):
                 content = output.text
 
             auto_tools_called = False
+
+            # Early check: if tool_choice="required" but the model hit
+            # the max token limit, give a clear error instead of a
+            # cryptic JSON parse failure.
+            if (request.tool_choice == "required"
+                    and output.finish_reason == "length"):
+                raise ValueError(
+                    "Model reached the max token limit "
+                    "(finish_reason='length') before generating "
+                    "complete tool calls, but tool_choice='required' "
+                    "demands valid tool calls. Please increase "
+                    "`max_tokens` to allow the model to finish "
+                    "generating the tool call."
+                )
+
             # if auto tools are not enabled, and a named tool choice using
             #   outlines is not being used
             tool_calls, content = self._parse_tool_calls_from_content(

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -13,7 +13,7 @@ from fastapi import Request
 from openai.types.responses import (
     ToolChoiceFunction,
 )
-from pydantic import ConfigDict, TypeAdapter
+from pydantic import ConfigDict, TypeAdapter, ValidationError
 from starlette.datastructures import Headers
 
 import vllm.envs as envs
@@ -1126,7 +1126,19 @@ class OpenAIServing:
             content = None  # Clear content since tool is called.
         elif request.tool_choice == "required":
             assert content is not None
-            tool_calls = TypeAdapter(list[FunctionDefinition]).validate_json(content)
+            try:
+                tool_calls = TypeAdapter(
+                    list[FunctionDefinition]).validate_json(content)
+            except ValidationError as e:
+                raise ValueError(
+                    "When tool_choice='required', the model must produce "
+                    "valid JSON tool calls, but the generated content "
+                    "could not be parsed. This can happen when the model "
+                    "hits the max token limit (finish_reason='length') "
+                    "before completing the tool call. Consider increasing "
+                    "`max_tokens` to allow the model to finish generating "
+                    "the tool call."
+                ) from e
             function_calls.extend(
                 [
                     FunctionCall(


### PR DESCRIPTION
## Summary

- When `tool_choice='required'` is set and the model exhausts `max_tokens` before producing a complete tool call, users previously received a cryptic JSON parse error (`Invalid JSON: EOF while parsing a string`). This PR adds clear, actionable error messages that guide users to increase `max_tokens`.
- Added an early check in `chat_completion_full_generator()` that detects `finish_reason='length'` with `tool_choice='required'` and raises a descriptive error before attempting JSON parsing.
- Wrapped `validate_json()` in `_parse_tool_calls_from_content()` with a try-except to provide a helpful error message as a fallback.

Fixes #36794

## Test plan

- [ ] Added unit test `test_parse_tool_calls_incomplete_json_gives_clear_error` verifying the improved error message
- [ ] Existing tool_choice=required tests continue to pass
- [ ] Manual verification: set `tool_choice="required"` with a low `max_tokens` and confirm the new error message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)