### PR TITLE
[CI] Pin helion version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -981,7 +981,7 @@ setup(
         # Optional deps for AMD FP4 quantization support
         "petit-kernel": ["petit-kernel"],
         # Optional deps for Helion kernel development
-        "helion": ["helion==0.3.1"],
+        "helion": ["helion==0.3.2"],
         # Optional deps for gRPC server (vllm serve --grpc)
         "grpc": ["smg-grpc-servicer[vllm] >= 0.5.0"],
         # Optional deps for OpenTelemetry tracing

--- a/setup.py
+++ b/setup.py
@@ -981,7 +981,7 @@ setup(
         # Optional deps for AMD FP4 quantization support
         "petit-kernel": ["petit-kernel"],
         # Optional deps for Helion kernel development
-        "helion": ["helion"],
+        "helion": ["helion==0.3.1"],
         # Optional deps for gRPC server (vllm serve --grpc)
         "grpc": ["smg-grpc-servicer[vllm] >= 0.5.0"],
         # Optional deps for OpenTelemetry tracing


### PR DESCRIPTION
Pin Helion version to avoid automatically adopting latest Helion releases before it is fully vetted against vLLM.
