### PR TITLE
[CI] Split V1 Others into 3 separate jobs

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -2,11 +2,54 @@ group: Miscellaneous
 depends_on: 
   - image-build
 steps:
-- label: V1 Others
-  timeout_in_minutes: 60
+- label: V1 Spec Decode
+  timeout_in_minutes: 30
   source_file_dependencies:
     - vllm/
-    - tests/v1
+    - tests/v1/spec_decode
+  commands:
+    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    # TODO: create another `optional` test group for slow tests
+    - pytest -v -s -m 'not slow_test' v1/spec_decode
+  mirror:
+    amd:
+      device: mi325_1
+      depends_on:
+      - image-build-amd
+
+- label: V1 Sample + Logits
+  timeout_in_minutes: 30
+  source_file_dependencies:
+    - vllm/
+    - tests/v1/sample
+    - tests/v1/logits_processors
+    - tests/v1/test_oracle.py
+    - tests/v1/test_request.py
+    - tests/v1/test_outputs.py
+  commands:
+    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    - pytest -v -s v1/sample
+    - pytest -v -s v1/logits_processors
+    - pytest -v -s v1/test_oracle.py
+    - pytest -v -s v1/test_request.py
+    - pytest -v -s v1/test_outputs.py
+  mirror:
+    amd:
+      device: mi325_1
+      depends_on:
+      - image-build-amd
+
+- label: V1 Core + KV + Metrics
+  timeout_in_minutes: 30
+  source_file_dependencies:
+    - vllm/
+    - tests/v1/core
+    - tests/v1/executor
+    - tests/v1/kv_offload
+    - tests/v1/worker
+    - tests/v1/kv_connector/unit
+    - tests/v1/metrics
+    - tests/entrypoints/openai/correctness/test_lmeval.py
   commands:
     - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -14,16 +57,9 @@ steps:
     - pytest -v -s -m 'not cpu_test' v1/core
     - pytest -v -s v1/executor
     - pytest -v -s v1/kv_offload
-    - pytest -v -s v1/sample
-    - pytest -v -s v1/logits_processors
     - pytest -v -s v1/worker
-    # TODO: create another `optional` test group for slow tests
-    - pytest -v -s -m 'not slow_test' v1/spec_decode
     - pytest -v -s -m 'not cpu_test' v1/kv_connector/unit
     - pytest -v -s -m 'not cpu_test' v1/metrics
-    - pytest -v -s v1/test_oracle.py
-    - pytest -v -s v1/test_request.py
-    - pytest -v -s v1/test_outputs.py
     # Integration test for streaming correctness (requires special branch).
     - pip install -U git+https://github.com/robertgshaw2-redhat/lm-evaluation-harness.git@streaming-api
     - pytest -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine


### PR DESCRIPTION
## Summary
- Split the single ~55m "V1 Others" job into three smaller jobs targeting ~20m each
- **V1 Spec Decode** (~19m): spec_decode tests (the heaviest single test suite)
- **V1 Sample + Logits** (~18m): sample (11m), logits_processors (6m), test_oracle, test_request, test_outputs
- **V1 Core + KV + Metrics** (~18m): core (1m), executor (1m), kv_offload (3m), worker (1m), kv_connector/unit (6m), metrics (1m), lm_eval integration (5m)
- Each job has properly scoped `source_file_dependencies` instead of the broad `tests/v1`
- AMD mirrors preserved for all three jobs

## Test plan
- [ ] Verify all three new jobs pass in CI
- [ ] Confirm no tests are missing compared to the original single job
- [ ] Check that source_file_dependencies correctly trigger each job

AI assistance was used (Claude). This is not duplicating any existing PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)