### PR TITLE
Fuse fp8 quant merge attn states vec128

### DIFF
--- a/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
+++ b/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
@@ -219,22 +219,35 @@ def bench_fp8_fused_vs_unfused(
         iters,
     )
 
-    # -- Unfused: CUDA merge (input_dtype output) + scaled_fp8_quant --
-    output_merge_buf = torch.empty(
+    # -- Unfused CUDA: CUDA merge (input_dtype output) + scaled_fp8_quant --
+    output_merge_buf_cuda = torch.empty(
         (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
     )
-    # scaled_fp8_quant expects 2-D input [M, N]
-    merge_buf_2d = output_merge_buf.view(-1, head_size)
-    # Static scale for quant (same value as fused path)
+    merge_buf_cuda_2d = output_merge_buf_cuda.view(-1, head_size)
     quant_scale = output_scale.clone()
 
-    def unfused_fn():
+    def unfused_cuda_fn():
         merge_attn_states_cuda(
-            output_merge_buf, prefix_out, prefix_lse, suffix_out, suffix_lse
+            output_merge_buf_cuda, prefix_out, prefix_lse, suffix_out, suffix_lse
         )
-        ops.scaled_fp8_quant(merge_buf_2d, quant_scale)
+        ops.scaled_fp8_quant(merge_buf_cuda_2d, quant_scale)
 
-    t_unfused = bench_fn(unfused_fn, warmup, iters)
+    t_unfused_cuda = bench_fn(unfused_cuda_fn, warmup, iters)
+
+    # -- Unfused Triton: Triton merge (input_dtype output) + scaled_fp8_quant --
+    output_merge_buf_triton = torch.empty(
+        (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
+    )
+    merge_buf_triton_2d = output_merge_buf_triton.view(-1, head_size)
+    quant_scale_triton = output_scale.clone()
+
+    def unfused_triton_fn():
+        merge_attn_states_triton(
+            output_merge_buf_triton, prefix_out, prefix_lse, suffix_out, suffix_lse
+        )
+        ops.scaled_fp8_quant(merge_buf_triton_2d, quant_scale_triton)
+
+    t_unfused_triton = bench_fn(unfused_triton_fn, warmup, iters)
 
     return [
         BenchResult(
@@ -261,8 +274,17 @@ def bench_fp8_fused_vs_unfused(
             num_heads,
             head_size,
             input_dtype,
-            "fp8_unfused",
-            t_unfused,
+            "fp8_unfused_cuda",
+            t_unfused_cuda,
+        ),
+        BenchResult(
+            config_label,
+            num_tokens,
+            num_heads,
+            head_size,
+            input_dtype,
+            "fp8_unfused_triton",
+            t_unfused_triton,
         ),
     ]
 
@@ -273,7 +295,7 @@ def bench_fp8_fused_vs_unfused(
 
 
 def print_fp8_table(results: list[BenchResult]):
-    """Print a comparison table: fused CUDA / fused Triton / unfused."""
+    """Print a comparison table: fused vs unfused for both CUDA and Triton."""
     from collections import defaultdict
 
     groups: dict[tuple, dict[str, float]] = defaultdict(dict)
@@ -286,8 +308,8 @@ def print_fp8_table(results: list[BenchResult]):
     header = (
         f"{'Config':<18} {'Tokens':>6} {'Heads':>5} {'Hdim':>5} "
         f"{'InDtype':<10} "
-        f"{'FusedCUDA':>11} {'FusedTriton':>13} {'Unfused':>11} "
-        f"{'SpeedupCUDA':>12} {'SpeedupTriton':>14}"
+        f"{'FuCUDA':>9} {'UnfCUDA':>10} {'SpdCUDA':>8} "
+        f"{'FuTriton':>11} {'UnfTriton':>12} {'SpdTriton':>10}"
     )
     sep = "-" * len(header)
 
@@ -303,18 +325,20 @@ def print_fp8_table(results: list[BenchResult]):
         g = groups[key]
         t_fused_cuda = g.get("fp8_fused_cuda", float("nan"))
         t_fused_triton = g.get("fp8_fused_triton", float("nan"))
-        t_unfused = g.get("fp8_unfused", float("nan"))
-        speedup_cuda = t_unfused / t_fused_cuda if t_fused_cuda > 0 else float("nan")
-        speedup_triton = (
-            t_unfused / t_fused_triton if t_fused_triton > 0 else float("nan")
+        t_unfused_cuda = g.get("fp8_unfused_cuda", float("nan"))
+        t_unfused_triton = g.get("fp8_unfused_triton", float("nan"))
+        spd_cuda = t_unfused_cuda / t_fused_cuda if t_fused_cuda > 0 else float("nan")
+        spd_triton = (
+            t_unfused_triton / t_fused_triton if t_fused_triton > 0 else float("nan")
         )
         print(
             f"{config_label:<18} {num_tokens:>6} {num_heads:>5} "
             f"{head_size:>5} "
             f"{short_dtype(input_dtype):<10} "
-            f"{t_fused_cuda:>9.1f}us {t_fused_triton:>11.1f}us "
-            f"{t_unfused:>9.1f}us "
-            f"{speedup_cuda:>11.2f}x {speedup_triton:>13.2f}x"
+            f"{t_fused_cuda:>7.1f}us {t_unfused_cuda:>8.1f}us "
+            f"{spd_cuda:>7.2f}x "
+            f"{t_fused_triton:>9.1f}us {t_unfused_triton:>10.1f}us "
+            f"{spd_triton:>9.2f}x"
         )
     print(sep)
 

--- a/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
+++ b/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
@@ -36,7 +36,7 @@ NUM_TOKENS_LIST = [1, 16, 64, 256, 1024, 4096]
 
 # (label, num_heads, head_size)
 HEAD_CONFIGS = [
-    ("DeepSeek-V3 MLA", 128, 512),
+    ("DeepSeek-V3 MLA", 128, 128),
     ("Llama-70B", 64, 128),
     ("Llama-8B", 32, 128),
 ]

--- a/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
+++ b/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
@@ -1,0 +1,452 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Benchmark: Fused FP8 output quantization in merge_attn_states
+
+Compares three approaches for producing FP8-quantized merged attention output:
+  1. CUDA  fused  -- single CUDA kernel (merge + FP8 quant)
+  2. Triton fused -- single Triton kernel (merge + FP8 quant)
+  3. Unfused       -- CUDA merge (BF16 output) + separate scaled_fp8_quant
+
+Also benchmarks the non-quantized (BF16/FP16/FP32) merge kernels for
+reference.
+
+Usage:
+    python benchmarks/fused_kernels/merge_attn_states_benchmarks.py
+"""
+
+import argparse
+import itertools
+from dataclasses import dataclass
+
+import torch
+
+import vllm._custom_ops as ops
+from vllm._custom_ops import merge_attn_states as merge_attn_states_cuda
+from vllm.platforms import current_platform
+from vllm.v1.attention.ops.triton_merge_attn_states import (
+    merge_attn_states as merge_attn_states_triton,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration defaults
+# ---------------------------------------------------------------------------
+
+NUM_TOKENS_LIST = [1, 16, 64, 256, 1024, 4096]
+
+# (label, num_heads, head_size)
+HEAD_CONFIGS = [
+    ("DeepSeek-V3 MLA", 128, 512),
+    ("Llama-70B", 64, 128),
+    ("Llama-8B", 32, 128),
+]
+
+INPUT_DTYPES = [torch.float32, torch.float16, torch.bfloat16]
+
+DEFAULT_WARMUP = 10
+DEFAULT_ITERS = 50
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchResult:
+    config_label: str
+    num_tokens: int
+    num_heads: int
+    head_size: int
+    input_dtype: torch.dtype
+    mode: str  # "fp8_fused_cuda", "fp8_fused_triton", "fp8_unfused", etc.
+    time_us: float
+
+
+def short_dtype(dtype: torch.dtype) -> str:
+    return str(dtype).removeprefix("torch.")
+
+
+def make_inputs(
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+):
+    """Create random prefix/suffix outputs and LSEs."""
+    prefix_output = torch.randn(
+        (num_tokens, num_heads, head_size), dtype=dtype, device="cuda"
+    )
+    suffix_output = torch.randn(
+        (num_tokens, num_heads, head_size), dtype=dtype, device="cuda"
+    )
+    prefix_lse = torch.randn(num_heads, num_tokens, dtype=torch.float32, device="cuda")
+    suffix_lse = torch.randn(num_heads, num_tokens, dtype=torch.float32, device="cuda")
+    # Sprinkle some inf values to exercise edge-case paths
+    mask = torch.rand(num_heads, num_tokens, device="cuda") < 0.05
+    prefix_lse[mask] = float("inf")
+    mask2 = torch.rand(num_heads, num_tokens, device="cuda") < 0.05
+    suffix_lse[mask2] = float("inf")
+    return prefix_output, suffix_output, prefix_lse, suffix_lse
+
+
+def bench_fn(fn, warmup: int, iters: int) -> float:
+    """Time *fn* using CUDA events. Returns mean elapsed time in
+    microseconds."""
+    for _ in range(warmup):
+        fn()
+    torch.accelerator.synchronize()
+
+    start = torch.Event(enable_timing=True)
+    end = torch.Event(enable_timing=True)
+    times_ms: list[float] = []
+    for _ in range(iters):
+        start.record()
+        fn()
+        end.record()
+        torch.accelerator.synchronize()
+        times_ms.append(start.elapsed_time(end))
+
+    mean_ms = sum(times_ms) / len(times_ms)
+    return mean_ms * 1000.0  # convert to microseconds
+
+
+# ---------------------------------------------------------------------------
+# Benchmark routines
+# ---------------------------------------------------------------------------
+
+
+def bench_nonfp8(
+    config_label: str,
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    warmup: int,
+    iters: int,
+) -> list[BenchResult]:
+    """Benchmark non-quantized merge_attn_states (CUDA vs Triton)."""
+    prefix_out, suffix_out, prefix_lse, suffix_lse = make_inputs(
+        num_tokens, num_heads, head_size, dtype
+    )
+    output_cuda = torch.empty_like(prefix_out)
+    output_triton = torch.empty_like(prefix_out)
+
+    t_cuda = bench_fn(
+        lambda: merge_attn_states_cuda(
+            output_cuda, prefix_out, prefix_lse, suffix_out, suffix_lse
+        ),
+        warmup,
+        iters,
+    )
+    t_triton = bench_fn(
+        lambda: merge_attn_states_triton(
+            output_triton, prefix_out, prefix_lse, suffix_out, suffix_lse
+        ),
+        warmup,
+        iters,
+    )
+
+    return [
+        BenchResult(
+            config_label,
+            num_tokens,
+            num_heads,
+            head_size,
+            dtype,
+            f"cuda_{short_dtype(dtype)}",
+            t_cuda,
+        ),
+        BenchResult(
+            config_label,
+            num_tokens,
+            num_heads,
+            head_size,
+            dtype,
+            f"triton_{short_dtype(dtype)}",
+            t_triton,
+        ),
+    ]
+
+
+def bench_fp8_fused_vs_unfused(
+    config_label: str,
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    input_dtype: torch.dtype,
+    warmup: int,
+    iters: int,
+) -> list[BenchResult]:
+    """Benchmark fused FP8 merge (CUDA & Triton) vs unfused merge+quant."""
+    fp8_dtype = current_platform.fp8_dtype()
+    prefix_out, suffix_out, prefix_lse, suffix_lse = make_inputs(
+        num_tokens, num_heads, head_size, input_dtype
+    )
+    output_scale = torch.tensor([0.1], dtype=torch.float32, device="cuda")
+
+    # -- Fused CUDA --
+    output_fused_cuda = torch.empty(
+        (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
+    )
+    t_fused_cuda = bench_fn(
+        lambda: merge_attn_states_cuda(
+            output_fused_cuda,
+            prefix_out,
+            prefix_lse,
+            suffix_out,
+            suffix_lse,
+            output_scale=output_scale,
+        ),
+        warmup,
+        iters,
+    )
+
+    # -- Fused Triton --
+    output_fused_triton = torch.empty(
+        (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
+    )
+    t_fused_triton = bench_fn(
+        lambda: merge_attn_states_triton(
+            output_fused_triton,
+            prefix_out,
+            prefix_lse,
+            suffix_out,
+            suffix_lse,
+            output_scale=output_scale,
+        ),
+        warmup,
+        iters,
+    )
+
+    # -- Unfused: CUDA merge (input_dtype output) + scaled_fp8_quant --
+    output_merge_buf = torch.empty(
+        (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
+    )
+    # scaled_fp8_quant expects 2-D input [M, N]
+    merge_buf_2d = output_merge_buf.view(-1, head_size)
+    # Static scale for quant (same value as fused path)
+    quant_scale = output_scale.clone()
+
+    def unfused_fn():
+        merge_attn_states_cuda(
+            output_merge_buf, prefix_out, prefix_lse, suffix_out, suffix_lse
+        )
+        ops.scaled_fp8_quant(merge_buf_2d, quant_scale)
+
+    t_unfused = bench_fn(unfused_fn, warmup, iters)
+
+    return [
+        BenchResult(
+            config_label,
+            num_tokens,
+            num_heads,
+            head_size,
+            input_dtype,
+            "fp8_fused_cuda",
+            t_fused_cuda,
+        ),
+        BenchResult(
+            config_label,
+            num_tokens,
+            num_heads,
+            head_size,
+            input_dtype,
+            "fp8_fused_triton",
+            t_fused_triton,
+        ),
+        BenchResult(
+            config_label,
+            num_tokens,
+            num_heads,
+            head_size,
+            input_dtype,
+            "fp8_unfused",
+            t_unfused,
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Table printing
+# ---------------------------------------------------------------------------
+
+
+def print_fp8_table(results: list[BenchResult]):
+    """Print a comparison table: fused CUDA / fused Triton / unfused."""
+    from collections import defaultdict
+
+    groups: dict[tuple, dict[str, float]] = defaultdict(dict)
+    meta: dict[tuple, tuple] = {}
+    for r in results:
+        key = (r.config_label, r.num_tokens, r.input_dtype)
+        groups[key][r.mode] = r.time_us
+        meta[key] = (r.num_heads, r.head_size)
+
+    header = (
+        f"{'Config':<18} {'Tokens':>6} {'Heads':>5} {'Hdim':>5} "
+        f"{'InDtype':<10} "
+        f"{'FusedCUDA':>11} {'FusedTriton':>13} {'Unfused':>11} "
+        f"{'SpeedupCUDA':>12} {'SpeedupTriton':>14}"
+    )
+    sep = "-" * len(header)
+
+    print("\n" + sep)
+    print("FP8 Fused vs Unfused merge_attn_states")
+    print(sep)
+    print(header)
+    print(sep)
+
+    for key in sorted(groups.keys(), key=lambda k: (k[0], str(k[2]), k[1])):
+        config_label, num_tokens, input_dtype = key
+        num_heads, head_size = meta[key]
+        g = groups[key]
+        t_fused_cuda = g.get("fp8_fused_cuda", float("nan"))
+        t_fused_triton = g.get("fp8_fused_triton", float("nan"))
+        t_unfused = g.get("fp8_unfused", float("nan"))
+        speedup_cuda = t_unfused / t_fused_cuda if t_fused_cuda > 0 else float("nan")
+        speedup_triton = (
+            t_unfused / t_fused_triton if t_fused_triton > 0 else float("nan")
+        )
+        print(
+            f"{config_label:<18} {num_tokens:>6} {num_heads:>5} "
+            f"{head_size:>5} "
+            f"{short_dtype(input_dtype):<10} "
+            f"{t_fused_cuda:>9.1f}us {t_fused_triton:>11.1f}us "
+            f"{t_unfused:>9.1f}us "
+            f"{speedup_cuda:>11.2f}x {speedup_triton:>13.2f}x"
+        )
+    print(sep)
+
+
+def print_nonfp8_table(results: list[BenchResult]):
+    """Print a comparison table for non-quantized merge: CUDA vs Triton."""
+    from collections import defaultdict
+
+    groups: dict[tuple, dict[str, float]] = defaultdict(dict)
+    meta: dict[tuple, tuple] = {}
+    for r in results:
+        key = (r.config_label, r.num_tokens, r.input_dtype)
+        groups[key][r.mode] = r.time_us
+        meta[key] = (r.num_heads, r.head_size)
+
+    header = (
+        f"{'Config':<18} {'Tokens':>6} {'Heads':>5} {'Hdim':>5} "
+        f"{'Dtype':<10} "
+        f"{'CUDA':>11} {'Triton':>11} {'Speedup':>8}"
+    )
+    sep = "-" * len(header)
+
+    print("\n" + sep)
+    print("Non-FP8 merge_attn_states: CUDA vs Triton")
+    print(sep)
+    print(header)
+    print(sep)
+
+    for key in sorted(groups.keys(), key=lambda k: (k[0], str(k[2]), k[1])):
+        config_label, num_tokens, input_dtype = key
+        num_heads, head_size = meta[key]
+        g = groups[key]
+        dtype_str = short_dtype(input_dtype)
+        t_cuda = g.get(f"cuda_{dtype_str}", float("nan"))
+        t_triton = g.get(f"triton_{dtype_str}", float("nan"))
+        speedup = t_triton / t_cuda if t_cuda > 0 else float("nan")
+        print(
+            f"{config_label:<18} {num_tokens:>6} {num_heads:>5} "
+            f"{head_size:>5} "
+            f"{dtype_str:<10} "
+            f"{t_cuda:>9.1f}us {t_triton:>9.1f}us {speedup:>7.2f}x"
+        )
+    print(sep)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark merge_attn_states fused FP8 quantization"
+    )
+    parser.add_argument(
+        "--fp8-only",
+        action="store_true",
+        help="Only run FP8 fused-vs-unfused benchmarks (skip non-FP8)",
+    )
+    parser.add_argument(
+        "--nonfp8-only",
+        action="store_true",
+        help="Only run non-FP8 CUDA-vs-Triton benchmarks (skip FP8)",
+    )
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        nargs="+",
+        default=None,
+        help=f"Override token counts (default: {NUM_TOKENS_LIST})",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=DEFAULT_WARMUP,
+        help=f"Warmup iterations (default: {DEFAULT_WARMUP})",
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=DEFAULT_ITERS,
+        help=f"Benchmark iterations (default: {DEFAULT_ITERS})",
+    )
+    args = parser.parse_args()
+
+    warmup = args.warmup
+    iters = args.iters
+    num_tokens_list = args.num_tokens if args.num_tokens else NUM_TOKENS_LIST
+
+    device_name = current_platform.get_device_name()
+    print(f"Device: {device_name}")
+    print(f"Warmup: {warmup}, Bench iters: {iters}")
+    print(f"Token counts: {num_tokens_list}")
+    print(f"Head configs: {[(c[0], c[1], c[2]) for c in HEAD_CONFIGS]}")
+    print(f"Input dtypes: {[short_dtype(d) for d in INPUT_DTYPES]}")
+
+    run_fp8 = not args.nonfp8_only
+    run_nonfp8 = not args.fp8_only
+
+    # --- Non-FP8 benchmarks ---
+    if run_nonfp8:
+        nonfp8_results: list[BenchResult] = []
+        configs = list(itertools.product(HEAD_CONFIGS, num_tokens_list, INPUT_DTYPES))
+        for count, ((label, nh, hs), nt, dtype) in enumerate(configs, 1):
+            print(
+                f"\r  Non-FP8 [{count}/{len(configs)}] "
+                f"{label} tokens={nt} dtype={short_dtype(dtype)}    ",
+                end="",
+                flush=True,
+            )
+            nonfp8_results.extend(bench_nonfp8(label, nt, nh, hs, dtype, warmup, iters))
+        print()
+        print_nonfp8_table(nonfp8_results)
+
+    # --- FP8 fused vs unfused benchmarks ---
+    if run_fp8:
+        fp8_results: list[BenchResult] = []
+        configs = list(itertools.product(HEAD_CONFIGS, num_tokens_list, INPUT_DTYPES))
+        for count, ((label, nh, hs), nt, dtype) in enumerate(configs, 1):
+            print(
+                f"\r  FP8 [{count}/{len(configs)}] "
+                f"{label} tokens={nt} dtype={short_dtype(dtype)}    ",
+                end="",
+                flush=True,
+            )
+            fp8_results.extend(
+                bench_fp8_fused_vs_unfused(label, nt, nh, hs, dtype, warmup, iters)
+            )
+        print()
+        print_fp8_table(fp8_results)
+
+
+if __name__ == "__main__":
+    with torch.inference_mode():
+        main()

--- a/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
+++ b/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
@@ -3,27 +3,30 @@
 """
 Benchmark: Fused FP8 output quantization in merge_attn_states
 
-Compares three approaches for producing FP8-quantized merged attention output:
-  1. CUDA  fused  -- single CUDA kernel (merge + FP8 quant)
-  2. Triton fused -- single Triton kernel (merge + FP8 quant)
-  3. Unfused       -- CUDA merge (BF16 output) + separate scaled_fp8_quant
-
-Also benchmarks the non-quantized (BF16/FP16/FP32) merge kernels for
-reference.
+Compares fused vs unfused approaches for producing FP8-quantized merged
+attention output:
+  1. Fused CUDA     -- single CUDA kernel (merge + FP8 quant)
+  2. Fused Triton   -- single Triton kernel (merge + FP8 quant)
+  3. Unfused CUDA   -- CUDA merge + torch.compiled FP8 quant
+  4. Unfused Triton  -- Triton merge + torch.compiled FP8 quant
 
 Usage:
     python benchmarks/fused_kernels/merge_attn_states_benchmarks.py
+    python benchmarks/fused_kernels/merge_attn_states_benchmarks.py --tp 1 4 8
+    python benchmarks/fused_kernels/merge_attn_states_benchmarks.py --dtype bfloat16
 """
 
 import argparse
 import itertools
-from dataclasses import dataclass
 
 import torch
 
-import vllm._custom_ops as ops
 from vllm._custom_ops import merge_attn_states as merge_attn_states_cuda
+from vllm.benchmarks.lib.utils import default_vllm_config
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.platforms import current_platform
+from vllm.triton_utils import triton
 from vllm.v1.attention.ops.triton_merge_attn_states import (
     merge_attn_states as merge_attn_states_triton,
 )
@@ -34,33 +37,23 @@ from vllm.v1.attention.ops.triton_merge_attn_states import (
 
 NUM_TOKENS_LIST = [1, 16, 64, 256, 1024, 4096]
 
-# (label, num_heads, head_size)
+# (label, num_heads, head_size) — num_heads is for TP=1
 HEAD_CONFIGS = [
     ("DeepSeek-V3 MLA", 128, 128),
     ("Llama-70B", 64, 128),
     ("Llama-8B", 32, 128),
 ]
 
+TP_SIZES = [1, 2, 4, 8]
+
 INPUT_DTYPES = [torch.float32, torch.float16, torch.bfloat16]
 
-DEFAULT_WARMUP = 10
-DEFAULT_ITERS = 50
+QUANTILES = [0.5, 0.2, 0.8]
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-@dataclass
-class BenchResult:
-    config_label: str
-    num_tokens: int
-    num_heads: int
-    head_size: int
-    input_dtype: torch.dtype
-    mode: str  # "fp8_fused_cuda", "fp8_fused_triton", "fp8_unfused", etc.
-    time_us: float
 
 
 def short_dtype(dtype: torch.dtype) -> str:
@@ -90,318 +83,22 @@ def make_inputs(
     return prefix_output, suffix_output, prefix_lse, suffix_lse
 
 
-def bench_fn(fn, warmup: int, iters: int) -> float:
-    """Time *fn* using CUDA events. Returns mean elapsed time in
-    microseconds."""
-    for _ in range(warmup):
-        fn()
-    torch.accelerator.synchronize()
-
-    start = torch.Event(enable_timing=True)
-    end = torch.Event(enable_timing=True)
-    times_ms: list[float] = []
-    for _ in range(iters):
-        start.record()
-        fn()
-        end.record()
-        torch.accelerator.synchronize()
-        times_ms.append(start.elapsed_time(end))
-
-    mean_ms = sum(times_ms) / len(times_ms)
-    return mean_ms * 1000.0  # convert to microseconds
+def build_configs(head_configs, num_tokens_list, input_dtypes, tp_sizes):
+    """Build (num_tokens, num_heads, head_size, dtype_str) config tuples,
+    applying TP division to num_heads and skipping invalid combos."""
+    configs = []
+    for (_, nh, hs), nt, dtype, tp in itertools.product(
+        head_configs, num_tokens_list, input_dtypes, tp_sizes
+    ):
+        nh_tp = nh // tp
+        if nh_tp >= 1:
+            configs.append((nt, nh_tp, hs, short_dtype(dtype)))
+    return configs
 
 
-# ---------------------------------------------------------------------------
-# Benchmark routines
-# ---------------------------------------------------------------------------
-
-
-def bench_nonfp8(
-    config_label: str,
-    num_tokens: int,
-    num_heads: int,
-    head_size: int,
-    dtype: torch.dtype,
-    warmup: int,
-    iters: int,
-) -> list[BenchResult]:
-    """Benchmark non-quantized merge_attn_states (CUDA vs Triton)."""
-    prefix_out, suffix_out, prefix_lse, suffix_lse = make_inputs(
-        num_tokens, num_heads, head_size, dtype
-    )
-    output_cuda = torch.empty_like(prefix_out)
-    output_triton = torch.empty_like(prefix_out)
-
-    t_cuda = bench_fn(
-        lambda: merge_attn_states_cuda(
-            output_cuda, prefix_out, prefix_lse, suffix_out, suffix_lse
-        ),
-        warmup,
-        iters,
-    )
-    t_triton = bench_fn(
-        lambda: merge_attn_states_triton(
-            output_triton, prefix_out, prefix_lse, suffix_out, suffix_lse
-        ),
-        warmup,
-        iters,
-    )
-
-    return [
-        BenchResult(
-            config_label,
-            num_tokens,
-            num_heads,
-            head_size,
-            dtype,
-            f"cuda_{short_dtype(dtype)}",
-            t_cuda,
-        ),
-        BenchResult(
-            config_label,
-            num_tokens,
-            num_heads,
-            head_size,
-            dtype,
-            f"triton_{short_dtype(dtype)}",
-            t_triton,
-        ),
-    ]
-
-
-def bench_fp8_fused_vs_unfused(
-    config_label: str,
-    num_tokens: int,
-    num_heads: int,
-    head_size: int,
-    input_dtype: torch.dtype,
-    warmup: int,
-    iters: int,
-) -> list[BenchResult]:
-    """Benchmark fused FP8 merge (CUDA & Triton) vs unfused merge+quant."""
-    fp8_dtype = current_platform.fp8_dtype()
-    prefix_out, suffix_out, prefix_lse, suffix_lse = make_inputs(
-        num_tokens, num_heads, head_size, input_dtype
-    )
-    output_scale = torch.tensor([0.1], dtype=torch.float32, device="cuda")
-
-    # -- Fused CUDA --
-    output_fused_cuda = torch.empty(
-        (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
-    )
-    t_fused_cuda = bench_fn(
-        lambda: merge_attn_states_cuda(
-            output_fused_cuda,
-            prefix_out,
-            prefix_lse,
-            suffix_out,
-            suffix_lse,
-            output_scale=output_scale,
-        ),
-        warmup,
-        iters,
-    )
-
-    # -- Fused Triton --
-    output_fused_triton = torch.empty(
-        (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
-    )
-    t_fused_triton = bench_fn(
-        lambda: merge_attn_states_triton(
-            output_fused_triton,
-            prefix_out,
-            prefix_lse,
-            suffix_out,
-            suffix_lse,
-            output_scale=output_scale,
-        ),
-        warmup,
-        iters,
-    )
-
-    # -- Unfused CUDA: CUDA merge (input_dtype output) + scaled_fp8_quant --
-    output_merge_buf_cuda = torch.empty(
-        (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
-    )
-    merge_buf_cuda_2d = output_merge_buf_cuda.view(-1, head_size)
-    quant_scale = output_scale.clone()
-
-    def unfused_cuda_fn():
-        merge_attn_states_cuda(
-            output_merge_buf_cuda, prefix_out, prefix_lse, suffix_out, suffix_lse
-        )
-        ops.scaled_fp8_quant(merge_buf_cuda_2d, quant_scale)
-
-    t_unfused_cuda = bench_fn(unfused_cuda_fn, warmup, iters)
-
-    # -- Unfused Triton: Triton merge (input_dtype output) + scaled_fp8_quant --
-    output_merge_buf_triton = torch.empty(
-        (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
-    )
-    merge_buf_triton_2d = output_merge_buf_triton.view(-1, head_size)
-    quant_scale_triton = output_scale.clone()
-
-    def unfused_triton_fn():
-        merge_attn_states_triton(
-            output_merge_buf_triton, prefix_out, prefix_lse, suffix_out, suffix_lse
-        )
-        ops.scaled_fp8_quant(merge_buf_triton_2d, quant_scale_triton)
-
-    t_unfused_triton = bench_fn(unfused_triton_fn, warmup, iters)
-
-    return [
-        BenchResult(
-            config_label,
-            num_tokens,
-            num_heads,
-            head_size,
-            input_dtype,
-            "fp8_fused_cuda",
-            t_fused_cuda,
-        ),
-        BenchResult(
-            config_label,
-            num_tokens,
-            num_heads,
-            head_size,
-            input_dtype,
-            "fp8_fused_triton",
-            t_fused_triton,
-        ),
-        BenchResult(
-            config_label,
-            num_tokens,
-            num_heads,
-            head_size,
-            input_dtype,
-            "fp8_unfused_cuda",
-            t_unfused_cuda,
-        ),
-        BenchResult(
-            config_label,
-            num_tokens,
-            num_heads,
-            head_size,
-            input_dtype,
-            "fp8_unfused_triton",
-            t_unfused_triton,
-        ),
-    ]
-
-
-# ---------------------------------------------------------------------------
-# Table printing
-# ---------------------------------------------------------------------------
-
-
-def print_fp8_table(results: list[BenchResult]):
-    """Print a comparison table: fused vs unfused for both CUDA and Triton."""
-    from collections import defaultdict
-
-    groups: dict[tuple, dict[str, float]] = defaultdict(dict)
-    meta: dict[tuple, tuple] = {}
-    for r in results:
-        key = (r.config_label, r.num_tokens, r.input_dtype)
-        groups[key][r.mode] = r.time_us
-        meta[key] = (r.num_heads, r.head_size)
-
-    header = (
-        f"{'Config':<18} {'Tokens':>6} {'Heads':>5} {'Hdim':>5} "
-        f"{'InDtype':<10} "
-        f"{'FuCUDA':>9} {'UnfCUDA':>10} {'SpdCUDA':>8} "
-        f"{'FuTriton':>11} {'UnfTriton':>12} {'SpdTriton':>10}"
-    )
-    sep = "-" * len(header)
-
-    print("\n" + sep)
-    print("FP8 Fused vs Unfused merge_attn_states")
-    print(sep)
-    print(header)
-    print(sep)
-
-    for key in sorted(groups.keys(), key=lambda k: (k[0], str(k[2]), k[1])):
-        config_label, num_tokens, input_dtype = key
-        num_heads, head_size = meta[key]
-        g = groups[key]
-        t_fused_cuda = g.get("fp8_fused_cuda", float("nan"))
-        t_fused_triton = g.get("fp8_fused_triton", float("nan"))
-        t_unfused_cuda = g.get("fp8_unfused_cuda", float("nan"))
-        t_unfused_triton = g.get("fp8_unfused_triton", float("nan"))
-        spd_cuda = t_unfused_cuda / t_fused_cuda if t_fused_cuda > 0 else float("nan")
-        spd_triton = (
-            t_unfused_triton / t_fused_triton if t_fused_triton > 0 else float("nan")
-        )
-        print(
-            f"{config_label:<18} {num_tokens:>6} {num_heads:>5} "
-            f"{head_size:>5} "
-            f"{short_dtype(input_dtype):<10} "
-            f"{t_fused_cuda:>7.1f}us {t_unfused_cuda:>8.1f}us "
-            f"{spd_cuda:>7.2f}x "
-            f"{t_fused_triton:>9.1f}us {t_unfused_triton:>10.1f}us "
-            f"{spd_triton:>9.2f}x"
-        )
-    print(sep)
-
-
-def print_nonfp8_table(results: list[BenchResult]):
-    """Print a comparison table for non-quantized merge: CUDA vs Triton."""
-    from collections import defaultdict
-
-    groups: dict[tuple, dict[str, float]] = defaultdict(dict)
-    meta: dict[tuple, tuple] = {}
-    for r in results:
-        key = (r.config_label, r.num_tokens, r.input_dtype)
-        groups[key][r.mode] = r.time_us
-        meta[key] = (r.num_heads, r.head_size)
-
-    header = (
-        f"{'Config':<18} {'Tokens':>6} {'Heads':>5} {'Hdim':>5} "
-        f"{'Dtype':<10} "
-        f"{'CUDA':>11} {'Triton':>11} {'Speedup':>8}"
-    )
-    sep = "-" * len(header)
-
-    print("\n" + sep)
-    print("Non-FP8 merge_attn_states: CUDA vs Triton")
-    print(sep)
-    print(header)
-    print(sep)
-
-    for key in sorted(groups.keys(), key=lambda k: (k[0], str(k[2]), k[1])):
-        config_label, num_tokens, input_dtype = key
-        num_heads, head_size = meta[key]
-        g = groups[key]
-        dtype_str = short_dtype(input_dtype)
-        t_cuda = g.get(f"cuda_{dtype_str}", float("nan"))
-        t_triton = g.get(f"triton_{dtype_str}", float("nan"))
-        speedup = t_triton / t_cuda if t_cuda > 0 else float("nan")
-        print(
-            f"{config_label:<18} {num_tokens:>6} {num_heads:>5} "
-            f"{head_size:>5} "
-            f"{dtype_str:<10} "
-            f"{t_cuda:>9.1f}us {t_triton:>9.1f}us {speedup:>7.2f}x"
-        )
-    print(sep)
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-
-def main():
+def parse_args():
     parser = argparse.ArgumentParser(
         description="Benchmark merge_attn_states fused FP8 quantization"
-    )
-    parser.add_argument(
-        "--fp8-only",
-        action="store_true",
-        help="Only run FP8 fused-vs-unfused benchmarks (skip non-FP8)",
-    )
-    parser.add_argument(
-        "--nonfp8-only",
-        action="store_true",
-        help="Only run non-FP8 CUDA-vs-Triton benchmarks (skip FP8)",
     )
     parser.add_argument(
         "--num-tokens",
@@ -411,64 +108,155 @@ def main():
         help=f"Override token counts (default: {NUM_TOKENS_LIST})",
     )
     parser.add_argument(
-        "--warmup",
+        "--tp",
         type=int,
-        default=DEFAULT_WARMUP,
-        help=f"Warmup iterations (default: {DEFAULT_WARMUP})",
+        nargs="+",
+        default=None,
+        help=f"TP sizes to simulate (divides num_heads) (default: {TP_SIZES})",
     )
     parser.add_argument(
-        "--iters",
-        type=int,
-        default=DEFAULT_ITERS,
-        help=f"Benchmark iterations (default: {DEFAULT_ITERS})",
+        "--dtype",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Input dtypes (e.g. bfloat16 float16 float32). "
+        f"Default: {[short_dtype(d) for d in INPUT_DTYPES]}",
     )
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    warmup = args.warmup
-    iters = args.iters
-    num_tokens_list = args.num_tokens if args.num_tokens else NUM_TOKENS_LIST
 
+# ---------------------------------------------------------------------------
+# Parse args and build configs before decorators
+# ---------------------------------------------------------------------------
+
+args = parse_args()
+
+num_tokens_list = args.num_tokens if args.num_tokens else NUM_TOKENS_LIST
+tp_sizes = args.tp if args.tp else TP_SIZES
+
+if args.dtype:
+    from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+
+    input_dtypes = [STR_DTYPE_TO_TORCH_DTYPE[d] for d in args.dtype]
+else:
+    input_dtypes = INPUT_DTYPES
+
+configs = build_configs(HEAD_CONFIGS, num_tokens_list, input_dtypes, tp_sizes)
+
+torch._dynamo.config.recompile_limit = 8888
+
+
+# ---------------------------------------------------------------------------
+# Benchmark function
+# ---------------------------------------------------------------------------
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_tokens", "num_heads", "head_size", "dtype_str"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["fused_cuda", "fused_triton", "unfused_cuda", "unfused_triton"],
+        line_names=["Fused CUDA", "Fused Triton", "Unfused CUDA", "Unfused Triton"],
+        styles=[("blue", "-"), ("green", "-"), ("blue", "--"), ("green", "--")],
+        ylabel="us",
+        plot_name="merge_attn_states FP8 (fused vs unfused)",
+        args={},
+    )
+)
+@default_vllm_config()
+def benchmark(num_tokens, num_heads, head_size, dtype_str, provider):
+    input_dtype = getattr(torch, dtype_str)
+    fp8_dtype = current_platform.fp8_dtype()
+    prefix_out, suffix_out, prefix_lse, suffix_lse = make_inputs(
+        num_tokens, num_heads, head_size, input_dtype
+    )
+    output_scale = torch.tensor([0.1], dtype=torch.float32, device="cuda")
+
+    if provider == "fused_cuda":
+        output = torch.empty(
+            (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
+        )
+        fn = lambda: merge_attn_states_cuda(
+            output,
+            prefix_out,
+            prefix_lse,
+            suffix_out,
+            suffix_lse,
+            output_scale=output_scale,
+        )
+    elif provider == "fused_triton":
+        output = torch.empty(
+            (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
+        )
+        fn = lambda: merge_attn_states_triton(
+            output,
+            prefix_out,
+            prefix_lse,
+            suffix_out,
+            suffix_lse,
+            output_scale=output_scale,
+        )
+    elif provider == "unfused_cuda":
+        merge_buf = torch.empty(
+            (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
+        )
+        quant_fp8 = QuantFP8(
+            static=True,
+            group_shape=GroupShape.PER_TENSOR,
+            column_major_scales=False,
+        )
+        quant_input = merge_buf.view(-1, head_size)
+        compiled_quant = torch.compile(
+            quant_fp8.forward_native, fullgraph=True, dynamic=False
+        )
+
+        def unfused_fn():
+            merge_attn_states_cuda(
+                merge_buf, prefix_out, prefix_lse, suffix_out, suffix_lse
+            )
+            compiled_quant(quant_input, output_scale)
+
+        fn = unfused_fn
+    else:  # unfused_triton
+        merge_buf = torch.empty(
+            (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
+        )
+        quant_fp8 = QuantFP8(
+            static=True,
+            group_shape=GroupShape.PER_TENSOR,
+            column_major_scales=False,
+        )
+        quant_input = merge_buf.view(-1, head_size)
+        compiled_quant = torch.compile(
+            quant_fp8.forward_native, fullgraph=True, dynamic=False
+        )
+
+        def unfused_fn():
+            merge_attn_states_triton(
+                merge_buf, prefix_out, prefix_lse, suffix_out, suffix_lse
+            )
+            compiled_quant(quant_input, output_scale)
+
+        fn = unfused_fn
+
+    ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(fn, quantiles=QUANTILES)
+    return 1000 * ms, 1000 * max_ms, 1000 * min_ms  # us
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
     device_name = current_platform.get_device_name()
     print(f"Device: {device_name}")
-    print(f"Warmup: {warmup}, Bench iters: {iters}")
     print(f"Token counts: {num_tokens_list}")
+    print(f"TP sizes: {tp_sizes}")
+    print(f"Input dtypes: {[short_dtype(d) for d in input_dtypes]}")
     print(f"Head configs: {[(c[0], c[1], c[2]) for c in HEAD_CONFIGS]}")
-    print(f"Input dtypes: {[short_dtype(d) for d in INPUT_DTYPES]}")
-
-    run_fp8 = not args.nonfp8_only
-    run_nonfp8 = not args.fp8_only
-
-    # --- Non-FP8 benchmarks ---
-    if run_nonfp8:
-        nonfp8_results: list[BenchResult] = []
-        configs = list(itertools.product(HEAD_CONFIGS, num_tokens_list, INPUT_DTYPES))
-        for count, ((label, nh, hs), nt, dtype) in enumerate(configs, 1):
-            print(
-                f"\r  Non-FP8 [{count}/{len(configs)}] "
-                f"{label} tokens={nt} dtype={short_dtype(dtype)}    ",
-                end="",
-                flush=True,
-            )
-            nonfp8_results.extend(bench_nonfp8(label, nt, nh, hs, dtype, warmup, iters))
-        print()
-        print_nonfp8_table(nonfp8_results)
-
-    # --- FP8 fused vs unfused benchmarks ---
-    if run_fp8:
-        fp8_results: list[BenchResult] = []
-        configs = list(itertools.product(HEAD_CONFIGS, num_tokens_list, INPUT_DTYPES))
-        for count, ((label, nh, hs), nt, dtype) in enumerate(configs, 1):
-            print(
-                f"\r  FP8 [{count}/{len(configs)}] "
-                f"{label} tokens={nt} dtype={short_dtype(dtype)}    ",
-                end="",
-                flush=True,
-            )
-            fp8_results.extend(
-                bench_fp8_fused_vs_unfused(label, nt, nh, hs, dtype, warmup, iters)
-            )
-        print()
-        print_fp8_table(fp8_results)
+    benchmark.run(print_data=True)
 
 
 if __name__ == "__main__":

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -21,29 +21,44 @@ __global__ void merge_attn_states_kernel(
     const float* suffix_lse, const float* output_scale, const uint num_tokens,
     const uint num_heads, const uint head_size, const uint prefix_head_stride,
     const uint output_head_stride) {
-  // Inputs always load 128-bit packs (pack_size elements of scalar_t).
-  // Outputs store pack_size elements of output_t, which is smaller for FP8.
-  using input_pack_t = uint4;
-  using output_pack_t =
+  // 128-bit pack type for input loads (and full output stores).
+  using pack_128b_t = uint4;
+  constexpr uint pack_size = 16 / sizeof(scalar_t);  // elements per input pack
+  // FP8: process multiple input packs per thread so output writes are 128-bit.
+  // sizeof(scalar_t) gives: bf16/fp16 -> 2 packs, fp32 -> 4 packs.
+  constexpr uint packs_per_group = USE_FP8_OUTPUT ? sizeof(scalar_t) : 1;
+  constexpr uint elems_per_group = pack_size * packs_per_group;  // 16 for FP8
+  // Fallback pack type for boundary threads that can't fill a full 128-bit
+  // output store (pack_size fp8 bytes: uint2 for bf16, uint for fp32).
+  using small_pack_t =
       std::conditional_t<USE_FP8_OUTPUT,
                          std::conditional_t<sizeof(scalar_t) == 4, uint, uint2>,
-                         uint4>;
-  const uint pack_size = 16 / sizeof(scalar_t);
-  const uint threads_per_head = head_size / pack_size;
+                         pack_128b_t>;
+  // Use ceiling division so the last thread handles any remainder.
+  // One thread per pack group.
+  const uint threads_per_head =
+      (head_size + elems_per_group - 1) / elems_per_group;
 
   const uint global_idx = blockIdx.x * NUM_THREADS + threadIdx.x;
   const uint token_head_threads = num_tokens * num_heads * threads_per_head;
 
   if (global_idx >= token_head_threads) return;
 
-  // global_idx -> token_idx + head_idx + pack_idx
+  // global_idx -> token_idx + head_idx + pack_group_idx
   const uint token_head_idx = global_idx / threads_per_head;
-  const uint pack_idx = global_idx % threads_per_head;
+  const uint pack_group_idx = global_idx % threads_per_head;
 
   const uint token_idx = token_head_idx / num_heads;
   const uint head_idx = token_head_idx % num_heads;
 
-  const uint pack_offset = pack_idx * pack_size;  // (0~15)*8, etc.
+  // pack idx and elem offset of base (first) pack in thread
+  const uint base_pack_idx = pack_group_idx * packs_per_group;
+  const uint base_elem_offset = pack_group_idx * elems_per_group;
+  // How many elements this thread actually processes (may be < elems_per_group
+  // for the last thread when head_size is not a multiple of elems_per_group).
+  const uint num_elems = min(elems_per_group, head_size - base_elem_offset);
+  const uint num_packs = num_elems / pack_size;
+
   const uint src_head_offset = token_idx * num_heads * prefix_head_stride +
                                head_idx * prefix_head_stride;
   const uint dst_head_offset = token_idx * num_heads * output_head_stride +
@@ -68,37 +83,47 @@ __global__ void merge_attn_states_kernel(
   /* In certain edge cases, MLA can produce p_lse = s_lse = -inf;
      continuing the pipeline then yields NaN. Root cause: with chunked prefill
      a batch may be split into two chunks; if a request in that batch has no
-     prefix hit, every LSE entry for that request's position is -inf, and at
+     prefix hit, every LSE entry for that request’s position is -inf, and at
      this moment we merge cross-attention at first. For now we simply emit
      prefix_output (expected to be all zeros) and prefix_lse (-inf) to fix
      this problem.
   */
   if (std::isinf(max_lse)) {
-    if (pack_offset < head_size) {
-      input_pack_t p_out_pack = reinterpret_cast<const input_pack_t*>(
-          prefix_head_ptr)[pack_offset / pack_size];
-
-      if constexpr (USE_FP8_OUTPUT) {
-        // Convert prefix values to FP8 (since -inf means no data,
-        // prefix_output is expected to be zeros)
-        output_t o_out_pack[pack_size];
+    if constexpr (USE_FP8_OUTPUT) {
+      // Load input packs, convert to FP8, store
+      output_t o_fp8[elems_per_group];
 #pragma unroll
-        for (uint i = 0; i < pack_size; ++i) {
-          const float val =
-              vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
-          o_out_pack[i] =
-              vllm::scaled_fp8_conversion<true, output_t>(val, fp8_scale_inv);
+      for (uint p = 0; p < packs_per_group; ++p) {
+        if (p < num_packs) {
+          pack_128b_t p_pack = reinterpret_cast<const pack_128b_t*>(
+              prefix_head_ptr)[base_pack_idx + p];
+#pragma unroll
+          for (uint i = 0; i < pack_size; ++i) {
+            const float val =
+                vllm::to_float(reinterpret_cast<const scalar_t*>(&p_pack)[i]);
+            o_fp8[p * pack_size + i] =
+                vllm::scaled_fp8_conversion<true, output_t>(val, fp8_scale_inv);
+          }
         }
-        reinterpret_cast<output_pack_t*>(
-            output_head_ptr)[pack_offset / pack_size] =
-            *reinterpret_cast<output_pack_t*>(o_out_pack);
-      } else {
-        reinterpret_cast<output_pack_t*>(
-            output_head_ptr)[pack_offset / pack_size] = p_out_pack;
       }
+      // Full 128-bit store when we have all packs, otherwise fall back
+      if (num_packs == packs_per_group) {
+        reinterpret_cast<pack_128b_t*>(output_head_ptr)[pack_group_idx] =
+            *reinterpret_cast<pack_128b_t*>(o_fp8);
+      } else {
+        for (uint p = 0; p < num_packs; ++p) {
+          reinterpret_cast<small_pack_t*>(output_head_ptr)[base_pack_idx + p] =
+              *reinterpret_cast<small_pack_t*>(&o_fp8[p * pack_size]);
+        }
+      }
+    } else {
+      // Non-FP8: single 128-bit load and store
+      pack_128b_t p_pack =
+          reinterpret_cast<const pack_128b_t*>(prefix_head_ptr)[base_pack_idx];
+      reinterpret_cast<pack_128b_t*>(output_head_ptr)[base_pack_idx] = p_pack;
     }
     // We only need to write to output_lse once per head.
-    if (output_lse != nullptr && pack_idx == 0) {
+    if (output_lse != nullptr && pack_group_idx == 0) {
       output_lse[head_idx * num_tokens + token_idx] = max_lse;
     }
     return;
@@ -112,47 +137,58 @@ __global__ void merge_attn_states_kernel(
   const float p_scale = p_se / out_se;
   const float s_scale = s_se / out_se;
 
-  if (pack_offset < head_size) {
-    input_pack_t p_out_pack = reinterpret_cast<const input_pack_t*>(
-        prefix_head_ptr)[pack_offset / pack_size];
-    input_pack_t s_out_pack = reinterpret_cast<const input_pack_t*>(
-        suffix_head_ptr)[pack_offset / pack_size];
-
-    // Compute merged values in float32
-    float o_out_f[pack_size];
+  // Merge, convert, and store
+  if constexpr (USE_FP8_OUTPUT) {
+    output_t o_fp8[elems_per_group];
+#pragma unroll
+    for (uint p = 0; p < packs_per_group; ++p) {
+      if (p < num_packs) {
+        pack_128b_t p_pack = reinterpret_cast<const pack_128b_t*>(
+            prefix_head_ptr)[base_pack_idx + p];
+        pack_128b_t s_pack = reinterpret_cast<const pack_128b_t*>(
+            suffix_head_ptr)[base_pack_idx + p];
+#pragma unroll
+        for (uint i = 0; i < pack_size; ++i) {
+          const float p_out_f =
+              vllm::to_float(reinterpret_cast<const scalar_t*>(&p_pack)[i]);
+          const float s_out_f =
+              vllm::to_float(reinterpret_cast<const scalar_t*>(&s_pack)[i]);
+          const float merged = p_out_f * p_scale + (s_out_f * s_scale);
+          o_fp8[p * pack_size + i] =
+              vllm::scaled_fp8_conversion<true, output_t>(merged,
+                                                          fp8_scale_inv);
+        }
+      }
+    }
+    // Full 128-bit store when we have all packs, otherwise fall back
+    if (num_packs == packs_per_group) {
+      reinterpret_cast<pack_128b_t*>(output_head_ptr)[pack_group_idx] =
+          *reinterpret_cast<pack_128b_t*>(o_fp8);
+    } else {
+      for (uint p = 0; p < num_packs; ++p) {
+        reinterpret_cast<small_pack_t*>(output_head_ptr)[base_pack_idx + p] =
+            *reinterpret_cast<small_pack_t*>(&o_fp8[p * pack_size]);
+      }
+    }
+  } else {
+    pack_128b_t p_pack =
+        reinterpret_cast<const pack_128b_t*>(prefix_head_ptr)[base_pack_idx];
+    pack_128b_t s_pack =
+        reinterpret_cast<const pack_128b_t*>(suffix_head_ptr)[base_pack_idx];
+    pack_128b_t o_pack;
 #pragma unroll
     for (uint i = 0; i < pack_size; ++i) {
       const float p_out_f =
-          vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+          vllm::to_float(reinterpret_cast<const scalar_t*>(&p_pack)[i]);
       const float s_out_f =
-          vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
-      o_out_f[i] = p_out_f * p_scale + (s_out_f * s_scale);
+          vllm::to_float(reinterpret_cast<const scalar_t*>(&s_pack)[i]);
+      const float merged = p_out_f * p_scale + (s_out_f * s_scale);
+      vllm::from_float(reinterpret_cast<scalar_t*>(&o_pack)[i], merged);
     }
-
-    // Convert and store
-    if constexpr (USE_FP8_OUTPUT) {
-      output_t o_out_pack[pack_size];
-#pragma unroll
-      for (uint i = 0; i < pack_size; ++i) {
-        o_out_pack[i] = vllm::scaled_fp8_conversion<true, output_t>(
-            o_out_f[i], fp8_scale_inv);
-      }
-      reinterpret_cast<output_pack_t*>(
-          output_head_ptr)[pack_offset / pack_size] =
-          *reinterpret_cast<output_pack_t*>(o_out_pack);
-    } else {
-      output_pack_t o_out_pack;
-#pragma unroll
-      for (uint i = 0; i < pack_size; ++i) {
-        vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i],
-                         o_out_f[i]);
-      }
-      reinterpret_cast<output_pack_t*>(
-          output_head_ptr)[pack_offset / pack_size] = o_out_pack;
-    }
+    reinterpret_cast<pack_128b_t*>(output_head_ptr)[base_pack_idx] = o_pack;
   }
   // We only need to write to output_lse once per head.
-  if (output_lse != nullptr && pack_idx == 0) {
+  if (output_lse != nullptr && pack_group_idx == 0) {
     float out_lse = logf(out_se) + max_lse;
     output_lse[head_idx * num_tokens + token_idx] = out_lse;
   }
@@ -217,10 +253,10 @@ void merge_attn_states_launcher(
   const uint head_size = prefix_output.size(2);
   const uint prefix_head_stride = prefix_output.stride(1);
   const uint output_head_stride = output.stride(1);
-  // Thread mapping is based on input BF16 pack_size
-  const uint pack_size = 16 / sizeof(scalar_t);
+  constexpr uint pack_size = 16 / sizeof(scalar_t);
   TORCH_CHECK(head_size % pack_size == 0,
               "headsize must be multiple of pack_size:", pack_size);
+
   float* output_lse_ptr = nullptr;
   if (output_lse.has_value()) {
     output_lse_ptr = output_lse.value().data_ptr<float>();
@@ -229,24 +265,28 @@ void merge_attn_states_launcher(
   if (output_scale.has_value()) {
     output_scale_ptr = output_scale.value().data_ptr<float>();
   }
-  // Process one pack elements per thread. for float, the
-  // pack_size is 4 for half/bf16, the pack_size is 8.
-  const uint threads_per_head = head_size / pack_size;
-  const uint total_threads = num_tokens * num_heads * threads_per_head;
-
-  dim3 block(NUM_THREADS);
-  dim3 grid((total_threads + NUM_THREADS - 1) / NUM_THREADS);
 
   const c10::cuda::OptionalCUDAGuard device_guard(prefix_output.device());
   auto stream = at::cuda::getCurrentCUDAStream();
 
   if (output_scale.has_value()) {
-    // FP8 output path - dispatch on output FP8 type
+    // FP8 output: each thread targets 16 elements for 128-bit output writes.
+    // Ceiling division so the last thread handles any remainder.
+    constexpr uint elems_per_group = 16;
+    const uint threads_per_head =
+        (head_size + elems_per_group - 1) / elems_per_group;
+    const uint total_threads = num_tokens * num_heads * threads_per_head;
+    dim3 grid((total_threads + NUM_THREADS - 1) / NUM_THREADS);
+    dim3 block(NUM_THREADS);
     VLLM_DISPATCH_FP8_TYPES(output.scalar_type(), "merge_attn_states_fp8", [&] {
       LAUNCH_MERGE_ATTN_STATES(scalar_t, fp8_t, NUM_THREADS, true);
     });
   } else {
-    // Original BF16/FP16/FP32 output path
+    // Non-FP8: each thread processes pack_size elements (128-bit I/O)
+    const uint threads_per_head = head_size / pack_size;
+    const uint total_threads = num_tokens * num_heads * threads_per_head;
+    dim3 grid((total_threads + NUM_THREADS - 1) / NUM_THREADS);
+    dim3 block(NUM_THREADS);
     LAUNCH_MERGE_ATTN_STATES(scalar_t, scalar_t, NUM_THREADS, false);
   }
 }

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -110,17 +110,24 @@ __global__ void merge_attn_states_kernel(
     input_pack_t s_out_pack = reinterpret_cast<const input_pack_t*>(
         suffix_head_ptr)[pack_offset / pack_size];
 
+    // Compute merged values in float32
+    float o_out_f[pack_size];
+#pragma unroll
+    for (uint i = 0; i < pack_size; ++i) {
+      const float p_out_f =
+          vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+      const float s_out_f =
+          vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
+      o_out_f[i] = p_out_f * p_scale + (s_out_f * s_scale);
+    }
+
+    // Convert and store
     if constexpr (FP8_OUTPUT) {
       out_t o_out_pack[pack_size];
 #pragma unroll
       for (uint i = 0; i < pack_size; ++i) {
-        const float p_out_f =
-            vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
-        const float s_out_f =
-            vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
-        const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
         o_out_pack[i] =
-            vllm::scaled_fp8_conversion<false, out_t>(o_out_f, fp8_scale);
+            vllm::scaled_fp8_conversion<false, out_t>(o_out_f[i], fp8_scale);
       }
       reinterpret_cast<output_pack_t*>(
           output_head_ptr)[pack_offset / pack_size] =
@@ -129,12 +136,8 @@ __global__ void merge_attn_states_kernel(
       output_pack_t o_out_pack;
 #pragma unroll
       for (uint i = 0; i < pack_size; ++i) {
-        const float p_out_f =
-            vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
-        const float s_out_f =
-            vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
-        const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
-        vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i], o_out_f);
+        vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i],
+                         o_out_f[i]);
       }
       reinterpret_cast<output_pack_t*>(
           output_head_ptr)[pack_offset / pack_size] = o_out_pack;
@@ -252,6 +255,17 @@ void merge_attn_states(torch::Tensor& output,
                        const torch::Tensor& suffix_output,
                        const torch::Tensor& suffix_lse,
                        const std::optional<torch::Tensor>& output_scale) {
+  if (output_scale.has_value()) {
+    TORCH_CHECK(output.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+                    output.scalar_type() == at::ScalarType::Float8_e4m3fnuz,
+                "output must be FP8 when output_scale is provided, got: ",
+                output.scalar_type());
+  } else {
+    TORCH_CHECK(output.scalar_type() == prefix_output.scalar_type(),
+                "output dtype (", output.scalar_type(),
+                ") must match prefix_output dtype (",
+                prefix_output.scalar_type(), ") when output_scale is not set");
+  }
   // Always dispatch on prefix_output (input) dtype
   DISPATCH_BY_SCALAR_DTYPE(prefix_output.dtype(),
                            CALL_MERGE_ATTN_STATES_LAUNCHER);

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -195,7 +195,7 @@ __global__ void merge_attn_states_kernel(
  * into the output tensor. NUM_TOKENS: n, NUM_HEADS: h, HEAD_SIZE: d
  *
  * @param output [n,h,d] The output tensor to store the merged attention states.
- * @param output_lse [h,d] Optional tensor to store the log-sum-exp values.
+ * @param output_lse [h,n] Optional tensor to store the log-sum-exp values.
  * @param prefix_output [n,h,d] The prefix attention states.
  * @param prefix_lse [h,n] The log-sum-exp values for the prefix attention
  * states.

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -13,19 +13,19 @@ namespace vllm {
 
 // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 // can be used to combine partial attention results (in the split-KV case)
-template <typename scalar_t, typename out_t, const uint NUM_THREADS,
-          bool FP8_OUTPUT>
+template <typename scalar_t, typename output_t, const uint NUM_THREADS,
+          bool USE_FP8_OUTPUT>
 __global__ void merge_attn_states_kernel(
-    out_t* output, float* output_lse, const scalar_t* prefix_output,
+    output_t* output, float* output_lse, const scalar_t* prefix_output,
     const float* prefix_lse, const scalar_t* suffix_output,
     const float* suffix_lse, const float* output_scale, const uint num_tokens,
     const uint num_heads, const uint head_size, const uint prefix_head_stride,
     const uint output_head_stride) {
   // Inputs always load 128-bit packs (pack_size elements of scalar_t).
-  // Outputs store pack_size elements of out_t, which is smaller for FP8.
+  // Outputs store pack_size elements of output_t, which is smaller for FP8.
   using input_pack_t = uint4;
   using output_pack_t =
-      std::conditional_t<FP8_OUTPUT,
+      std::conditional_t<USE_FP8_OUTPUT,
                          std::conditional_t<sizeof(scalar_t) == 4, uint, uint2>,
                          uint4>;
   const uint pack_size = 16 / sizeof(scalar_t);
@@ -50,12 +50,12 @@ __global__ void merge_attn_states_kernel(
                                head_idx * output_head_stride;
   const scalar_t* prefix_head_ptr = prefix_output + src_head_offset;
   const scalar_t* suffix_head_ptr = suffix_output + src_head_offset;
-  out_t* output_head_ptr = output + dst_head_offset;
+  output_t* output_head_ptr = output + dst_head_offset;
 
-  // Load scale once for FP8 path
-  float fp8_scale = 1.0f;
-  if constexpr (FP8_OUTPUT) {
-    fp8_scale = *output_scale;
+  // Pre-invert scale: multiplication is faster than division
+  float fp8_scale_inv = 1.0f;
+  if constexpr (USE_FP8_OUTPUT) {
+    fp8_scale_inv = 1.0f / *output_scale;
   }
 
   float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
@@ -65,21 +65,29 @@ __global__ void merge_attn_states_kernel(
 
   const float max_lse = fmaxf(p_lse, s_lse);
 
+  /* In certain edge cases, MLA can produce p_lse = s_lse = -inf;
+     continuing the pipeline then yields NaN. Root cause: with chunked prefill
+     a batch may be split into two chunks; if a request in that batch has no
+     prefix hit, every LSE entry for that request's position is -inf, and at
+     this moment we merge cross-attention at first. For now we simply emit
+     prefix_output (expected to be all zeros) and prefix_lse (-inf) to fix
+     this problem.
+  */
   if (std::isinf(max_lse)) {
     if (pack_offset < head_size) {
       input_pack_t p_out_pack = reinterpret_cast<const input_pack_t*>(
           prefix_head_ptr)[pack_offset / pack_size];
 
-      if constexpr (FP8_OUTPUT) {
+      if constexpr (USE_FP8_OUTPUT) {
         // Convert prefix values to FP8 (since -inf means no data,
         // prefix_output is expected to be zeros)
-        out_t o_out_pack[pack_size];
+        output_t o_out_pack[pack_size];
 #pragma unroll
         for (uint i = 0; i < pack_size; ++i) {
           const float val =
               vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
           o_out_pack[i] =
-              vllm::scaled_fp8_conversion<false, out_t>(val, fp8_scale);
+              vllm::scaled_fp8_conversion<true, output_t>(val, fp8_scale_inv);
         }
         reinterpret_cast<output_pack_t*>(
             output_head_ptr)[pack_offset / pack_size] =
@@ -122,12 +130,12 @@ __global__ void merge_attn_states_kernel(
     }
 
     // Convert and store
-    if constexpr (FP8_OUTPUT) {
-      out_t o_out_pack[pack_size];
+    if constexpr (USE_FP8_OUTPUT) {
+      output_t o_out_pack[pack_size];
 #pragma unroll
       for (uint i = 0; i < pack_size; ++i) {
-        o_out_pack[i] =
-            vllm::scaled_fp8_conversion<false, out_t>(o_out_f[i], fp8_scale);
+        o_out_pack[i] = vllm::scaled_fp8_conversion<true, output_t>(
+            o_out_f[i], fp8_scale_inv);
       }
       reinterpret_cast<output_pack_t*>(
           output_head_ptr)[pack_offset / pack_size] =
@@ -168,11 +176,13 @@ __global__ void merge_attn_states_kernel(
     }                                                                   \
   }
 
-#define LAUNCH_MERGE_ATTN_STATES(scalar_t, out_t, NUM_THREADS, FP8_OUTPUT)     \
+#define LAUNCH_MERGE_ATTN_STATES(scalar_t, output_t, NUM_THREADS,              \
+                                 USE_FP8_OUTPUT)                               \
   {                                                                            \
-    vllm::merge_attn_states_kernel<scalar_t, out_t, NUM_THREADS, FP8_OUTPUT>   \
+    vllm::merge_attn_states_kernel<scalar_t, output_t, NUM_THREADS,            \
+                                   USE_FP8_OUTPUT>                             \
         <<<grid, block, 0, stream>>>(                                          \
-            reinterpret_cast<out_t*>(output.data_ptr()), output_lse_ptr,       \
+            reinterpret_cast<output_t*>(output.data_ptr()), output_lse_ptr,    \
             reinterpret_cast<scalar_t*>(prefix_output.data_ptr()),             \
             reinterpret_cast<float*>(prefix_lse.data_ptr()),                   \
             reinterpret_cast<scalar_t*>(suffix_output.data_ptr()),             \

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -6,19 +6,28 @@
 
 #include "attention_dtypes.h"
 #include "attention_utils.cuh"
+#include "../quantization/w8a8/fp8/common.cuh"
+#include "../dispatch_utils.h"
 
 namespace vllm {
 
 // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 // can be used to combine partial attention results (in the split-KV case)
-template <typename scalar_t, const uint NUM_THREADS>
+template <typename scalar_t, typename out_t, const uint NUM_THREADS,
+          bool FP8_OUTPUT>
 __global__ void merge_attn_states_kernel(
-    scalar_t* output, float* output_lse, const scalar_t* prefix_output,
+    out_t* output, float* output_lse, const scalar_t* prefix_output,
     const float* prefix_lse, const scalar_t* suffix_output,
-    const float* suffix_lse, const uint num_tokens, const uint num_heads,
-    const uint head_size, const uint prefix_head_stride,
+    const float* suffix_lse, const float* output_scale, const uint num_tokens,
+    const uint num_heads, const uint head_size, const uint prefix_head_stride,
     const uint output_head_stride) {
-  using pack_128b_t = uint4;
+  // Inputs always load 128-bit packs (pack_size elements of scalar_t).
+  // Outputs store pack_size elements of out_t, which is smaller for FP8.
+  using input_pack_t = uint4;
+  using output_pack_t =
+      std::conditional_t<FP8_OUTPUT,
+                         std::conditional_t<sizeof(scalar_t) == 4, uint, uint2>,
+                         uint4>;
   const uint pack_size = 16 / sizeof(scalar_t);
   const uint threads_per_head = head_size / pack_size;
 
@@ -41,7 +50,13 @@ __global__ void merge_attn_states_kernel(
                                head_idx * output_head_stride;
   const scalar_t* prefix_head_ptr = prefix_output + src_head_offset;
   const scalar_t* suffix_head_ptr = suffix_output + src_head_offset;
-  scalar_t* output_head_ptr = output + dst_head_offset;
+  out_t* output_head_ptr = output + dst_head_offset;
+
+  // Load scale once for FP8 path
+  float fp8_scale = 1.0f;
+  if constexpr (FP8_OUTPUT) {
+    fp8_scale = *output_scale;
+  }
 
   float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
   float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
@@ -50,23 +65,29 @@ __global__ void merge_attn_states_kernel(
 
   const float max_lse = fmaxf(p_lse, s_lse);
 
-  /* In certain edge cases, MLA can produce p_lse = s_lse = -inf;
-     continuing the pipeline then yields NaN. Root cause: with chunked prefill
-     a batch may be split into two chunks; if a request in that batch has no
-     prefix hit, every LSE entry for that request’s position is -inf, and at
-     this moment we merge cross-attention at first. For now we simply emit
-     prefix_output (expected to be all zeros) and prefix_lse (-inf) to fix
-     this problem.
-  */
   if (std::isinf(max_lse)) {
     if (pack_offset < head_size) {
-      // Pack 128b load
-      pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
+      input_pack_t p_out_pack = reinterpret_cast<const input_pack_t*>(
           prefix_head_ptr)[pack_offset / pack_size];
 
-      // Pack 128b storage
-      reinterpret_cast<pack_128b_t*>(output_head_ptr)[pack_offset / pack_size] =
-          p_out_pack;
+      if constexpr (FP8_OUTPUT) {
+        // Convert prefix values to FP8 (since -inf means no data,
+        // prefix_output is expected to be zeros)
+        out_t o_out_pack[pack_size];
+#pragma unroll
+        for (uint i = 0; i < pack_size; ++i) {
+          const float val =
+              vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+          o_out_pack[i] =
+              vllm::scaled_fp8_conversion<false, out_t>(val, fp8_scale);
+        }
+        reinterpret_cast<output_pack_t*>(
+            output_head_ptr)[pack_offset / pack_size] =
+            *reinterpret_cast<output_pack_t*>(o_out_pack);
+      } else {
+        reinterpret_cast<output_pack_t*>(
+            output_head_ptr)[pack_offset / pack_size] = p_out_pack;
+      }
     }
     // We only need to write to output_lse once per head.
     if (output_lse != nullptr && pack_idx == 0) {
@@ -84,30 +105,40 @@ __global__ void merge_attn_states_kernel(
   const float s_scale = s_se / out_se;
 
   if (pack_offset < head_size) {
-    // Pack 128b load
-    pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
+    input_pack_t p_out_pack = reinterpret_cast<const input_pack_t*>(
         prefix_head_ptr)[pack_offset / pack_size];
-    pack_128b_t s_out_pack = reinterpret_cast<const pack_128b_t*>(
+    input_pack_t s_out_pack = reinterpret_cast<const input_pack_t*>(
         suffix_head_ptr)[pack_offset / pack_size];
-    pack_128b_t o_out_pack;
 
+    if constexpr (FP8_OUTPUT) {
+      out_t o_out_pack[pack_size];
 #pragma unroll
-    for (uint i = 0; i < pack_size; ++i) {
-      // Always use float for FMA to keep high precision.
-      // half(uint16_t), bfloat16, float -> float.
-      const float p_out_f =
-          vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
-      const float s_out_f =
-          vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
-      // fma: a * b + c = p_out_f * p_scale + (s_out_f * s_scale)
-      const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
-      // float -> half(uint16_t), bfloat16, float.
-      vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i], o_out_f);
+      for (uint i = 0; i < pack_size; ++i) {
+        const float p_out_f =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+        const float s_out_f =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
+        const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
+        o_out_pack[i] =
+            vllm::scaled_fp8_conversion<false, out_t>(o_out_f, fp8_scale);
+      }
+      reinterpret_cast<output_pack_t*>(
+          output_head_ptr)[pack_offset / pack_size] =
+          *reinterpret_cast<output_pack_t*>(o_out_pack);
+    } else {
+      output_pack_t o_out_pack;
+#pragma unroll
+      for (uint i = 0; i < pack_size; ++i) {
+        const float p_out_f =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+        const float s_out_f =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
+        const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
+        vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i], o_out_f);
+      }
+      reinterpret_cast<output_pack_t*>(
+          output_head_ptr)[pack_offset / pack_size] = o_out_pack;
     }
-
-    // Pack 128b storage
-    reinterpret_cast<pack_128b_t*>(output_head_ptr)[pack_offset / pack_size] =
-        o_out_pack;
   }
   // We only need to write to output_lse once per head.
   if (output_lse != nullptr && pack_idx == 0) {
@@ -134,16 +165,17 @@ __global__ void merge_attn_states_kernel(
     }                                                                   \
   }
 
-#define LAUNCH_MERGE_ATTN_STATES(scalar_t, NUM_THREADS)                     \
-  {                                                                         \
-    vllm::merge_attn_states_kernel<scalar_t, NUM_THREADS>                   \
-        <<<grid, block, 0, stream>>>(                                       \
-            reinterpret_cast<scalar_t*>(output.data_ptr()), output_lse_ptr, \
-            reinterpret_cast<scalar_t*>(prefix_output.data_ptr()),          \
-            reinterpret_cast<float*>(prefix_lse.data_ptr()),                \
-            reinterpret_cast<scalar_t*>(suffix_output.data_ptr()),          \
-            reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,    \
-            num_heads, head_size, prefix_head_stride, output_head_stride);  \
+#define LAUNCH_MERGE_ATTN_STATES(scalar_t, out_t, NUM_THREADS, FP8_OUTPUT)     \
+  {                                                                            \
+    vllm::merge_attn_states_kernel<scalar_t, out_t, NUM_THREADS, FP8_OUTPUT>   \
+        <<<grid, block, 0, stream>>>(                                          \
+            reinterpret_cast<out_t*>(output.data_ptr()), output_lse_ptr,       \
+            reinterpret_cast<scalar_t*>(prefix_output.data_ptr()),             \
+            reinterpret_cast<float*>(prefix_lse.data_ptr()),                   \
+            reinterpret_cast<scalar_t*>(suffix_output.data_ptr()),             \
+            reinterpret_cast<float*>(suffix_lse.data_ptr()), output_scale_ptr, \
+            num_tokens, num_heads, head_size, prefix_head_stride,              \
+            output_head_stride);                                               \
   }
 
 /*@brief Merges the attention states from prefix and suffix
@@ -157,26 +189,32 @@ __global__ void merge_attn_states_kernel(
  * @param suffix_output [n,h,d] The suffix attention states.
  * @param suffix_lse [h,n] The log-sum-exp values for the suffix attention
  * states.
+ * @param output_scale Optional scalar tensor for FP8 static quantization.
+ * When provided, output must be FP8 dtype.
  */
 template <typename scalar_t>
-void merge_attn_states_launcher(torch::Tensor& output,
-                                std::optional<torch::Tensor> output_lse,
-                                const torch::Tensor& prefix_output,
-                                const torch::Tensor& prefix_lse,
-                                const torch::Tensor& suffix_output,
-                                const torch::Tensor& suffix_lse) {
+void merge_attn_states_launcher(
+    torch::Tensor& output, std::optional<torch::Tensor> output_lse,
+    const torch::Tensor& prefix_output, const torch::Tensor& prefix_lse,
+    const torch::Tensor& suffix_output, const torch::Tensor& suffix_lse,
+    const std::optional<torch::Tensor>& output_scale) {
   constexpr uint NUM_THREADS = 128;
-  const uint num_tokens = output.size(0);
-  const uint num_heads = output.size(1);
-  const uint head_size = output.size(2);
+  const uint num_tokens = prefix_output.size(0);
+  const uint num_heads = prefix_output.size(1);
+  const uint head_size = prefix_output.size(2);
   const uint prefix_head_stride = prefix_output.stride(1);
   const uint output_head_stride = output.stride(1);
+  // Thread mapping is based on input BF16 pack_size
   const uint pack_size = 16 / sizeof(scalar_t);
   TORCH_CHECK(head_size % pack_size == 0,
               "headsize must be multiple of pack_size:", pack_size);
   float* output_lse_ptr = nullptr;
   if (output_lse.has_value()) {
     output_lse_ptr = output_lse.value().data_ptr<float>();
+  }
+  float* output_scale_ptr = nullptr;
+  if (output_scale.has_value()) {
+    output_scale_ptr = output_scale.value().data_ptr<float>();
   }
   // Process one pack elements per thread. for float, the
   // pack_size is 4 for half/bf16, the pack_size is 8.
@@ -189,14 +227,22 @@ void merge_attn_states_launcher(torch::Tensor& output,
   const c10::cuda::OptionalCUDAGuard device_guard(prefix_output.device());
   auto stream = at::cuda::getCurrentCUDAStream();
 
-  LAUNCH_MERGE_ATTN_STATES(scalar_t, NUM_THREADS);
+  if (output_scale.has_value()) {
+    // FP8 output path - dispatch on output FP8 type
+    VLLM_DISPATCH_FP8_TYPES(output.scalar_type(), "merge_attn_states_fp8", [&] {
+      LAUNCH_MERGE_ATTN_STATES(scalar_t, fp8_t, NUM_THREADS, true);
+    });
+  } else {
+    // Original BF16/FP16/FP32 output path
+    LAUNCH_MERGE_ATTN_STATES(scalar_t, scalar_t, NUM_THREADS, false);
+  }
 }
 
 #define CALL_MERGE_ATTN_STATES_LAUNCHER(scalar_t)                           \
   {                                                                         \
     merge_attn_states_launcher<scalar_t>(output, output_lse, prefix_output, \
                                          prefix_lse, suffix_output,         \
-                                         suffix_lse);                       \
+                                         suffix_lse, output_scale);         \
   }
 
 void merge_attn_states(torch::Tensor& output,
@@ -204,6 +250,9 @@ void merge_attn_states(torch::Tensor& output,
                        const torch::Tensor& prefix_output,
                        const torch::Tensor& prefix_lse,
                        const torch::Tensor& suffix_output,
-                       const torch::Tensor& suffix_lse) {
-  DISPATCH_BY_SCALAR_DTYPE(output.dtype(), CALL_MERGE_ATTN_STATES_LAUNCHER);
+                       const torch::Tensor& suffix_lse,
+                       const std::optional<torch::Tensor>& output_scale) {
+  // Always dispatch on prefix_output (input) dtype
+  DISPATCH_BY_SCALAR_DTYPE(prefix_output.dtype(),
+                           CALL_MERGE_ATTN_STATES_LAUNCHER);
 }

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -53,12 +53,11 @@ void paged_attention_v2(
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
     const int64_t blocksparse_head_sliding_step);
 
-void merge_attn_states(torch::Tensor& output,
-                       std::optional<torch::Tensor> output_lse,
-                       const torch::Tensor& prefix_output,
-                       const torch::Tensor& prefix_lse,
-                       const torch::Tensor& suffix_output,
-                       const torch::Tensor& suffix_lse);
+void merge_attn_states(
+    torch::Tensor& output, std::optional<torch::Tensor> output_lse,
+    const torch::Tensor& prefix_output, const torch::Tensor& prefix_lse,
+    const torch::Tensor& suffix_output, const torch::Tensor& suffix_lse,
+    const std::optional<torch::Tensor>& output_scale = std::nullopt);
 #ifndef USE_ROCM
 void convert_vertical_slash_indexes(
     torch::Tensor& block_count,      // [BATCH, N_HEADS, NUM_ROWS]

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -73,7 +73,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    Tensor prefix_output,"
       "    Tensor prefix_lse,"
       "    Tensor suffix_output,"
-      "    Tensor suffix_lse) -> ()");
+      "    Tensor suffix_lse,"
+      "    Tensor? output_scale=None) -> ()");
   ops.impl("merge_attn_states", torch::kCUDA, &merge_attn_states);
 #ifndef USE_ROCM
   ops.def(

--- a/tests/kernels/attention/test_merge_attn_states.py
+++ b/tests/kernels/attention/test_merge_attn_states.py
@@ -330,11 +330,15 @@ FP8_NUM_QUERY_HEADS = [8, 16, 64]
 FP8_HEAD_SIZES = [64, 128, 256]
 
 
+FP8_INPUT_DTYPES = [torch.float32, torch.float16, torch.bfloat16]
+
+
 @pytest.mark.parametrize("num_tokens", FP8_NUM_BATCH_TOKENS)
 @pytest.mark.parametrize("num_query_heads", FP8_NUM_QUERY_HEADS)
 @pytest.mark.parametrize("head_size", FP8_HEAD_SIZES)
 @pytest.mark.parametrize("output_scale_val", [0.5, 0.05])
 @pytest.mark.parametrize("use_output_lse", [True, False])
+@pytest.mark.parametrize("input_dtype", FP8_INPUT_DTYPES)
 @torch.inference_mode()
 def test_merge_attn_states_fp8(
     num_tokens: int,
@@ -342,11 +346,10 @@ def test_merge_attn_states_fp8(
     head_size: int,
     output_scale_val: float,
     use_output_lse: bool,
+    input_dtype: torch.dtype,
 ):
     if not current_platform.is_cuda():
         pytest.skip("FP8 merge_attn_states test requires CUDA")
-
-    input_dtype = torch.bfloat16
     fp8_dtype = current_platform.fp8_dtype()
 
     print(
@@ -438,13 +441,13 @@ def test_merge_attn_states_fp8(
         output_scale=output_scale,
     )
 
-    # 3. Compare — use scale-dependent tolerances
-    # scale=0.5: values stay in low-magnitude FP8 range, finer granularity
-    # scale=0.05: values pushed to high-magnitude range, coarse quantization
+    # 3. Compare — use scale-dependent tolerances.
+    # FP8 e4m3 spacing grows with magnitude (e.g. 4.0 at magnitude 32),
+    # so smaller scales (larger FP8 magnitudes) need wider absolute tolerance.
     if output_scale_val >= 0.5:
-        fp8_atol, fp8_rtol = 0.5, 0.05
+        fp8_atol, fp8_rtol = 2.5, 0.05
     else:
-        fp8_atol, fp8_rtol = 2.5, 0.15
+        fp8_atol, fp8_rtol = 5.0, 0.10
 
     def diff(a: torch.Tensor, b: torch.Tensor):
         return torch.max(torch.abs(a.float() - b.float()))

--- a/tests/kernels/attention/test_merge_attn_states.py
+++ b/tests/kernels/attention/test_merge_attn_states.py
@@ -20,7 +20,9 @@ def merge_attn_states_torch(
     suffix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     suffix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
     output_lse: torch.Tensor | None = None,  # [NUM_HEADS, NUM_TOKENS]
+    output_scale: torch.Tensor | None = None,  # scalar, per-tensor FP8 scale
 ):
+    out_dtype = output.dtype  # save before reassignment
     p_lse = prefix_lse
     s_lse = suffix_lse
     # inf -> -inf
@@ -40,6 +42,10 @@ def merge_attn_states_torch(
     p_scale = torch.transpose(p_scale, 0, 1).unsqueeze(2)  # [NUM_TOKENS, NUM_HEADS, 1]
     s_scale = torch.transpose(s_scale, 0, 1).unsqueeze(2)  # [NUM_TOKENS, NUM_HEADS, 1]
     output = prefix_output * p_scale + suffix_output * s_scale
+    if output_scale is not None:
+        dtype_max = torch.finfo(out_dtype).max
+        output = (output.float() / output_scale.item()).clamp(-dtype_max, dtype_max)
+        output = output.to(out_dtype)
     return output, output_lse
 
 
@@ -317,3 +323,113 @@ def test_merge_attn_states(
         len(NUM_BATCH_TOKENS) * len(HEAD_SIZES) * len(NUM_QUERY_HEADS) * len(DTYPES)
     ):
         generate_markdown_table()
+
+
+FP8_NUM_BATCH_TOKENS = [256, 512, 1024]
+FP8_NUM_QUERY_HEADS = [8, 16, 64]
+FP8_HEAD_SIZES = [64, 128, 256]
+
+
+@pytest.mark.parametrize("num_tokens", FP8_NUM_BATCH_TOKENS)
+@pytest.mark.parametrize("num_query_heads", FP8_NUM_QUERY_HEADS)
+@pytest.mark.parametrize("head_size", FP8_HEAD_SIZES)
+@torch.inference_mode()
+def test_merge_attn_states_fp8(num_tokens: int, num_query_heads: int, head_size: int):
+    if not current_platform.is_cuda():
+        pytest.skip("FP8 merge_attn_states test requires CUDA")
+
+    input_dtype = torch.bfloat16
+    fp8_dtype = current_platform.fp8_dtype()
+
+    print(
+        f"\n[FP8] NUM_TOKENS:{num_tokens}, NUM_HEADS:{num_query_heads}, "
+        f"HEAD_SIZE:{head_size}, input_dtype:{input_dtype}, "
+        f"fp8_dtype:{fp8_dtype}"
+    )
+
+    # Create inputs in BF16
+    prefix_output = torch.randn(
+        (num_tokens, num_query_heads, head_size), dtype=input_dtype, device="cuda"
+    )
+    suffix_output = torch.randn(
+        (num_tokens, num_query_heads, head_size), dtype=input_dtype, device="cuda"
+    )
+
+    # LSE values with some inf edge cases
+    prefix_lse = torch.randn(
+        num_query_heads, num_tokens, dtype=torch.float32, device="cuda"
+    )
+    suffix_lse = torch.randn(
+        num_query_heads, num_tokens, dtype=torch.float32, device="cuda"
+    )
+    mask_prefix = torch.rand(num_query_heads, num_tokens) < 0.1
+    mask_suffix = torch.rand(num_query_heads, num_tokens) < 0.1
+    combined_mask = torch.logical_and(mask_prefix, mask_suffix)
+    mask_prefix = torch.logical_and(mask_prefix, ~combined_mask)
+    mask_suffix = torch.logical_and(mask_suffix, ~combined_mask)
+    prefix_lse[mask_prefix] = float("inf")
+    suffix_lse[mask_suffix] = float("inf")
+
+    # Output scale for static FP8 quantization
+    output_scale = torch.tensor([0.05], dtype=torch.float32, device="cuda")
+
+    # 0. Compute reference using torch with output_scale
+    ref_fp8, _ = merge_attn_states_torch(
+        torch.zeros(
+            (num_tokens, num_query_heads, head_size), dtype=fp8_dtype, device="cuda"
+        ),
+        prefix_output,
+        prefix_lse.clone(),
+        suffix_output,
+        suffix_lse.clone(),
+        output_scale=output_scale,
+    )
+
+    # 1. Run CUDA kernel with output_scale
+    output_cuda = torch.empty(
+        (num_tokens, num_query_heads, head_size), dtype=fp8_dtype, device="cuda"
+    )
+    merge_attn_states_cuda(
+        output_cuda,
+        prefix_output,
+        prefix_lse,
+        suffix_output,
+        suffix_lse,
+        output_scale=output_scale,
+    )
+
+    # 2. Run Triton kernel with output_scale
+    output_triton = torch.empty(
+        (num_tokens, num_query_heads, head_size), dtype=fp8_dtype, device="cuda"
+    )
+    merge_attn_states_triton(
+        output_triton,
+        prefix_output,
+        prefix_lse,
+        suffix_output,
+        suffix_lse,
+        output_scale=output_scale,
+    )
+
+    # 3. Compare — FP8 has limited precision so use wider tolerances
+    def diff(a: torch.Tensor, b: torch.Tensor):
+        return torch.max(torch.abs(a.float() - b.float()))
+
+    print(f"  (CUDA vs Ref)   max diff: {diff(output_cuda, ref_fp8)}")
+    print(f"  (Triton vs Ref) max diff: {diff(output_triton, ref_fp8)}")
+    print(f"  (CUDA vs Triton) max diff: {diff(output_cuda, output_triton)}")
+
+    # FP8 E4M3 has coarse quantization levels (e.g. ..., 16, 18, 20, ...),
+    # so rounding boundary differences between GPU kernels and PyTorch
+    # reference can produce up to 1 quantization step difference (~2.0
+    # at larger magnitudes). Use tolerances that accommodate this.
+    torch.testing.assert_close(
+        output_cuda.float(), ref_fp8.float(), atol=2.5, rtol=0.15
+    )
+    torch.testing.assert_close(
+        output_triton.float(), ref_fp8.float(), atol=2.5, rtol=0.15
+    )
+    torch.testing.assert_close(
+        output_cuda.float(), output_triton.float(), atol=2.5, rtol=0.15
+    )
+    print("[FP8] All tests passed!")

--- a/tests/kernels/attention/test_merge_attn_states.py
+++ b/tests/kernels/attention/test_merge_attn_states.py
@@ -333,8 +333,16 @@ FP8_HEAD_SIZES = [64, 128, 256]
 @pytest.mark.parametrize("num_tokens", FP8_NUM_BATCH_TOKENS)
 @pytest.mark.parametrize("num_query_heads", FP8_NUM_QUERY_HEADS)
 @pytest.mark.parametrize("head_size", FP8_HEAD_SIZES)
+@pytest.mark.parametrize("output_scale_val", [0.5, 0.05])
+@pytest.mark.parametrize("use_output_lse", [True, False])
 @torch.inference_mode()
-def test_merge_attn_states_fp8(num_tokens: int, num_query_heads: int, head_size: int):
+def test_merge_attn_states_fp8(
+    num_tokens: int,
+    num_query_heads: int,
+    head_size: int,
+    output_scale_val: float,
+    use_output_lse: bool,
+):
     if not current_platform.is_cuda():
         pytest.skip("FP8 merge_attn_states test requires CUDA")
 
@@ -344,7 +352,8 @@ def test_merge_attn_states_fp8(num_tokens: int, num_query_heads: int, head_size:
     print(
         f"\n[FP8] NUM_TOKENS:{num_tokens}, NUM_HEADS:{num_query_heads}, "
         f"HEAD_SIZE:{head_size}, input_dtype:{input_dtype}, "
-        f"fp8_dtype:{fp8_dtype}"
+        f"fp8_dtype:{fp8_dtype}, output_scale:{output_scale_val}, "
+        f"use_output_lse:{use_output_lse}"
     )
 
     # Create inputs in BF16
@@ -371,10 +380,25 @@ def test_merge_attn_states_fp8(num_tokens: int, num_query_heads: int, head_size:
     suffix_lse[mask_suffix] = float("inf")
 
     # Output scale for static FP8 quantization
-    output_scale = torch.tensor([0.05], dtype=torch.float32, device="cuda")
+    output_scale = torch.tensor([output_scale_val], dtype=torch.float32, device="cuda")
+
+    # Optional output_lse
+    output_lse_ref = None
+    output_lse_cuda = None
+    output_lse_triton = None
+    if use_output_lse:
+        output_lse_ref = torch.zeros(
+            num_query_heads, num_tokens, dtype=torch.float32, device="cuda"
+        )
+        output_lse_cuda = torch.zeros(
+            num_query_heads, num_tokens, dtype=torch.float32, device="cuda"
+        )
+        output_lse_triton = torch.zeros(
+            num_query_heads, num_tokens, dtype=torch.float32, device="cuda"
+        )
 
     # 0. Compute reference using torch with output_scale
-    ref_fp8, _ = merge_attn_states_torch(
+    ref_fp8, output_lse_ref = merge_attn_states_torch(
         torch.zeros(
             (num_tokens, num_query_heads, head_size), dtype=fp8_dtype, device="cuda"
         ),
@@ -382,6 +406,7 @@ def test_merge_attn_states_fp8(num_tokens: int, num_query_heads: int, head_size:
         prefix_lse.clone(),
         suffix_output,
         suffix_lse.clone(),
+        output_lse=output_lse_ref,
         output_scale=output_scale,
     )
 
@@ -395,6 +420,7 @@ def test_merge_attn_states_fp8(num_tokens: int, num_query_heads: int, head_size:
         prefix_lse,
         suffix_output,
         suffix_lse,
+        output_lse=output_lse_cuda,
         output_scale=output_scale,
     )
 
@@ -408,10 +434,18 @@ def test_merge_attn_states_fp8(num_tokens: int, num_query_heads: int, head_size:
         prefix_lse,
         suffix_output,
         suffix_lse,
+        output_lse=output_lse_triton,
         output_scale=output_scale,
     )
 
-    # 3. Compare — FP8 has limited precision so use wider tolerances
+    # 3. Compare — use scale-dependent tolerances
+    # scale=0.5: values stay in low-magnitude FP8 range, finer granularity
+    # scale=0.05: values pushed to high-magnitude range, coarse quantization
+    if output_scale_val >= 0.5:
+        fp8_atol, fp8_rtol = 0.5, 0.05
+    else:
+        fp8_atol, fp8_rtol = 2.5, 0.15
+
     def diff(a: torch.Tensor, b: torch.Tensor):
         return torch.max(torch.abs(a.float() - b.float()))
 
@@ -419,17 +453,27 @@ def test_merge_attn_states_fp8(num_tokens: int, num_query_heads: int, head_size:
     print(f"  (Triton vs Ref) max diff: {diff(output_triton, ref_fp8)}")
     print(f"  (CUDA vs Triton) max diff: {diff(output_cuda, output_triton)}")
 
-    # FP8 E4M3 has coarse quantization levels (e.g. ..., 16, 18, 20, ...),
-    # so rounding boundary differences between GPU kernels and PyTorch
-    # reference can produce up to 1 quantization step difference (~2.0
-    # at larger magnitudes). Use tolerances that accommodate this.
     torch.testing.assert_close(
-        output_cuda.float(), ref_fp8.float(), atol=2.5, rtol=0.15
+        output_cuda.float(), ref_fp8.float(), atol=fp8_atol, rtol=fp8_rtol
     )
     torch.testing.assert_close(
-        output_triton.float(), ref_fp8.float(), atol=2.5, rtol=0.15
+        output_triton.float(), ref_fp8.float(), atol=fp8_atol, rtol=fp8_rtol
     )
     torch.testing.assert_close(
-        output_cuda.float(), output_triton.float(), atol=2.5, rtol=0.15
+        output_cuda.float(), output_triton.float(), atol=fp8_atol, rtol=fp8_rtol
     )
+
+    # 4. Compare output_lse if provided (float32, unaffected by FP8)
+    if use_output_lse:
+        cuda_lse_diff = diff(output_lse_cuda, output_lse_ref)
+        triton_lse_diff = diff(output_lse_triton, output_lse_ref)
+        print(f"  (CUDA LSE vs Ref)   max diff: {cuda_lse_diff}")
+        print(f"  (Triton LSE vs Ref) max diff: {triton_lse_diff}")
+        torch.testing.assert_close(
+            output_lse_cuda, output_lse_ref, atol=1e-3, rtol=1e-2
+        )
+        torch.testing.assert_close(
+            output_lse_triton, output_lse_ref, atol=1e-3, rtol=1e-2
+        )
+
     print("[FP8] All tests passed!")

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -189,9 +189,16 @@ def merge_attn_states(
     suffix_output: torch.Tensor,
     suffix_lse: torch.Tensor,
     output_lse: torch.Tensor | None = None,
+    output_scale: torch.Tensor | None = None,
 ) -> None:
     torch.ops._C.merge_attn_states(
-        output, output_lse, prefix_output, prefix_lse, suffix_output, suffix_lse
+        output,
+        output_lse,
+        prefix_output,
+        prefix_lse,
+        suffix_output,
+        suffix_lse,
+        output_scale,
     )
 
 

--- a/vllm/v1/attention/ops/merge_attn_states.py
+++ b/vllm/v1/attention/ops/merge_attn_states.py
@@ -19,6 +19,12 @@ def merge_attn_states(
     # does not support FP8 dtype for inputs, fallback to use Triton kernel.
     # However, when output_scale is provided, the inputs are still BF16/FP16
     # and the output is FP8 — both CUDA and Triton support this.
+    # FP8 output requires output_scale to be set.
+    if output.dtype not in (torch.float32, torch.half, torch.bfloat16):
+        assert output_scale is not None, (
+            f"output_scale is required when output is {output.dtype}"
+        )
+
     def supported_dtypes(prefix: torch.Tensor) -> bool:
         return prefix.dtype in [torch.float32, torch.half, torch.bfloat16]
 

--- a/vllm/v1/attention/ops/merge_attn_states.py
+++ b/vllm/v1/attention/ops/merge_attn_states.py
@@ -13,35 +13,52 @@ def merge_attn_states(
     suffix_output: torch.Tensor,
     suffix_lse: torch.Tensor,
     output_lse: torch.Tensor | None = None,
+    output_scale: torch.Tensor | None = None,
 ) -> None:
     # NOTE(DefTruth): Currently, custom merge_attn_states CUDA kernel
-    # does not support FP8 dtype, fallback to use Triton kernel.
-    def supported_dtypes(o: torch.Tensor) -> bool:
-        return o.dtype in [torch.float32, torch.half, torch.bfloat16]
+    # does not support FP8 dtype for inputs, fallback to use Triton kernel.
+    # However, when output_scale is provided, the inputs are still BF16/FP16
+    # and the output is FP8 — both CUDA and Triton support this.
+    def supported_dtypes(prefix: torch.Tensor) -> bool:
+        return prefix.dtype in [torch.float32, torch.half, torch.bfloat16]
 
     # NOTE(DefTruth): Currently, custom merge_attn_states CUDA
     # kernel load/store 128b(16 bytes) per memory issue within
     # thread. Namely, the headsize(headdim) must be multiple of
-    # pack_size (float32 -> 4, half/bfloat16 -> 8).
-    def supported_headdim(o: torch.Tensor) -> bool:
-        headdim = o.shape[2]  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-        if o.dtype == torch.float32:
+    # pack_size based on input dtype (float32 -> 4, half/bfloat16 -> 8).
+    def supported_headdim(prefix: torch.Tensor) -> bool:
+        headdim = prefix.shape[2]  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+        if prefix.dtype == torch.float32:
             return headdim % 4 == 0
         return headdim % 8 == 0
 
     if (
         current_platform.is_cuda()
-        and supported_dtypes(output)
-        and supported_headdim(output)
+        and supported_dtypes(prefix_output)
+        and supported_headdim(prefix_output)
     ):
         from vllm._custom_ops import merge_attn_states
 
         return merge_attn_states(
-            output, prefix_output, prefix_lse, suffix_output, suffix_lse, output_lse
+            output,
+            prefix_output,
+            prefix_lse,
+            suffix_output,
+            suffix_lse,
+            output_lse,
+            output_scale,
         )
     else:
-        from vllm.v1.attention.ops.triton_merge_attn_states import merge_attn_states
+        from vllm.v1.attention.ops.triton_merge_attn_states import (
+            merge_attn_states,
+        )
 
         return merge_attn_states(
-            output, prefix_output, prefix_lse, suffix_output, suffix_lse, output_lse
+            output,
+            prefix_output,
+            prefix_lse,
+            suffix_output,
+            suffix_lse,
+            output_lse,
+            output_scale,
         )

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -32,8 +32,13 @@ def merge_attn_states(
     output_head_stride = output.stride(1)
 
     use_fp8 = output_scale is not None
-    # Pre-invert scale: multiplication is faster than division in Triton
-    output_scale_inv = (1.0 / output_scale.item()) if use_fp8 else 0.0
+    if use_fp8:
+        scale_val = output_scale.item()
+        assert scale_val != 0.0, "output_scale must be non-zero"
+        # Pre-invert: multiplication is faster than division in Triton
+        output_scale_inv = 1.0 / scale_val
+    else:
+        output_scale_inv = 0.0
 
     # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
     merge_attn_states_kernel[(num_tokens, num_query_heads)](

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -31,13 +31,7 @@ def merge_attn_states(
     output_head_stride = output.stride(1)
 
     use_fp8 = output_scale is not None
-    if use_fp8:
-        scale_val = output_scale.item()
-        assert scale_val != 0.0, "output_scale must be non-zero"
-        # Pre-invert: multiplication is faster than division in Triton
-        output_scale_inv = 1.0 / scale_val
-    else:
-        output_scale_inv = 0.0
+    output_scale_inv = 1.0 / output_scale if use_fp8 else None
 
     # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
     merge_attn_states_kernel[(num_tokens, num_query_heads)](
@@ -67,7 +61,7 @@ def merge_attn_states_kernel(
     suffix_lse,  # [NUM_HEADS, NUM_TOKENS]
     prefix_head_stride,
     output_head_stride,
-    output_scale_inv,
+    output_scale_inv,  # pre-computed 1/scale tensor or None
     HEAD_SIZE: tl.constexpr,
     PADDED_HEAD_SIZE: tl.constexpr,
     OUTPUT_LSE: tl.constexpr,
@@ -128,7 +122,7 @@ def merge_attn_states_kernel(
     out = p_out * p_scale + s_out * s_scale
 
     if USE_FP8:
-        out = out * output_scale_inv
+        out = out * tl.load(output_scale_inv)
         out = tl.clamp(out, FP8_MIN, FP8_MAX)
         out = out.to(output.dtype.element_ty)
 

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -5,6 +5,10 @@ import torch
 
 from vllm.triton_utils import tl, triton
 
+# FP8 E4M3 range constants (must be constexpr for use in @jit kernels)
+FP8_E4M3_MAX = tl.constexpr(448.0)
+FP8_E4M3_MIN = tl.constexpr(-448.0)
+
 
 # Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 # can be used to combine partial attention results (in the split-KV case)
@@ -15,16 +19,22 @@ def merge_attn_states(
     suffix_output: torch.Tensor,
     suffix_lse: torch.Tensor,
     output_lse: torch.Tensor | None = None,
+    output_scale: torch.Tensor | None = None,
 ) -> None:
-    num_tokens = output.shape[0]
-    num_query_heads = output.shape[1]
-    head_size = output.shape[2]
+    num_tokens = prefix_output.shape[0]
+    num_query_heads = prefix_output.shape[1]
+    head_size = prefix_output.shape[2]
     padded_head_size = triton.next_power_of_2(head_size)
     # We assume the output stride on num_head is not always as same as the
-    # `suffix_output` and `prefix_output`, as them might be padded by the attention
-    # backend.
+    # `suffix_output` and `prefix_output`, as them might be padded by the
+    # attention backend.
     prefix_head_stride = prefix_output.stride(1)
     output_head_stride = output.stride(1)
+
+    use_fp8 = output_scale is not None
+    # Pre-invert scale: multiplication is faster than division in Triton
+    output_scale_inv = (1.0 / output_scale.item()) if use_fp8 else 0.0
+
     # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
     merge_attn_states_kernel[(num_tokens, num_query_heads)](
         output,
@@ -35,9 +45,11 @@ def merge_attn_states(
         suffix_lse,
         prefix_head_stride,
         output_head_stride,
+        output_scale_inv,
         head_size,
         padded_head_size,
         output_lse is not None,
+        use_fp8,
     )
 
 
@@ -51,9 +63,11 @@ def merge_attn_states_kernel(
     suffix_lse,  # [NUM_HEADS, NUM_TOKENS]
     prefix_head_stride,
     output_head_stride,
+    output_scale_inv,
     HEAD_SIZE: tl.constexpr,
     PADDED_HEAD_SIZE: tl.constexpr,
     OUTPUT_LSE: tl.constexpr,
+    USE_FP8: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
     num_tokens = tl.num_programs(0)
@@ -106,11 +120,16 @@ def merge_attn_states_kernel(
     p_scale = p_se / out_se
     s_scale = s_se / out_se
     out = p_out * p_scale + s_out * s_scale
+
+    if USE_FP8:
+        out = out * output_scale_inv
+        out = tl.clamp(out, FP8_E4M3_MIN, FP8_E4M3_MAX)
+
     tl.store(
         output
         + token_idx * num_heads * output_head_stride
         + head_idx * output_head_stride
         + head_arange,
-        out,
+        out.to(output.dtype.element_ty),
         mask=head_mask,
     )

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -31,7 +31,6 @@ def merge_attn_states(
     output_head_stride = output.stride(1)
 
     use_fp8 = output_scale is not None
-    output_scale_inv = 1.0 / output_scale if use_fp8 else None
 
     # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
     merge_attn_states_kernel[(num_tokens, num_query_heads)](
@@ -43,7 +42,7 @@ def merge_attn_states(
         suffix_lse,
         prefix_head_stride,
         output_head_stride,
-        output_scale_inv,
+        output_scale if use_fp8 else None,
         head_size,
         padded_head_size,
         output_lse is not None,
@@ -61,7 +60,7 @@ def merge_attn_states_kernel(
     suffix_lse,  # [NUM_HEADS, NUM_TOKENS]
     prefix_head_stride,
     output_head_stride,
-    output_scale_inv,  # pre-computed 1/scale tensor or None
+    output_scale,  # scale tensor or None
     HEAD_SIZE: tl.constexpr,
     PADDED_HEAD_SIZE: tl.constexpr,
     OUTPUT_LSE: tl.constexpr,
@@ -122,7 +121,7 @@ def merge_attn_states_kernel(
     out = p_out * p_scale + s_out * s_scale
 
     if USE_FP8:
-        out = out * tl.load(output_scale_inv)
+        out = out * (1.0 / tl.load(output_scale))
         out = tl.clamp(out, FP8_MIN, FP8_MAX)
         out = out.to(output.dtype.element_ty)
 

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -30,8 +30,6 @@ def merge_attn_states(
     prefix_head_stride = prefix_output.stride(1)
     output_head_stride = output.stride(1)
 
-    use_fp8 = output_scale is not None
-
     # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
     merge_attn_states_kernel[(num_tokens, num_query_heads)](
         output,
@@ -42,11 +40,11 @@ def merge_attn_states(
         suffix_lse,
         prefix_head_stride,
         output_head_stride,
-        output_scale if use_fp8 else None,
+        output_scale,
         head_size,
         padded_head_size,
         output_lse is not None,
-        use_fp8,
+        output_scale is not None,
     )
 
 

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -3,11 +3,10 @@
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
-# FP8 E4M3 range constants (must be constexpr for use in @jit kernels)
-FP8_E4M3_MAX = tl.constexpr(448.0)
-FP8_E4M3_MIN = tl.constexpr(-448.0)
+float8_info = torch.finfo(current_platform.fp8_dtype())
 
 
 # Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
@@ -21,9 +20,9 @@ def merge_attn_states(
     output_lse: torch.Tensor | None = None,
     output_scale: torch.Tensor | None = None,
 ) -> None:
-    num_tokens = prefix_output.shape[0]
-    num_query_heads = prefix_output.shape[1]
-    head_size = prefix_output.shape[2]
+    num_tokens = output.shape[0]
+    num_query_heads = output.shape[1]
+    head_size = output.shape[2]
     padded_head_size = triton.next_power_of_2(head_size)
     # We assume the output stride on num_head is not always as same as the
     # `suffix_output` and `prefix_output`, as them might be padded by the
@@ -73,6 +72,8 @@ def merge_attn_states_kernel(
     PADDED_HEAD_SIZE: tl.constexpr,
     OUTPUT_LSE: tl.constexpr,
     USE_FP8: tl.constexpr,
+    FP8_MIN: tl.constexpr = float8_info.min,
+    FP8_MAX: tl.constexpr = float8_info.max,
 ):
     token_idx = tl.program_id(0)
     num_tokens = tl.num_programs(0)
@@ -128,13 +129,14 @@ def merge_attn_states_kernel(
 
     if USE_FP8:
         out = out * output_scale_inv
-        out = tl.clamp(out, FP8_E4M3_MIN, FP8_E4M3_MAX)
+        out = tl.clamp(out, FP8_MIN, FP8_MAX)
+        out = out.to(output.dtype.element_ty)
 
     tl.store(
         output
         + token_idx * num_heads * output_head_stride
         + head_idx * output_head_stride
         + head_arange,
-        out.to(output.dtype.element_ty),
+        out,
         mask=head_mask,
     )


### PR DESCRIPTION

## Purpose
Alternative to #36518 that loads mutliple input packs to produce a unit4 FP8 output, for vectorized store.

## Test Plan
- [x] Benchmark and compare results between two implementations.

## Test Result
Branch 1: original PR #36518 
Branch 2: this PR, 128-bit vectorized FP8 output writes
Observations:
- performance is close for bf16
- branch 1 is better on large batch with float32

```
merge_attn_states benchmark: Branch comparison on NVIDIA H100 80GB HBM3
========================================================================
Warmup: 10, Bench iters: 50, Head dim: 128 for all configs

---------------------------------------------------------------------------------------------
                                        Branch 1              Branch 2
Config             Tokens Dtype      Fused   Unfused  Spd   Fused   Unfused  Spd    Fused delta
---------------------------------------------------------------------------------------------
DeepSeek-V3 MLA         1 bfloat16    7.2us   17.6us 2.43x   7.6us   16.1us 2.13x   +6%
DeepSeek-V3 MLA        16 bfloat16    7.4us   16.5us 2.22x   7.7us   16.7us 2.16x   +4%
DeepSeek-V3 MLA        64 bfloat16    8.3us   20.1us 2.43x   8.2us   20.5us 2.49x   -1%
DeepSeek-V3 MLA       256 bfloat16   11.8us   35.1us 2.99x  10.8us   35.2us 3.27x   -8%
DeepSeek-V3 MLA      1024 bfloat16   35.3us  123.0us 3.48x  35.5us  122.9us 3.46x   +1%
DeepSeek-V3 MLA      4096 bfloat16  116.9us  460.0us 3.94x 116.3us  459.5us 3.95x   -1%
DeepSeek-V3 MLA         1 float16     7.4us   15.7us 2.13x   7.8us   16.5us 2.13x   +5%
DeepSeek-V3 MLA        16 float16     7.5us   16.1us 2.15x   7.9us   16.8us 2.14x   +5%
DeepSeek-V3 MLA        64 float16     8.1us   19.6us 2.42x   8.2us   20.3us 2.46x   +1%
DeepSeek-V3 MLA       256 float16    11.6us   35.4us 3.05x  10.6us   35.3us 3.32x   -9%
DeepSeek-V3 MLA      1024 float16    35.2us  122.7us 3.48x  35.2us  122.6us 3.48x    0%
DeepSeek-V3 MLA      4096 float16   116.7us  464.7us 3.98x 116.4us  459.2us 3.95x    0%
DeepSeek-V3 MLA         1 float32     7.2us   15.9us 2.21x   7.7us   16.7us 2.17x   +7%
DeepSeek-V3 MLA        16 float32     7.9us   17.3us 2.19x   8.4us   16.6us 1.98x   +6%
DeepSeek-V3 MLA        64 float32     8.6us   19.9us 2.32x   8.9us   20.4us 2.29x   +3%
DeepSeek-V3 MLA       256 float32    15.2us   46.0us 3.03x  14.8us   45.7us 3.08x   -3%
DeepSeek-V3 MLA      1024 float32    56.4us  153.5us 2.72x  65.0us  153.2us 2.36x  +15%
DeepSeek-V3 MLA      4096 float32   202.0us  587.1us 2.91x 367.2us  586.6us 1.60x  +82%
Llama-70B               1 bfloat16    7.7us   16.6us 2.15x   7.5us   15.8us 2.10x   -3%
Llama-70B              64 bfloat16    8.2us   18.3us 2.23x   7.9us   18.2us 2.29x   -4%
Llama-70B             256 bfloat16    9.9us   26.0us 2.63x   9.2us   25.6us 2.79x   -7%
Llama-70B            1024 bfloat16   20.0us   67.0us 3.35x  18.6us   66.4us 3.56x   -7%
Llama-70B            4096 bfloat16   62.9us  235.3us 3.74x  62.4us  234.7us 3.76x   -1%
Llama-70B            1024 float32    32.5us   81.6us 2.51x  38.3us   81.1us 2.12x  +18%
Llama-70B            4096 float32   105.5us  297.8us 2.82x 124.3us  297.3us 2.39x  +18%
Llama-8B                1 bfloat16    8.2us   16.5us 2.00x   7.4us   16.1us 2.18x  -10%
Llama-8B               64 bfloat16    7.8us   17.3us 2.21x   7.8us   16.8us 2.15x    0%
Llama-8B              256 bfloat16    8.8us   20.9us 2.39x   8.1us   20.3us 2.49x   -8%
Llama-8B             1024 bfloat16   12.2us   35.9us 2.94x  10.9us   35.3us 3.24x  -11%
Llama-8B             4096 bfloat16   35.8us  123.4us 3.45x  35.4us  123.0us 3.48x   -1%
Llama-8B             1024 float32    16.0us   46.5us 2.91x  15.2us   45.5us 3.00x   -5%
Llama-8B             4096 float32    56.7us  153.6us 2.71x  65.1us  153.1us 2.35x  +15%
---------------------------------------------------------------------------------------------
```

Benchmark result :
```
Device: NVIDIA H100 80GB HBM3
Warmup: 10, Bench iters: 50
Token counts: [1, 16, 64, 256, 1024, 4096]
Head configs: [('DeepSeek-V3 MLA', 128, 128), ('Llama-70B', 64, 128), ('Llama-8B', 32, 128)]
Input dtypes: ['float32', 'float16', 'bfloat16']

------------------------------------------------------------------------------------------------------------------
FP8 Fused vs Unfused merge_attn_states
------------------------------------------------------------------------------------------------------------------
Config             Tokens Heads  Hdim InDtype       FuCUDA    UnfCUDA  SpdCUDA    FuTriton    UnfTriton  SpdTriton
------------------------------------------------------------------------------------------------------------------
DeepSeek-V3 MLA         1   128   128 bfloat16       7.6us     16.1us    2.13x      26.9us       27.3us      1.02x
DeepSeek-V3 MLA        16   128   128 bfloat16       7.7us     16.7us    2.16x      27.0us       27.3us      1.01x
DeepSeek-V3 MLA        64   128   128 bfloat16       8.2us     20.5us    2.49x      30.3us       31.1us      1.03x
DeepSeek-V3 MLA       256   128   128 bfloat16      10.8us     35.2us    3.27x      45.6us       59.4us      1.30x
DeepSeek-V3 MLA      1024   128   128 bfloat16      35.5us    122.9us    3.46x     106.2us      179.1us      1.69x
DeepSeek-V3 MLA      4096   128   128 bfloat16     116.3us    459.5us    3.95x     343.9us      657.9us      1.91x
DeepSeek-V3 MLA         1   128   128 float16        7.8us     16.5us    2.13x      26.5us       28.1us      1.06x
DeepSeek-V3 MLA        16   128   128 float16        7.9us     16.8us    2.14x      27.1us       27.6us      1.02x
DeepSeek-V3 MLA        64   128   128 float16        8.2us     20.3us    2.46x      30.7us       31.4us      1.02x
DeepSeek-V3 MLA       256   128   128 float16       10.6us     35.3us    3.32x      45.3us      219.3us      4.84x
DeepSeek-V3 MLA      1024   128   128 float16       35.2us    122.6us    3.48x     106.2us      178.9us      1.68x
DeepSeek-V3 MLA      4096   128   128 float16      116.4us    459.2us    3.95x     344.0us      657.6us      1.91x
DeepSeek-V3 MLA         1   128   128 float32        7.7us     16.7us    2.17x      27.1us       27.8us      1.03x
DeepSeek-V3 MLA        16   128   128 float32        8.4us     16.6us    1.98x      26.7us       27.5us      1.03x
DeepSeek-V3 MLA        64   128   128 float32        8.9us     20.4us    2.29x      30.4us       31.2us      1.03x
DeepSeek-V3 MLA       256   128   128 float32       14.8us     45.7us    3.08x      45.9us       60.3us      1.31x
DeepSeek-V3 MLA      1024   128   128 float32       65.0us    153.2us    2.36x     106.6us      180.5us      1.69x
DeepSeek-V3 MLA      4096   128   128 float32      367.2us    586.6us    1.60x     344.0us      662.6us      1.93x
Llama-70B               1    64   128 bfloat16       7.5us     15.8us    2.10x      26.3us       26.7us      1.01x
Llama-70B              16    64   128 bfloat16       7.6us     16.0us    2.11x      26.1us       26.8us      1.03x
Llama-70B              64    64   128 bfloat16       7.9us     18.2us    2.29x      73.2us       28.9us      0.40x
Llama-70B             256    64   128 bfloat16       9.2us     25.6us    2.79x      35.3us       38.9us      1.10x
Llama-70B            1024    64   128 bfloat16      18.6us     66.4us    3.56x      66.5us       99.1us      1.49x
Llama-70B            4096    64   128 bfloat16      62.4us    234.7us    3.76x     185.2us      338.3us      1.83x
Llama-70B               1    64   128 float16        7.5us     15.8us    2.11x      26.4us       26.8us      1.02x
Llama-70B              16    64   128 float16        7.8us     16.0us    2.05x      26.5us       27.2us      1.02x
Llama-70B              64    64   128 float16        7.9us     17.8us    2.26x      28.0us       28.8us      1.03x
Llama-70B             256    64   128 float16        9.2us     25.4us    2.75x      35.3us       38.6us      1.09x
Llama-70B            1024    64   128 float16       19.1us     66.6us    3.48x      66.8us       98.8us      1.48x
Llama-70B            4096    64   128 float16       62.4us    234.9us    3.77x     185.2us      339.1us      1.83x
Llama-70B               1    64   128 float32        7.7us     15.9us    2.06x      26.0us       26.9us      1.03x
Llama-70B              16    64   128 float32        8.3us     16.1us    1.95x     107.9us       27.4us      0.25x
Llama-70B              64    64   128 float32        8.3us     18.2us    2.19x      27.9us       29.0us      1.04x
Llama-70B             256    64   128 float32       10.4us     25.5us    2.45x      35.3us       38.9us      1.10x
Llama-70B            1024    64   128 float32       38.3us     81.1us    2.12x      66.7us      100.2us      1.50x
Llama-70B            4096    64   128 float32      124.3us    297.3us    2.39x     186.5us      342.1us      1.83x
Llama-8B                1    32   128 bfloat16       7.4us     16.1us    2.18x      26.2us       27.0us      1.03x
Llama-8B               16    32   128 bfloat16       7.5us     16.2us    2.15x      26.7us       27.9us      1.05x
Llama-8B               64    32   128 bfloat16       7.8us     16.8us    2.15x      26.5us       28.3us      1.07x
Llama-8B              256    32   128 bfloat16       8.1us     20.3us    2.49x      30.4us       31.0us      1.02x
Llama-8B             1024    32   128 bfloat16      10.9us     35.3us    3.24x      45.2us       59.5us      1.32x
Llama-8B             4096    32   128 bfloat16      35.4us    123.0us    3.48x     106.2us      179.1us      1.69x
Llama-8B                1    32   128 float16        7.5us     15.9us    2.14x      26.0us       27.1us      1.04x
Llama-8B               16    32   128 float16        7.7us     16.4us    2.13x      27.5us       27.4us      1.00x
Llama-8B               64    32   128 float16        7.7us     16.6us    2.15x      27.2us       27.5us      1.01x
Llama-8B              256    32   128 float16        8.1us     20.5us    2.52x      30.2us       31.3us      1.04x
Llama-8B             1024    32   128 float16       10.5us     35.3us    3.35x      45.6us       59.0us      1.29x
Llama-8B             4096    32   128 float16       35.3us    123.0us    3.49x     106.1us      179.0us      1.69x
Llama-8B                1    32   128 float32        7.8us     16.1us    2.07x      25.9us       27.1us      1.05x
Llama-8B               16    32   128 float32        7.8us     16.9us    2.16x      27.0us       27.5us      1.02x
Llama-8B               64    32   128 float32        8.2us     16.4us    1.99x      26.8us       27.5us      1.02x
Llama-8B              256    32   128 float32        8.9us     20.6us    2.30x      30.3us       31.4us      1.03x
Llama-8B             1024    32   128 float32       15.2us     45.5us    3.00x      46.0us       60.3us      1.31x
Llama-8B             4096    32   128 float32       65.1us    153.1us    2.35x     106.4us      180.0us      1.69x
------------------------------------------------------------------------------------------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

