### PR TITLE
fix(moe): detect and handle unquantized MoE weights in NVFP4 checkpoints

### DIFF
--- a/tests/distributed/test_eplb_fused_moe_layer_dep_nvfp4.py
+++ b/tests/distributed/test_eplb_fused_moe_layer_dep_nvfp4.py
@@ -17,6 +17,9 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+    UnquantizedFusedMoEMethod,
+)
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptNvFp4Config,
     ModelOptNvFp4FusedMoE,
@@ -103,6 +106,149 @@ def make_fused_moe_layer(
     fml.maybe_init_modular_kernel()
 
     return fml
+
+
+def make_cpu_nvfp4_fused_moe(test_config: TestConfig) -> FusedMoE:
+    quant_config = ModelOptNvFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+
+    fml = FusedMoE(
+        num_experts=test_config.num_experts,
+        top_k=test_config.num_topk,
+        hidden_size=test_config.hidden_size,
+        intermediate_size=test_config.intermediate_size,
+        prefix="dummy_layer_cpu",
+        activation="silu",
+        is_act_and_mul=True,
+        params_dtype=torch.bfloat16,
+        quant_config=quant_config,
+    )
+
+    ModelOptNvFp4FusedMoE(quant_config, fml).create_weights(
+        fml,
+        test_config.num_local_experts,
+        test_config.hidden_size,
+        test_config.intermediate_size,
+        params_dtype=torch.uint8,
+        global_num_experts=test_config.num_experts,
+    )
+    return fml
+
+
+def test_nvfp4_moe_weight_loader_accepts_consistently_unquantized_weights():
+    test_config = TestConfig(
+        num_layers=1,
+        num_experts=2,
+        num_local_experts=2,
+        num_topk=1,
+        hidden_size=16,
+        intermediate_size=8,
+        num_tokens=4,
+    )
+    fml = make_cpu_nvfp4_fused_moe(test_config)
+
+    param = fml.w2_weight
+    packed_shape = tuple(param.data.shape)
+    unpacked_shape = list(param.data[0].shape)
+    unpacked_shape[-1] *= 2
+
+    expert_0 = torch.randn(unpacked_shape, dtype=torch.bfloat16)
+    expert_1 = torch.randn(unpacked_shape, dtype=torch.bfloat16)
+
+    fml.weight_loader(param, expert_0, "dummy_layer_cpu.w2_weight", "w2", 0)
+    fml.weight_loader(param, expert_1, "dummy_layer_cpu.w2_weight", "w2", 1)
+
+    assert isinstance(fml.quant_method, UnquantizedFusedMoEMethod)
+    assert isinstance(fml.base_quant_method, UnquantizedFusedMoEMethod)
+    assert param.data.dtype == torch.bfloat16
+    assert tuple(param.data.shape) == packed_shape[:-1] + (packed_shape[-1] * 2,)
+    torch.testing.assert_close(param.data[0], expert_0)
+    torch.testing.assert_close(param.data[1], expert_1)
+
+
+def test_nvfp4_moe_weight_loader_switches_to_unquantized_post_load_path():
+    test_config = TestConfig(
+        num_layers=1,
+        num_experts=2,
+        num_local_experts=2,
+        num_topk=1,
+        hidden_size=16,
+        intermediate_size=8,
+        num_tokens=4,
+    )
+    fml = make_cpu_nvfp4_fused_moe(test_config)
+
+    w13_shape = list(fml.w13_weight.data[0].shape)
+    w13_shape[-1] *= 2
+    w2_shape = list(fml.w2_weight.data[0].shape)
+    w2_shape[-1] *= 2
+
+    fml.weight_loader(
+        fml.w13_weight,
+        torch.randn(w13_shape, dtype=torch.bfloat16),
+        "dummy_layer_cpu.w13_weight",
+        "w13",
+        0,
+    )
+
+    for expert_id in range(test_config.num_local_experts):
+        if expert_id != 0:
+            fml.weight_loader(
+                fml.w13_weight,
+                torch.randn(w13_shape, dtype=torch.bfloat16),
+                "dummy_layer_cpu.w13_weight",
+                "w13",
+                expert_id,
+            )
+        fml.weight_loader(
+            fml.w2_weight,
+            torch.randn(w2_shape, dtype=torch.bfloat16),
+            "dummy_layer_cpu.w2_weight",
+            "w2",
+            expert_id,
+        )
+
+    assert isinstance(fml.quant_method, UnquantizedFusedMoEMethod)
+    assert isinstance(fml.base_quant_method, UnquantizedFusedMoEMethod)
+    assert fml.runner.quant_method is fml.quant_method
+
+    fml.quant_method.process_weights_after_loading(fml)
+
+    assert fml.w13_weight.dtype == torch.bfloat16
+    assert fml.w2_weight.dtype == torch.bfloat16
+
+
+def test_nvfp4_moe_weight_loader_rejects_mixed_packed_and_unpacked_weights():
+    test_config = TestConfig(
+        num_layers=1,
+        num_experts=2,
+        num_local_experts=2,
+        num_topk=1,
+        hidden_size=16,
+        intermediate_size=8,
+        num_tokens=4,
+    )
+    fml = make_cpu_nvfp4_fused_moe(test_config)
+
+    param = fml.w2_weight
+    packed_expert = torch.randint(0, 16, tuple(param.data[0].shape), dtype=torch.uint8)
+    unpacked_shape = list(param.data[0].shape)
+    unpacked_shape[-1] *= 2
+    unpacked_expert = torch.randn(unpacked_shape, dtype=torch.bfloat16)
+
+    fml.weight_loader(param, packed_expert, "dummy_layer_cpu.w2_weight", "w2", 0)
+
+    with pytest.raises(ValueError, match="consistent format per parameter"):
+        fml.weight_loader(
+            param,
+            unpacked_expert,
+            "dummy_layer_cpu.w2_weight",
+            "w2",
+            1,
+        )
 
 
 def _test_eplb_fml(env, world_size: int, test_config: TestConfig):

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -629,6 +629,13 @@ class FusedMoE(CustomOp):
 
         self.quant_method.create_weights(layer=self, **moe_quant_params)
         self.base_quant_method = self.quant_method
+        self._weight_loader_quant_method_name = self.quant_method.__class__.__name__
+        self._weight_loader_use_global_sf = getattr(
+            self.quant_method, "use_global_sf", False
+        )
+        self._weight_loader_uses_weight_scale_2 = (
+            self.quant_method.uses_weight_scale_2_pattern()
+        )
 
         # Disable shared expert overlap if:
         #   - we are using eplb with non-default backend, because of correctness issues
@@ -1077,13 +1084,12 @@ class FusedMoE(CustomOp):
                 param.data[:, :dim1, :dim2].copy_(loaded_weight)
             return True if return_success else None
 
-        quant_method_name = self.quant_method.__class__.__name__
+        quant_method_name = self._weight_loader_quant_method_name
         global_expert_id = expert_id
         expert_id = self._map_global_expert_id_to_local_expert_id(global_expert_id)
 
         use_global_sf = (
-            getattr(self.quant_method, "use_global_sf", False)
-            and "input_scale" in weight_name
+            self._weight_loader_use_global_sf and "input_scale" in weight_name
         )
 
         if expert_id == -1 and not use_global_sf:
@@ -1202,9 +1208,63 @@ class FusedMoE(CustomOp):
 
         # TODO @dsikka: ModelOpt should follow the proper MoE loading pattern
         if "ModelOpt" in quant_method_name:
+            if (
+                "NvFp4" in quant_method_name
+                and "weight" in weight_name
+                and "scale" not in weight_name
+            ):
+                format_attr = "_modelopt_nvfp4_moe_weight_format"
+                loaded_is_unquantized = loaded_weight.dtype in (
+                    torch.bfloat16,
+                    torch.float16,
+                    torch.float32,
+                )
+                loaded_format = "unpacked" if loaded_is_unquantized else "packed"
+                param_format = getattr(param, format_attr, None)
+
+                if param_format is not None and param_format != loaded_format:
+                    raise ValueError(
+                        "ModelOpt NVFP4 MoE checkpoints must use a consistent "
+                        f"format per parameter. Found {loaded_format} weights "
+                        f"for {weight_name} after loading {param_format} experts."
+                    )
+
+                if loaded_is_unquantized and param.data.dtype == torch.uint8:
+                    logger.warning_once(
+                        f"NVFP4 MoE checkpoint has unquantized weights "
+                        f"(found {loaded_weight.dtype}, expected uint8). "
+                        f"Falling back to unquantized loading for MoE experts."
+                    )
+                    if not isinstance(self.quant_method, UnquantizedFusedMoEMethod):
+                        unquantized_method = UnquantizedFusedMoEMethod(self.moe_config)
+                        self._replace_quant_method(unquantized_method)
+                        self.base_quant_method = unquantized_method
+                    # The param was created for packed FP4 (half-sized last dim),
+                    # but the checkpoint stores full-width expert weights.
+                    new_shape = list(param.data.shape)
+                    new_shape[-1] *= 2
+                    param.data = torch.zeros(
+                        new_shape,
+                        dtype=loaded_weight.dtype,
+                        device=param.data.device,
+                    )
+                    expert_data = param.data if full_load else param.data[expert_id]
+
+                setattr(param, format_attr, loaded_format)
+
+                if loaded_is_unquantized:
+                    self._load_model_weight_or_group_weight_scale(
+                        shard_id=shard_id,
+                        shard_dim=shard_dim,
+                        loaded_weight=loaded_weight,
+                        expert_data=expert_data,
+                        tp_rank=self.tp_rank,
+                    )
+                    return True if return_success else None
+
             # Determine per-tensor weight scale patterns based on variant
             # Use the dedicated method instead of brittle string matching
-            uses_weight_scale_2 = self.quant_method.uses_weight_scale_2_pattern()
+            uses_weight_scale_2 = self._weight_loader_uses_weight_scale_2
             quant_method = getattr(param, "quant_method", None)
 
             # Call _load_per_tensor_weight_scale() to load per-tensor (scalar)


### PR DESCRIPTION
## Summary

ModelOpt NVFP4 exports can leave MoE expert weights unquantized while the checkpoint metadata still says NVFP4. In that case, vLLM allocates packed `uint8` tensors for the MoE weights, but the checkpoint can contain `bf16`/`fp16`/`fp32` tensors instead, which causes loading to fail.

I originally built this for myself while experimenting with local models on my DGX Spark, but a couple of comments on the fork PR suggested this may be useful upstream too.

Original fork PR and discussion:
https://github.com/Th0rgal/vllm/pull/2

Thanks for the nudge here, @catswe and @voipmonitor.

## Changes

- Detect unquantized MoE expert weights in ModelOpt NVFP4 checkpoints during load.
- Log a warning once when mixed quantization is detected.
- Resize the target parameter tensor back to the unpacked shape and switch dtype to match the checkpoint tensor.
- Fall back to the standard unquantized loading path for the affected experts.

## Limitations

- This fixes loading for affected layers only.
- Full inference support may still require kernel selection changes for unquantized MoE experts.
- The ideal long-term fix is likely on the ModelOpt export side so these checkpoints are emitted consistently.

## Testing

Tested with GLM-4.7-Flash quantized using ModelOpt 0.35.0 on a DGX Spark GB10 GPU.
