### PR TITLE
[CI] Add AVX2-only CPU image build for GitHub Actions compatibility

### DIFF
--- a/.buildkite/image_build/image_build.yaml
+++ b/.buildkite/image_build/image_build.yaml
@@ -27,6 +27,20 @@ steps:
         - exit_status: -10  # Agent was lost
           limit: 2
 
+  - label: ":docker: Build CPU AVX2 image"
+    key: image-build-cpu-avx2
+    depends_on: []
+    commands:
+    - .buildkite/image_build/image_build_cpu_avx2.sh $REGISTRY $REPO $BUILDKITE_COMMIT
+    env:
+      DOCKER_BUILDKIT: "1"
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: -10  # Agent was lost
+          limit: 2
+
   - label: ":docker: Build HPU image"
     soft_fail: true
     depends_on: []

--- a/.buildkite/image_build/image_build_cpu_avx2.sh
+++ b/.buildkite/image_build/image_build_cpu_avx2.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Builds an x86_64 CPU image targeting AVX2 only (no AVX-512).
+# This image is compatible with GitHub Actions runners, which may
+# land on AMD EPYC Zen 1-3 CPUs that lack AVX-512 support.
+
+set -e
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <registry> <repo> <commit>"
+  exit 1
+fi
+
+REGISTRY=$1
+REPO=$2
+BUILDKITE_COMMIT=$3
+
+# authenticate with AWS ECR
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin "$REGISTRY"
+
+# skip build if image already exists
+if [[ -z $(docker manifest inspect "$REGISTRY"/"$REPO":"$BUILDKITE_COMMIT"-cpu-avx2) ]]; then
+  echo "Image not found, proceeding with build..."
+else
+  echo "Image found"
+  exit 0
+fi
+
+# build
+docker build --file docker/Dockerfile.cpu \
+  --build-arg max_jobs=16 \
+  --build-arg buildkite_commit="$BUILDKITE_COMMIT" \
+  --build-arg VLLM_CPU_DISABLE_AVX512=true \
+  --build-arg VLLM_CPU_AVX2=1 \
+  --tag "$REGISTRY"/"$REPO":"$BUILDKITE_COMMIT"-cpu-avx2 \
+  --target vllm-test \
+  --progress plain .
+
+# push
+docker push "$REGISTRY"/"$REPO":"$BUILDKITE_COMMIT"-cpu-avx2

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -90,6 +90,19 @@ steps:
         env:
           DOCKER_BUILDKIT: "1"
 
+      - label: "Build wheel - x86_64 - CPU AVX2"
+        depends_on: ~
+        id: build-wheel-x86-cpu-avx2
+        agents:
+          queue: cpu_queue_postmerge
+        commands:
+          - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --build-arg VLLM_CPU_DISABLE_AVX512=true --build-arg VLLM_CPU_AVX2=1 --tag vllm-ci:build-image-avx2 --target vllm-build --progress plain -f docker/Dockerfile.cpu ."
+          - "mkdir -p artifacts"
+          - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image-avx2 bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
+          - "bash .buildkite/scripts/upload-nightly-wheels.sh manylinux_2_35"
+        env:
+          DOCKER_BUILDKIT: "1"
+
   - group: "Build release Docker images"
     key: "build-release-images"
     steps:
@@ -163,7 +176,7 @@ steps:
         depends_on: ~
 
       - label: "Build release image - arm64 - CPU"
-        depends_on: 
+        depends_on:
           - block-arm64-cpu-release-image-build
           - input-release-version
         agents:
@@ -173,6 +186,24 @@ steps:
           - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --tag public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:$(buildkite-agent meta-data get release-version) --tag public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:latest --progress plain --target vllm-openai -f docker/Dockerfile.cpu ."
           - "docker push public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:latest"
           - "docker push public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:$(buildkite-agent meta-data get release-version)"
+        env:
+          DOCKER_BUILDKIT: "1"
+
+      - block: "Build release image for x86_64 CPU AVX2 (GHA-compatible)"
+        key: block-cpu-avx2-release-image-build
+        depends_on: ~
+
+      - label: "Build release image - x86_64 - CPU AVX2"
+        depends_on:
+          - block-cpu-avx2-release-image-build
+          - input-release-version
+        agents:
+          queue: cpu_queue_postmerge
+        commands:
+          - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
+          - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --build-arg VLLM_CPU_DISABLE_AVX512=true --build-arg VLLM_CPU_AVX2=1 --tag public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$(buildkite-agent meta-data get release-version)-avx2 --tag public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest-avx2 --progress plain --target vllm-openai -f docker/Dockerfile.cpu ."
+          - "docker push public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest-avx2"
+          - "docker push public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$(buildkite-agent meta-data get release-version)-avx2"
         env:
           DOCKER_BUILDKIT: "1"
 

--- a/.buildkite/scripts/annotate-release.sh
+++ b/.buildkite/scripts/annotate-release.sh
@@ -37,6 +37,7 @@ docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${BUILDKITE_COMMIT}-rocm-b
 docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${BUILDKITE_COMMIT}-rocm
 docker pull public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v${RELEASE_VERSION}
 docker pull public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:v${RELEASE_VERSION}
+docker pull public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v${RELEASE_VERSION}-avx2
 
 # Tag and push images:
 
@@ -93,6 +94,14 @@ docker tag vllm/vllm-openai-cpu:arm64 vllm/vllm-openai-cpu:latest-arm64
 docker tag vllm/vllm-openai-cpu:arm64 vllm/vllm-openai-cpu:v${RELEASE_VERSION}-arm64
 docker push vllm/vllm-openai-cpu:latest-arm64
 docker push vllm/vllm-openai-cpu:v${RELEASE_VERSION}-arm64
+
+## CPU AVX2 (GitHub Actions compatible - no AVX-512)
+
+docker tag public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v${RELEASE_VERSION}-avx2 vllm/vllm-openai-cpu:avx2
+docker tag vllm/vllm-openai-cpu:avx2 vllm/vllm-openai-cpu:latest-avx2
+docker tag vllm/vllm-openai-cpu:avx2 vllm/vllm-openai-cpu:v${RELEASE_VERSION}-avx2
+docker push vllm/vllm-openai-cpu:latest-avx2
+docker push vllm/vllm-openai-cpu:v${RELEASE_VERSION}-avx2
 
 # Create multi-arch manifest:
 


### PR DESCRIPTION
## Purpose
GitHub Actions runners use Azure VMs that may land on AMD EPYC Zen 1-3 CPUs without AVX-512 support, causing SIGILL crashes with the standard CPU image. This adds a second CPU image variant built with VLLM_CPU_DISABLE_AVX512=true and VLLM_CPU_AVX2=1, published alongside the existing CPU image without changing it.

Adds:
- CI build script and step for AVX2-only CPU image ({commit}-cpu-avx2)
- Release pipeline wheel build and image build steps (behind block approval)
- Docker Hub publish commands for vllm/vllm-openai-cpu:*-avx2 tags

Fixes #36898

## Test Plan
I've done these builds in a different PR (https://github.com/opendatahub-io/llama-stack-distribution/pull/203) but via a different methodology outside of the vLLM upstream build system - so I'm not sure if this has been done 100%, but I am happy to try and test it with whatever I can do within my control

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

