### PR TITLE
[Bugfix] Streaming finish_reason chunk should have empty delta content

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat.py
@@ -336,8 +336,47 @@ async def test_chat_streaming(client: openai.AsyncOpenAI, model_name: str):
     # finish reason should only return in last block
     assert finish_reason_count == 1
     assert chunk.choices[0].finish_reason == stop_reason
-    assert delta.content
+    assert not delta.content
     assert "".join(chunks) == output
+
+
+@pytest.mark.asyncio
+async def test_streaming_finish_reason_length_empty_delta(
+    client: openai.AsyncOpenAI,
+):
+    """The final chunk with finish_reason set should have an empty delta,
+    matching OpenAI's streaming convention."""
+    messages = [
+        {"role": "user", "content": "Tell me a long story about a dragon"},
+    ]
+
+    stream = await client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=messages,
+        max_completion_tokens=5,
+        temperature=0.0,
+        stream=True,
+    )
+
+    chunks_content: list[str] = []
+    finish_reason = None
+    async for chunk in stream:
+        choice = chunk.choices[0]
+        delta = choice.delta
+        if delta.content:
+            # Content chunks must have finish_reason=None
+            assert choice.finish_reason is None, (
+                "Chunk with content should have finish_reason=None"
+            )
+            chunks_content.append(delta.content)
+        if choice.finish_reason is not None:
+            finish_reason = choice.finish_reason
+
+    # The final chunk should have finish_reason="length" with empty delta
+    assert finish_reason == "length"
+    assert not delta.content
+    # We should have received some content tokens
+    assert len(chunks_content) > 0
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1179,18 +1179,16 @@ class OpenAIServingChat(OpenAIServing):
                         )
 
                         if has_content:
-                            content_choice = (
-                                ChatCompletionResponseStreamChoice(
-                                    index=i,
-                                    delta=delta_message,
-                                    logprobs=logprobs,
-                                    finish_reason=None,
-                                    token_ids=(
-                                        as_list(output.token_ids)
-                                        if request.return_token_ids
-                                        else None
-                                    ),
-                                )
+                            content_choice = ChatCompletionResponseStreamChoice(
+                                index=i,
+                                delta=delta_message,
+                                logprobs=logprobs,
+                                finish_reason=None,
+                                token_ids=(
+                                    as_list(output.token_ids)
+                                    if request.return_token_ids
+                                    else None
+                                ),
                             )
                             content_choice = maybe_filter_parallel_tool_calls(
                                 content_choice, request
@@ -1211,9 +1209,7 @@ class OpenAIServingChat(OpenAIServing):
                                         num_prompt_tokens + completion_tokens
                                     ),
                                 )
-                            data = content_chunk.model_dump_json(
-                                exclude_unset=True
-                            )
+                            data = content_chunk.model_dump_json(exclude_unset=True)
                             yield f"data: {data}\n\n"
 
                         # Yield the finish chunk with empty delta

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1169,17 +1169,60 @@ class OpenAIServingChat(OpenAIServing):
                             finish_reason_ = (
                                 output.finish_reason if output.finish_reason else "stop"
                             )
+                        # OpenAI convention: when finish_reason is set,
+                        # delta should be empty. If there's remaining
+                        # content, yield it first with finish_reason=None.
+                        has_content = (
+                            delta_message.content
+                            or delta_message.reasoning
+                            or delta_message.tool_calls
+                        )
+
+                        if has_content:
+                            content_choice = (
+                                ChatCompletionResponseStreamChoice(
+                                    index=i,
+                                    delta=delta_message,
+                                    logprobs=logprobs,
+                                    finish_reason=None,
+                                    token_ids=(
+                                        as_list(output.token_ids)
+                                        if request.return_token_ids
+                                        else None
+                                    ),
+                                )
+                            )
+                            content_choice = maybe_filter_parallel_tool_calls(
+                                content_choice, request
+                            )
+                            content_chunk = ChatCompletionStreamResponse(
+                                id=request_id,
+                                object=chunk_object_type,
+                                created=created_time,
+                                choices=[content_choice],
+                                model=model_name,
+                            )
+                            if include_continuous_usage:
+                                completion_tokens = previous_num_tokens[i]
+                                content_chunk.usage = UsageInfo(
+                                    prompt_tokens=num_prompt_tokens,
+                                    completion_tokens=completion_tokens,
+                                    total_tokens=(
+                                        num_prompt_tokens + completion_tokens
+                                    ),
+                                )
+                            data = content_chunk.model_dump_json(
+                                exclude_unset=True
+                            )
+                            yield f"data: {data}\n\n"
+
+                        # Yield the finish chunk with empty delta
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=i,
-                            delta=delta_message,
-                            logprobs=logprobs,
+                            delta=DeltaMessage(),
+                            logprobs=None,
                             finish_reason=finish_reason_,
                             stop_reason=output.stop_reason,
-                            token_ids=(
-                                as_list(output.token_ids)
-                                if request.return_token_ids
-                                else None
-                            ),
                         )
 
                         finish_reason_sent[i] = True


### PR DESCRIPTION
## Summary

- When `finish_reason` is set (e.g. `"length"`, `"stop"`, `"tool_calls"`), split the final streaming chunk into two: a content chunk with `finish_reason=null`, followed by an empty-delta finish chunk with the actual `finish_reason`
- This matches OpenAI's streaming API convention where the finish chunk always has `delta: {}`
- Previously vLLM combined the last content token and `finish_reason` into the same chunk, breaking clients that rely on `finish_reason` to signal "no more content"

Fixes #35705

## Test plan

- [x] `test_chat_streaming` updated and passing (both `zephyr-7b-beta` and `zephyr-lora` variants)
- [x] New `test_streaming_finish_reason_length_empty_delta` added and passing — forces `finish_reason="length"` via `max_completion_tokens=5`, verifies all content chunks have `finish_reason=null` and the final chunk has empty delta