### PR TITLE
[FlashInfer] Revert block_size 16 + head_size 256 workaround on Blackwell

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from vllm.logger import init_logger
 from vllm.model_executor.models import ModelRegistry
-from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -148,17 +147,6 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
             ).page_size_bytes
         else:
             kernel_block_alignment_size = 16
-            if (
-                current_platform.is_device_capability_family(100)
-                and model_config.get_head_size() == 256
-                and (
-                    attention_config.backend is None
-                    or attention_config.backend == AttentionBackendEnum.FLASHINFER
-                )
-            ):
-                # https://github.com/flashinfer-ai/flashinfer/issues/1993 reports that`
-                # head size 256 and block size 16 is not supported on blackwell.
-                kernel_block_alignment_size = 32
             attn_page_size_1_token = FullAttentionSpec(
                 block_size=1,
                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -630,15 +630,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.paged_kv_indices = self._make_buffer(max_num_pages)
         self.paged_kv_last_page_len = self._make_buffer(max_num_reqs)
 
-        if self.head_dim == 256 and current_platform.is_device_capability_family(100):
-            # https://github.com/flashinfer-ai/flashinfer/issues/1993 reports that
-            # head size 256 and block size 16 is not supported on blackwell.
-            assert kv_cache_spec.block_size != 16, (
-                "There is a bug in FlashInfer "
-                "block_size 16 head size 256 support. Please avoid this combination by "
-                "passing --block-size 32 or --block-size 64."
-            )
-
     def _make_buffer(
         self, *size: int | torch.SymInt, dtype: torch.dtype = torch.int32
     ) -> CpuGpuBuffer:


### PR DESCRIPTION
## Purpose

Revert the workaround introduced in [vllm-project/vllm#27994](https://github.com/vllm-project/vllm/pull/27994).

PR #27994 was originally merged to work around a FlashInfer bug tracked in [flashinfer-ai/flashinfer#1993](https://github.com/flashinfer-ai/flashinfer/issues/1993), which reported that the combination of `block_size=16` and `head_size=256` produced incorrect results on Blackwell. The workaround forced `kernel_block_alignment_size=32` (instead of 16) when this combination was detected, and added an assertion in the FlashInfer attention backend to block the problematic configuration entirely.

Since then, the upstream FlashInfer issue has been fixed and vLLM's FlashInfer dependency has been updated (in https://github.com/vllm-project/vllm/pull/30993) to a version that includes the fix (`v0.6`). The workaround is no longer necessary and can be safely removed.


## Test Plan

Tested on B200 GPUs.

### Qwen3-Next-80B-A3B-Instruct (hybrid mamba model, head_size 256)

This is the same model used to validate PR #27994. Ran full GSM8K 5-shot evaluation to confirm no accuracy regression.

```bash
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct -tp 4
lm_eval --model local-completions \
    --model_args model=Qwen/Qwen3-Next-80B-A3B-Instruct,base_url=http://localhost:8000/v1/completions,num_concurrent=109 \
    --tasks gsm8k --num_fewshot 5
```

**Results comparison:**

|                   | flexible-extract | strict-match |
|-------------------|-----------------|--------------|
| Before PR #27994  | 0.2123 ±0.0113  | 0.1933 ±0.0109 |
| After PR #27994   | 0.8491 ±0.0099  | 0.8120 ±0.0108 |
| **This PR (revert)** | **0.8567 ±0.0097** | **0.8127 ±0.0107** |




