### PR TITLE
[Tool Parser] Kimi K2: guided decoding for tool_choice="auto" — 75% → 100% schema accuracy

### DIFF
--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -106,9 +106,7 @@ class KimiK2ToolParser(ToolParser):
                 "tokens in the tokenizer!"
             )
 
-    def adjust_request(
-        self, request: ChatCompletionRequest
-    ) -> ChatCompletionRequest:
+    def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
         request = super().adjust_request(request)
 
         if request.structured_outputs is not None:
@@ -135,22 +133,24 @@ class KimiK2ToolParser(ToolParser):
                 "type": "object",
                 "properties": {},
             }
-            tags.append({
-                "type": "tag",
-                "begin": f"<|tool_call_begin|>functions.{name}",
-                "content": {
-                    "type": "sequence",
-                    "elements": [
-                        {"type": "regex", "pattern": r":\d+"},
-                        {
-                            "type": "const_string",
-                            "value": "<|tool_call_argument_begin|>",
-                        },
-                        {"type": "json_schema", "json_schema": params},
-                    ],
-                },
-                "end": "<|tool_call_end|>",
-            })
+            tags.append(
+                {
+                    "type": "tag",
+                    "begin": f"<|tool_call_begin|>functions.{name}",
+                    "content": {
+                        "type": "sequence",
+                        "elements": [
+                            {"type": "regex", "pattern": r":\d+"},
+                            {
+                                "type": "const_string",
+                                "value": "<|tool_call_argument_begin|>",
+                            },
+                            {"type": "json_schema", "json_schema": params},
+                        ],
+                    },
+                    "end": "<|tool_call_end|>",
+                }
+            )
 
         if not tags:
             return None

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # code modified from deepseekv3_tool_parser.py
 
+import json
 from collections.abc import Sequence
 
 import regex as re
@@ -18,6 +19,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     ToolCall,
 )
 from vllm.logger import init_logger
+from vllm.sampling_params import StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import (
     ToolParser,
@@ -103,6 +105,67 @@ class KimiK2ToolParser(ToolParser):
                 "Kimi-K2 Tool parser could not locate tool call start/end "
                 "tokens in the tokenizer!"
             )
