### PR TITLE
[Bugfix] Fix FlatLogprobs empty slice crash and delta-mode logprobs stale data

### DIFF
--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -208,3 +208,26 @@ def test_flat_logprobs_access() -> None:
     assert logprobs_last2.logprobs == [0.4, 0.5, 0.6, 0.1]
     assert logprobs_last2.ranks == [40, 50, 60, 10]
     assert logprobs_last2.decoded_tokens == ["40", "50", "60", "10"]
+
+    # Test __getitem__ : empty slice (should return empty FlatLogprobs,
+    # not raise IndexError)
+    logprobs_empty = logprobs[0:0]
+    assert isinstance(logprobs_empty, FlatLogprobs)
+    assert len(logprobs_empty) == 0
+    assert logprobs_empty.start_indices == []
+    assert logprobs_empty.end_indices == []
+    assert logprobs_empty.token_ids == []
+    assert logprobs_empty.logprobs == []
+
+    # Test __getitem__ : empty slice at end
+    logprobs_empty_end = logprobs[3:3]
+    assert isinstance(logprobs_empty_end, FlatLogprobs)
+    assert len(logprobs_empty_end) == 0
+
+    # Test __getitem__ : negative zero slice (Python's -0 == 0)
+    # This exercises the same code path used by delta-mode logprobs
+    # slicing in the output processor: logprobs[-0:] should behave
+    # the same as logprobs[0:] (returning all elements), but when
+    # the intent is "last 0 elements", the caller must guard for it.
+    logprobs_neg0 = logprobs[-0:]
+    assert len(logprobs_neg0) == 3  # -0 == 0, so returns all

--- a/vllm/logprobs.py
+++ b/vllm/logprobs.py
@@ -119,13 +119,18 @@ class FlatLogprobs(MutableSequence[LogprobsOnePosition | None]):
                 for i in range(self.start_indices[index], self.end_indices[index])
             }
         elif isinstance(index, slice):
-            min_index = self.start_indices[index][0]
-            max_index = self.end_indices[index][-1]
+            sliced_starts = self.start_indices[index]
+            sliced_ends = self.end_indices[index]
+            if not sliced_starts:
+                # Empty slice: return an empty FlatLogprobs
+                return FlatLogprobs()
+            min_index = sliced_starts[0]
+            max_index = sliced_ends[-1]
             return FlatLogprobs(
                 # Shift updated start_indices and end_indices to
                 # be 0-indexed
-                start_indices=[i - min_index for i in self.start_indices[index]],
-                end_indices=[i - min_index for i in self.end_indices[index]],
+                start_indices=[i - min_index for i in sliced_starts],
+                end_indices=[i - min_index for i in sliced_ends],
                 token_ids=self.token_ids[min_index:max_index],
                 logprobs=self.logprobs[min_index:max_index],
                 ranks=self.ranks[min_index:max_index],

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -393,7 +393,10 @@ class RequestState:
         # Prepare logprobs, based on delta mode
         logprobs = self.logprobs_processor.logprobs
         if delta and logprobs:
-            logprobs = logprobs[-len(token_ids) :]
+            n = len(token_ids)
+            # Guard against -0 == 0: when n is 0, logprobs[-0:] would
+            # incorrectly return ALL accumulated logprobs instead of none.
+            logprobs = logprobs[-n:] if n > 0 else logprobs[0:0]
 
         return CompletionOutput(
             index=self.request_index,


### PR DESCRIPTION
## Summary

Fixes two related bugs in logprobs handling:

- **FlatLogprobs.__getitem__** crashes with `IndexError` when given an empty slice (e.g., `logprobs[0:0]`) because it unconditionally accesses `[0]` on a potentially empty sliced list. Fixed by returning an empty `FlatLogprobs()` when the slice yields no positions.
- **output_processor delta-mode logprobs** uses `logprobs[-len(token_ids):]` which evaluates to `logprobs[0:]` (all logprobs) when `token_ids` is empty, due to Python's `-0 == 0`. Fixed by guarding the zero-length case explicitly.

Fixes #37037

## Test plan

- [x] Added empty slice tests in `tests/test_logprobs.py` (`logprobs[0:0]`, `logprobs[3:3]`, `logprobs[-0:]`)
- [x] All existing logprobs tests still pass
- [x] Pre-commit checks pass on changed files

```bash
pytest tests/test_logprobs.py -v
```

## AI disclosure

AI assistance (Claude) was used in developing this change. All code has been reviewed and tested by the human submitter.