### PR TITLE
[BugFix] Fix "DP Coordinator receives unexpected..." messages

### DIFF
--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -248,9 +248,9 @@ class DPCoordinatorProc:
                         # Subscription message, on the other hand, is sent
                         # by each engine during initialization
                         publish_back.send(b"READY")
-                    else:
+                    elif buffer != b"\x00":
                         logger.error(
-                            "DP Coordinator receives unexpected message from engines"
+                            "DP Coordinator received unexpected message from engines"
                         )
 
                 if publish_front in events:


### PR DESCRIPTION
This error is sometimes logged during shutdown, it is because of pub/sub socket unsubscribe messages, which are expected:

<img width="914" height="47" alt="image" src="https://github.com/user-attachments/assets/9efbf70a-360b-4f4d-983e-c36c5eb80b18" />


Introduced by https://github.com/vllm-project/vllm/pull/34861
