### PR TITLE
Allow platform plugins to override gpu_memory_utilization default

### DIFF
--- a/tests/v1/engine/test_gpu_memory_utilization.py
+++ b/tests/v1/engine/test_gpu_memory_utilization.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for gpu_memory_utilization None-sentinel semantics."""
+
+import pytest
+
+from vllm import LLM
+from vllm.engine.arg_utils import EngineArgs
+from vllm.platforms import current_platform
+from vllm.usage.usage_lib import UsageContext
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+def test_cli_unset_defaults_to_0_9():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args([])
+    assert args.gpu_memory_utilization is None
+
+    vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
+    assert vllm_config.cache_config.gpu_memory_utilization == 0.9
+
+
+@pytest.mark.parametrize("value", [0.9, 0.5])
+def test_cli_explicit_value_respected(value: float):
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--gpu-memory-utilization", str(value)])
+    assert args.gpu_memory_utilization == value
+
+    vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
+    assert vllm_config.cache_config.gpu_memory_utilization == value
+
+
+def test_engine_args_unset_defaults_to_0_9():
+    vllm_config = EngineArgs(model="facebook/opt-125m").create_engine_config(
+        UsageContext.LLM_CLASS
+    )
+    assert vllm_config.cache_config.gpu_memory_utilization == 0.9
+
+
+def test_engine_args_explicit_value_respected():
+    vllm_config = EngineArgs(
+        model="facebook/opt-125m",
+        gpu_memory_utilization=0.5,
+    ).create_engine_config(UsageContext.LLM_CLASS)
+    assert vllm_config.cache_config.gpu_memory_utilization == 0.5
+
+
+def test_platform_hook_sees_none_and_can_override(monkeypatch):
+    seen_none = False
+
+    def fake_check_and_update_config(vllm_config):
+        nonlocal seen_none
+        seen_none = vllm_config.cache_config.gpu_memory_utilization is None
+        vllm_config.cache_config.gpu_memory_utilization = 0.42
+
+    monkeypatch.setattr(
+        current_platform,
+        "check_and_update_config",
+        fake_check_and_update_config,
+    )
+
+    vllm_config = EngineArgs(model="facebook/opt-125m").create_engine_config(
+        UsageContext.LLM_CLASS
+    )
+
+    assert seen_none
+    # Platform set 0.42, so fallback 0.9 should NOT overwrite
+    assert vllm_config.cache_config.gpu_memory_utilization == 0.42
+
+
+def test_llm_omitted_gpu_memory_utilization_passes_none(monkeypatch):
+    captured = {}
+
+    class DummyEngine:
+        def get_supported_tasks(self):
+            return ["generate"]
+
+    def fake_from_engine_args(*, engine_args, usage_context):
+        captured["gpu_memory_utilization"] = engine_args.gpu_memory_utilization
+        captured["usage_context"] = usage_context
+        return DummyEngine()
+
+    monkeypatch.setattr(
+        "vllm.entrypoints.llm.LLMEngine.from_engine_args", fake_from_engine_args
+    )
+
+    LLM(model="facebook/opt-125m", enforce_eager=True)
+
+    assert captured["gpu_memory_utilization"] is None
+    assert captured["usage_context"] == UsageContext.LLM_CLASS
+
+
+def test_llm_explicit_gpu_memory_utilization_is_preserved(monkeypatch):
+    captured = {}
+
+    class DummyEngine:
+        def get_supported_tasks(self):
+            return ["generate"]
+
+    def fake_from_engine_args(*, engine_args, usage_context):
+        captured["gpu_memory_utilization"] = engine_args.gpu_memory_utilization
+        captured["usage_context"] = usage_context
+        return DummyEngine()
+
+    monkeypatch.setattr(
+        "vllm.entrypoints.llm.LLMEngine.from_engine_args", fake_from_engine_args
+    )
+
+    LLM(model="facebook/opt-125m", gpu_memory_utilization=0.5, enforce_eager=True)
+
+    assert captured["gpu_memory_utilization"] == 0.5
+    assert captured["usage_context"] == UsageContext.LLM_CLASS

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -189,6 +189,14 @@ class CacheConfig:
         # metrics info
         return {key: str(value) for key, value in self.__dict__.items()}
 
+    def resolved_gpu_memory_utilization(self) -> float:
+        """Return a concrete gpu_memory_utilization value after config resolution."""
+        if self.gpu_memory_utilization is None:
+            raise RuntimeError(
+                "gpu_memory_utilization must be resolved before worker startup"
+            )
+        return self.gpu_memory_utilization
+
     _block_size_resolved: bool = field(default=False, init=False)
     """Guard against pydantic re-running _apply_block_size_default."""
 

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -37,14 +37,15 @@ class CacheConfig:
     Accepts None (meaning "use default"). After construction, always int."""
     user_specified_block_size: bool = field(default=False, init=False)
     """Whether block_size was explicitly provided. Derived automatically."""
