### PR TITLE
fix(serving): add bounds check for prev_tool_call_arr in streaming tool calls

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1177,6 +1177,8 @@ class OpenAIServingChat(OpenAIServing):
                                 delta_message, output
                             )
                             and tool_parser
+                            and index < len(tool_parser.prev_tool_call_arr)
+                            and index < len(tool_parser.streamed_args_for_tool)
                         ):
                             latest_delta_len = 0
                             if (


### PR DESCRIPTION
## Summary
- Adds bounds checks for `tool_parser.prev_tool_call_arr` and `tool_parser.streamed_args_for_tool` before accessing them by index in the streaming chat completion generator
- When using `/v1/chat/completions` with streaming + `tool_call_parser=openai`, the stream generator crashes with `IndexError: list index out of range` at `tool_parser.prev_tool_call_arr[index]` if the tool parser's `prev_tool_call_arr` is empty when the model emits tool-call-like output

## Root Cause
In `chat_completion_stream_generator`, when `output.finish_reason is not None`:
1. `auto_tools_called = len(tool_parser.prev_tool_call_arr) > 0` → `False` (empty)
2. `index = 0` (the else branch)
3. `_should_check_for_unstreamed_tool_arg_tokens` returns `True` because `delta_message.tool_calls` exists
4. `tool_parser.prev_tool_call_arr[0]` → **IndexError**

## Fix
Add `index < len(tool_parser.prev_tool_call_arr)` and `index < len(tool_parser.streamed_args_for_tool)` to the guard condition, so the unstreamed-args recovery block is skipped when the arrays are empty.

Fixes #36849