### PR TITLE
[bnb] Skip moe + bnb test

### DIFF
--- a/tests/models/quantization/test_bitsandbytes.py
+++ b/tests/models/quantization/test_bitsandbytes.py
@@ -6,10 +6,9 @@ Run `pytest tests/quantization/test_bitsandbytes.py`.
 """
 
 import pytest
-import importlib.metadata
-
-from packaging import version
+from packaging.version import Version
 from transformers import BitsAndBytesConfig
+from transformers import __version__ as TRANSFORMERS_VERSION
 
 from tests.quantization.utils import is_quant_method_supported
 from vllm.platforms import current_platform
@@ -142,10 +141,10 @@ def test_load_pp_4bit_bnb_model(model_name, description) -> None:
 
 
 @pytest.mark.skipif(
-    version.parse(importlib.metadata.version("transformers")) >= version.parse("5.0.0"),
-    reason="Need to add support for quantizing MoE experts with bnb in transformers v5. "
-    "See https://github.com/bitsandbytes-foundation/bitsandbytes/issues/1849 "
-    "and https://github.com/huggingface/transformers/issues/43472",
+    Version(TRANSFORMERS_VERSION) >= Version("5.0.0"),
+    reason="Need to add support for quantizing MoE experts with bnb"
+    " in transformers v5. See"
+    " https://github.com/bitsandbytes-foundation/bitsandbytes/issues/1849",
 )
 @pytest.mark.skipif(
     not is_quant_method_supported("bitsandbytes"),

--- a/tests/models/quantization/test_bitsandbytes.py
+++ b/tests/models/quantization/test_bitsandbytes.py
@@ -6,6 +6,9 @@ Run `pytest tests/quantization/test_bitsandbytes.py`.
 """
 
 import pytest
+import importlib.metadata
+
+from packaging import version
 from transformers import BitsAndBytesConfig
 
 from tests.quantization.utils import is_quant_method_supported
@@ -138,7 +141,12 @@ def test_load_pp_4bit_bnb_model(model_name, description) -> None:
     compare_two_settings(model_name, common_args, pp_args)
 
 
-@pytest.mark.skip(reason="Need to add support for quantizing MoE experts with bnb in transformers")
+@pytest.mark.skipif(
+    version.parse(importlib.metadata.version("transformers")) >= version.parse("5.0.0"),
+    reason="Need to add support for quantizing MoE experts with bnb in transformers v5. "
+    "See https://github.com/bitsandbytes-foundation/bitsandbytes/issues/1849 "
+    "and https://github.com/huggingface/transformers/issues/43472",
+)
 @pytest.mark.skipif(
     not is_quant_method_supported("bitsandbytes"),
     reason="bitsandbytes is not supported on this GPU type.",

--- a/tests/models/quantization/test_bitsandbytes.py
+++ b/tests/models/quantization/test_bitsandbytes.py
@@ -138,6 +138,7 @@ def test_load_pp_4bit_bnb_model(model_name, description) -> None:
     compare_two_settings(model_name, common_args, pp_args)
 
 
+@pytest.mark.skip(reason="Need to add support for quantizing MoE experts with bnb in transformers")
 @pytest.mark.skipif(
     not is_quant_method_supported("bitsandbytes"),
     reason="bitsandbytes is not supported on this GPU type.",


### PR DESCRIPTION
# What does this PR do ?

This PR skips the `test_4bit_bnb_moe_model` test because in v5, the MoE implementation changed to 3D params and our bnb integration don't support quantizing 3D params yet. So, this is might be why it is failing since the two models are not the same. Note that on H100, the test actually pass but on the CI, it's always failing. 

cc @hmellor 