### PR TITLE
fix: Resolve template name to Jinja content in resolve_chat_template to prevent dropped kwargs

### DIFF
--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -108,13 +108,12 @@ def resolve_chat_template(
 ) -> str | None:
     # 1st priority: The given chat template
     if chat_template is not None:
-        # FIX: Check if the tokenizer has named templates and if our string is one of those names
-        if hasattr(tokenizer, "chat_template") and isinstance(tokenizer.chat_template, dict):
-            if chat_template in tokenizer.chat_template:
-                # Return the actual Jinja string from the dictionary
-                return tokenizer.chat_template[chat_template]
-
-        # If it's not a dictionary key, assume it's already a Jinja string and return as-is
+        # Check if tokenizer has named templates and string is a key
+        if (hasattr(tokenizer, "chat_template")
+            and isinstance(tokenizer.chat_template, dict)
+            and chat_template in tokenizer.chat_template):
+            return tokenizer.chat_template[chat_template]
+            
         return chat_template
     
     # ... rest of the function remains the same

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -99,17 +99,19 @@ def _try_get_processor_chat_template(
     return None
 
 
-def resolve_chat_template(
-    tokenizer: HfTokenizer,
-    chat_template: str | None,
-    tools: list[dict[str, Any]] | None,
-    *,
-    model_config: "ModelConfig",
-) -> str | None:
+def resolve_chat_template(tokenizer, chat_template, tools, *, model_config):
     # 1st priority: The given chat template
     if chat_template is not None:
-        return chat_template
+        # FIX: Check if the tokenizer has named templates and if our string is one of those names
+        if hasattr(tokenizer, "chat_template") and isinstance(tokenizer.chat_template, dict):
+            if chat_template in tokenizer.chat_template:
+                # Return the actual Jinja string from the dictionary
+                return tokenizer.chat_template[chat_template]
 
+        # If it's not a dictionary key, assume it's already a Jinja string and return as-is
+        return chat_template
+    
+    # ... rest of the function remains the same
     # 2nd priority: AutoProcessor chat template, unless tool calling is enabled
     if tools is None:
         chat_template = _try_get_processor_chat_template(

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -99,7 +99,13 @@ def _try_get_processor_chat_template(
     return None
 
 
-def resolve_chat_template(tokenizer, chat_template, tools, *, model_config):
+def resolve_chat_template(
+    tokenizer: "HfTokenizer",
+    chat_template: str | None,
+    tools: list[dict[str, Any]] | None,
+    *,
+    model_config: "ModelConfig",
+) -> str | None:
     # 1st priority: The given chat template
     if chat_template is not None:
         # FIX: Check if the tokenizer has named templates and if our string is one of those names


### PR DESCRIPTION
Description of fix
This PR fixes a bug where `resolve_chat_template` returns the template name string (e.g., `"tool_use"`) verbatim instead of resolving it to the actual Jinja content when the `chat_template` is passed as a string key. 

Because the downstream `resolve_chat_template_kwargs` function expects Jinja content to parse for variables, passing a simple name string causes it to silently drop valid kwargs (like `tools`, `documents`, etc.) since no variables are detected in a plain string.

Changes:
- Added a check in `resolve_chat_template` to verify if the passed string exists as a key within `tokenizer.chat_template` (when it's a dictionary).
- If it is a key, it now correctly returns the underlying Jinja template string, allowing downstream kwargs parsing to function as expected.