### PR TITLE
[Bugfix] Fix FusedMoE weight loading with padded hidden dimensions

### DIFF
--- a/tests/kernels/moe/test_moe_weight_loading_padded.py
+++ b/tests/kernels/moe/test_moe_weight_loading_padded.py
@@ -266,13 +266,11 @@ class TestWeightLoadingWithPaddedHiddenSize:
         original_packed = 2688  # original packed size
 
         # Build a param that looks like a BnB 4-bit MoE weight.
-        param_data = torch.zeros(num_experts, padded_packed, 1,
-                                 dtype=torch.uint8)
+        param_data = torch.zeros(num_experts, padded_packed, 1, dtype=torch.uint8)
         param = torch.nn.Parameter(param_data, requires_grad=False)
         param.use_bitsandbytes_4bit = True
 
-        loaded_weight = torch.randint(
-            0, 255, (original_packed, 1), dtype=torch.uint8)
+        loaded_weight = torch.randint(0, 255, (original_packed, 1), dtype=torch.uint8)
 
         # Minimal FusedMoE mock so weight_loader reaches the BnB path.
         moe = MagicMock(spec=FusedMoE)
@@ -285,7 +283,10 @@ class TestWeightLoadingWithPaddedHiddenSize:
         # Call the real weight_loader (unbound) with our mock as self.
         with pytest.raises(ValueError, match="BitsAndBytes"):
             FusedMoE.weight_loader(
-                moe, param, loaded_weight,
-                weight_name="w2", shard_id="w2",
+                moe,
+                param,
+                loaded_weight,
+                weight_name="w2",
+                shard_id="w2",
                 expert_id=0,
             )

