### PR TITLE
[Hardware][XPU] Align memory usage with cuda on xpu

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -736,6 +736,7 @@ class RocmPlatform(Platform):
     def get_current_memory_usage(
         cls, device: torch.types.Device | None = None
     ) -> float:
+        torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats(device)
         free_mem, total_mem = torch.cuda.mem_get_info(device)
         return total_mem - free_mem

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -736,7 +736,6 @@ class RocmPlatform(Platform):
     def get_current_memory_usage(
         cls, device: torch.types.Device | None = None
     ) -> float:
-        torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats(device)
         free_mem, total_mem = torch.cuda.mem_get_info(device)
         return total_mem - free_mem

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -248,6 +248,7 @@ class XPUPlatform(Platform):
     def get_current_memory_usage(
         cls, device: torch.types.Device | None = None
     ) -> float:
+        torch.xpu.empty_cache()
         torch.xpu.reset_peak_memory_stats(device)
         return torch.xpu.max_memory_allocated(device)
 


### PR DESCRIPTION

## Purpose
cuda platform add `empty_cache` for `get_current_memory_usage` in https://github.com/vllm-project/vllm/issues/19033
xpu/rocm platform should add this to keep memory profiling part align with cuda.

~cc @gshtras @tjtanaa for rocm change.~ revert rocm change.

## Test Plan
CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

