### PR TITLE
[Bugfix] Fix Responses API harmony streaming: token splitting, missing done events, nested sequence_number

### DIFF
--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -994,9 +994,51 @@ class OpenAIServing:
             )
 
             async for res in generator:
-                context.append_output(res)
-                # NOTE(woosuk): The stop condition is handled by the engine.
-                yield context
+                # For streaming harmony models with speculative decoding
+                # (Eagle), multi-token RequestOutputs can span channel
+                # boundaries. Split them into single-token outputs so the
+                # harmony parser processes tokens one at a time, preventing
+                # intermediate channel transitions from being lost.
+                if (
+                    isinstance(context, StreamingHarmonyContext)
+                    and res.outputs
+                    and len(res.outputs[0].token_ids) > 1
+                ):
+                    token_ids = res.outputs[0].token_ids
+                    for tok_i, token_id in enumerate(token_ids):
+                        is_last = tok_i == len(token_ids) - 1
+                        single_output = CompletionOutput(
+                            index=res.outputs[0].index,
+                            text="",
+                            token_ids=[token_id],
+                            cumulative_logprob=res.outputs[0].cumulative_logprob,
+                            logprobs=(
+                                res.outputs[0].logprobs[tok_i : tok_i + 1]
+                                if res.outputs[0].logprobs
+                                else None
+                            ),
+                            finish_reason=(
+                                res.outputs[0].finish_reason if is_last else None
+                            ),
+                            stop_reason=(
+                                res.outputs[0].stop_reason if is_last else None
+                            ),
+                        )
+                        single_res = RequestOutput(
+                            request_id=res.request_id,
+                            prompt=res.prompt,
+                            prompt_token_ids=res.prompt_token_ids,
+                            prompt_logprobs=res.prompt_logprobs,
+                            outputs=[single_output],
+                            finished=res.finished if is_last else False,
+                        )
+                        context.append_output(single_res)
+                        yield context
+                else:
+                    context.append_output(res)
+                    # NOTE(woosuk): The stop condition is handled by
+                    # the engine.
+                    yield context
 
             if not context.need_builtin_tool_call():
                 # The model did not ask for a tool call, so we're done.

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1807,6 +1807,7 @@ class OpenAIServingResponses(OpenAIServing):
         ],
     ) -> AsyncGenerator[StreamingResponsesResponse, None]:
         state = StreamingState()
+        ctx = None
 
         async for ctx in result_generator:
             assert isinstance(ctx, StreamingHarmonyContext)
@@ -1827,6 +1828,15 @@ class OpenAIServingResponses(OpenAIServing):
 
             # Stream tool call outputs
             for event in emit_tool_action_events(ctx, state, self.tool_server):
+                yield _increment_sequence_number_and_return(event)
+
+        # After the loop ends, emit done events for the last message
+        # that was being streamed. During the loop, done events are only
+        # emitted when a *new* message starts (is_expecting_start), so
+        # the final message never gets its done events.
+        if ctx is not None and hasattr(ctx, "parser") and len(ctx.parser.messages) > 0:
+            last_item = ctx.parser.messages[-1]
+            for event in emit_previous_item_done_events(last_item, state):
                 yield _increment_sequence_number_and_return(event)
 
     async def responses_stream_generator(
@@ -1854,6 +1864,12 @@ class OpenAIServingResponses(OpenAIServing):
             # Set sequence_number if the event has this attribute
             if hasattr(event, "sequence_number"):
                 event.sequence_number = sequence_number
+            # Also fix sequence_number on nested items (e.g.
+            # ResponseFunctionToolCall inside ResponseOutputItemDoneEvent)
+            # which are created with placeholder sequence_number=-1.
+            item = getattr(event, "item", None)
+            if item is not None and hasattr(item, "sequence_number"):
+                item.sequence_number = sequence_number
             sequence_number += 1
             return event
 


### PR DESCRIPTION
## Purpose

Three fixes for Responses API streaming with harmony models (e.g., `gpt_oss`):

### Bug 1: Multi-token RequestOutput loses intermediate channel transitions

With Eagle speculative decoding, `RequestOutput` objects contain multiple `token_ids`. In `_generate_with_builtin_tools`, the entire multi-token output is passed to `StreamingHarmonyContext.append_output()`, which processes all tokens in a loop but only yields the context once. If the batch crosses channel boundaries (e.g., reasoning → function call), intermediate channel transitions and their content are lost.

**Fix:** In `_generate_with_builtin_tools` (`engine/serving.py`), split multi-token `RequestOutput` objects into single-token ones for `StreamingHarmonyContext` before calling `append_output()`. Each single-token output gets its own `yield context`, ensuring the harmony parser processes tokens one at a time.

### Bug 2: Final message done events not emitted

In `_process_harmony_streaming_events`, done events (\`response.output_text.done\`, \`response.content_part.done\`, \`response.output_item.done\`) are only emitted when the *next* message starts (\`is_expecting_start()\`). The last message never triggers this because the \`async for\` loop ends first.

**Symptom:** Streamed content is truncated — e.g., streaming gives \`"2 + 2 equals"\` but \`response.completed\` has \`"2 + 2 equals 4."\`.

**Fix:** After the \`async for\` loop in \`_process_harmony_streaming_events\`, emit done events for the final message.

### Bug 3: \`sequence_number=-1\` in nested response items

Events in \`streaming_events.py\` are created with placeholder \`sequence_number=-1\`. \`_increment_sequence_number_and_return\` fixes the top-level event but not nested items (e.g., \`ResponseFunctionToolCall\` inside \`ResponseOutputItemDoneEvent.item\`).

**Fix:** Also set \`sequence_number\` on nested \`item\` attributes.

**Not duplicating existing PRs:** #36445 is about non-harmony models. No other open PRs target these specific issues.

**AI assistance:** This PR was developed with AI assistance (Claude). The submitter has reviewed all changes and tested end-to-end.

## Test Plan

\`\`\`bash
# Start vLLM with a harmony model + Eagle speculative decoding
python -m vllm.entrypoints.openai.api_server --model <harmony-model-path>

# Test streaming text (checks for last-token loss)
curl -X POST http://localhost:8000/v1/responses \
  -H "Content-Type: application/json" \
  -d '{"model": "<model>", "stream": true, "input": "What is 2+2? Answer briefly."}'

# Test tool call (checks for sequence_number=-1 and channel transitions)
curl -X POST http://localhost:8000/v1/responses \
  -H "Content-Type: application/json" \
  -d '{"model": "<model>", "stream": true, "input": "What is the weather in Tokyo?",
       "tools": [{"type": "function", "name": "get_weather", "description": "Get weather",
                  "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}]}'
\`\`\`

## Test Result

**Bug 1 — Before:** With Eagle, multi-token batches crossing channel boundaries lose intermediate content.
**Bug 1 — After:** Each token processed individually; all channel transitions preserved.

**Bug 2 — Before:** Streaming gives \`"2 + 2 equals"\`, completed gives \`"2 + 2 equals 4."\` — last tokens lost.
**Bug 2 — After:** Streamed content matches completed content exactly.

**Bug 3 — Before:** \`ResponseFunctionToolCall\` nested in \`response.output_item.done\` has \`sequence_number: -1\`.
**Bug 3 — After:** Nested item carries the correct sequence number.

Tested with gpt-oss-120b model across all scenarios.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] (Optional) Documentation update
- [ ] (Optional) Release notes update
</details>