### PR TITLE
[Bugfix] Fix harmony parser crash on terminal tokens after end-of-message

### DIFF
--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -15,6 +15,7 @@ from openai_harmony import (
     ReasoningEffort,
     Role,
     StreamableParser,
+    StreamState,
     SystemContent,
     TextContent,
     ToolDescription,
@@ -32,6 +33,51 @@ REASONING_EFFORT = {
     "medium": ReasoningEffort.MEDIUM,
     "low": ReasoningEffort.LOW,
 }
+
+# Harmony terminal token IDs that signal end-of-generation
+_HARMONY_RETURN_TOKEN_ID = 200002  # <|return|>
+_HARMONY_CALL_TOKEN_ID = 200012  # <|call|>
+_HARMONY_TERMINAL_TOKEN_IDS = frozenset(
+    {
+        _HARMONY_RETURN_TOKEN_ID,
+        _HARMONY_CALL_TOKEN_ID,
+    }
+)
+
+
+class SafeStreamableParser:
+    """Wrapper around StreamableParser that handles terminal tokens gracefully.
+
+    Harmony models can emit <|return|> or <|call|> tokens after <|end|>,
+    which puts the parser in EXPECT_START state. These tokens are valid
+    stop signals but would cause "Unexpected token while expecting start
+    token" errors if passed directly to process(). This wrapper detects
+    that situation and calls process_eos() instead.
+    """
+
+    def __init__(self, inner: StreamableParser):
+        self._inner = inner
+
+    def process(self, token_id: int) -> None:
+        if (
+            self._inner.state == StreamState.EXPECT_START
+            and token_id in _HARMONY_TERMINAL_TOKEN_IDS
+        ):
+            logger.debug(
+                "Harmony parser received terminal token %d in "
+                "EXPECT_START state; treating as EOS",
+                token_id,
+            )
+            self._inner.process_eos()
+        else:
+            self._inner.process(token_id)
+
+    def process_eos(self) -> None:
+        self._inner.process_eos()
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
 
 _harmony_encoding = None
 
@@ -328,11 +374,11 @@ def get_stop_tokens_for_assistant_actions() -> list[int]:
     return get_encoding().stop_tokens_for_assistant_actions()
 
 
-def get_streamable_parser_for_assistant() -> StreamableParser:
-    return StreamableParser(get_encoding(), role=Role.ASSISTANT)
+def get_streamable_parser_for_assistant() -> SafeStreamableParser:
+    return SafeStreamableParser(StreamableParser(get_encoding(), role=Role.ASSISTANT))
 
 
-def parse_output_into_messages(token_ids: Iterable[int]) -> StreamableParser:
+def parse_output_into_messages(token_ids: Iterable[int]) -> SafeStreamableParser:
     parser = get_streamable_parser_for_assistant()
     for token_id in token_ids:
         parser.process(token_id)


### PR DESCRIPTION
## Purpose

Fix "Unexpected token while expecting start token" errors (~1.5% failure rate) when harmony models (`gpt_oss`) generate `<|return|>` (token ID 200002) or `<|call|>` (token ID 200012) tokens after `<|end|>`.

Per the [harmony format spec](https://github.com/openai/harmony/blob/main/docs/format.md), both `<|return|>` and `<|call|>` are valid **stop tokens** that signal end-of-generation. However, when the `StreamableParser` from `openai_harmony` is in `EXPECT_START` state (after processing `<|end|>`), it only accepts `<|start|>` (new message) or EOS. Receiving `<|return|>` or `<|call|>` instead causes an "Unexpected token" error.

**Fix:** Add a `SafeStreamableParser` wrapper around `StreamableParser` in `harmony_utils.py`. The wrapper intercepts `process()` calls and checks:
1. Is the parser in `EXPECT_START` state?
2. Is the incoming token a terminal token (200002 or 200012)?

If both are true, it calls `process_eos()` instead of `process()`, cleanly signaling end-of-generation. For all other tokens, it delegates directly to the inner parser. The wrapper is transparent for attribute access via `__getattr__`.

This covers all call sites automatically since they all go through `get_streamable_parser_for_assistant()`:
- Chat Completions streaming path
- Responses API non-streaming path
- Responses API streaming path

**Note:** The root fix ideally belongs in the `openai_harmony` library's `StreamableParser` itself, which should handle these terminal tokens natively in `EXPECT_START` state. This wrapper is a pragmatic fix on the vLLM side until the library is updated.

**Not duplicating existing PRs:** No open PRs address this specific terminal token handling in `EXPECT_START` state.

**AI assistance:** This PR was developed with AI assistance (Claude). The submitter has reviewed all changes and tested end-to-end.

## Test Plan

```bash
# Start vLLM with a harmony model + Eagle speculative decoding
vllm serve <harmony-model-path> \
  --enable-auto-tool-choice --tool-call-parser openai \
  --reasoning-parser openai_gptoss \
  --speculative-config '{"method":"eagle3","model":"<eagle-head-path>","num_speculative_tokens":5}'

# Run many requests to trigger the ~1.5% failure rate:
OPENAI_BASE_URL="http://localhost:8000/v1" \
OPENAI_API_KEY="fake" \
bfcl generate \
  --model <model> \
  --test-category multi_turn \
  --num-threads 8
```

## Test Result

**Before fix:** Approximately 1-2 out of 100 requests fail with:
```
"Unexpected token while expecting start token"
```

**After fix:** 0 failures across 800 BFCL multi-turn test cases.

**BFCL multi-turn results (gpt-oss-120b with Eagle3 speculative decoding):**

| Category | Accuracy |
|----------|----------|
| Multi Turn Overall | 54.75% |
| Base | 65.00% |
| Miss Func | 51.50% |
| Miss Param | 48.50% |
| Long Context | 54.00% |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] (Optional) Documentation update
- [ ] (Optional) Release notes update
</details>