### PR TITLE
Add Medusa Spec Decode e2e Test

### DIFF
--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -700,6 +700,44 @@ def test_eagle_correctness_heavy(
     )
 
 
+@single_gpu_only
+def test_medusa_correctness(
+    sampling_config: SamplingParams,
+):
+    """Test Medusa speculative decoding e2e with a tiny random model."""
+    target_model = "JackFram/llama-68m"
+    medusa_model = "abhigoyal/vllm-medusa-llama-68m-random"
+    prompts = _build_gsm8k_prompts(num_questions=5, num_shots=1)[0]
+
+    ref_llm = LLM(
+        model=target_model,
+        max_model_len=256,
+        enforce_eager=True,
+    )
+    ref_outputs = ref_llm.generate(prompts, sampling_config)
+    del ref_llm
+    torch.accelerator.empty_cache()
+    cleanup_dist_env_and_memory()
+
+    spec_llm = LLM(
+        model=target_model,
+        speculative_config={
+            "model": medusa_model,
+            "num_speculative_tokens": 3,
+        },
+        max_model_len=256,
+        enforce_eager=True,
+    )
+    spec_outputs = spec_llm.generate(prompts, sampling_config)
+    del spec_llm
+    torch.accelerator.empty_cache()
+    cleanup_dist_env_and_memory()
+
+    assert len(ref_outputs) == len(spec_outputs)
+    for ref_output, spec_output in zip(ref_outputs, spec_outputs):
+        assert ref_output.outputs[0].text == spec_output.outputs[0].text
+
+
 @pytest.mark.parametrize(
     ["model_setup", "mm_enabled", "expected_accuracy_threshold"],
     [


### PR DESCRIPTION
## Purpose

Add an e2e test for Medusa speculative decoding in v1. Medusa is the only spec decode proposer in vLLM v1 without any functional test coverage — EAGLE, EAGLE3, MTP, NGram, Suffix, Draft Model, and Hidden State Extraction all have existing e2e tests.

The Medusa code path in `gpu_model_runner.py` (lines ~4302-4327) has unique logic for hidden state extraction that is completely disjoint from the other proposers. Without a test, regressions in this path go undetected.

## Test Plan

python -m pytest tests/v1/e2e/test_spec_decode.py::test_medusa_correctness -v -s

Uses tiny models (JackFram/llama-68m + abhigoyal/vllm-medusa-llama-68m-random) already registered in tests/models/registry.py. Runs in ~18 seconds, uses <1GB VRAM.