### PR TITLE
feat: Standardize load_weights API via AutoWeightsLoader

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -52,10 +52,6 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from vllm.model_executor.model_loader.weight_utils import (
-    default_weight_loader,
-    maybe_remap_kv_scale_name,
-)
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
@@ -71,7 +67,6 @@ from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
     extract_layer_index,
-    is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
@@ -447,60 +442,11 @@ class LlamaModel(nn.Module, EagleModelMixin):
             (".gate_up_proj", ".gate_proj", 0),
             (".gate_up_proj", ".up_proj", 1),
         ]
-        params_dict = dict(self.named_parameters())
-        loaded_params: set[str] = set()
-        for name, loaded_weight in weights:
-            if "rotary_emb.inv_freq" in name:
-                continue
-            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
-                # Models trained using ColossalAI may include these tensors in
-                # the checkpoint. Skip them.
-                continue
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                # Loading kv cache quantization scales
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = (
-                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
-                )
-                weight_loader(param, loaded_weight)
-                loaded_params.add(scale_name)
-                continue
-            if "scale" in name or "zero_point" in name:
-                # Remapping the name of FP8 kv-scale or zero point.
-                name = maybe_remap_kv_scale_name(name, params_dict)
-                if name is None:
-                    continue
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
-                if is_pp_missing_parameter(name, self):
-                    continue
-
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
-                if is_pp_missing_parameter(name, self):
-                    continue
-
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
-            loaded_params.add(name)
-        return loaded_params
+        loader = AutoWeightsLoader(
+            self,
+            stacked_params_mapping=stacked_params_mapping,
+        )
+        return loader.load_weights(weights)
 
 
 class LlamaForCausalLM(

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -147,6 +147,8 @@ class AutoWeightsLoader:
         skip_substrs: list[str] | None = None,
         ignore_unexpected_prefixes: list[str] | None = None,
         ignore_unexpected_suffixes: list[str] | None = None,
+        stacked_params_mapping: list[tuple[str, str, Any]] | None = None,
+        expert_params_mapping: list[tuple[str, str, Any, Any]] | None = None,
     ) -> None:
         super().__init__()
 
@@ -155,6 +157,8 @@ class AutoWeightsLoader:
         self.skip_substrs = skip_substrs or []
         self.ignore_unexpected_prefixes = ignore_unexpected_prefixes or []
         self.ignore_unexpected_suffixes = ignore_unexpected_suffixes or []
+        self.stacked_params_mapping = stacked_params_mapping or []
+        self.expert_params_mapping = expert_params_mapping or []
         # update default skip_substrs
         self.skip_substrs += self.ROTARY_EMBEDS_UNUSED_WEIGHTS
 
@@ -340,12 +344,106 @@ class AutoWeightsLoader:
     ) -> set[str]:
         if mapper is not None:
             weights = mapper.apply(weights)
+
         # filter out weights with first-prefix/substr to skip in name
         weights = (
             (name, weight) for name, weight in weights if not self._can_skip(name)
         )
 
