### PR TITLE
[WIP][BugFix] Add missing shutdown() to LMCacheConnectorV1 to fix GPU failure on repeated model loading

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
@@ -339,6 +339,13 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         """
         return self._lmcache_engine.request_finished(request, block_ids)
 
+    def shutdown(self):
+        """
+        Shutdown the connector and release all resources.
+        """
+        if hasattr(self._lmcache_engine, "shutdown"):
+            self._lmcache_engine.shutdown()
+
     def take_events(self) -> Iterable["KVCacheEvent"]:
         """
         Take the KV cache events from the connector.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -718,52 +718,24 @@ class LMCacheConnectorV1Impl:
         """Shutdown the LMCache connector and release all resources."""
         logger.info("Shutting down LMCacheConnectorV1Impl")
 
-        # Stop auxiliary services first (they may hold references to engine)
-        if api_server := getattr(self, "api_server", None):
-            try:
-                if hasattr(api_server, "stop"):
-                    api_server.stop()
-                elif hasattr(api_server, "shutdown"):
-                    api_server.shutdown()
-            except Exception:
-                logger.exception("Error stopping API server")
-
-        if plugin_launcher := getattr(self, "plugin_launcher", None):
-            try:
-                if hasattr(plugin_launcher, "stop"):
-                    plugin_launcher.stop()
-                elif hasattr(plugin_launcher, "shutdown"):
-                    plugin_launcher.shutdown()
-            except Exception:
-                logger.exception("Error stopping plugin launcher")
-
-        if offload_server := getattr(self, "offload_server", None):
-            try:
-                if hasattr(offload_server, "close"):
-                    offload_server.close()
-                elif hasattr(offload_server, "shutdown"):
-                    offload_server.shutdown()
-            except Exception:
-                logger.exception("Error closing offload server")
-
-        # Close lookup server/client
-        if lookup_server := getattr(self, "lookup_server", None):
-            try:
-                if hasattr(lookup_server, "close"):
-                    lookup_server.close()
-                elif hasattr(lookup_server, "shutdown"):
-                    lookup_server.shutdown()
-            except Exception:
-                logger.exception("Error closing lookup server")
-
-        if lookup_client := getattr(self, "lookup_client", None):
-            try:
-                if hasattr(lookup_client, "close"):
-                    lookup_client.close()
-                elif hasattr(lookup_client, "shutdown"):
-                    lookup_client.shutdown()
-            except Exception:
-                logger.exception("Error closing lookup client")
+        # Stop auxiliary services first (they may hold references to engine),
+        # then close network resources.
+        components_to_shutdown = [
+            ("api_server", ["stop", "shutdown"], "Error stopping API server"),
+            ("plugin_launcher", ["stop", "shutdown"], "Error stopping plugin launcher"),
+            ("offload_server", ["close", "shutdown"], "Error closing offload server"),
+            ("lookup_server", ["close", "shutdown"], "Error closing lookup server"),
+            ("lookup_client", ["close", "shutdown"], "Error closing lookup client"),
+        ]
+        for attr_name, methods, error_msg in components_to_shutdown:
+            if component := getattr(self, attr_name, None):
+                try:
+                    for method_name in methods:
+                        if hasattr(component, method_name):
+                            getattr(component, method_name)()
+                            break
+                except Exception:
+                    logger.exception(error_msg)
 
         # Destroy singleton builders (frees GPU buffers)
         try:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -714,6 +714,69 @@ class LMCacheConnectorV1Impl:
             getattr(self.lmcache_engine, "metadata", None),
         )
 
+    def shutdown(self):
+        """Shutdown the LMCache connector and release all resources."""
+        logger.info("Shutting down LMCacheConnectorV1Impl")
+
+        # Stop auxiliary services first (they may hold references to engine)
+        if api_server := getattr(self, "api_server", None):
+            try:
+                if hasattr(api_server, "stop"):
+                    api_server.stop()
+                elif hasattr(api_server, "shutdown"):
+                    api_server.shutdown()
+            except Exception:
+                logger.exception("Error stopping API server")
+
+        if plugin_launcher := getattr(self, "plugin_launcher", None):
+            try:
+                if hasattr(plugin_launcher, "stop"):
+                    plugin_launcher.stop()
+                elif hasattr(plugin_launcher, "shutdown"):
+                    plugin_launcher.shutdown()
+            except Exception:
+                logger.exception("Error stopping plugin launcher")
+
+        if offload_server := getattr(self, "offload_server", None):
+            try:
+                if hasattr(offload_server, "close"):
+                    offload_server.close()
+                elif hasattr(offload_server, "shutdown"):
+                    offload_server.shutdown()
+            except Exception:
+                logger.exception("Error closing offload server")
+
+        # Close lookup server/client
+        if lookup_server := getattr(self, "lookup_server", None):
+            try:
+                if hasattr(lookup_server, "close"):
+                    lookup_server.close()
+                elif hasattr(lookup_server, "shutdown"):
+                    lookup_server.shutdown()
+            except Exception:
+                logger.exception("Error closing lookup server")
+
+        if lookup_client := getattr(self, "lookup_client", None):
+            try:
+                if hasattr(lookup_client, "close"):
+                    lookup_client.close()
+                elif hasattr(lookup_client, "shutdown"):
+                    lookup_client.shutdown()
+            except Exception:
+                logger.exception("Error closing lookup client")
+
+        # Destroy singleton builders (frees GPU buffers)
+        try:
+            if getattr(self, "enable_blending", False):
+                LMCBlenderBuilder.destroy(ENGINE_NAME)
+        except Exception:
+            logger.exception("Error destroying LMCBlenderBuilder")
+
+        try:
+            LMCacheEngineBuilder.destroy(ENGINE_NAME)
+        except Exception:
+            logger.exception("Error destroying LMCacheEngine")
+
     def get_inference_info(self) -> dict:
         """Get inference information including vLLM config and related details.
 


### PR DESCRIPTION
## Purpose

Fixes #36852.

`LMCacheConnectorV1` did not override `shutdown()`, inheriting the base class no-op from `KVConnectorBase_V1`. When `GPUWorker.shutdown()` calls `ensure_kv_transfer_shutdown()`, the connector's `shutdown()` was a no-op, so none of the LMCache resources were cleaned up:

- **LMCacheEngine** (GPU buffers, CUDA state) — created via `LMCacheEngineBuilder.get_or_create()` singleton
- **GPU connectors** (CUDA memory buffers)
- **ZMQOffloadServer**, **InternalAPIServer**, **RuntimePluginLauncher**
- **Lookup server/client**

This caused `cudaErrorLaunchFailure` on the second model load because stale GPU resources from the first run corrupted GPU state.

This PR adds `shutdown()` to both `LMCacheConnectorV1` (wrapper) and `LMCacheConnectorV1Impl` (native adapter) to properly tear down all resources in the correct order:
1. Stop auxiliary services (API server, plugin launcher, offload server)
2. Close network resources (lookup server/client)
3. Destroy singleton builders via `LMCacheEngineBuilder.destroy()` and `LMCBlenderBuilder.destroy()` to free GPU buffers

Each cleanup step is wrapped in `try/except` (following the `MultiConnector.shutdown()` pattern) to ensure all resources are cleaned up even if one step fails.

Note: `LMCacheMPConnector` already had a proper `shutdown()` — this bug only affected `LMCacheConnectorV1`.

## Test Plan

Wait for @lavanyabollepalli 's input

## Test Result