### PR TITLE
Update FP8 MoE backend selection for B200 (Blackwell)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1172,6 +1172,10 @@ class FusedMoEConfig:
     # kernel is free to use inplace or not.
     disable_inplace: bool = True
 
+    # The resolved model architecture string (e.g. "MiniMaxM2ForCausalLM").
+    # Used by the backend oracle to apply model-specific kernel selection rules.
+    model_arch: str | None = None
+
     def __post_init__(self):
         if self.dp_size > 1:
             logger.debug_once(

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -564,6 +564,11 @@ class FusedMoE(CustomOp):
             routing_method=self.routing_method_type,
             # TODO: in_dtype == out_dtype?
             disable_inplace=disable_inplace() or self._shared_experts is not None,
+            model_arch=(
+                vllm_config.model_config.architecture
+                if vllm_config.model_config is not None
+                else None
+            ),
         )
         if self.moe_config.use_mori_kernels:
             assert self.rocm_aiter_fmoe_enabled, (

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -296,6 +296,16 @@ def select_fp8_moe_backend(
             requested_backend, config, weight_key, activation_key, activation_format
         )
 
+    # On Blackwell (SM100+), FlashInfer FP8 MoE is not preferred by default.
+    # Remove FlashInfer backends unless the user has explicitly opted in.
+    if (
+        current_platform.is_cuda()
+        and current_platform.is_device_capability_family(100)
+        and not envs.is_set("VLLM_USE_FLASHINFER_MOE_FP8")
+    ):
+        AVAILABLE_BACKENDS.remove(Fp8MoeBackend.FLASHINFER_TRTLLM)
+        AVAILABLE_BACKENDS.remove(Fp8MoeBackend.FLASHINFER_CUTLASS)
+
     # Handle explicit FlashInfer FP8 configuration.
     if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP8"):
         if not envs.VLLM_USE_FLASHINFER_MOE_FP8:

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -296,10 +296,11 @@ def select_fp8_moe_backend(
             requested_backend, config, weight_key, activation_key, activation_format
         )
 
-    # On Blackwell (SM100+), FlashInfer FP8 MoE is not preferred by default.
-    # Remove FlashInfer backends unless the user has explicitly opted in.
+    # For MiniMaxM2 on Blackwell (SM100+), FlashInfer FP8 MoE backends are not
+    # preferred. Remove them unless the user has explicitly opted in.
     if (
-        current_platform.is_cuda()
+        config.model_arch == "MiniMaxM2ForCausalLM"
+        and current_platform.is_cuda()
         and current_platform.is_device_capability_family(100)
         and not envs.is_set("VLLM_USE_FLASHINFER_MOE_FP8")
     ):


### PR DESCRIPTION
Addressing the comment: https://github.com/vllm-project/recipes/pull/272/changes#r2933403229

- On Blackwell (SM100+) GPUs, FlashInfer FP8 MoE backends (`FLASHINFER_TRTLLM`, `FLASHINFER_CUTLASS`) are now removed from the default candidate list automatically, rather than requiring users to set `VLLM_USE_FLASHINFER_MOE_FP8=0`
- Users can still opt in explicitly by setting `VLLM_USE_FLASHINFER_MOE_FP8=1`, which restores the previous behavior

Recipe PR: https://github.com/vllm-project/recipes/pull/272
InferenceX PR: https://github.com/SemiAnalysisAI/InferenceX/pull/757