### PR TITLE
Make skip_special_tokens configurable on the server side

### DIFF
--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -1043,19 +1043,22 @@ def test_skip_special_tokens_default():
 
 
 def test_skip_special_tokens_server_override():
-    """Test that server-side skip_special_tokens overrides request default."""
+    """Test that server-side skip_special_tokens overrides request default
+    when client does not explicitly set it."""
     request = ChatCompletionRequest(
         model="test-model",
         messages=[{"role": "user", "content": "Hello"}],
         max_tokens=10,
     )
+    # Client did not explicitly set skip_special_tokens
+    assert "skip_special_tokens" not in request.model_fields_set
 
-    # Simulate the serving layer override
+    # Simulate _apply_default_sampling_overrides
     default_sampling_params = {"skip_special_tokens": False}
-    if "skip_special_tokens" in default_sampling_params:
-        request.skip_special_tokens = (
-            default_sampling_params["skip_special_tokens"]
-        )
+    if "skip_special_tokens" not in request.model_fields_set:
+        request.skip_special_tokens = default_sampling_params[
+            "skip_special_tokens"
+        ]
 
     sampling_params = request.to_sampling_params(
         max_tokens=10,
@@ -1064,7 +1067,34 @@ def test_skip_special_tokens_server_override():
     assert sampling_params.skip_special_tokens is False
 
 
-def test_skip_special_tokens_client_explicit():
+def test_skip_special_tokens_client_override():
+    """Test that client-set skip_special_tokens takes precedence over
+    server default."""
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=10,
+        skip_special_tokens=True,
+    )
+    # Client explicitly set skip_special_tokens
+    assert "skip_special_tokens" in request.model_fields_set
+
+    # Simulate _apply_default_sampling_overrides with server default False
+    default_sampling_params = {"skip_special_tokens": False}
+    if "skip_special_tokens" not in request.model_fields_set:
+        request.skip_special_tokens = default_sampling_params[
+            "skip_special_tokens"
+        ]
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=10,
+        default_sampling_params=default_sampling_params,
+    )
+    # Client's explicit True wins over server's False
+    assert sampling_params.skip_special_tokens is True
+
+
+def test_skip_special_tokens_client_explicit_no_server_override():
     """Test that client-set skip_special_tokens is used when no server
     override."""
     request = ChatCompletionRequest(

--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -1021,3 +1021,83 @@ def test_chat_completion_request_n_parameter_various_values():
         assert sampling_params.n == n_value, (
             f"Expected n={n_value}, got n={sampling_params.n}"
         )
+
+
+# Unit tests for skip_special_tokens server-side override
+
+
+def test_skip_special_tokens_default():
+    """Test that skip_special_tokens defaults to True."""
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=10,
+    )
+    assert request.skip_special_tokens is True
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=10,
+        default_sampling_params={},
+    )
+    assert sampling_params.skip_special_tokens is True
+
+
+def test_skip_special_tokens_server_override():
+    """Test that server-side skip_special_tokens overrides request default."""
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=10,
+    )
+
+    # Simulate the serving layer override
+    default_sampling_params = {"skip_special_tokens": False}
+    if "skip_special_tokens" in default_sampling_params:
+        request.skip_special_tokens = (
+            default_sampling_params["skip_special_tokens"]
+        )
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=10,
+        default_sampling_params=default_sampling_params,
+    )
+    assert sampling_params.skip_special_tokens is False
+
+
+def test_skip_special_tokens_client_explicit():
+    """Test that client-set skip_special_tokens is used when no server
+    override."""
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=10,
+        skip_special_tokens=False,
+    )
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=10,
+        default_sampling_params={},
+    )
+    assert sampling_params.skip_special_tokens is False
+
+
+def test_skip_special_tokens_cli_flag():
+    """Test that --skip-special-tokens and --no-skip-special-tokens CLI flags
+    work correctly."""
+    from vllm.entrypoints.openai.cli_args import BaseFrontendArgs
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    parser = FlexibleArgumentParser()
+    BaseFrontendArgs.add_cli_args(parser)
+
+    # Default is True
+    args = parser.parse_args([])
+    assert args.skip_special_tokens is True
+
+    # --no-skip-special-tokens sets False
+    args = parser.parse_args(["--no-skip-special-tokens"])
+    assert args.skip_special_tokens is False
+
+    # --skip-special-tokens explicitly sets True
+    args = parser.parse_args(["--skip-special-tokens"])
+    assert args.skip_special_tokens is True

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -276,10 +276,7 @@ class OpenAIServingChat(OpenAIServing):
                 self.override_max_tokens,
             )
 
