### PR TITLE
Add Mistral Guidance

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -31,7 +31,7 @@ partial-json-parser # used for parsing partial JSON outputs
 pyzmq >= 25.0.0
 msgspec
 gguf >= 0.17.0
-mistral_common[image] >= 1.9.1
+mistral_common[image] >= 1.10.0
 opencv-python-headless >= 4.13.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12

--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -95,7 +95,7 @@ transformers==4.57.5
 # Pin HF Hub version
 huggingface-hub==0.36.2
 # Pin Mistral Common
-mistral-common[image,audio]==1.9.1
+mistral-common[image,audio]==1.10.0
 # Required for Prithvi tests
 terratorch==1.2.2
 # Required for Prithvi tests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -482,7 +482,7 @@ mbstrdecoder==1.1.3
     #   typepy
 mdurl==0.1.2
     # via markdown-it-py
-mistral-common==1.9.1
+mistral-common==1.10.0
     # via -r requirements/test.in
 more-itertools==10.5.0
     # via lm-eval

--- a/tests/reasoning/test_mistral_reasoning_parser.py
+++ b/tests/reasoning/test_mistral_reasoning_parser.py
@@ -346,3 +346,57 @@ def test_mistral_reasoning(
     else:
         content = parser.extract_content_ids(output_tokens)
         assert content == []
+
+
+def test_is_reasoning_end_with_prefilled_system_prompt(
+    mistral_tokenizer: MistralTokenizer,
+):
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        mistral_tokenizer
+    )
+
+    # Simulate a prompt that ends with a closed think block followed by
+    # regular content (as in system prompts with pre-filled thinking).
+    prompt_text_before = "System prompt text. "
+    think_content = "I am thinking about the task."
+    prompt_text_after = " Continue with the task."
+
+    prompt_tokens = (
+        mistral_tokenizer.tokenizer.encode(prompt_text_before, bos=False, eos=False)
+        + [mistral_tokenizer.instruct.BEGIN_THINK]
+        + mistral_tokenizer.tokenizer.encode(think_content, bos=False, eos=False)
+        + [mistral_tokenizer.instruct.END_THINK]
+        + mistral_tokenizer.tokenizer.encode(prompt_text_after, bos=False, eos=False)
+    )
+
+    assert parser.is_reasoning_end(prompt_tokens) is True
+
+    reasoning, content = run_reasoning_extraction_mistral(
+        parser,
+        model_output=(
+            [mistral_tokenizer.instruct.BEGIN_THINK]
+            + mistral_tokenizer.tokenizer.encode(
+                "Let me reason about this.", bos=False, eos=False
+            )
+            + [mistral_tokenizer.instruct.END_THINK]
+            + mistral_tokenizer.tokenizer.encode(
+                "Here is the answer.", bos=False, eos=False
+            )
+        ),
+        streaming=True,
+    )
+    assert reasoning == "Let me reason about this."
+    assert content == "Here is the answer."
+
+
+def test_is_reasoning_end_prompt_only_content(
+    mistral_tokenizer: MistralTokenizer,
+):
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        mistral_tokenizer
+    )
+
+    prompt_tokens = mistral_tokenizer.tokenizer.encode(
+        "Just a regular prompt.", bos=False, eos=False
+    )
+    assert parser.is_reasoning_end(prompt_tokens) is False

--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -3,6 +3,8 @@
 
 import json
 from collections.abc import Generator
+from typing import Any, Literal
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import partial_json_parser
 import pytest
@@ -11,11 +13,22 @@ from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.protocol.instruct.tool_calls import FunctionCall, ToolCall
 from partial_json_parser.core.options import Allow
 
-from vllm.entrypoints.openai.engine.protocol import DeltaMessage, DeltaToolCall
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaMessage,
+    DeltaToolCall,
+    FunctionDefinition,
+)
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.tokenizers.detokenizer_utils import detokenize_incrementally
 from vllm.tokenizers.mistral import MistralTokenizer
-from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
+from vllm.tool_parsers.mistral_tool_parser import (
+    ChatCompletionToolsParam,
+    MistralGrammarFactory,
+    MistralToolCall,
+    MistralToolParser,
+    ToolsLarkConverter,
+)
 
 
 @pytest.fixture(scope="module")
@@ -426,20 +439,26 @@ def _test_extract_tool_calls_streaming(
 
     assert other_content == expected_content
 
-    actual_tool_calls = [
-        ToolCall(
-            id=tool_call_id,
-            function=FunctionCall(
-                name=function_name,
-                arguments=partial_json_parser.ensure_json(
-                    function_args_str, Allow.OBJ | Allow.STR
+    actual_tool_calls = []
+    for tool_call_id, function_name, function_args_str in zip(
+        tool_call_ids, function_names, function_args_strs
+    ):
+        actual_id: str = (
+            tool_call_id
+            if tool_call_id is not None
+            else MistralToolCall.generate_random_id()
+        )
+        actual_tool_calls.append(
+            ToolCall(
+                id=actual_id,
+                function=FunctionCall(
+                    name=function_name,
+                    arguments=partial_json_parser.ensure_json(
+                        function_args_str, Allow.OBJ | Allow.STR
+                    ),
                 ),
-            ),
+            )
         )
-        for tool_call_id, function_name, function_args_str in zip(
-            tool_call_ids, function_names, function_args_strs
-        )
-    ]
     assert_tool_calls(actual_tool_calls, expected_tool_calls)
 
 
@@ -890,3 +909,654 @@ def test_extract_tool_calls_streaming_pre_v11_tokenizer_one_chunk(
         assert expected_content == ""
     else:
         assert delta_message.content == expected_content
+
+
+def _create_tool(
+    name: str, parameters: dict[str, Any], strict: bool = False
+) -> ChatCompletionToolsParam:
+    """Helper function to create a tool with optional strict attribute"""
+    func = FunctionDefinition(
+        name=name,
+        description="test",
+        parameters=parameters,
+    )
+    if strict:
+        func.strict = True  # type: ignore[attr-defined]
+    return ChatCompletionToolsParam(function=func)
+
+
+class TestToolsLarkConverter:
+    @pytest.mark.parametrize(
+        ("tool", "expected"),
+        [
+            (
+                _create_tool("function", {"parameter": 1}, strict=True),
+                {"parameter": 1},
+            ),
+            (
+                _create_tool("function", {"parameter": 1}, strict=False),
+                {"type": "object"},
+            ),
+            (
+                _create_tool("function", {}, strict=True),
+                {"type": "object", "properties": {}, "additionalProperties": False},
+            ),
+        ],
+    )
+    def test_get_args_json(
+        self, tool: ChatCompletionToolsParam, expected: dict[str, Any]
+    ) -> None:
+        assert ToolsLarkConverter().get_args_json(tool=tool) == expected
+
+    @pytest.mark.parametrize(
+        "tools,tokenizer_version,mode,parallel_tool_calls,expected",
+        [
+            # mode="none" always returns empty string
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                7,
+                "none",
+                True,
+                "",
+            ),
+            # Pre-v11: non-strict parallel vs no-parallel (maxItems difference)
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                7,
+                "auto",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "enum": ["non_strict_func"]}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}}\n',  # noqa: E501
+            ),
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                7,
+                "auto",
+                False,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "enum": ["non_strict_func"]}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}, "maxItems": 1}\n',  # noqa: E501
+            ),
+            # Pre-v11: strict tool uses anyOf with const name
+            (
+                [_create_tool("strict_func", {"param": "value"}, strict=True)],
+                7,
+                "auto",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}]}}\n',  # noqa: E501
+            ),
+            # Pre-v11: empty strict params get default schema
+            (
+                [_create_tool("empty_strict_func", {}, strict=True)],
+                7,
+                "auto",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "empty_strict_func"}, "arguments": {"type": "object", "properties": {}, "additionalProperties": false}}}]}}\n',  # noqa: E501
+            ),
+            # Pre-v11: mixed strict/non-strict
+            (
+                [
+                    _create_tool("strict_func", {"param": "value"}, strict=True),
+                    _create_tool("non_strict_func", {"param": "value"}, strict=False),
+                ],
+                7,
+                "auto",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "non_strict_func"}, "arguments": {"type": "object"}}}]}}\n',  # noqa: E501
+            ),
+            # Post-v11: non-strict parallel vs no-parallel (+ suffix difference)
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                11,
+                "auto",
+                True,
+                '((<TOOL_CALLS> SAFE_WS? "non_strict_func" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+',  # noqa: E501
+            ),
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                11,
+                "auto",
+                False,
+                '(<TOOL_CALLS> SAFE_WS? "non_strict_func" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)',  # noqa: E501
+            ),
+            # Post-v11: strict tool embeds schema directly
+            (
+                [_create_tool("strict_func", {"param": "value"}, strict=True)],
+                11,
+                "auto",
+                True,
+                '((<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?))+',  # noqa: E501
+            ),
+            # Post-v11: multiple tools use | separator
+            (
+                [
+                    _create_tool("strict_func", {"param": "value"}, strict=True),
+                    _create_tool("non_strict_func", {"param": "value"}, strict=False),
+                ],
+                11,
+                "auto",
+                True,
+                '((<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "non_strict_func" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+',  # noqa: E501
+            ),
+            # mode="required" uses same grammar as "auto"
+            (
+                [_create_tool("test_func", {"param": "value"}, strict=True)],
+                7,
+                "required",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "test_func"}, "arguments": {"param": "value"}}}]}}\n',  # noqa: E501
+            ),
+        ],
+        ids=[
+            "none_returns_empty",
+            "pre_v11_non_strict_parallel",
+            "pre_v11_non_strict_no_parallel",
+            "pre_v11_strict",
+            "pre_v11_empty_strict",
+            "pre_v11_mixed",
+            "post_v11_non_strict_parallel",
+            "post_v11_non_strict_no_parallel",
+            "post_v11_strict",
+            "post_v11_mixed",
+            "required_same_as_auto",
+        ],
+    )
+    def test_convert(
+        self,
+        tools: list[ChatCompletionToolsParam] | None,
+        tokenizer_version: int,
+        mode: Literal["auto", "required", "none"],
+        parallel_tool_calls: bool,
+        expected: str,
+    ):
+        assert (
+            ToolsLarkConverter().convert(
+                tools=tools,
+                tokenizer_version=tokenizer_version,
+                mode=mode,
+                parallel_tool_calls=parallel_tool_calls,
+            )
+            == expected
+        )
+
+
+class TestMistralGrammarFactory:
+    @pytest.mark.parametrize(
+        "tokenizer_version,reasoning,expected_body_rule,expect_think",
+        [
+            # version < 13: BASE_LARK_GRAMMAR regardless of reasoning
+            (11, True, "body: content | (content? fcalls)", False),
+            # version >= 13, reasoning=False: BASE_LARK_GRAMMAR
+            (13, False, "body: content | (content? fcalls)", False),
+            # 13 <= version < 15, reasoning=True: OPTIONAL_THINK_LARK_GRAMMAR
+            (13, True, "body: think? (content | fcalls)", True),
+            # version >= 15, reasoning=False: BASE_LARK_GRAMMAR
+            (15, False, "body: content | (content? fcalls)", False),
+            # version >= 15, reasoning=True: THINK_LARK_GRAMMAR
+            (15, True, "body: (think (content | content? fcalls)) | fcalls", True),
+        ],
+        ids=[
+            "pre_v13_ignores_reasoning",
+            "v13_no_reasoning_base",
+            "v13_reasoning_optional_think",
+            "v15_no_reasoning_base",
+            "v15_reasoning_required_think",
+        ],
+    )
+    def test_get_lark_from_jinja_template_selection(
+        self,
+        tokenizer_version: int,
+        reasoning: bool,
+        expected_body_rule: str,
+        expect_think: bool,
+    ):
+        tools = [_create_tool("func", {}, strict=False)]
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            factory = MistralGrammarFactory.__new__(MistralGrammarFactory)
+            factory._tokenizer_version = tokenizer_version
+
+            grammar = factory.get_lark_from_jinja(
+                mode="auto",
+                tools=tools,
+                reasoning=reasoning,
+                parallel_tool_calls=True,
+            )
+
+        assert expected_body_rule in grammar
+
+        if expect_think:
+            assert "think: <THINK> content </THINK>" in grammar
+        else:
+            assert "think:" not in grammar
+
+    @pytest.mark.parametrize(
+        "mode,expected_body_rule",
+        [
+            ("auto", "body: content | (content? fcalls)"),
+            ("required", "body: content? fcalls"),
+            ("none", "body: content"),
+        ],
+        ids=["auto", "required", "none"],
+    )
+    def test_get_lark_from_jinja_mode_handling(
+        self,
+        mode: str,
+        expected_body_rule: str,
+    ):
+        tools = [_create_tool("func", {}, strict=False)]
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            factory = MistralGrammarFactory.__new__(MistralGrammarFactory)
+            factory._tokenizer_version = 11
+
+            grammar = factory.get_lark_from_jinja(
+                mode=mode,
+                tools=tools,
+                reasoning=False,
+                parallel_tool_calls=True,
+            )
+
+        assert expected_body_rule in grammar
+
+        # "none" mode should not have fcalls rule
+        if mode == "none":
+            assert "fcalls:" not in grammar
+        else:
+            assert "fcalls:" in grammar
+
+    def test_get_lark_from_jinja_none_mode_defaults_to_auto(self):
+        tools = [_create_tool("func", {}, strict=False)]
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            factory = MistralGrammarFactory.__new__(MistralGrammarFactory)
+            factory._tokenizer_version = 11
+
+            grammar_none = factory.get_lark_from_jinja(
+                mode=None,
+                tools=tools,
+                reasoning=False,
+                parallel_tool_calls=True,
+            )
+            grammar_auto = factory.get_lark_from_jinja(
+                mode="auto",
+                tools=tools,
+                reasoning=False,
+                parallel_tool_calls=True,
+            )
+
+        assert grammar_none == grammar_auto
+
+
+def _create_request(
+    tools: list[ChatCompletionToolsParam] | None = None,
+    tool_choice: str | None = None,
+    reasoning_effort: str | None = None,
+) -> ChatCompletionRequest:
+    if tool_choice is None:
+        tool_choice = "auto" if tools else "none"
+    return ChatCompletionRequest(
+        messages=[{"role": "user", "content": "test"}],
+        model="test-model",
+        tools=tools,
+        tool_choice=tool_choice,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def _create_mock_tool_parser(tokenizer_version: int, has_reasoning_parser: bool):
+    mock_tokenizer = MagicMock(spec=MistralTokenizer)
+    type(mock_tokenizer).version = PropertyMock(return_value=tokenizer_version)
+
+    # Set up a mock vocab with the TOOL_CALLS token
+    mock_tokenizer.get_vocab.return_value = {"[TOOL_CALLS]": 999}
+
+    with patch(
+        "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+        return_value=True,
+    ):
+        parser = MistralToolParser.__new__(MistralToolParser)
+        parser.model_tokenizer = mock_tokenizer
+        parser.vocab = {"[TOOL_CALLS]": 999}
+        parser.bot_token = "[TOOL_CALLS]"
+        parser.bot_token_id = 999
+        parser._is_pre_v11 = tokenizer_version < 11
+        parser.prev_tool_call_arr = []
+        parser.current_tool_id = -1
+        parser._has_reasoning_parser = has_reasoning_parser
+
+        # Set up the grammar factory
+        factory = MistralGrammarFactory.__new__(MistralGrammarFactory)
+        factory._tokenizer = mock_tokenizer
+        factory._tokenizer_version = tokenizer_version
+        parser.grammar_factory = factory
+
+    return parser
+
+
+class TestAdjustRequestReasoningEffort:
+    @pytest.mark.parametrize(
+        "tokenizer_version,reasoning_effort",
+        [
+            (11, "high"),
+            (15, "high"),
+        ],
+        ids=["pre_v15", "v15"],
+    )
+    def test_should_reason_no_reasoning_parser(
+        self,
+        tokenizer_version: int,
+        reasoning_effort: str | None,
+    ):
+        parser = _create_mock_tool_parser(tokenizer_version, has_reasoning_parser=False)
+        request = _create_request(reasoning_effort=reasoning_effort)
+        assert parser._should_reason(request) is False
+
+    @pytest.mark.parametrize(
+        "tokenizer_version,reasoning_effort,expected",
+        [
+            # Pre-v15: always True regardless of effort
+            (13, None, True),
+            (13, "high", True),
+            (13, "none", True),
+            # V15+: depends on reasoning_effort
+            (15, None, False),
+            (15, "none", False),
+            (15, "high", True),
+        ],
+        ids=[
+            "pre_v15_none",
+            "pre_v15_high",
+            "pre_v15_effort_none",
+            "v15_none",
+            "v15_effort_none",
+            "v15_high",
+        ],
+    )
+    def test_should_reason_with_reasoning_parser(
+        self,
+        tokenizer_version: int,
+        reasoning_effort: str | None,
+        expected: bool,
+    ):
+        parser = _create_mock_tool_parser(tokenizer_version, has_reasoning_parser=True)
+        request = _create_request(reasoning_effort=reasoning_effort)
+        assert parser._should_reason(request) is expected
+
+    @pytest.mark.parametrize(
+        "tokenizer_version,reasoning_effort,has_reasoning_parser,"
+        "expected_body_rule,expect_think",
+        [
+            # Pre-v13 with parser: BASE (reasoning ignored below v13)
+            (11, "high", True, "body: content | (content? fcalls)", False),
+            # V13 with parser: OPTIONAL_THINK
+            (13, "high", True, "body: think? (content | fcalls)", True),
+            # V15 with parser + high effort: THINK (required)
+            (
+                15,
+                "high",
+                True,
+                "body: (think (content | content? fcalls)) | fcalls",
+                True,
+            ),
+            # V15 without parser: BASE regardless of effort
+            (15, "high", False, "body: content | (content? fcalls)", False),
+        ],
+        ids=[
+            "pre_v13_base",
+            "v13_optional_think",
+            "v15_required_think",
+            "v15_no_parser_base",
+        ],
+    )
+    def test_adjust_request_grammar_selection(
+        self,
+        tokenizer_version: int,
+        reasoning_effort: str | None,
+        has_reasoning_parser: bool,
+        expected_body_rule: str,
+        expect_think: bool,
+    ):
+        tools = [_create_tool("func", {"param": "value"}, strict=False)]
+        parser = _create_mock_tool_parser(
+            tokenizer_version, has_reasoning_parser=has_reasoning_parser
+        )
+
+        request = _create_request(
+            tools=tools,
+            tool_choice="auto",
+            reasoning_effort=reasoning_effort,
+        )
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            result = parser.adjust_request(request)
+
+        assert result.structured_outputs is not None
+        grammar = result.structured_outputs.lark
+        assert grammar is not None
+        assert expected_body_rule in grammar
+
+        if expect_think:
+            assert "think: <THINK> content </THINK>" in grammar
+        else:
+            assert "think:" not in grammar
+
+        assert result.response_format is None
+
+    def test_adjust_request_sets_structured_outputs(self):
+        """Verify adjust_request sets structured_outputs and clears
+        response_format."""
+        tools = [_create_tool("add", {"a": "int", "b": "int"}, strict=True)]
+        parser = _create_mock_tool_parser(
+            tokenizer_version=11, has_reasoning_parser=False
+        )
+
+        request = _create_request(
+            tools=tools,
+            tool_choice="auto",
+            reasoning_effort=None,
+        )
+        assert request.structured_outputs is None
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            result = parser.adjust_request(request)
+
+        assert result.structured_outputs is not None
+        assert result.structured_outputs.lark is not None
+        assert result.response_format is None
+
+    def test_adjust_request_no_tools_sanitizes_tool_choice(self):
+        """When no tools are provided, tool_choice should be set to 'none'
+        by adjust_request, and the grammar should only allow content."""
+        parser = _create_mock_tool_parser(
+            tokenizer_version=11, has_reasoning_parser=False
+        )
+
+        request = _create_request(
+            tools=None,
+            tool_choice="none",
+            reasoning_effort=None,
+        )
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            result = parser.adjust_request(request)
+
+        assert result.tool_choice == "none"
+
+        assert result.structured_outputs is not None
+        grammar = result.structured_outputs.lark
+        assert grammar is not None
+        assert "body: content" in grammar
+        assert "fcalls:" not in grammar
+
+    @pytest.mark.parametrize(
+        "tokenizer_version,has_reasoning_parser,reasoning_effort,"
+        "expected_body_rule,expect_think",
+        [
+            # No reasoning: BASE grammar, body: content
+            (11, False, None, "body: content", False),
+            # Pre-v15 with reasoning parser: OPTIONAL_THINK, think is optional
+            (13, True, None, "body: think? content", True),
+            # V15 with reasoning enabled: THINK, think is required
+            (15, True, "high", "body: think content", True),
+            # V15 with reasoning disabled: BASE, no think
+            (15, True, None, "body: content", False),
+        ],
+        ids=[
+            "v11_no_reasoning_base",
+            "v13_with_reasoning_optional_think",
+            "v15_reasoning_high_required_think",
+            "v15_reasoning_none_base",
+        ],
+    )
+    def test_adjust_request_none_mode_grammar_with_tools(
+        self,
+        tokenizer_version: int,
+        has_reasoning_parser: bool,
+        reasoning_effort: str | None,
+        expected_body_rule: str,
+        expect_think: bool,
+    ):
+        tools = [_create_tool("func", {"param": "value"}, strict=False)]
+        parser = _create_mock_tool_parser(
+            tokenizer_version, has_reasoning_parser=has_reasoning_parser
+        )
+
+        request = _create_request(
+            tools=tools,
+            tool_choice="none",
+            reasoning_effort=reasoning_effort,
+        )
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            result = parser.adjust_request(request)
+
+        assert result.structured_outputs is not None
+        grammar = result.structured_outputs.lark
+        assert grammar is not None
+        assert expected_body_rule in grammar
+        assert "fcalls:" not in grammar
+
+        if expect_think:
+            assert "think: <THINK> content </THINK>" in grammar
+        else:
+            assert "think:" not in grammar
+
+    @pytest.mark.parametrize(
+        "tool_choice,expected_mode",
+        [
+            ("auto", "auto"),
+            ("required", "required"),
+            ("none", "none"),
+        ],
+        ids=["auto", "required", "none"],
+    )
+    def test_adjust_request_tool_choice_modes(
+        self,
+        tool_choice: str,
+        expected_mode: str,
+    ):
+        tools = [_create_tool("func", {"param": "value"}, strict=False)]
+        parser = _create_mock_tool_parser(
+            tokenizer_version=11, has_reasoning_parser=False
+        )
+
+        request = _create_request(
+            tools=tools,
+            tool_choice=tool_choice,
+            reasoning_effort=None,
+        )
+
+        with (
+            patch(
+                "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+                return_value=True,
+            ),
+            patch.object(
+                parser.grammar_factory,
+                "get_lark_from_jinja",
+                wraps=parser.grammar_factory.get_lark_from_jinja,
+            ) as mock_get_lark,
+        ):
+            parser.adjust_request(request)
+
+        mock_get_lark.assert_called_once_with(
+            mode=expected_mode,
+            tools=tools,
+            reasoning=False,
+            parallel_tool_calls=True,
+        )
+
+    @pytest.mark.parametrize(
+        "tokenizer_version,reasoning_effort,has_reasoning_parser,"
+        "expected_reasoning_flag",
+        [
+            # Pre-v15: reasoning flag follows has_reasoning_parser
+            (11, None, True, True),
+            (11, None, False, False),
+            # V15+: reasoning flag depends on effort when parser present
+            (15, "high", True, True),
+            (15, None, True, False),
+        ],
+        ids=[
+            "pre_v15_with_parser",
+            "pre_v15_no_parser",
+            "v15_high_with_parser",
+            "v15_none_with_parser",
+        ],
+    )
+    def test_adjust_request_reasoning_flag_passed_to_grammar(
+        self,
+        tokenizer_version: int,
+        reasoning_effort: str | None,
+        has_reasoning_parser: bool,
+        expected_reasoning_flag: bool,
+    ):
+        tools = [_create_tool("func", {"param": "value"}, strict=False)]
+        parser = _create_mock_tool_parser(
+            tokenizer_version, has_reasoning_parser=has_reasoning_parser
+        )
+
+        request = _create_request(
+            tools=tools,
+            tool_choice="auto",
+            reasoning_effort=reasoning_effort,
+        )
+
+        with (
+            patch(
+                "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+                return_value=True,
+            ),
+            patch.object(
+                parser.grammar_factory,
+                "get_lark_from_jinja",
+                wraps=parser.grammar_factory.get_lark_from_jinja,
+            ) as mock_get_lark,
+        ):
+            parser.adjust_request(request)
+
+        mock_get_lark.assert_called_once_with(
+            mode="auto",
+            tools=tools,
+            reasoning=expected_reasoning_flag,
+            parallel_tool_calls=True,
+        )

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -150,6 +150,7 @@ def test_mp_client_uses_env_timeout(monkeypatch: pytest.MonkeyPatch):
         data_parallel_hybrid_lb=False,
         data_parallel_external_lb=False,
         local_engines_only=False,
+        enable_elastic_ep=False,
     )
     vllm_config = SimpleNamespace(parallel_config=parallel_config)
 

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -43,6 +43,7 @@ All2AllBackend = Literal[
     "deepep_high_throughput",
     "deepep_low_latency",
     "mori",
+    "nixl_ep",
     "allgather_reducescatter",
     "flashinfer_all2allv",
 ]