-    gpu_memory_utilization: float = Field(default=0.9, gt=0, le=1)
+    gpu_memory_utilization: float | None = Field(default=None, gt=0, le=1)
     """The fraction of GPU memory to be used for the model executor, which can
     range from 0 to 1. For example, a value of 0.5 would imply 50% GPU memory
-    utilization. If unspecified, will use the default value of 0.9. This is a
-    per-instance limit, and only applies to the current vLLM instance. It does
-    not matter if you have another vLLM instance running on the same GPU. For
-    example, if you have two vLLM instances running on the same GPU, you can
-    set the GPU memory utilization to 0.5 for each instance."""
+    utilization. If left unspecified, the value is resolved after platform
+    config hooks run (default: 0.9). This is a per-instance limit, and only
+    applies to the current vLLM instance. It does not matter if you have
+    another vLLM instance running on the same GPU. For example, if you have
+    two vLLM instances running on the same GPU, you can set the GPU memory
+    utilization to 0.5 for each instance."""
     cache_dtype: CacheDType = "auto"
     """Data type for kv cache storage. If "auto", will use model data type.
     CUDA 11.8+ supports fp8 (=fp8_e4m3) and fp8_e5m2. ROCm (AMD GPU) supports

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1019,6 +1019,8 @@ class VllmConfig:
                 "to True to enable."
             )
         current_platform.check_and_update_config(self)
+        if self.cache_config.gpu_memory_utilization is None:
+            self.cache_config.gpu_memory_utilization = 0.9
 
         # Do this after all the updates to compilation_config.mode
         effective_dp_size = (

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -453,7 +453,7 @@ class EngineArgs:
     offload_num_in_group: int = PrefetchOffloadConfig.offload_num_in_group
     offload_prefetch_step: int = PrefetchOffloadConfig.offload_prefetch_step
     offload_params: set[str] = get_field(PrefetchOffloadConfig, "offload_params")
-    gpu_memory_utilization: float = CacheConfig.gpu_memory_utilization
+    gpu_memory_utilization: float | None = None
     kv_cache_memory_bytes: int | None = CacheConfig.kv_cache_memory_bytes
     max_num_batched_tokens: int | None = None
     max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
@@ -951,9 +951,9 @@ class EngineArgs:
             description=CacheConfig.__doc__,
         )
         cache_group.add_argument("--block-size", **cache_kwargs["block_size"])
-        cache_group.add_argument(
-            "--gpu-memory-utilization", **cache_kwargs["gpu_memory_utilization"]
-        )
+        gpu_mem_util_kwargs = cache_kwargs["gpu_memory_utilization"].copy()
+        gpu_mem_util_kwargs["default"] = None
+        cache_group.add_argument("--gpu-memory-utilization", **gpu_mem_util_kwargs)
         cache_group.add_argument(
             "--kv-cache-memory-bytes", **cache_kwargs["kv_cache_memory_bytes"]
         )
@@ -1509,9 +1509,12 @@ class EngineArgs:
             "enable_prefix_caching must be set by this point"
         )
 
+        cache_config_kwargs: dict[str, Any] = {}
+        if self.gpu_memory_utilization is not None:
+            cache_config_kwargs["gpu_memory_utilization"] = self.gpu_memory_utilization
+
         cache_config = CacheConfig(
             block_size=self.block_size,  # type: ignore[arg-type]
-            gpu_memory_utilization=self.gpu_memory_utilization,
             kv_cache_memory_bytes=self.kv_cache_memory_bytes,
             cache_dtype=resolved_cache_dtype,  # type: ignore[arg-type]
             is_attention_free=model_config.is_attention_free,
@@ -1527,6 +1530,7 @@ class EngineArgs:
             mamba_cache_mode=self.mamba_cache_mode,
             kv_offloading_size=self.kv_offloading_size,
             kv_offloading_backend=self.kv_offloading_backend,
+            **cache_config_kwargs,
         )
 
         ray_runtime_env = None

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -233,7 +233,7 @@ class LLM:
         tokenizer_revision: str | None = None,
         chat_template: Path | str | None = None,
         seed: int = 0,
-        gpu_memory_utilization: float = 0.9,
+        gpu_memory_utilization: float | None = None,
         cpu_offload_gb: float = 0,
         offload_group_size: int = 0,
         offload_num_in_group: int = 1,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -437,10 +437,11 @@ class Worker(WorkerBase):
         )
 
         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
