### PR TITLE
[Bugfix][sleepmode] Serialize GPU VMM operations to fix sleep/wakeup race condition

### DIFF
--- a/vllm/config/device.py
+++ b/vllm/config/device.py
@@ -27,6 +27,9 @@ class DeviceConfig:
     """Device type from the current platform. This is set in
     `__post_init__`."""
 
+    device_ids: list[int] = field(default_factory=list)
+    """List of physical GPU IDs used by this instance."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -71,3 +74,6 @@ class DeviceConfig:
         else:
             # Set device with device type
             self.device = torch.device(self.device_type)
+
+        if not self.device_ids:
+            self.device_ids = [0] if self.device_type == "cuda" else []

--- a/vllm/config/device.py
+++ b/vllm/config/device.py
@@ -76,4 +76,15 @@ class DeviceConfig:
             self.device = torch.device(self.device_type)
 
         if not self.device_ids:
-            self.device_ids = [0] if self.device_type == "cuda" else []
+            if current_platform.is_cuda_alike():
+                logical_id = (
+                    self.device.index
+                    if self.device.index is not None
+                    else torch.accelerator.current_device_index()
+                )
+                physical_id = current_platform.device_id_to_physical_device_id(
+                    logical_id
+                )
+                self.device_ids = [physical_id]
+            else:
+                self.device_ids = []

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1074,7 +1074,20 @@ class AsyncMPClient(MPClient):
         )
         await self._send_input_message(message, engine, args)
         self._ensure_output_queue_task()
-        return await future
+
+        timeout = 300.0 if method in ("wake_up", "sleep") else 60.0
+        try:
+            return await asyncio.wait_for(future, timeout=timeout)
+        except asyncio.TimeoutError:
+            self.resources.engine_dead = True
+            logger.error(
+                "Engine utility call '%s' timed out after %.1fs. "
+                "This might be a GPU memory deadlock.",
+                method,
+                timeout,
+            )
+            self.shutdown()
+            raise EngineDeadError(f"EngineCore unresponsive during {method}") from None
 
     async def get_supported_tasks_async(self) -> tuple[SupportedTask, ...]:
         return await self.call_utility_async("get_supported_tasks")

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
+import os
+import socket
+import tempfile
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from concurrent.futures import Future
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeVar, overload
 
 from vllm.config import VllmConfig
@@ -308,18 +313,82 @@ class Executor(ABC):
         """Reset the encoder cache in each worker to clear cached encoder outputs."""
         self.collective_rpc("reset_encoder_cache")
 
+    def _get_gpu_access_signal_path(self) -> Path:
+        """Get a node-local signal path to serialize VMM operations per GPU."""
+        device_id = 0
+        p_cfg = self.parallel_config
+        if hasattr(p_cfg, "device_ids") and p_cfg.device_ids:
+            device_id = p_cfg.device_ids[0]
+        else:
+            device_id = p_cfg.rank // p_cfg.tensor_parallel_size
+
+        hostname = socket.gethostname()
+        if os.path.exists("/dev/shm"):
+            base_dir = Path("/dev/shm")
+        else:
+            tmp_dir = os.environ.get("VLLM_TEMP_DIR", tempfile.gettempdir())
+            base_dir = Path(tmp_dir)
+
+        sig_dir = base_dir / "vllm_signals"
+        with contextlib.suppress(Exception):
+            sig_dir.mkdir(parents=True, exist_ok=True)
+            if os.name != "nt":
+                os.chmod(sig_dir, 0o777)
+
+        return sig_dir / f"vmm_{hostname}_gpu_{device_id}.signal"
+
+    def _wait_and_acquire_gpu_access(self, signal_path: Path):
+        """Atomic acquire with stale process detection to prevent deadlocks."""
+        my_pid = os.getpid()
+        while True:
+            try:
+                flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+                fd = os.open(str(signal_path), flags)
+                with os.fdopen(fd, "w") as f:
+                    f.write(str(my_pid))
+                return
+            except FileExistsError:
+                try:
+                    with open(signal_path) as f:
+                        owner_pid = int(f.read().strip())
+                    if owner_pid == my_pid:
+                        return
+                    os.kill(owner_pid, 0)
+                except (ProcessLookupError, ValueError, OSError):
+                    with contextlib.suppress(Exception):
+                        signal_path.unlink(missing_ok=True)
+                    continue
+
+                logger.info("GPU VMM busy (Owner: %d), retrying...", owner_pid)
+                time.sleep(0.5)
+
+    def _release_gpu_access(self, signal_path: Path):
+        """Relinquish GPU access after verifying ownership."""
+        with contextlib.suppress(Exception):
+            if signal_path.exists():
+                with open(signal_path) as f:
+                    content = f.read().strip()
+                if content and int(content) == os.getpid():
+                    signal_path.unlink(missing_ok=True)
+
     def sleep(self, level: int = 1):
         if self.is_sleeping:
             logger.warning("Executor is already sleeping.")
             return
-        time_before_sleep = time.perf_counter()
-        self.collective_rpc("sleep", kwargs=dict(level=level))
-        time_after_sleep = time.perf_counter()
-        self.sleeping_tags = {"weights", "kv_cache"}
-        self.is_sleeping = True
-        logger.info(
-            "It took %.6f seconds to fall asleep.", time_after_sleep - time_before_sleep
-        )
+        signal_path = self._get_gpu_access_signal_path()
+        self._wait_and_acquire_gpu_access(signal_path)
+        try:
+            time_before_sleep = time.perf_counter()
+            self.collective_rpc("sleep", kwargs=dict(level=level))
+            time_after_sleep = time.perf_counter()
+            self.sleeping_tags = {"weights", "kv_cache"}
+            self.is_sleeping = True
+            logger.info(
+                "It took %.6f seconds to fall asleep.",
+                time_after_sleep - time_before_sleep,
+            )
+        finally:
+            self._release_gpu_access(signal_path)
 
     def wake_up(self, tags: list[str] | None = None):
         if not self.is_sleeping:
@@ -332,14 +401,19 @@ class Executor(ABC):
                         "Tag %s is not in sleeping tags %s", tag, self.sleeping_tags
                     )
                     return
-        time_before_wakeup = time.perf_counter()
-        self.collective_rpc("wake_up", kwargs=dict(tags=tags))
-        time_after_wakeup = time.perf_counter()
-        logger.info(
-            "It took %.6f seconds to wake up tags %s.",
-            time_after_wakeup - time_before_wakeup,
-            tags if tags is not None else self.sleeping_tags,
-        )
+        signal_path = self._get_gpu_access_signal_path()
+        self._wait_and_acquire_gpu_access(signal_path)
+        try:
+            time_before_wakeup = time.perf_counter()
+            self.collective_rpc("wake_up", kwargs=dict(tags=tags))
+            time_after_wakeup = time.perf_counter()
+            logger.info(
+                "It took %.6f seconds to wake up tags %s.",
+                time_after_wakeup - time_before_wakeup,
+                tags if tags is not None else self.sleeping_tags,
+            )
+        finally:
+            self._release_gpu_access(signal_path)
         if tags:
             for tag in tags:
                 self.sleeping_tags.remove(tag)

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
 import os
-import psutil
 import socket
 import tempfile
 import time
@@ -341,24 +340,21 @@ class Executor(ABC):
 
     def _acquire_gpu_access(self):
         """Acquire atomic signals for all GPUs managed by this executor."""
-        my_pid = os.getpid()
-        try:
-            # Obtain the current process's startup time and add a uniqueness check.
-            my_create_time = psutil.Process(my_pid).create_time()
-        except psutil.Error:
-            my_create_time = -1.0
-
-        my_lock_info = f"{my_pid}:{my_create_time}"
         device_ids = self.device_config.device_ids
         if not device_ids:
             logger.warning(
                 "Could not determine device IDs for GPU access lock. "
-                "This may cause issues in multi-instance or multi-GPU scenarios. "
                 "Falling back to locking GPU 0."
             )
             device_ids = [0]
 
         sorted_ids = sorted(list(set(device_ids)))
+        my_pid = os.getpid()
+        try:
+            my_create_time = psutil.Process(my_pid).create_time()
+        except psutil.Error:
+            my_create_time = -1.0
+        my_lock_info = f"{my_pid}:{my_create_time}"
         acquired_paths: list[Path] = []
 
         for d_id in sorted_ids:
@@ -368,36 +364,30 @@ class Executor(ABC):
                     flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
                     fd = os.open(str(sig_path), flags)
                     with os.fdopen(fd, "w") as f:
-                        f.write(str(my_lock_info))
+                        f.write(my_lock_info)
                     acquired_paths.append(sig_path)
                     break
                 except FileExistsError:
                     try:
-                        content = sig_path.read_text().strip()
-                        if not content:
-                            raise ValueError("Lock file is empty.")
-                        owner_pid_str, owner_create_time_str = content.split(":", 1)
-                        owner_pid = int(owner_pid_str)
-                        owner_create_time = float(owner_create_time_str)
-                        if owner_pid == my_pid and owner_create_time == my_create_time:
+                        owner_info = sig_path.read_text().strip()
+                        if owner_info == my_lock_info:
                             acquired_paths.append(sig_path)
                             break
-                        # Verify whether the lock holder is still alive
-                        # and whether the startup time is consistent.
-                        p = psutil.Process(owner_pid)
-                        if p.create_time() != owner_create_time:
-                            raise ProcessLookupError
+                        owner_pid = -1
+                        if owner_info:
+                            try:
+                                owner_pid = int(owner_info.split(":", 1)[0])
+                            except (ValueError, IndexError):
+                                raise ProcessLookupError from None
 
-                    except (
-                        psutil.NoSuchProcess,
-                        ProcessLookupError,
-                        ValueError,
-                        OSError,
-                    ):
-                        with contextlib.suppress(OSError):
+                        if owner_pid != -1:
+                            os.kill(owner_pid, 0)
+                        else:
+                            raise ProcessLookupError from None
+                    except (ProcessLookupError, ValueError, OSError, psutil.Error):
+                        with contextlib.suppress(Exception):
                             sig_path.unlink(missing_ok=True)
                         continue
-
                     logger.info(
                         "GPU %d is busy (Owner: %d), retrying...", d_id, owner_pid
                     )
@@ -405,14 +395,19 @@ class Executor(ABC):
         return acquired_paths
 
     def _release_gpu_access(self, acquired_paths: list[Path]):
-        """Release all held GPU signals."""
+        """Release all held GPU signals with PID and create_time validation."""
         my_pid = os.getpid()
+        try:
+            my_create_time = psutil.Process(my_pid).create_time()
+        except psutil.Error:
+            my_create_time = -1.0
+        my_lock_info = f"{my_pid}:{my_create_time}"
+
         for sig_path in acquired_paths:
             try:
                 if sig_path.exists():
-                    with open(sig_path) as f:
-                        content = f.read().strip()
-                    if content and int(content) == my_pid:
+                    content = sig_path.read_text().strip()
+                    if content == my_lock_info:
                         sig_path.unlink(missing_ok=True)
             except (OSError, ValueError):
                 pass

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -339,8 +339,10 @@ class Executor(ABC):
 
     def _acquire_gpu_access(self):
         """Acquire atomic signals for all GPUs managed by this executor."""
-        # Get all associated physical GPU IDs from device_config
-        device_ids = self.device_config.device_ids
+        # Use getattr to satisfy mypy since device_ids may not be explicitly
+        # typed in DeviceConfig.
+        device_ids = getattr(self.device_config, "device_ids", None)
+
         if not device_ids:
             logger.warning(
                 "Could not determine device IDs for GPU access lock. "
@@ -371,7 +373,7 @@ class Executor(ABC):
                         if owner_pid == my_pid:
                             break
 
-                        # Use safer check (Bot recommendation)
+                        # Use safer check to avoid os.kill(-1, 0)
                         if owner_pid != -1:
                             os.kill(owner_pid, 0)
                         else:

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
 import os
+import psutil
 import socket
 import tempfile
 import time

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -339,8 +339,7 @@ class Executor(ABC):
 
     def _acquire_gpu_access(self):
         """Acquire atomic signals for all GPUs managed by this executor."""
-        # Get all associated physical GPU IDs
-        p_cfg = self.parallel_config
+        # Get all associated physical GPU IDs from device_config
         device_ids = self.device_config.device_ids
         if not device_ids:
             logger.warning(
@@ -371,10 +370,11 @@ class Executor(ABC):
                             owner_pid = int(content) if content else -1
                         if owner_pid == my_pid:
                             break
+
+                        # Use safer check (Bot recommendation)
                         if owner_pid != -1:
                             os.kill(owner_pid, 0)
                         else:
-                            # Stale lock file with empty content, treat as dead process.
                             raise ProcessLookupError
                     except (ProcessLookupError, ValueError, OSError):
                         with contextlib.suppress(Exception):

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -316,12 +316,11 @@ class Executor(ABC):
     def _get_gpu_access_signal_path(self, device_id: int) -> Path:
         """Get a node-local signal path for a specific GPU device."""
         hostname = socket.gethostname()
-        if os.path.exists("/dev/shm"):
-            base_dir = Path("/dev/shm")
-        else:
-            tmp_dir = os.environ.get("VLLM_TEMP_DIR", tempfile.gettempdir())
-            base_dir = Path(tmp_dir)
-
+        base_dir = (
+            Path("/dev/shm")
+            if os.path.exists("/dev/shm")
+            else Path(tempfile.gettempdir())
+        )
         sig_dir = base_dir / "vllm_signals"
         try:
             # 0o1777 sets the sticky bit,
@@ -339,10 +338,7 @@ class Executor(ABC):
 
     def _acquire_gpu_access(self):
         """Acquire atomic signals for all GPUs managed by this executor."""
-        # Use getattr to satisfy mypy since device_ids may not be explicitly
-        # typed in DeviceConfig.
-        device_ids = getattr(self.device_config, "device_ids", None)
-
+        device_ids = self.device_config.device_ids
         if not device_ids:
             logger.warning(
                 "Could not determine device IDs for GPU access lock. "

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
 import os
 import socket
 import tempfile
@@ -312,15 +313,8 @@ class Executor(ABC):
         """Reset the encoder cache in each worker to clear cached encoder outputs."""
         self.collective_rpc("reset_encoder_cache")
 
-    def _get_gpu_access_signal_path(self) -> Path:
-        """Get a node-local signal path to serialize VMM operations per GPU."""
-        device_id = 0
-        p_cfg = self.parallel_config
-        if hasattr(p_cfg, "device_ids") and p_cfg.device_ids:
-            device_id = p_cfg.device_ids[0]
-        else:
-            device_id = p_cfg.rank // p_cfg.tensor_parallel_size
-
+    def _get_gpu_access_signal_path(self, device_id: int) -> Path:
+        """Get a node-local signal path for a specific GPU device."""
         hostname = socket.gethostname()
         if os.path.exists("/dev/shm"):
             base_dir = Path("/dev/shm")
@@ -329,7 +323,6 @@ class Executor(ABC):
             base_dir = Path(tmp_dir)
 
         sig_dir = base_dir / "vllm_signals"
-
         try:
             # 0o1777 sets the sticky bit,
             # so only the owner can delete their signal files.
@@ -339,67 +332,72 @@ class Executor(ABC):
                 os.chmod(sig_dir, mode)
         except OSError as e:
             logger.warning(
-                "Failed to set permissions on signal directory %s. "
-                "GPU VMM serialization may be affected. Error: %s",
-                sig_dir,
-                e,
+                "Failed to set permissions on signal directory %s: %s", sig_dir, e
             )
+
         return sig_dir / f"vmm_{hostname}_gpu_{device_id}.signal"
 
-    def _wait_and_acquire_gpu_access(self, signal_path: Path):
-        """Atomic acquire with stale process detection and error handling."""
+    def _acquire_gpu_access(self):
+        """Acquire atomic signals for all GPUs managed by this executor."""
+        # Get all associated physical GPU IDs
+        p_cfg = self.parallel_config
+        device_ids = p_cfg.device_ids if hasattr(p_cfg, "device_ids") else []
+        if not device_ids:
+            # Fallback to single device from rank calculation
+            device_ids = [p_cfg.rank // p_cfg.tensor_parallel_size]
+
+        sorted_ids = sorted(list(set(device_ids)))
         my_pid = os.getpid()
-        while True:
-            try:
-                flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
-                fd = os.open(str(signal_path), flags)
-                with os.fdopen(fd, "w") as f:
-                    f.write(str(my_pid))
-                return
-            except FileExistsError:
+        acquired_paths: list[Path] = []
+
+        for d_id in sorted_ids:
+            sig_path = self._get_gpu_access_signal_path(d_id)
+            while True:
                 try:
-                    with open(signal_path) as f:
-                        content = f.read().strip()
-                        owner_pid = int(content) if content else -1
-
-                    if owner_pid == my_pid:
-                        return
-
-                    os.kill(owner_pid, 0)
-                except (ProcessLookupError, ValueError, OSError):
+                    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+                    fd = os.open(str(sig_path), flags)
+                    with os.fdopen(fd, "w") as f:
+                        f.write(str(my_pid))
+                    acquired_paths.append(sig_path)
+                    break
+                except FileExistsError:
                     try:
-                        signal_path.unlink(missing_ok=True)
-                        continue
-                    except OSError as e:
-                        logger.error(
-                            "Failed to remove stale signal file %s: %s. "
-                            "This may lead to a deadlock.",
-                            signal_path,
-                            e,
-                        )
-                        time.sleep(1.0)
+                        with open(sig_path) as f:
+                            content = f.read().strip()
+                            owner_pid = int(content) if content else -1
+                        if owner_pid == my_pid:
+                            break
+                        os.kill(owner_pid, 0)
+                    except (ProcessLookupError, ValueError, OSError):
+                        with contextlib.suppress(Exception):
+                            sig_path.unlink(missing_ok=True)
                         continue
 
-                logger.info("GPU VMM busy (Owner: %d), retrying...", owner_pid)
-                time.sleep(0.5)
+                    logger.info(
+                        "GPU %d is busy (Owner: %d), retrying...", d_id, owner_pid
+                    )
+                    time.sleep(0.5)
+        return acquired_paths
 
-    def _release_gpu_access(self, signal_path: Path):
-        """Safely release the signal file after verifying ownership."""
-        try:
-            if signal_path.exists():
-                with open(signal_path) as f:
-                    content = f.read().strip()
-                if content and int(content) == os.getpid():
-                    signal_path.unlink(missing_ok=True)
-        except (OSError, ValueError) as e:
-            logger.warning("Error releasing GPU access signal %s: %s", signal_path, e)
+    def _release_gpu_access(self, acquired_paths: list[Path]):
+        """Release all held GPU signals."""
+        my_pid = os.getpid()
+        for sig_path in acquired_paths:
+            try:
+                if sig_path.exists():
+                    with open(sig_path) as f:
+                        content = f.read().strip()
+                    if content and int(content) == my_pid:
+                        sig_path.unlink(missing_ok=True)
+            except (OSError, ValueError):
+                pass
 
     def sleep(self, level: int = 1):
         if self.is_sleeping:
             logger.warning("Executor is already sleeping.")
             return
-        signal_path = self._get_gpu_access_signal_path()
-        self._wait_and_acquire_gpu_access(signal_path)
+
+        acquired = self._acquire_gpu_access()
         try:
             time_before_sleep = time.perf_counter()
             self.collective_rpc("sleep", kwargs=dict(level=level))
@@ -411,7 +409,7 @@ class Executor(ABC):
                 time_after_sleep - time_before_sleep,
             )
         finally:
-            self._release_gpu_access(signal_path)
+            self._release_gpu_access(acquired)
 
     def wake_up(self, tags: list[str] | None = None):
         if not self.is_sleeping:
@@ -424,8 +422,8 @@ class Executor(ABC):
                         "Tag %s is not in sleeping tags %s", tag, self.sleeping_tags
                     )
                     return
-        signal_path = self._get_gpu_access_signal_path()
-        self._wait_and_acquire_gpu_access(signal_path)
+
+        acquired = self._acquire_gpu_access()
         try:
             time_before_wakeup = time.perf_counter()
             self.collective_rpc("wake_up", kwargs=dict(tags=tags))
@@ -436,7 +434,8 @@ class Executor(ABC):
                 tags if tags is not None else self.sleeping_tags,
             )
         finally:
-            self._release_gpu_access(signal_path)
+            self._release_gpu_access(acquired)
+
         if tags:
             for tag in tags:
                 self.sleeping_tags.remove(tag)

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -12,6 +12,8 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeVar, overload
 
+import psutil
+
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -338,6 +340,14 @@ class Executor(ABC):
 
     def _acquire_gpu_access(self):
         """Acquire atomic signals for all GPUs managed by this executor."""
+        my_pid = os.getpid()
+        try:
+            # Obtain the current process's startup time and add a uniqueness check.
+            my_create_time = psutil.Process(my_pid).create_time()
+        except psutil.Error:
+            my_create_time = -1.0
+
+        my_lock_info = f"{my_pid}:{my_create_time}"
         device_ids = self.device_config.device_ids
         if not device_ids:
             logger.warning(
@@ -348,7 +358,6 @@ class Executor(ABC):
             device_ids = [0]
 
         sorted_ids = sorted(list(set(device_ids)))
-        my_pid = os.getpid()
         acquired_paths: list[Path] = []
 
         for d_id in sorted_ids:
@@ -358,24 +367,33 @@ class Executor(ABC):
                     flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
                     fd = os.open(str(sig_path), flags)
                     with os.fdopen(fd, "w") as f:
-                        f.write(str(my_pid))
+                        f.write(str(my_lock_info))
                     acquired_paths.append(sig_path)
                     break
                 except FileExistsError:
                     try:
-                        with open(sig_path) as f:
-                            content = f.read().strip()
-                            owner_pid = int(content) if content else -1
-                        if owner_pid == my_pid:
+                        content = sig_path.read_text().strip()
+                        if not content:
+                            raise ValueError("Lock file is empty.")
+                        owner_pid_str, owner_create_time_str = content.split(":", 1)
+                        owner_pid = int(owner_pid_str)
+                        owner_create_time = float(owner_create_time_str)
+                        if owner_pid == my_pid and owner_create_time == my_create_time:
+                            acquired_paths.append(sig_path)
                             break
-
-                        # Use safer check to avoid os.kill(-1, 0)
-                        if owner_pid != -1:
-                            os.kill(owner_pid, 0)
-                        else:
+                        # Verify whether the lock holder is still alive
+                        # and whether the startup time is consistent.
+                        p = psutil.Process(owner_pid)
+                        if p.create_time() != owner_create_time:
                             raise ProcessLookupError
-                    except (ProcessLookupError, ValueError, OSError):
-                        with contextlib.suppress(Exception):
+
+                    except (
+                        psutil.NoSuchProcess,
+                        ProcessLookupError,
+                        ValueError,
+                        OSError,
+                    ):
+                        with contextlib.suppress(OSError):
                             sig_path.unlink(missing_ok=True)
                         continue
 

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -341,10 +341,14 @@ class Executor(ABC):
         """Acquire atomic signals for all GPUs managed by this executor."""
         # Get all associated physical GPU IDs
         p_cfg = self.parallel_config
-        device_ids = p_cfg.device_ids if hasattr(p_cfg, "device_ids") else []
+        device_ids = self.device_config.device_ids
         if not device_ids:
-            # Fallback to single device from rank calculation
-            device_ids = [p_cfg.rank // p_cfg.tensor_parallel_size]
+            logger.warning(
+                "Could not determine device IDs for GPU access lock. "
+                "This may cause issues in multi-instance or multi-GPU scenarios. "
+                "Falling back to locking GPU 0."
+            )
+            device_ids = [0]
 
         sorted_ids = sorted(list(set(device_ids)))
         my_pid = os.getpid()

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import contextlib
 import os
 import socket
 import tempfile
@@ -330,15 +329,25 @@ class Executor(ABC):
             base_dir = Path(tmp_dir)
 
         sig_dir = base_dir / "vllm_signals"
-        with contextlib.suppress(Exception):
-            sig_dir.mkdir(parents=True, exist_ok=True)
-            if os.name != "nt":
-                os.chmod(sig_dir, 0o777)
 
+        try:
+            # 0o1777 sets the sticky bit,
+            # so only the owner can delete their signal files.
+            mode = 0o1777
+            sig_dir.mkdir(mode=mode, parents=True, exist_ok=True)
+            if os.name != "nt":
+                os.chmod(sig_dir, mode)
+        except OSError as e:
+            logger.warning(
+                "Failed to set permissions on signal directory %s. "
+                "GPU VMM serialization may be affected. Error: %s",
+                sig_dir,
+                e,
+            )
         return sig_dir / f"vmm_{hostname}_gpu_{device_id}.signal"
 
     def _wait_and_acquire_gpu_access(self, signal_path: Path):
-        """Atomic acquire with stale process detection to prevent deadlocks."""
+        """Atomic acquire with stale process detection and error handling."""
         my_pid = os.getpid()
         while True:
             try:
@@ -350,26 +359,40 @@ class Executor(ABC):
             except FileExistsError:
                 try:
                     with open(signal_path) as f:
-                        owner_pid = int(f.read().strip())
+                        content = f.read().strip()
+                        owner_pid = int(content) if content else -1
+
                     if owner_pid == my_pid:
                         return
+
                     os.kill(owner_pid, 0)
                 except (ProcessLookupError, ValueError, OSError):
-                    with contextlib.suppress(Exception):
+                    try:
                         signal_path.unlink(missing_ok=True)
-                    continue
+                        continue
+                    except OSError as e:
+                        logger.error(
+                            "Failed to remove stale signal file %s: %s. "
+                            "This may lead to a deadlock.",
+                            signal_path,
+                            e,
+                        )
+                        time.sleep(1.0)
+                        continue
 
                 logger.info("GPU VMM busy (Owner: %d), retrying...", owner_pid)
                 time.sleep(0.5)
 
     def _release_gpu_access(self, signal_path: Path):
-        """Relinquish GPU access after verifying ownership."""
-        with contextlib.suppress(Exception):
+        """Safely release the signal file after verifying ownership."""
+        try:
             if signal_path.exists():
                 with open(signal_path) as f:
                     content = f.read().strip()
                 if content and int(content) == os.getpid():
                     signal_path.unlink(missing_ok=True)
+        except (OSError, ValueError) as e:
+            logger.warning("Error releasing GPU access signal %s: %s", signal_path, e)
 
     def sleep(self, level: int = 1):
         if self.is_sleeping:

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -371,7 +371,11 @@ class Executor(ABC):
                             owner_pid = int(content) if content else -1
                         if owner_pid == my_pid:
                             break
-                        os.kill(owner_pid, 0)
+                        if owner_pid != -1:
+                            os.kill(owner_pid, 0)
+                        else:
+                            # Stale lock file with empty content, treat as dead process.
+                            raise ProcessLookupError
                     except (ProcessLookupError, ValueError, OSError):
                         with contextlib.suppress(Exception):
                             sig_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Purpose
Fixes #36753

This PR addresses a critical race condition in vLLM V1's sleep and wake_up transitions when multiple engine instances share the same GPU.

### Problem
In vLLM V1, independent API server processes manage their own physical memory mappings via CUDA VMM. When multiple models on the same GPU attempt concurrent VMM operations, specifically when Model A is sleeping (releasing memory) while Model B is waking up (acquiring memory), the CUDA driver's internal state becomes inconsistent.

### This leads to two failure modes:
Silent Livelock: The process hangs indefinitely in kernel space.
EngineDeadError: The process crashes with a hard error during memory re-mapping (as reported by users).

### Solution
Implemented a Node-Local Atomic Signaling mechanism in Executor:
Atomic Serialization: Uses os.O_EXCL to ensure only one process per GPU can perform VMM operations (sleep/wake_up) at any given time.
Self-Healing: Automatically detects and cleans up stale signal files if a process crashes (through os.kill(pid, 0)), preventing deadlocks.
Cluster Safety: Incorporates hostname in the signal path to prevent false contention on shared filesystems (NFS/Ceph).

## Test Plan
Environment
GPU: A100 80GB (or H100)

Config: lmcache and Two V1 instances (Model A & Model B) with gpu_memory_utilization=0.8. 
see user original issue script

Reproduce Steps
Concurrent Wakeup: Trigger wake_up for both models simultaneously.

Transition Race:
Wake up Model A.
Simultaneously send POST /sleep to Model A and POST /wake_up to Model B.

Expected Behavior
Processes should wait for each other in a queue. Logs should show GPU VMM busy (Owner: ...), waiting... instead of hanging or crashing.

## Test Result
Before Fix
Concurrent transitions led to EngineDeadError or indefinite hangs:

```
(APIServer pid=68) ERROR: Exception in ASGI application
Traceback (most recent call last):
  ...
  File ".../vllm/v1/engine/core_client.py", line 566, in ensure_alive
    raise EngineDeadError()
vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue.
```

After Fix
Transitions are now serialized and stable:
```

----------------------------------------------------------------
ALL READY! Initial sequence complete. Both models ready in Sleep Mode.
----------------------------------------------------------------
(APIServer pid=374540) INFO 03-14 17:24:18 [api_router.py:39] wake up the engine with tags: None
(EngineCore pid=375193) INFO 03-14 17:24:19 [abstract.py:396] It took 1.082721 seconds to wake up tags {'weights', 'kv_cache'}.
(APIServer pid=374540) INFO:     127.0.0.1:58278 - "POST /wake_up HTTP/1.1" 200 OK
(APIServer pid=376649) INFO 03-14 17:24:26 [api_router.py:39] wake up the engine with tags: None
(EngineCore pid=375193) INFO 03-14 17:24:26 [block_pool.py:472] Successfully reset prefix cache
(EngineCore pid=377264) INFO 03-14 17:24:26 [abstract.py:353] GPU VMM busy (Owner: 375193), waiting...
(EngineCore pid=377264) INFO 03-14 17:24:26 [abstract.py:353] GPU VMM busy (Owner: 375193), waiting...
(EngineCore pid=375193) INFO 03-14 17:24:27 [cumem.py:216] CuMemAllocator: sleep freed 38.11 GiB memory in total, of which 15.05 GiB is backed up in CPU and the rest 23.06 GiB is discarded directly.
(EngineCore pid=375193) INFO 03-14 17:24:27 [gpu_worker.py:175] Sleep mode freed 38.11 GiB memory, 2.92 GiB memory is still in use.
(EngineCore pid=375193) INFO 03-14 17:24:27 [abstract.py:375] It took 0.687472 seconds to fall asleep.
(APIServer pid=374540) INFO:     127.0.0.1:50660 - "POST /sleep?level=1 HTTP/1.1" 200 OK
(EngineCore pid=377264) INFO 03-14 17:24:29 [abstract.py:399] It took 1.693557 seconds to wake up tags {'weights', 'kv_cache'}.
(APIServer pid=376649) INFO:     127.0.0.1:47442 - "POST /wake_up HTTP/1.1" 200 OK
```