@@ -156,6 +157,7 @@ class ParallelConfig:
     - "deepep_high_throughput": Use deepep high-throughput kernels\n
     - "deepep_low_latency": Use deepep low-latency kernels\n
     - "mori": Use mori kernels\n
+    - "nixl_ep": Use nixl-ep kernels\n
     - "flashinfer_all2allv": Use flashinfer alltoallv kernels for mnnvl"""
 
     max_parallel_loading_workers: int | None = None
@@ -580,6 +582,7 @@ class ParallelConfig:
                 "deepep_high_throughput",
                 "deepep_low_latency",
                 "mori",
+                "nixl_ep",
             )
             and self.enable_expert_parallel
             and self.tensor_parallel_size > 1

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
 from typing import Any
 
 import torch
@@ -409,6 +410,121 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         return handle
 
     # DeepEP LL uses RDMA so no SMs are used for communication
+    def max_sms_used(self) -> int | None:
+        return 0
+
+
+class NixlEPAll2AllManager(All2AllManagerBase):
+    """
+    All2All communication based on NIXL EP kernels.
+    This backend supports elastic EP with dynamic rank connection/disconnection.
+    """
+
+    # (nixl_ep_buffer, ep_size)
+    _buffer: tuple[Any, int] | None = None
+    _lock = threading.Lock()
+
+    def __init__(self, cpu_group, tcp_store_group=None):
+        super().__init__(cpu_group, tcp_store_group)
+
+        self.max_num_ep_ranks = envs.VLLM_NIXL_EP_MAX_NUM_RANKS
+
+    def _init_buffer(
+        self,
+        max_num_tokens_per_dp_rank: int,
+        token_hidden_size: int,
+        num_experts_per_rank: int,
+    ) -> None:
+        from nixl_ep import Buffer  # type: ignore[import-not-found]
+
+        max_num_global_experts = self.max_num_ep_ranks * num_experts_per_rank
+        num_rdma_bytes = Buffer.get_rdma_size_hint(
+            num_max_dispatch_tokens_per_rank=max_num_tokens_per_dp_rank,
+            hidden=token_hidden_size,
+            num_ranks=self.max_num_ep_ranks,
+            num_experts=max_num_global_experts,
+        )
+        assert NixlEPAll2AllManager._buffer is None, (
+            "NIXL EP buffer already initialized"
+        )
+        buffer = Buffer(
+            rank=self.rank,
+            tcp_store_group=self.tcp_store_group.store,
+        )
+        buffer.update_memory_buffers(
+            num_ranks=self.max_num_ep_ranks,
+            num_experts_per_rank=num_experts_per_rank,
+            num_rdma_bytes=num_rdma_bytes,
+        )
+        ranks_to_connect = list(range(self.cpu_group.size()))
+        buffer.connect_ranks(ranks_to_connect)
+        NixlEPAll2AllManager._buffer = (buffer, self.cpu_group.size())
+
+    def _update_buffer(self):
+        assert NixlEPAll2AllManager._buffer is not None
+        buffer, current_ep_size = NixlEPAll2AllManager._buffer
+        current_ranks = list(range(current_ep_size))
+        new_ep_size = self.cpu_group.size()
+        buffer.set_tcp_store_group(self.tcp_store_group.store)
+        if new_ep_size > len(current_ranks):
+            ranks_to_connect = list(range(len(current_ranks), new_ep_size))
+            buffer.connect_ranks(ranks_to_connect)
+        else:
+            ranks_to_disconnect = current_ranks[new_ep_size:]
+            buffer.disconnect_ranks(ranks_to_disconnect)
+        NixlEPAll2AllManager._buffer = (buffer, new_ep_size)
+
+    def get_handle(self, kwargs):
+        with NixlEPAll2AllManager._lock:
+            if (
+                NixlEPAll2AllManager._buffer is not None
+                and NixlEPAll2AllManager._buffer[1] == self.cpu_group.size()
+            ):
+                return NixlEPAll2AllManager._buffer[0]
+
+            num_experts_per_rank = (
+                kwargs["num_global_experts"] // kwargs["num_ep_ranks"]
+            )
+            nixl_kwargs = dict(
+                max_num_tokens_per_dp_rank=kwargs["max_num_tokens_per_dp_rank"],
+                token_hidden_size=kwargs["token_hidden_size"],
+                num_experts_per_rank=num_experts_per_rank,
+            )
+            if NixlEPAll2AllManager._buffer is None:
+                self._init_buffer(**nixl_kwargs)
+            else:
+                self._update_buffer()
+
+            assert NixlEPAll2AllManager._buffer is not None
+            handle = NixlEPAll2AllManager._buffer[0]
+            return handle
+
+    def dispatch(
+        self,
+        hidden_states: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        is_sequence_parallel: bool = False,
+        extra_tensors: list[torch.Tensor] | None = None,
+    ) -> (
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+        | tuple[torch.Tensor, torch.Tensor, torch.Tensor, list[torch.Tensor]]
+    ):
+        raise NotImplementedError
+
+    def combine(
+        self, hidden_states: torch.Tensor, is_sequence_parallel: bool = False
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    def destroy(self):
+        # NOTE(yongji): NIXLEPAll2AllManager instance is recreated during
+        # scale-up/down, so we cannot destroy the persistent buffer here.
+        assert NixlEPAll2AllManager._buffer is not None
+        buffer = NixlEPAll2AllManager._buffer[0]
+        buffer.set_tcp_store_group(None)
+
+    # NIXL EP uses RDMA so no SMs are used for communication
     def max_sms_used(self) -> int | None:
         return 0
 

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -143,6 +143,12 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 from .all2all import MoriAll2AllManager
 
                 self.all2all_manager = MoriAll2AllManager(self.cpu_group)
+            elif self.all2all_backend == "nixl_ep":
+                from .all2all import NixlEPAll2AllManager
+
+                self.all2all_manager = NixlEPAll2AllManager(
+                    self.cpu_group, tcp_store_group
+                )
             elif self.all2all_backend == "flashinfer_all2allv":
                 from .all2all import FlashInferAllToAllManager
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -67,11 +67,17 @@ from vllm.logprobs import Logprob
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.parser import ParserManager
 from vllm.reasoning import ReasoningParser
+from vllm.reasoning.mistral_reasoning_parser import MistralReasoningParser
 from vllm.renderers import ChatParams
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers import ToolParser
-from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
+from vllm.tool_parsers.mistral_tool_parser import (
+    MistralToolCall,
+    MistralToolParser,
+    is_mistral_lark_grammar_active,
+)
 from vllm.tool_parsers.utils import partial_json_loads
 from vllm.utils.collection_utils import as_list
 from vllm.utils.mistral import is_mistral_tokenizer
@@ -125,6 +131,10 @@ class OpenAIServingChat(OpenAIServing):
         self.reasoning_parser_cls = ParserManager.get_reasoning_parser(
             reasoning_parser_name=reasoning_parser
         )
+        self._is_mistral_reasoning_parser = (
+            self.reasoning_parser_cls is not None
+            and issubclass(self.reasoning_parser_cls, MistralReasoningParser)
+        )
         # set up tool use
         self.enable_auto_tools: bool = enable_auto_tools
         self.tool_parser = ParserManager.get_tool_parser(
@@ -132,6 +142,12 @@ class OpenAIServingChat(OpenAIServing):
             enable_auto_tools=enable_auto_tools,
             model_name=self.model_config.model,
         )
+        _is_mistral_tool_parser = self.tool_parser is not None and issubclass(
+            self.tool_parser, MistralToolParser
+        )
+        if _is_mistral_tool_parser and self.reasoning_parser_cls is not None:
+            MistralToolParser._has_reasoning_parser = True
+
         self.exclude_tools_when_tool_choice_none = exclude_tools_when_tool_choice_none
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
@@ -224,15 +240,24 @@ class OpenAIServingChat(OpenAIServing):
         assert tokenizer is not None
         reasoning_parser: ReasoningParser | None = None
         if self.reasoning_parser_cls:
-            # Pass the same chat template kwargs as used in tokenization
-            chat_template_kwargs = self._prepare_extra_chat_template_kwargs(
-                request.chat_template_kwargs,
-                self.default_chat_template_kwargs,
+            # For Mistral v15+ tokenizers, reasoning is only active when the
+            # request explicitly enables it (reasoning_effort not in
+            # [None, "none"]).
+            skip_reasoning = (
+                isinstance(tokenizer, MistralTokenizer)
+                and tokenizer.version >= 15
+                and request.reasoning_effort in (None, "none")
             )
-            reasoning_parser = self.reasoning_parser_cls(
-                tokenizer,
-                chat_template_kwargs=chat_template_kwargs,  # type: ignore[call-arg]
-            )
+            if not skip_reasoning:
+                # Pass the same chat template kwargs as used in tokenization
+                chat_template_kwargs = self._prepare_extra_chat_template_kwargs(
+                    request.chat_template_kwargs,
+                    self.default_chat_template_kwargs,
+                )
+                reasoning_parser = self.reasoning_parser_cls(
+                    tokenizer,
+                    chat_template_kwargs=chat_template_kwargs,  # type: ignore[call-arg]
+                )
         result = await self.render_chat_request(request)
         if isinstance(result, ErrorResponse):
             return result
@@ -309,11 +334,21 @@ class OpenAIServingChat(OpenAIServing):
                     trace_headers=trace_headers,
                 )
             else:
-                reasoning_ended = (
-                    reasoning_parser.is_reasoning_end(prompt_token_ids or [])
-                    if reasoning_parser
-                    else None
+                # Mistral lark grammar handles think/no-think structure
+                # itself, so mark reasoning as ended from token 0.
+                is_mistral_lark_grammar = is_mistral_lark_grammar_active(
+                    request, tokenizer, self.tool_parser
                 )
+                if is_mistral_lark_grammar:
+                    reasoning_ended = True
+                elif reasoning_parser is not None:
+                    reasoning_ended = reasoning_parser.is_reasoning_end(
+                        prompt_token_ids or []
+                    )
+                elif self.reasoning_parser_cls is not None:
+                    reasoning_ended = True
+                else:
+                    reasoning_ended = None
 
                 generator = self.engine_client.generate(
                     engine_prompt,
@@ -526,6 +561,10 @@ class OpenAIServingChat(OpenAIServing):
             harmony_tools_streamed = [False] * num_choices
         tools_streamed = [False] * num_choices
 
+        use_mistral_grammar = is_mistral_lark_grammar_active(
+            request, tokenizer, self.tool_parser
+        )
+
         if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):
             tool_choice_function_name = request.tool_choice.function.name
         else:
@@ -549,7 +588,7 @@ class OpenAIServingChat(OpenAIServing):
 
         # Only one of these will be used, thus previous_texts and
         # all_previous_token_ids will not be used twice in the same iteration.
-        if tool_choice_auto or reasoning_parser:
+        if use_mistral_grammar or tool_choice_auto or reasoning_parser:
             # These are only required in "auto" tool choice case
             all_previous_token_ids = [[]] * num_choices
             # For reasoning parser and tool call all enabled
@@ -561,7 +600,7 @@ class OpenAIServingChat(OpenAIServing):
 
         # Prepare the tool parser if it's needed
         try:
-            if tool_choice_auto and self.tool_parser:
+            if (use_mistral_grammar or tool_choice_auto) and self.tool_parser:
                 if tokenizer is None:
                     raise ValueError(
                         "Tokenizer not available when `skip_tokenizer_init=True`"
@@ -742,7 +781,7 @@ class OpenAIServingChat(OpenAIServing):
                     delta_message: DeltaMessage | None
 
                     # just update previous_texts and previous_token_ids
-                    if tool_choice_auto or reasoning_parser:
+                    if use_mistral_grammar or tool_choice_auto or reasoning_parser:
                         assert previous_texts is not None
                         assert all_previous_token_ids is not None
                         previous_text = previous_texts[i]
@@ -766,6 +805,91 @@ class OpenAIServingChat(OpenAIServing):
                             )
                         )
                         harmony_tools_streamed[i] |= tools_streamed_flag
+                    elif use_mistral_grammar and reasoning_parser:
+                        assert tool_parser is not None
+                        assert added_content_delta_arr is not None
+                        assert reasoning_end_arr is not None
+                        output_token_ids = as_list(output.token_ids)
+                        if not reasoning_end_arr[i]:
+                            # Pre-v15 models may have pre-filled
+                            # [THINK]...[/THINK] in system prompts, so
+                            # skip the prompt-level reasoning-end check
+                            # and wait for the output's own end-of-think.
+                            _is_pre_v15 = (
+                                isinstance(tokenizer, MistralTokenizer)
+                                and tokenizer.version < 15
+                            )
+                            if not _is_pre_v15 and prompt_is_reasoning_end_arr[i]:
+                                reasoning_end_arr[i] = True
+                                current_token_ids = output_token_ids
+                            else:
+                                delta_message = (
+                                    reasoning_parser.extract_reasoning_streaming(
+                                        previous_text,
+                                        current_text,
+                                        delta_text,
+                                        previous_token_ids,
+                                        current_token_ids,
+                                        output_token_ids,
+                                    )
+                                )
+                                if reasoning_parser.is_reasoning_end_streaming(
+                                    current_token_ids, output_token_ids
+                                ):
+                                    reasoning_end_arr[i] = True
+                                    current_token_ids = (
+                                        reasoning_parser.extract_content_ids(
+                                            output_token_ids
+                                        )
+                                    )
+                                    if delta_message and delta_message.content:
+                                        current_text = delta_message.content
+                                        delta_message.content = None
+                                    else:
+                                        current_text = ""
+                                # Mistral grammar fallback:
+                                # fcalls-only grammar path and skip
+                                # reasoning and start tool parsing.
+                                elif (
+                                    self._is_mistral_reasoning_parser
+                                    and tool_parser.bot_token_id in output_token_ids
+                                ):
+                                    reasoning_end_arr[i] = True
+                                    current_token_ids = output_token_ids
+
+                        if reasoning_end_arr[i]:
+                            delta_token_ids = output_token_ids
+                            if not added_content_delta_arr[i]:
+                                added_content_delta_arr[i] = True
+                                previous_text = ""
+                                previous_token_ids = []
+                                delta_text = current_text
+                                delta_token_ids = current_token_ids
+
+                            delta_message = tool_parser.extract_tool_calls_streaming(
+                                previous_text=previous_text,
+                                current_text=current_text,
+                                delta_text=delta_text,
+                                previous_token_ids=previous_token_ids,
+                                current_token_ids=current_token_ids,
+                                delta_token_ids=delta_token_ids,
+                                request=request,
+                            )
+                            if delta_message and delta_message.tool_calls:
+                                tools_streamed[i] = True
+                    elif use_mistral_grammar:
+                        assert tool_parser is not None
+                        delta_message = tool_parser.extract_tool_calls_streaming(
+                            previous_text=previous_text,
+                            current_text=current_text,
+                            delta_text=delta_text,
+                            previous_token_ids=previous_token_ids,
+                            current_token_ids=current_token_ids,
+                            delta_token_ids=output.token_ids,
+                            request=request,
+                        )
+                        if delta_message and delta_message.tool_calls:
+                            tools_streamed[i] = True
                     # handle streaming deltas for tools with named tool_choice
                     elif tool_choice_function_name:
                         # When encountering think end id in prompt_token_ids
@@ -1012,7 +1136,9 @@ class OpenAIServingChat(OpenAIServing):
                         delta_message = DeltaMessage(content=delta_text)
 
                     # update the previous values for the next iteration
-                    if (tool_choice_auto or reasoning_parser) and not self.use_harmony:
+                    if (
+                        use_mistral_grammar or tool_choice_auto or reasoning_parser
+                    ) and not self.use_harmony:
                         assert previous_texts is not None
                         assert all_previous_token_ids is not None
                         previous_texts[i] = current_text
@@ -1094,7 +1220,10 @@ class OpenAIServingChat(OpenAIServing):
                         # only happens if we are NOT using structured outputs
                         auto_tools_called = False
                         if tool_parser:
-                            auto_tools_called = len(tool_parser.prev_tool_call_arr) > 0
+                            auto_tools_called = (
+                                len(tool_parser.prev_tool_call_arr) > 0
+                                and not tool_choice_function_name
+                            )
                             index = (
                                 len(tool_parser.prev_tool_call_arr) - 1
                                 if auto_tools_called
@@ -1394,7 +1523,40 @@ class OpenAIServingChat(OpenAIServing):
             tool_call_class = (
                 MistralToolCall if is_mistral_tokenizer(tokenizer) else ToolCall
             )
-            if (not self.enable_auto_tools or not self.tool_parser) and (
+
+            use_mistral_grammar = is_mistral_lark_grammar_active(
+                request, tokenizer, self.tool_parser
+            )
+            if use_mistral_grammar:
+                if tool_calls:
+                    tool_call_items = [
+                        MistralToolCall(
+                            id=tc.id if tc.id else None,
+                            function=tc,
+                        )
+                        for tc in tool_calls
+                    ]
+                    # Per the OpenAI API spec, finish_reason is
+                    # "tool_calls" for auto/required but "stop" for
+                    # named tool choice.
+                    auto_tools_called = not isinstance(
+                        request.tool_choice,
+                        ChatCompletionNamedToolChoiceParam,
+                    )
+                    message = ChatMessage(
+                        role=role,
+                        reasoning=reasoning,
+                        content=content,
+                        tool_calls=tool_call_items,
+                    )
+                else:
+                    message = ChatMessage(
+                        role=role,
+                        reasoning=reasoning,
+                        content=content,
+                    )
+
+            elif (not self.enable_auto_tools or not self.tool_parser) and (
                 not isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
                 and request.tool_choice != "required"
             ):

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -105,7 +105,12 @@ from vllm.renderers.inputs.preprocess import (
 )
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers import ToolParser
+from vllm.tool_parsers.mistral_tool_parser import (
+    MistralToolParser,
+    is_mistral_lark_grammar_active,
+)
 from vllm.tracing import (
     contains_trace_headers,
     extract_trace_headers,
@@ -910,9 +915,18 @@ class OpenAIServing:
         # tool parsing is done only if a tool_parser has been set and if
         # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
         # is set, we want to prevent parsing a tool_call hallucinated by the LLM
+        #
+        # Exception: MistralToolParser always calls adjust_request() (even for
+        # tool_choice="none") so the grammar prevents raw special tokens
+        # from leaking into the response.
         if tool_parser is not None:
             tool_choice = getattr(request, "tool_choice", "none")
-            if tool_choice != "none":
+            tokenizer = renderer.get_tokenizer()
+            is_mistral_grammar = issubclass(
+                tool_parser,  # type: ignore[arg-type]
+                MistralToolParser,
+            ) and isinstance(tokenizer, MistralTokenizer)
+            if tool_choice != "none" or is_mistral_grammar:
                 if not isinstance(request, ChatCompletionRequest | ResponsesRequest):
                     msg = (
                         "Tool usage is only supported for Chat Completions API "
@@ -921,7 +935,6 @@ class OpenAIServing:
                     raise NotImplementedError(msg)
 
                 # TODO: Update adjust_request to accept ResponsesRequest
-                tokenizer = renderer.get_tokenizer()
                 request = tool_parser(tokenizer).adjust_request(request=request)  # type: ignore[arg-type]
 
         return conversation, [engine_prompt]
@@ -1109,7 +1122,52 @@ class OpenAIServing:
         content: str | None = None,
     ) -> tuple[list[FunctionCall] | None, str | None]:
         function_calls = list[FunctionCall]()
-        if request.tool_choice and isinstance(request.tool_choice, ToolChoiceFunction):
+
+        use_mistral_grammar = is_mistral_lark_grammar_active(
+            request,
+            tokenizer,
+            tool_parser_cls,  # type: ignore[arg-type]
+        )
+        if use_mistral_grammar or (
+            tool_parser_cls
+            and enable_auto_tools
+            and (request.tool_choice == "auto" or request.tool_choice is None)
+        ):
+            if tokenizer is None:
+                raise ValueError(
+                    "Tokenizer not available when `skip_tokenizer_init=True`"
+                )
+
+            # Automatic Tool Call Parsing
+            try:
+                assert tool_parser_cls is not None
+                tool_parser = tool_parser_cls(tokenizer)
+            except RuntimeError as e:
+                logger.exception("Error in tool parser creation.")
+                raise e
+            tool_call_info = tool_parser.extract_tool_calls(
+                content if content is not None else "",
+                request=request,  # type: ignore
+            )
+            if tool_call_info is not None and tool_call_info.tools_called:
+                # extract_tool_calls() returns a list of tool calls.
+                function_calls.extend(
+                    FunctionCall(
+                        id=tool_call.id,
+                        name=tool_call.function.name,
+                        arguments=tool_call.function.arguments,
+                    )
+                    for tool_call in tool_call_info.tool_calls
+                )
+                content = tool_call_info.content
+                if content and content.strip() == "":
+                    content = None
+            else:
+                # No tool calls.
+                return None, content
+        elif request.tool_choice and isinstance(
+            request.tool_choice, ToolChoiceFunction
+        ):
             assert content is not None
             # Forced Function Call
             function_calls.append(
@@ -1140,42 +1198,6 @@ class OpenAIServing:
                     )
                 )
             content = None  # Clear content since tool is called.
-        elif (
-            tool_parser_cls
-            and enable_auto_tools
-            and (request.tool_choice == "auto" or request.tool_choice is None)
-        ):
-            if tokenizer is None:
-                raise ValueError(
-                    "Tokenizer not available when `skip_tokenizer_init=True`"
-                )
-
-            # Automatic Tool Call Parsing
-            try:
-                tool_parser = tool_parser_cls(tokenizer)
-            except RuntimeError as e:
-                logger.exception("Error in tool parser creation.")
-                raise e
-            tool_call_info = tool_parser.extract_tool_calls(
-                content if content is not None else "",
-                request=request,  # type: ignore
-            )
-            if tool_call_info is not None and tool_call_info.tools_called:
-                # extract_tool_calls() returns a list of tool calls.
-                function_calls.extend(
-                    FunctionCall(
-                        id=tool_call.id,
-                        name=tool_call.function.name,
-                        arguments=tool_call.function.arguments,
-                    )
-                    for tool_call in tool_call_info.tool_calls
-                )
-                content = tool_call_info.content
-                if content and content.strip() == "":
-                    content = None
-            else:
-                # No tool calls.
-                return None, content
 
         return function_calls, content
 

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -31,7 +31,9 @@ from vllm.parser import ParserManager
 from vllm.renderers import BaseRenderer, merge_kwargs
 from vllm.renderers.inputs.preprocess import parse_model_prompt, prompt_to_seq
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers import ToolParser
+from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
 from vllm.utils.mistral import is_mistral_tokenizer
 from vllm.utils.mistral import mt as _mt
 
@@ -146,7 +148,11 @@ class OpenAIServingRender:
                 )
 
         if request.tools is None or (
-            request.tool_choice == "none" and self.exclude_tools_when_tool_choice_none
+            request.tool_choice == "none"
+            and (
+                self.exclude_tools_when_tool_choice_none
+                or is_mistral_tokenizer(tokenizer)
+            )
         ):
             tool_dicts = None
         else:
@@ -394,9 +400,18 @@ class OpenAIServingRender:
         # tool parsing is done only if a tool_parser has been set and if
         # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
         # is set, we want to prevent parsing a tool_call hallucinated by the LLM
+        #
+        # Exception: MistralToolParser always calls adjust_request() (even for
+        # tool_choice="none") so the grammar prevents raw special tokens
+        # from leaking into the response.
         if tool_parser is not None:
             tool_choice = getattr(request, "tool_choice", "none")
-            if tool_choice != "none":
+            tokenizer = renderer.get_tokenizer()
+            is_mistral_grammar = issubclass(
+                tool_parser,  # type: ignore[arg-type]
+                MistralToolParser,
+            ) and isinstance(tokenizer, MistralTokenizer)
+            if tool_choice != "none" or is_mistral_grammar:
                 if not isinstance(request, ChatCompletionRequest):
                     msg = (
                         "Tool usage is only supported "
@@ -404,7 +419,6 @@ class OpenAIServingRender:
                         f"{type(request).__name__}"
                     )
                     raise NotImplementedError(msg)
-                tokenizer = renderer.get_tokenizer()
                 request = tool_parser(tokenizer).adjust_request(request=request)  # type: ignore[arg-type]
 
         return conversation, [engine_prompt]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -244,6 +244,7 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_SCALE_UP_LAUNCH: bool = False
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = False
+    VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
 
 
 def get_default_cache_root():
@@ -1627,6 +1628,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # memory allocation. Disabled by default to preserve existing behavior.
     "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", "0"))
+    ),
+    # NIXL EP environment variables
+    "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(
+        os.getenv("VLLM_NIXL_EP_MAX_NUM_RANKS", "32")
     ),
 }
 

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -25,7 +25,7 @@ from vllm.model_executor.layers.fused_moe.prepare_finalize import (
     make_moe_prepare_and_finalize_no_dp_ep,
 )
 from vllm.platforms import current_platform
-from vllm.utils.import_utils import has_deep_ep, has_mori
+from vllm.utils.import_utils import has_deep_ep, has_mori, has_nixl_ep
 
 logger = init_logger(__name__)
 
@@ -38,6 +38,11 @@ if current_platform.is_cuda_alike():
         )
     if has_mori():
         from .mori_prepare_finalize import MoriPrepareAndFinalize
+    if has_nixl_ep():
+        from .nixl_ep_prepare_finalize import (
+            NIXL_EP_QUANT_BLOCK_SHAPE,
+            NixlEPPrepareAndFinalize,
+        )
 
 
 def maybe_roundup_layer_hidden_size(
@@ -66,6 +71,11 @@ def maybe_roundup_layer_hidden_size(
 
     if moe_parallel_config.use_deepep_ll_kernels:
         hidden_size = DeepEPLLPrepareAndFinalize.maybe_roundup_layer_hidden_size(
+            hidden_size
+        )
+
+    if moe_parallel_config.use_nixl_ep_kernels:
+        hidden_size = NixlEPPrepareAndFinalize.maybe_roundup_layer_hidden_size(
             hidden_size
         )
 
@@ -207,6 +217,41 @@ def maybe_make_prepare_finalize(
             use_monolithic=use_monolithic,
             is_sequence_parallel=moe.moe_parallel_config.is_sequence_parallel,
             num_dispatchers=all2all_manager.world_size,
+        )
+
+    elif moe.use_nixl_ep_kernels:
+        assert quant_config is not None
+        global_to_physical = physical_to_global = local_expert_global_ids = None
+        if routing_tables is not None:
+            (
+                global_to_physical,
+                physical_to_global,
+                local_expert_global_ids,
+            ) = routing_tables
+        all_to_all_args = dict(
+            max_num_tokens_per_dp_rank=moe.max_num_tokens,
+            token_hidden_size=moe.hidden_dim,
+            num_ep_ranks=all2all_manager.world_size,
+            num_global_experts=moe.num_experts,
+            num_local_experts=moe.num_experts // all2all_manager.world_size,
+        )
+        handle = all2all_manager.get_handle(all_to_all_args)
+
+        # Note: We may want to use FP8 dispatch just to reduce
+        # data movement.
+        use_fp8_dispatch = (
+            quant_config.quant_dtype == current_platform.fp8_dtype()
+            and quant_config.block_shape == NIXL_EP_QUANT_BLOCK_SHAPE
+        )
+
+        prepare_finalize = NixlEPPrepareAndFinalize(
+            handle,
+            max_tokens_per_rank=moe.max_num_tokens,
+            num_dispatchers=all2all_manager.world_size,
+            use_fp8_dispatch=use_fp8_dispatch,
+            global_to_physical=global_to_physical,
+            physical_to_global=physical_to_global,
+            local_expert_global_ids=local_expert_global_ids,
         )
 
     return prepare_finalize

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -976,6 +976,10 @@ class FusedMoEParallelConfig:
     def use_mori_kernels(self):
         return self.use_all2all_kernels and self.all2all_backend == "mori"
 
+    @property
+    def use_nixl_ep_kernels(self):
+        return self.use_all2all_kernels and self.all2all_backend == "nixl_ep"
+
     @staticmethod
     def flatten_tp_across_dp_and_pcp(
         tp_size: int, dp_size: int, dp_rank: int, pcp_size: int, pcp_rank: int
@@ -1242,3 +1246,7 @@ class FusedMoEConfig:
     @property
     def use_naive_all2all_kernels(self):
         return self.moe_parallel_config.use_naive_all2all_kernels
+
+    @property
+    def use_nixl_ep_kernels(self):
+        return self.moe_parallel_config.use_nixl_ep_kernels

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -177,10 +177,11 @@ def determine_expert_placement_strategy(
         if (
             moe_parallel_config.use_all2all_kernels
             and not moe_parallel_config.use_deepep_ll_kernels
+            and not moe_parallel_config.use_nixl_ep_kernels
         ):
             logger.warning(
                 "Round-robin expert placement currently only supports "
-                "the DeepEP low-latency backend, but '%s' was configured. "
+                "the DeepEP low-latency or NIXL EP backend, but '%s' was configured. "
                 "Falling back to linear expert placement.",
                 moe_parallel_config.all2all_backend,
             )
@@ -745,10 +746,10 @@ class FusedMoE(CustomOp):
         self,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
         # Currently routing_tables only needed for round-robin expert placement
-        # with DeepEP-ll all2all backend.
-        if (
-            self.expert_placement_strategy != "round_robin"
-            or not self.moe_parallel_config.use_deepep_ll_kernels
+        # with DeepEP-ll or NIXL EP all2all backends.
+        if self.expert_placement_strategy != "round_robin" or (
+            not self.moe_parallel_config.use_deepep_ll_kernels
+            and not self.moe_parallel_config.use_nixl_ep_kernels
         ):
             return None
 

--- a/vllm/model_executor/layers/fused_moe/nixl_ep_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/nixl_ep_prepare_finalize.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
+
+import nixl_ep
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm import envs
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate,
+)
+from vllm.model_executor.layers.fused_moe.utils import (
+    moe_kernel_quantize_input,
+    normalize_batched_scales_shape,
+)
+from vllm.v1.worker.ubatching import (
+    dbo_current_ubatch_id,
+    dbo_enabled,
+    dbo_maybe_run_recv_hook,
+)
+
+logger = init_logger(__name__)
+
+# NIXL EP kernels quantize dispatch inputs in 128 element chunks.
+NIXL_EP_QUANT_BLOCK_SIZE = 128
+NIXL_EP_QUANT_BLOCK_SHAPE = [NIXL_EP_QUANT_BLOCK_SIZE, NIXL_EP_QUANT_BLOCK_SIZE]
+
+
+def dequant_fp8(
+    expert_x_fp8: torch.Tensor, expert_x_scales: torch.Tensor
+) -> torch.Tensor:
+    """
+    Return dequantized tensor in fp32
+    """
+    assert expert_x_fp8.is_contiguous()
+    expert_x_scales = expert_x_scales.contiguous()
+    num_experts = expert_x_fp8.size(0)
+
+    expert_x_fp32 = expert_x_fp8.to(torch.float32).view(
+        num_experts, -1, NIXL_EP_QUANT_BLOCK_SIZE
+    )
+    expert_x_scales = expert_x_scales.view(num_experts, -1, 1)
+    return (expert_x_fp32 * expert_x_scales).view(expert_x_fp8.size())
+
+
+class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
+    """
+    Prepare/Finalize using NIXL EP kernels.
+    """
+
+    # NIXL EP kernels are compiled only for certain specific hidden sizes.
+    # NOTE: Keep this list sorted, maybe_roundup_layer_hidden_size depends
+    # on it.
+    SUPPORTED_HIDDEN_SIZES = [2048, 2560, 3072, 4096, 5120, 6144, 7168, 8192]
+    assert sorted(set(SUPPORTED_HIDDEN_SIZES)) == SUPPORTED_HIDDEN_SIZES
+
+    @staticmethod
+    def maybe_roundup_layer_hidden_size(hidden_size: int) -> int:
+        # Round up hidden size to the closest supported hidden size.
+        _supported_hs = NixlEPPrepareAndFinalize.SUPPORTED_HIDDEN_SIZES
+
+        for x in _supported_hs:
+            if x >= hidden_size:
+                return x
+
+        raise ValueError(
+            f"Hidden Size {hidden_size} is greater than the "
+            f"maximum supported hidden size {_supported_hs[-1]}"
+        )
+
+    def __init__(
+        self,
+        buffer: nixl_ep.Buffer,
+        max_tokens_per_rank: int,
+        num_dispatchers: int,
+        use_fp8_dispatch: bool = False,
+        global_to_physical: torch.Tensor | None = None,
+        physical_to_global: torch.Tensor | None = None,
+        local_expert_global_ids: torch.Tensor | None = None,
+    ):
+        super().__init__()
+
+        self.buffer = buffer
+        self.max_tokens_per_rank = max_tokens_per_rank
+        self.use_fp8_dispatch = use_fp8_dispatch
+        # The dispatch function returns a handle that the combine function
+        # requires. We store the handle here so it is available to the
+        # combine function.
+        self.handles: list[tuple | None] = [None, None]
+        self.num_dispatchers_ = num_dispatchers
+
+        topk_indices_dtype = self.topk_indices_dtype()
+
+        def _maybe_cast(tensor: torch.Tensor | None) -> torch.Tensor | None:
+            if tensor is None or topk_indices_dtype is None:
+                return tensor
+            return tensor.to(dtype=topk_indices_dtype)
+
+        self.global_to_physical = _maybe_cast(global_to_physical)
+        self.physical_to_global = _maybe_cast(physical_to_global)
+        self.local_expert_global_ids = _maybe_cast(local_expert_global_ids)
+
+        # We don't have enough information to determine if we should dispatch
+        # activation scales in a packed ue8m0 format during object construction
+        # time. This setting is handled by post_init_setup.
+        self.use_ue8m0_dispatch = False
+
+    def post_init_setup(self, fused_experts: mk.FusedMoEExperts):
+        if not fused_experts.supports_packed_ue8m0_act_scales():
+            # Early exit.
+            return
+
+        if self.use_fp8_dispatch:
+            logger.debug_once(
+                "Update NixlEPPrepareAndFinalize to do packed ue8m0 scales dispatch."
+            )
+            self.use_ue8m0_dispatch = True
+        else:
+            logger.warning_once(
+                "NixlEPPrepareAndFinalize is setup to dispatch raw/unquantized "
+                f"activations despite ({fused_experts.__class__.__name__}) being able "
+                "to support quantized activations.",
+                scope="local",
+            )
+
+    def num_dispatchers(self) -> int:
+        return self.num_dispatchers_
+
+    def output_is_reduced(self) -> bool:
+        return True
+
+    @property
+    def activation_format(self) -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.BatchedExperts
+
+    def max_num_tokens_per_rank(self) -> int | None:
+        return self.max_tokens_per_rank
+
+    def topk_indices_dtype(self) -> torch.dtype | None:
+        return torch.int64
+
+    def _map_global_to_physical_ids(self, topk_ids: torch.Tensor) -> torch.Tensor:
+        if self.global_to_physical is None:
+            return topk_ids
+        return self.global_to_physical[topk_ids]
+
+    def _map_local_to_global_ids(self, expert_topk_ids: torch.Tensor) -> torch.Tensor:
+        if self.local_expert_global_ids is None:
+            return expert_topk_ids
+        return self.local_expert_global_ids[expert_topk_ids]
+
+    def _do_quant(
+        self,
+        x: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        a1_dtype: torch.dtype,
+        quant_config: FusedMoEQuantConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if self.use_fp8_dispatch:
+            block_k = (
+                quant_config.block_shape[1]
+                if quant_config.block_shape is not None
+                else None
+            )
+            if block_k == NIXL_EP_QUANT_BLOCK_SIZE:
+                # NIXL EP kernels did the quantization for us.
+                x, x_scales = x
+                return x, x_scales
+
+            # Dequant to get back the tokens in the datatype we dispatched in.
+            x_fp8, x_scales = x
+            x = dequant_fp8(x_fp8, x_scales).to(dtype=a1_dtype)
+
+        assert isinstance(x, torch.Tensor)
+
+        num_experts, max_tokens, hidden_dim = x.size()
+
+        x = x.view((-1, hidden_dim))
+        q_dtype = quant_config.quant_dtype
+
+        if envs.VLLM_FLASHINFER_MOE_BACKEND == "masked_gemm":
+            logger.info_once(
+                "Skip quantization when using FlashInfer CUTEDSL(masked_gemm) "
+                "for ModelOptNvFp4FusedMoE."
+            )
+            q_dtype = None
+
+        x, x_scales = moe_kernel_quantize_input(
+            x,
+            quant_config.a1_scale,
+            q_dtype,
+            quant_config.per_act_token_quant,
+            quant_config.block_shape,
+        )
+        x = x.view((num_experts, -1, hidden_dim))
+
+        if q_dtype is not None:
+            assert x_scales is not None
+            x_scales = normalize_batched_scales_shape(x_scales, num_experts)
+
+        return x, x_scales
+
+    def supports_async(self) -> bool:
+        return True
+
+    def prepare_async(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        num_experts: int,
+        expert_map: torch.Tensor | None,
+        apply_router_weight_on_input: bool,
+        quant_config: FusedMoEQuantConfig,
+        defer_input_quant: bool = False,
+    ) -> tuple[Callable, mk.ReceiverType]:
+        if defer_input_quant:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} does not support defer_input_quant=True. "
+                "Please select an MoE kernel that accepts quantized inputs."
+            )
+
+        hidden_size = a1.size(1)
+        assert hidden_size in self.SUPPORTED_HIDDEN_SIZES, (
+            f"Hidden Size {hidden_size} not in supported list of hidden sizes"
+            f"{self.SUPPORTED_HIDDEN_SIZES}"
+        )
+
+        a2a_idx = dbo_current_ubatch_id()
+
+        if self.use_fp8_dispatch:
+            assert hidden_size % 128 == 0, (
+                "NIXL EP kernels quantize the inputs in blocks of shape 128"
+            )
+
+        has_per_token_scales = (
+            quant_config.a1_scale.numel() != 1
+            if quant_config.a1_scale is not None
+            else (
+                quant_config.a2_scale.numel() != 1
+                if quant_config.a2_scale is not None
+                else False
+            )
+        )
+        assert not has_per_token_scales, (
+            "NIXL EP kernels don't support dispatching per-token scales"
+        )
+
+        if apply_router_weight_on_input:
+            topk = topk_ids.size(1)
+            # TODO: this only works for topK=1, will need to update for topK>1
+            assert topk == 1, (
+                "apply_router_weight_on_input is only implemented for topk=1"
+            )
+            a1 = a1 * topk_weights.to(a1.dtype)
+
+        # Dispatch
+        dispatch_topk_ids = self._map_global_to_physical_ids(topk_ids)
+        expert_x, expert_num_tokens, handle, _, hook = self.buffer.dispatch(
+            a1,
+            dispatch_topk_ids,
+            self.max_tokens_per_rank,
+            num_experts,
+            use_fp8=self.use_fp8_dispatch,
+            # round_scale needs to be set to dispatch in ue8m0
+            round_scale=self.use_ue8m0_dispatch,
+            use_ue8m0=self.use_ue8m0_dispatch,
+            async_finish=False,
+            return_recv_hook=True,
+        )
+        self.handles[a2a_idx] = handle
+
+        return (
+            hook,
+            lambda: self._receiver(
+                expert_x,
+                expert_num_tokens,
+                quant_config.a1_scale,
+                a1.dtype,
+                quant_config,
+            ),
+        )
+
+    def _receiver(
+        self,
+        expert_x: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        expert_num_tokens: torch.Tensor,
+        a1_scale: torch.Tensor | None,
+        a1_dtype: torch.dtype,
+        quant_config: FusedMoEQuantConfig,
+    ) -> mk.PrepareResultType:
+        expert_x, expert_x_scale = self._do_quant(expert_x, a1_dtype, quant_config)
+
+        expert_tokens_meta = mk.ExpertTokensMetadata(
+            expert_num_tokens=expert_num_tokens, expert_num_tokens_cpu=None
+        )
+
+        return expert_x, expert_x_scale, expert_tokens_meta, None, None
+
+    def prepare(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        num_experts: int,
+        expert_map: torch.Tensor | None,
+        apply_router_weight_on_input: bool,
+        quant_config: FusedMoEQuantConfig,
+        defer_input_quant: bool = False,
+    ) -> mk.PrepareResultType:
+        if defer_input_quant:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} does not support defer_input_quant=True. "
+                "Please select an MoE kernel that accepts quantized inputs."
+            )
+        hook, receiver = self.prepare_async(
+            a1,
+            topk_weights,
+            topk_ids,
+            num_experts,
+            expert_map,
+            apply_router_weight_on_input,
+            quant_config,
+        )
+        hook()
+        return receiver()
+
+    def _finalize(
+        self,
+        output: torch.Tensor,
+        fused_expert_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        weight_and_reduce_impl: mk.TopKWeightAndReduce,
+        do_async: bool,
+    ) -> tuple[Callable, Callable]:
+        assert isinstance(weight_and_reduce_impl, TopKWeightAndReduceDelegate), (
+            "Weight application and reduction happens in the combine kernel."
+        )
+
+        a2a_idx = dbo_current_ubatch_id()
+        do_recv_hook = dbo_enabled() or do_async
+        handle = self.handles[a2a_idx]
+        assert handle is not None
+
+        combine_topk_weights = topk_weights
+        if apply_router_weight_on_input:
+            # weights have already been applied.
+            combine_topk_weights = torch.ones_like(topk_weights)
+
+        combine_topk_ids = self._map_global_to_physical_ids(topk_ids)
+        # TODO (varun) : Enable zero copy mode
+        dbo_maybe_run_recv_hook()
+        _, _, recv_hook = self.buffer.combine(
+            fused_expert_output,
+            combine_topk_ids,
+            combine_topk_weights,
+            handle,
+            async_finish=False,
+            zero_copy=False,
+            return_recv_hook=do_recv_hook,
+            out=output,
+        )
+
+        return recv_hook, lambda: None
+
+    def finalize_async(
+        self,
+        output: torch.Tensor,
+        fused_expert_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        weight_and_reduce_impl: mk.TopKWeightAndReduce,
+    ) -> tuple[Callable, Callable]:
+        return self._finalize(
+            output,
+            fused_expert_output,
+            topk_weights,
+            topk_ids,
+            apply_router_weight_on_input,
+            weight_and_reduce_impl,
+            do_async=True,
+        )
+
+    def finalize(
+        self,
+        output: torch.Tensor,
+        fused_expert_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        weight_and_reduce_impl: mk.TopKWeightAndReduce,
+    ) -> None:
+        self._finalize(
+            output,
+            fused_expert_output,
+            topk_weights,
+            topk_ids,
+            apply_router_weight_on_input,
+            weight_and_reduce_impl,
+            do_async=False,
+        )

--- a/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py
@@ -234,6 +234,7 @@ class DefaultMoERunner(MoERunner):
             self.moe_config.moe_parallel_config.use_deepep_ll_kernels
             or self.moe_config.moe_parallel_config.use_mori_kernels
             or self.moe_config.moe_parallel_config.use_fi_all2allv_kernels
+            or self.moe_config.moe_parallel_config.use_nixl_ep_kernels
         ) and envs.VLLM_ENABLE_MOE_DP_CHUNK
 
     def _maybe_setup_shared_experts_stream(

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -896,7 +896,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             # batched activation format. As self.fused_experts is not
             # initialized at this point, we resort to checking the MoE config
             # directly.
-            is_batched_moe = self.moe.use_deepep_ll_kernels
+            is_batched_moe = (
+                self.moe.use_deepep_ll_kernels or self.moe.use_nixl_ep_kernels
+            )
             if is_batched_moe:
                 num_warps = 4 if envs.VLLM_MOE_DP_CHUNK_SIZE <= 512 else 8
             else:

--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -25,6 +25,7 @@ import torch.nn as nn
 from einops import rearrange
 from transformers import BaseImageProcessor, BatchFeature, PretrainedConfig
 from transformers.activations import GELUActivation
+from transformers.image_utils import ChannelDimension
 from transformers.modeling_outputs import (
     BaseModelOutputWithPooling,
 )
@@ -249,8 +250,12 @@ class PaddleOCRVLMultiModalProcessor(
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
         if mm_data:
+            final_mm_kwargs = dict(mm_kwargs or {})
+            final_mm_kwargs.setdefault("images_kwargs", {})
+            # vLLM use PIL.Image, always set channel_last
+            final_mm_kwargs["input_data_format"] = ChannelDimension.LAST
             processed_outputs = self.info.ctx.call_hf_processor(
-                self.info.get_hf_processor(**mm_kwargs),
+                self.info.get_hf_processor(**final_mm_kwargs),
                 dict(text=prompt, **mm_data),
                 dict(**mm_kwargs, **tok_kwargs),
             )

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -167,7 +167,7 @@ class XPUPlatform(Platform):
             cache_config.block_size = 64
 
         # lazy import to avoid circular import
-        from vllm.config import CompilationMode, CUDAGraphMode
+        from vllm.config import CUDAGraphMode
 
         compilation_config = vllm_config.compilation_config
         if compilation_config.compile_sizes is None:
@@ -200,8 +200,6 @@ class XPUPlatform(Platform):
                     "falling back to PIECEWISE graph mode on XPU platform."
                 )
 
-        if vllm_config.lora_config is not None:
-            compilation_config.mode = CompilationMode.NONE
         # check and update parallel config
         parallel_config = vllm_config.parallel_config
         # Only override worker_cls if it's still the default "auto"

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -39,6 +39,7 @@ class StructuredOutputsParams:
     regex: str | None = None
     choice: list[str] | None = None
     grammar: str | None = None
+    lark: str | None = None
     json_object: bool | None = None
     # These are other options that can be set.
     disable_any_whitespace: bool = False
@@ -59,6 +60,7 @@ class StructuredOutputsParams:
                 self.regex is not None,
                 self.choice is not None,
                 self.grammar is not None,
+                self.lark is not None,
                 self.json_object is not None,
                 self.structural_tag is not None,
             ]
@@ -85,6 +87,7 @@ class StructuredOutputsParams:
                 "regex",
                 "choice",
                 "grammar",
+                "lark",
                 "json_object",
                 "structural_tag",
             )
@@ -101,6 +104,7 @@ class StructuredOutputsParams:
                 "regex",
                 "choice",
                 "grammar",
+                "lark",
                 "json_object",
             )
         )
@@ -784,12 +788,6 @@ class SamplingParams(
             # allows <|special_token|> and similar, see
             # https://github.com/guidance-ai/llguidance/blob/main/docs/syntax.md#special-tokens
             # Without tokenizer these are disallowed in grammars.
-            if is_mistral_tokenizer(tokenizer):
-                raise ValueError(
-                    "Mistral tokenizer is not supported for the 'guidance' "
-                    "structured output backend. Please use ['xgrammar', 'outlines'] "
-                    "backends or tokenizer_mode='hf' instead."
-                )
             validate_guidance_grammar(self, tokenizer=None)
         elif backend == "outlines":
             # outlines backend
@@ -828,9 +826,9 @@ class SamplingParams(
                         schema = so_params.json
                     skip_guidance = has_guidance_unsupported_json_features(schema)
 
-                if is_mistral_tokenizer(tokenizer) or skip_guidance:
-                    # Fall back to outlines if the tokenizer is Mistral
-                    # or if schema contains features unsupported by guidance
+                if skip_guidance:
+                    # Fall back to outlines if schema contains features
+                    # unsupported by guidance
                     validate_structured_output_request_outlines(self)
                     self.structured_outputs._backend = "outlines"
                 else:

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -195,14 +195,15 @@ def validate_request_params(request: "ChatCompletionRequest"):
     if request.chat_template is not None or request.chat_template_kwargs is not None:
         raise ValueError("chat_template is not supported for Mistral tokenizers.")
 
-    if request.reasoning_effort and request.reasoning_effort not in list(
-        ReasoningEffort
+    if (
+        request.reasoning_effort
+        and request.reasoning_effort not in ReasoningEffort
     ):
         raise ValueError(
             f"reasoning_effort={request.reasoning_effort} is not supported by "
-            "Mistral models. Only 'high' and 'none' are."
+            "Mistral models. Supported values are: "
+            f"{[e.value for e in ReasoningEffort]}."
         )
-
 
 def _tekken_token_to_id(tokenizer: "Tekkenizer", t: str | bytes) -> int:
     assert isinstance(tokenizer, Tekkenizer), type(tokenizer)

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, Any, cast, overload
 from mistral_common.protocol.instruct.request import (
     ChatCompletionRequest as MistralChatCompletionRequest,
 )
+from mistral_common.protocol.instruct.request import (
+    ReasoningEffort,
+)
 from mistral_common.protocol.instruct.tool_calls import Function, Tool
 from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.base import (
@@ -191,6 +194,15 @@ def _prepare_apply_chat_template_tools_and_messages(
 def validate_request_params(request: "ChatCompletionRequest"):
     if request.chat_template is not None or request.chat_template_kwargs is not None:
         raise ValueError("chat_template is not supported for Mistral tokenizers.")
+
+    if (
+        request.reasoning_effort
+        and request.reasoning_effort not in ReasoningEffort.__members__.values()
+    ):
+        raise ValueError(
+            f"reasoning_effort={request.reasoning_effort} is not supported by "
+            "Mistral models. Only 'high' and 'none' are."
+        )
 
 
 def _tekken_token_to_id(tokenizer: "Tekkenizer", t: str | bytes) -> int:
@@ -419,6 +431,12 @@ class MistralTokenizer(TokenizerLike):
         truncation = kwargs.get("truncation", False)
         max_length = kwargs.get("max_length")
 
+        version_kwargs = {}
+        # NOTE: This is for backward compatibility.
+        # Transformers should be passed arguments it knows.
+        if self.version >= 15:
+            version_kwargs["reasoning_effort"] = kwargs.get("reasoning_effort")
+
         messages, tools = _prepare_apply_chat_template_tools_and_messages(
             messages, tools, continue_final_message, add_generation_prompt
         )
@@ -433,6 +451,7 @@ class MistralTokenizer(TokenizerLike):
             max_length=max_length,
             return_tensors=None,
             return_dict=False,
+            **version_kwargs,
         )
 
     def decode(

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast, overload
 
+import regex as re
 from mistral_common.protocol.instruct.request import (
     ChatCompletionRequest as MistralChatCompletionRequest,
 )
@@ -15,8 +16,15 @@ from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.base import (
     SpecialTokenPolicy,
     SpecialTokens,
+    Tokenizer,
 )
-from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV13
+from mistral_common.tokens.tokenizers.instruct import (
+    InstructTokenizerBase,
+    InstructTokenizerV13,
+)
+from mistral_common.tokens.tokenizers.mistral import (
+    MistralTokenizer as MistralCommonTokenizer,
+)
 from mistral_common.tokens.tokenizers.sentencepiece import (
     SentencePieceTokenizer,
 )
@@ -26,10 +34,18 @@ from pydantic import ValidationError
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.logger import init_logger
+from vllm.tokenizers.protocol import TokenizerLike
 
-from .protocol import TokenizerLike
-
+try:
+    # Transformers v5
+    from transformers.tokenization_mistral_common import MistralCommonBackend
+except ImportError:
+    # Transformers v4
+    from transformers.tokenization_mistral_common import (
+        MistralCommonTokenizer as MistralCommonBackend,
+    )
 if TYPE_CHECKING:
+    import llguidance as llg
     from transformers import BatchEncoding
 
     try:
@@ -224,6 +240,7 @@ def _tekken_token_to_id(tokenizer: "Tekkenizer", t: str | bytes) -> int:
 
 class MistralTokenizer(TokenizerLike):
     IS_MISTRAL_TOKENIZER = True  # used by vllm.utils.mistral
+    _cached_llg_tokenizer: "llg.LLTokenizer | None" = None
 
     @classmethod
     def from_pretrained(
@@ -235,15 +252,6 @@ class MistralTokenizer(TokenizerLike):
         download_dir: str | None = None,
         **kwargs,
     ) -> "MistralTokenizer":
-        try:
-            # Transformers v5
-            from transformers.tokenization_mistral_common import MistralCommonBackend
-        except ImportError:
-            # Transformers v4
-            from transformers.tokenization_mistral_common import (
-                MistralCommonTokenizer as MistralCommonBackend,
-            )
-
         tokenizer = MistralCommonBackend.from_pretrained(
             path_or_repo_id,
             *args,
@@ -258,10 +266,10 @@ class MistralTokenizer(TokenizerLike):
     def __init__(self, tokenizer: "MistralCommonBackend") -> None:
         super().__init__()
 
-        self.transformers_tokenizer = tokenizer
-        self.mistral = tokenizer.tokenizer
-        self.instruct = self.mistral.instruct_tokenizer
-        self.tokenizer = self.instruct.tokenizer
+        self.transformers_tokenizer: MistralCommonBackend = tokenizer
+        self.mistral: MistralCommonTokenizer = tokenizer.tokenizer
+        self.instruct: InstructTokenizerBase = self.mistral.instruct_tokenizer
+        self.tokenizer: Tokenizer = self.instruct.tokenizer
 
         mode = self.mistral._chat_completion_request_validator._mode
         if mode != ValidationMode.test:
@@ -351,6 +359,19 @@ class MistralTokenizer(TokenizerLike):
     @property
     def truncation_side(self) -> str:
         return self.transformers_tokenizer.truncation_side
+
+    @property
+    def llg_tokenizer(self) -> "llg.LLTokenizer | None":
+        return self._cached_llg_tokenizer
+
+    @llg_tokenizer.setter
+    def llg_tokenizer(self, llg_tokenizer: "llg.LLTokenizer") -> None:
+        import llguidance as llg
+
+        assert isinstance(llg_tokenizer, llg.LLTokenizer), (
+            f"Got {type(llg_tokenizer)} instead of `llg.LLTokenizer`"
+        )
+        self._cached_llg_tokenizer = llg_tokenizer
 
     def _is_special_token_id(self, token_id: int) -> bool:
         return token_id in self._special_token_ids_set
@@ -483,7 +504,11 @@ class MistralTokenizer(TokenizerLike):
         return self.transformers_tokenizer.convert_tokens_to_ids(tokens)
 
     def convert_tokens_to_string(self, tokens: list[str]) -> str:
-        to_decode_special_tokens = {SpecialTokens.tool_calls}
+        to_decode_special_tokens = {
+            SpecialTokens.tool_calls,
+            SpecialTokens.begin_think,
+            SpecialTokens.end_think,
+        }
         if self.is_tekken:
             assert isinstance(self.tokenizer, Tekkenizer), type(self.tokenizer)
             tokens = [
@@ -573,3 +598,74 @@ class MistralTokenizer(TokenizerLike):
             ]
 
         return tokens
+
+
+class MistralLLGTokenizer:
+    """Wraps a mistral tokenizer for use with llguidance."""
+
+    eos_token_id: int
+    bos_token_id: int
+    tokens: list[bytes]
+    special_token_ids: list[int]
+
+    def __init__(self, tokenizer: MistralTokenizer) -> None:
+        self._tokenizer = tokenizer.tokenizer
+        self.eos_token_id = self._tokenizer.eos_id
+        self.bos_token_id = self._tokenizer.bos_id
+
+        self.tokens: list[bytes] = []
+        self.special_token_ids: list[int] = []
+
+        seen_special_tokens: set[str] = set()
+        for i in range(self._tokenizer.n_words):
+            # Convert square brackets to angle brackets for special tokens,
+            # since llg only recognizes the latter.
+            if self._tokenizer.is_special(i):
+                token_rep = self._tokenizer.id_to_piece(i)
+                if match := re.fullmatch(r"\[(.*)\]", token_rep):
+                    token_rep_llg = f"<{match.group(1)}>"
+                else:
+                    token_rep_llg = token_rep
+
+                if not re.fullmatch(r"<.*>", token_rep_llg):
+                    raise ValueError(
+                        f"Invalid special token: {token_rep_llg} ({token_rep})"
+                    )
+                assert token_rep_llg not in seen_special_tokens, (
+                    token_rep_llg,
+                    seen_special_tokens,
+                )
+                seen_special_tokens.add(token_rep_llg)
+                self.special_token_ids.append(i)
+                self.tokens.append(token_rep_llg.encode("utf-8"))
+            else:
+                token = self._tokenizer.id_to_byte_piece(i, SpecialTokenPolicy.RAISE)
+                self.tokens.append(token)
+
+        assert len(self.special_token_ids) == self._tokenizer.num_special_tokens, (
+            len(self.special_token_ids),
+            self._tokenizer.num_special_tokens,
+        )
+
+    def __call__(self, s: str, *args, **kwds) -> list[int]:
+        # HACK: add a null byte to the start of the string to avoid the tokenizer
+        # absorbing the first character of tokens that start with "▁".
+        # we then ignore the first two tokens the "▁" and the null byte.
+        # This gives us the pure tokenized text without SentencePiece artifacts.
+        if isinstance(self._tokenizer, SentencePieceTokenizer):
+            return self._tokenizer.encode("\00" + s, bos=False, eos=False)[2:]
+        else:
+            return self._tokenizer.encode(s, bos=False, eos=False)
+
+
+def guidance_tokenizer_from_mistral_tokenizer(
+    tokenizer: MistralTokenizer,
+) -> "llg.LLTokenizer":
+    import llguidance as llg
+
+    if tokenizer.llg_tokenizer is not None:
+        return tokenizer.llg_tokenizer
+
+    tokenizer_data = MistralLLGTokenizer(tokenizer)
+    tokenizer.llg_tokenizer = llg.LLTokenizer(llg.TokenizerWrapper(tokenizer_data))
+    return tokenizer.llg_tokenizer

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -195,9 +195,8 @@ def validate_request_params(request: "ChatCompletionRequest"):
     if request.chat_template is not None or request.chat_template_kwargs is not None:
         raise ValueError("chat_template is not supported for Mistral tokenizers.")
 
-    if (
-        request.reasoning_effort
-        and request.reasoning_effort not in ReasoningEffort.__members__.values()
+    if request.reasoning_effort and request.reasoning_effort not in list(
+        ReasoningEffort
     ):
         raise ValueError(
             f"reasoning_effort={request.reasoning_effort} is not supported by "

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -195,15 +195,15 @@ def validate_request_params(request: "ChatCompletionRequest"):
     if request.chat_template is not None or request.chat_template_kwargs is not None:
         raise ValueError("chat_template is not supported for Mistral tokenizers.")
 
-    if (
-        request.reasoning_effort
-        and request.reasoning_effort not in ReasoningEffort
+    if request.reasoning_effort and request.reasoning_effort not in list(
+        ReasoningEffort
     ):
         raise ValueError(
             f"reasoning_effort={request.reasoning_effort} is not supported by "
             "Mistral models. Supported values are: "
             f"{[e.value for e in ReasoningEffort]}."
         )
+
 
 def _tekken_token_to_id(tokenizer: "Tekkenizer", t: str | bytes) -> int:
     assert isinstance(tokenizer, Tekkenizer), type(tokenizer)

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -6,14 +6,17 @@ from collections.abc import Sequence
 from enum import Enum, auto
 from random import choices
 from string import ascii_letters, digits
-from typing import Any
+from typing import Any, Literal
 
 import ijson
 import regex as re
+from jinja2 import Template
 from pydantic import Field
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
@@ -23,8 +26,11 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
+from vllm.sampling_params import StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers.abstract_tool_parser import (
     ToolParser,
 )
@@ -33,6 +39,72 @@ from vllm.utils.mistral import is_mistral_tokenizer
 logger = init_logger(__name__)
 
 ALPHANUMERIC = ascii_letters + digits
+
+
+def is_mistral_lark_grammar_active(
+    request: ChatCompletionRequest,
+    tokenizer: TokenizerLike,
+    tool_parser_cls: type | None,
+) -> bool:
+    r"""Check if the Mistral lark grammar is active for the given request."""
+    return (
+        tool_parser_cls is not None
+        and issubclass(tool_parser_cls, MistralToolParser)
+        and is_mistral_tokenizer(tokenizer)
+        and getattr(request, "structured_outputs", None) is not None
+        and request.structured_outputs.lark is not None
+    )
+
+
+BASE_LARK_GRAMMAR = r"""start: body
+{% if mode == "auto" -%}
+{% if tokenizer_version < 7 -%}
+body: content | fcalls
+{% else -%}
+body: content | (content? fcalls)
+{% endif -%}
+fcalls: {{ fcall }}
+{% elif mode == "required" -%}
+body: content? fcalls
+fcalls: {{ fcall }}
+{% elif mode == "none" -%}
+body: content
+{% endif -%}
+{% if tokenizer_version < 7 -%}
+content: /(.|\n)+/
+{% else -%}
+content: (/(.|\n)+/)+
+{% endif -%}
+SAFE_WS: /[ \t\r\n]+/"""
+
+OPTIONAL_THINK_LARK_GRAMMAR = r"""start: body
+{% if mode == "auto" -%}
+body: think? (content | fcalls)
+fcalls: content? {{ fcall }}
+{% elif mode == "required" -%}
+body: think? fcalls
+fcalls: content? {{ fcall }}
+{% elif mode == "none" -%}
+body: think? content
+{% endif -%}
+think: <THINK> content </THINK>
+content: (/(.|\n)+/)+
+SAFE_WS: /[ \t\r\n]+/"""
+
+
+THINK_LARK_GRAMMAR = r"""start: body
+{% if mode == "auto" -%}
+body: (think (content | content? fcalls)) | fcalls
+fcalls: {{ fcall }}
+{% elif mode == "required" -%}
+body: (think content? fcalls) | fcalls
+fcalls: {{ fcall }}
+{% elif mode == "none" -%}
+body: think content
+{% endif -%}
+think: <THINK> content </THINK>
+content: (/(.|\n)+/)+
+SAFE_WS: /[ \t\r\n]+/"""
 
 
 class StreamingState(Enum):
@@ -49,6 +121,166 @@ class StreamingState(Enum):
     PARSING_ARGUMENTS_COMPLETED = auto()
     TOOL_COMPLETE = auto()
     ALL_TOOLS_COMPLETE = auto()
+
+
+def _is_strict_tool(tool: ChatCompletionToolsParam) -> bool:
+    return getattr(tool.function, "strict", False)
+
+
+class ToolsLarkConverter:
+    """Converts tools to a lark grammar"""
+
+    def _convert(
+        self,
+        tools: list[ChatCompletionToolsParam],
+        any_strict_true: bool,
+        parallel_tool_calls: bool,
+    ) -> str:
+        raise NotImplementedError
+
+    def get_args_json(self, tool: ChatCompletionToolsParam) -> dict[str, Any]:
+        args = tool.function.parameters if _is_strict_tool(tool) else {"type": "object"}
+        # Handle empty parameters case
+        if args == {}:
+            args = {"type": "object", "properties": {}, "additionalProperties": False}
+        return args
+
+    @staticmethod
+    def convert(
+        tools: list[ChatCompletionToolsParam],
+        tokenizer_version: int,
+        mode: Literal["auto", "required", "none"],
+        parallel_tool_calls: bool,
+    ) -> str:
+        if mode == "none":
+            return ""
+
+        any_strict_true = any(_is_strict_tool(tool) for tool in tools)
+        converter = (
+            PostV11ToolsLarkConverter()
+            if tokenizer_version >= 11
+            else PreV11ToolsLarkConverter()
+        )
+        return converter._convert(tools, any_strict_true, parallel_tool_calls)
+
+
+class PostV11ToolsLarkConverter(ToolsLarkConverter):
+    """Converts tools to a lark grammar for v11+ tokenizers"""
+
+    def _convert(
+        self,
+        tools: list[ChatCompletionToolsParam],
+        any_strict_true: bool,
+        parallel_tool_calls: bool,
+    ) -> str:
+        individual_tool_calls = []
+        for tool in tools:
+            # We enforce the naming to be correct even when strict is False but not
+            # arguments
+            args = self.get_args_json(tool) if any_strict_true else {"type": "object"}
+            individual_tool_calls.append(
+                f'(<TOOL_CALLS> SAFE_WS? "{tool.function.name}" <ARGS> '
+                f"SAFE_WS? %json {json.dumps(args, ensure_ascii=False)} SAFE_WS?)"
+            )
+
+        single_tool_call = f"{' | '.join(individual_tool_calls)}"
+        return f"({single_tool_call})+" if parallel_tool_calls else single_tool_call
+
+
+class PreV11ToolsLarkConverter(ToolsLarkConverter):
+    """Converts tools to a lark grammar for v10- tokenizers"""
+
+    def _convert(
+        self,
+        tools: list[ChatCompletionToolsParam],
+        any_strict_true: bool,
+        parallel_tool_calls: bool,
+    ) -> str:
+        if not any_strict_true:
+            # We enforce the naming to be correct even when strict is False.
+            tool_names = [tool.function.name for tool in tools]
+            items = {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "name": {"type": "string", "enum": tool_names},
+                    "arguments": {"type": "object"},
+                },
+                "required": ["name", "arguments"],
+            }
+        else:
+            items = self._from_tools(tools)
+
+        schema = {"minItems": 1, "type": "array", "items": items}
+
+        if not parallel_tool_calls:
+            schema["maxItems"] = 1
+
+        return f"""<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?
+fcall_array: %json {json.dumps(schema, ensure_ascii=False)}
+"""
+
+    def _from_tools(self, tools: list[ChatCompletionToolsParam]) -> dict[str, Any]:
+        return {"anyOf": [self._tool_to_call(tool) for tool in tools]}
+
+    def _tool_to_call(self, tool: ChatCompletionToolsParam) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "required": ["name", "arguments"],
+            "additionalProperties": False,
+            "properties": {
+                "name": {"const": f"{tool.function.name}"},
+                "arguments": self.get_args_json(tool),
+            },
+        }
+
+
+class MistralGrammarFactory:
+    """Generates grammars for a given tokenizer version"""
+
+    def __init__(self, tokenizer: MistralTokenizer) -> None:
+        if not is_mistral_tokenizer(tokenizer):
+            raise ValueError("`MistralGrammarFactory` expects a `MistralTokenizer`.")
+        self._tokenizer = tokenizer
+        self._tokenizer_version = tokenizer.version
+
+    def get_lark_from_jinja(
+        self,
+        mode: Literal["auto", "required", "none"] | None,
+        tools: list[ChatCompletionToolsParam],
+        reasoning: bool,
+        parallel_tool_calls: bool,
+    ) -> str:
+        r"""Render a lark grammar from a jinja template.
+
+        Note:
+            Currently we support the following variables in the Lark jinja
+            template: `tokenizer_version`, `mode`, and `fcall`.
+
+        Args:
+            mode: Function calling mode (auto, required, none).
+            tools: The available tools.
+            reasoning: Whether to include think block rules in the grammar.
+            parallel_tool_calls: Whether parallel tool calls are allowed.
+        """
+        if mode is None:
+            mode = "auto"
+
+        if self._tokenizer_version < 13 or not reasoning:
+            jinja_template = BASE_LARK_GRAMMAR
+        elif self._tokenizer_version < 15:
+            jinja_template = OPTIONAL_THINK_LARK_GRAMMAR
+        else:
+            jinja_template = THINK_LARK_GRAMMAR
+
+        lark_grammar = Template(jinja_template).render(
+            tokenizer_version=self._tokenizer_version,
+            mode=mode,
+            fcall=ToolsLarkConverter.convert(
+                tools, self._tokenizer_version, mode, parallel_tool_calls
+            ),
+        )
+        return lark_grammar
 
 
 class MistralToolCall(ToolCall):
@@ -71,12 +303,14 @@ def _is_pre_v11_tokeniser(model_tokenizer: TokenizerLike) -> bool:
 
 class MistralToolParser(ToolParser):
     """
