### PR TITLE
[Bugfix] Fix delta_text and delta_token_ids desync with stop strings

### DIFF
--- a/tests/v1/engine/test_detokenizer_stop_string_sync.py
+++ b/tests/v1/engine/test_detokenizer_stop_string_sync.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Regression test for issue #36830: delta_text and delta_token_ids
+desync with stop sequences.
+
+This test verifies that when stop strings are used, the delta_text and
+delta_token_ids outputs remain synchronized - i.e., the number of characters
+in delta_text corresponds to the tokens in delta_token_ids.
+
+The fix ensures that when stop buffers hold back text to check for stop strings,
+the corresponding token IDs are ALSO held back, maintaining synchronization.
+"""
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.detokenizer import BaseIncrementalDetokenizer
+
+
+def _make_request(
+    stop: list[str] | None = None,
+    include_stop_str_in_output: bool = False,
+) -> EngineCoreRequest:
+    """Create a minimal EngineCoreRequest for testing."""
+    return EngineCoreRequest(
+        request_id="test",
+        external_req_id="test-ext",
+        prompt_token_ids=[],
+        mm_features=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        sampling_params=SamplingParams(
+            skip_special_tokens=False,
+            spaces_between_special_tokens=True,
+            stop=stop,
+            include_stop_str_in_output=include_stop_str_in_output,
+            detokenize=True,
+        ),
+        pooling_params=None,
+    )
+
+
+class SimpleTestDetokenizer(BaseIncrementalDetokenizer):
+    """Simple test detokenizer that maps token IDs to text without a real tokenizer."""
+
+    def __init__(self, request: EngineCoreRequest, text_map: dict[int, str]):
+        super().__init__(request)
+        self.text_map = text_map
+
+    def decode_next(self, next_token_id: int) -> str:
+        return self.text_map.get(next_token_id, f"<unk{next_token_id}>")
+
+
+class SimpleTestDetokenizerWithPrompt(SimpleTestDetokenizer):
+    """Simulates SlowIncrementalDetokenizer by prepending prompt tokens."""
+
+    def __init__(
+        self,
+        request: EngineCoreRequest,
+        text_map: dict[int, str],
+        prompt_token_ids: list[int],
+    ):
+        super().__init__(request, text_map)
+        self._prompt_len = len(prompt_token_ids)
+        # Prepend prompt tokens like SlowIncrementalDetokenizer does.
+        self.token_ids: list[int] = list(prompt_token_ids) + self.token_ids
+
+    @property
+    def _output_token_id_start(self) -> int:
+        return self._prompt_len
+
+    def num_output_tokens(self) -> int:
+        return len(self.token_ids) - self._prompt_len
+
+
+def test_released_token_count_without_stop_buffer():
+    """Test _released_token_count when there's no stop buffer."""
+    request = _make_request()
+    text_map = {1: "Hello", 2: " ", 3: "world"}
+    detokenizer = SimpleTestDetokenizer(request, text_map)
+
+    detokenizer.update([1], stop_terminated=False)
+    detokenizer.update([2], stop_terminated=False)
+    detokenizer.update([3], stop_terminated=False)
+
+    released = detokenizer._released_token_count(finished=True)
+    assert released == 3
+
+
+def test_released_token_count_with_stop_buffer():
+    """Test _released_token_count when stop buffer holds back tokens."""
+    request = _make_request(stop=["world"])
+    text_map = {1: "Hello", 2: " ", 3: "world", 4: "!"}
+    detokenizer = SimpleTestDetokenizer(request, text_map)
+
+    assert detokenizer.stop_buffer_length == 4
+
+    # Add tokens without triggering stop string
+    detokenizer.update([1], stop_terminated=False)  # "Hello"
+    detokenizer.update([2], stop_terminated=False)  # "Hello "
+    detokenizer.update([4], stop_terminated=False)  # "Hello !"
+
+    # Token offsets: [5, 6, 7]
+    # When finished, buffer_length = 0, so all tokens released
+    assert detokenizer._released_token_count(finished=True) == 3
+
+    # When not finished, buffer_length = 4
+    # text_length = 7 - 4 = 3
+    # No token has offset <= 3, so 0 released
+    assert detokenizer._released_token_count(finished=False) == 0
+
+
+def test_get_next_output_token_ids_uses_released_count():
+    """Test that get_next_output_token_ids returns only released tokens."""
+    request = _make_request(stop=["xyz"])
+    text_map = {1: "a", 2: "b", 3: "c", 4: "d", 5: "e"}
+    detokenizer = SimpleTestDetokenizer(request, text_map)
+
+    for token_id in [1, 2, 3, 4, 5]:
+        detokenizer.update([token_id], stop_terminated=False)
+
+    assert len(detokenizer.token_ids) == 5
+
+    released = detokenizer._released_token_count(finished=False)
+    assert released < 5
+
+    token_ids = detokenizer.get_next_output_token_ids(finished=False, delta=False)
+    assert len(token_ids) == released
+
+    token_ids_finished = detokenizer.get_next_output_token_ids(
+        finished=True, delta=False
+    )
+    assert len(token_ids_finished) == 5
+
+
+def test_token_offset_tracking():
+    """Test that _token_text_offsets tracks cumulative text length."""
+    request = _make_request()
+    text_map = {1: "abc", 2: "def", 3: "g"}
+    detokenizer = SimpleTestDetokenizer(request, text_map)
+
+    detokenizer.update([1], stop_terminated=False)
+    assert detokenizer._token_text_offsets == [3]
+
+    detokenizer.update([2], stop_terminated=False)
+    assert detokenizer._token_text_offsets == [3, 6]
+
+    detokenizer.update([3], stop_terminated=False)
+    assert detokenizer._token_text_offsets == [3, 6, 7]
+
+    assert detokenizer._released_token_count(finished=True) == 3
+
+
+def test_delta_text_and_token_ids_stay_in_sync():
+    """End-to-end test: delta_text and delta_token_ids stay synchronized.
+
+    This is the core regression test for issue #36830. Text is released at
+    character granularity while tokens are atomic, so during streaming the
+    token-decoded text is always a prefix of the cumulative delta text
+    (tokens never outpace text). On finish, both must be equal.
+
+    Before the fix, token IDs were NOT held back by the stop buffer at all,
+    so delta_token_ids would race far ahead of delta_text.
+    """
+    request = _make_request(stop=["stop"])
+    # stop_buffer_length = len("stop") - 1 = 3
+    text_map = {10: "He", 20: "ll", 30: "o ", 40: "wor", 50: "ld"}
+    detokenizer = SimpleTestDetokenizer(request, text_map)
+
+    all_delta_text = ""
+    all_delta_token_ids: list[int] = []
+
+    for token_id in [10, 20, 30, 40, 50]:
+        detokenizer.update([token_id], stop_terminated=False)
+        dt = detokenizer.get_next_output_text(finished=False, delta=True)
+        dtids = detokenizer.get_next_output_token_ids(finished=False, delta=True)
+        all_delta_text += dt
+        all_delta_token_ids.extend(dtids)
+
+        # Token-decoded text must be a prefix of cumulative delta text.
+        # Tokens are held back until their full text clears the buffer,
+        # so they never outpace the released text.
+        token_text = "".join(text_map[tid] for tid in all_delta_token_ids)
+        assert all_delta_text.startswith(token_text), (
+            f"Desync after token {token_id}: "
+            f"delta_text={all_delta_text!r} does not start with "
+            f"token_text={token_text!r}"
+        )
+
+    # On finish, remaining buffered text/tokens are flushed.
+    dt = detokenizer.get_next_output_text(finished=True, delta=True)
+    dtids = detokenizer.get_next_output_token_ids(finished=True, delta=True)
+    all_delta_text += dt
+    all_delta_token_ids.extend(dtids)
+
+    # After finish, both must be exactly equal.
+    expected_text = "".join(text_map[tid] for tid in all_delta_token_ids)
+    assert all_delta_text == expected_text
+    assert all_delta_token_ids == [10, 20, 30, 40, 50]
+
+
+def test_prompt_prefix_not_included_in_output_token_ids():
+    """Test that prompt tokens are excluded from get_next_output_token_ids.
+
+    SlowIncrementalDetokenizer prepends prompt tokens to token_ids.
+    The output must only contain generated tokens, not the prompt.
+    """
+    request = _make_request(stop=["zz"])
+    text_map = {101: "x", 102: "y", 103: "z"}
+    prompt_ids = [900, 901, 902]  # 3 prompt tokens
+    detokenizer = SimpleTestDetokenizerWithPrompt(request, text_map, prompt_ids)
+
+    for token_id in [101, 102, 103]:
+        detokenizer.update([token_id], stop_terminated=False)
+
+    # Non-delta, finished: should return only output tokens, not prompt
+    token_ids = detokenizer.get_next_output_token_ids(finished=True, delta=False)
+    assert token_ids == [101, 102, 103]
+    assert 900 not in token_ids
+
+    # Non-delta, not finished: should still exclude prompt, respect buffer
+    token_ids_buffered = detokenizer.get_next_output_token_ids(
+        finished=False, delta=False
+    )
+    assert all(tid not in token_ids_buffered for tid in prompt_ids)
+
+
+def test_prompt_prefix_excluded_in_delta_mode():
+    """Test delta mode also excludes prompt tokens."""
+    request = _make_request()  # no stop string
+    text_map = {10: "a", 20: "b"}
+    prompt_ids = [900, 901]
+    detokenizer = SimpleTestDetokenizerWithPrompt(request, text_map, prompt_ids)
+
+    detokenizer.update([10], stop_terminated=False)
+    dtids = detokenizer.get_next_output_token_ids(finished=False, delta=True)
+    assert dtids == [10]
+
+    detokenizer.update([20], stop_terminated=False)
+    dtids = detokenizer.get_next_output_token_ids(finished=False, delta=True)
+    assert dtids == [20]

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from abc import ABC, abstractmethod
+from bisect import bisect_right
 
 import tokenizers
 from packaging import version
