### PR TITLE
feat(riscv64): platform-gate dependencies without riscv64 wheels

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,7 +21,7 @@ prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.11.3
 llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le"
-outlines_core == 0.2.14
+outlines_core == 0.2.14; platform_machine != "riscv64" # Rust/maturin, no riscv64 wheel
 # required for outlines backend disk cache
 diskcache == 5.6.3
 lark == 1.2.2
@@ -32,8 +32,9 @@ partial-json-parser # used for parsing partial JSON outputs
 pyzmq >= 25.0.0
 msgspec
 gguf >= 0.17.0
-mistral_common[image] >= 1.11.3
-opencv-python-headless >= 4.13.0    # required for video IO
+mistral_common[image] >= 1.11.3; platform_machine != "riscv64"
+mistral_common >= 1.11.3; platform_machine == "riscv64" # [image] extra requires opencv, unavailable on riscv64
+opencv-python-headless >= 4.13.0; platform_machine != "riscv64"    # required for video IO (no riscv64 wheel)
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -23,7 +23,7 @@ prometheus-fastapi-instrumentator >= 8.0.0 # v8 unblocks starlette >= 1.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.11.3
 llguidance >= 1.7.0, < 1.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "s390x"
-outlines_core == 0.2.14
+outlines_core == 0.2.14; platform_machine != "riscv64" # Rust/maturin, no riscv64 wheel
 lark == 1.2.2
 xgrammar >= 0.2.1, < 1.0.0; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 typing_extensions >= 4.10
@@ -32,8 +32,9 @@ partial-json-parser # used for parsing partial JSON outputs
 jsonschema >= 4.23.0 # required for MiniMax M3 tool schema validation
 pyzmq >= 25.0.0
 msgspec
-mistral_common[image] >= 1.11.6
-opencv-python-headless >= 4.13.0    # required for video IO
+mistral_common[image] >= 1.11.6; platform_machine != "riscv64"
+mistral_common >= 1.11.6; platform_machine == "riscv64" # [image] extra requires opencv, unavailable on riscv64
+opencv-python-headless >= 4.13.0; platform_machine != "riscv64"    # required for video IO (no riscv64 wheel)
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -4,7 +4,7 @@
 
 setuptools==77.0.3 # this version can reuse CMake build dir
 
-numba == 0.65.0; platform_machine != "s390x" # Required for N-gram speculative decoding
+numba == 0.65.0; platform_machine != "s390x" and platform_machine != "riscv64" # Required for N-gram speculative decoding (llvmlite has no riscv64 support)
 
 # Dependencies for CPUs
 torch==2.11.0+cpu; platform_machine == "x86_64" or platform_machine == "s390x" or platform_machine == "aarch64"

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -3,7 +3,7 @@
 
 setuptools==77.0.3 # this version can reuse CMake build dir
 
-numba == 0.65.0; platform_machine != "s390x" # Required for N-gram speculative decoding
+numba == 0.65.0; platform_machine != "s390x" and platform_machine != "riscv64" # Required for N-gram speculative decoding (llvmlite has no riscv64 support)
 
 # Dependencies for CPUs
 torch==2.13.0+cpu; platform_machine == "x86_64" or platform_machine == "s390x" or platform_machine == "aarch64"

--- a/setup.py
+++ b/setup.py
@@ -1084,6 +1084,10 @@ if _is_cpu():
         ext_modules.append(CMakeExtension(name="vllm._C"))
         ext_modules.append(CMakeExtension(name="vllm._C_AVX512"))
         ext_modules.append(CMakeExtension(name="vllm._C_AVX2"))
+    elif platform.machine() == "riscv64":
+        # RISC-V: skip C++ extensions for now (pure-Python mode).
+        # RVV kernel support will be added in a follow-up PR.
+        pass
     else:
         ext_modules.append(CMakeExtension(name="vllm._C"))
 

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -11,13 +11,11 @@ from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.utils.import_utils import LazyLoader
-from vllm.v1.structured_output.backend_guidance import GuidanceBackend
 from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
     StructuredOutputGrammar,
     StructuredOutputOptions,
 )
-from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
 
 if TYPE_CHECKING:
     import numpy as np
@@ -132,12 +130,14 @@ class StructuredOutputManager:
             backend = request.sampling_params.structured_outputs._backend
             vocab_size = self.vllm_config.model_config.get_vocab_size()
             if backend == "xgrammar":
+                from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
                 self.backend = XgrammarBackend(
                     self.vllm_config,
                     tokenizer=self.tokenizer,
                     vocab_size=vocab_size,
                 )
             elif backend == "guidance":