-    Tool call parser for Mistral 7B Instruct v0.3, intended for use with
+    Tool call parser for Mistral models, intended for use with either:
     - [`mistral_common`](https://github.com/mistralai/mistral-common/)
     - the examples/tool_chat_template_mistral.jinja template.
 
-    Used when --enable-auto-tool-choice --tool-call-parser mistral are all set
+    Used when `--enable-auto-tool-choice --tool-call-parser mistral` are all set
     """
+
+    _has_reasoning_parser: bool = False
 
     def __init__(self, tokenizer: TokenizerLike):
         super().__init__(tokenizer)
@@ -109,20 +343,77 @@ class MistralToolParser(ToolParser):
                 "Mistral Tool Parser could not locate the tool call token in "
                 "the tokenizer!"
             )
+        self.grammar_factory = MistralGrammarFactory(tokenizer)
+
+    def _should_reason(self, request: ChatCompletionRequest) -> bool:
+        if not self.has_reasoning_parser:
+            return False
+        if (
+            isinstance(self.model_tokenizer, MistralTokenizer)
+            and self.model_tokenizer.version >= 15
+        ):
+            return request.reasoning_effort not in (None, "none")
+        return True
+
+    @property
+    def has_reasoning_parser(self) -> bool:
+        return self._has_reasoning_parser
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
-        request = super().adjust_request(request)
+        if not is_mistral_tokenizer(self.model_tokenizer):
+            # For non-Mistral tokenizers, use the parent's adjust_request
+            # which sets JSON schema for required/named tool_choice.
+            request = super().adjust_request(request)
+            if request.tools and request.tool_choice != "none":
+                # Do not skip special tokens when using chat template
+                # with Mistral parser as TOOL_CALL token is needed
+                # for tool detection.
+                # Note: we don't want skip_special_tokens=False
+                # with MistralTokenizer as it is incompatible
+                request.skip_special_tokens = False
+            return request
+
         if (
-            not is_mistral_tokenizer(self.model_tokenizer)
-            and request.tools
-            and request.tool_choice != "none"
+            request.response_format is not None
+            and hasattr(request.response_format, "type")
+            and request.response_format.type != "text"
+        ) or (
+            # Skip if user explicitly set structured outputs
+            request.structured_outputs is not None
+            and (
+                request.structured_outputs.json is not None
+                or request.structured_outputs.json_object is not None
+            )
         ):
-            # Do not skip special tokens when using chat template
-            # with Mistral parser as TOOL_CALL token is needed
-            # for tool detection.
-            # Note: we don't want skip_special_tokens=False
-            # with MistralTokenizer as it is incompatible
-            request.skip_special_tokens = False
+            return request
+
+        if not request.tools:
+            # Sanitize tool_choice.
+            request.tool_choice = "none"
+
+        # Set structured output params for tool calling
+        if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):
+            selected_tools = [
+                tool
+                for tool in request.tools
+                if tool.function.name == request.tool_choice.function.name
+            ]
+            mode: Literal["auto", "required", "none"] | None = "required"
+        else:
+            selected_tools = request.tools
+            mode = request.tool_choice
+        lark_grammar = self.grammar_factory.get_lark_from_jinja(
+            mode=mode,
+            tools=selected_tools,
+            reasoning=self._should_reason(request=request),
+            parallel_tool_calls=True,
+        )
+        if isinstance(request, ChatCompletionRequest):
+            request.structured_outputs = StructuredOutputsParams(lark=lark_grammar)  # type: ignore[call-arg]
+            request.response_format = None
+        elif isinstance(request, ResponsesRequest):
+            raise ValueError("`ResponsesRequest` not supported.")
+
         return request
 
     def extract_tool_calls(
@@ -241,7 +532,10 @@ class MistralToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        if self.bot_token_id not in current_token_ids:
+        has_bot_token = (
+            self.bot_token_id in current_token_ids or self.bot_token in current_text
+        )
+        if not has_bot_token:
             # if the tool call token is not in the tokens generated so far,
             # append output to contents since it's not a tool
             return DeltaMessage(content=delta_text)
@@ -275,7 +569,8 @@ class MistralToolParser(ToolParser):
         additional_content: str = ""
         if self.streaming_state == StreamingState.WAITING_FOR_TOOL_START:
             # this is the first tool call
-            assert self.bot_token_id in delta_token_ids
+            if self.bot_token not in delta_text:
+                return DeltaMessage(content=delta_text)
             if not delta_text.startswith(self.bot_token):
                 additional_content += delta_text.split(self.bot_token)[0]
                 delta_text = self.bot_token + "".join(
@@ -411,7 +706,7 @@ class MistralToolParser(ToolParser):
             index=self.current_tool_id, type="function"
         )
         current_tool_call_modified = False
-        if self.bot_token_id in delta_token_ids:
+        if self.bot_token_id in delta_token_ids or self.bot_token in delta_text:
             # this is the first tool call
             if not delta_text.startswith(self.bot_token):
                 content = delta_text.split(self.bot_token)[0]

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -412,6 +412,11 @@ def has_deep_gemm() -> bool:
     return _has_module("deep_gemm")
 
 
+def has_nixl_ep() -> bool:
+    """Whether the optional `nixl_ep` package is available."""
+    return _has_module("nixl_ep")
+
+
 def has_triton_kernels() -> bool:
     """Whether the optional `triton_kernels` package is available."""
     is_available = _has_module("triton_kernels") or _has_module(

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -288,6 +288,7 @@ def make_zmq_socket(
     bind: bool | None = None,
     identity: bytes | None = None,
     linger: int | None = None,
+    router_handover: bool = False,
 ) -> zmq.Socket | zmq.asyncio.Socket:  # type: ignore[name-defined]
     """Make a ZMQ socket with the proper bind/connect semantics."""
 
@@ -313,6 +314,10 @@ def make_zmq_socket(
     if socket_type in (zmq.PUSH, zmq.DEALER, zmq.ROUTER):
         socket.setsockopt(zmq.SNDHWM, 0)
         socket.setsockopt(zmq.SNDBUF, buf_size)
+
+    if socket_type == zmq.ROUTER and router_handover:
+        # Let a new connection take over an identity left behind by a dead one.
+        socket.setsockopt(zmq.ROUTER_HANDOVER, 1)
 
     if identity is not None:
         socket.setsockopt(zmq.IDENTITY, identity)
@@ -344,12 +349,20 @@ def zmq_socket_ctx(
     bind: bool | None = None,
     linger: int = 0,
     identity: bytes | None = None,
+    router_handover: bool = False,
 ) -> Iterator[zmq.Socket]:
     """Context manager for a ZMQ socket"""
 
     ctx = zmq.Context()  # type: ignore[attr-defined]
     try:
-        yield make_zmq_socket(ctx, path, socket_type, bind=bind, identity=identity)
+        yield make_zmq_socket(
+            ctx,
+            path,
+            socket_type,
+            bind=bind,
+            identity=identity,
+            router_handover=router_handover,
+        )
     except KeyboardInterrupt:
         logger.debug("Got Keyboard Interrupt.")
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -544,6 +544,11 @@ class MPClient(EngineCoreClient):
         try:
             # State used for data parallel.
             self.engines_running = False
+            parallel_config = vllm_config.parallel_config
+            # Elastic EP can remove a rank and later add it back with the same
+            # identity. The client input ROUTER needs handover to allow the new
+            # engine to replace the dead connection.
+            enable_input_socket_handover = parallel_config.enable_elastic_ep
 
             self.stats_update_address: str | None = None
             if client_addresses:
@@ -552,7 +557,11 @@ class MPClient(EngineCoreClient):
                 output_address = client_addresses["output_address"]
                 self.stats_update_address = client_addresses.get("stats_update_address")
                 self.input_socket = self.resources.input_socket = make_zmq_socket(
-                    self.ctx, input_address, zmq.ROUTER, bind=True
+                    self.ctx,
+                    input_address,
+                    zmq.ROUTER,
+                    bind=True,
+                    router_handover=enable_input_socket_handover,
                 )
                 self.resources.output_socket = make_zmq_socket(
                     self.ctx, output_address, zmq.PULL
@@ -561,7 +570,11 @@ class MPClient(EngineCoreClient):
                 # Engines are managed by this client.
                 addresses = get_engine_zmq_addresses(vllm_config)
                 self.input_socket = self.resources.input_socket = make_zmq_socket(
-                    self.ctx, addresses.inputs[0], zmq.ROUTER, bind=True
+                    self.ctx,
+                    addresses.inputs[0],
+                    zmq.ROUTER,
+                    bind=True,
+                    router_handover=enable_input_socket_handover,
                 )
                 self.resources.output_socket = make_zmq_socket(
                     self.ctx, addresses.outputs[0], zmq.PULL
@@ -582,7 +595,6 @@ class MPClient(EngineCoreClient):
                         coordinator.get_stats_publish_address()
                     )
 
-            parallel_config = vllm_config.parallel_config
             dp_size = parallel_config.data_parallel_size
             dp_rank = parallel_config.data_parallel_index
             dp_local_size = parallel_config.data_parallel_size_local

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -21,6 +21,7 @@ class StructuredOutputOptions(enum.Enum):
     JSON_OBJECT = enum.auto()
     REGEX = enum.auto()
     GRAMMAR = enum.auto()
+    LARK = enum.auto()
     CHOICE = enum.auto()
     STRUCTURAL_TAG = enum.auto()
 

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -354,3 +354,8 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
                 xgr.Grammar.from_structural_tag(so_params.structural_tag)
         except Exception as e:
             raise ValueError("Invalid structural tag specification.") from e
+
+    if so_params.lark:
+        raise ValueError(
+            "xgrammar does not support grammar from Lark. Use guidance instead."
+        )

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -86,6 +86,8 @@ def get_structured_output_key(params: StructuredOutputsParams) -> StructuredOutp
         return StructuredOutputOptions.CHOICE, json_str
     if params.grammar is not None:
         return StructuredOutputOptions.GRAMMAR, params.grammar
+    if params.lark is not None:
+        return StructuredOutputOptions.LARK, params.lark
     if params.structural_tag is not None:
         return StructuredOutputOptions.STRUCTURAL_TAG, params.structural_tag
     raise ValueError("No valid structured output parameter found")


### PR DESCRIPTION
## Purpose

Add mistral guidance:
- support tool call parsing + reasoning
- support streaming
- support all tool choices
- add lark to llguidance
- add MistralGrammarFactory using lark through llguidance
- support reasoning prior v15 and after v15
- support tool call prior v11 and after v11 

## Test Plan

some unit tests were added

vibe coded scripts to check it works

```bash
# Ask access for Hub weights
python test_vllm_tools.py \
    --base-url http://localhost:8000/v1
```

<details>
<summary> Python script post v15 </summary>

```python
"""
Standalone test script for vLLM tool calling.

Tests tool_choice modes (auto, required, named, none) with and without
streaming, and with different reasoning_effort levels (None, "none", "high")
against a running vLLM-compatible server. Prints a colored summary table
and writes detailed results (tool calls, reasoning trace, content) to a
JSON file.

When reasoning_effort is supported by the model:
  - None  (omitted):  model reasons (thinking enabled by default)
  - "high":           model reasons explicitly
  - "none":           reasoning disabled, no thinking trace expected

Use --no-reasoning-effort for models that do not support the parameter.
In that mode the reasoning_effort dimension is skipped entirely and the
model is assumed to always reason.

Usage:
    python test_vllm_tools.py --base-url http://localhost:8000/v1
    python test_vllm_tools.py --base-url http://localhost:8000/v1 --model my-model
    python test_vllm_tools.py --base-url http://localhost:8000/v1 -o results.json
    python test_vllm_tools.py --base-url http://localhost:8000/v1 --no-reasoning-effort
"""

from __future__ import annotations

import argparse
import asyncio
import json
import sys
import time
import traceback
from dataclasses import dataclass, field
from datetime import datetime, timezone
from typing import Any

from openai import AsyncOpenAI

# ---------------------------------------------------------------------------
# ANSI helpers
# ---------------------------------------------------------------------------
_SUPPORTS_COLOR = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()


def _c(code: str, text: str) -> str:
    if not _SUPPORTS_COLOR:
        return text
    return f"\033[{code}m{text}\033[0m"


def green(t: str) -> str:
    return _c("32", t)


def red(t: str) -> str:
    return _c("31", t)


def yellow(t: str) -> str:
    return _c("33", t)


def cyan(t: str) -> str:
    return _c("36", t)


def bold(t: str) -> str:
    return _c("1", t)


def dim(t: str) -> str:
    return _c("2", t)


# ---------------------------------------------------------------------------
# Tool definitions
# ---------------------------------------------------------------------------
WEATHER_TOOL: dict[str, Any] = {
    "type": "function",
    "function": {
        "name": "get_current_weather",
        "description": "Get the current weather in a given location",
        "parameters": {
            "type": "object",
            "properties": {
                "city": {
                    "type": "string",
                    "description": "The city to find the weather for, e.g. 'San Francisco'",
                },
                "state": {
                    "type": "string",
                    "description": (
                        "The two-letter abbreviation for the state that the city is in, "
                        "e.g. 'CA' for California"
                    ),
                },
                "unit": {
                    "type": "string",
                    "description": "The unit to fetch the temperature in",
                    "enum": ["celsius", "fahrenheit"],
                },
            },
            "required": ["city", "state"],
        },
    },
}

SEARCH_TOOL: dict[str, Any] = {
    "type": "function",
    "function": {
        "name": "web_search",
        "description": (
            "Search the internet and get a summary of the top 10 webpages. "
            "Should only be used if you don't know the answer to a user query."
        ),
        "parameters": {
            "type": "object",
            "properties": {
                "search_term": {
                    "type": "string",
                    "description": "Keywords to search for",
                }
            },
            "required": ["search_term"],
        },
    },
}

ALL_TOOLS = [WEATHER_TOOL, SEARCH_TOOL]

# ---------------------------------------------------------------------------
# Messages for different scenarios
# ---------------------------------------------------------------------------
# Should trigger a tool call (weather)
MESSAGES_WANT_TOOL: list[dict[str, Any]] = [
    {
        "role": "user",
        "content": "What is the weather in Dallas, Texas in Fahrenheit?",
    }
]

# Should NOT trigger a tool call
MESSAGES_NO_TOOL: list[dict[str, Any]] = [
    {"role": "user", "content": "Tell me a short joke about programming."}
]

# Tool result follow-up (model should respond with content, not more tools)
MESSAGES_TOOL_RESULT: list[dict[str, Any]] = [
    {
        "role": "user",
        "content": "What is the weather in Dallas, Texas in Fahrenheit?",
    },
    {
        "role": "assistant",
        "tool_calls": [
            {
                "id": "chatcmpl0",
                "type": "function",
                "function": {
                    "name": "get_current_weather",
                    "arguments": '{"city": "Dallas", "state": "TX", "unit": "fahrenheit"}',
                },
            }
        ],
    },
    {
        "role": "tool",
        "tool_call_id": "chatcmpl0",
        "content": (
            "The weather in Dallas is 98 degrees Fahrenheit, with partly "
            "cloudy skies and a low chance of rain."
        ),
    },
]


# ---------------------------------------------------------------------------
# Test case definitions
# ---------------------------------------------------------------------------
@dataclass
class TestCase:
    """A single test scenario."""

    name: str
    description: str
    messages: list[dict[str, Any]]
    tools: list[dict[str, Any]]
    tool_choice: str | dict[str, Any]
    stream: bool
    reasoning_effort: str | None  # None = omit, "none" = disable, "high" = enable
    # Expectations
    expect_tool_calls: bool | None  # True = must have, False = must not, None = either
    expect_content: bool | None  # True = must have, False = must not, None = either
    expect_finish_reason: str | None  # expected finish_reason, None = don't check
    expect_reasoning: bool | None  # True = must have, False = must not, None = either


def _reasoning_effort_label(re_val: str | None) -> str:
    """Human-readable label for a reasoning_effort value."""
    if re_val is None:
        return "re=None"
    return f"re={re_val}"


def build_test_cases(
    reasoning_efforts: list[str | None],
) -> list[TestCase]:
    """Build the full test matrix.

    Args:
        reasoning_efforts: list of reasoning_effort values to iterate over.
            When the model does not support reasoning_effort, pass ``[None]``
            so that the dimension is effectively collapsed (one iteration,
            param omitted from the request, model always reasons).
    """
    cases: list[TestCase] = []

    for re_val in reasoning_efforts:
        re_label = _reasoning_effort_label(re_val)

        # When reasoning_effort is "none" the server disables thinking,
        # so we must NOT expect reasoning content.  For None / "high" the
        # model should reason — but the Mistral grammar only requires
        # thinking when content is generated.  If the model produces
        # only tool calls (via the fcalls-only grammar path), there
        # is no thinking.  We use two flavours:
        #   expect_reasoning_content: True when content IS expected
        #   expect_reasoning_maybe:   None when model might skip think
        if re_val == "none":
            expect_reasoning_content: bool | None = False
            expect_reasoning_maybe: bool | None = False
        elif re_val in ("high",):
            # Grammar requires thinking only before content, not before
            # bare tool calls, so tool-call-only tests may not have
            # reasoning output.
            expect_reasoning_content = True
            expect_reasoning_maybe = None
        else:
            # None – param omitted; model reasons by default but we
            # cannot be 100 % sure for every model, so don't enforce.
            expect_reasoning_content = None
            expect_reasoning_maybe = None

        for stream in (False, True):
            sfx_parts = []
            sfx_parts.append("stream" if stream else "non-stream")
            sfx_parts.append(re_label)
            sfx = " (" + ", ".join(sfx_parts) + ")"

            # --- tool_choice = "auto" ---
            # Prompt that SHOULD trigger tools
            cases.append(
                TestCase(
                    name=f"auto_with_tool_prompt{sfx}",
                    description=f"tool_choice=auto, prompt wants weather{sfx}",
                    messages=MESSAGES_WANT_TOOL,
                    tools=ALL_TOOLS,
                    tool_choice="auto",
                    stream=stream,
                    reasoning_effort=re_val,
                    expect_tool_calls=True,
                    expect_content=None,
                    expect_finish_reason="tool_calls",
                    expect_reasoning=expect_reasoning_maybe,
                )
            )
            # Prompt that should NOT trigger tools
            cases.append(
                TestCase(
                    name=f"auto_no_tool_prompt{sfx}",
                    description=f"tool_choice=auto, prompt wants joke{sfx}",
                    messages=MESSAGES_NO_TOOL,
                    tools=ALL_TOOLS,
                    tool_choice="auto",
                    stream=stream,
                    reasoning_effort=re_val,
                    expect_tool_calls=False,
                    expect_content=True,
                    expect_finish_reason="stop",
                    expect_reasoning=expect_reasoning_content,
                )
            )
            # Tool result follow-up: model should answer with content
            # With re=high the model can be more aggressive and may call
            # tools again instead of answering, so we relax expectations.
            cases.append(
                TestCase(
                    name=f"auto_tool_result{sfx}",
                    description=f"tool_choice=auto, tool result follow-up{sfx}",
                    messages=MESSAGES_TOOL_RESULT,
                    tools=ALL_TOOLS,
                    tool_choice="auto",
                    stream=stream,
                    reasoning_effort=re_val,
                    expect_tool_calls=False if re_val != "high" else None,
                    expect_content=True if re_val != "high" else None,
                    expect_finish_reason=None,
                    expect_reasoning=expect_reasoning_maybe,
                )
            )

            # --- tool_choice = "required" ---
            cases.append(
                TestCase(
                    name=f"required_tool_prompt{sfx}",
                    description=f"tool_choice=required, prompt wants weather{sfx}",
                    messages=MESSAGES_WANT_TOOL,
                    tools=ALL_TOOLS,
                    tool_choice="required",
                    stream=stream,
                    reasoning_effort=re_val,
                    expect_tool_calls=True,
                    expect_content=None,
                    expect_finish_reason="tool_calls",
                    expect_reasoning=expect_reasoning_maybe,
                )
            )
            # --- tool_choice = named (specific function) ---
            # Per the OpenAI API spec, finish_reason is "stop" for
            # named tool calls (not "tool_calls").
            cases.append(
                TestCase(
                    name=f"named_weather{sfx}",
                    description=f"tool_choice=get_current_weather (named){sfx}",
                    messages=MESSAGES_WANT_TOOL,
                    tools=ALL_TOOLS,
                    tool_choice={
                        "type": "function",
                        "function": {"name": "get_current_weather"},
                    },
                    stream=stream,
                    reasoning_effort=re_val,
                    expect_tool_calls=True,
                    expect_content=None,
                    expect_finish_reason="stop",
                    expect_reasoning=expect_reasoning_maybe,
                )
            )
            # Named tool but prompt doesn't naturally want it
            cases.append(
                TestCase(
                    name=f"named_search_wrong_prompt{sfx}",
                    description=f"tool_choice=web_search (named), weather prompt{sfx}",
                    messages=MESSAGES_WANT_TOOL,
                    tools=ALL_TOOLS,
                    tool_choice={
                        "type": "function",
                        "function": {"name": "web_search"},
                    },
                    stream=stream,
                    reasoning_effort=re_val,
                    expect_tool_calls=True,
                    expect_content=None,
                    expect_finish_reason="stop",
                    expect_reasoning=expect_reasoning_maybe,
                )
            )

            # --- tool_choice = "none" ---
            # For Mistral models, tool_choice=none now injects a Lark
            # grammar that constrains output to ``think? content`` (no
            # tool calls).  Whether reasoning is present depends on the
            # tokenizer version and reasoning_effort setting.
            # When re_val == "none", reasoning is explicitly disabled.
            expect_reasoning_none_mode = False if re_val == "none" else None
            cases.append(
                TestCase(
                    name=f"none_tool_prompt{sfx}",
                    description=f"tool_choice=none, prompt wants weather{sfx}",
                    messages=MESSAGES_WANT_TOOL,
                    tools=ALL_TOOLS,
                    tool_choice="none",
                    stream=stream,
                    reasoning_effort=re_val,
                    expect_tool_calls=False,
                    expect_content=True,
                    expect_finish_reason=None,
                    expect_reasoning=expect_reasoning_none_mode,
                )
            )
            cases.append(
                TestCase(
                    name=f"none_no_tool_prompt{sfx}",
                    description=f"tool_choice=none, prompt wants joke{sfx}",
                    messages=MESSAGES_NO_TOOL,
                    tools=ALL_TOOLS,
                    tool_choice="none",
                    stream=stream,
                    reasoning_effort=re_val,
                    expect_tool_calls=False,
                    expect_content=True,
                    expect_finish_reason=None,
                    expect_reasoning=expect_reasoning_none_mode,
                )
            )

    return cases


# ---------------------------------------------------------------------------
# Result container
# ---------------------------------------------------------------------------
@dataclass
class TestResult:
    name: str
    description: str
    tool_choice: str | dict
    stream: bool
    reasoning_effort: str | None
    passed: bool = False
    checks: dict[str, dict[str, Any]] = field(default_factory=dict)
    error: str | None = None
    # Raw response data
    content: str | None = None
    tool_calls: list[dict[str, Any]] = field(default_factory=list)
    reasoning_content: str | None = None
    finish_reason: str | None = None
    duration_s: float = 0.0


# ---------------------------------------------------------------------------
# Streaming reconstruction helpers
# ---------------------------------------------------------------------------
def reconstruct_streaming(
    chunks: list,
) -> tuple[str | None, list[dict[str, Any]], str | None, str | None]:
    """Reconstruct content, tool_calls, reasoning_content, and finish_reason
    from a list of streaming ChatCompletionChunk objects."""
    content_parts: list[str] = []
    reasoning_parts: list[str] = []
    tool_map: dict[int, dict[str, Any]] = {}  # index -> {id, name, arguments}
    finish_reason: str | None = None

    for chunk in chunks:
        if not chunk.choices:
            continue
        choice = chunk.choices[0]

        if choice.finish_reason:
            finish_reason = choice.finish_reason

        delta = choice.delta

        # Content
        if delta.content:
            content_parts.append(delta.content)

        # Reasoning content — vLLM uses the field name ``reasoning``
        rc = getattr(delta, "reasoning", None) or getattr(
            delta, "reasoning_content", None
        )
        if rc:
            reasoning_parts.append(rc)

        # Tool calls
        if delta.tool_calls:
            for tc in delta.tool_calls:
                idx = tc.index
                if idx not in tool_map:
                    tool_map[idx] = {"id": None, "name": None, "arguments": ""}
                if tc.id:
                    tool_map[idx]["id"] = tc.id
                if tc.function:
                    if tc.function.name:
                        tool_map[idx]["name"] = tc.function.name
                    if tc.function.arguments:
                        tool_map[idx]["arguments"] += tc.function.arguments

    content = "".join(content_parts) if content_parts else None
    reasoning = "".join(reasoning_parts) if reasoning_parts else None

    tool_calls_list: list[dict[str, Any]] = []
    for idx in sorted(tool_map.keys()):
        tc = tool_map[idx]
        entry: dict[str, Any] = {
            "id": tc["id"],
            "type": "function",
            "function": {
                "name": tc["name"],
                "arguments": tc["arguments"],
            },
        }
        # Try to parse arguments as JSON
        try:
            entry["function"]["arguments_parsed"] = json.loads(tc["arguments"])
        except (json.JSONDecodeError, TypeError):
            entry["function"]["arguments_parsed"] = None
        tool_calls_list.append(entry)

    return content, tool_calls_list, reasoning, finish_reason


# ---------------------------------------------------------------------------
# Core test runner
# ---------------------------------------------------------------------------
async def run_single_test(
    client: AsyncOpenAI,
    model: str,
    tc: TestCase,
) -> TestResult:
    """Run a single test case and return the result."""
    result = TestResult(
        name=tc.name,
        description=tc.description,
        tool_choice=tc.tool_choice
        if isinstance(tc.tool_choice, str)
        else tc.tool_choice,
        stream=tc.stream,
        reasoning_effort=tc.reasoning_effort,
    )

    t0 = time.monotonic()
    try:
        kwargs: dict[str, Any] = {
            "model": model,
            "messages": tc.messages,
            "tools": tc.tools,
            "tool_choice": tc.tool_choice,
            "temperature": 0,
            "max_completion_tokens": 4096,
            "stream": tc.stream,
        }

        # reasoning_effort is a vLLM extension; pass via extra_body when set.
        if tc.reasoning_effort is not None:
            kwargs["extra_body"] = {"reasoning_effort": tc.reasoning_effort}

        if tc.stream:
            stream = await client.chat.completions.create(**kwargs)
            chunks = []
            async for chunk in stream:
                chunks.append(chunk)

            content, tool_calls, reasoning, finish_reason = reconstruct_streaming(
                chunks
            )
            result.content = content
            result.tool_calls = tool_calls
            result.reasoning_content = reasoning
            result.finish_reason = finish_reason
        else:
            resp = await client.chat.completions.create(**kwargs)
            choice = resp.choices[0]
            result.content = choice.message.content
            result.finish_reason = choice.finish_reason

            # Reasoning content — vLLM uses the field name ``reasoning``
            rc = getattr(choice.message, "reasoning", None) or getattr(
                choice.message, "reasoning_content", None
            )
            if rc:
                result.reasoning_content = rc

            # Tool calls
            if choice.message.tool_calls:
                for tc_obj in choice.message.tool_calls:
                    entry: dict[str, Any] = {
                        "id": tc_obj.id,
                        "type": tc_obj.type,
                        "function": {
                            "name": tc_obj.function.name,
                            "arguments": tc_obj.function.arguments,
                        },
                    }
                    try:
                        entry["function"]["arguments_parsed"] = json.loads(
                            tc_obj.function.arguments
                        )
                    except (json.JSONDecodeError, TypeError):
                        entry["function"]["arguments_parsed"] = None
                    result.tool_calls.append(entry)

    except Exception as exc:
        result.error = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
        result.duration_s = time.monotonic() - t0
        return result

    result.duration_s = time.monotonic() - t0

    # ----- Validation checks -----
    all_ok = True

    # Check: no HTTP / server error
    result.checks["no_error"] = {"expected": "no error", "actual": "ok", "passed": True}
    if result.error:
        result.checks["no_error"] = {
            "expected": "no error",
            "actual": result.error[:120],
            "passed": False,
        }
        all_ok = False

    has_tool_calls = len(result.tool_calls) > 0
    has_content = result.content is not None and len(result.content.strip()) > 0

    # Check: tool_calls presence
    if tc.expect_tool_calls is True:
        ok = has_tool_calls
        result.checks["tool_calls_present"] = {
            "expected": "tool calls present",
            "actual": f"{len(result.tool_calls)} tool call(s)"
            if ok
            else "no tool calls",
            "passed": ok,
        }
        if not ok:
            all_ok = False

        # If tool calls expected, validate structure
        if has_tool_calls:
            for i, tcc in enumerate(result.tool_calls):
                fn = tcc.get("function", {})
                name_ok = fn.get("name") is not None and isinstance(fn.get("name"), str)
                args_ok = fn.get("arguments") is not None
                parsed_ok = fn.get("arguments_parsed") is not None
                check_ok = name_ok and args_ok and parsed_ok
                result.checks[f"tool_call_{i}_valid"] = {
                    "expected": "valid function name + parseable JSON args",
                    "actual": (f"name={fn.get('name')!r}, args_parseable={parsed_ok}"),
                    "passed": check_ok,
                }
                if not check_ok:
                    all_ok = False

    elif tc.expect_tool_calls is False:
        ok = not has_tool_calls
        result.checks["no_tool_calls"] = {
            "expected": "no tool calls",
            "actual": "no tool calls"
            if ok
            else f"{len(result.tool_calls)} tool call(s)",
            "passed": ok,
        }
        if not ok:
            all_ok = False

    # Check: content presence
    if tc.expect_content is True:
        ok = has_content
        result.checks["content_present"] = {
            "expected": "content present",
            "actual": (
                f"content ({len(result.content)} chars)" if ok else "no content"
            ),
            "passed": ok,
        }
        if not ok:
            all_ok = False
    elif tc.expect_content is False:
        ok = not has_content
        result.checks["no_content"] = {
            "expected": "no content",
            "actual": "no content" if ok else f"content ({len(result.content)} chars)",
            "passed": ok,
        }
        if not ok:
            all_ok = False

    # Check: finish_reason
    if tc.expect_finish_reason is not None:
        ok = result.finish_reason == tc.expect_finish_reason
        result.checks["finish_reason"] = {
            "expected": tc.expect_finish_reason,
            "actual": result.finish_reason,
            "passed": ok,
        }
        if not ok:
            all_ok = False

    # Check: named tool_choice forces the correct function name
    if isinstance(tc.tool_choice, dict) and has_tool_calls:
        expected_name = tc.tool_choice["function"]["name"]
        actual_name = result.tool_calls[0]["function"].get("name")
        ok = actual_name == expected_name
        result.checks["named_tool_match"] = {
            "expected": f"function name = {expected_name!r}",
            "actual": f"function name = {actual_name!r}",
            "passed": ok,
        }
        if not ok:
            all_ok = False

    # Check: reasoning content presence
    has_reasoning = (
        result.reasoning_content is not None
        and len(result.reasoning_content.strip()) > 0
    )
    if tc.expect_reasoning is True:
        ok = has_reasoning
        result.checks["reasoning_present"] = {
            "expected": "reasoning content present",
            "actual": (
                f"reasoning ({len(result.reasoning_content)} chars)"
                if ok
                else "no reasoning content"
            ),
            "passed": ok,
        }
        if not ok:
            all_ok = False
    elif tc.expect_reasoning is False:
        ok = not has_reasoning
        result.checks["no_reasoning"] = {
            "expected": "no reasoning content",
            "actual": (
                "no reasoning content"
                if ok
                else f"reasoning ({len(result.reasoning_content)} chars)"
            ),
            "passed": ok,
        }
        if not ok:
            all_ok = False

    result.passed = all_ok
    return result


# ---------------------------------------------------------------------------
# Pretty printing
# ---------------------------------------------------------------------------
def print_result(result: TestResult, index: int, total: int) -> None:
    status = green("PASS") if result.passed else red("FAIL")
    stream_tag = cyan("stream") if result.stream else dim("no-stream")
    re_tag = _reasoning_effort_label(result.reasoning_effort)

    tc_str = (
        result.tool_choice
        if isinstance(result.tool_choice, str)
        else result.tool_choice["function"]["name"]
    )

    print(
        f"\n{'=' * 72}\n"
        f"[{index}/{total}] {status}  {bold(result.name)}\n"
        f"  {result.description}\n"
        f"  tool_choice={tc_str}  {stream_tag}  {re_tag}  "
        f"duration={result.duration_s:.2f}s"
    )

    if result.error:
        print(f"  {red('ERROR:')} {result.error[:200]}")

    for check_name, check_info in result.checks.items():
        icon = green("OK") if check_info["passed"] else red("FAIL")
        print(
            f"    [{icon}] {check_name}: "
            f"expected={check_info['expected']}, "
            f"actual={check_info['actual']}"
        )

    # Show a snippet of content / tool calls
    if result.content:
        snippet = result.content[:150].replace("\n", " ")
        if len(result.content) > 150:
            snippet += "..."
        print(f"  {dim('content:')} {snippet}")
    if result.reasoning_content:
        snippet = result.reasoning_content[:150].replace("\n", " ")
        if len(result.reasoning_content) > 150:
            snippet += "..."
        print(f"  {dim('reasoning:')} {snippet}")
    if result.tool_calls:
        for i, tc in enumerate(result.tool_calls):
            fn = tc.get("function", {})
            print(
                f"  {dim(f'tool_call[{i}]:')} "
                f"{fn.get('name')}({fn.get('arguments', '')[:100]})"
            )


def print_summary_table(results: list[TestResult]) -> None:
    """Print a nice ASCII summary table."""
    print(f"\n\n{'=' * 96}")
    print(bold("                              SUMMARY TABLE"))
    print(f"{'=' * 96}")

    # Column widths
    col_name = 38
    col_tc = 12
    col_mode = 11
    col_re = 9
    col_status = 8
    col_dur = 8

    header = (
        f"{'Test Name':<{col_name}} "
        f"{'Tool Choice':<{col_tc}} "
        f"{'Mode':<{col_mode}} "
        f"{'Reason':<{col_re}} "
        f"{'Status':<{col_status}} "
        f"{'Time':<{col_dur}}"
    )
    print(bold(header))
    print("-" * 96)

    for r in results:
        tc_str = (
            r.tool_choice
            if isinstance(r.tool_choice, str)
            else r.tool_choice["function"]["name"]
        )
        mode = "stream" if r.stream else "non-stream"
        re_str = str(r.reasoning_effort) if r.reasoning_effort is not None else "-"
        status = green("PASS") if r.passed else red("FAIL")
        dur = f"{r.duration_s:.2f}s"

        # Truncate name if needed
        name = r.name
        if len(name) > col_name:
            name = name[: col_name - 3] + "..."

        print(
            f"{name:<{col_name}} "
            f"{tc_str:<{col_tc}} "
            f"{mode:<{col_mode}} "
            f"{re_str:<{col_re}} "
            f"{status:<{col_status + 9}} "  # +9 for ANSI escape codes
            f"{dur:<{col_dur}}"
        )

    print("-" * 96)

    passed = sum(1 for r in results if r.passed)
    failed = sum(1 for r in results if not r.passed)
    total = len(results)
    total_time = sum(r.duration_s for r in results)

    summary_color = green if failed == 0 else red
    print(
        summary_color(
            f"\n  {passed}/{total} passed, {failed} failed  "
            f"(total time: {total_time:.2f}s)"
        )
    )

    if failed > 0:
        print(f"\n  {red('Failed tests:')}")
        for r in results:
            if not r.passed:
                failed_checks = [k for k, v in r.checks.items() if not v["passed"]]
                print(f"    - {r.name}: {', '.join(failed_checks)}")
                if r.error:
                    print(f"      error: {r.error[:150]}")

    print()


# ---------------------------------------------------------------------------
# JSON export
# ---------------------------------------------------------------------------
def export_results(
    results: list[TestResult], path: str, model: str, base_url: str
) -> None:
    """Write detailed results to a JSON file."""
    data = {
        "metadata": {
            "timestamp": datetime.now(timezone.utc).isoformat(),
            "model": model,
            "base_url": base_url,
            "total_tests": len(results),
            "passed": sum(1 for r in results if r.passed),
            "failed": sum(1 for r in results if not r.passed),
        },
        "results": [],
    }

    for r in results:
        entry = {
            "name": r.name,
            "description": r.description,
            "tool_choice": r.tool_choice,
            "stream": r.stream,
            "reasoning_effort": r.reasoning_effort,
            "passed": r.passed,
            "duration_s": r.duration_s,
            "finish_reason": r.finish_reason,
            "checks": r.checks,
            "content": r.content,
            "reasoning_content": r.reasoning_content,
            "tool_calls": r.tool_calls,
            "error": r.error,
        }
        data["results"].append(entry)

    with open(path, "w") as f:
        json.dump(data, f, indent=2, default=str)

    print(f"\nDetailed results written to {bold(path)}")


# ---------------------------------------------------------------------------
# Main
# ---------------------------------------------------------------------------
async def main() -> int:
    parser = argparse.ArgumentParser(
        description=(
            "Test vLLM tool calling (auto / required / named / none, "
            "streaming & non-streaming, reasoning_effort: None / none / high)"
        ),
    )
    parser.add_argument(
        "--base-url",
        required=True,
        help="Base URL of the vLLM-compatible server (e.g. http://localhost:8000/v1)",
    )
    parser.add_argument(
        "--model",
        default=None,
        help="Model name to use. If omitted, the first model from /v1/models is used.",
    )
    parser.add_argument(
        "-o",
        "--output",
        default="vllm_tool_test_results.json",
        help="Path to the output JSON file (default: vllm_tool_test_results.json)",
    )
    parser.add_argument(
        "--api-key",
        default="EMPTY",
        help="API key for the server (default: EMPTY)",
    )
    parser.add_argument(
        "--filter",
        default=None,
        help="Only run tests whose name contains this substring",
    )
    parser.add_argument(
        "--no-reasoning-effort",
        action="store_true",
        default=False,
        help=(
            "Disable the reasoning_effort test dimension. Use this for "
            "models that do not support reasoning_effort. The parameter "
            "will be omitted from all requests and the model is assumed "
            "to always reason."
        ),
    )
    args = parser.parse_args()

    client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)

    # Resolve model name
    model = args.model
    if model is None:
        print("Fetching model list from server...")
        models = await client.models.list()
        if not models.data:
            print(red("ERROR: No models available on the server."))
            return 1
        model = models.data[0].id
    print(f"Using model: {bold(model)}")
    print(f"Server:      {args.base_url}")
    print()

    # Build test cases
    if args.no_reasoning_effort:
        # Model does not support reasoning_effort; skip the dimension.
        # Pass [None] so reasoning_effort is never sent in the request
        # and the model is assumed to always reason (expect_reasoning=None).
        reasoning_efforts: list[str | None] = [None]
        print(
            dim(
                "reasoning_effort dimension disabled "
                "(--no-reasoning-effort); model always reasons"
            )
        )
    else:
        reasoning_efforts = [None, "none", "high"]
        print(
            f"reasoning_effort dimension: "
            f"{', '.join(str(v) for v in reasoning_efforts)}"
        )

    test_cases = build_test_cases(reasoning_efforts=reasoning_efforts)
    if args.filter:
        test_cases = [tc for tc in test_cases if args.filter in tc.name]
        print(f"Filter '{args.filter}' matched {len(test_cases)} test(s)")

    if not test_cases:
        print(yellow("No test cases to run."))
        return 0

    print(f"Running {bold(str(len(test_cases)))} test cases...\n")

    # Run tests sequentially (to avoid overloading the server and to get
    # clean deterministic output)
    results: list[TestResult] = []
    for i, tc in enumerate(test_cases, 1):
        result = await run_single_test(client, model, tc)
        results.append(result)
        print_result(result, i, len(test_cases))

    # Summary
    print_summary_table(results)

    # Export
    export_results(results, args.output, model, args.base_url)

    # Exit code
    failed = sum(1 for r in results if not r.passed)
    return 1 if failed > 0 else 0


if __name__ == "__main__":
    exit_code = asyncio.run(main())
    sys.exit(exit_code)
```
</details>
