### PR TITLE
[Bugfix] fix paddleocr crash on some image shape

### DIFF
--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -25,6 +25,7 @@ import torch.nn as nn
 from einops import rearrange
 from transformers import BaseImageProcessor, BatchFeature, PretrainedConfig
 from transformers.activations import GELUActivation
+from transformers.image_utils import ChannelDimension
 from transformers.modeling_outputs import (
     BaseModelOutputWithPooling,
 )
@@ -249,6 +250,10 @@ class PaddleOCRVLMultiModalProcessor(
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
         if mm_data:
+            mm_kwargs = mm_kwargs or {}
+            mm_kwargs["images_kwargs"] = mm_kwargs.get("images_kwargs", {})
+            # vLLM use PIL.Image, always set channel_last
+            mm_kwargs["input_data_format"] = ChannelDimension.LAST
             processed_outputs = self.info.ctx.call_hf_processor(
                 self.info.get_hf_processor(**mm_kwargs),
                 dict(text=prompt, **mm_data),

--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -250,12 +250,12 @@ class PaddleOCRVLMultiModalProcessor(
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
         if mm_data:
-            mm_kwargs = mm_kwargs or {}
-            mm_kwargs["images_kwargs"] = mm_kwargs.get("images_kwargs", {})
+            final_mm_kwargs = dict(mm_kwargs or {})
+            final_mm_kwargs.setdefault("images_kwargs", {})
             # vLLM use PIL.Image, always set channel_last
-            mm_kwargs["input_data_format"] = ChannelDimension.LAST
+            final_mm_kwargs["input_data_format"] = ChannelDimension.LAST
             processed_outputs = self.info.ctx.call_hf_processor(
-                self.info.get_hf_processor(**mm_kwargs),
+                self.info.get_hf_processor(**final_mm_kwargs),
                 dict(text=prompt, **mm_data),
                 dict(**mm_kwargs, **tok_kwargs),
             )


### PR DESCRIPTION

## Purpose
Fix PaddleOCR server crash caused by embedding mismatch on specific image dimensions

### Bug Description

The vLLM PaddleOCR server crashes immediately when processing images with specific shapes (e.g., H=3, W=22) due to a mismatch between expected and actual multimodal embedding counts. The error manifests as:
```
/pytorch/aten/src/ATen/native/cuda/IndexKernel.cu:400: masked_scatter_size_check: block: [0,0,0], thread: [0,0,0] Assertion `totalElements <= srcSize` failed.
```
### Root Cause
When vLLM merges multimodal embeddings into input_embeds, the expected number of vision tokens exceeds the actual mm_embeddings length.

For an image with H=3, W=22:

- Expected tokens (✅)  vLLM correctly identifies H=3, W=22, applies smart_resize(), and calculates 165 expected tokens. 
- Actual embeddings (❌): When vLLM invokes `_call_hf_processor`, the input pixel_values have shape (3, 22, 3). If `input_data_format` is unspecified, the PaddleOCR processor uses `transformers.image_utils.infer_channel_dimension_format` to auto-detect the channel dimension (checking which axis equals 1 or 3). For shape (3, 22, 3), the heuristic emits::
```
The channel dimension is ambiguous. Got image shape (3, 22, 3). Assuming channels are the first dimension. Use the [input_data_format](https://huggingface.co/docs/transformers/main/internal/image_processing_utils#transformers.image_transforms.rescale.input_data_format) parameter to assign the channel dimension.
```
Defaulting to channels-first interprets the dimensions as H=22, W=3. Since `smart_resize()` applies asymmetric scaling to height and width, this yields only 160 embeddings instead of 165, triggering the size mismatch assertion.

### Solution
- Explicitly set input_data_format="channels_last" in vLLM, since PIL Images are always channel-last.
- Merge [PR #90](https://huggingface.co/PaddlePaddle/PaddleOCR-VL/discussions/90) to enable passing image_kwargs to the Hugging Face processor..


## Test Plan


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

