### PR TITLE
fix: sync delta_token_ids with delta_text during stop-sequence buffering

### DIFF
--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -51,6 +51,8 @@ class IncrementalDetokenizer:
         """Return token_ids consistent with the text from
         get_next_output_text. The default implementation just returns the
         input token_ids unchanged (no stop-string buffering)."""
+        if not delta:
+            return self.output_token_ids
         return token_ids
 
     @classmethod
@@ -206,7 +208,9 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         This ensures ``delta_token_ids`` stays in sync with ``delta_text``.
         """
         if not self.stop_buffer_length:
-            # No stop-string buffering, token_ids are already correct.
+            if not delta:
+                return self.output_token_ids
+            # For delta mode, the input token_ids are correct.
             return token_ids
 
         if not delta:

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -45,6 +45,14 @@ class IncrementalDetokenizer:
     def get_next_output_text(self, finished: bool, delta: bool) -> str:
         return ""
 
+    def get_next_output_token_ids(
+        self, finished: bool, delta: bool, token_ids: list[int]
+    ) -> list[int]:
+        """Return token_ids consistent with the text from
+        get_next_output_text. The default implementation just returns the
+        input token_ids unchanged (no stop-string buffering)."""
+        return token_ids
+
     @classmethod
     def from_new_request(
         cls,
@@ -89,6 +97,11 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
             self.stop_buffer_length = 0
         self._last_output_text_offset: int = 0
 
+        # Track cumulative text length after each output token so that
+        # token_ids can be held back in sync with stop-string text buffering.
+        self._cumulative_text_len: list[int] = []
+        self._last_output_token_offset: int = 0
+
         # Generation data
         self.output_text = ""
 
@@ -117,6 +130,7 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         for new_token_id in new_token_ids:
             self.token_ids.append(new_token_id)
             self.output_text += self.decode_next(new_token_id)
+            self._cumulative_text_len.append(len(self.output_text))
             # Support min_tokens, see https://github.com/vllm-project/vllm/pull/22014
             if self.min_tokens and self.num_output_tokens() <= self.min_tokens:
                 stop_check_offset = len(self.output_text)
@@ -124,6 +138,10 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         if skipped_stop_token_id is not None:
             # Cleanup after skipping detokenization.
             self.token_ids.append(skipped_stop_token_id)
+            # The skipped token produces no text, so cumulative length
+            # stays the same as the previous token.
+            prev = self._cumulative_text_len[-1] if self._cumulative_text_len else 0
+            self._cumulative_text_len.append(prev)
 
         # 2) Evaluate stop strings.
         stop_string = None
@@ -145,6 +163,19 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
     def decode_next(self, next_token_id: int) -> str:
         raise NotImplementedError
 
+    def _token_index_for_text_offset(self, text_offset: int) -> int:
+        """Return the number of output tokens whose cumulative decoded text
+        is fully contained within ``text_offset`` characters.
+
+        Uses a simple linear scan from the last known position since the
+        offset typically advances by a small number of tokens each call.
+        """
+        idx = self._last_output_token_offset
+        n = len(self._cumulative_text_len)
+        while idx < n and self._cumulative_text_len[idx] <= text_offset:
+            idx += 1
+        return idx
+
     def get_next_output_text(self, finished: bool, delta: bool) -> str:
         """If delta is True, only new text since the last call to
         this method is returned"""
@@ -162,6 +193,41 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
             self._last_output_text_offset = length
             return self.output_text[last_offset:length]
         return ""
+
+    def get_next_output_token_ids(
+        self, finished: bool, delta: bool, token_ids: list[int]
+    ) -> list[int]:
+        """Return token_ids that correspond to the text returned by
+        ``get_next_output_text`` for the same ``finished`` and ``delta``
+        arguments.
+
+        When stop-string buffering is active, some trailing tokens may be
+        held back because their decoded text has not yet been released.
+        This ensures ``delta_token_ids`` stays in sync with ``delta_text``.
+        """
+        if not self.stop_buffer_length:
+            # No stop-string buffering, token_ids are already correct.
+            return token_ids
+
+        if not delta:
+            # Non-delta: return all output token_ids up to the text boundary.
+            buffer_length = 0 if finished else self.stop_buffer_length
+            if not buffer_length:
+                return self.output_token_ids
+            text_len = len(self.output_text) - buffer_length
+            count = self._token_index_for_text_offset(text_len)
+            return self.output_token_ids[:count]
+
+        # Delta mode: return only tokens whose text was released since
+        # the last call to get_next_output_text (which updates
+        # _last_output_text_offset).
+        text_offset = self._last_output_text_offset
+        new_token_end = self._token_index_for_text_offset(text_offset)
+        old_token_end = self._last_output_token_offset
+        self._last_output_token_offset = new_token_end
+        if new_token_end > old_token_end:
+            return self.output_token_ids[old_token_end:new_token_end]
+        return []
 
 
 class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -385,10 +385,14 @@ class RequestState:
         finished = finish_reason is not None
         delta = self.output_kind == RequestOutputKind.DELTA
 
-        # Prepare text and token_ids, based on delta mode
+        # Prepare text and token_ids, based on delta mode.
+        # get_next_output_text must be called before
+        # get_next_output_token_ids so that the text offset is updated
+        # first and the token_ids can be aligned to the released text.
         text = self.detokenizer.get_next_output_text(finished, delta)
-        if not delta:
-            token_ids = self.detokenizer.output_token_ids
+        token_ids = self.detokenizer.get_next_output_token_ids(
+            finished, delta, token_ids
+        )
 
         # Prepare logprobs, based on delta mode
         logprobs = self.logprobs_processor.logprobs


### PR DESCRIPTION
## Summary

Fixes #36830

When stop sequences are configured, the detokenizer holds back trailing characters (up to `max(len(s) for s in stop) - 1`) via `stop_buffer_length` to check for partial stop-string matches before releasing text to the stream. However, `delta_token_ids` was not subject to the same hold-back, causing it to include tokens whose decoded text had not yet been emitted in `delta_text`.

This resulted in `delta_text=''` being paired with non-empty `delta_token_ids` at the start of generation, and later a burst of accumulated text paired with unrelated token IDs -- breaking any tool-call parser that relies on the two being in sync.

### Changes

- **`vllm/v1/engine/detokenizer.py`**:
  - Added `_cumulative_text_len` list to `BaseIncrementalDetokenizer` that tracks the cumulative `output_text` length after each token is decoded
  - Added `_last_output_token_offset` counter (analogous to `_last_output_text_offset` for text)
  - Added `get_next_output_token_ids(finished, delta, token_ids)` method that returns only the token IDs whose decoded text has been released by `get_next_output_text()`
  - Added default pass-through implementation on base `IncrementalDetokenizer` for cases with no stop-string buffering

- **`vllm/v1/engine/output_processor.py`**:
  - Updated `_new_completion_output()` to call `get_next_output_token_ids()` after `get_next_output_text()`, ensuring token IDs are aligned with the released text in both delta and non-delta modes

### How it works

Each call to `decode_next()` appends the new cumulative text length to `_cumulative_text_len`. When `get_next_output_token_ids()` is called (after `get_next_output_text()` has updated `_last_output_text_offset`), it finds how many tokens' cumulative text fits within the released text boundary using a linear scan, and returns only those token IDs. Tokens whose text is still held back in the stop-string buffer are deferred to the next iteration -- exactly mirroring the text behavior.

## Test plan

- [ ] Verify with the reproduction from #36830 (tool call streaming with stop sequences) that `delta_text` and `delta_token_ids` are now in sync
- [ ] Run existing detokenizer tests to ensure no regressions
- [ ] Run tool parser streaming tests with and without stop sequences

Supersedes #37039 (which was closed due to merge conflicts with the branch being recreated).