### PR TITLE
build: update smg-grpc-servicer to use vllm extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -983,7 +983,7 @@ setup(
         # Optional deps for Helion kernel development
         "helion": ["helion"],
         # Optional deps for gRPC server (vllm serve --grpc)
-        "grpc": ["smg-grpc-servicer >= 0.4.2"],
+        "grpc": ["smg-grpc-servicer[vllm] >= 0.5.0"],
         # Optional deps for OpenTelemetry tracing
         "otel": [
             "opentelemetry-sdk>=1.26.0",


### PR DESCRIPTION
## Summary
- Update `smg-grpc-servicer` dependency from `>= 0.4.2` to `smg-grpc-servicer[vllm] >= 0.5.0`
- v0.5.0 moved backend dependencies to optional extras; the `[vllm]` extra ensures vllm is pulled in correctly when installing `pip install vllm[grpc]`

## Test plan
- [ ] `pip install vllm[grpc]` installs `smg-grpc-servicer[vllm]` which pulls in the vllm servicer
- [ ] `vllm serve --grpc` works end-to-end