### PR TITLE
fix: correct misleading FP8 error message about CUDA version vs compute capability

### DIFF
--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -282,7 +282,17 @@ def torchao_quantize_param_data(
         )
 
     dummy_linear[0].weight = param
-    quantize_(dummy_linear, torchao_config)
+    try:
+        quantize_(dummy_linear, torchao_config)
+    except AssertionError as e:
+        if "CUDA>=8.9" in str(e):
+            raise AssertionError(
+                "Float8 dynamic activation quantization is only supported "
+                "on GPUs with compute capability >= 8.9 "
+                "(e.g., Ada Lovelace, Hopper) or AMD MI300+. "
+                "Your GPU does not meet this requirement."
+            ) from e
+        raise
     return dummy_linear[0].weight
 
 


### PR DESCRIPTION
## Summary

- Fixes #36805: The upstream TorchAO assertion error says `CUDA>=8.9` when FP8 dynamic activation quantization fails, but the actual requirement is **GPU compute capability >= 8.9** (SM89+), not a CUDA toolkit version. This is confusing for users with older GPUs like the GTX 1650 (compute 7.5).
- Wraps the `quantize_()` call in `torchao_quantize_param_data` with a try/except to catch this specific assertion and re-raise with a clear message mentioning compute capability (e.g., Ada Lovelace, Hopper) and AMD MI300+.

## Test plan

- [x] Verify the error message text matches the upstream TorchAO assertion (`"CUDA>=8.9"`)
- [ ] Test on a GPU with compute capability < 8.9 using an FP8 TorchAO quantized model to confirm the new error message appears
- [ ] Test on a GPU with compute capability >= 8.9 to confirm normal operation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)