### PR TITLE
Add Mistral Guidance

### DIFF
--- a/tests/reasoning/test_mistral_reasoning_parser.py
+++ b/tests/reasoning/test_mistral_reasoning_parser.py
@@ -346,3 +346,57 @@ def test_mistral_reasoning(
     else:
         content = parser.extract_content_ids(output_tokens)
         assert content == []
+
+
+def test_is_reasoning_end_with_prefilled_system_prompt(
+    mistral_tokenizer: MistralTokenizer,
+):
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        mistral_tokenizer
+    )
+
+    # Simulate a prompt that ends with a closed think block followed by
+    # regular content (as in system prompts with pre-filled thinking).
+    prompt_text_before = "System prompt text. "
+    think_content = "I am thinking about the task."
+    prompt_text_after = " Continue with the task."
+
+    prompt_tokens = (
+        mistral_tokenizer.tokenizer.encode(prompt_text_before, bos=False, eos=False)
+        + [mistral_tokenizer.instruct.BEGIN_THINK]
+        + mistral_tokenizer.tokenizer.encode(think_content, bos=False, eos=False)
+        + [mistral_tokenizer.instruct.END_THINK]
+        + mistral_tokenizer.tokenizer.encode(prompt_text_after, bos=False, eos=False)
+    )
+
+    assert parser.is_reasoning_end(prompt_tokens) is True
+
+    reasoning, content = run_reasoning_extraction_mistral(
+        parser,
+        model_output=(
+            [mistral_tokenizer.instruct.BEGIN_THINK]
+            + mistral_tokenizer.tokenizer.encode(
+                "Let me reason about this.", bos=False, eos=False
+            )
+            + [mistral_tokenizer.instruct.END_THINK]
+            + mistral_tokenizer.tokenizer.encode(
+                "Here is the answer.", bos=False, eos=False
+            )
+        ),
+        streaming=True,
+    )
+    assert reasoning == "Let me reason about this."
+    assert content == "Here is the answer."
+
+
+def test_is_reasoning_end_prompt_only_content(
+    mistral_tokenizer: MistralTokenizer,
+):
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        mistral_tokenizer
+    )
+
+    prompt_tokens = mistral_tokenizer.tokenizer.encode(
+        "Just a regular prompt.", bos=False, eos=False
+    )
+    assert parser.is_reasoning_end(prompt_tokens) is False

--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -1187,12 +1187,15 @@ class TestMistralGrammarFactory:
         assert grammar_none == grammar_auto
 
 
+_UNSET = object()
+
+
 def _create_request(
     tools: list[ChatCompletionToolsParam] | None = None,
-    tool_choice: str | None = None,
+    tool_choice: str | None | object = _UNSET,
     reasoning_effort: str | None = None,
 ) -> ChatCompletionRequest:
