### PR TITLE
[CI][Bugfix] Fix incorrect status handling with `set -e` in CI shell scripts

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-hpu-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-hpu-test.sh
@@ -63,7 +63,7 @@ EOF
 # separate remove_docker_containers and remove_docker_containers_and_exit
 # functions, while other platforms only need one remove_docker_container
 # function.
-EXITCODE=1
+EXITCODE=0
 remove_docker_containers() { docker rm -f "${container_name}" || true; }
 trap 'remove_docker_containers; exit $EXITCODE;' EXIT
 remove_docker_containers
@@ -77,9 +77,8 @@ docker run --rm --runtime=habana --name="${container_name}" --network=host \
   "${image_name}" \
   /bin/bash -c '
   cd vllm; timeout 120s python -u examples/basic/offline_inference/generate.py --model facebook/opt-125m
-'
+' || EXITCODE=$?
 
-EXITCODE=$?
 if [ $EXITCODE -eq 0 ]; then
   echo "Test with basic model passed"
 else

--- a/.buildkite/scripts/run-benchmarks.sh
+++ b/.buildkite/scripts/run-benchmarks.sh
@@ -11,11 +11,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 (which wget && which curl) || (apt-get update && apt-get install -y wget curl)
 
 # run python-based benchmarks and upload the result to buildkite
-vllm bench latency --output-json latency_results.json 2>&1 | tee benchmark_latency.txt
-bench_latency_exit_code=$?
+bench_latency_exit_code=0
+vllm bench latency --output-json latency_results.json 2>&1 | tee benchmark_latency.txt || bench_latency_exit_code=${PIPESTATUS[0]}
 
-vllm bench throughput --input-len 256 --output-len 256 --output-json throughput_results.json 2>&1 | tee benchmark_throughput.txt
-bench_throughput_exit_code=$?
+bench_throughput_exit_code=0
+vllm bench throughput --input-len 256 --output-len 256 --output-json throughput_results.json 2>&1 | tee benchmark_throughput.txt || bench_throughput_exit_code=${PIPESTATUS[0]}
 
 # run server-based benchmarks and upload the result to buildkite
 vllm serve meta-llama/Llama-2-7b-chat-hf &
@@ -24,6 +24,7 @@ wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/r
 
 # wait for server to start, timeout after 600 seconds
 timeout 600 bash -c 'until curl localhost:8000/v1/models; do sleep 1; done' || exit 1
+bench_serving_exit_code=0
 vllm bench serve \
     --backend vllm \
     --dataset-name sharegpt \
@@ -33,8 +34,7 @@ vllm bench serve \
     --endpoint /v1/completions \
     --tokenizer meta-llama/Llama-2-7b-chat-hf \
     --save-result \
-    2>&1 | tee benchmark_serving.txt
-bench_serving_exit_code=$?
+    2>&1 | tee benchmark_serving.txt || bench_serving_exit_code=${PIPESTATUS[0]}
 kill $server_pid
 
 # write the results into a markdown file


### PR DESCRIPTION
## Purpose
This PR fixes two CI shell-script correctness bugs related to exit-code handling under errexit (`set -e`).

- In `.buildkite/scripts/run-benchmarks.sh`, benchmark commands were executed with errexit enabled and exit codes were captured afterward, even though with errexit the script terminates whenever a non-0 exit code is returned (so effectively `$?` could only be 0).
- In `.buildkite/scripts/run-hpu-test.sh`, the same bug was present with a `docker run` command's exit status.

## Test Plan
Run minimal examples with the same structure as the scripts (but with dummy commands that return 0 or 1) and verify that original scripts crash before error handling while fixed versions correctly execute.

## Test Result
Fixed scripts do not crash.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results