### PR TITLE
Fix Qwen3.5 rope validation TypeError: list | set (#36920)

### DIFF
--- a/vllm/transformers_utils/configs/qwen3_5.py
+++ b/vllm/transformers_utils/configs/qwen3_5.py
@@ -68,10 +68,10 @@ class Qwen3_5TextConfig(PretrainedConfig):
         eos_token_id=None,
         **kwargs,
     ):
-        kwargs["ignore_keys_at_rope_validation"] = [
+        kwargs["ignore_keys_at_rope_validation"] = {
             "mrope_section",
             "mrope_interleaved",
-        ]
+        }
         self.vocab_size = vocab_size
         self.max_position_embeddings = max_position_embeddings
         self.hidden_size = hidden_size

--- a/vllm/transformers_utils/configs/qwen3_5_moe.py
+++ b/vllm/transformers_utils/configs/qwen3_5_moe.py
@@ -75,10 +75,10 @@ class Qwen3_5MoeTextConfig(PretrainedConfig):
         eos_token_id=None,
         **kwargs,
     ):
-        kwargs["ignore_keys_at_rope_validation"] = [
+        kwargs["ignore_keys_at_rope_validation"] = {
             "mrope_section",
             "mrope_interleaved",
-        ]
+        }
         self.vocab_size = vocab_size
         self.max_position_embeddings = max_position_embeddings
         self.hidden_size = hidden_size


### PR DESCRIPTION
Summary:

`ignore_keys_at_rope_validation` was set as a Python `list` but
transformers' `convert_rope_params_to_dict` does
`ignore_keys_at_rope_validation | {"partial_rotary_factor"}` which
requires a `set`. This caused:

    TypeError: unsupported operand type(s) for |: 'list' and 'set'

during Qwen3.5 dense model config initialization, preventing all
Qwen3.5 vLLM inference from working.

Qwen3.5TextConfig.__init__ passes ignore_keys_at_rope_validation as a list via kwargs to PretrainedConfig.__init__, which forwards it to convert_rope_params_to_dict(). That function does ignore_keys_at_rope_validation | {"partial_rotary_factor"} — the | operator requires both operands to be set, not list. All upstream HF models pass a set. Fix: [...] → {...}.

Fix: change `[...]` to `{...}` in both dense and MoE configs

Note that all of the Huggingface Transfromers use {}: 
  The upstream HF pattern (all {set}):

  From third-party/pypi/transformers/5.2.0/transformers/models/:
  - qwen3_5/configuration_qwen3_5.py:158: kwargs["ignore_keys_at_rope_validation"] = {"mrope_section", "mrope_interleaved"}
  - qwen3_5_moe/configuration_qwen3_5_moe.py:176: kwargs["ignore_keys_at_rope_validation"] = {"mrope_section", "mrope_interleaved"}
  - qwen2_vl/configuration_qwen2_vl.py:215: ignore_keys_at_rope_validation={"mrope_section"}
  - qwen2_5_vl/configuration_qwen2_5_vl.py:226: ignore_keys_at_rope_validation={"mrope_section"}
  - qwen2_5_omni/configuration_qwen2_5_omni.py:373: ignore_keys_at_rope_validation={"mrope_section"}
  - qwen3_vl/configuration_qwen3_vl.py:175: ignore_keys_at_rope_validation={"mrope_section", "mrope_interleaved"}
  - qwen3_vl_moe/configuration_qwen3_vl_moe.py:177: ignore_keys_at_rope_validation={"mrope_section", "mrope_interleaved"}
  - glm4v/configuration_glm4v.py:236: ignore_keys_at_rope_validation={"mrope_section"}
  - glm4v_moe/configuration_glm4v_moe.py:197: ignore_keys_at_rope_validation={"mrope_section"}
  - glm_image/configuration_glm_image.py:269: ignore_keys_at_rope_validation={"mrope_section"}
  - glm_ocr/configuration_glm_ocr.py:228: ignore_keys_at_rope_validation={"mrope_section"}
  - ernie4_5_vl_moe/configuration_ernie4_5_vl_moe.py:252: ignore_keys_at_rope_validation={"mrope_section"}
  - ministral3/configuration_ministral3.py:193: ignore_keys_at_rope_validation={"llama_4_scaling_beta", "max_position_embeddings"}

Signed-off-by: Diego Urgell <diegourgell@meta.com>

Test Plan:
- Launching MAST job with `mitra launch-mast -p llm_examples -c vllm_inference_qwen3_5 -h 1 --host-type zionex_80g --no-maybe-pull -- constants.model_size=0.8B`

Successful job: 
https://www.internalfb.com/mlhub/pipelines/runs/mast/torchx-qwen35-oi-text-v6-z54xk0j9?job_attempt=0&version=0&tab=summary

Reviewed By: houseroad, richardwang-at-fb

Differential Revision: D96080423