-            if "skip_special_tokens" in self.default_sampling_params:
-                request.skip_special_tokens = (
-                    self.default_sampling_params["skip_special_tokens"]
-                )
+            self._apply_default_sampling_overrides(request)
 
             sampling_params: SamplingParams | BeamSearchParams
             if request.use_beam_search:

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -276,6 +276,11 @@ class OpenAIServingChat(OpenAIServing):
                 self.override_max_tokens,
             )
 
+            if "skip_special_tokens" in self.default_sampling_params:
+                request.skip_special_tokens = (
+                    self.default_sampling_params["skip_special_tokens"]
+                )
+
             sampling_params: SamplingParams | BeamSearchParams
             if request.use_beam_search:
                 sampling_params = request.to_beam_search_params(

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -154,9 +154,11 @@ class BaseFrontendArgs:
     """
     log_error_stack: bool = envs.VLLM_SERVER_DEV_MODE
     """If set to True, log the stack trace of error responses"""
+    skip_special_tokens: bool = True
+    """Whether to skip special tokens in the output."""
     tokens_only: bool = False
     """
-    If set to True, only enable the Tokens In<>Out endpoint. 
+    If set to True, only enable the Tokens In<>Out endpoint.
     This is intended for use in a Disaggregated Everything setup.
     """
 

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -154,10 +154,7 @@ class OpenAIServingCompletion(OpenAIServing):
                 self.override_max_tokens,
             )
 
-            if "skip_special_tokens" in self.default_sampling_params:
-                request.skip_special_tokens = (
-                    self.default_sampling_params["skip_special_tokens"]
-                )
+            self._apply_default_sampling_overrides(request)
 
             sampling_params: SamplingParams | BeamSearchParams
             if request.use_beam_search:

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -154,6 +154,11 @@ class OpenAIServingCompletion(OpenAIServing):
                 self.override_max_tokens,
             )
 
+            if "skip_special_tokens" in self.default_sampling_params:
+                request.skip_special_tokens = (
+                    self.default_sampling_params["skip_special_tokens"]
+                )
+
             sampling_params: SamplingParams | BeamSearchParams
             if request.use_beam_search:
                 sampling_params = request.to_beam_search_params(

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -216,6 +216,19 @@ class OpenAIServing:
         self.renderer = engine_client.renderer
         self.io_processor = engine_client.io_processor
         self.input_processor = engine_client.input_processor
+        self.default_sampling_params: dict[str, Any] = {}
+
+    def _apply_default_sampling_overrides(self, request: Any) -> None:
+        """Apply server-side sampling param overrides to the request.
+
+        Only overrides fields that the client did not explicitly set.
+        """
+        if "skip_special_tokens" not in getattr(
+            request, "model_fields_set", set()
+        ):
+            request.skip_special_tokens = self.default_sampling_params.get(
+                "skip_special_tokens", request.skip_special_tokens
+            )
 
     async def beam_search(
         self,

--- a/vllm/entrypoints/openai/generate/api_router.py
+++ b/vllm/entrypoints/openai/generate/api_router.py
@@ -153,6 +153,17 @@ async def init_generate_state(
         if "generate" in supported_tasks
         else None
     )
+    # Inject server-side skip_special_tokens into default sampling params
+    for serving in (
+        state.openai_serving_responses,
+        state.openai_serving_chat,
+        state.openai_serving_completion,
+    ):
+        if serving is not None:
+            serving.default_sampling_params["skip_special_tokens"] = (
+                args.skip_special_tokens
+            )
+
     state.anthropic_serving_messages = (
         AnthropicServingMessages(
             engine_client,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -427,10 +427,7 @@ class OpenAIServingResponses(OpenAIServing):
                 self.override_max_tokens,
             )
 
-            if "skip_special_tokens" in self.default_sampling_params:
-                request.skip_special_tokens = (
-                    self.default_sampling_params["skip_special_tokens"]
-                )
+            self._apply_default_sampling_overrides(request)
 
             sampling_params = request.to_sampling_params(
                 default_max_tokens, self.default_sampling_params

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -427,6 +427,11 @@ class OpenAIServingResponses(OpenAIServing):
                 self.override_max_tokens,
             )
 
+            if "skip_special_tokens" in self.default_sampling_params:
+                request.skip_special_tokens = (
+                    self.default_sampling_params["skip_special_tokens"]
+                )
+
             sampling_params = request.to_sampling_params(
                 default_max_tokens, self.default_sampling_params
             )


### PR DESCRIPTION
Co-authored-by: Claude


## Purpose

Add skip_special_tokens as a configurable server-side flag (default: True). Operators can use --no-skip-special-tokens to include special tokens in output for all requests.

## Test Plan

Added unit tests.

Also started vLLM on GB300 with --no-skip-special-tokens, and verified it didn't skip special tokens without any overrides in client requests.

## Test Result

Unit tests passed. Integration test passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

