### PR TITLE
[Frontend] Avoid startup error log for models without chat template

### DIFF
--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -176,6 +176,8 @@ class BaseRenderer(ABC, Generic[_T]):
         For multi-modal requests:
         - Importing libraries such as librosa triggers JIT compilation.
         """
+        from vllm.entrypoints.chat_utils import ChatTemplateResolutionError
+
         try:
             logger.info("Warming up chat template processing...")
             start_time = time.perf_counter()
@@ -184,6 +186,8 @@ class BaseRenderer(ABC, Generic[_T]):
 
             elapsed = time.perf_counter() - start_time
             logger.info("Chat template warmup completed in %.3fs", elapsed)
+        except ChatTemplateResolutionError:
+            logger.info("This model does not support chat template.")
         except Exception:
             logger.exception("Chat template warmup failed")
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

During chat template warmup, models without a valid chat template raise `ChatTemplateResolutionError`, causing some confusion among users as it was logged with a stack trace. This PR catches the specific error and downgrades the log to INFO level.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

