### PR TITLE
fix: correct FP8 error message to reference compute capability

### DIFF
--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -24,6 +24,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.utils import set_weight_attrs
+from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
@@ -255,6 +256,40 @@ class TorchAOConfig(QuantizationConfig):
         return []
 
 
+def _is_float8_config(torchao_config: Any) -> bool:
+    """Check if a torchao config uses Float8 quantization."""
+    config_cls_name = type(torchao_config).__name__
+    return "Float8" in config_cls_name or "float8" in config_cls_name
+
+
+def _check_fp8_compute_capability(torchao_config: Any) -> None:
+    """Validate GPU compute capability for FP8 quantization configs.
+
+    FP8 (Float8) quantization requires GPUs with compute capability >= 8.9
+    (e.g., Ada Lovelace GPUs like RTX 4090, or Hopper GPUs like H100).
+    The upstream torchao error message incorrectly refers to "CUDA>=8.9"
+    which is misleading since CUDA toolkit versions are unrelated to this
+    requirement.
+    """
+    if not _is_float8_config(torchao_config):
+        return
+
+    if not torch.cuda.is_available():
+        return
+
+    if not current_platform.has_device_capability(89):
+        capability = current_platform.get_device_capability()
+        capability_str = (
+            f"{capability.major}.{capability.minor}" if capability else "unknown"
+        )
+        raise ValueError(
+            f"Float8 quantization requires a GPU with compute capability "
+            f">= 8.9 (e.g., Ada Lovelace or Hopper GPUs), but the current "
+            f"GPU has compute capability {capability_str}. This is a GPU "
+            f"hardware limitation, not a CUDA toolkit version issue."
+        )
+
+
 def torchao_quantize_param_data(
     param: torch.Tensor, torchao_config: Any
 ) -> torch.nn.Parameter:
@@ -269,6 +304,10 @@ def torchao_quantize_param_data(
     from torchao.quantization import quantize_
 
     assert isinstance(torchao_config, AOBaseConfig), f"{torchao_config}"
+
+    # Validate compute capability early with a clear error message,
+    # before torchao raises a misleading "CUDA>=8.9" assertion.
+    _check_fp8_compute_capability(torchao_config)
     """
     Avoid real weight allocation for faster load, since we will
     end up setting it to param.

--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -258,6 +258,15 @@ class TorchAOConfig(QuantizationConfig):
 
 def _is_float8_config(torchao_config: Any) -> bool:
     """Check if a torchao config uses Float8 quantization."""
+    # The torchao API is not stable, so we check for FP8 dtypes in the config
+    # attributes first for robustness, then fall back to a class name check.
+    fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+    if getattr(torchao_config, "weight_dtype", None) in fp8_dtypes:
+        return True
+    if getattr(torchao_config, "activation_dtype", None) in fp8_dtypes:
+        return True
+
+    # Fallback to class name check for other configs
     config_cls_name = type(torchao_config).__name__
     return "Float8" in config_cls_name or "float8" in config_cls_name
 


### PR DESCRIPTION
## Summary

- Fixes misleading FP8 quantization error that says "CUDA>=8.9" when the actual requirement is GPU compute capability >= 8.9
- Adds an early validation check in vllm's torchao integration (`torchao_quantize_param_data`) that raises a clear `ValueError` before torchao's confusing assertion fires
- The new error message tells users exactly what is needed: a GPU with compute capability >= 8.9 (e.g., Ada Lovelace or Hopper GPUs)

Fixes #36805

## Details

The upstream `torchao` assertion in `quant_api.py` checks `is_sm_at_least_89()` but produces the error:

```
Float8 dynamic activation quantization is only supported on CUDA>=8.9 and MI300+
```

This misleads users into thinking they need a newer CUDA toolkit version. The actual requirement is GPU **compute capability** (SM version) >= 8.9, which is a hardware property.

This PR adds two helper functions:
- `_is_float8_config()`: detects whether a torchao config uses Float8 quantization
- `_check_fp8_compute_capability()`: validates GPU compute capability and raises a clear error

The check runs in `torchao_quantize_param_data()` before `quantize_()` is called, so the user sees a clear message like:

```
ValueError: Float8 quantization requires a GPU with compute capability >= 8.9
(e.g., Ada Lovelace or Hopper GPUs), but the current GPU has compute
capability 7.5. This is a GPU hardware limitation, not a CUDA toolkit
version issue.
```

## Test plan

- [ ] Verify on a GPU with compute capability < 8.9 (e.g., GTX 1650, T4) that the new error message appears when loading an FP8 torchao model
- [ ] Verify on a GPU with compute capability >= 8.9 (e.g., RTX 4090, H100) that FP8 quantization still works normally
- [ ] Verify non-FP8 torchao quantization is unaffected on older GPUs

🤖 Generated with [Claude Code](https://claude.com/claude-code)