+
+    def adjust_request(
+        self, request: ChatCompletionRequest
+    ) -> ChatCompletionRequest:
+        request = super().adjust_request(request)
+
+        if request.structured_outputs is not None:
+            return request
+
+        if request.tools and request.tool_choice in ("auto", None):
+            tag_json = self._build_structural_tag(request.tools)
+            if tag_json is not None:
+                request.structured_outputs = StructuredOutputsParams(
+                    structural_tag=tag_json
+                )
+
+        if request.tools and request.tool_choice != "none":
+            request.skip_special_tokens = False
+
+        return request
+
+    def _build_structural_tag(self, tools) -> str | None:
+        """Build a structural_tag JSON from tools for guided decoding."""
+        tags = []
+        for tool in tools:
+            name = tool.function.name
+            params = tool.function.parameters or {
+                "type": "object",
+                "properties": {},
+            }
+            tags.append({
+                "type": "tag",
+                "begin": f"<|tool_call_begin|>functions.{name}",
+                "content": {
+                    "type": "sequence",
+                    "elements": [
+                        {"type": "regex", "pattern": r":\d+"},
+                        {
+                            "type": "const_string",
+                            "value": "<|tool_call_argument_begin|>",
+                        },
+                        {"type": "json_schema", "json_schema": params},
+                    ],
+                },
+                "end": "<|tool_call_end|>",
+            })
+
+        if not tags:
+            return None
+
+        structural_tag = {
+            "type": "structural_tag",
+            "format": {
+                "type": "triggered_tags",
+                "triggers": ["<|tool_call_begin|>"],
+                "tags": tags,
+                "at_least_one": False,
+                "stop_after_first": False,
+            },
+        }
+        return json.dumps(structural_tag)
 
     def _check_and_strip_markers(self, text: str) -> tuple[str, bool, bool]:
         """


### PR DESCRIPTION
Co-authored with @Yzong-rh

## Purpose
The Kimi K2 tool parser currently relies on post-hoc parsing for `tool_choice="auto"` — the model generates freely and vLLM extracts tool calls afterward. This works most of the time, but the model can hallucinate tool names not in the user's schema (e.g., calling `img_gen` when only `search` is available), causing schema validation failures.

This PR adds generation-time enforcement via xgrammar's structural tag mechanism, ensuring that once the model decides to make a tool call, it can only produce tool names and arguments that conform to the provided schema. This is the first tool parser in vLLM to use guided decoding for `tool_choice="auto"`.

For background on Kimi K2 tool calling on vLLM, see: [Chasing 100% Accuracy: A Deep Dive into Debugging Kimi K2's Tool-Calling on vLLM](https://blog.vllm.ai/2025/10/28/Kimi-K2-Accuracy.html).

**Key benefits:**
- **100% schema accuracy** on the [K2-Vendor-Verifier](https://github.com/MoonshotAI/K2-Vendor-Verifier) benchmark (up from 75.4%), eliminating all tool name hallucination
- **Zero overhead for non-tool-call tokens** — the grammar only activates after the `<|tool_call_begin|>` trigger, so free-text generation is unconstrained
- **Composable with existing behavior** — `tool_choice="required"` and forced function still use the base class JSON schema path; this only fills the gap for `"auto"`
- **Generalizable pattern** — the same `TriggeredTagsFormat` approach can be applied to other tool parsers (hermes, jamba, etc.) that suffer from similar hallucination issues

## Summary

- This is the first tool parser in vLLM to apply guided decoding for `tool_choice="auto"`, and the approach generalizes to other parsers
- Add xgrammar structural tag guided decoding to the Kimi K2 tool parser when `tool_choice` is `"auto"` or unset
- Eliminates tool name hallucination (e.g., model calling `img_gen` when only `search`/`urls_fetch_tool` are available) by constraining generation at the token level
- No change to `tool_choice="required"` or forced function behavior (handled by base class)

## Approach

Override `adjust_request()` in `KimiK2ToolParser` to build a `TriggeredTagsFormat` structural tag from the request's tool definitions:

- **Trigger**: `<|tool_call_begin|>` — free text allowed until this token
- **Per-tool tag**: `<|tool_call_begin|>{name}:\d+<|tool_call_argument_begin|>{json}<|tool_call_end|>`
- **Composable content**: `sequence` of `regex` (call ID) + `const_string` (argument marker) + `json_schema` (parameters)
- Supports multiple tool calls per response (`stop_after_first=False`)
- Respects existing `structured_outputs` if already set (e.g., by `tool_choice="required"`)

## Evaluation

K2-Vendor-Verifier benchmark, 2000 samples, `moonshotai/Kimi-K2-Instruct-0905` (revision `94a4053eb8863059dd8afc00937f054e1365abbd`):

| | Tool Calls | Schema Errors | Accuracy |
|---|---|---|---|
| Baseline (no guided decoding) | 678 | 167 | 75.4% |
| **This PR** | 677 | **0** | **100%** |

The dominant failure mode in the baseline was tool name hallucination — the model generating calls to tools not in the provided schema (e.g., `img_gen`). With structural tag enforcement, the grammar only allows tokens that match valid tool names after the `<|tool_call_begin|>` trigger.

**Reproduction:**
```bash
# Server
vllm serve moonshotai/Kimi-K2-Instruct-0905 \
  --revision 94a4053eb8863059dd8afc00937f054e1365abbd \ # changing this might results in regression, still verifying
  --tensor-parallel-size 8 --trust-remote-code \
  --enable-auto-tool-choice --tool-call-parser kimi_k2

# Eval (using K2-Vendor-Verifier)
python tool_calls_eval.py downloads/tool-calls/samples.jsonl \
  --model moonshotai/Kimi-K2-Instruct-0905 \
  --base-url http://localhost:8000/v1 --api-key dummy \
  --concurrency 8 --temperature 0.6 --max-tokens 64000 \
  --output results.jsonl --summary summary.json
```

## Caveats/Limitations

- **Performance not benchmarked** — throughput/latency overhead of structural tag guided decoding has not been measured. The grammar only constrains tokens inside tool calls (not free text), so overhead should be minimal, but this needs validation. 

## Future work
- [ ] Integrate per-function `strict` parameter for argument schema guidance (add `strict` to `FunctionDefinition` in vLLM's protocol layer first). 
- [ ] Generalize this approach to other tool parsers (hermes, jamba, etc.) that suffer from similar hallucination in `tool_choice="auto"`
- [ ] Validate `tool_choice='required'` path. 
- [ ] Benchmark throughput/latency overhead of structural tag guided decoding vs. unconstrained generation

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