--- a/tests/kernels/moe/test_moe_weight_loading_padded.py
+++ b/tests/kernels/moe/test_moe_weight_loading_padded.py
@@ -9,9 +9,56 @@ have the original unpadded size. These tests verify that weight loading
 correctly handles this mismatch.
 """
 
+import pytest
 import torch
 
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+
+class TestGetHiddenDim:
+    """Unit tests for _get_hidden_dim."""
+
+    def test_2d_non_transposed_w2(self):
+        # w2: shard_dim=1 (intermediate), hidden=0
+        assert FusedMoE._get_hidden_dim(shard_dim=1, ndim=2) == 0
+
+    def test_2d_non_transposed_w13(self):
+        # w1/w3: shard_dim=0 (intermediate), hidden=1
+        assert FusedMoE._get_hidden_dim(shard_dim=0, ndim=2) == 1
+
+    def test_2d_transposed_w2(self):
+        # transposed w2: shard_dim=0, hidden=1
+        assert FusedMoE._get_hidden_dim(shard_dim=0, ndim=2) == 1
+
+    def test_2d_transposed_w13(self):
+        # transposed w1/w3: shard_dim=1, hidden=0
+        assert FusedMoE._get_hidden_dim(shard_dim=1, ndim=2) == 0
+
+    def test_3d_non_transposed_w2(self):
+        # 3D w2: shard_dim=2, hidden=1
+        assert FusedMoE._get_hidden_dim(shard_dim=2, ndim=3) == 1
+
+    def test_3d_non_transposed_w13(self):
+        # 3D w1/w3: shard_dim=1, hidden=2
+        assert FusedMoE._get_hidden_dim(shard_dim=1, ndim=3) == 2
+
+    def test_3d_transposed_w2(self):
+        # transposed 3D w2: shard_dim=1, hidden=2
+        assert FusedMoE._get_hidden_dim(shard_dim=1, ndim=3) == 2
+
+    def test_3d_transposed_w13(self):
+        # transposed 3D w1/w3: shard_dim=2, hidden=1
+        assert FusedMoE._get_hidden_dim(shard_dim=2, ndim=3) == 1
+
+    def test_1d_returns_zero(self):
+        # 1D per-channel scales: always returns 0
+        assert FusedMoE._get_hidden_dim(shard_dim=0, ndim=1) == 0
+        assert FusedMoE._get_hidden_dim(shard_dim=1, ndim=1) == 0
+
+    def test_invalid_shard_dim_raises(self):
+        # shard_dim outside the data dimensions should raise
+        with pytest.raises(ValueError, match="not a valid data dimension"):
+            FusedMoE._get_hidden_dim(shard_dim=0, ndim=3)
 
 
 class TestNarrowExpertDataForPadding:
@@ -20,51 +67,107 @@ class TestNarrowExpertDataForPadding:
     def test_no_narrowing_when_shapes_match(self):
         expert_data = torch.zeros(1024, 1024)
         loaded_weight = torch.randn(1024, 1024)
-        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=0
+        )
         assert result.shape == loaded_weight.shape
         assert result.data_ptr() == expert_data.data_ptr()
 
     def test_narrow_w2_hidden_dim(self):
-        # w2: (hidden_size, intermediate_size) - hidden_size padded
+        # w2: (hidden_size, intermediate_size) - hidden_size padded at dim 0
         expert_data = torch.zeros(3072, 1024)
         loaded_weight = torch.randn(2688, 1024)
-        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=0
+        )
         assert result.shape == (2688, 1024)
 
     def test_narrow_w13_hidden_dim(self):
-        # w1/w3: (intermediate_size, hidden_size) - hidden_size padded
+        # w1/w3: (intermediate_size, hidden_size) - hidden_size padded at dim 1
         expert_data = torch.zeros(2048, 3072)
         loaded_weight = torch.randn(2048, 2688)
-        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=1
+        )
         assert result.shape == (2048, 2688)
 
+    def test_narrow_transposed_w2(self):
+        # transposed w2: (intermediate_size, hidden_size) - hidden at dim 1
+        expert_data = torch.zeros(1024, 3072)
+        loaded_weight = torch.randn(1024, 2688)
+        hidden_dim = FusedMoE._get_hidden_dim(shard_dim=0, ndim=2)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=hidden_dim
+        )
+        assert result.shape == (1024, 2688)
+
     def test_narrow_3d_full_load(self):
-        # 3D tensor for full_load path
+        # 3D tensor for full_load path: w2 (num_experts, hidden_size, intermediate)
         expert_data = torch.zeros(8, 3072, 1024)
         loaded_weight = torch.randn(8, 2688, 1024)
-        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=1
+        )
         assert result.shape == (8, 2688, 1024)
 
     def test_narrow_1d_scale(self):
-        # 1D scale tensor
+        # 1D scale tensor: per-channel w2 scale (hidden_size,)
         expert_data = torch.zeros(3072)
         loaded_weight = torch.randn(2688)
-        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=0
+        )
         assert result.shape == (2688,)
 
     def test_scalar_weight_no_op(self):
         # 0-dim tensor should be a no-op
         expert_data = torch.zeros(3072)
         loaded_weight = torch.tensor(1.0)
-        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
-        # ndim == 0, so loop doesn't execute
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=0
+        )
+        # ndim == 0, so no narrowing
         assert result.shape == (3072,)
+
+    def test_no_narrowing_when_loaded_weight_larger(self):
+        # Guard: don't narrow if loaded_weight is larger than expert_data
+        expert_data = torch.zeros(2688, 1024)
+        loaded_weight = torch.randn(3072, 1024)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=0
+        )
+        assert result.shape == (2688, 1024)
+        assert result.data_ptr() == expert_data.data_ptr()
+
+    def test_negative_hidden_dim_is_noop(self):
+        # Negative hidden_dim should be a safe no-op (0 <= check)
+        expert_data = torch.zeros(3072, 1024)
+        loaded_weight = torch.randn(2688, 1024)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=-1
+        )
+        # -1 fails the 0 <= check, so no narrowing
+        assert result.shape == (3072, 1024)
+        assert result.data_ptr() == expert_data.data_ptr()
+
+    def test_only_narrows_hidden_dim(self):
+        # Verify that only the specified hidden_dim is narrowed,
+        # even when other dimensions also differ
+        expert_data = torch.zeros(3072, 2048)
+        loaded_weight = torch.randn(2688, 1024)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=0
+        )
+        # Only dim 0 (hidden) should be narrowed; dim 1 stays at 2048
+        assert result.shape == (2688, 2048)
 
     def test_narrowed_data_shares_storage(self):
         # Verify narrowing returns a view (writes go to original tensor)
         expert_data = torch.zeros(3072, 1024)
         loaded_weight = torch.randn(2688, 1024)
-        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        result = FusedMoE._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=0
+        )
         result.copy_(loaded_weight)
         # The first 2688 rows of expert_data should now have loaded_weight
         assert torch.equal(expert_data[:2688, :], loaded_weight)
@@ -81,20 +184,17 @@ class TestWeightLoadingWithPaddedHiddenSize:
         original_hidden = 2688
         intermediate = 1024
 
-        # Simulate padded expert_data (as would be allocated by the layer)
         expert_data_full = torch.zeros(padded_hidden, intermediate)
-        # Simulate checkpoint weight with original size
         loaded_weight = torch.randn(original_hidden, intermediate)
 
-        # This is what _load_w2 does (without tp sharding for simplicity)
+        # w2 non-transposed: shard_dim=1, hidden_dim=0
+        hidden_dim = FusedMoE._get_hidden_dim(shard_dim=1, ndim=2)
         expert_data = FusedMoE._narrow_expert_data_for_padding(
-            expert_data_full, loaded_weight
+            expert_data_full, loaded_weight, hidden_dim=hidden_dim
         )
         expert_data.copy_(loaded_weight)
 
-        # Verify: loaded region has correct values
         assert torch.equal(expert_data_full[:original_hidden, :], loaded_weight)
-        # Verify: padded region remains zero
         assert torch.equal(
             expert_data_full[original_hidden:, :],
             torch.zeros(padded_hidden - original_hidden, intermediate),
@@ -110,8 +210,10 @@ class TestWeightLoadingWithPaddedHiddenSize:
         expert_data_full = torch.zeros(intermediate, padded_hidden)
         loaded_weight = torch.randn(intermediate, original_hidden)
 
+        # w1 non-transposed: shard_dim=0, hidden_dim=1
+        hidden_dim = FusedMoE._get_hidden_dim(shard_dim=0, ndim=2)
         expert_data = FusedMoE._narrow_expert_data_for_padding(
-            expert_data_full, loaded_weight
+            expert_data_full, loaded_weight, hidden_dim=hidden_dim
         )
         expert_data.copy_(loaded_weight)
 
@@ -121,6 +223,24 @@ class TestWeightLoadingWithPaddedHiddenSize:
             torch.zeros(intermediate, padded_hidden - original_hidden),
         )
 
+    def test_load_transposed_w2_with_padding(self):
+        """Simulate loading transposed w2 (GPTQ) with padded hidden_size."""
+        padded_hidden = 3072
+        original_hidden = 2688
+        intermediate = 1024
+
+        # transposed w2: (intermediate_size, hidden_size), shard_dim=0
+        expert_data_full = torch.zeros(intermediate, padded_hidden)
+        loaded_weight = torch.randn(intermediate, original_hidden)
+
+        hidden_dim = FusedMoE._get_hidden_dim(shard_dim=0, ndim=2)
+        expert_data = FusedMoE._narrow_expert_data_for_padding(
+            expert_data_full, loaded_weight, hidden_dim=hidden_dim
+        )
+        expert_data.copy_(loaded_weight)
+
+        assert torch.equal(expert_data_full[:, :original_hidden], loaded_weight)
+
     def test_no_padding_is_noop(self):
         """Verify that when sizes match, behavior is unchanged."""
         hidden = 2048
@@ -129,9 +249,43 @@ class TestWeightLoadingWithPaddedHiddenSize:
         expert_data_full = torch.zeros(hidden, intermediate)
         loaded_weight = torch.randn(hidden, intermediate)
 
+        hidden_dim = FusedMoE._get_hidden_dim(shard_dim=1, ndim=2)
         expert_data = FusedMoE._narrow_expert_data_for_padding(
-            expert_data_full, loaded_weight
+            expert_data_full, loaded_weight, hidden_dim=hidden_dim
         )
         expert_data.copy_(loaded_weight)
 
         assert torch.equal(expert_data_full, loaded_weight)
+
+    def test_bnb_shape_mismatch_raises(self):
+        """BnB + padded hidden_size should raise via weight_loader."""
+        from unittest.mock import MagicMock
+
+        num_experts = 1
+        padded_packed = 3072  # padded packed size
+        original_packed = 2688  # original packed size
+
+        # Build a param that looks like a BnB 4-bit MoE weight.
+        param_data = torch.zeros(num_experts, padded_packed, 1,
+                                 dtype=torch.uint8)
+        param = torch.nn.Parameter(param_data, requires_grad=False)
+        param.use_bitsandbytes_4bit = True
+
+        loaded_weight = torch.randint(
+            0, 255, (original_packed, 1), dtype=torch.uint8)
+
+        # Minimal FusedMoE mock so weight_loader reaches the BnB path.
+        moe = MagicMock(spec=FusedMoE)
+        moe.quant_config = None
+        moe.quant_method = MagicMock()
+        moe.quant_method.__class__.__name__ = "BitsAndBytesMethod"
+        moe._expert_map = None
+        moe.tp_rank = 0
+
+        # Call the real weight_loader (unbound) with our mock as self.
+        with pytest.raises(ValueError, match="BitsAndBytes"):
+            FusedMoE.weight_loader(
+                moe, param, loaded_weight,
+                weight_name="w2", shard_id="w2",
+                expert_id=0,
+            )

--- a/tests/kernels/moe/test_moe_weight_loading_padded.py
+++ b/tests/kernels/moe/test_moe_weight_loading_padded.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for FusedMoE weight loading with padded hidden dimensions.
+
+When using DeepEP backends or NIXL EP with models like nemotron_h,
+hidden_size may be rounded up (e.g., 2688 -> 3072) for backend requirements.
+Weight parameters are created with the padded size, but checkpoint weights
+have the original unpadded size. These tests verify that weight loading
+correctly handles this mismatch.
+"""
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+
+class TestNarrowExpertDataForPadding:
+    """Unit tests for _narrow_expert_data_for_padding."""
+
+    def test_no_narrowing_when_shapes_match(self):
+        expert_data = torch.zeros(1024, 1024)
+        loaded_weight = torch.randn(1024, 1024)
+        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        assert result.shape == loaded_weight.shape
+        assert result.data_ptr() == expert_data.data_ptr()
+
+    def test_narrow_w2_hidden_dim(self):
+        # w2: (hidden_size, intermediate_size) - hidden_size padded
+        expert_data = torch.zeros(3072, 1024)
+        loaded_weight = torch.randn(2688, 1024)
+        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        assert result.shape == (2688, 1024)
+
+    def test_narrow_w13_hidden_dim(self):
+        # w1/w3: (intermediate_size, hidden_size) - hidden_size padded
+        expert_data = torch.zeros(2048, 3072)
+        loaded_weight = torch.randn(2048, 2688)
+        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        assert result.shape == (2048, 2688)
+
+    def test_narrow_3d_full_load(self):
+        # 3D tensor for full_load path
+        expert_data = torch.zeros(8, 3072, 1024)
+        loaded_weight = torch.randn(8, 2688, 1024)
+        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        assert result.shape == (8, 2688, 1024)
+
+    def test_narrow_1d_scale(self):
+        # 1D scale tensor
+        expert_data = torch.zeros(3072)
+        loaded_weight = torch.randn(2688)
+        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        assert result.shape == (2688,)
+
+    def test_scalar_weight_no_op(self):
+        # 0-dim tensor should be a no-op
+        expert_data = torch.zeros(3072)
+        loaded_weight = torch.tensor(1.0)
+        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        # ndim == 0, so loop doesn't execute
+        assert result.shape == (3072,)
+
+    def test_narrowed_data_shares_storage(self):
+        # Verify narrowing returns a view (writes go to original tensor)
+        expert_data = torch.zeros(3072, 1024)
+        loaded_weight = torch.randn(2688, 1024)
+        result = FusedMoE._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        result.copy_(loaded_weight)
+        # The first 2688 rows of expert_data should now have loaded_weight
+        assert torch.equal(expert_data[:2688, :], loaded_weight)
+        # Padded region should remain zero
+        assert torch.equal(expert_data[2688:, :], torch.zeros(3072 - 2688, 1024))
+
+
+class TestWeightLoadingWithPaddedHiddenSize:
+    """Integration-style tests that simulate padded weight loading."""
+
+    def test_load_w2_with_padding(self):
+        """Simulate loading w2 weights when hidden_size is padded."""
+        padded_hidden = 3072
+        original_hidden = 2688
+        intermediate = 1024
+
+        # Simulate padded expert_data (as would be allocated by the layer)
+        expert_data_full = torch.zeros(padded_hidden, intermediate)
+        # Simulate checkpoint weight with original size
+        loaded_weight = torch.randn(original_hidden, intermediate)
+
+        # This is what _load_w2 does (without tp sharding for simplicity)
+        expert_data = FusedMoE._narrow_expert_data_for_padding(
+            expert_data_full, loaded_weight
+        )
+        expert_data.copy_(loaded_weight)
+
+        # Verify: loaded region has correct values
+        assert torch.equal(expert_data_full[:original_hidden, :], loaded_weight)
+        # Verify: padded region remains zero
+        assert torch.equal(
+            expert_data_full[original_hidden:, :],
+            torch.zeros(padded_hidden - original_hidden, intermediate),
+        )
+
+    def test_load_w13_with_padding(self):
+        """Simulate loading w1/w3 weights when hidden_size is padded."""
+        padded_hidden = 3072
+        original_hidden = 2688
+        intermediate = 1024
+
+        # w1/w3: (intermediate_size, hidden_size)
+        expert_data_full = torch.zeros(intermediate, padded_hidden)
+        loaded_weight = torch.randn(intermediate, original_hidden)
+
+        expert_data = FusedMoE._narrow_expert_data_for_padding(
+            expert_data_full, loaded_weight
+        )
+        expert_data.copy_(loaded_weight)
+
+        assert torch.equal(expert_data_full[:, :original_hidden], loaded_weight)
+        assert torch.equal(
+            expert_data_full[:, original_hidden:],
+            torch.zeros(intermediate, padded_hidden - original_hidden),
+        )
+
+    def test_no_padding_is_noop(self):
+        """Verify that when sizes match, behavior is unchanged."""
+        hidden = 2048
+        intermediate = 1024
+
+        expert_data_full = torch.zeros(hidden, intermediate)
+        loaded_weight = torch.randn(hidden, intermediate)
+
+        expert_data = FusedMoE._narrow_expert_data_for_padding(
+            expert_data_full, loaded_weight
+        )
+        expert_data.copy_(loaded_weight)
+
+        assert torch.equal(expert_data_full, loaded_weight)

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -860,8 +860,9 @@ class FusedMoE(CustomOp):
     ):
         # for per channel weight quantization
         if shard_id == "w2":
