### PR TITLE
[MTP][Sparse MLA] Take advantage of native MTP support in indexer when possible

### DIFF
--- a/csrc/sampler.cu
+++ b/csrc/sampler.cu
@@ -575,7 +575,7 @@ static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowDecode(
   // The range of logits within the row.
   int rowStart = 0;
   int seq_len = seqLens[rowIdx / next_n];
-  int rowEnd = seq_len - next_n + (rowIdx % next_n) + 1;
+  int rowEnd = max(0, seq_len - next_n + (rowIdx % next_n) + 1);
 
   // Local pointers to this block
   if constexpr (!multipleBlocksPerRow && !mergeBlocks) {

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -230,10 +230,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             if self.vllm_config.speculative_config
             else 0
         )
+        next_n = self.num_speculative_tokens + 1
         self.reorder_batch_threshold += self.num_speculative_tokens
-        self.use_flattening = (
-            self.num_speculative_tokens + 1
-        ) not in self.natively_supported_next_n
+        self.use_flattening = next_n not in self.natively_supported_next_n
 
         sm_count = num_compute_units(self.device.index)
         self.num_sms = sm_count
@@ -243,10 +242,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             dtype=torch.int32,
             device=self.device,
         )
-
-        # Pre-allocated buffers for flattening (spec decode).
+        self.offsets_buffer = torch.arange(
+            next_n, device=self.device, dtype=torch.int32
+        )
         self.arange_buffer = torch.arange(
-            scheduler_config.max_num_seqs * (1 + self.num_speculative_tokens),
+            scheduler_config.max_num_seqs * next_n,
             dtype=torch.int32,
             device=self.device,
         )
@@ -380,7 +380,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             use_native = not self.use_flattening and max_decode_len == next_n
 
             if use_native and next_n > 1:
-                offsets = torch.arange(next_n, device=self.device, dtype=torch.int32)
+                offsets = self.offsets_buffer
                 batch_size = num_decodes
             elif max_decode_len > 1:
                 # Flatten multi-token decode requests into single-token

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -203,6 +203,8 @@ def get_max_prefill_buffer_size(vllm_config: VllmConfig):
 
 class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
     reorder_batch_threshold: int = 1
+    natively_supported_next_n: list[int] = [1, 2]
+    # TODO (matt): integrate kernel with next_n = 4 support
 
     @classmethod
     def get_cudagraph_support(
@@ -229,6 +231,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             else 0
         )
         self.reorder_batch_threshold += self.num_speculative_tokens
+        self.use_flattening = (
+            self.num_speculative_tokens + 1
+        ) not in self.natively_supported_next_n
 
         sm_count = num_compute_units(self.device.index)
         self.num_sms = sm_count
@@ -320,7 +325,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
             split_decodes_and_prefills(
-                common_attn_metadata, decode_threshold=self.reorder_batch_threshold
+                common_attn_metadata,
+                decode_threshold=self.reorder_batch_threshold,
+                require_uniform=not self.use_flattening,
             )
         )
 
@@ -369,10 +376,20 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             block_table.clamp_(min=0)
 
             max_decode_len = int(decode_lens_cpu.max().item())
-            if max_decode_len > 1:
+            next_n = 1 + self.num_speculative_tokens
+            use_native = not self.use_flattening and max_decode_len == next_n
+
+            if use_native and next_n > 1:
+                offsets = torch.arange(next_n, device=self.device, dtype=torch.int32)
+                batch_size = num_decodes
+            elif max_decode_len > 1:
                 # Flatten multi-token decode requests into single-token
                 # batch entries, expanding seq_lens and block tables so
                 # the kernel always sees next_n=1.
+
+                # Also handles the edge case where use_flattening=False
+                # but max_decode_len != next_n (e.g. a batch containing some
+                # single-token prefills and no decodes when num_speculative_tokens = 1).
 
                 # Assume 4 requests with seq_lens [10, 7, 12, 0] (the final req is
                 # padding) and decode_lens [3, 1, 4, 0] in the below example comments.
