### PR TITLE
[UX]: Fix unclean shutdown from ctrl-c with AR Fusion

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import atexit
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -139,11 +140,20 @@ def destroy_fi_ar_workspace():
         _fi_ar_quant_workspace is not None
         and _fi_ar_quant_workspace is not _fi_ar_workspace
     ):
-        _fi_ar_quant_workspace.destroy()
+        try:
+            _fi_ar_quant_workspace.destroy()
+        except Exception:
+            pass
     _fi_ar_quant_workspace = None
     if _fi_ar_workspace is not None:
-        _fi_ar_workspace.destroy()
+        try:
+            _fi_ar_workspace.destroy()
+        except Exception:
+            pass
         _fi_ar_workspace = None
+
+
+atexit.register(destroy_fi_ar_workspace)
 
 
 class FlashInferAllReduce:

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -3,6 +3,7 @@
 
 
 import atexit
+import gc
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -155,6 +156,7 @@ def destroy_fi_ar_workspace():
                 "Failed to destroy flashinfer workspace during shutdown: %s",
                 e)
         _fi_ar_workspace = None
+    gc.collect()
 
 
 atexit.register(destroy_fi_ar_workspace)

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -142,14 +142,18 @@ def destroy_fi_ar_workspace():
     ):
         try:
             _fi_ar_quant_workspace.destroy()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(
+                "Failed to destroy flashinfer quant workspace during shutdown: %s",
+                e)
     _fi_ar_quant_workspace = None
     if _fi_ar_workspace is not None:
         try:
             _fi_ar_workspace.destroy()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(
+                "Failed to destroy flashinfer workspace during shutdown: %s",
+                e)
         _fi_ar_workspace = None
 
 


### PR DESCRIPTION
Fixes #35686

This PR addresses the `ImportError: sys.meta_path is None` encountered during shutdown when FlashInfer All-Reduce fusion is enabled.

### Description
When the Python interpreter shuts down, it clears modules and eventually sets `sys.meta_path` to `None`. If `AllReduceFusionWorkspace` objects are left to be cleaned up by the garbage collector at this stage, their `__del__` methods (in the `flashinfer` dependency) fail when they attempt to perform imports or use module-level variables.

By registering the cleanup function with `atexit`, we ensure that `destroy()` is called on these workspaces while the interpreter is still fully functional.

### Changes
- Registered `destroy_fi_ar_workspace` with `atexit`.
- Added `try-except` blocks in `destroy_fi_ar_workspace` to gracefully handle any errors during shutdown.
- Added `gc.collect()` to the cleanup function to ensure `__del__` is triggered while the interpreter is still stable.

### Testing
- Verified with a mock script that `atexit` handlers run while `sys.meta_path` is still valid, whereas `__del__` runs after it is cleared.
- Verified that `destroy_fi_ar_workspace` is idempotent and handles exceptions.