+            hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
             expert_data = self._narrow_expert_data_for_padding(
-                expert_data, loaded_weight
+                expert_data, loaded_weight, hidden_dim=hidden_dim
             )
             expert_data.copy_(loaded_weight)
         elif shard_id in ("w1", "w3"):
@@ -874,19 +875,56 @@ class FusedMoE(CustomOp):
             )
 
     @staticmethod
+    def _get_hidden_dim(shard_dim: int, ndim: int) -> int:
+        """Compute the hidden dimension index from the shard (intermediate)
+        dimension and tensor rank.
+
+        For 2D weight tensors the two data dims are (0, 1). For 3D tensors
+        with an expert dimension at dim 0, they are (1, 2). ``shard_dim``
+        occupies one of these; the hidden dimension is the other.
+        For 1D tensors (e.g. per-channel scales) returns 0.
+        """
+        if ndim < 2:
+            return 0
+        dim_a = ndim - 2
+        dim_b = ndim - 1
+        if shard_dim == dim_a:
+            return dim_b
+        if shard_dim == dim_b:
+            return dim_a
+        raise ValueError(
+            f"shard_dim={shard_dim} is not a valid data dimension "
+            f"for a {ndim}D tensor (expected {dim_a} or {dim_b})"
+        )
+
+    @staticmethod
     def _narrow_expert_data_for_padding(
-        expert_data: torch.Tensor, loaded_weight: torch.Tensor
+        expert_data: torch.Tensor,
+        loaded_weight: torch.Tensor,
+        hidden_dim: int,
     ) -> torch.Tensor:
