### PR TITLE
[Feature] Add /health/ready endpoint for GPU health verification

### DIFF
--- a/tests/entrypoints/serve/instrumentator/test_basic.py
+++ b/tests/entrypoints/serve/instrumentator/test_basic.py
@@ -220,3 +220,47 @@ async def test_health_check_engine_dead_error():
 
     # Assert that it returns 503 Service Unavailable
     assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_health_ready_ok():
+    from vllm.entrypoints.serve.instrumentator.health import health_ready
+
+    mock_request = Mock(spec=Request)
+    mock_app_state = Mock()
+    mock_engine_client = AsyncMock()
+    mock_app_state.engine_client = mock_engine_client
+    mock_request.app.state = mock_app_state
+
+    response = await health_ready(mock_request)
+    assert response.status_code == 200
+    mock_engine_client.check_health_gpu.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_health_ready_engine_dead():
+    from vllm.entrypoints.serve.instrumentator.health import health_ready
+
+    mock_request = Mock(spec=Request)
+    mock_app_state = Mock()
+    mock_engine_client = AsyncMock()
+    mock_engine_client.check_health_gpu.side_effect = EngineDeadError()
+    mock_app_state.engine_client = mock_engine_client
+    mock_request.app.state = mock_app_state
+
+    response = await health_ready(mock_request)
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_health_ready_no_engine():
+    """Render-only servers have no engine; they are always healthy."""
+    from vllm.entrypoints.serve.instrumentator.health import health_ready
+
+    mock_request = Mock(spec=Request)
+    mock_app_state = Mock()
+    mock_app_state.engine_client = None
+    mock_request.app.state = mock_app_state
+
+    response = await health_ready(mock_request)
+    assert response.status_code == 200