-    if tool_choice is None:
+    if tool_choice is _UNSET:
         tool_choice = "auto" if tools else "none"
     return ChatCompletionRequest(
         messages=[{"role": "user", "content": "test"}],
@@ -1345,9 +1348,9 @@ class TestAdjustRequestReasoningEffort:
 
         assert result.response_format is None
 
-    def test_adjust_request_no_tools_sanitizes_tool_choice(self):
-        """When no tools are provided, tool_choice should be set to 'none'
-        by adjust_request, and the grammar should only allow content."""
+    def test_adjust_request_no_tools_preserves_tool_choice(self):
+        """When no tools are provided, tool_choice should not be
+        overridden by adjust_request."""
         parser = _create_mock_tool_parser(
             tokenizer_version=11, has_reasoning_parser=False
         )
@@ -1371,6 +1374,34 @@ class TestAdjustRequestReasoningEffort:
         assert grammar is not None
         assert "body: content" in grammar
         assert "fcalls:" not in grammar
+
+    def test_adjust_request_none_tool_choice_defaults_to_auto(self):
+        """When tools are provided but tool_choice is None, it should
+        default to 'auto'."""
+        tools = [_create_tool("func", {"param": "value"}, strict=False)]
+        parser = _create_mock_tool_parser(
+            tokenizer_version=11, has_reasoning_parser=False
+        )
+
+        request = _create_request(
+            tools=tools,
+            tool_choice=None,
+            reasoning_effort=None,
+        )
+        assert request.tool_choice is None
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            result = parser.adjust_request(request)
+
+        assert result.tool_choice == "auto"
+
+        assert result.structured_outputs is not None
+        grammar = result.structured_outputs.lark
+        assert grammar is not None
+        assert "body: content | (content? fcalls)" in grammar
 
     @pytest.mark.parametrize(
         "tokenizer_version,has_reasoning_parser,reasoning_effort,"

--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -26,7 +26,7 @@ from vllm.tool_parsers.mistral_tool_parser import (
     ChatCompletionToolsParam,
     MistralGrammarFactory,
     MistralToolParser,
-    ToolsLarkConverter,
+    PostV11ToolsLarkConverter,
 )
 
 
@@ -939,7 +939,7 @@ class TestToolsLarkConverter:
     def test_get_args_json(
         self, tool: ChatCompletionToolsParam, expected: dict[str, Any]
     ) -> None:
-        assert ToolsLarkConverter().get_args_json(tool=tool) == expected
+        assert PostV11ToolsLarkConverter().get_args_json(tool=tool) == expected
 
     @pytest.mark.parametrize(
         "tools,tokenizer_version,mode,parallel_tool_calls,expected",
@@ -1060,7 +1060,7 @@ class TestToolsLarkConverter:
         expected: str,
     ):
         assert (
-            ToolsLarkConverter().convert(
+            PostV11ToolsLarkConverter().convert(
                 tools=tools,
                 tokenizer_version=tokenizer_version,
                 mode=mode,

--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -3,6 +3,8 @@
 
 import json
 from collections.abc import Generator
+from typing import Any, Literal
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import partial_json_parser
 import pytest
@@ -11,11 +13,21 @@ from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.protocol.instruct.tool_calls import FunctionCall, ToolCall
 from partial_json_parser.core.options import Allow
 
-from vllm.entrypoints.openai.engine.protocol import DeltaMessage, DeltaToolCall
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaMessage,
+    DeltaToolCall,
+    FunctionDefinition,
+)
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.tokenizers.detokenizer_utils import detokenize_incrementally
 from vllm.tokenizers.mistral import MistralTokenizer
-from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
+from vllm.tool_parsers.mistral_tool_parser import (
+    ChatCompletionToolsParam,
+    MistralGrammarFactory,
+    MistralToolParser,
+    ToolsLarkConverter,
+)
 
 
 @pytest.fixture(scope="module")
@@ -890,3 +902,528 @@ def test_extract_tool_calls_streaming_pre_v11_tokenizer_one_chunk(
         assert expected_content == ""
     else:
         assert delta_message.content == expected_content
+
+
+def _create_tool(
+    name: str, parameters: dict[str, Any], strict: bool = False
+) -> ChatCompletionToolsParam:
+    """Helper function to create a tool with optional strict attribute"""
+    func = FunctionDefinition(
+        name=name,
+        description="test",
+        parameters=parameters,
+    )
+    if strict:
+        func.strict = True  # type: ignore[attr-defined]
+    return ChatCompletionToolsParam(function=func)
+
+
+class TestToolsLarkConverter:
+    @pytest.mark.parametrize(
+        ("tool", "expected"),
+        [
+            (
+                _create_tool("function", {"parameter": 1}, strict=True),
+                {"parameter": 1},
+            ),
+            (
+                _create_tool("function", {"parameter": 1}, strict=False),
+                {"type": "object"},
+            ),
+            (
+                _create_tool("function", {}, strict=True),
+                {"type": "object", "properties": {}, "additionalProperties": False},
+            ),
+        ],
+    )
+    def test_get_args_json(
+        self, tool: ChatCompletionToolsParam, expected: dict[str, Any]
+    ) -> None:
+        assert ToolsLarkConverter().get_args_json(tool=tool) == expected
+
+    @pytest.mark.parametrize(
+        "tools,tokenizer_version,mode,parallel_tool_calls,expected",
+        [
+            # mode="none" always returns empty string
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                7,
+                "none",
+                True,
+                "",
+            ),
+            # Pre-v11: non-strict parallel vs no-parallel (maxItems difference)
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                7,
+                "auto",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "enum": ["non_strict_func"]}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}}\n',  # noqa: E501
+            ),
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                7,
+                "auto",
+                False,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "enum": ["non_strict_func"]}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}, "maxItems": 1}\n',  # noqa: E501
+            ),
+            # Pre-v11: strict tool uses anyOf with const name
+            (
+                [_create_tool("strict_func", {"param": "value"}, strict=True)],
+                7,
+                "auto",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}]}}\n',  # noqa: E501
+            ),
+            # Pre-v11: empty strict params get default schema
+            (
+                [_create_tool("empty_strict_func", {}, strict=True)],
+                7,
+                "auto",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "empty_strict_func"}, "arguments": {"type": "object", "properties": {}, "additionalProperties": false}}}]}}\n',  # noqa: E501
+            ),
+            # Pre-v11: mixed strict/non-strict
+            (
+                [
+                    _create_tool("strict_func", {"param": "value"}, strict=True),
+                    _create_tool("non_strict_func", {"param": "value"}, strict=False),
+                ],
+                7,
+                "auto",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "non_strict_func"}, "arguments": {"type": "object"}}}]}}\n',  # noqa: E501
+            ),
+            # Post-v11: non-strict parallel vs no-parallel (+ suffix difference)
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                11,
+                "auto",
+                True,
+                '((<TOOL_CALLS> SAFE_WS? "non_strict_func" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+',  # noqa: E501
+            ),
+            (
+                [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
+                11,
+                "auto",
+                False,
+                '(<TOOL_CALLS> SAFE_WS? "non_strict_func" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)',  # noqa: E501
+            ),
+            # Post-v11: strict tool embeds schema directly
+            (
+                [_create_tool("strict_func", {"param": "value"}, strict=True)],
+                11,
+                "auto",
+                True,
+                '((<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?))+',  # noqa: E501
+            ),
+            # Post-v11: multiple tools use | separator
+            (
+                [
+                    _create_tool("strict_func", {"param": "value"}, strict=True),
+                    _create_tool("non_strict_func", {"param": "value"}, strict=False),
+                ],
+                11,
+                "auto",
+                True,
+                '((<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "non_strict_func" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+',  # noqa: E501
+            ),
+            # mode="required" uses same grammar as "auto"
+            (
+                [_create_tool("test_func", {"param": "value"}, strict=True)],
+                7,
+                "required",
+                True,
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "test_func"}, "arguments": {"param": "value"}}}]}}\n',  # noqa: E501
+            ),
+        ],
+        ids=[
+            "none_returns_empty",
+            "pre_v11_non_strict_parallel",
+            "pre_v11_non_strict_no_parallel",
+            "pre_v11_strict",
+            "pre_v11_empty_strict",
+            "pre_v11_mixed",
+            "post_v11_non_strict_parallel",
+            "post_v11_non_strict_no_parallel",
+            "post_v11_strict",
+            "post_v11_mixed",
+            "required_same_as_auto",
+        ],
+    )
+    def test_convert(
+        self,
+        tools: list[ChatCompletionToolsParam] | None,
+        tokenizer_version: int,
+        mode: Literal["auto", "required", "none"],
+        parallel_tool_calls: bool,
+        expected: str,
+    ):
+        assert (
+            ToolsLarkConverter().convert(
+                tools=tools,
+                tokenizer_version=tokenizer_version,
+                mode=mode,
+                parallel_tool_calls=parallel_tool_calls,
+            )
+            == expected
+        )
+
+
+class TestMistralGrammarFactory:
+    @pytest.mark.parametrize(
+        "tokenizer_version,reasoning,expected_body_rule,expect_think",
+        [
+            # version < 13: BASE_LARK_GRAMMAR regardless of reasoning
+            (11, True, "body: content | (content? fcalls)", False),
+            # version >= 13, reasoning=False: BASE_LARK_GRAMMAR
+            (13, False, "body: content | (content? fcalls)", False),
+            # 13 <= version < 15, reasoning=True: OPTIONAL_THINK_LARK_GRAMMAR
+            (13, True, "body: think? (content | fcalls)", True),
+            # version >= 15, reasoning=False: BASE_LARK_GRAMMAR
+            (15, False, "body: content | (content? fcalls)", False),
+            # version >= 15, reasoning=True: THINK_LARK_GRAMMAR
+            (15, True, "body: (think (content | content? fcalls)) | fcalls", True),
+        ],
+        ids=[
+            "pre_v13_ignores_reasoning",
+            "v13_no_reasoning_base",
+            "v13_reasoning_optional_think",
+            "v15_no_reasoning_base",
+            "v15_reasoning_required_think",
+        ],
+    )
+    def test_get_lark_from_jinja_template_selection(
+        self,
+        tokenizer_version: int,
+        reasoning: bool,
+        expected_body_rule: str,
+        expect_think: bool,
+    ):
+        tools = [_create_tool("func", {}, strict=False)]
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            factory = MistralGrammarFactory.__new__(MistralGrammarFactory)
+            factory._tokenizer_version = tokenizer_version
+
+            grammar = factory.get_lark_from_jinja(
+                mode="auto",
+                tools=tools,
+                reasoning=reasoning,
+                parallel_tool_calls=True,
+            )
+
+        assert expected_body_rule in grammar
+
+        if expect_think:
+            assert "think: <THINK> content </THINK>" in grammar
+        else:
+            assert "think:" not in grammar
+
+    @pytest.mark.parametrize(
+        "mode,expected_body_rule",
+        [
+            ("auto", "body: content | (content? fcalls)"),
+            ("required", "body: content? fcalls"),
+            ("none", "body: content"),
+        ],
+        ids=["auto", "required", "none"],
+    )
+    def test_get_lark_from_jinja_mode_handling(
+        self,
+        mode: str,
+        expected_body_rule: str,
+    ):
+        tools = [_create_tool("func", {}, strict=False)]
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            factory = MistralGrammarFactory.__new__(MistralGrammarFactory)
+            factory._tokenizer_version = 11
+
+            grammar = factory.get_lark_from_jinja(
+                mode=mode,
+                tools=tools,
+                reasoning=False,
+                parallel_tool_calls=True,
+            )
+
+        assert expected_body_rule in grammar
+
+        # "none" mode should not have fcalls rule
+        if mode == "none":
+            assert "fcalls:" not in grammar
+        else:
+            assert "fcalls:" in grammar
+
+    def test_get_lark_from_jinja_none_mode_defaults_to_auto(self):
+        tools = [_create_tool("func", {}, strict=False)]
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            factory = MistralGrammarFactory.__new__(MistralGrammarFactory)
+            factory._tokenizer_version = 11
+
+            grammar_none = factory.get_lark_from_jinja(
+                mode=None,
+                tools=tools,
+                reasoning=False,
+                parallel_tool_calls=True,
+            )
+            grammar_auto = factory.get_lark_from_jinja(
+                mode="auto",
+                tools=tools,
+                reasoning=False,
+                parallel_tool_calls=True,
+            )
+
+        assert grammar_none == grammar_auto
+
+
+def _create_request(
+    tools: list[ChatCompletionToolsParam] | None = None,
+    tool_choice: str | None = None,
+    reasoning_effort: str | None = None,
+) -> ChatCompletionRequest:
+    if tool_choice is None:
+        tool_choice = "auto" if tools else "none"
+    return ChatCompletionRequest(
+        messages=[{"role": "user", "content": "test"}],
+        model="test-model",
+        tools=tools,
+        tool_choice=tool_choice,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def _create_mock_tool_parser(tokenizer_version: int, has_reasoning_parser: bool):
+    mock_tokenizer = MagicMock(spec=MistralTokenizer)
+    type(mock_tokenizer).version = PropertyMock(return_value=tokenizer_version)
+
+    # Set up a mock vocab with the TOOL_CALLS token
+    mock_tokenizer.get_vocab.return_value = {"[TOOL_CALLS]": 999}
+
+    with patch(
+        "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+        return_value=True,
+    ):
+        parser = MistralToolParser.__new__(MistralToolParser)
+        parser.model_tokenizer = mock_tokenizer
+        parser.vocab = {"[TOOL_CALLS]": 999}
+        parser.bot_token = "[TOOL_CALLS]"
+        parser.bot_token_id = 999
+        parser._is_pre_v11 = tokenizer_version < 11
+        parser.prev_tool_call_arr = []
+        parser.current_tool_id = -1
+        parser._has_reasoning_parser = has_reasoning_parser
+
+        # Set up the grammar factory
+        factory = MistralGrammarFactory.__new__(MistralGrammarFactory)
+        factory._tokenizer = mock_tokenizer
+        factory._tokenizer_version = tokenizer_version
+        parser.grammar_factory = factory
+
+    return parser
+
+
+class TestAdjustRequestReasoningEffort:
+    @pytest.mark.parametrize(
+        "tokenizer_version,reasoning_effort",
+        [
+            (11, "high"),
+            (15, "high"),
+        ],
+        ids=["pre_v15", "v15"],
+    )
+    def test_should_reason_no_reasoning_parser(
+        self,
+        tokenizer_version: int,
+        reasoning_effort: str | None,
+    ):
+        parser = _create_mock_tool_parser(tokenizer_version, has_reasoning_parser=False)
+        request = _create_request(reasoning_effort=reasoning_effort)
+        assert parser._should_reason(request) is False
+
+    @pytest.mark.parametrize(
+        "tokenizer_version,reasoning_effort,expected",
+        [
+            # Pre-v15: always True regardless of effort
+            (13, None, True),
+            (13, "high", True),
+            (13, "none", True),
+            # V15+: depends on reasoning_effort
+            (15, None, False),
+            (15, "none", False),
+            (15, "high", True),
+        ],
+        ids=[
+            "pre_v15_none",
+            "pre_v15_high",
+            "pre_v15_effort_none",
+            "v15_none",
+            "v15_effort_none",
+            "v15_high",
+        ],
+    )
+    def test_should_reason_with_reasoning_parser(
+        self,
+        tokenizer_version: int,
+        reasoning_effort: str | None,
+        expected: bool,
+    ):
+        parser = _create_mock_tool_parser(tokenizer_version, has_reasoning_parser=True)
+        request = _create_request(reasoning_effort=reasoning_effort)
+        assert parser._should_reason(request) is expected
+
+    @pytest.mark.parametrize(
+        "tokenizer_version,reasoning_effort,has_reasoning_parser,"
+        "expected_body_rule,expect_think",
+        [
+            # Pre-v13 with parser: BASE (reasoning ignored below v13)
+            (11, "high", True, "body: content | (content? fcalls)", False),
+            # V13 with parser: OPTIONAL_THINK
+            (13, "high", True, "body: think? (content | fcalls)", True),
+            # V15 with parser + high effort: THINK (required)
+            (
+                15,
+                "high",
+                True,
+                "body: (think (content | content? fcalls)) | fcalls",
+                True,
+            ),
+            # V15 without parser: BASE regardless of effort
+            (15, "high", False, "body: content | (content? fcalls)", False),
+        ],
+        ids=[
+            "pre_v13_base",
+            "v13_optional_think",
+            "v15_required_think",
+            "v15_no_parser_base",
+        ],
+    )
+    def test_adjust_request_grammar_selection(
+        self,
+        tokenizer_version: int,
+        reasoning_effort: str | None,
+        has_reasoning_parser: bool,
+        expected_body_rule: str,
+        expect_think: bool,
+    ):
+        tools = [_create_tool("func", {"param": "value"}, strict=False)]
+        parser = _create_mock_tool_parser(
+            tokenizer_version, has_reasoning_parser=has_reasoning_parser
+        )
+
+        request = _create_request(
+            tools=tools,
+            tool_choice="auto",
+            reasoning_effort=reasoning_effort,
+        )
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            result = parser.adjust_request(request)
+
+        assert result.structured_outputs is not None
+        grammar = result.structured_outputs.lark
+        assert grammar is not None
+        assert expected_body_rule in grammar
+
+        if expect_think:
+            assert "think: <THINK> content </THINK>" in grammar
+        else:
+            assert "think:" not in grammar
+
+        assert result.response_format is None
+
+    def test_adjust_request_no_tools_sanitizes_tool_choice(self):
+        """When no tools are provided, tool_choice should be set to 'none'
+        by adjust_request, and the grammar should only allow content."""
+        parser = _create_mock_tool_parser(
+            tokenizer_version=11, has_reasoning_parser=False
+        )
+
+        request = _create_request(
+            tools=None,
+            tool_choice="none",
+            reasoning_effort=None,
+        )
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            result = parser.adjust_request(request)
+
+        assert result.tool_choice == "none"
+
+        assert result.structured_outputs is not None
+        grammar = result.structured_outputs.lark
+        assert grammar is not None
+        assert "body: content" in grammar
+        assert "fcalls:" not in grammar
+
+    @pytest.mark.parametrize(
+        "tokenizer_version,has_reasoning_parser,reasoning_effort,"
+        "expected_body_rule,expect_think",
+        [
+            # No reasoning: BASE grammar, body: content
+            (11, False, None, "body: content", False),
+            # Pre-v15 with reasoning parser: OPTIONAL_THINK, think is optional
+            (13, True, None, "body: think? content", True),
+            # V15 with reasoning enabled: THINK, think is required
+            (15, True, "high", "body: think content", True),
+            # V15 with reasoning disabled: BASE, no think
+            (15, True, None, "body: content", False),
+        ],
+        ids=[
+            "v11_no_reasoning_base",
+            "v13_with_reasoning_optional_think",
+            "v15_reasoning_high_required_think",
+            "v15_reasoning_none_base",
+        ],
+    )
+    def test_adjust_request_none_mode_grammar_with_tools(
+        self,
+        tokenizer_version: int,
+        has_reasoning_parser: bool,
+        reasoning_effort: str | None,
+        expected_body_rule: str,
+        expect_think: bool,
+    ):
+        tools = [_create_tool("func", {"param": "value"}, strict=False)]
+        parser = _create_mock_tool_parser(
+            tokenizer_version, has_reasoning_parser=has_reasoning_parser
+        )
+
+        request = _create_request(
+            tools=tools,
+            tool_choice="none",
+            reasoning_effort=reasoning_effort,
+        )
+
+        with patch(
+            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+            return_value=True,
+        ):
+            result = parser.adjust_request(request)
+
+        assert result.structured_outputs is not None
+        grammar = result.structured_outputs.lark
+        assert grammar is not None
+        assert expected_body_rule in grammar
+        assert "fcalls:" not in grammar
+
+        if expect_think:
+            assert "think: <THINK> content </THINK>" in grammar
+        else:
+            assert "think:" not in grammar

--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -1348,9 +1348,9 @@ class TestAdjustRequestReasoningEffort:
 
         assert result.response_format is None
 
-    def test_adjust_request_no_tools_preserves_tool_choice(self):
-        """When no tools are provided, tool_choice should not be
-        overridden by adjust_request."""
+    def test_adjust_request_no_tools_skips_grammar(self):
+        """When no tools are provided, adjust_request should return
+        early without setting up any grammar."""
         parser = _create_mock_tool_parser(
             tokenizer_version=11, has_reasoning_parser=False
         )
@@ -1368,12 +1368,7 @@ class TestAdjustRequestReasoningEffort:
             result = parser.adjust_request(request)
 
         assert result.tool_choice == "none"
-
-        assert result.structured_outputs is not None
-        grammar = result.structured_outputs.lark
-        assert grammar is not None
-        assert "body: content" in grammar
-        assert "fcalls:" not in grammar
+        assert result.structured_outputs is None
 
     def test_adjust_request_none_tool_choice_defaults_to_auto(self):
         """When tools are provided but tool_choice is None, it should
@@ -1403,58 +1398,25 @@ class TestAdjustRequestReasoningEffort:
         assert grammar is not None
         assert "body: content | (content? fcalls)" in grammar
 
-    @pytest.mark.parametrize(
-        "tokenizer_version,has_reasoning_parser,reasoning_effort,"
-        "expected_body_rule,expect_think",
-        [
-            # No reasoning: BASE grammar, body: content
-            (11, False, None, "body: content", False),
-            # Pre-v15 with reasoning parser: OPTIONAL_THINK, think is optional
-            (13, True, None, "body: think? content", True),
-            # V15 with reasoning enabled: THINK, think is required
-            (15, True, "high", "body: think content", True),
-            # V15 with reasoning disabled: BASE, no think
-            (15, True, None, "body: content", False),
-        ],
-        ids=[
-            "v11_no_reasoning_base",
-            "v13_with_reasoning_optional_think",
-            "v15_reasoning_high_required_think",
-            "v15_reasoning_none_base",
-        ],
-    )
-    def test_adjust_request_none_mode_grammar_with_tools(
-        self,
-        tokenizer_version: int,
-        has_reasoning_parser: bool,
-        reasoning_effort: str | None,
-        expected_body_rule: str,
-        expect_think: bool,
-    ):
+    def test_adjust_request_none_mode_with_tools_raises(self):
+        """When tool_choice='none' is used with tools, it should raise
+        because only 'auto' tool_choice is currently supported."""
         tools = [_create_tool("func", {"param": "value"}, strict=False)]
         parser = _create_mock_tool_parser(
-            tokenizer_version, has_reasoning_parser=has_reasoning_parser
+            tokenizer_version=11, has_reasoning_parser=False
         )
 
         request = _create_request(
             tools=tools,
             tool_choice="none",
-            reasoning_effort=reasoning_effort,
+            reasoning_effort=None,
         )
 
-        with patch(
-            "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
-            return_value=True,
+        with (
+            patch(
+                "vllm.tool_parsers.mistral_tool_parser.is_mistral_tokenizer",
+                return_value=True,
+            ),
+            pytest.raises(ValueError, match="only 'auto' tool choice"),
         ):
-            result = parser.adjust_request(request)
-
-        assert result.structured_outputs is not None
-        grammar = result.structured_outputs.lark
-        assert grammar is not None
-        assert expected_body_rule in grammar
-        assert "fcalls:" not in grammar
-
-        if expect_think:
-            assert "think: <THINK> content </THINK>" in grammar
-        else:
-            assert "think:" not in grammar
+            parser.adjust_request(request)

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -67,11 +67,17 @@ from vllm.logprobs import Logprob
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.parser import ParserManager
 from vllm.reasoning import ReasoningParser
+from vllm.reasoning.mistral_reasoning_parser import MistralReasoningParser
 from vllm.renderers import ChatParams
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers import ToolParser
-from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
+from vllm.tool_parsers.mistral_tool_parser import (
+    MistralToolCall,
+    MistralToolParser,
+    is_mistral_lark_grammar_active,
+)
 from vllm.tool_parsers.utils import partial_json_loads
 from vllm.utils.collection_utils import as_list
 from vllm.utils.mistral import is_mistral_tokenizer
@@ -125,6 +131,10 @@ class OpenAIServingChat(OpenAIServing):
         self.reasoning_parser_cls = ParserManager.get_reasoning_parser(
             reasoning_parser_name=reasoning_parser
         )
+        self._is_mistral_reasoning_parser = (
+            self.reasoning_parser_cls is not None
+            and issubclass(self.reasoning_parser_cls, MistralReasoningParser)
+        )
         # set up tool use
         self.enable_auto_tools: bool = enable_auto_tools
         self.tool_parser = ParserManager.get_tool_parser(
@@ -132,6 +142,12 @@ class OpenAIServingChat(OpenAIServing):
             enable_auto_tools=enable_auto_tools,
             model_name=self.model_config.model,
         )
+        _is_mistral_tool_parser = self.tool_parser is not None and issubclass(
+            self.tool_parser, MistralToolParser
+        )
+        if _is_mistral_tool_parser and self.reasoning_parser_cls is not None:
+            MistralToolParser._has_reasoning_parser = True
+
         self.exclude_tools_when_tool_choice_none = exclude_tools_when_tool_choice_none
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
@@ -224,15 +240,24 @@ class OpenAIServingChat(OpenAIServing):
         assert tokenizer is not None
         reasoning_parser: ReasoningParser | None = None
         if self.reasoning_parser_cls:
-            # Pass the same chat template kwargs as used in tokenization
-            chat_template_kwargs = self._prepare_extra_chat_template_kwargs(
-                request.chat_template_kwargs,
-                self.default_chat_template_kwargs,
+            # For Mistral v15+ tokenizers, reasoning is only active when the
+            # request explicitly enables it (reasoning_effort not in
+            # [None, "none"]).
+            skip_reasoning = (
+                isinstance(tokenizer, MistralTokenizer)
+                and tokenizer.version >= 15
+                and request.reasoning_effort in (None, "none")
             )
-            reasoning_parser = self.reasoning_parser_cls(
-                tokenizer,
-                chat_template_kwargs=chat_template_kwargs,  # type: ignore[call-arg]
-            )
+            if not skip_reasoning:
+                # Pass the same chat template kwargs as used in tokenization
+                chat_template_kwargs = self._prepare_extra_chat_template_kwargs(
+                    request.chat_template_kwargs,
+                    self.default_chat_template_kwargs,
+                )
+                reasoning_parser = self.reasoning_parser_cls(
+                    tokenizer,
+                    chat_template_kwargs=chat_template_kwargs,  # type: ignore[call-arg]
+                )
         result = await self.render_chat_request(request)
         if isinstance(result, ErrorResponse):
             return result
@@ -309,11 +334,19 @@ class OpenAIServingChat(OpenAIServing):
                     trace_headers=trace_headers,
                 )
             else:
-                reasoning_ended = (
-                    reasoning_parser.is_reasoning_end(prompt_token_ids or [])
-                    if reasoning_parser
-                    else None
+                # Mistral lark grammar handles think/no-think structure
+                # itself, so mark reasoning as ended from token 0.
+                is_mistral_lark_grammar = is_mistral_lark_grammar_active(
+                    request, tokenizer, self.tool_parser
                 )
+                if is_mistral_lark_grammar:
+                    reasoning_ended = True
+                elif reasoning_parser is not None:
+                    reasoning_ended = reasoning_parser.is_reasoning_end(
+                        prompt_token_ids or []
+                    )
+                else:
+                    reasoning_ended = None
 
                 generator = self.engine_client.generate(
                     engine_prompt,
@@ -526,6 +559,10 @@ class OpenAIServingChat(OpenAIServing):
             harmony_tools_streamed = [False] * num_choices
         tools_streamed = [False] * num_choices
 
+        use_mistral_grammar = is_mistral_lark_grammar_active(
+            request, tokenizer, self.tool_parser
+        )
+
         if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):
             tool_choice_function_name = request.tool_choice.function.name
         else:
@@ -549,7 +586,7 @@ class OpenAIServingChat(OpenAIServing):
 
         # Only one of these will be used, thus previous_texts and
         # all_previous_token_ids will not be used twice in the same iteration.
-        if tool_choice_auto or reasoning_parser:
+        if use_mistral_grammar or tool_choice_auto or reasoning_parser:
             # These are only required in "auto" tool choice case
             all_previous_token_ids = [[]] * num_choices
             # For reasoning parser and tool call all enabled
@@ -561,7 +598,7 @@ class OpenAIServingChat(OpenAIServing):
 
         # Prepare the tool parser if it's needed
         try:
-            if tool_choice_auto and self.tool_parser:
+            if (use_mistral_grammar or tool_choice_auto) and self.tool_parser:
                 if tokenizer is None:
                     raise ValueError(
                         "Tokenizer not available when `skip_tokenizer_init=True`"
@@ -742,7 +779,7 @@ class OpenAIServingChat(OpenAIServing):
                     delta_message: DeltaMessage | None
 
                     # just update previous_texts and previous_token_ids
-                    if tool_choice_auto or reasoning_parser:
+                    if use_mistral_grammar or tool_choice_auto or reasoning_parser:
                         assert previous_texts is not None
                         assert all_previous_token_ids is not None
                         previous_text = previous_texts[i]
@@ -766,6 +803,91 @@ class OpenAIServingChat(OpenAIServing):
                             )
                         )
                         harmony_tools_streamed[i] |= tools_streamed_flag
+                    elif use_mistral_grammar and reasoning_parser:
+                        assert tool_parser is not None
+                        assert added_content_delta_arr is not None
+                        assert reasoning_end_arr is not None
+                        output_token_ids = as_list(output.token_ids)
+                        if not reasoning_end_arr[i]:
+                            # Pre-v15 models may have pre-filled
+                            # [THINK]...[/THINK] in system prompts, so
+                            # skip the prompt-level reasoning-end check
+                            # and wait for the output's own end-of-think.
+                            _is_pre_v15 = (
+                                isinstance(tokenizer, MistralTokenizer)
+                                and tokenizer.version < 15
+                            )
+                            if not _is_pre_v15 and prompt_is_reasoning_end_arr[i]:
+                                reasoning_end_arr[i] = True
+                                current_token_ids = output_token_ids
+                            else:
+                                delta_message = (
+                                    reasoning_parser.extract_reasoning_streaming(
+                                        previous_text,
+                                        current_text,
+                                        delta_text,
+                                        previous_token_ids,
+                                        current_token_ids,
+                                        output_token_ids,
+                                    )
+                                )
+                                if reasoning_parser.is_reasoning_end_streaming(
+                                    current_token_ids, output_token_ids
+                                ):
+                                    reasoning_end_arr[i] = True
+                                    current_token_ids = (
+                                        reasoning_parser.extract_content_ids(
+                                            output_token_ids
+                                        )
+                                    )
+                                    if delta_message and delta_message.content:
+                                        current_text = delta_message.content
+                                        delta_message.content = None
+                                    else:
+                                        current_text = ""
+                                # Mistral grammar fallback:
+                                # fcalls-only grammar path and skip
+                                # reasoning and start tool parsing.
+                                elif (
+                                    self._is_mistral_reasoning_parser
+                                    and tool_parser.bot_token_id in output_token_ids
+                                ):
+                                    reasoning_end_arr[i] = True
+                                    current_token_ids = output_token_ids
+
+                        if reasoning_end_arr[i]:
+                            delta_token_ids = output_token_ids
+                            if not added_content_delta_arr[i]:
+                                added_content_delta_arr[i] = True
+                                previous_text = ""
+                                previous_token_ids = []
+                                delta_text = current_text
+                                delta_token_ids = current_token_ids
+
+                            delta_message = tool_parser.extract_tool_calls_streaming(
+                                previous_text=previous_text,
+                                current_text=current_text,
+                                delta_text=delta_text,
+                                previous_token_ids=previous_token_ids,
+                                current_token_ids=current_token_ids,
+                                delta_token_ids=delta_token_ids,
+                                request=request,
+                            )
+                            if delta_message and delta_message.tool_calls:
+                                tools_streamed[i] = True
+                    elif use_mistral_grammar:
+                        assert tool_parser is not None
+                        delta_message = tool_parser.extract_tool_calls_streaming(
+                            previous_text=previous_text,
+                            current_text=current_text,
+                            delta_text=delta_text,
+                            previous_token_ids=previous_token_ids,
+                            current_token_ids=current_token_ids,
+                            delta_token_ids=output.token_ids,
+                            request=request,
+                        )
+                        if delta_message and delta_message.tool_calls:
+                            tools_streamed[i] = True
                     # handle streaming deltas for tools with named tool_choice
                     elif tool_choice_function_name:
                         # When encountering think end id in prompt_token_ids
@@ -1012,7 +1134,9 @@ class OpenAIServingChat(OpenAIServing):
                         delta_message = DeltaMessage(content=delta_text)
 
                     # update the previous values for the next iteration
-                    if (tool_choice_auto or reasoning_parser) and not self.use_harmony:
+                    if (
+                        use_mistral_grammar or tool_choice_auto or reasoning_parser
+                    ) and not self.use_harmony:
                         assert previous_texts is not None
                         assert all_previous_token_ids is not None
                         previous_texts[i] = current_text
@@ -1394,7 +1518,40 @@ class OpenAIServingChat(OpenAIServing):
             tool_call_class = (
                 MistralToolCall if is_mistral_tokenizer(tokenizer) else ToolCall
             )
-            if (not self.enable_auto_tools or not self.tool_parser) and (
+
+            use_mistral_grammar = is_mistral_lark_grammar_active(
+                request, tokenizer, self.tool_parser
+            )
+            if use_mistral_grammar:
+                if tool_calls:
+                    tool_call_items = [
+                        MistralToolCall(
+                            id=tc.id if tc.id else None,
+                            function=tc,
+                        )
+                        for tc in tool_calls
+                    ]
+                    # Per the OpenAI API spec, finish_reason is
+                    # "tool_calls" for auto/required but "stop" for
+                    # named tool choice.
+                    auto_tools_called = not isinstance(
+                        request.tool_choice,
+                        ChatCompletionNamedToolChoiceParam,
+                    )
+                    message = ChatMessage(
+                        role=role,
+                        reasoning=reasoning,
+                        content=content,
+                        tool_calls=tool_call_items,
+                    )
+                else:
+                    message = ChatMessage(
+                        role=role,
+                        reasoning=reasoning,
+                        content=content,
+                    )
+
+            elif (not self.enable_auto_tools or not self.tool_parser) and (
                 not isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
                 and request.tool_choice != "required"
             ):

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -850,7 +850,7 @@ class OpenAIServingChat(OpenAIServing):
                                 # reasoning and start tool parsing.
                                 elif (
                                     self._is_mistral_reasoning_parser
-                                    and tool_parser.bot_token_id in output_token_ids
+                                    and tool_parser.bot_token_id in output_token_ids  # type: ignore[attr-defined]
                                 ):
                                     reasoning_end_arr[i] = True
                                     current_token_ids = output_token_ids
@@ -1522,6 +1522,7 @@ class OpenAIServingChat(OpenAIServing):
             use_mistral_grammar = is_mistral_lark_grammar_active(
                 request, tokenizer, self.tool_parser
             )
+            tool_call_items: list[ToolCall]
             if use_mistral_grammar:
                 if tool_calls:
                     tool_call_items = [

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -105,7 +105,12 @@ from vllm.renderers.inputs.preprocess import (
 )
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers import ToolParser
+from vllm.tool_parsers.mistral_tool_parser import (
+    MistralToolParser,
+    is_mistral_lark_grammar_active,
+)
 from vllm.tracing import (
     contains_trace_headers,
     extract_trace_headers,
@@ -910,9 +915,18 @@ class OpenAIServing:
         # tool parsing is done only if a tool_parser has been set and if
         # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
         # is set, we want to prevent parsing a tool_call hallucinated by the LLM
+        #
+        # Exception: MistralToolParser always calls adjust_request() (even for
+        # tool_choice="none") so the grammar prevents raw special tokens
+        # from leaking into the response.
         if tool_parser is not None:
             tool_choice = getattr(request, "tool_choice", "none")
-            if tool_choice != "none":
+            tokenizer = renderer.get_tokenizer()
+            is_mistral_grammar = issubclass(
+                tool_parser,  # type: ignore[arg-type]
+                MistralToolParser,
+            ) and isinstance(tokenizer, MistralTokenizer)
+            if tool_choice != "none" or is_mistral_grammar:
                 if not isinstance(request, ChatCompletionRequest | ResponsesRequest):
                     msg = (
                         "Tool usage is only supported for Chat Completions API "
@@ -921,7 +935,6 @@ class OpenAIServing:
                     raise NotImplementedError(msg)
 
                 # TODO: Update adjust_request to accept ResponsesRequest
-                tokenizer = renderer.get_tokenizer()
                 request = tool_parser(tokenizer).adjust_request(request=request)  # type: ignore[arg-type]
 
         return conversation, [engine_prompt]
@@ -1109,7 +1122,52 @@ class OpenAIServing:
         content: str | None = None,
     ) -> tuple[list[FunctionCall] | None, str | None]:
         function_calls = list[FunctionCall]()
-        if request.tool_choice and isinstance(request.tool_choice, ToolChoiceFunction):
+
+        use_mistral_grammar = is_mistral_lark_grammar_active(
+            request,
+            tokenizer,
+            tool_parser_cls,  # type: ignore[arg-type]
+        )
+        if use_mistral_grammar or (
+            tool_parser_cls
+            and enable_auto_tools
+            and (request.tool_choice == "auto" or request.tool_choice is None)
+        ):
+            if tokenizer is None:
+                raise ValueError(
+                    "Tokenizer not available when `skip_tokenizer_init=True`"
+                )
+
+            # Automatic Tool Call Parsing
+            try:
+                assert tool_parser_cls is not None
+                tool_parser = tool_parser_cls(tokenizer)
+            except RuntimeError as e:
+                logger.exception("Error in tool parser creation.")
+                raise e
+            tool_call_info = tool_parser.extract_tool_calls(
+                content if content is not None else "",
+                request=request,  # type: ignore
+            )
+            if tool_call_info is not None and tool_call_info.tools_called:
+                # extract_tool_calls() returns a list of tool calls.
+                function_calls.extend(
+                    FunctionCall(
+                        id=tool_call.id,
+                        name=tool_call.function.name,
+                        arguments=tool_call.function.arguments,
+                    )
+                    for tool_call in tool_call_info.tool_calls
+                )
+                content = tool_call_info.content
+                if content and content.strip() == "":
+                    content = None
+            else:
+                # No tool calls.
+                return None, content
+        elif request.tool_choice and isinstance(
+            request.tool_choice, ToolChoiceFunction
+        ):
             assert content is not None
             # Forced Function Call
             function_calls.append(
@@ -1140,42 +1198,6 @@ class OpenAIServing:
                     )
                 )
             content = None  # Clear content since tool is called.
-        elif (
-            tool_parser_cls
-            and enable_auto_tools
-            and (request.tool_choice == "auto" or request.tool_choice is None)
-        ):
-            if tokenizer is None:
-                raise ValueError(
-                    "Tokenizer not available when `skip_tokenizer_init=True`"
-                )
-
-            # Automatic Tool Call Parsing
-            try:
-                tool_parser = tool_parser_cls(tokenizer)
-            except RuntimeError as e:
-                logger.exception("Error in tool parser creation.")
-                raise e
-            tool_call_info = tool_parser.extract_tool_calls(
-                content if content is not None else "",
-                request=request,  # type: ignore
-            )
-            if tool_call_info is not None and tool_call_info.tools_called:
-                # extract_tool_calls() returns a list of tool calls.
-                function_calls.extend(
-                    FunctionCall(
-                        id=tool_call.id,
-                        name=tool_call.function.name,
-                        arguments=tool_call.function.arguments,
-                    )
-                    for tool_call in tool_call_info.tool_calls
-                )
-                content = tool_call_info.content
-                if content and content.strip() == "":
-                    content = None
-            else:
-                # No tool calls.
-                return None, content
 
         return function_calls, content
 

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -1119,10 +1119,14 @@ class OpenAIServing:
     ) -> tuple[list[FunctionCall] | None, str | None]:
         function_calls = list[FunctionCall]()
 
-        use_mistral_grammar = is_mistral_lark_grammar_active(
-            request,
-            tokenizer,
-            tool_parser_cls,  # type: ignore[arg-type]
+        use_mistral_grammar = (
+            isinstance(request, ChatCompletionRequest)
+            and tokenizer is not None
+            and is_mistral_lark_grammar_active(
+                request,
+                tokenizer,
+                tool_parser_cls,  # type: ignore[arg-type]
+            )
         )
         if use_mistral_grammar or (
             tool_parser_cls

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -105,11 +105,10 @@ from vllm.renderers.inputs.preprocess import (
 )
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
-from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers import ToolParser
 from vllm.tool_parsers.mistral_tool_parser import (
-    MistralToolParser,
     is_mistral_lark_grammar_active,
+    should_apply_mistral_grammar,
 )
 from vllm.tracing import (
     contains_trace_headers,
@@ -922,10 +921,7 @@ class OpenAIServing:
         if tool_parser is not None:
             tool_choice = getattr(request, "tool_choice", "none")
             tokenizer = renderer.get_tokenizer()
-            is_mistral_grammar = issubclass(
-                tool_parser,  # type: ignore[arg-type]
-                MistralToolParser,
-            ) and isinstance(tokenizer, MistralTokenizer)
+            is_mistral_grammar = should_apply_mistral_grammar(tool_parser, tokenizer)  # type: ignore[arg-type]
             if tool_choice != "none" or is_mistral_grammar:
                 if not isinstance(request, ChatCompletionRequest | ResponsesRequest):
                     msg = (

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -45,10 +45,9 @@ from vllm.renderers.inputs.preprocess import (
     prompt_to_seq,
 )
 from vllm.tokenizers import TokenizerLike
-from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers import ToolParser
+from vllm.tool_parsers.mistral_tool_parser import should_apply_mistral_grammar
 from vllm.utils import random_uuid
-from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
 from vllm.utils.mistral import is_mistral_tokenizer
 from vllm.utils.mistral import mt as _mt
 
@@ -547,10 +546,7 @@ class OpenAIServingRender:
         if tool_parser is not None:
             tool_choice = getattr(request, "tool_choice", "none")
             tokenizer = renderer.get_tokenizer()
-            is_mistral_grammar = issubclass(
-                tool_parser,  # type: ignore[arg-type]
-                MistralToolParser,
-            ) and isinstance(tokenizer, MistralTokenizer)
+            is_mistral_grammar = should_apply_mistral_grammar(tool_parser, tokenizer)  # type: ignore[arg-type]
             if tool_choice != "none" or is_mistral_grammar:
                 if not isinstance(request, ChatCompletionRequest):
                     msg = (

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -45,8 +45,10 @@ from vllm.renderers.inputs.preprocess import (
     prompt_to_seq,
 )
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers import ToolParser
 from vllm.utils import random_uuid
+from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
 from vllm.utils.mistral import is_mistral_tokenizer
 from vllm.utils.mistral import mt as _mt
 
@@ -218,7 +220,11 @@ class OpenAIServingRender:
                 )
 
         if request.tools is None or (
-            request.tool_choice == "none" and self.exclude_tools_when_tool_choice_none
+            request.tool_choice == "none"
+            and (
+                self.exclude_tools_when_tool_choice_none
+                or is_mistral_tokenizer(tokenizer)
+            )
         ):
             tool_dicts = None
         else:
@@ -534,9 +540,18 @@ class OpenAIServingRender:
         # tool parsing is done only if a tool_parser has been set and if
         # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
         # is set, we want to prevent parsing a tool_call hallucinated by the LLM
+        #
+        # Exception: MistralToolParser always calls adjust_request() (even for
+        # tool_choice="none") so the grammar prevents raw special tokens
+        # from leaking into the response.
         if tool_parser is not None:
             tool_choice = getattr(request, "tool_choice", "none")
-            if tool_choice != "none":
+            tokenizer = renderer.get_tokenizer()
+            is_mistral_grammar = issubclass(
+                tool_parser,  # type: ignore[arg-type]
+                MistralToolParser,
+            ) and isinstance(tokenizer, MistralTokenizer)
+            if tool_choice != "none" or is_mistral_grammar:
                 if not isinstance(request, ChatCompletionRequest):
                     msg = (
                         "Tool usage is only supported "
@@ -544,7 +559,6 @@ class OpenAIServingRender:
                         f"{type(request).__name__}"
                     )
                     raise NotImplementedError(msg)
-                tokenizer = renderer.get_tokenizer()
                 request = tool_parser(tokenizer).adjust_request(request=request)  # type: ignore[arg-type]
 
         return conversation, [engine_prompt]

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -39,6 +39,7 @@ class StructuredOutputsParams:
     regex: str | None = None
     choice: list[str] | None = None
     grammar: str | None = None
+    lark: str | None = None
     json_object: bool | None = None
     # These are other options that can be set.
     disable_any_whitespace: bool = False
@@ -59,6 +60,7 @@ class StructuredOutputsParams:
                 self.regex is not None,
                 self.choice is not None,
                 self.grammar is not None,
+                self.lark is not None,
                 self.json_object is not None,
                 self.structural_tag is not None,
             ]
@@ -85,6 +87,7 @@ class StructuredOutputsParams:
                 "regex",
                 "choice",
                 "grammar",
+                "lark",
                 "json_object",
                 "structural_tag",
             )
@@ -101,6 +104,7 @@ class StructuredOutputsParams:
                 "regex",
                 "choice",
                 "grammar",
+                "lark",
                 "json_object",
             )
         )
@@ -784,12 +788,6 @@ class SamplingParams(
             # allows <|special_token|> and similar, see
             # https://github.com/guidance-ai/llguidance/blob/main/docs/syntax.md#special-tokens
             # Without tokenizer these are disallowed in grammars.
-            if is_mistral_tokenizer(tokenizer):
-                raise ValueError(
-                    "Mistral tokenizer is not supported for the 'guidance' "
-                    "structured output backend. Please use ['xgrammar', 'outlines'] "
-                    "backends or tokenizer_mode='hf' instead."
-                )
             validate_guidance_grammar(self, tokenizer=None)
         elif backend == "outlines":
             # outlines backend
@@ -828,9 +826,9 @@ class SamplingParams(
                         schema = so_params.json
                     skip_guidance = has_guidance_unsupported_json_features(schema)
 
-                if is_mistral_tokenizer(tokenizer) or skip_guidance:
-                    # Fall back to outlines if the tokenizer is Mistral
-                    # or if schema contains features unsupported by guidance
+                if skip_guidance:
+                    # Fall back to outlines if schema contains features
+                    # unsupported by guidance
                     validate_structured_output_request_outlines(self)
                     self.structured_outputs._backend = "outlines"
                 else:

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast, overload
 
+import regex as re
 from mistral_common.protocol.instruct.request import (
     ChatCompletionRequest as MistralChatCompletionRequest,
 )
@@ -15,8 +16,15 @@ from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.base import (
     SpecialTokenPolicy,
     SpecialTokens,
+    Tokenizer,
 )
-from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV13
+from mistral_common.tokens.tokenizers.instruct import (
+    InstructTokenizerBase,
+    InstructTokenizerV13,
+)
+from mistral_common.tokens.tokenizers.mistral import (
+    MistralTokenizer as MistralCommonTokenizer,
+)
 from mistral_common.tokens.tokenizers.sentencepiece import (
     SentencePieceTokenizer,
 )
@@ -26,10 +34,19 @@ from pydantic import ValidationError
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.logger import init_logger
+from vllm.tokenizers.protocol import TokenizerLike
 
-from .protocol import TokenizerLike
+try:
+    # Transformers v5
+    from transformers.tokenization_mistral_common import MistralCommonBackend
+except ImportError:
+    # Transformers v4
+    from transformers.tokenization_mistral_common import (
+        MistralCommonTokenizer as MistralCommonBackend,
+    )
 
 if TYPE_CHECKING:
+    import llguidance as llg
     from transformers import BatchEncoding
 
     try:
@@ -224,6 +241,7 @@ def _tekken_token_to_id(tokenizer: "Tekkenizer", t: str | bytes) -> int:
 
 class MistralTokenizer(TokenizerLike):
     IS_MISTRAL_TOKENIZER = True  # used by vllm.utils.mistral
+    _cached_llg_tokenizer: "llg.LLTokenizer | None" = None
 
     @classmethod
     def from_pretrained(
@@ -235,15 +253,6 @@ class MistralTokenizer(TokenizerLike):
         download_dir: str | None = None,
         **kwargs,
     ) -> "MistralTokenizer":
-        try:
-            # Transformers v5
-            from transformers.tokenization_mistral_common import MistralCommonBackend
-        except ImportError:
-            # Transformers v4
-            from transformers.tokenization_mistral_common import (
-                MistralCommonTokenizer as MistralCommonBackend,
-            )
-
         tokenizer = MistralCommonBackend.from_pretrained(
             path_or_repo_id,
             *args,
@@ -258,10 +267,10 @@ class MistralTokenizer(TokenizerLike):
     def __init__(self, tokenizer: "MistralCommonBackend") -> None:
         super().__init__()
 
-        self.transformers_tokenizer = tokenizer
-        self.mistral = tokenizer.tokenizer
-        self.instruct = self.mistral.instruct_tokenizer
-        self.tokenizer = self.instruct.tokenizer
+        self.transformers_tokenizer: MistralCommonBackend = tokenizer
+        self.mistral: MistralCommonTokenizer = tokenizer.tokenizer
+        self.instruct: InstructTokenizerBase = self.mistral.instruct_tokenizer
+        self.tokenizer: Tokenizer = self.instruct.tokenizer
 
         mode = self.mistral._chat_completion_request_validator._mode
         if mode != ValidationMode.test:
@@ -351,6 +360,19 @@ class MistralTokenizer(TokenizerLike):
     @property
     def truncation_side(self) -> str:
         return self.transformers_tokenizer.truncation_side
+
+    @property
+    def llg_tokenizer(self) -> "llg.LLTokenizer | None":
+        return self._cached_llg_tokenizer
+
+    @llg_tokenizer.setter
+    def llg_tokenizer(self, llg_tokenizer: "llg.LLTokenizer") -> None:
+        import llguidance as llg
+
+        assert isinstance(llg_tokenizer, llg.LLTokenizer), (
+            f"Got {type(llg_tokenizer)} instead of `llg.LLTokenizer`"
+        )
+        self._cached_llg_tokenizer = llg_tokenizer
 
     def _is_special_token_id(self, token_id: int) -> bool:
         return token_id in self._special_token_ids_set
@@ -483,7 +505,11 @@ class MistralTokenizer(TokenizerLike):
         return self.transformers_tokenizer.convert_tokens_to_ids(tokens)
 
     def convert_tokens_to_string(self, tokens: list[str]) -> str:
-        to_decode_special_tokens = {SpecialTokens.tool_calls}
+        to_decode_special_tokens = {
+            SpecialTokens.tool_calls,
+            SpecialTokens.begin_think,
+            SpecialTokens.end_think,
+        }
         if self.is_tekken:
             assert isinstance(self.tokenizer, Tekkenizer), type(self.tokenizer)
             tokens = [
@@ -573,3 +599,74 @@ class MistralTokenizer(TokenizerLike):
             ]
 
         return tokens
+
+
+class MistralLLGTokenizer:
+    """Wraps a mistral tokenizer for use with llguidance."""
+
+    eos_token_id: int
+    bos_token_id: int
+    tokens: list[bytes]
+    special_token_ids: list[int]
+
+    def __init__(self, tokenizer: MistralTokenizer) -> None:
+        self._tokenizer = tokenizer.tokenizer
+        self.eos_token_id = self._tokenizer.eos_id
+        self.bos_token_id = self._tokenizer.bos_id
+
+        self.tokens: list[bytes] = []
+        self.special_token_ids: list[int] = []
+
+        seen_special_tokens: set[str] = set()
+        for i in range(self._tokenizer.n_words):
+            # Convert square brackets to angle brackets for special tokens,
+            # since llg only recognizes the latter.
+            if self._tokenizer.is_special(i):
+                token_rep = self._tokenizer.id_to_piece(i)
+                if match := re.fullmatch(r"\[(.*)\]", token_rep):
+                    token_rep_llg = f"<{match.group(1)}>"
+                else:
+                    token_rep_llg = token_rep
+
+                if not re.fullmatch(r"<.*>", token_rep_llg):
+                    raise ValueError(
+                        f"Invalid special token: {token_rep_llg} ({token_rep})"
+                    )
+                assert token_rep_llg not in seen_special_tokens, (
+                    token_rep_llg,
+                    seen_special_tokens,
+                )
+                seen_special_tokens.add(token_rep_llg)
+                self.special_token_ids.append(i)
+                self.tokens.append(token_rep_llg.encode("utf-8"))
+            else:
+                token = self._tokenizer.id_to_byte_piece(i, SpecialTokenPolicy.RAISE)
+                self.tokens.append(token)
+
+        assert len(self.special_token_ids) == self._tokenizer.num_special_tokens, (
+            len(self.special_token_ids),
+            self._tokenizer.num_special_tokens,
+        )
+
+    def __call__(self, s: str, *args, **kwds) -> list[int]:
+        # HACK: add a null byte to the start of the string to avoid the tokenizer
+        # absorbing the first character of tokens that start with "▁".
+        # we then ignore the first two tokens the "▁" and the null byte.
+        # This gives us the pure tokenized text without SentencePiece artifacts.
+        if isinstance(self._tokenizer, SentencePieceTokenizer):
+            return self._tokenizer.encode("\00" + s, bos=False, eos=False)[2:]
+        else:
+            return self._tokenizer.encode(s, bos=False, eos=False)
+
+
+def guidance_tokenizer_from_mistral_tokenizer(
+    tokenizer: MistralTokenizer,
+) -> "llg.LLTokenizer":
+    import llguidance as llg
+
+    if tokenizer.llg_tokenizer is not None:
+        return tokenizer.llg_tokenizer
+
+    tokenizer_data = MistralLLGTokenizer(tokenizer)
+    tokenizer.llg_tokenizer = llg.LLTokenizer(llg.TokenizerWrapper(tokenizer_data))
+    return tokenizer.llg_tokenizer

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -6,14 +6,17 @@ from collections.abc import Sequence
 from enum import Enum, auto
 from random import choices
 from string import ascii_letters, digits
-from typing import Any
+from typing import Any, Literal
 
 import ijson
 import regex as re
+from jinja2 import Template
 from pydantic import Field
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
@@ -23,8 +26,11 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
+from vllm.sampling_params import StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers.abstract_tool_parser import (
     ToolParser,
 )
@@ -33,6 +39,71 @@ from vllm.utils.mistral import is_mistral_tokenizer
 logger = init_logger(__name__)
 
 ALPHANUMERIC = ascii_letters + digits
+
+
+def is_mistral_lark_grammar_active(
+    request: ChatCompletionRequest,
+    tokenizer: TokenizerLike,
+    tool_parser_cls: type | None,
+) -> bool:
+    r"""Check if the Mistral lark grammar is active for the given request."""
+    return (
+        tool_parser_cls is not None
+        and issubclass(tool_parser_cls, MistralToolParser)
+        and is_mistral_tokenizer(tokenizer)
+        and getattr(request, "structured_outputs", None) is not None
+        and request.structured_outputs.lark is not None
+    )
+
+
+BASE_LARK_GRAMMAR = r"""start: body
+{% if mode == "auto" -%}
+{% if tokenizer_version < 7 -%}
+body: content | fcalls
+{% else -%}
+body: content | (content? fcalls)
+{% endif -%}
+fcalls: {{ fcall }}
+{% elif mode == "required" -%}
+body: content? fcalls
+fcalls: {{ fcall }}
+{% elif mode == "none" -%}
+body: content
+{% endif -%}
+{% if tokenizer_version < 7 -%}
+content: /(.|\n)+/
+{% else -%}
+content: (/(.|\n)+/)+
+{% endif -%}
+SAFE_WS: /[ \t\r\n]+/"""
+
+OPTIONAL_THINK_LARK_GRAMMAR = r"""start: body
+{% if mode == "auto" -%}
+body: think? (content | fcalls)
+fcalls: content? {{ fcall }}
+{% elif mode == "required" -%}
+body: think? fcalls
+fcalls: content? {{ fcall }}
+{% elif mode == "none" -%}
+body: think? content
+{% endif -%}
+think: <THINK> content </THINK>
+content: (/(.|\n)+/)+
+SAFE_WS: /[ \t\r\n]+/"""
+
+THINK_LARK_GRAMMAR = r"""start: body
+{% if mode == "auto" -%}
+body: (think (content | content? fcalls)) | fcalls
+fcalls: {{ fcall }}
+{% elif mode == "required" -%}
+body: (think content? fcalls) | fcalls
+fcalls: {{ fcall }}
+{% elif mode == "none" -%}
+body: think content
+{% endif -%}
+think: <THINK> content </THINK>
+content: (/(.|\n)+/)+
+SAFE_WS: /[ \t\r\n]+/"""
 
 
 class StreamingState(Enum):
@@ -49,6 +120,166 @@ class StreamingState(Enum):
     PARSING_ARGUMENTS_COMPLETED = auto()
     TOOL_COMPLETE = auto()
     ALL_TOOLS_COMPLETE = auto()
+
+
+def _is_strict_tool(tool: ChatCompletionToolsParam) -> bool:
+    return getattr(tool.function, "strict", False)
+
+
+class ToolsLarkConverter:
+    """Converts tools to a lark grammar"""
+
+    def _convert(
+        self,
+        tools: list[ChatCompletionToolsParam],
+        any_strict_true: bool,
+        parallel_tool_calls: bool,
+    ) -> str:
+        raise NotImplementedError
+
+    def get_args_json(self, tool: ChatCompletionToolsParam) -> dict[str, Any]:
+        args = tool.function.parameters if _is_strict_tool(tool) else {"type": "object"}
+        # Handle empty parameters case
+        if args == {}:
+            args = {"type": "object", "properties": {}, "additionalProperties": False}
+        return args
+
+    @staticmethod
+    def convert(
+        tools: list[ChatCompletionToolsParam],
+        tokenizer_version: int,
+        mode: Literal["auto", "required", "none"],
+        parallel_tool_calls: bool,
+    ) -> str:
+        if mode == "none":
+            return ""
+
+        any_strict_true = any(_is_strict_tool(tool) for tool in tools)
+        converter = (
+            PostV11ToolsLarkConverter()
+            if tokenizer_version >= 11
+            else PreV11ToolsLarkConverter()
+        )
+        return converter._convert(tools, any_strict_true, parallel_tool_calls)
+
+
+class PostV11ToolsLarkConverter(ToolsLarkConverter):
+    """Converts tools to a lark grammar for v11+ tokenizers"""
+
+    def _convert(
+        self,
+        tools: list[ChatCompletionToolsParam],
+        any_strict_true: bool,
+        parallel_tool_calls: bool,
+    ) -> str:
+        individual_tool_calls = []
+        for tool in tools:
+            # We enforce the naming to be correct even when strict is False but not
+            # arguments
+            args = self.get_args_json(tool) if any_strict_true else {"type": "object"}
+            individual_tool_calls.append(
+                f'(<TOOL_CALLS> SAFE_WS? "{tool.function.name}" <ARGS> '
+                f"SAFE_WS? %json {json.dumps(args, ensure_ascii=False)} SAFE_WS?)"
+            )
+
+        single_tool_call = f"{' | '.join(individual_tool_calls)}"
+        return f"({single_tool_call})+" if parallel_tool_calls else single_tool_call
+
+
+class PreV11ToolsLarkConverter(ToolsLarkConverter):
+    """Converts tools to a lark grammar for v10- tokenizers"""
+
+    def _convert(
+        self,
+        tools: list[ChatCompletionToolsParam],
+        any_strict_true: bool,
+        parallel_tool_calls: bool,
+    ) -> str:
+        if not any_strict_true:
+            # We enforce the naming to be correct even when strict is False.
+            tool_names = [tool.function.name for tool in tools]
+            items = {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "name": {"type": "string", "enum": tool_names},
+                    "arguments": {"type": "object"},
+                },
+                "required": ["name", "arguments"],
+            }
+        else:
+            items = self._from_tools(tools)
+
+        schema = {"minItems": 1, "type": "array", "items": items}
+
+        if not parallel_tool_calls:
+            schema["maxItems"] = 1
+
+        return f"""<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?
+fcall_array: %json {json.dumps(schema, ensure_ascii=False)}
+"""
+
+    def _from_tools(self, tools: list[ChatCompletionToolsParam]) -> dict[str, Any]:
+        return {"anyOf": [self._tool_to_call(tool) for tool in tools]}
+
+    def _tool_to_call(self, tool: ChatCompletionToolsParam) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "required": ["name", "arguments"],
+            "additionalProperties": False,
+            "properties": {
+                "name": {"const": f"{tool.function.name}"},
+                "arguments": self.get_args_json(tool),
+            },
+        }
+
+
+class MistralGrammarFactory:
+    """Generates grammars for a given tokenizer version"""
+
+    def __init__(self, tokenizer: MistralTokenizer) -> None:
+        if not is_mistral_tokenizer(tokenizer):
+            raise ValueError("`MistralGrammarFactory` expects a `MistralTokenizer`.")
+        self._tokenizer = tokenizer
+        self._tokenizer_version = tokenizer.version
+
+    def get_lark_from_jinja(
+        self,
+        mode: Literal["auto", "required", "none"] | None,
+        tools: list[ChatCompletionToolsParam],
+        reasoning: bool,
+        parallel_tool_calls: bool,
+    ) -> str:
+        r"""Render a lark grammar from a jinja template.
+
+        Note:
+            Currently we support the following variables in the Lark jinja
+            template: `tokenizer_version`, `mode`, and `fcall`.
+
+        Args:
+            mode: Function calling mode (auto, required, none).
+            tools: The available tools.
+            reasoning: Whether to include think block rules in the grammar.
+            parallel_tool_calls: Whether parallel tool calls are allowed.
+        """
+        if mode is None:
+            mode = "auto"
+
+        if self._tokenizer_version < 13 or not reasoning:
+            jinja_template = BASE_LARK_GRAMMAR
+        elif self._tokenizer_version < 15:
+            jinja_template = OPTIONAL_THINK_LARK_GRAMMAR
+        else:
+            jinja_template = THINK_LARK_GRAMMAR
+
+        lark_grammar = Template(jinja_template).render(
+            tokenizer_version=self._tokenizer_version,
+            mode=mode,
+            fcall=ToolsLarkConverter.convert(
+                tools, self._tokenizer_version, mode, parallel_tool_calls
+            ),
+        )
+        return lark_grammar
 
 
 class MistralToolCall(ToolCall):
@@ -71,12 +302,17 @@ def _is_pre_v11_tokeniser(model_tokenizer: TokenizerLike) -> bool:
 
 class MistralToolParser(ToolParser):
     """
-    Tool call parser for Mistral 7B Instruct v0.3, intended for use with
+    Tool call parser for Mistral models, intended for use with either:
     - [`mistral_common`](https://github.com/mistralai/mistral-common/)
     - the examples/tool_chat_template_mistral.jinja template.
 
-    Used when --enable-auto-tool-choice --tool-call-parser mistral are all set
+    Used when `--enable-auto-tool-choice --tool-call-parser mistral` are all set
     """
+
+    # `_has_reasoning_parser`` is intentionally a class attribute rather than an
+    # instance attribute because the tool-parser is instantiated in multiple independent
+    # code paths do not receive not configuration state from the serving layer.
+    _has_reasoning_parser: bool = False
 
     def __init__(self, tokenizer: TokenizerLike):
         super().__init__(tokenizer)
@@ -109,20 +345,77 @@ class MistralToolParser(ToolParser):
                 "Mistral Tool Parser could not locate the tool call token in "
                 "the tokenizer!"
             )
+        self.grammar_factory = MistralGrammarFactory(tokenizer)
+
+    def _should_reason(self, request: ChatCompletionRequest) -> bool:
+        if not self.has_reasoning_parser:
+            return False
+        if (
+            isinstance(self.model_tokenizer, MistralTokenizer)
+            and self.model_tokenizer.version >= 15
+        ):
+            return request.reasoning_effort not in (None, "none")
+        return True
+
+    @property
+    def has_reasoning_parser(self) -> bool:
+        return self._has_reasoning_parser
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
-        request = super().adjust_request(request)
+        if not is_mistral_tokenizer(self.model_tokenizer):
+            # For non-Mistral tokenizers, use the parent's adjust_request
+            # which sets JSON schema for required/named tool_choice.
+            request = super().adjust_request(request)
+            if request.tools and request.tool_choice != "none":
+                # Do not skip special tokens when using chat template
+                # with Mistral parser as TOOL_CALL token is needed
+                # for tool detection.
+                # Note: we don't want skip_special_tokens=False
+                # with MistralTokenizer as it is incompatible
+                request.skip_special_tokens = False
+            return request
+
         if (
-            not is_mistral_tokenizer(self.model_tokenizer)
-            and request.tools
-            and request.tool_choice != "none"
+            request.response_format is not None
+            and hasattr(request.response_format, "type")
+            and request.response_format.type != "text"
+        ) or (
+            # Skip if user explicitly set structured outputs
+            request.structured_outputs is not None
+            and (
+                request.structured_outputs.json is not None
+                or request.structured_outputs.json_object is not None
+            )
         ):
-            # Do not skip special tokens when using chat template
-            # with Mistral parser as TOOL_CALL token is needed
-            # for tool detection.
-            # Note: we don't want skip_special_tokens=False
-            # with MistralTokenizer as it is incompatible
-            request.skip_special_tokens = False
+            return request
+
+        if not request.tools:
+            # Sanitize tool_choice.
+            request.tool_choice = "none"
+
+        # Set structured output params for tool calling
+        if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):
+            selected_tools = [
+                tool
+                for tool in request.tools
+                if tool.function.name == request.tool_choice.function.name
+            ]
+            mode: Literal["auto", "required", "none"] | None = "required"
+        else:
+            selected_tools = request.tools
+            mode = request.tool_choice
+        lark_grammar = self.grammar_factory.get_lark_from_jinja(
+            mode=mode,
+            tools=selected_tools,
+            reasoning=self._should_reason(request=request),
+            parallel_tool_calls=True,
+        )
+        if isinstance(request, ChatCompletionRequest):
+            request.structured_outputs = StructuredOutputsParams(lark=lark_grammar)  # type: ignore[call-arg]
+            request.response_format = None
+        elif isinstance(request, ResponsesRequest):
+            raise ValueError("`ResponsesRequest` not supported.")
+
         return request
 
     def extract_tool_calls(
@@ -241,7 +534,10 @@ class MistralToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        if self.bot_token_id not in current_token_ids:
+        has_bot_token = (
+            self.bot_token_id in current_token_ids or self.bot_token in current_text
+        )
+        if not has_bot_token:
             # if the tool call token is not in the tokens generated so far,
             # append output to contents since it's not a tool
             return DeltaMessage(content=delta_text)
@@ -275,7 +571,8 @@ class MistralToolParser(ToolParser):
         additional_content: str = ""
         if self.streaming_state == StreamingState.WAITING_FOR_TOOL_START:
             # this is the first tool call
-            assert self.bot_token_id in delta_token_ids
+            if self.bot_token not in delta_text:
+                return DeltaMessage(content=delta_text)
             if not delta_text.startswith(self.bot_token):
                 additional_content += delta_text.split(self.bot_token)[0]
                 delta_text = self.bot_token + "".join(
@@ -411,7 +708,7 @@ class MistralToolParser(ToolParser):
             index=self.current_tool_id, type="function"
         )
         current_tool_call_modified = False
-        if self.bot_token_id in delta_token_ids:
+        if self.bot_token_id in delta_token_ids or self.bot_token in delta_text:
             # this is the first tool call
             if not delta_text.startswith(self.bot_token):
                 content = delta_text.split(self.bot_token)[0]

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -409,6 +409,9 @@ class MistralToolParser(ToolParser):
             # Default to "auto" when no explicit choice is specified.
             request.tool_choice = "auto"
 
+        if not request.tools:
+            return request
+
         if request.tool_choice != "auto":
             raise ValueError(
                 "For now only 'auto' tool choice is supported, we're in "

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -64,7 +64,7 @@ def is_mistral_lark_grammar_active(
     return (
         should_apply_mistral_grammar(tool_parser_cls, tokenizer)
         and structured_outputs is not None
-        and request.structured_outputs.lark is not None
+        and structured_outputs.lark is not None
     )
 
 
@@ -357,7 +357,11 @@ class MistralToolParser(ToolParser):
                 "Mistral Tool Parser could not locate the tool call token in "
                 "the tokenizer!"
             )
-        self.grammar_factory = MistralGrammarFactory(tokenizer)
+        self.grammar_factory = (
+            MistralGrammarFactory(tokenizer)  # type: ignore[arg-type]
+            if is_mistral_tokenizer(self.model_tokenizer)
+            else None
+        )
 
     def _should_reason(self, request: ChatCompletionRequest) -> bool:
         if not self.has_reasoning_parser:
@@ -416,6 +420,11 @@ class MistralToolParser(ToolParser):
         else:
             selected_tools = request.tools or []
             mode = request.tool_choice
+
+        assert self.grammar_factory is not None, (
+            "Grammar factory is only support for Mistral Tokenizer"
+        )
+
         lark_grammar = self.grammar_factory.get_lark_from_jinja(
             mode=mode,
             tools=selected_tools,

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -60,9 +60,10 @@ def is_mistral_lark_grammar_active(
     tool_parser_cls: type | None,
 ) -> bool:
     """Check if the Mistral lark grammar is active for the given request."""
+    structured_outputs = getattr(request, "structured_outputs", None)
     return (
         should_apply_mistral_grammar(tool_parser_cls, tokenizer)
-        and getattr(request, "structured_outputs", None) is not None
+        and structured_outputs is not None
         and request.structured_outputs.lark is not None
     )
 
@@ -151,7 +152,7 @@ class ToolsLarkConverter(ABC):
     def get_args_json(self, tool: ChatCompletionToolsParam) -> dict[str, Any]:
         args = tool.function.parameters if _is_strict_tool(tool) else {"type": "object"}
         # Handle empty parameters case
-        if args == {}:
+        if not args:
             args = {"type": "object", "properties": {}, "additionalProperties": False}
         return args
 

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum, auto
 from random import choices
@@ -41,16 +42,26 @@ logger = init_logger(__name__)
 ALPHANUMERIC = ascii_letters + digits
 
 
+def should_apply_mistral_grammar(
+    tool_parser_cls: type | None,
+    tokenizer: TokenizerLike,
+) -> bool:
+    """Check if the Mistral grammar path should be used."""
+    return (
+        tool_parser_cls is not None
+        and issubclass(tool_parser_cls, MistralToolParser)
+        and is_mistral_tokenizer(tokenizer)
+    )
+
+
 def is_mistral_lark_grammar_active(
     request: ChatCompletionRequest,
     tokenizer: TokenizerLike,
     tool_parser_cls: type | None,
 ) -> bool:
-    r"""Check if the Mistral lark grammar is active for the given request."""
+    """Check if the Mistral lark grammar is active for the given request."""
     return (
-        tool_parser_cls is not None
-        and issubclass(tool_parser_cls, MistralToolParser)
-        and is_mistral_tokenizer(tokenizer)
+        should_apply_mistral_grammar(tool_parser_cls, tokenizer)
         and getattr(request, "structured_outputs", None) is not None
         and request.structured_outputs.lark is not None
     )
@@ -126,16 +137,16 @@ def _is_strict_tool(tool: ChatCompletionToolsParam) -> bool:
     return getattr(tool.function, "strict", False)
 
 
-class ToolsLarkConverter:
-    """Converts tools to a lark grammar"""
+class ToolsLarkConverter(ABC):
+    """Converts tools to a lark grammar."""
 
+    @abstractmethod
     def _convert(
         self,
         tools: list[ChatCompletionToolsParam],
         any_strict_true: bool,
         parallel_tool_calls: bool,
-    ) -> str:
-        raise NotImplementedError
+    ) -> str: ...
 
     def get_args_json(self, tool: ChatCompletionToolsParam) -> dict[str, Any]:
         args = tool.function.parameters if _is_strict_tool(tool) else {"type": "object"}
@@ -397,12 +408,12 @@ class MistralToolParser(ToolParser):
         if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):
             selected_tools = [
                 tool
-                for tool in request.tools
+                for tool in (request.tools or [])
                 if tool.function.name == request.tool_choice.function.name
             ]
             mode: Literal["auto", "required", "none"] | None = "required"
         else:
-            selected_tools = request.tools
+            selected_tools = request.tools or []
             mode = request.tool_choice
         lark_grammar = self.grammar_factory.get_lark_from_jinja(
             mode=mode,

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -405,9 +405,16 @@ class MistralToolParser(ToolParser):
         ):
             return request
 
-        if not request.tools:
-            # Sanitize tool_choice.
-            request.tool_choice = "none"
+        if request.tool_choice is None:
+            # Default to "auto" when no explicit choice is specified.
+            request.tool_choice = "auto"
+
+        if request.tool_choice != "auto":
+            raise ValueError(
+                "For now only 'auto' tool choice is supported, we're in "
+                "the processing of improving the design of lark grammar "
+                "to properly supported all kind of tool choices."
+            )
 
         # Set structured output params for tool calling
         if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -21,6 +21,7 @@ class StructuredOutputOptions(enum.Enum):
     JSON_OBJECT = enum.auto()
     REGEX = enum.auto()
     GRAMMAR = enum.auto()
+    LARK = enum.auto()
     CHOICE = enum.auto()
     STRUCTURAL_TAG = enum.auto()
 

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -354,3 +354,8 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
                 xgr.Grammar.from_structural_tag(so_params.structural_tag)
         except Exception as e:
             raise ValueError("Invalid structural tag specification.") from e
+
+    if so_params.lark:
+        raise ValueError(
+            "xgrammar does not support grammar from Lark. Use guidance instead."
+        )

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -86,6 +86,8 @@ def get_structured_output_key(params: StructuredOutputsParams) -> StructuredOutp
         return StructuredOutputOptions.CHOICE, json_str
     if params.grammar is not None:
         return StructuredOutputOptions.GRAMMAR, params.grammar
+    if params.lark is not None:
+        return StructuredOutputOptions.LARK, params.lark
     if params.structural_tag is not None:
         return StructuredOutputOptions.STRUCTURAL_TAG, params.structural_tag
     raise ValueError("No valid structured output parameter found")


### PR DESCRIPTION
## Purpose

Fix Mistral tool calling and reasoning parsing by introducing Lark grammar-based structured output for Mistral models. This ensures correct tool call parsing for both streaming and non-streaming modes across all `tool_choice` values (`auto`, `required`, named, `none`) and all Mistral tokenizer versions.

Problems on `main`:
- Streaming tool calls are broken for post-v15 Mistral tokenizers: `[TOOL_CALLS]` tokens leak into content instead of being parsed as tool calls.
- `tool_choice="required"` and named tool choice produce unparseable arguments (e.g., `[TOOL_CALLS]get_current_weather{...}` embedded in the arguments string).
- `tool_choice="none"` leaks raw `[TOOL_CALLS]` special tokens into user-visible content.
- Reasoning content (`[THINK]...[/THINK]`) is not separated from content for pre-v15 models and not properly controlled via `reasoning_effort` for v15+ models.

This PR fixes by:
- Introduce `MistralGrammarFactory` that generates Lark grammars from Jinja templates, selecting the appropriate grammar variant. This involves adding Lark grammar and support for Mistral Tokenizer to llguidace.
- Update the OpenAI chat serving layer to use the Mistral grammar path for both streaming and non-streaming responses.

## Test Plan

### Unit tests (in this repo)

```bash
# Mistral tool parser tests (grammar factory, lark converter, adjust_request, streaming)
pytest tests/tool_parsers/test_mistral_tool_parser.py -v -s

# Mistral reasoning parser tests (is_reasoning_end with prefilled prompts)
pytest tests/reasoning/test_mistral_reasoning_parser.py -v -s

# Guidance backend lark grammar test
pytest tests/v1/structured_output/test_backend_guidance.py -v -s -k test_backend_guidance_lark_grammar
```

### End-to-end tests (external repo)

Scripts and results are available at: https://github.com/juliendenize/vllm-test-tool-and-reasoning-parsing

**Post-v15 tokenizer**: 48 tests (8 scenarios × 2 stream modes × 3 `reasoning_effort` values)
```bash
python test_vllm_tools_post_v15.py --base-url http://localhost:8000/v1
```

**Pre-v15 tokenizer**: 16 tests (8 scenarios × 2 stream modes)
```bash
python test_vllm_tools_pre_v15.py --base-url http://localhost:8000/v1
```

## Test Result

### End-to-end results comparison

| Model / Tokenizer | Branch | Passed | Failed | Total |
|---|---|---|---|---|
| Post-v15 | **This PR** | **48** | **0** | 48 |
| Post-v15 | `main` | 26 | 22 | 48 |
| Pre-v15 | **This PR** | **16** | **0** | 16 |
| Pre-v15  | `main` | 12 | 4 | 16 |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>

