### PR TITLE
[Tests] Shutdown test `RemoteVLLMServer` cleanly

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -235,13 +235,10 @@ class RemoteVLLMServer:
         except (ProcessLookupError, OSError):
             pgid = None
 
-        # Phase 1: graceful SIGTERM to the entire process group
-        if pgid is not None:
-            with contextlib.suppress(ProcessLookupError, OSError):
-                os.killpg(pgid, signal.SIGTERM)
-                print(f"[RemoteOpenAIServer] Sent SIGTERM to process group {pgid}")
-        else:
+        # Phase 1: graceful SIGTERM to the root process
+        with contextlib.suppress(ProcessLookupError, OSError):
             self.proc.terminate()
+            print(f"[RemoteOpenAIServer] Sent SIGTERM to process {pid}")
 
         try:
             self.proc.wait(timeout=15)


### PR DESCRIPTION
Recent PR https://github.com/vllm-project/vllm/pull/33949 changed the teardown logic of the `RemoteVLLMServer` test utility class to send SIGTERM to all vllm (sub)processes at once, which breaks the clean/coordinated shutdown logic that assumes only the top-level process will receive a signal (for example when running in a container that's shut down).

This caused a bunch of errors and stacktraces in some test logs, even though those tests still pass. We should still attempt a normal shutdown and only kill other procs if they are still running after a few seconds.

Example of test containing the shutdown mess: https://buildkite.com/vllm/ci/builds/55850#019cdeea-4528-4cbd-b7e7-277742a3e3e9 (in particular `tests/v1/distributed/test_external_lb_dp.py::test_external_lb_completion_streaming`)