### PR TITLE
[Bugfix] Add Qwen3.5 MoE support to benchmark_moe.py

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -778,12 +778,16 @@ def get_model_params(config):
         "Qwen2MoeForCausalLM",
         "Qwen3MoeForCausalLM",
         "Qwen3NextForCausalLM",
+        "Qwen3_5MoeForCausalLM",
     ):
         E = config.num_experts
         topk = config.num_experts_per_tok
         intermediate_size = config.moe_intermediate_size
         hidden_size = config.hidden_size
-    elif config.architectures[0] == "Qwen3VLMoeForConditionalGeneration":
+    elif config.architectures[0] in (
+        "Qwen3VLMoeForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    ):
         text_config = config.get_text_config()
         E = text_config.num_experts
         topk = text_config.num_experts_per_tok

--- a/benchmarks/kernels/benchmark_moe_permute_unpermute.py
+++ b/benchmarks/kernels/benchmark_moe_permute_unpermute.py
@@ -262,9 +262,17 @@ def main(args: argparse.Namespace):
     ):
         E = config.n_routed_experts
         topk = config.num_experts_per_tok
-    elif config.architectures[0] in ["Qwen2MoeForCausalLM", "Qwen3MoeForCausalLM"]:
+    elif config.architectures[0] in [
+        "Qwen2MoeForCausalLM",
+        "Qwen3MoeForCausalLM",
+        "Qwen3_5MoeForCausalLM",
+    ]:
         E = config.num_experts
         topk = config.num_experts_per_tok
+    elif config.architectures[0] == "Qwen3_5MoeForConditionalGeneration":
+        text_config = config.get_text_config()
+        E = text_config.num_experts
+        topk = text_config.num_experts_per_tok
 
     else:
         # Support for llama4

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -178,6 +178,8 @@ def fused_moe_kernel_gptq_awq(
     # Cast to int64 to prevent overflow in stride*offset products
     offs_token = tl.load(sorted_token_ids_ptr + offs_token_id).to(tl.int64)
     token_mask = offs_token < num_valid_tokens
+    # Pre-compute 2D mask to avoid MLIR dominance issues when used inside loops
+    token_mask_2d = token_mask[:, None]
 
     off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
     if off_experts == -1:
@@ -246,7 +248,7 @@ def fused_moe_kernel_gptq_awq(
 
         a = tl.load(
             a_ptrs,
-            mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            mask=token_mask_2d & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
             other=0.0,
         )
         b = tl.load(b_ptrs)
@@ -307,7 +309,7 @@ def fused_moe_kernel_gptq_awq(
     # Write back the block of the output
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+    c_mask = token_mask_2d & (offs_cn[None, :] < N)
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
@@ -432,6 +434,8 @@ def fused_moe_kernel(
     offs_token = offs_token.to(tl.int64)
 
     token_mask = offs_token < num_valid_tokens
+    # Pre-compute 2D mask to avoid MLIR dominance issues when used inside loops
+    token_mask_2d = token_mask[:, None]
 
     off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
     if off_experts == -1:
@@ -505,7 +509,7 @@ def fused_moe_kernel(
         # K dimension.
         a = tl.load(
             a_ptrs,
-            mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            mask=token_mask_2d & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
             other=0.0,
         )
         b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
@@ -571,7 +575,7 @@ def fused_moe_kernel(
     # Write back the block of the output
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+    c_mask = token_mask_2d & (offs_cn[None, :] < N)
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 


### PR DESCRIPTION
The benchmark_moe.py and benchmark_moe_permute_unpermute.py scripts failed when running with Qwen3.5 MoE models because get_model_params() didn't recognize the Qwen3_5MoeForConditionalGeneration architecture.

The Qwen3.5 MoE uses a multimodal architecture that stores MoE parameters (num_experts, num_experts_per_tok, moe_intermediate_size, hidden_size) in a nested text_config, similar to Qwen3VLMoeForConditionalGeneration.

This adds handlers for:
- Qwen3_5MoeForCausalLM (text-only, direct config access)
- Qwen3_5MoeForConditionalGeneration (multimodal, uses text_config)

<!-- markdownlint-disable -->

## Purpose

Enable benchmark for Qwen 3.5 family of models

## Test Plan

Functional, run the script against a Qwen 3.5

```
python3 /models/benchmarks/kernels/benchmark_moe.py --model /models/Qwen3.5-35B-A3B-FP8 --tp-size 1 --tune --save-dir test
```

## Test Result

```
CUDA_VISIBLE_DEVICES=0 python3 /models/benchmarks/kernels/benchmark_moe.py --model /models/Qwen3.5-35B-A3B-FP8 --tp-size 1 --tune --save-dir test
Namespace(model='/models/Qwen3.5-35B-A3B-FP8', tp_size=1, enable_expert_parallel=False, dtype='auto', use_deep_gemm=False, save_dir='test', seed=0, batch_size=None, tune=True, trust_remote_code=False, model_prefix=None)
2026-03-14 19:44:28,430 INFO worker.py:2013 -- Started a local Ray instance.
/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py:2052: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
Start tuning over 1920 configurations...
(pid=6559) :  88%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏                        | 1.69k/1.92k [09:46<02:49, 1.35it/s]
```

