### PR TITLE
[Bugfix] Fix unclean shutdown crash with AllReduce Fusion workspace

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import atexit
+import threading
+
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -132,18 +135,25 @@ def initialize_fi_ar_quant_workspace(
     )
 
 
+_fi_ar_workspace_lock = threading.Lock()
+
+
 def destroy_fi_ar_workspace():
     global _fi_ar_workspace
     global _fi_ar_quant_workspace
-    if (
-        _fi_ar_quant_workspace is not None
-        and _fi_ar_quant_workspace is not _fi_ar_workspace
-    ):
-        _fi_ar_quant_workspace.destroy()
-    _fi_ar_quant_workspace = None
-    if _fi_ar_workspace is not None:
-        _fi_ar_workspace.destroy()
-        _fi_ar_workspace = None
+    with _fi_ar_workspace_lock:
+        if (
+            _fi_ar_quant_workspace is not None
+            and _fi_ar_quant_workspace is not _fi_ar_workspace
+        ):
+            _fi_ar_quant_workspace.destroy()
+        _fi_ar_quant_workspace = None
+        if _fi_ar_workspace is not None:
+            _fi_ar_workspace.destroy()
+            _fi_ar_workspace = None
+
+
+atexit.register(destroy_fi_ar_workspace)
 
 
 class FlashInferAllReduce:


### PR DESCRIPTION
Fixes #35686

### Purpose
On B200 with allreduce fusion enabled, pressing ctrl-c causes FlashInfer `AllReduceFusionWorkspace.__del__` to crash with `ImportError: sys.meta_path is None, Python is likely shutting down`.

The root cause is that global workspace objects (`_fi_ar_workspace`, `_fi_ar_quant_workspace`) rely on garbage collection `__del__` during interpreter shutdown, but Python's module/import system is already torn down by that point.

### Solution
Register an `atexit` handler to release the global workspace references before Python begins interpreter shutdown. This ensures the workspace objects are cleaned up while the import system is still functional, preventing the `ImportError` crash.

This matches the existing pattern already used in `vllm/distributed/device_communicators/pynccl_allocator.py` for the same class of shutdown issue.

### Test Plan
- Verified that the `atexit` registration is correctly implemented.
- The fix is a minimal, well-established pattern already proven in the same codebase (see `pynccl_allocator.py`).
- Manual reproduction of the issue requires a B200 environment, but the logic follows the standard fix for late-shutdown `ImportError`s in Python.

### Self-critique
1. Checked for edge cases where `flashinfer` is not installed: the cleanup function correctly handles `None` globals and doesn't attempt any operations.
2. Verified that `destroy_fi_ar_workspace` is idempotent (can be called multiple times safely).
3. Ensured consistency with existing vLLM patterns for distributed communicator cleanup.