-        autoloaded_weights = set(self._load_module("", self.module, weights))
+        autoloaded_weights = set()
+        remaining_weights: list[tuple[str, torch.Tensor]] = []
+
+        params_dict = None
+
+        def get_params_dict():
+            nonlocal params_dict
+            if params_dict is None:
+                params_dict = dict(self.module.named_parameters())
+            return params_dict
+
+        from vllm.model_executor.model_loader.weight_utils import (
+            default_weight_loader,
+            maybe_remap_kv_scale_name,
+        )
+
+        for name, loaded_weight in weights:
+            handled = False
+
+            # 1. KV Cache Scales
+            quant_config = getattr(self.module, "quant_config", None)
+            if quant_config is not None and getattr(
+                quant_config, "get_cache_scale", None
+            ):
+                scale_name = quant_config.get_cache_scale(name)
+                if scale_name:
+                    p_dict = get_params_dict()
+                    if scale_name in p_dict:
+                        param = p_dict[scale_name]
+                        weight_loader = getattr(
+                            param, "weight_loader", default_weight_loader
+                        )
+                        weight_loader(
+                            param,
+                            loaded_weight
+                            if loaded_weight.dim() == 0
+                            else loaded_weight[0],
+                        )
+                        autoloaded_weights.add(scale_name)
+                        handled = True
+
+            # FP8 / KV scale remapping handling (scale or zero_point)
+            if not handled and ("scale" in name or "zero_point" in name):
+                name = maybe_remap_kv_scale_name(name, get_params_dict())
+                if name is None:
+                    handled = True
+
+            # 2. Stacked Params Mapping (e.g., qkv_proj)
+            if not handled and self.stacked_params_mapping:
+                for param_name, weight_name, shard_id in self.stacked_params_mapping:
+                    if weight_name not in name:
+                        continue
+
+                    mapped_name = name.replace(weight_name, param_name)
+                    # Skip extra bias for GPTQ models
+                    p_dict = get_params_dict()
+                    if mapped_name.endswith(".bias") and mapped_name not in p_dict:
+                        continue
+
+                    if mapped_name in p_dict:
+                        param = p_dict[mapped_name]
+                        weight_loader = param.weight_loader
+                        weight_loader(param, loaded_weight, shard_id)
+                        autoloaded_weights.add(mapped_name)
+                        handled = True
+                        break
+
+            # 3. Expert Params Mapping (e.g., MoE w1/w2/w3)
+            if not handled and self.expert_params_mapping:
+                for (
+                    param_name,
+                    weight_name,
+                    expert_id,
+                    shard_id,
+                ) in self.expert_params_mapping:
+                    if weight_name not in name:
+                        continue
+
+                    mapped_name = name.replace(weight_name, param_name)
+                    p_dict = get_params_dict()
+                    if mapped_name in p_dict:
+                        param = p_dict[mapped_name]
+                        weight_loader = param.weight_loader
+                        weight_loader(
+                            param, loaded_weight, weight_name, shard_id, expert_id
+                        )
+                        autoloaded_weights.add(mapped_name)
+                        handled = True
+                        break
+
+            if not handled:
+                remaining_weights.append((name, loaded_weight))
+
+        autoloaded_weights.update(self._load_module("", self.module, remaining_weights))
         return autoloaded_weights
 
 


### PR DESCRIPTION
## Description
This Pull Request begins the "Cleanup of the Weight Loading" effort tracked in the [vLLM Roadmap Q1 2026  32455] by decoupling model architecture definitions from the mechanics of weight loading.

**Closes #37084**

### Changes Made:
- **Expanded `AutoWeightsLoader` (`vllm/model_executor/models/utils.py`)**:
  - The loader can now natively intercept and process `stacked_params_mapping` (for fusions like `qkv_proj` and `gate_up_proj`).
  - Added support for `expert_params_mapping` to automatically handle complex routing to local MoE physical experts.
  - Centralized the handling of KV cache scales and FP8 zero points (e.g., `quant_config.get_cache_scale(name)`), freeing individual models from needing to manually process these.
- **Refactored `LlamaModel` (`vllm/model_executor/models/llama.py`)**:
  - Deleted 60+ lines of an imperative, custom `load_weights` iteration loop.
  - Replaced it with a clean, declarative initialization of `AutoWeightsLoader` that delegates the routing of its `stacked_params_mapping`.

### Why this matters
Currently, over 50+ models duplicate logic for fusing projection layers or splitting shards. This change centralizes these tensor operations, ensuring new storage formats (like GGUF or TorchAO) can be supported globally without manually updating dozens of custom loops. This establishes a stable internal model API.

### Testing
- I have outlined a comprehensive testing strategy in `plan.md` involving exact output equivalency checks using `torch.testing.assert_close`. (Currently pending GPU availability).