### PR TITLE
fix: add "context_length_exceeded" error code to match OpenAI convention

### DIFF
--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -59,7 +59,7 @@ class ErrorInfo(OpenAIBaseModel):
     message: str
     type: str
     param: str | None = None
-    code: int
+    code: int | str
 
 
 class ErrorResponse(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -744,6 +744,7 @@ class OpenAIServing:
                     f"Please reduce the length of the input.",
                     parameter="input_tokens",
                     value=token_num,
+                    error_code="context_length_exceeded",
                 )
             return TokensPrompt(prompt=input_text, prompt_token_ids=input_ids)
 
@@ -772,6 +773,7 @@ class OpenAIServing:
                 "the input messages.",
                 parameter="input_tokens",
                 value=token_num,
+                error_code="context_length_exceeded",
             )
 
         if max_tokens is not None and token_num + max_tokens > max_model_len:
@@ -787,6 +789,7 @@ class OpenAIServing:
                 f"number of requested output tokens.",
                 parameter="max_tokens",
                 value=max_tokens,
+                error_code="context_length_exceeded",
             )
 
         return TokensPrompt(prompt=input_text, prompt_token_ids=input_ids)

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -304,6 +304,7 @@ def create_error_response(
     param: str | None = None,
 ) -> ErrorResponse:
     exc: Exception | None = None
+    error_code: str | None = None
 
     if isinstance(message, Exception):
         exc = message
@@ -314,6 +315,7 @@ def create_error_response(
             err_type = "BadRequestError"
             status_code = HTTPStatus.BAD_REQUEST
             param = exc.parameter
+            error_code = exc.error_code
         elif isinstance(exc, VLLMNotFoundError):
             err_type = "NotFoundError"
             status_code = HTTPStatus.NOT_FOUND
@@ -347,7 +349,7 @@ def create_error_response(
         error=ErrorInfo(
             message=sanitize_message(message),
             type=err_type,
-            code=status_code.value,
+            code=error_code if error_code is not None else status_code.value,
             param=param,
         )
     )

--- a/vllm/exceptions.py
+++ b/vllm/exceptions.py
@@ -13,6 +13,11 @@ class VLLMValidationError(ValueError):
         message: The error message describing the validation failure.
         parameter: Optional parameter name that failed validation.
         value: Optional value that was rejected during validation.
+        error_code: Optional string error code for the response body
+            (e.g. ``"context_length_exceeded"``).  When set, the code
+            field in the JSON error response will use this string
+            instead of the numeric HTTP status code, matching the
+            OpenAI API convention.
     """
 
     def __init__(
@@ -21,10 +26,12 @@ class VLLMValidationError(ValueError):
         *,
         parameter: str | None = None,
         value: Any = None,
+        error_code: str | None = None,
     ) -> None:
         super().__init__(message)
         self.parameter = parameter
         self.value = value
+        self.error_code = error_code
 
     def __str__(self):
         base = super().__str__()

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -315,6 +315,7 @@ class TokenizeParams:
                     f"number of requested output tokens.",
                     parameter="input_text",
                     value=len(text),
+                    error_code="context_length_exceeded",
                 )
 
         return text
@@ -403,6 +404,7 @@ class TokenizeParams:
                 f"number of requested output tokens.",
                 parameter="input_tokens",
                 value=token_count,
+                error_code="context_length_exceeded",
             )
 
         return tokens


### PR DESCRIPTION
## Summary

When a request exceeds the model's maximum context length, vLLM previously returned a generic HTTP 400 error with no way to programmatically distinguish it from other bad request errors.

This PR adds a string `error_code` field to `VLLMValidationError` and surfaces it in the JSON error response as `code: "context_length_exceeded"`, matching the [OpenAI API convention](https://platform.openai.com/docs/guides/error-codes).

### Before
```json
{"error": {"message": "...", "type": "BadRequestError", "code": 400}}
```

### After
```json
{"error": {"message": "...", "type": "BadRequestError", "code": "context_length_exceeded"}}
```

## Changes

- **`vllm/exceptions.py`**: Add optional `error_code: str` to `VLLMValidationError`
- **`vllm/entrypoints/openai/engine/protocol.py`**: Widen `ErrorInfo.code` type from `int` to `int | str`
- **`vllm/entrypoints/utils.py`**: Pass `error_code` through to `ErrorInfo.code` when set
- **`vllm/entrypoints/openai/engine/serving.py`**: Set `error_code="context_length_exceeded"` at all 3 context-length validation points
- **`vllm/renderers/params.py`**: Set `error_code="context_length_exceeded"` at both text/token length checks

## Notes

- HTTP status remains 400 (matching OpenAI behavior)
- The `error_code` mechanism is extensible for other validation errors in the future
- Non-context-length errors continue to use the numeric HTTP status code as before