### PR TITLE
[Bugfix] Avoid KeyError when loading Qwen3.5 MoE expert weights

### DIFF
--- a/tests/model_executor/test_issue_36954.py
+++ b/tests/model_executor/test_issue_36954.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MultiTokenPredictor
+
+
+def test_load_fused_expert_weights_missing_param_does_not_raise():
+    loaded_weight = torch.empty((1, 1))
+    assert (
+        Qwen3_5MultiTokenPredictor.load_fused_expert_weights(
+            None, "layers.0.mlp.experts.w2_weight", {}, loaded_weight, "w2", 1
+        )
+        is False
+    )
+    assert (
+        Qwen3_5Model.load_fused_expert_weights(
+            None, "layers.0.mlp.experts.w2_weight", {}, loaded_weight, "w2", 1
+        )
+        is False
+    )
+
+
+def test_load_fused_expert_weights_returns_true_if_any_local_expert_loaded():
+    class DummyParam:
+        weight_loader: object
+
+    param = DummyParam()
+
+    def weight_loader(
+        param,
+        curr_expert_weight,
+        name,
+        shard_id,
+        expert_id,
+        return_success=False,
+    ):
+        return expert_id == 0
+
+    param.weight_loader = weight_loader
+
+    params_dict = {"layers.0.mlp.experts.w2_weight": param}
+    loaded_weight = torch.empty((2, 1))
+    assert (
+        Qwen3_5MultiTokenPredictor.load_fused_expert_weights(
+            None,
+            "layers.0.mlp.experts.w2_weight",
+            params_dict,
+            loaded_weight,
+            "w2",
+            2,
+        )
+        is True
+    )

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -368,6 +368,8 @@ class Qwen3_5Model(Qwen3NextModel):
         shard_id: str,
         num_experts: int,
     ) -> bool:
+        if name not in params_dict:
+            return False
         param = params_dict[name]
         weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
         loaded_local_expert = False
@@ -405,6 +407,14 @@ class Qwen3_5Model(Qwen3NextModel):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        ignore_suffixes = (
+            ".bias",
+            "_bias",
+            "_scale",
+            "_weight_scale",
+            "_input_scale",
+            "_output_scale",
+        )
         expert_params_mapping = self.get_expert_mapping()
         is_fused_expert = False
         fused_expert_params_mapping = [
@@ -438,19 +448,20 @@ class Qwen3_5Model(Qwen3NextModel):
                 if "mlp.experts" in name:
                     continue
 
-                name = name.replace(weight_name, param_name)
+                name_mapped = name.replace(weight_name, param_name)
                 # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
+                if name_mapped.endswith(".bias") and name_mapped not in params_dict:
                     continue
                 # Skip layers on other devices.
-                if is_pp_missing_parameter(name, self):
+                if is_pp_missing_parameter(name_mapped, self):
                     continue
                 # name = apply_attn_prefix(name, params_dict)
-                if name not in params_dict:
+                if name_mapped not in params_dict:
                     continue
-                param = params_dict[name]
+                param = params_dict[name_mapped]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
+                name = name_mapped
                 break
             else:
                 is_expert_weight = False
@@ -501,6 +512,10 @@ class Qwen3_5Model(Qwen3NextModel):
                             name_mapped.endswith(".bias")
                             or name_mapped.endswith("_bias")
                         ) and name_mapped not in params_dict:
+                            continue
+                        if name_mapped not in params_dict:
+                            if name_mapped.endswith(ignore_suffixes):
+                                continue
                             continue
                         param = params_dict[name_mapped]
                         weight_loader = param.weight_loader

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -155,6 +155,8 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         shard_id: str,
         num_experts: int,
     ) -> bool:
+        if name not in params_dict:
+            return False
         param = params_dict[name]
         weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
         loaded_local_expert = False
@@ -197,6 +199,14 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        ignore_suffixes = (
+            ".bias",
+            "_bias",
+            "_scale",
+            "_weight_scale",
+            "_input_scale",
+            "_output_scale",
+        )
         is_fused_expert = False
         fused_expert_params_mapping = [
             ("experts.w13_weight", "experts.gate_up_proj", 0, "w1"),
@@ -220,18 +230,19 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
                 if "mlp.experts" in name:
                     continue
 
-                name = name.replace(weight_name, param_name)
+                name_mapped = name.replace(weight_name, param_name)
                 # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
+                if name_mapped.endswith(".bias") and name_mapped not in params_dict:
                     continue
                 # Skip layers on other devices.
-                if is_pp_missing_parameter(name, self):
+                if is_pp_missing_parameter(name_mapped, self):
                     continue
-                if name not in params_dict:
+                if name_mapped not in params_dict:
                     continue
-                param = params_dict[name]
+                param = params_dict[name_mapped]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
+                name = name_mapped
                 break
             else:
                 is_expert_weight = False
@@ -282,6 +293,10 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
                             name_mapped.endswith(".bias")
                             or name_mapped.endswith("_bias")
                         ) and name_mapped not in params_dict:
+                            continue
+                        if name_mapped not in params_dict:
+                            if name_mapped.endswith(ignore_suffixes):
+                                continue
                             continue
                         param = params_dict[name_mapped]
                         weight_loader = param.weight_loader


### PR DESCRIPTION
Fixes crash when MTP/speculative loading maps fused expert weights and the mapped param is absent on this rank. Also avoid mutating the original weight name during stacked mapping.

Fixes #36954

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

