### PR TITLE
[Misc]: clean up non-core lint issues

### DIFF
--- a/benchmarks/attention_benchmarks/benchmark.py
+++ b/benchmarks/attention_benchmarks/benchmark.py
@@ -546,10 +546,7 @@ def main():
         args.prefill_backends = yaml_config.get("prefill_backends", None)
 
         # Check for special modes
-        if "mode" in yaml_config:
-            args.mode = yaml_config["mode"]
-        else:
-            args.mode = None
+        args.mode = yaml_config.get("mode", None)
 
         # Batch specs and sizes
         # Support both explicit batch_specs and generated batch_spec_ranges
@@ -572,10 +569,7 @@ def main():
             elif "batch_specs" in yaml_config:
                 args.batch_specs = yaml_config["batch_specs"]
 
-        if "batch_sizes" in yaml_config:
-            args.batch_sizes = yaml_config["batch_sizes"]
-        else:
-            args.batch_sizes = None
+        args.batch_sizes = yaml_config.get("batch_sizes", None)
 
         # Model config
         if "model" in yaml_config:

--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -153,7 +153,7 @@ class MarkdownFormatter(HelpFormatter):
             heading_md = f"{self._argument_heading_prefix} {option_strings}\n\n"
             self._markdown_output.append(heading_md)
 
-            if action.choices or isinstance(action.metavar, (list, tuple)):
+            if action.choices or isinstance(action.metavar, list | tuple):
                 choices_iterable = action.choices or action.metavar
                 choices = f"`{'`, `'.join(str(c) for c in choices_iterable)}`"
                 self._markdown_output.append(f":   Possible choices: {choices}\n\n")


### PR DESCRIPTION
## Purpose

Clean up a few small lint issues in non-core files:

- simplify two redundant `if/else` assignments in `benchmarks/attention_benchmarks/benchmark.py`
- modernize one `isinstance` check in `docs/mkdocs/hooks/generate_argparse.py`

These changes are limited to benchmarks/docs tooling and do not change core runtime behavior.

## Test Plan

Run:

```bash
ruff check benchmarks/attention_benchmarks/benchmark.py docs/mkdocs/hooks/generate_argparse.py --output-format concise
git diff -- benchmarks/attention_benchmarks/benchmark.py docs/mkdocs/hooks/generate_argparse.py
```
Test Result
```sh
ruff check benchmarks/attention_benchmarks/benchmark.py docs/mkdocs/hooks/generate_argparse.py --output-format concise
```
returned `All checks passed!`

`git diff ` shows only the intended non-core lint cleanup changes

- [x]  The purpose of the PR
- [x]  The test plan
- [x]  The test results

 - [ ]  Necessary documentation update
 - [ ]  Release notes update not needed