@@ -30,6 +31,7 @@ INVALID_PREFIX_ERR_MSG = "Invalid prefix encountered"
 class IncrementalDetokenizer:
     def __init__(self):
         self.token_ids: list[int] = []
+        self._last_output_token_offset: int = 0
 
     @property
     def output_token_ids(self) -> list[int]:
@@ -44,6 +46,16 @@ class IncrementalDetokenizer:
 
     def get_next_output_text(self, finished: bool, delta: bool) -> str:
         return ""
+
+    def get_next_output_token_ids(self, finished: bool, delta: bool) -> list[int]:
+        if not delta:
+            return self.token_ids
+        last = self._last_output_token_offset
+        current = len(self.token_ids)
+        if last < current:
+            self._last_output_token_offset = current
+            return self.token_ids[last:current]
+        return []
 
     @classmethod
     def from_new_request(
@@ -89,6 +101,10 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
             self.stop_buffer_length = 0
         self._last_output_text_offset: int = 0
 
+        # Cumulative text length after decoding each token, used to
+        # synchronize token_ids output with the text stop-buffer.
+        self._token_text_offsets: list[int] = []
+
         # Generation data
         self.output_text = ""
 
@@ -117,6 +133,7 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         for new_token_id in new_token_ids:
             self.token_ids.append(new_token_id)
             self.output_text += self.decode_next(new_token_id)
+            self._token_text_offsets.append(len(self.output_text))
             # Support min_tokens, see https://github.com/vllm-project/vllm/pull/22014
             if self.min_tokens and self.num_output_tokens() <= self.min_tokens:
                 stop_check_offset = len(self.output_text)
@@ -124,6 +141,7 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         if skipped_stop_token_id is not None:
             # Cleanup after skipping detokenization.
             self.token_ids.append(skipped_stop_token_id)
+            self._token_text_offsets.append(len(self.output_text))
 
         # 2) Evaluate stop strings.
         stop_string = None
@@ -145,6 +163,23 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
     def decode_next(self, next_token_id: int) -> str:
         raise NotImplementedError
 
+    @property
+    def _output_token_id_start(self) -> int:
+        """Index into self.token_ids where output tokens begin.
+        Overridden by SlowIncrementalDetokenizer to skip prompt tokens."""
+        return 0
+
+    def _released_token_count(self, finished: bool) -> int:
+        """Return the number of tokens whose decoded text has been
+        fully released past the stop-string buffer."""
+        buffer_length = 0 if finished else self.stop_buffer_length
+        if not buffer_length:
+            return len(self._token_text_offsets)
+
+        text_length = len(self.output_text) - buffer_length
+        # _token_text_offsets is monotonically non-decreasing.
+        return bisect_right(self._token_text_offsets, text_length)
+
     def get_next_output_text(self, finished: bool, delta: bool) -> str:
         """If delta is True, only new text since the last call to
         this method is returned"""
@@ -162,6 +197,23 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
             self._last_output_text_offset = length
             return self.output_text[last_offset:length]
         return ""
+
+    def get_next_output_token_ids(self, finished: bool, delta: bool) -> list[int]:
+        """Return token IDs synchronized with the text stop-buffer.
+
+        When stop strings cause text to be held back, the corresponding
+        token IDs are also held back so that delta_text and
+        delta_token_ids stay in sync."""
+        released = self._released_token_count(finished)
+        start = self._output_token_id_start
+        if not delta:
+            return self.token_ids[start : start + released]
+
+        last_offset = self._last_output_token_offset
+        if last_offset < released:
+            self._last_output_token_offset = released
+            return self.token_ids[start + last_offset : start + released]
+        return []
 
 
 class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
@@ -273,6 +325,10 @@ class SlowIncrementalDetokenizer(BaseIncrementalDetokenizer):
 
         self.skip_special_tokens = params.skip_special_tokens
         self.spaces_between_special_tokens = params.spaces_between_special_tokens
+
+    @property
+    def _output_token_id_start(self) -> int:
+        return self.prompt_len
 
     @property
     def output_token_ids(self) -> list[int]:

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -298,11 +298,6 @@ class RequestState:
                 return None
 
             if self.output_kind == RequestOutputKind.DELTA:
-                # Send tokens from the offset in DELTA mode, otherwise all
-                # tokens are sent.
-                new_token_ids = self.detokenizer.output_token_ids[
-                    self.sent_tokens_offset :
-                ]
                 self.sent_tokens_offset = self.detokenizer.num_output_tokens()
 
         external_req_id = self.external_req_id
@@ -314,9 +309,7 @@ class RequestState:
                 finished,
             )
 