+                from vllm.v1.structured_output.backend_guidance import GuidanceBackend
                 self.backend = GuidanceBackend(
                     self.vllm_config,
                     tokenizer=self.tokenizer,

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -131,6 +131,7 @@ class StructuredOutputManager:
             vocab_size = self.vllm_config.model_config.get_vocab_size()
             if backend == "xgrammar":
                 from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
+
                 self.backend = XgrammarBackend(
                     self.vllm_config,
                     tokenizer=self.tokenizer,
@@ -138,6 +139,7 @@ class StructuredOutputManager:
                 )
             elif backend == "guidance":
                 from vllm.v1.structured_output.backend_guidance import GuidanceBackend
+
                 self.backend = GuidanceBackend(
                     self.vllm_config,
                     tokenizer=self.tokenizer,

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -12,12 +12,10 @@ from vllm.parser.engine.adapters import ParserEngineReasoningAdapter
 from vllm.reasoning import ReasoningParserManager
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.utils.import_utils import LazyLoader
-from vllm.v1.structured_output.backend_guidance import GuidanceBackend
 from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
     StructuredOutputGrammar,
 )
-from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
 
 if TYPE_CHECKING:
     import numpy as np
@@ -132,12 +130,16 @@ class StructuredOutputManager:
             backend = request.sampling_params.structured_outputs._backend
             vocab_size = self.vllm_config.model_config.get_vocab_size()
             if backend == "xgrammar":
+                from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
+
                 self.backend = XgrammarBackend(
                     self.vllm_config,
                     tokenizer=self.tokenizer,
                     vocab_size=vocab_size,
                 )
             elif backend == "guidance":
+                from vllm.v1.structured_output.backend_guidance import GuidanceBackend
+
                 self.backend = GuidanceBackend(
                     self.vllm_config,
                     tokenizer=self.tokenizer,

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
 
 import copy
 import json

--- a/vllm/v1/structured_output/backend_lm_format_enforcer.py
+++ b/vllm/v1/structured_output/backend_lm_format_enforcer.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import ast
 import json
 from dataclasses import dataclass, field

--- a/vllm/v1/structured_output/backend_lm_format_enforcer.py
+++ b/vllm/v1/structured_output/backend_lm_format_enforcer.py
@@ -35,7 +35,7 @@ else:
 @lru_cache
 def _cached_build_vllm_token_enforcer_tokenizer_data(
     tokenizer: PreTrainedTokenizerBase, vocab_size: int
-) -> "lmfe_vllm.TokenEnforcerTokenizerData":
+) -> lmfe_vllm.TokenEnforcerTokenizerData:
     return lmfe_vllm.build_vllm_token_enforcer_tokenizer_data(
         tokenizer, use_bitmask=True, vocab_size=vocab_size
     )

--- a/vllm/v1/structured_output/backend_lm_format_enforcer.py
+++ b/vllm/v1/structured_output/backend_lm_format_enforcer.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import ast
 import json
 from dataclasses import dataclass, field
@@ -35,7 +37,7 @@ else:
 @lru_cache
 def _cached_build_vllm_token_enforcer_tokenizer_data(
     tokenizer: PreTrainedTokenizerBase, vocab_size: int
-) -> "lmfe_vllm.TokenEnforcerTokenizerData":
+) -> lmfe_vllm.TokenEnforcerTokenizerData:
     return lmfe_vllm.build_vllm_token_enforcer_tokenizer_data(
         tokenizer, use_bitmask=True, vocab_size=vocab_size
     )

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Purpose

Make `pip install` work on riscv64. Four requirements have no riscv64 wheels and no platform marker, so installation fails before vLLM is ever imported:

| Package | Why it fails |
|---|---|
| `numba` | `llvmlite` has no riscv64 backend; 0.49.0 still publishes no riscv64 wheel |
| `outlines_core` | Rust/maturin, no riscv64 wheel |
| `opencv-python-headless` | C++ build, no riscv64 wheel |
| `mistral_common[image]` | the `[image]` extra pulls in opencv |

The markers follow the pattern already used for `s390x` and `ppc64le` in the same files, and match the `riscv64` marker already on the `torch` line of `requirements/cpu.txt`.

Dropping `numba` costs N-gram speculative decoding and nothing else: every import of `ngram_proposer` is function-local or under `TYPE_CHECKING`, so the startup path never reaches it.

The second change defers `GuidanceBackend` and `XgrammarBackend` to local imports in `grammar_init`, which is what `OutlinesBackend` and `LMFormatEnforcerBackend` already do a few lines below. `llguidance` and `xgrammar` are both already gated off riscv64, so the eager module-level imports break `import vllm` there. The three `from __future__ import annotations` keep `@dataclass` field annotations from resolving the LazyLoader at class definition time.

Rebased onto main today and reduced. An earlier version of this PR also skipped the C++ extension build to run pure-Python; that is obsolete now the RVV CPU backend is in main, and has been dropped. Install failure independently reported by @jysh1214 in this thread.

## Test Plan

```bash
python -c "
from packaging.requirements import Requirement
for path in ('requirements/common.txt', 'requirements/cpu.txt'):
    for ln in open(path):
        ln = ln.split('#')[0].strip()
        if not ln or ln.startswith('-'): continue
        r = Requirement(ln)
        if r.marker and 'riscv64' in str(r.marker):
            for m in ('riscv64', 'x86_64', 'aarch64', 's390x', 'ppc64le'):
                print(path, r.name, m, r.marker.evaluate({'platform_machine': m}))
"
ruff check vllm/v1/structured_output/
ruff format --diff vllm/v1/structured_output/
```

## Test Result

Marker evaluation: on riscv64 the four packages resolve `False` and base `mistral_common` resolves `True`; on x86_64, aarch64 and ppc64le nothing changes; the pre-existing `s390x` exclusion on `numba` is preserved. No other requirement line is affected.

`ruff check` and `ruff format --diff` are clean on the four changed Python files, with ruff 0.15.10 rather than the 0.14.0 pinned in `.pre-commit-config.yaml`. `pre-commit` itself is skipped in CI because `pre-run-check` gates it.

Not re-tested on riscv64 hardware since the rebase. The earlier hardware run (BananaPi F3, SpacemiT K1, rv64gcv) validated the previous pure-Python version of this branch, which took a different build path, so I am not carrying that result forward as evidence for this diff.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