-        """Narrow expert_data dims to match loaded_weight for padded hidden_size.
+        """Narrow expert_data hidden dim to match loaded_weight for padded
+        hidden_size.
 
         When backends (e.g., DeepEP) round up hidden_size, weight parameters
-        are larger than checkpoint weights. Narrow the padded dimensions
+        are larger than checkpoint weights. Narrow the padded hidden dimension
         before copying.
+
+        Args:
+            expert_data: The (possibly padded) parameter tensor to narrow.
+            loaded_weight: The checkpoint weight tensor with original size.
+            hidden_dim: The dimension index corresponding to hidden_size.
+                Must be non-negative.
         """
-        if loaded_weight.ndim > 0:
-            for d in range(min(expert_data.ndim, loaded_weight.ndim)):
-                if expert_data.shape[d] != loaded_weight.shape[d]:
-                    expert_data = expert_data.narrow(d, 0, loaded_weight.shape[d])
+        if (
+            loaded_weight.ndim > 0
+            and 0 <= hidden_dim < expert_data.ndim
+            and hidden_dim < loaded_weight.ndim
+            and expert_data.shape[hidden_dim] > loaded_weight.shape[hidden_dim]
+        ):
+            expert_data = expert_data.narrow(
+                hidden_dim, 0, loaded_weight.shape[hidden_dim]
+            )
         return expert_data
 
     def _load_w13(
@@ -926,7 +964,10 @@ class FusedMoE(CustomOp):
         else:
             assert shard_id == "w3"
             expert_data = expert_data.narrow(shard_dim, shard_size, shard_size)
-        expert_data = self._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
+        expert_data = self._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=hidden_dim
+        )
         expert_data.copy_(loaded_weight)
 
     def _load_w2(
@@ -956,7 +997,10 @@ class FusedMoE(CustomOp):
             narrow_size = min(shard_size, available)
             loaded_weight = loaded_weight.narrow(shard_dim, start_offset, narrow_size)
         # w2, down_proj: Load into only logical weight of w2.
-        expert_data = self._narrow_expert_data_for_padding(expert_data, loaded_weight)
+        hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
+        expert_data = self._narrow_expert_data_for_padding(
+            expert_data, loaded_weight, hidden_dim=hidden_dim
+        )
         expert_data.copy_(loaded_weight)
 
     def _load_single_value(
@@ -1103,12 +1147,25 @@ class FusedMoE(CustomOp):
 
             expert_data = param.data[expert_id]
             if shard_id == "w2":
-                # BnB params are flat packed-integer tensors; copy_() is
-                # intercepted by __torch_function__ for in-flight quantization.
-                # Do NOT narrow — shapes are intentionally different.
+                # BnB params are stored as flat packed tensors (e.g.
+                # (packed_size, 1)), not in the logical weight layout.
+                # Narrowing packed data for hidden-dim padding is not
+                # meaningful, so require an exact shape match.
+                if expert_data.shape != loaded_weight.shape:
+                    raise ValueError(
+                        "BitsAndBytes quantization with padded hidden_size "
+                        "(e.g., from DeepEP) is not supported. "
+                        f"Parameter shape {tuple(expert_data.shape)} != "
+                        f"checkpoint shape {tuple(loaded_weight.shape)}"
+                    )
                 expert_data.copy_(loaded_weight)
             elif shard_id in ("w1", "w3"):
-                # BNB inflight quantization has already sharded the weights
+                # BnB stores weights as flat packed tensors.  _load_w13 is
+                # still used to split the w1/w3 portions along shard_dim.
+                # _narrow_expert_data_for_padding will be a no-op since
+                # packed sizes should already match; if DeepEP padding
+                # causes a mismatch the copy_() will fail with a clear
+                # shape error.
                 full_load = True
                 self._load_w13(
                     shard_id=shard_id,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -860,6 +860,9 @@ class FusedMoE(CustomOp):
     ):
         # for per channel weight quantization
         if shard_id == "w2":
+            expert_data = self._narrow_expert_data_for_padding(
+                expert_data, loaded_weight
+            )
             expert_data.copy_(loaded_weight)
         elif shard_id in ("w1", "w3"):
             self._load_w13(
@@ -869,6 +872,22 @@ class FusedMoE(CustomOp):
                 expert_data=expert_data,
                 tp_rank=tp_rank,
             )
+
+    @staticmethod
+    def _narrow_expert_data_for_padding(
+        expert_data: torch.Tensor, loaded_weight: torch.Tensor
+    ) -> torch.Tensor:
+        """Narrow expert_data dims to match loaded_weight for padded hidden_size.
+
+        When backends (e.g., DeepEP) round up hidden_size, weight parameters
+        are larger than checkpoint weights. Narrow the padded dimensions
+        before copying.
+        """
+        if loaded_weight.ndim > 0:
+            for d in range(min(expert_data.ndim, loaded_weight.ndim)):
+                if expert_data.shape[d] != loaded_weight.shape[d]:
+                    expert_data = expert_data.narrow(d, 0, loaded_weight.shape[d])
+        return expert_data
 
     def _load_w13(
         self,
@@ -907,13 +926,7 @@ class FusedMoE(CustomOp):
         else:
             assert shard_id == "w3"
             expert_data = expert_data.narrow(shard_dim, shard_size, shard_size)
-
-        # Handle padding: if loaded_weight is smaller than expert_data (can happen
-        # on last TP shard with padding), copy to top-left corner
-        if expert_data.shape != loaded_weight.shape:
-            expert_data = expert_data[
-                : loaded_weight.shape[0], : loaded_weight.shape[1]
-            ]
+        expert_data = self._narrow_expert_data_for_padding(expert_data, loaded_weight)
         expert_data.copy_(loaded_weight)
 
     def _load_w2(
@@ -943,12 +956,7 @@ class FusedMoE(CustomOp):
             narrow_size = min(shard_size, available)
             loaded_weight = loaded_weight.narrow(shard_dim, start_offset, narrow_size)
         # w2, down_proj: Load into only logical weight of w2.
-        # Handle padding: if loaded_weight is smaller than expert_data (can happen
-        # on last TP shard with padding), copy to top-left corner
-        if expert_data.shape != loaded_weight.shape:
-            expert_data = expert_data[
-                : loaded_weight.shape[0], : loaded_weight.shape[1]
-            ]
+        expert_data = self._narrow_expert_data_for_padding(expert_data, loaded_weight)
         expert_data.copy_(loaded_weight)
 
     def _load_single_value(
@@ -1095,6 +1103,9 @@ class FusedMoE(CustomOp):
 
             expert_data = param.data[expert_id]
             if shard_id == "w2":
+                # BnB params are flat packed-integer tensors; copy_() is
+                # intercepted by __torch_function__ for in-flight quantization.
+                # Do NOT narrow — shapes are intentionally different.
                 expert_data.copy_(loaded_weight)
             elif shard_id in ("w1", "w3"):
                 # BNB inflight quantization has already sharded the weights


### PR DESCRIPTION
 ## Summary

  Fixes #36926

  When DeepEP/NIXL EP backends round up `hidden_size` for alignment (e.g., 2688 → 3072), `FusedMoE` weight parameters are allocated with the **padded** size but
  checkpoint weights have the **original** size. This causes `RuntimeError: The size of tensor a (3072) must match the size of tensor b (2688)` during
  `expert_data.copy_(loaded_weight)` in weight loading.

  - Added `_narrow_expert_data_for_padding()` static method that narrows padded parameter dimensions to match checkpoint weights before copying
  - Applied to `_load_w2`, `_load_w13`, and `_load_per_channel_weight_scale` (3 paths)
  - **Excluded** BitsAndBytes w2 path — BnB params are flat packed-integer tensors where `copy_()` is intercepted by `__torch_function__` for in-flight quantization;
   shapes are intentionally different
  - When hidden_size is not padded (common case), the helper is a no-op since all dimensions already match
  - Follows the existing narrowing pattern used by the mxfp4 quantization path (line 1069-1078)

  **Not a duplicate:** Checked open PRs — #34285 and #30647 address roundup refactoring and forward-pass padding, not weight loading.
  
  ## Test plan

  - [x] New unit tests for `_narrow_expert_data_for_padding` (7 cases: matching shapes, w2/w13 dims, 3D tensors, 1D scales, scalar weights, storage sharing)
  - [x] New integration tests for padded weight loading (w2, w13, no-padding no-op)
  - [x] `python -m pytest tests/kernels/moe/test_moe_weight_loading_padded.py -v` — 10/10 pass
  - [ ] `python -m pytest tests/kernels/moe/ -v -k "not deepep"` — existing MoE tests