--- a/tests/v1/engine/test_async_llm_health.py
+++ b/tests/v1/engine/test_async_llm_health.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.exceptions import EngineDeadError
+
+
+@pytest.fixture
+def async_llm_for_health_check(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("vllm.envs.VLLM_HEALTH_CHECK_GPU_TIMEOUT", 1)
+
+    async_llm = AsyncLLM.__new__(AsyncLLM)
+    async_llm.engine_core = SimpleNamespace(
+        resources=SimpleNamespace(engine_dead=False),
+        execute_dummy_batch_async=AsyncMock(),
+        shutdown=Mock(),
+    )
+    async_llm.output_handler = None
+    async_llm.output_processor = Mock()
+    async_llm.output_processor.has_unfinished_requests.return_value = False
+
+    return async_llm
+
+
+@pytest.mark.asyncio
+async def test_check_health_gpu_runs_dummy_batch_when_idle(async_llm_for_health_check):
+    await async_llm_for_health_check.check_health_gpu()
+
+    output_processor = async_llm_for_health_check.output_processor
+    output_processor.has_unfinished_requests.assert_called_once()
+    engine_core = async_llm_for_health_check.engine_core
+    engine_core.execute_dummy_batch_async.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_check_health_gpu_skips_dummy_batch_when_busy(async_llm_for_health_check):
+    output_processor = async_llm_for_health_check.output_processor
+    output_processor.has_unfinished_requests.return_value = True
+
+    await async_llm_for_health_check.check_health_gpu()
+
+    output_processor.has_unfinished_requests.assert_called_once()
+    engine_core = async_llm_for_health_check.engine_core
+    engine_core.execute_dummy_batch_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_check_health_gpu_fails_when_engine_dead(async_llm_for_health_check):
+    async_llm_for_health_check.engine_core.resources.engine_dead = True
+
+    with pytest.raises(EngineDeadError):
+        await async_llm_for_health_check.check_health_gpu()
+
+    output_processor = async_llm_for_health_check.output_processor
+    output_processor.has_unfinished_requests.assert_not_called()
+    engine_core = async_llm_for_health_check.engine_core
+    engine_core.execute_dummy_batch_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_check_health_gpu_fails_when_dummy_batch_fails(
+    async_llm_for_health_check,
+):
+    engine_core = async_llm_for_health_check.engine_core
+    engine_core.execute_dummy_batch_async.side_effect = RuntimeError("GPU failed")
+
+    with pytest.raises(EngineDeadError):
+        await async_llm_for_health_check.check_health_gpu()
+
+    engine_core.execute_dummy_batch_async.assert_awaited_once()

--- a/tests/v1/shutdown/test_forward_error.py
+++ b/tests/v1/shutdown/test_forward_error.py
@@ -92,6 +92,10 @@ async def test_async_llm_model_error(
     # AsyncLLM should be errored.
     assert async_llm.errored
 
+    # GPU health check should also fail after engine death.
+    with pytest.raises(EngineDeadError):
+        await async_llm.check_health_gpu()
+
     # We should not be able to make another request.
     with pytest.raises(EngineDeadError):
         async for _ in async_llm.generate(

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -121,6 +121,14 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    async def check_health_gpu(self) -> None:
+        """Raise if GPU is unhealthy.
+
+        Runs a dummy forward pass to verify GPU can execute inference.
+        """
+        ...
+
+    @abstractmethod
     async def start_profile(self) -> None:
         """Start profiling the engine"""
         ...

--- a/vllm/entrypoints/serve/instrumentator/health.py
+++ b/vllm/entrypoints/serve/instrumentator/health.py
@@ -31,3 +31,16 @@ async def health(raw_request: Request) -> Response:
         return Response(status_code=200)
     except EngineDeadError:
         return Response(status_code=503)
+
+
+@router.get("/health/ready", response_class=Response)
+async def health_ready(raw_request: Request) -> Response:
+    """Readiness check — verifies GPU can execute inference."""
+    client = engine_client(raw_request)
+    if client is None:
+        return Response(status_code=200)
+    try:
+        await client.check_health_gpu()
+        return Response(status_code=200)
+    except EngineDeadError:
+        return Response(status_code=503)

--- a/vllm/entrypoints/serve/instrumentator/health.py
+++ b/vllm/entrypoints/serve/instrumentator/health.py
@@ -33,7 +33,7 @@ async def health(raw_request: Request) -> Response:
         return Response(status_code=503)
 
 
-@router.get("/health/ready", response_class=Response)
+@router.get("/ready", response_class=Response)
 async def health_ready(raw_request: Request) -> Response:
     """Readiness check — verifies GPU can execute inference."""
     client = engine_client(raw_request)

--- a/vllm/entrypoints/serve/instrumentator/metrics.py
+++ b/vllm/entrypoints/serve/instrumentator/metrics.py
@@ -29,6 +29,7 @@ def attach_router(app: FastAPI):
         excluded_handlers=[
             "/metrics",
             "/health",
+            "/ready",
             "/load",
             "/ping",
             "/version",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     CUDA_VISIBLE_DEVICES: str | None = None
     VLLM_ENGINE_ITERATION_TIMEOUT_S: int = 60
     VLLM_ENGINE_READY_TIMEOUT_S: int = 600
+    VLLM_HEALTH_CHECK_GPU_TIMEOUT: int = 20
     VLLM_API_KEY: str | None = None
     VLLM_DEBUG_LOG_API_SERVER_RESPONSE: bool = False
     S3_ACCESS_KEY_ID: str | None = None
@@ -641,6 +642,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # during startup. Default is 600 seconds (10 minutes).
     "VLLM_ENGINE_READY_TIMEOUT_S": lambda: int(
         os.environ.get("VLLM_ENGINE_READY_TIMEOUT_S", "600")
+    ),
+    # Timeout in seconds for GPU health check (dummy forward pass).
+    # Default is 20 seconds.
+    "VLLM_HEALTH_CHECK_GPU_TIMEOUT": lambda: int(
+        os.environ.get("VLLM_HEALTH_CHECK_GPU_TIMEOUT", "20")
     ),
     # API key for vLLM API server
     "VLLM_API_KEY": lambda: os.environ.get("VLLM_API_KEY", None),
@@ -1768,6 +1774,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_DEBUG_LOG_API_SERVER_RESPONSE",
         "VLLM_TUNED_CONFIG_FOLDER",
         "VLLM_ENGINE_ITERATION_TIMEOUT_S",
+        "VLLM_HEALTH_CHECK_GPU_TIMEOUT",
         "VLLM_HTTP_TIMEOUT_KEEP_ALIVE",
         "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS",
         "VLLM_KEEP_ALIVE_ON_ENGINE_DEATH",

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -876,6 +876,26 @@ class AsyncLLM(EngineClient):
         if self.errored:
             raise self.dead_error
 
+    async def check_health_gpu(self) -> None:
+        logger.debug("Called check_health_gpu.")
+        # First do the basic liveness check.
+        await self.check_health()
+        # Then verify GPU can execute a forward pass.
+        try:
+            await asyncio.wait_for(
+                self.engine_core.execute_dummy_batch_async(),
+                timeout=envs.VLLM_HEALTH_CHECK_GPU_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "GPU health check timed out after %ss",
+                envs.VLLM_HEALTH_CHECK_GPU_TIMEOUT,
+            )
+            raise self.dead_error from None
+        except Exception:
+            logger.warning("GPU health check failed", exc_info=True)
+            raise self.dead_error from None
+
     async def start_profile(self, profile_prefix: str | None = None) -> None:
         coros = [self.engine_core.profile_async(True, profile_prefix)]
         if self.profiler is not None:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -880,7 +880,14 @@ class AsyncLLM(EngineClient):
         logger.debug("Called check_health_gpu.")
         # First do the basic liveness check.
         await self.check_health()
-        # Then verify GPU can execute a forward pass.
+
+        # Like SGLang's health_generate path, avoid injecting extra GPU work
+        # while real requests are in flight. If the engine is making progress,
+        # the output handler will detect engine death via normal request flow.
+        if self.output_processor.has_unfinished_requests():
+            return
+
+        # When idle, verify GPU can execute a forward pass.
         try:
             await asyncio.wait_for(
                 self.engine_core.execute_dummy_batch_async(),


### PR DESCRIPTION
## Purpose

Fix #36960

Add a `/health/ready` readiness endpoint that verifies GPU can actually execute inference, complementing the existing `/health` liveness check.

**Problem**: `/health` only checks the `engine_dead` boolean. When a GPU encounters a page fault or illegal memory access, the process stays alive but inference fails silently. K8s keeps routing traffic to a broken pod because liveness probe passes.

**Solution**: `/health/ready` runs `execute_dummy_batch_async()` (1-token GPU forward pass) to verify end-to-end inference capability. This reuses existing warmup infrastructure — no new GPU code.

Key design decisions:
- Uses `call_utility_async()` path, not the scheduler's request queue — avoids contention with real inference requests (unlike SGLang's approach which required multiple workaround PRs: sgl-project/sglang#8444, sgl-project/sglang#8757, sgl-project/sglang#13320)
- Configurable timeout via `VLLM_HEALTH_CHECK_GPU_TIMEOUT` env var (default 20s)
- K8s probe mapping: liveness=`/health`, readiness=`/health/ready`
- Existing `/health` is completely untouched

**Changes** (~96 lines added across 6 files):
| File | Change |
|------|--------|
| `vllm/engine/protocol.py` | `check_health_gpu()` abstract method on `EngineClient` |
| `vllm/v1/engine/async_llm.py` | Implementation: `check_health()` + `execute_dummy_batch_async()` with timeout |
| `vllm/envs.py` | `VLLM_HEALTH_CHECK_GPU_TIMEOUT` env var (default 20s) |
| `vllm/entrypoints/serve/instrumentator/health.py` | `GET /health/ready` endpoint |
| `tests/entrypoints/instrumentator/test_basic.py` | 3 mock-based unit tests (ok, dead, no_engine) |
| `tests/v1/shutdown/test_forward_error.py` | Integration test: `check_health_gpu()` fails after engine death |

AI assistance was used (Claude). This is not duplicating any existing PR — searched open PRs and found none addressing GPU-level health verification.

## Test Plan

- Unit tests (mock-based, no GPU required):
  ```bash
  pytest tests/entrypoints/instrumentator/test_basic.py -v -k "health_ready"
  ```
- Integration test (requires GPU):
  ```bash
  pytest tests/v1/shutdown/test_forward_error.py -v -k "test_async_llm_model_error"
  ```
- Manual verification:
  ```bash
  vllm serve hmellor/tiny-random-LlamaForCausalLM --enforce-eager
  curl http://localhost:8000/health        # 200 (liveness)
  curl http://localhost:8000/health/ready   # 200 (readiness)
  ```

## Test Result

All pre-commit hooks passed (ruff check, ruff format, typos, mypy, sign-off, etc.).

Unit tests verified locally via direct mock execution — health_ready returns 200 on success, 503 on EngineDeadError, 200 when no engine (render-only server).
