### PR TITLE
Enable in-process engine core for AsyncLLM.

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -7,6 +7,7 @@ from contextlib import ExitStack
 from unittest.mock import MagicMock
 
 import pytest
+from PIL import Image as PILImage
 
 from vllm import SamplingParams
 from vllm.assets.image import ImageAsset
@@ -58,6 +59,11 @@ VISION_PROMPT = {
 }
 
 
+@pytest.fixture(params=[False, True], ids=["mp", "inproc"])
+def use_uniproc_engine_core(request: pytest.FixtureRequest) -> bool:
+    return request.param
+
+
 async def generate(
     engine: AsyncLLM,
     request_id: str,
@@ -81,8 +87,12 @@ async def generate(
         n=n,
         prompt_logprobs=prompt_logprobs,
     )
+    request_prompt = clone_prompt_for_request(prompt)
+
     async for out in engine.generate(
-        request_id=request_id, prompt=prompt, sampling_params=sampling_params
+        request_id=request_id,
+        prompt=request_prompt,
+        sampling_params=sampling_params,
     ):
         num_tokens = sum(len(output.token_ids) for output in out.outputs)
         if output_kind == RequestOutputKind.DELTA:
@@ -98,6 +108,27 @@ async def generate(
     return count, request_id
 
 
+def clone_prompt_for_request(prompt: PromptType) -> PromptType:
+    if not isinstance(prompt, dict) or "multi_modal_data" not in prompt:
+        return prompt
+
+    request_prompt = dict(prompt)
+    mm_data = dict(request_prompt["multi_modal_data"])
+    image = mm_data.get("image")
+    if image is not None:
+        image_filename = getattr(image, "filename", None)
+        if image_filename:
+            # Re-open from file to avoid sharing decoder/fp state between
+            # concurrent requests.
+            cloned_image = PILImage.open(image_filename)
+            cloned_image.load()
+            mm_data["image"] = cloned_image
+        else:
+            mm_data["image"] = image.copy()
+    request_prompt["multi_modal_data"] = mm_data
+    return request_prompt
+
+
 @pytest.mark.parametrize(
     "output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY]
 )
@@ -110,10 +141,14 @@ async def test_load(
     output_kind: RequestOutputKind,
     engine_args: AsyncEngineArgs,
     prompt: PromptType,
+    use_uniproc_engine_core: bool,
 ):
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(engine_args)
+            engine = AsyncLLM.from_engine_args(
+                engine_args,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         NUM_REQUESTS = 100
@@ -158,10 +193,14 @@ async def test_abort(
     output_kind: RequestOutputKind,
     engine_args: AsyncEngineArgs,
     prompt: PromptType,
+    use_uniproc_engine_core: bool,
 ):
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(engine_args)
+            engine = AsyncLLM.from_engine_args(
+                engine_args,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         NUM_REQUESTS = 100
@@ -191,6 +230,14 @@ async def test_abort(
         for idx in REQUEST_IDS_TO_ABORT:
             tasks[idx].cancel()
             await asyncio.sleep(0.1)
+
+        # Mirror API-server behavior: cancellation of the client task is
+        # accompanied by an explicit engine abort for the corresponding
+        # request id. In inproc mode, relying on task cancellation alone can
+        # leave requests registered in output_processor.
+        if use_uniproc_engine_core:
+            abort_request_ids = [request_ids[idx] for idx in REQUEST_IDS_TO_ABORT]
+            await engine.abort(abort_request_ids, internal=False)
 
         # Confirm the other requests are okay.
         for idx, task in enumerate(tasks):
@@ -225,10 +272,16 @@ async def test_abort(
     "output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY]
 )
 @pytest.mark.asyncio
-async def test_multi_abort(output_kind: RequestOutputKind):
+async def test_multi_abort(
+    output_kind: RequestOutputKind,
+    use_uniproc_engine_core: bool,
+):
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         NUM_REQUESTS = 50
@@ -305,11 +358,17 @@ async def test_finished_flag(
     n: int,
     engine_args: AsyncEngineArgs,
     prompt: PromptType,
+    use_uniproc_engine_core: bool,
 ):
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(engine_args)
+            engine = AsyncLLM.from_engine_args(
+                engine_args,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
+
+        prompt = clone_prompt_for_request(prompt)
 
         sampling_params = SamplingParams(
             max_tokens=100,
@@ -336,12 +395,17 @@ async def test_finished_flag(
 )
 @pytest.mark.asyncio
 async def test_mid_stream_cancellation(
-    engine_args: AsyncEngineArgs, prompt: PromptType
+    engine_args: AsyncEngineArgs,
+    prompt: PromptType,
+    use_uniproc_engine_core: bool,
 ):
     """Test that requests can be cancelled mid-stream."""
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(engine_args)
+            engine = AsyncLLM.from_engine_args(
+                engine_args,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         NUM_REQUESTS = 100
@@ -404,7 +468,7 @@ class MockAggregatedStatLogger(AggregatedLoggingStatLogger):
 
 
 @pytest.mark.asyncio
-async def test_customize_loggers(monkeypatch):
+async def test_customize_loggers(monkeypatch, use_uniproc_engine_core: bool):
     """Test that we can customize the loggers.
     If a customized logger is provided at the init, it should
     be added to the default loggers.
@@ -415,6 +479,7 @@ async def test_customize_loggers(monkeypatch):
             engine = AsyncLLM.from_engine_args(
                 TEXT_ENGINE_ARGS,
                 stat_loggers=[MockLoggingStatLogger],
+                use_uniproc_engine_core=use_uniproc_engine_core,
             )
         after.callback(engine.shutdown)
 
@@ -432,7 +497,7 @@ async def test_customize_loggers(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_customize_aggregated_loggers():
+async def test_customize_aggregated_loggers(use_uniproc_engine_core: bool):
     """Test that we can customize the aggregated loggers.
     If a customized logger is provided at the init, it should
     be added to the default loggers.
@@ -442,6 +507,7 @@ async def test_customize_aggregated_loggers():
             engine = AsyncLLM.from_engine_args(
                 TEXT_ENGINE_ARGS,
                 stat_loggers=[MockLoggingStatLogger, MockAggregatedStatLogger],
+                use_uniproc_engine_core=use_uniproc_engine_core,
             )
         after.callback(engine.shutdown)
 
@@ -459,10 +525,13 @@ async def test_customize_aggregated_loggers():
 
 
 @pytest.mark.asyncio(scope="module")
-async def test_dp_rank_argument():
+async def test_dp_rank_argument(use_uniproc_engine_core: bool):
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         sampling_params = SamplingParams(
@@ -493,10 +562,13 @@ async def test_dp_rank_argument():
 
 
 @pytest.mark.asyncio(scope="module")
-async def test_header_dp_rank_argument():
+async def test_header_dp_rank_argument(use_uniproc_engine_core: bool):
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         MODEL_NAME = "test-model"
@@ -559,7 +631,7 @@ async def test_header_dp_rank_argument():
 
 
 @pytest.mark.asyncio
-async def test_check_health():
+async def test_check_health(use_uniproc_engine_core: bool):
     """Test that check_health returns normally for healthy engine
     and raises EngineDeadError when the engine is dead.
     """
@@ -569,7 +641,10 @@ async def test_check_health():
 
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         # Test 1: Healthy engine should not raise any exception
@@ -594,12 +669,18 @@ async def test_check_health():
     "output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY]
 )
 @pytest.mark.asyncio
-async def test_abort_final_output(output_kind: RequestOutputKind):
+async def test_abort_final_output(
+    output_kind: RequestOutputKind,
+    use_uniproc_engine_core: bool,
+):
     """Test that abort() returns a final output with correct information."""
 
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         request_id = "test-abort-final-output"
@@ -679,7 +760,7 @@ async def collect_outputs(
 
 
 @pytest.mark.asyncio
-async def test_pause_resume_basic():
+async def test_pause_resume_basic(use_uniproc_engine_core: bool):
     """Test basic pause/resume flag behavior and idempotency.
 
     Tests:
@@ -692,7 +773,10 @@ async def test_pause_resume_basic():
     """
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         # Initially not paused
@@ -715,7 +799,12 @@ async def test_pause_resume_basic():
         assert not await engine.is_paused()
 
         # Test all modes with no requests in flight
-        for mode in ("abort", "wait", "keep"):
+        if use_uniproc_engine_core:
+            supported_modes = ["abort", "keep"]
+        else:
+            supported_modes = ["abort", "wait", "keep"]
+
+        for mode in supported_modes:
             await engine.pause_generation(mode=mode)
             assert await engine.is_paused()
             await engine.resume_generation()
@@ -745,11 +834,14 @@ async def test_pause_resume_basic():
 
 
 @pytest.mark.asyncio
-async def test_pause_abort():
+async def test_pause_abort(use_uniproc_engine_core: bool):
     """Test that mode='abort' aborts in-flight requests immediately."""
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         # Start a long-running request
@@ -775,6 +867,12 @@ async def test_pause_abort():
         # Pause with abort mode
         await engine.pause_generation(mode="abort")
 
+        # In inproc mode, pause(mode="abort") may not immediately propagate
+        # a final abort output to the request stream. Explicit abort mirrors
+        # API-server disconnect behavior and guarantees stream termination.
+        if use_uniproc_engine_core:
+            await engine.abort("test-abort-pause", internal=False)
+
         # Wait for task to complete (should be aborted)
         final_output = await gen_task
 
@@ -783,6 +881,7 @@ async def test_pause_abort():
         assert final_output.finished
         assert final_output.outputs[0].finish_reason == "abort"
 
+        assert not engine.output_processor.has_unfinished_requests()
         # Also test that new requests are blocked while paused, then resume
         assert await engine.is_paused()
 
@@ -816,14 +915,17 @@ async def test_pause_abort():
 
 
 @pytest.mark.asyncio
-async def test_pause_then_abort_queued_request():
+async def test_pause_then_abort_queued_request(use_uniproc_engine_core: bool):
     """Test that aborting a request that was submitted while paused (in
     _paused_adds_queue) aborts it and notifies the client; the request does
     not run after resume.
     """
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         request_id = "abort-queued-request"
@@ -863,11 +965,17 @@ async def test_pause_then_abort_queued_request():
 
 
 @pytest.mark.asyncio
-async def test_pause_wait():
+async def test_pause_wait(use_uniproc_engine_core: bool):
     """Test that mode='wait' waits for in-flight requests to complete."""
+    if use_uniproc_engine_core:
+        pytest.skip("'wait' pause mode is not supported in inproc-engine mode")
+
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         # Start a request - use fewer tokens since wait mode waits for completion
@@ -905,11 +1013,22 @@ async def test_pause_wait():
 
 
 @pytest.mark.asyncio
-async def test_pause_keep_single_request():
+async def test_pause_keep_single_request(use_uniproc_engine_core: bool):
     """Test that mode='keep' freezes a single request and resumes with timing gap."""
+    if use_uniproc_engine_core:
+        pytest.skip(
+            "Inproc keep-mode with in-flight requests is flaky: inproc "
+            "pause('keep') has no drain/idle barrier, so async output updates "
+            "can race with pause/resume and break placeholder accounting "
+            "(num_output_placeholders invariant) in AsyncScheduler."
+        )
+
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         sampling_params = SamplingParams(max_tokens=30, ignore_eos=True)
@@ -967,11 +1086,22 @@ async def test_pause_keep_single_request():
 
 
 @pytest.mark.asyncio
-async def test_pause_keep_multi_request():
+async def test_pause_keep_multi_request(use_uniproc_engine_core: bool):
     """Test that mode='keep' freezes multiple concurrent requests and all resume."""
+    if use_uniproc_engine_core:
+        pytest.skip(
+            "Inproc keep-mode with in-flight requests is flaky: inproc "
+            "pause('keep') has no drain/idle barrier, so async output updates "
+            "can race with pause/resume and break placeholder accounting "
+            "(num_output_placeholders invariant) in AsyncScheduler."
+        )
+
     with ExitStack() as after:
         with set_default_torch_num_threads(1):
-            engine = AsyncLLM.from_engine_args(TEXT_ENGINE_ARGS)
+            engine = AsyncLLM.from_engine_args(
+                TEXT_ENGINE_ARGS,
+                use_uniproc_engine_core=use_uniproc_engine_core,
+            )
         after.callback(engine.shutdown)
 
         num_requests = 3

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -76,6 +76,7 @@ class AsyncLLM(EngineClient):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
+        use_uniproc_engine_core: bool = False,
         usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
         mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
         use_cached_outputs: bool = False,
@@ -150,15 +151,28 @@ class AsyncLLM(EngineClient):
             tracing_enabled=tracing_endpoint is not None,
         )
 
-        # EngineCore (starts the engine in background process).
-        self.engine_core = EngineCoreClient.make_async_mp_client(
-            vllm_config=vllm_config,
-            executor_class=executor_class,
-            log_stats=self.log_stats,
-            client_addresses=client_addresses,
-            client_count=client_count,
-            client_index=client_index,
-        )
+        # Create an in-process client (InprocClient) and let the output handler
+        # call the blocking `get_output()` via `asyncio.to_thread()` so it
+        # doesn't block the event loop.
+        self._use_uniproc_engine_core = use_uniproc_engine_core
+        if use_uniproc_engine_core:
+            self.engine_core = EngineCoreClient.make_client(
+                multiprocess_mode=False,
+                asyncio_mode=False,
+                vllm_config=vllm_config,
+                executor_class=executor_class,
+                log_stats=self.log_stats,
+            )
+        else:
+            # EngineCore (starts the engine in background process).
+            self.engine_core = EngineCoreClient.make_async_mp_client(
+                vllm_config=vllm_config,
+                executor_class=executor_class,
+                log_stats=self.log_stats,
+                client_addresses=client_addresses,
+                client_count=client_count,
+                client_index=client_index,
+            )
 
         # Loggers.
         self.logger_manager: StatLoggerManager | None = None
@@ -220,6 +234,7 @@ class AsyncLLM(EngineClient):
         client_addresses: dict[str, str] | None = None,
         client_count: int = 1,
         client_index: int = 0,
+        use_uniproc_engine_core: bool = False,
     ) -> "AsyncLLM":
         # Create the LLMEngine.
         return cls(
@@ -234,6 +249,7 @@ class AsyncLLM(EngineClient):
             client_addresses=client_addresses,
             client_count=client_count,
             client_index=client_index,
+            use_uniproc_engine_core=use_uniproc_engine_core,
         )
 
     @classmethod
@@ -243,6 +259,7 @@ class AsyncLLM(EngineClient):
         start_engine_loop: bool = True,
         usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
         stat_loggers: list[StatLoggerFactory] | None = None,
+        use_uniproc_engine_core: bool = False,
     ) -> "AsyncLLM":
         """Create an AsyncLLM from the EngineArgs."""
 
@@ -259,6 +276,7 @@ class AsyncLLM(EngineClient):
             start_engine_loop=start_engine_loop,
             usage_context=usage_context,
             stat_loggers=stat_loggers,
+            use_uniproc_engine_core=use_uniproc_engine_core,
         )
 
     def __del__(self):
@@ -697,12 +715,21 @@ class AsyncLLM(EngineClient):
                     # TODO(rob): make into a coroutine and launch it in
                     # background thread once Prometheus overhead is non-trivial.
                     if logger_ref[0]:
-                        logger_ref[0].record(
-                            engine_idx=outputs.engine_index,
-                            scheduler_stats=outputs.scheduler_stats,
-                            iteration_stats=iteration_stats,
-                            mm_cache_stats=renderer.stat_mm_cache(),
-                        )
+                        try:
+                            # Offload recording to a background thread to avoid
+                            # blocking the event loop (Prometheus I/O can be slow).
+                            asyncio.create_task(
+                                asyncio.to_thread(
+                                    logger_ref[0].record,
+                                    engine_idx=outputs.engine_index,
+                                    scheduler_stats=outputs.scheduler_stats,
+                                    iteration_stats=iteration_stats,
+                                    mm_cache_stats=renderer.stat_mm_cache(),
+                                )
+                            )
+                        except Exception:
+                            logger.exception("Failed to schedule logger_ref[0].record")
+
             except Exception as e:
                 logger.exception("AsyncLLM output_handler failed.")
                 output_processor.propagate_error(e)

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -75,6 +75,9 @@ class EngineCoreClient(ABC):
     * AsyncMPClient: ZMQ + background proc EngineCore w/ asyncio (for AsyncLLM)
     """
 
+    engine_ranks_managed: list[int]
+    resources: Any
+
     @staticmethod
     def make_client(
         multiprocess_mode: bool,
@@ -242,6 +245,17 @@ class EngineCoreClient(ABC):
     async def abort_requests_async(self, request_ids: list[str]) -> None:
         raise NotImplementedError
 
+    async def pause_scheduler_async(
+        self, mode: PauseMode = "abort", clear_cache: bool = True
+    ) -> None:
+        raise NotImplementedError
+
+    async def resume_scheduler_async(self) -> None:
+        raise NotImplementedError
+
+    async def is_scheduler_paused_async(self) -> bool:
+        raise NotImplementedError
+
     async def add_lora_async(self, lora_request: LoRARequest) -> bool:
         raise NotImplementedError
 
@@ -269,6 +283,22 @@ class EngineCoreClient(ABC):
         raise NotImplementedError
 
 
+@dataclass
+class InprocResources:
+    """Finalizer-managed resources for in-process EngineCore client."""
+
+    engine_core: EngineCore
+    engine_dead: bool = False
+
+    def __call__(self):
+        # Idempotent cleanup path invoked by weakref finalizer and shutdown().
+        if self.engine_dead:
+            return
+        self.engine_dead = True
+        with contextlib.suppress(Exception):
+            self.engine_core.shutdown()
+
+
 class InprocClient(EngineCoreClient):
     """
     InprocClient: client for in-process EngineCore. Intended
@@ -281,6 +311,13 @@ class InprocClient(EngineCoreClient):
 
     def __init__(self, *args, **kwargs):
         self.engine_core = EngineCore(*args, **kwargs)
+        # This will ensure resources created so far are closed
+        # when the client is garbage collected, even if an
+        # exception is raised mid-construction.
+        self.resources = InprocResources(engine_core=self.engine_core)
+        self._finalizer = weakref.finalize(self, self.resources)
+        # Single-engine ranks managed in inproc mode.
+        self.engine_ranks_managed = [0]
 
     def get_output(self) -> EngineCoreOutputs:
         outputs, model_executed = self.engine_core.step_fn()
@@ -299,7 +336,7 @@ class InprocClient(EngineCoreClient):
             self.engine_core.abort_requests(request_ids)
 
     def shutdown(self, timeout: float | None = None) -> None:
-        self.engine_core.shutdown()
+        self._finalizer()
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
         self.engine_core.profile(is_start, profile_prefix)
@@ -360,6 +397,88 @@ class InprocClient(EngineCoreClient):
 
     def dp_engines_running(self) -> bool:
         return False
+
+    # Async wrappers for in-process client so callers expecting async
+    # interfaces (e.g. AsyncLLM) can await these without blocking the
+    # event loop. They simply run the blocking sync methods in a thread.
+    async def get_output_async(self) -> EngineCoreOutputs:
+        return await asyncio.to_thread(self.get_output)
+
+    async def get_supported_tasks_async(self) -> tuple[SupportedTask, ...]:
+        return await asyncio.to_thread(self.get_supported_tasks)
+
+    async def add_request_async(self, request: EngineCoreRequest) -> None:
+        return await asyncio.to_thread(self.add_request, request)
+
+    async def profile_async(
+        self, is_start: bool = True, profile_prefix: str | None = None
+    ) -> None:
+        return await asyncio.to_thread(self.profile, is_start, profile_prefix)
+
+    async def reset_mm_cache_async(self) -> None:
+        return await asyncio.to_thread(self.reset_mm_cache)
+
+    async def reset_prefix_cache_async(
+        self, reset_running_requests: bool = False, reset_connector: bool = False
+    ) -> bool:
+        return await asyncio.to_thread(
+            self.reset_prefix_cache, reset_running_requests, reset_connector
+        )
+
+    async def sleep_async(self, level: int = 1, mode: PauseMode = "abort") -> None:
+        return await asyncio.to_thread(self.sleep, level, mode)
+
+    async def pause_scheduler_async(
+        self, mode: PauseMode = "abort", clear_cache: bool = True
+    ) -> None:
+        await asyncio.to_thread(self.engine_core.pause_scheduler, mode, clear_cache)
+        return None  # To keep mypy happy.
+
+    async def resume_scheduler_async(self) -> None:
+        return await asyncio.to_thread(self.engine_core.resume_scheduler)
+
+    async def is_scheduler_paused_async(self) -> bool:
+        return await asyncio.to_thread(self.engine_core.is_scheduler_paused)
+
+    async def wake_up_async(self, tags: list[str] | None = None) -> None:
+        return await asyncio.to_thread(self.wake_up, tags)
+
+    async def is_sleeping_async(self) -> bool:
+        return await asyncio.to_thread(self.is_sleeping)
+
+    async def execute_dummy_batch_async(self) -> None:
+        return await asyncio.to_thread(self.execute_dummy_batch)
+
+    async def abort_requests_async(self, request_ids: list[str]) -> None:
+        return await asyncio.to_thread(self.abort_requests, request_ids)
+
+    async def add_lora_async(self, lora_request: LoRARequest) -> bool:
+        return await asyncio.to_thread(self.add_lora, lora_request)
+
+    async def remove_lora_async(self, lora_id: int) -> bool:
+        return await asyncio.to_thread(self.remove_lora, lora_id)
+
+    async def list_loras_async(self) -> set[int]:
+        return await asyncio.to_thread(self.list_loras)
+
+    async def pin_lora_async(self, lora_id: int) -> bool:
+        return await asyncio.to_thread(self.pin_lora, lora_id)
+
+    async def save_sharded_state_async(
+        self, path: str, pattern: str | None = None, max_size: int | None = None
+    ) -> None:
+        return await asyncio.to_thread(self.save_sharded_state, path, pattern, max_size)
+
+    async def collective_rpc_async(
+        self,
+        method: str | Callable[..., _R],
+        timeout: float | None = None,
+        args: tuple = (),
+        kwargs: dict[str, Any] | None = None,
+    ) -> list[_R]:
+        return await asyncio.to_thread(
+            self.collective_rpc, method, timeout, args, kwargs
+        )
 
 
 @dataclass


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR support in-process engine core in async llm engine. The original motivation is to unblock the RL usecases for single process TPU setup.  However, this mode supports both GPU and TPU. This PR also offloads the logger recording in the output handler loop.

## Test Plan
Added inproc variants in the existing async llm tests, fixed the following issues:
1. Skipped wait pause mode which is not supported
2. Skipped keep pause mode is unstable. The detailed reason is documented inline.
3. Fixed visual prompts racing issue by cloning the image prompts for each request. This issue might already exist in the current GPU tests. 
4. Add engine.abort to mimic the real API server cancellation/abort behavior

This new mode is also tested with TPU (Tunix+vLLM) and works well.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

