### PR TITLE
[Bugfix] Fix harmony streaming tool call crash and argument splitting

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -708,24 +708,64 @@ class OpenAIServingChat(OpenAIServing):
                         harmony_parser = harmony_parsers[i]
                         prev_recipient = harmony_parser.current_recipient
 
-                        # Track accumulated content per token with their state
+                        # Process each token and extract its delta immediately,
+                        # before processing the next token. This is critical
+                        # because extract_harmony_streaming_delta reads
+                        # harmony_parser.messages to compute tool call indices.
+                        # Processing all tokens first would advance the parser
+                        # state past the point where early tokens' indices are
+                        # correct, causing tool call argument fragments to be
+                        # split across different tool call indices.
                         token_states: list[TokenState] = []
+                        combined_delta: DeltaMessage | None = None
                         for token_id in output.token_ids:
                             harmony_parser.process(token_id)
                             token_delta = harmony_parser.last_content_delta or ""
-                            token_states.append(
-                                TokenState(
-                                    harmony_parser.current_channel,
-                                    harmony_parser.current_recipient,
-                                    token_delta,
+                            ts = TokenState(
+                                harmony_parser.current_channel,
+                                harmony_parser.current_recipient,
+                                token_delta,
+                            )
+                            token_states.append(ts)
+
+                            # Extract delta for THIS token immediately
+                            per_tok_delta, per_tok_tools = (
+                                extract_harmony_streaming_delta(
+                                    harmony_parser=harmony_parser,
+                                    token_states=[ts],
+                                    prev_recipient=prev_recipient,
+                                    include_reasoning=request.include_reasoning,
                                 )
                             )
+                            if per_tok_tools:
+                                harmony_tools_streamed[i] = True
+                            if ts.recipient:
+                                prev_recipient = ts.recipient
+                            if per_tok_delta is not None:
+                                if combined_delta is None:
+                                    combined_delta = per_tok_delta
+                                else:
+                                    if per_tok_delta.content:
+                                        combined_delta.content = (
+                                            combined_delta.content or ""
+                                        ) + per_tok_delta.content
+                                    if per_tok_delta.reasoning:
+                                        combined_delta.reasoning = (
+                                            combined_delta.reasoning or ""
+                                        ) + per_tok_delta.reasoning
+                                    if per_tok_delta.tool_calls:
+                                        if combined_delta.tool_calls is None:
+                                            combined_delta.tool_calls = []
+                                        combined_delta.tool_calls.extend(
+                                            per_tok_delta.tool_calls
+                                        )
+
                         delta_text = "".join(delta for _, _, delta in token_states)
                         cur_channel = harmony_parser.current_channel
 
-                        # handle the case where several tokens where generated at once
-                        # including the final token, leading to a delta in the text
-                        # but the current channel to be empty (start state)
+                        # handle the case where several tokens where generated
+                        # at once including the final token, leading to a delta
+                        # in the text but the current channel to be empty
                         if not cur_channel and delta_text:
                             cur_channel = "final"
                     else:
@@ -757,15 +797,8 @@ class OpenAIServingChat(OpenAIServing):
                             current_token_ids = as_list(output.token_ids)
 
                     if self.use_harmony:
-                        delta_message, tools_streamed_flag = (
-                            extract_harmony_streaming_delta(
-                                harmony_parser=harmony_parser,
-                                token_states=token_states,
-                                prev_recipient=prev_recipient,
-                                include_reasoning=request.include_reasoning,
-                            )
-                        )
-                        harmony_tools_streamed[i] |= tools_streamed_flag
+                        # Delta already computed in the per-token loop above
+                        delta_message = combined_delta
                     # handle streaming deltas for tools with named tool_choice
                     elif tool_choice_function_name:
                         # When encountering think end id in prompt_token_ids
@@ -1108,6 +1141,7 @@ class OpenAIServingChat(OpenAIServing):
                                 delta_message, output
                             )
                             and tool_parser
+                            and not self.use_harmony
                         ):
                             latest_delta_len = 0
                             if (


### PR DESCRIPTION
## Purpose

Two fixes for Chat Completions streaming with harmony models (e.g., `gpt_oss`):

### Bug 1: Tool call arguments split across indices

With speculative decoding (Eagle), multi-token batches can span channel boundaries. `extract_harmony_streaming_delta` reads `harmony_parser.messages` to compute tool call indices, so it must be called immediately after each token is processed — not after the entire batch. Otherwise the parser state is fully advanced and `base_index` is wrong for early tokens, causing argument fragments to land in separate tool calls.

For example, a single tool call produces two entries on the client:
```
Tool[0] get_weather: {"city": "Tokyo"    ← missing closing }
Tool[1] None: }                           ← stray } as separate "tool call"
```

**Fix:** Interleave token processing with delta extraction — process one token through `harmony_parser.process()`, immediately call `extract_harmony_streaming_delta` for that token, then process the next token. Merge the per-token deltas into a single `DeltaMessage`.

### Bug 2: Server crash (IndexError) in autocomplete logic

The "unstreamed tool arg tokens" autocomplete logic at lines 1232-1281 accesses `tool_parser.prev_tool_call_arr[index]` and `tool_parser.streamed_args_for_tool[index]`. Harmony models use `extract_harmony_streaming_delta()` for tool call parsing, which never populates these arrays. Indexing into empty arrays raises `IndexError`.

**Fix:** Add `and not self.use_harmony` guard to skip the autocomplete block for harmony models.

**Not duplicating existing PRs:** Checked open PRs #33520, #35449, #35907, #36011, #36445 — none address these specific bugs (argument splitting across indices or IndexError in autocomplete logic).

**AI assistance:** This PR was developed with AI assistance (Claude). The submitter has reviewed all changes and tested end-to-end.

## Test Plan

```bash
# Start vLLM with a harmony model + Eagle speculative decoding
vllm serve <harmony-model-path> \
  --enable-auto-tool-choice --tool-call-parser openai \
  --reasoning-parser openai_gptoss \
  --speculative-config '{"method":"eagle3","model":"<eagle-head-path>","num_speculative_tokens":5}'

# Streaming tool call (was crashing / producing malformed args):
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "<model>",
    "stream": true,
    "messages": [{"role": "user", "content": "What is the weather in Tokyo?"}],
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get weather", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}]
  }'

# BFCL multi-turn function calling benchmark:
OPENAI_BASE_URL="http://localhost:8000/v1" \
OPENAI_API_KEY="fake" \
bfcl generate \
  --model <model> \
  --test-category multi_turn \
  --num-threads 8
```

## Test Result

**Before fix (Bug 1):** Streaming tool call arguments split across indices:
```
Tool[0] get_weather: {"city": "Tokyo"     ← incomplete
Tool[1] None: }                            ← stray fragment
```

**Before fix (Bug 2):** Server returns 500:
```json
{"error": {"message": "list index out of range", "type": "InternalServerError", "code": 500}}
```

**After fix:** Streaming tool calls produce correct, complete JSON:
```
Tool[0] get_weather: {"city": "Tokyo", "units": "celsius"}
```

**BFCL multi-turn results (gpt-oss-120b with Eagle3 speculative decoding):**

| Category | Accuracy |
|----------|----------|
| Multi Turn Overall | 54.75% |
| Base | 65.00% |
| Miss Func | 51.50% |
| Miss Param | 48.50% |
| Long Context | 54.00% |

All 800 test cases completed with 0 malformed JSON errors in tool call arguments.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] (Optional) Documentation update
- [ ] (Optional) Release notes update
</details>