### PR TITLE
[Bugfix] Fix DeepSeek-V3.2 tokenizer stripping spaces

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -540,6 +540,8 @@ class ModelConfig:
                 self.tokenizer_mode = "kimi_audio"
             elif arch == "QwenVLForConditionalGeneration":
                 self.tokenizer_mode = "qwen_vl"
+            elif arch == "DeepseekV32ForCausalLM":
+                self.tokenizer_mode = "deepseek_v32"
 
             if self.tokenizer_mode != "auto":
                 logger.info(

--- a/vllm/tokenizers/deepseek_v32.py
+++ b/vllm/tokenizers/deepseek_v32.py
@@ -3,7 +3,7 @@
 import copy
 from typing import Any
 
-from transformers import AutoTokenizer
+from transformers import PreTrainedTokenizerFast
 
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
 
@@ -85,5 +85,5 @@ def get_deepseek_v32_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
 class DeepseekV32Tokenizer(TokenizerLike):
     @classmethod
     def from_pretrained(cls, *args, **kwargs) -> HfTokenizer:
-        tokenizer = AutoTokenizer.from_pretrained(*args, **kwargs)
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(*args, **kwargs)
         return get_cached_tokenizer(get_deepseek_v32_tokenizer(tokenizer))


### PR DESCRIPTION
<!-- markdownlint-disable -->
DISCLAIMER: Generated with claude code

## Purpose
DeepSeek-V3.2's `tokenizer_config.json` specifies `LlamaTokenizerFast`, but the tokenizer is byte-level BPE. `LlamaTokenizer` remaps the vocab incorrectly — space-prefixed tokens like `Ġcapital` (ID 6102) get mapped to `capital` (ID 79666), and `decode()` produces spaceless text like `"ThecapitalofFranceisParis."`.

Fix: use `PreTrainedTokenizerFast` directly in `DeepseekV32Tokenizer`, which handles byte-level BPE correctly. Also auto-select the `deepseek_v32` tokenizer mode for `DeepseekV32ForCausalLM` so users don't need to pass `--tokenizer-mode` manually.

This also eliminates the following error which happens during server startup on main:

```
vllm serve deepseek-ai/DeepSeek-V3.2 -tp 8 -ep
```

```
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188] Chat template warmup failed
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188] Traceback (most recent call last):
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]   File "/home/MatthewBonanni/local/vllm/vllm/renderers/base.py", line 183, in warmup
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     self.render_chat([[{"role": "user", "content": "warmup"}]], chat_params)
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]   File "/home/MatthewBonanni/local/vllm/vllm/renderers/base.py", line 774, in render_chat
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     self.render_messages(conversation, chat_params)
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]   File "/home/MatthewBonanni/local/vllm/vllm/renderers/hf.py", line 664, in render_messages
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     prompt_raw = safe_apply_chat_template(
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]         model_config,
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     ...<2 lines>...
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]         **params.get_apply_chat_template_kwargs(),
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     )
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]   File "/home/MatthewBonanni/local/vllm/vllm/renderers/hf.py", line 481, in safe_apply_chat_template
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     raise ChatTemplateResolutionError(
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     ...<3 lines>...
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188]     )
(APIServer pid=2095436) ERROR 03-13 15:46:09 [base.py:188] vllm.entrypoints.chat_utils.ChatTemplateResolutionError: As of transformers v4.44, default chat template is no longer allowed, so you must provide a chat template if the tokenizer does not define one.
```

## Test Plan
```
from vllm.tokenizers.deepseek_v32 import DeepseekV32Tokenizer
t = DeepseekV32Tokenizer.from_pretrained('deepseek-ai/DeepSeek-V3.2')
t.decode(t.encode('The capital of France is Paris.'))
```

## Test Result
main: `'ThecapitalofFranceisParis.'`
PR:  `'The capital of France is Paris.'`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