-        output = self._new_completion_output(
-            new_token_ids, finish_reason, stop_reason, routed_experts
-        )
+        output = self._new_completion_output(finish_reason, stop_reason, routed_experts)
 
         if self.parent_req is None:
             outputs = [output]
@@ -375,7 +368,6 @@ class RequestState:
 
     def _new_completion_output(
         self,
-        token_ids: list[int],
         finish_reason: FinishReason | None,
         stop_reason: int | str | None,
         routed_experts: np.ndarray | None = None,
@@ -387,8 +379,7 @@ class RequestState:
 
         # Prepare text and token_ids, based on delta mode
         text = self.detokenizer.get_next_output_text(finished, delta)
-        if not delta:
-            token_ids = self.detokenizer.output_token_ids
+        token_ids = self.detokenizer.get_next_output_token_ids(finished, delta)
 
         # Prepare logprobs, based on delta mode
         logprobs = self.logprobs_processor.logprobs


### PR DESCRIPTION
## Summary
- When stop strings are used, the text stop-buffer holds back characters to check for matches, but `delta_token_ids` were not held back correspondingly — causing them to race ahead of `delta_text`
- Fix by tracking cumulative text offsets per token and using `bisect_right` to determine how many tokens have been fully released past the stop buffer
- Add `get_next_output_token_ids()` to the detokenizer API so token IDs are synchronized with text output in both delta and non-delta modes
- Simplify `output_processor.py` by delegating token ID slicing to the detokenizer

Fixes #36830

## Test plan
- [x] Added 7 unit tests in `tests/v1/engine/test_detokenizer_stop_string_sync.py`
- [x] Core regression test: `test_delta_text_and_token_ids_stay_in_sync` verifies delta text/tokens never desync during streaming
- [x] Tests cover: offset tracking, stop buffer interaction, released token count, prompt prefix exclusion, delta vs non-delta modes
- [x] All tests pass: `pytest tests/v1/engine/test_detokenizer_stop_string_sync.py -v`
- [x] Pre-commit hooks pass on all changed files

## AI disclosure
AI assistance (Claude) was used in developing this change. All code has been reviewed and tested by the human submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)