### PR TITLE
[WIP][BugFix] Fix PP OOM for Qwen3Next/Qwen3_5 by guarding embed_tokens and lm_head

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -330,10 +330,15 @@ class Qwen3_5Model(Qwen3NextModel):
 
         self.vocab_size = config.vocab_size
 
-        self.embed_tokens = VocabParallelEmbedding(
-            self.vocab_size,
-            config.hidden_size,
-        )
+        if get_pp_group().is_first_rank or (
+            config.tie_word_embeddings and get_pp_group().is_last_rank
+        ):
+            self.embed_tokens = VocabParallelEmbedding(
+                self.vocab_size,
+                config.hidden_size,
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
 
         def get_layer(prefix: str):
             return Qwen3_5DecoderLayer(

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -1124,10 +1124,15 @@ class Qwen3NextModel(nn.Module):
 
         self.vocab_size = config.vocab_size
 
-        self.embed_tokens = VocabParallelEmbedding(
-            self.vocab_size,
-            config.hidden_size,
-        )
+        if get_pp_group().is_first_rank or (
+            config.tie_word_embeddings and get_pp_group().is_last_rank
+        ):
+            self.embed_tokens = VocabParallelEmbedding(
+                self.vocab_size,
+                config.hidden_size,
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
 
         def get_layer(prefix: str):
             return Qwen3NextDecoderLayer(
@@ -1384,11 +1389,16 @@ class Qwen3NextForCausalLM(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
 
-        self.lm_head = ParallelLMHead(
-            config.vocab_size,
-            config.hidden_size,
-            prefix=maybe_prefix(prefix, "lm_head"),
-        )
+        if get_pp_group().is_last_rank:
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
+            if config.tie_word_embeddings:
+                self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)
+        else:
+            self.lm_head = PPMissingLayer()
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors


### PR DESCRIPTION
## Purpose

Fixes #36861.

When using pipeline parallelism (PP > 1), `embed_tokens` (`VocabParallelEmbedding`) is allocated on **all** PP ranks instead of only the first rank. Similarly, `Qwen3NextForCausalLM.lm_head` (`ParallelLMHead`) is allocated on all ranks instead of only the last rank. This wastes significant GPU memory (~1-1.5 GB per unnecessary layer), which on tight-memory GPUs (e.g., A10 24GB) pushes the available KV cache memory to ≤ 0, triggering:

```
ValueError: No available memory for the cache blocks.
```

This PR adds PP rank guards following the canonical pattern used by Llama and other models:

- `Qwen3NextModel.embed_tokens`: Only allocate on first rank (or last rank when `tie_word_embeddings=True`), use `PPMissingLayer()` otherwise.
- `Qwen3NextForCausalLM.lm_head`: Only allocate on last rank, use `PPMissingLayer()` otherwise.
- `Qwen3_5Model.embed_tokens`: Same guard as above.

No changes to `forward()` methods (already guarded with `is_first_rank`/`is_last_rank`), weight loading (both `AutoWeightsLoader` and `is_pp_missing_parameter()` already handle `PPMissingLayer`), or `Qwen3_5ForCausalLMBase.lm_head` (already correctly guarded).

## Test Plan

## Test Result