+        gpu_memory_utilization = self.cache_config.resolved_gpu_memory_utilization()
         logger.debug(
             "Initial free memory: %s GiB; Requested memory: %f (util), %s GiB",
             format_gib(self.init_snapshot.free_memory),
-            self.cache_config.gpu_memory_utilization,
+            gpu_memory_utilization,
             format_gib(self.requested_memory),
         )
         logger.debug(
@@ -457,7 +458,7 @@ class Worker(WorkerBase):
 
         if cudagraph_memory_estimate > 0:
             total_mem = self.init_snapshot.total_memory
-            current_util = self.cache_config.gpu_memory_utilization
+            current_util = gpu_memory_utilization
             cg_util_delta = cudagraph_memory_estimate / total_mem
             if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS:
                 equiv_util = round(current_util - cg_util_delta, 4)
@@ -600,6 +601,7 @@ class Worker(WorkerBase):
         # cuda graph capture.
         kernel_warmup(self)
 
+        gpu_memory_utilization = self.cache_config.resolved_gpu_memory_utilization()
         cuda_graph_memory_bytes = 0
         if not self.model_config.enforce_eager:
             cuda_graph_memory_bytes = self.model_runner.capture_model()
@@ -657,7 +659,7 @@ class Worker(WorkerBase):
                 f"({format_gib(self.init_snapshot.free_memory)}/"
                 f"{format_gib(self.init_snapshot.total_memory)} GiB) on startup. "
                 f"Desired GPU memory utilization is "
-                f"({self.cache_config.gpu_memory_utilization}, "
+                f"({gpu_memory_utilization}, "
                 f"{format_gib(self.requested_memory)} GiB). "
                 f"Actual usage is {format_gib(self.model_runner.model_memory_usage)} "
                 f"GiB for weight, {format_gib(self.peak_activation_memory)} GiB "

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -405,9 +405,8 @@ def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> 
     Calculate the amount of memory required by vLLM, then validate
     that the current amount of free memory is sufficient for that.
     """
-    requested_memory = math.ceil(
-        init_snapshot.total_memory * cache_config.gpu_memory_utilization
-    )
+    gpu_memory_utilization = cache_config.resolved_gpu_memory_utilization()
+    requested_memory = math.ceil(init_snapshot.total_memory * gpu_memory_utilization)
 
     if init_snapshot.free_memory < requested_memory:
         raise ValueError(
@@ -415,7 +414,7 @@ def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> 
             f"({format_gib(init_snapshot.free_memory)}/"
             f"{format_gib(init_snapshot.total_memory)} GiB) on startup "
             f"is less than desired GPU memory utilization "
-            f"({cache_config.gpu_memory_utilization}, "
+            f"({gpu_memory_utilization}, "
             f"{format_gib(requested_memory)} GiB). Decrease GPU memory "
             f"utilization or reduce GPU memory used by other processes."
         )


### PR DESCRIPTION
## Purpose

Allow platform plugins to distinguish between:

- user did not set `gpu_memory_utilization`
- user explicitly set `gpu_memory_utilization=0.9`

Today, `EngineArgs` always materializes a concrete `0.9` and passes it into `CacheConfig`, so `check_and_update_config()` cannot tell whether that value came from user intent or from the default. As a result, platforms that need custom defaulting are forced into value-based heuristics, which can silently overwrite intentional user choices.

This PR makes `gpu_memory_utilization` follow the same general unset-sentinel pattern already used by fields like `block_size`: `None` means “unset”, platform hooks may resolve it, and vLLM applies a universal fallback if no platform does.

Changes in this PR:
- `CacheConfig.gpu_memory_utilization`: `float -> float | None`, default `None`
- `EngineArgs`: default `None`, omit the field from `CacheConfig(...)` when unset
- CLI `--gpu-memory-utilization`: default `None`
- `LLM.__init__`: default `None`
- `VllmConfig.__post_init__`: universal fallback to `0.9` after platform hooks run if still unset

Expected behavior is unchanged for standard CLI / `EngineArgs` / `LLM()` flows. Users who do not specify `gpu_memory_utilization` still end up with `0.9` unless a platform intentionally overrides the unset case.

## Test Plan

```bash
python -m pytest tests/v1/engine/test_gpu_memory_utilization.py -v
```

Tests cover:
- CLI unset -> resolves to `0.9`
- CLI explicit `0.9` and `0.5` -> preserved
- `EngineArgs(...)` unset -> `0.9`
- `EngineArgs(..., gpu_memory_utilization=0.5)` -> `0.5`
- platform hook observes `None` and sets a custom value (`0.42`) -> preserved, fallback does not overwrite
- `LLM()` omitted / explicit `gpu_memory_utilization` pass-through behavior

## Test Result

To be filled after running in the normal vLLM test environment / CI.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. N/A — no separate user docs needed; inline docstrings updated.
- [x] (Optional) Release notes update. N/A — config-plumbing change, no intended behavior change for standard flows.
</details>

