### PR TITLE
fix: generalize LoRA layer handling for N-way fused projections

### DIFF
--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -283,10 +283,9 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         packed_modules_list: list,
         model_config: PretrainedConfig | None = None,
     ) -> bool:
-        return (
-            type(source_layer) is MergedColumnParallelLinear
-            and len(packed_modules_list) == len(source_layer.output_sizes)
-        )
+        return type(source_layer) is MergedColumnParallelLinear and len(
+            packed_modules_list
+        ) == len(source_layer.output_sizes)
 
 
 class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -465,18 +465,14 @@ class MergedColumnParallelLinearWithShardedLoRA(MergedColumnParallelLinearWithLo
     def slice_lora_a(
         self, lora_a: list[torch.Tensor | None]
     ) -> list[torch.Tensor | None]:
-        # NOTE: lora_a contains 2 subloras, and each sublora could be None.
         output_shard_size = self.lora_a_stacked[0].shape[2]
         output_start_idx = self.tp_rank * output_shard_size
-        lora_a = [
-            lora_a[0][output_start_idx : output_start_idx + output_shard_size, :]
-            if lora_a[0] is not None
-            else None,
-            lora_a[1][output_start_idx : output_start_idx + output_shard_size, :]
-            if lora_a[1] is not None
-            else None,
+        return [
+            a[output_start_idx : output_start_idx + output_shard_size, :]
+            if a is not None
+            else None
+            for a in lora_a
         ]
-        return lora_a
 
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
         return _mcp_apply(x, bias, self)
@@ -547,21 +543,12 @@ class MergedQKVParallelLinearWithShardedLoRA(MergedQKVParallelLinearWithLoRA):
     def slice_lora_a(
         self, lora_a: list[torch.Tensor | None]
     ) -> list[torch.Tensor | None]:
-        # NOTE: lora_a contains 3 subloras, and each sublora could be None.
-        shard_size = [self.lora_a_stacked[i].shape[2] for i in range(3)]
-        start_idx = [self.tp_rank * shard_size[i] for i in range(3)]
-        lora_a = [
-            lora_a[0][start_idx[0] : start_idx[0] + shard_size[0], :]
-            if lora_a[0] is not None
-            else None,
-            lora_a[1][start_idx[1] : start_idx[1] + shard_size[1], :]
-            if lora_a[1] is not None
-            else None,
-            lora_a[2][start_idx[2] : start_idx[2] + shard_size[2], :]
-            if lora_a[2] is not None
-            else None,
+        return [
+            a[self.tp_rank * s.shape[2] : (self.tp_rank + 1) * s.shape[2], :]
+            if a is not None
+            else None
+            for a, s in zip(lora_a, self.lora_a_stacked)
         ]
-        return lora_a
 
     def apply(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
         return _mcp_apply(x, bias, self)

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -616,9 +616,8 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         # count. E.g. Qwen3.5 GDN layers have 2 packed modules
         # (in_proj_qkv, in_proj_z) but 4 output_sizes — one HF weight
         # covers multiple output slices.
-        if (
-            hasattr(source_layer, "output_sizes")
-            and len(packed_modules_list) != len(source_layer.output_sizes)
+        if hasattr(source_layer, "output_sizes") and len(packed_modules_list) != len(
+            source_layer.output_sizes
         ):
             return True
 
@@ -705,8 +704,7 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
                         for j in range(start_slice, slice_idx):
                             sz = output_sizes[j]
                             expanded_a.append(a_i)
-                            expanded_b.append(
-                                b_i[split_start:split_start + sz, :])
+                            expanded_b.append(b_i[split_start : split_start + sz, :])
                             split_start += sz
 
             # Pad remaining slices with None (e.g. dummy LoRA warmup

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -285,7 +285,7 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
     ) -> bool:
         return (
             type(source_layer) is MergedColumnParallelLinear
-            and len(packed_modules_list) == 2
+            and len(packed_modules_list) == len(source_layer.output_sizes)
         )
 
 

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -612,8 +612,18 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         if len(packed_modules_list) >= 3:
             return True
 
-        # If packed_modules_list has exactly 2 items, let
-        # MergedColumnParallelLinearWithLoRA handle it
+        # Handle mismatch between packed modules count and output_sizes
+        # count. E.g. Qwen3.5 GDN layers have 2 packed modules
+        # (in_proj_qkv, in_proj_z) but 4 output_sizes — one HF weight
+        # covers multiple output slices.
+        if (
+            hasattr(source_layer, "output_sizes")
+            and len(packed_modules_list) != len(source_layer.output_sizes)
+        ):
+            return True
+
+        # If packed_modules_list has exactly 2 items matching output_sizes,
+        # let MergedColumnParallelLinearWithLoRA handle it
         if len(packed_modules_list) == 2:
             return False
 
@@ -632,9 +642,18 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         lora_a: torch.Tensor | list[torch.Tensor],
         lora_b: torch.Tensor | list[torch.Tensor],
     ):
-        """Override to handle single tensor weights
-        that need to be split into slices."""
+        """Override to handle weights that need to be split into slices.
+
+        Handles three cases:
+        1. Single tensor: split lora_b by output_sizes, duplicate lora_a
+        2. List matching n_slices: pass through directly
+        3. List shorter than n_slices: expand by splitting lora_b entries
+           that cover multiple output slices (e.g., 2 packed modules
+           mapping to 4 output_sizes in Qwen3.5 GDN layers)
+        """
         self.reset_lora(index)
+
+        output_sizes = self.base_layer.output_sizes
 
         # Handle case where checkpoint has single tensor weights
         # lora_a shape: (rank, input_size) - same for all slices, duplicate it
@@ -644,7 +663,6 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
         # lora_b shape: (total_output_size, rank) -
         # split along dim 0 based on output_sizes
         if isinstance(lora_b, torch.Tensor):
-            output_sizes = self.base_layer.output_sizes
             lora_b_list = []
             start_idx = 0
             for output_size in output_sizes:
@@ -652,6 +670,53 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
                 lora_b_list.append(lora_b[start_idx:end_idx, :])
                 start_idx = end_idx
             lora_b = lora_b_list
+
+        # Handle list shorter than n_slices: one packed module may cover
+        # multiple output slices. Greedily match each lora_b entry to
+        # consecutive output_sizes by dimension, then split accordingly.
+        if isinstance(lora_a, list) and len(lora_a) < self.n_slices:
+            expanded_a: list[torch.Tensor | None] = []
+            expanded_b: list[torch.Tensor | None] = []
+            slice_idx = 0
+            for i, (a_i, b_i) in enumerate(zip(lora_a, lora_b)):
+                if b_i is None:
+                    # Figure out how many slices this None covers
+                    remaining = len(lora_a) - i - 1
+                    remaining_slices = self.n_slices - slice_idx
+                    count = remaining_slices - remaining
+                    expanded_a.extend([None] * count)
+                    expanded_b.extend([None] * count)
+                    slice_idx += count
+                else:
+                    b_dim = b_i.shape[0]
+                    # Greedily consume output_sizes until we match b_dim
+                    consumed = 0
+                    start_slice = slice_idx
+                    while slice_idx < self.n_slices and consumed < b_dim:
+                        consumed += output_sizes[slice_idx]
+                        slice_idx += 1
+                    num_covered = slice_idx - start_slice
+                    if num_covered == 1:
+                        expanded_a.append(a_i)
+                        expanded_b.append(b_i)
+                    else:
+                        # Split lora_b and duplicate lora_a
+                        split_start = 0
+                        for j in range(start_slice, slice_idx):
+                            sz = output_sizes[j]
+                            expanded_a.append(a_i)
+                            expanded_b.append(
+                                b_i[split_start:split_start + sz, :])
+                            split_start += sz
+
+            # Pad remaining slices with None (e.g. dummy LoRA warmup
+            # where per-slice dimensions don't span multiple output_sizes)
+            while len(expanded_a) < self.n_slices:
+                expanded_a.append(None)
+                expanded_b.append(None)
+
+            lora_a = expanded_a
+            lora_b = expanded_b
 
         # Now call parent's set_lora which expects lists
         super().set_lora(index, lora_a, lora_b)

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -694,6 +694,11 @@ class MergedColumnParallelLinearVariableSliceWithLoRA(
                     while slice_idx < self.n_slices and consumed < b_dim:
                         consumed += output_sizes[slice_idx]
                         slice_idx += 1
+                    if consumed != b_dim:
+                        raise ValueError(
+                            f"Packed LoRA B dimension {b_dim} does not match "
+                            f"the sum of output sizes {consumed} for LoRA {i}."
+                        )
                     num_covered = slice_idx - start_slice
                     if num_covered == 1:
                         expanded_a.append(a_i)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -528,8 +528,9 @@ class Qwen3_5ForCausalLMBase(
             "v_proj",
         ],
         "gate_up_proj": ["gate_proj", "up_proj"],
-        # GDN fused projections.
-        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        # GDN fused projections — 4 packed modules to match 4 output_sizes
+        # in create_qkvz_proj for correct per-slice TP sharding with LoRA.
+        "in_proj_qkvz": ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 
@@ -632,7 +633,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
     supports_multimodal_pruning = False
 
     packed_modules_mapping = Qwen3VLForConditionalGeneration.packed_modules_mapping | {
-        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_qkvz": ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -528,9 +528,8 @@ class Qwen3_5ForCausalLMBase(
             "v_proj",
         ],
         "gate_up_proj": ["gate_proj", "up_proj"],
-        # GDN fused projections — 4 packed modules to match 4 output_sizes
-        # in create_qkvz_proj for correct per-slice TP sharding with LoRA.
-        "in_proj_qkvz": ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"],
+        # GDN fused projections.
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 
@@ -633,7 +632,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
     supports_multimodal_pruning = False
 
     packed_modules_mapping = Qwen3VLForConditionalGeneration.packed_modules_mapping | {
-        "in_proj_qkvz": ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     }
 


### PR DESCRIPTION
## Summary

Fixes LoRA support for models with non-standard N-way fused projections (e.g., Qwen3.5 GDN layers that fuse 4 projections into a single `MergedColumnParallelLinear`).

Three changes in `column_parallel_linear.py`:

1. **`MergedColumnParallelLinearWithLoRA.can_replace_layer`**: changed from `len(packed_modules_list) == 2` to `len(packed_modules_list) == len(source_layer.output_sizes)` — so it correctly handles any N-way merged column parallel linear, not just 2-way.

2. **`MergedColumnParallelLinearVariableSliceWithLoRA.set_lora`**: added greedy expansion logic for when a LoRA weight list is shorter than `n_slices`. This handles the case where M packed modules map to N output sizes (M < N) — each `lora_b` entry is greedily matched to consecutive `output_sizes` by dimension, then split accordingly.

3. **`slice_lora_a` generalization**: both `MergedColumnParallelLinearWithShardedLoRA` (was hardcoded for 2 subloras) and `MergedQKVParallelLinearWithShardedLoRA` (was hardcoded for 3) now use a list comprehension over the actual `lora_a` inputs, supporting any N. This fixes `fully_sharded_loras=True` for models with >2 or >3 fused projections.

These are LoRA infrastructure fixes — no model code changes required. A related PR #36976 solves a similar problem for Qwen3.5 specifically via model-side changes; this PR instead fixes it generically at the LoRA layer so any future model with a similar fusion pattern gets the fix for free.

Related: #36372, #36478, #36976

## Test plan

Tested on 2x RTX PRO 6000 Blackwell with LoRA adapters targeting GDN layers (`in_proj_qkv`, `in_proj_z`):

**Qwen/Qwen3.5-9B (dense)**
- [x] GDN LoRA, TP=1, `fully_sharded_loras=False` — PASS
- [x] GDN LoRA, TP=1, `fully_sharded_loras=True` — PASS
- [x] GDN LoRA, TP=2, `fully_sharded_loras=False` — PASS
- [x] Standard LoRA (attention/MLP only), TP=1, `fully_sharded_loras=False` — PASS (regression)
- [x] Standard LoRA (attention/MLP only), TP=1, `fully_sharded_loras=True` — PASS (regression)

**Qwen/Qwen3.5-35B-A3B (MoE)**
- [x] GDN LoRA, TP=2, `fully_sharded_loras=False` — PASS
- [x] GDN LoRA, TP=2, `fully_sharded_loras=True` — PASS

**Unit tests**
- [x] `test_column_parallel_packed` — all 36 parametrized cases pass (`fully_shard=True/False` × `repeats=1,2,3` × `num_loras=1,2,4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)