@@ -425,13 +442,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 offsets = None
                 batch_size = num_decode_tokens
             else:
-                next_n = 1 + self.num_speculative_tokens
-                if next_n > 1:
-                    offsets = torch.arange(
-                        next_n, device=self.device, dtype=torch.int32
-                    )
-                else:
-                    offsets = None
+                offsets = None
                 batch_size = num_decodes
 
             # DeepGEMM is required for the paged MQA logits on CUDA devices

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -389,7 +389,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
                 # Also handles the edge case where use_flattening=False
                 # but max_decode_len != next_n (e.g. a batch containing some
-                # single-token prefills and no decodes when num_speculative_tokens = 1).
+                # short prefills (q_len < next_n) and no true decodes).
 
                 # Assume 4 requests with seq_lens [10, 7, 12, 0] (the final req is
                 # padding) and decode_lens [3, 1, 4, 0] in the below example comments.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
PR #34552 added support for MTP > 1 with sparse MLA by unconditionally flattening all requests into single-token decodes. The indexer kernel does support MTP = 1, though, and future iterations of the kernel will support other token counts e.g. MTP = 3. This PR takes advantage of this support by only flattening when the specified `num_speculative_tokens` is not natively supported by the kernel.

It does this by turning on `require_uniform` when taking this pathway. When very short prefills (< `1 + num_speculative_tokens`) are present in the batch, these requests and all others below (including decodes) will be treated as prefills. This is suboptimal, but expected to be very rare. Addressing it would require reordering the batch into [speculative decodes, short prefills, all other prefills] rather than just [decodes, prefills], which would add complexity.

## Test Plan
```
vllm serve deepseek-ai/DeepSeek-V3.2 \
    -tp 8 -ep \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 1}' \
    --no-enable-prefix-caching
```
with
```
vllm bench serve \
    --dataset-name spec_bench \
    --dataset-path question.jsonl \
    --spec-bench-output-len 1024 \
    --seed 42 \
    --ignore-eos \
    --temperature 0 \
    --tokenizer deepseek-ai/DeepSeek-V3
```

## Test Result
### Main
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  96.72     
Total input tokens:                      310052    
Total generated tokens:                  1024000   
Request throughput (req/s):              10.34     
Output token throughput (tok/s):         10587.74  
Peak output token throughput (tok/s):    9616.00   
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          13793.54  
---------------Time to First Token----------------
Mean TTFT (ms):                          7737.62   
Median TTFT (ms):                        7051.60   
P99 TTFT (ms):                           15349.34  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          72.98     
Median TPOT (ms):                        72.92     
P99 TPOT (ms):                           81.29     
---------------Inter-token Latency----------------
Mean ITL (ms):                           139.33    
Median ITL (ms):                         113.82    
P99 ITL (ms):                            368.19    
---------------Speculative Decoding---------------
Acceptance rate (%):                     91.04     
Acceptance length:                       1.91      
Drafts:                                  535608    
Draft tokens:                            535608    
Accepted tokens:                         487602    
Per-position acceptance (%):
  Position 0:                            91.04     
==================================================
```
### PR
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  95.90     
Total input tokens:                      310052    
Total generated tokens:                  1024000   
Request throughput (req/s):              10.43     
Output token throughput (tok/s):         10678.25  
Peak output token throughput (tok/s):    9786.00   
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          13911.46  
---------------Time to First Token----------------
Mean TTFT (ms):                          7779.73   
Median TTFT (ms):                        7314.22   
P99 TTFT (ms):                           15318.20  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          72.71     
Median TPOT (ms):                        72.83     
P99 TPOT (ms):                           80.71     
---------------Inter-token Latency----------------
Mean ITL (ms):                           138.74    
Median ITL (ms):                         113.15    
P99 ITL (ms):                            366.24    
---------------Speculative Decoding---------------
Acceptance rate (%):                     90.96     
Acceptance length:                       1.91      
Drafts:                                  535831    
Draft tokens:                            535831    
Accepted tokens:                         487380    
Per-position acceptance (%):
  Position 0:                            90.96     
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

