### PR TITLE
[BUG] Fix rank calculation in NCCLWeightTransferEngine

### DIFF
--- a/vllm/distributed/weight_transfer/nccl_engine.py
+++ b/vllm/distributed/weight_transfer/nccl_engine.py
@@ -132,7 +132,7 @@ class NCCLWeightTransferEngine(
 
         # Calculate the global rank in the trainer-worker process group
         # Must account for data parallel to get unique ranks across all workers
-        dp_rank = self.parallel_config.data_parallel_rank
+        dp_rank = self.parallel_config.data_parallel_index
         world_size_per_dp = self.parallel_config.world_size  # TP * PP
         rank_within_dp = self.parallel_config.rank
 


### PR DESCRIPTION


## Purpose
closes https://github.com/vllm-project/vllm/issues/36932
Rank calculations were not being made correctly, `parallel_config.data_parallel_rank` for non moe models is always 0, switched to using `self.parallel_config.data_parallel_index` instead.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

