### PR TITLE
fix: resolve kv_cache_dtype='auto' from checkpoint kv_cache_quant_algo

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1149,3 +1149,45 @@ def test_eagle_draft_model_config():
     assert draft_model_config.hf_text_config.model_type == "eagle"
     assert draft_model_config.architectures == ["EagleLlamaForCausalLM"]
     assert draft_model_config.architecture == "EagleLlamaForCausalLM"
+
+
+def test_resolve_kv_cache_dtype_string():
+    """Test that resolve_kv_cache_dtype_string correctly resolves 'auto'
+    to the appropriate dtype when a model checkpoint specifies
+    kv_cache_quant_algo."""
+    from unittest.mock import MagicMock
+
+    from vllm.utils.torch_utils import resolve_kv_cache_dtype_string
+
+    # Case 1: No quantization config -> stays "auto"
+    model_config = MagicMock()
+    model_config.hf_config = MagicMock()
+    model_config.hf_config.quantization_config = None
+    assert resolve_kv_cache_dtype_string("auto", model_config) == "auto"
+
+    # Case 2: modelopt with FP8 kv_cache_quant_algo -> resolves to "fp8_e4m3"
+    model_config.hf_config.quantization_config = {
+        "quant_method": "modelopt",
+        "quantization": {
+            "quant_algo": "FP8",
+            "kv_cache_quant_algo": "FP8",
+        },
+    }
+    assert resolve_kv_cache_dtype_string("auto", model_config) == "fp8_e4m3"
+
+    # Case 3: modelopt without kv_cache_quant_algo -> stays "auto"
+    model_config.hf_config.quantization_config = {
+        "quant_method": "modelopt",
+        "quantization": {
+            "quant_algo": "FP8",
+        },
+    }
+    assert resolve_kv_cache_dtype_string("auto", model_config) == "auto"
+
+    # Case 4: Non-auto value passes through unchanged
+    assert resolve_kv_cache_dtype_string("fp8", model_config) == "fp8"
+    assert resolve_kv_cache_dtype_string("bfloat16", model_config) == "bfloat16"
+
+    # Case 5: No hf_config -> stays "auto"
+    model_config.hf_config = None
+    assert resolve_kv_cache_dtype_string("auto", model_config) == "auto"

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1580,6 +1580,27 @@ class VllmConfig:
                     f"Model: {self.model_config.model}"
                 )
 
+        # Resolve kv_cache_dtype="auto" using the model's quantization config.
+        # When a checkpoint specifies kv_cache_quant_algo (e.g., FP8), we
+        # should auto-detect and use it instead of falling back to model dtype.
+        if (
+            self.cache_config is not None
+            and self.cache_config.cache_dtype == "auto"
+        ):
+            from vllm.utils.torch_utils import resolve_kv_cache_dtype_string
+
+            resolved = resolve_kv_cache_dtype_string(
+                "auto", self.model_config
+            )
+            if resolved != "auto":
+                logger.info(
+                    "Auto-detected kv_cache_dtype='%s' from model "
+                    "checkpoint quantization config.", resolved,
+                )
+                object.__setattr__(
+                    self.cache_config, "cache_dtype", resolved
+                )
+
     def compile_debug_dump_path(self) -> Path | None:
         """Returns a rank-aware path for dumping
         torch.compile debug information.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1583,23 +1583,17 @@ class VllmConfig:
         # Resolve kv_cache_dtype="auto" using the model's quantization config.
         # When a checkpoint specifies kv_cache_quant_algo (e.g., FP8), we
         # should auto-detect and use it instead of falling back to model dtype.
-        if (
-            self.cache_config is not None
-            and self.cache_config.cache_dtype == "auto"
-        ):
+        if self.cache_config is not None and self.cache_config.cache_dtype == "auto":
             from vllm.utils.torch_utils import resolve_kv_cache_dtype_string
 
-            resolved = resolve_kv_cache_dtype_string(
-                "auto", self.model_config
-            )
+            resolved = resolve_kv_cache_dtype_string("auto", self.model_config)
             if resolved != "auto":
                 logger.info(
                     "Auto-detected kv_cache_dtype='%s' from model "
-                    "checkpoint quantization config.", resolved,
+                    "checkpoint quantization config.",
+                    resolved,
                 )
-                object.__setattr__(
-                    self.cache_config, "cache_dtype", resolved
-                )
+                object.__setattr__(self.cache_config, "cache_dtype", resolved)
 
     def compile_debug_dump_path(self) -> Path | None:
         """Returns a rank-aware path for dumping


### PR DESCRIPTION
## Summary

Fixes #34752

When a model checkpoint specifies `kv_cache_quant_algo` (e.g., FP8 via modelopt quantization config), `--kv-cache-dtype auto` should auto-detect and use that dtype instead of falling back to `model_config.dtype`.

### Changes

- **`vllm/config/vllm.py`**: Added KV cache dtype resolution logic at the end of `try_verify_and_update_config()`. When `cache_dtype` is `"auto"`, it calls the existing `resolve_kv_cache_dtype_string()` helper from `torch_utils.py` to check if the model's quantization config specifies a `kv_cache_quant_algo`. If found (e.g., FP8), it updates `cache_dtype` accordingly and logs the auto-detected value.

- **`tests/test_config.py`**: Added `test_resolve_kv_cache_dtype_string` unit test covering:
  - No quantization config -> stays "auto"
  - modelopt with FP8 `kv_cache_quant_algo` -> resolves to "fp8_e4m3"
  - modelopt without `kv_cache_quant_algo` -> stays "auto"
  - Non-auto values pass through unchanged
  - Missing `hf_config` -> stays "auto"

### Resolution Logic

The existing `resolve_kv_cache_dtype_string` and `get_kv_cache_quant_algo_string` helpers in `torch_utils.py` already handle the mapping from modelopt's `kv_cache_quant_algo` to vLLM's cache dtype strings. This PR simply wires them into the config initialization flow so that auto-detection happens automatically.

| `--kv-cache-dtype` | Model has `kv_cache_quant_algo=FP8` | Result |
|---|---|---|
| `auto` (default) | Yes | `fp8_e4m3` (auto-detected) |
| `auto` (default) | No | `auto` (uses model dtype) |
| `fp8` | Yes/No | `fp8` (explicit override) |
| `bfloat16` | Yes/No | `bfloat16` (explicit override) |

## Test plan

- [ ] `pytest tests/test_config.py::test_resolve_kv_cache_dtype_string -v`
- [ ] Verify with a model that has `kv_cache_quant_algo` set (e.g., `nvidia/Qwen3-30B-A3B-NVFP4`) that auto-detection works
- [ ] Verify that explicit `--kv-cache-dtype` values still override the auto-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)