### PR TITLE
  [Perf] Skip unnecessary int64 round-trip in sampler

### DIFF
--- a/tests/v1/sample/test_sampler.py
+++ b/tests/v1/sample/test_sampler.py
@@ -200,6 +200,57 @@ def _create_weighted_output_token_list(
 
 
 @pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("batch_size", [1, 32])
+@pytest.mark.parametrize(
+    "all_greedy, max_num_logprobs",
+    [
+        (True, None),  # greedy, no logprobs
+        (False, None),  # random, no logprobs
+        (True, -1),  # greedy, full unsorted logprobs (skips gather_logprobs)
+        (False, -1),  # random, full unsorted logprobs
+        (True, 5),  # greedy, with logprobs (exercises gather_logprobs)
+        (False, 5),  # random, with logprobs
+    ],
+)
+def test_sampler_output_dtype(
+    device: str,
+    batch_size: int,
+    all_greedy: bool,
+    max_num_logprobs: int | None,
+):
+    """
+    Test that sampler always outputs int32 sampled_token_ids regardless of
+    whether logprobs are requested, and that the logprobs branch presence
+    matches the num_logprobs setting.
+    """
+    torch.set_default_device(device)
+    fake_logits = _create_fake_logits(batch_size, VOCAB_SIZE)
+    sampling_metadata = _create_default_sampling_metadata(
+        NUM_OUTPUT_TOKENS, batch_size, VOCAB_SIZE, torch.device(device)
+    )
+    sampling_metadata.max_num_logprobs = max_num_logprobs
+    if all_greedy:
+        sampling_metadata.temperature = torch.full((batch_size,), 0.0)
+        sampling_metadata.all_greedy = True
+        sampling_metadata.all_random = False
+    else:
+        sampling_metadata.temperature = torch.full((batch_size,), 1.0)
+        sampling_metadata.all_greedy = False
+        sampling_metadata.all_random = True
+
+    sampler = Sampler()
+    sampler_output = sampler.forward(fake_logits, sampling_metadata)
+
+    # Output token IDs must always be int32.
+    assert sampler_output.sampled_token_ids.dtype == torch.int32
+
+    if max_num_logprobs is None:
+        assert sampler_output.logprobs_tensors is None
+    else:
+        assert sampler_output.logprobs_tensors is not None
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
 @pytest.mark.parametrize("batch_size", [1, 2, 32])
 @pytest.mark.parametrize("presence_penalty", [-2.0, 2.0])
 def test_sampler_presence_penalty(

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -96,11 +96,6 @@ class Sampler(nn.Module):
         sampled, processed_logprobs = self.sample(logits, sampling_metadata)
         if processed_logprobs is not None:
             raw_logprobs = processed_logprobs
-        # Convert sampled token ids to int64 (long) type to ensure compatibility
-        # with subsequent operations that may use these values as indices.
-        # This conversion is necessary because FlashInfer sampling operations
-        # return int32 (while PyTorch argmax and topk return int64).
-        sampled = sampled.long()
 
         if num_logprobs is None:
             logprobs_tensors = None
@@ -111,12 +106,18 @@ class Sampler(nn.Module):
             )
         else:
             # Gather the logprobs and ranks of the topk and sampled token.
+            # gather_logprobs requires int64 token_ids for torch.gather
+            # indexing. Convert only here since this is the only branch
+            # that needs it.
             logprobs_tensors = self.gather_logprobs(
-                raw_logprobs, num_logprobs, token_ids=sampled
+                raw_logprobs, num_logprobs, token_ids=sampled.long()
             )
 
-        # Use int32 to reduce the tensor size.
-        sampled = sampled.to(torch.int32)
+        # Ensure int32 output for downstream consumers.
+        # FlashInfer sampling returns int32; PyTorch argmax/topk return
+        # int64. When sampled is already int32, this is a no-op.
+        if sampled.dtype != torch.int32:
+            sampled = sampled.to(torch.int32)
 
         # These are GPU tensors.
         sampler_output = SamplerOutput(


### PR DESCRIPTION


<!-- markdownlint-disable -->

## Purpose

  Only the gather_logprobs() path requires sampled token IDs in int64.
  Avoid converting sampled IDs to int64 on branches that do not call
  gather_logprobs(), and keep the final int32 cast conditional.

  Also add sampler tests covering None / -1 / positive num_logprobs
  across greedy and random sampling.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

