### PR TITLE
[Bugfix] Fix unclean shutdown from ctrl-c with AR Fusion

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import atexit
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -29,6 +30,23 @@ _fi_ar_workspace = None
 # Extra workspace for quant fusion patterns (only supported by trtllm backend)
 # Only created if primary workspace is not already trtllm
 _fi_ar_quant_workspace = None
+
+
+def _cleanup_fi_ar_workspace():
+    global _fi_ar_workspace
+    global _fi_ar_quant_workspace
+    if (
+        _fi_ar_quant_workspace is not None
+        and _fi_ar_quant_workspace is not _fi_ar_workspace
+    ):
+        _fi_ar_quant_workspace.destroy()
+    _fi_ar_quant_workspace = None
+    if _fi_ar_workspace is not None:
+        _fi_ar_workspace.destroy()
+        _fi_ar_workspace = None
+
+
+atexit.register(_cleanup_fi_ar_workspace)
 
 
 def get_fi_ar_workspace():


### PR DESCRIPTION
## Purpose
Fixes #35686

This PR fixes the unclean shutdown issue when pressing Ctrl-C with AR Fusion enabled. The error was caused by the Python interpreter shutting down before the FlashInfer workspace destructor could complete, resulting in an `ImportError: sys.meta_path is None`.

## Test Plan
1. Verified that the `atexit` handler follows the established pattern in `vllm/distributed/device_communicators/pynccl_allocator.py`.
2. Verified that the `destroy()` method is called while the interpreter is still functional.
3. Edge case check: multiple calls to destruction (e.g. manual `destroy()` then `atexit`) are handled safely by `is not None` checks.
4. Edge case check: partial initialization of workspaces is handled safely.

## Test Result
The logic matches PR #36747 which was verified on B200 hardware to resolve the crash. Since this is a shutdown-only change to module-level globals, it does not affect runtime inference performance or correctness.

## Self-Critique
1. **Double Destruction:** Checked that the cleanup handler is safe if `destroy_fi_ar_workspace()` is called manually before shutdown. The `is not None` checks prevent double-free errors.
2. **Partial Initialization:** The handler correctly handles cases where only one or neither of the workspaces (`_fi_ar_workspace`, `_fi_ar_quant_workspace`) has been initialized.
3. **Shutdown Context:** By using `atexit`, we ensure that garbage collection happens while `sys.meta_path` is still available, directly addressing the root cause of the `ImportError` reported in the issue.