### PR TITLE
[Bugfix] Add FLA_USE_TMA env var to disable TMA in FLA ops (#36973)

### DIFF
--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -152,9 +152,14 @@ is_nvidia_hopper = is_nvidia and (
 )
 use_cuda_graph = is_nvidia and os.environ.get("FLA_USE_CUDA_GRAPH", "0") == "1"
 is_gather_supported = hasattr(triton.language, "gather")
-is_tma_supported = (is_nvidia and torch.cuda.get_device_capability(0)[0] >= 9) and (
-    hasattr(triton.language, "_experimental_make_tensor_descriptor")
-    or hasattr(triton.language, "make_tensor_descriptor")
+is_tma_supported = (
+    os.environ.get("FLA_USE_TMA", "1") == "1"
+    and is_nvidia
+    and torch.cuda.get_device_capability(0)[0] >= 9
+    and (
+        hasattr(triton.language, "_experimental_make_tensor_descriptor")
+        or hasattr(triton.language, "make_tensor_descriptor")
+    )
 )
 
 


### PR DESCRIPTION
## Propose

Fixes #36973 which reports that `_warmup_prefill_kernels()` during V1 profiling leaks ~3.4 GiB GPU memory on RTX 5090, reducing KV cache from ~134K to ~44K tokens.

### Root Cause

On Blackwell GPUs, the CUDA driver pre-allocates **~22 MiB per SM** for TMA (Tensor Memory Accelerator) hardware resources when the first Triton kernel using `make_tensor_descriptor` is launched.

The FLA `solve_tril` kernels (`vllm/model_executor/layers/fla/ops/solve_tril.py`) use TMA when `is_tma_supported=True` (GPU capability >= 9). On RTX 5090 with 170 SMs, this costs **170 × 22 = ~3.7 GiB** permanently.

Evidence (verified on RTX 5090):
- Same kernel with `USE_TMA=False`: **+0 MiB**
- Same kernel with `USE_TMA=True`: **+3728 MiB**
- The overhead scales linearly with SM count (GB10 with 48 SMs: +1077 MiB, 22.4 MiB/SM)
- The memory is allocated by the CUDA driver during kernel execution, not by PyTorch or Triton's allocator, and cannot be freed

All `solve_tril` kernels already have non-TMA fallback paths using `tl.make_block_ptr`, so disabling TMA does not break functionality.

### Fix

Add `FLA_USE_TMA` environment variable (default `"1"`) to `is_tma_supported` in `vllm/model_executor/layers/fla/ops/utils.py`. Users on memory-constrained Blackwell GPUs can set `FLA_USE_TMA=0` to disable TMA and recover the ~3.7 GiB.

This follows the existing pattern in the same file (`FLA_USE_CUDA_GRAPH`, `FLA_USE_FAST_OPS`).

## Test Plan

- [x] E2E: `vllm serve Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` with issue reporter's exact params (`--gpu-memory-utilization 0.95 --max-model-len 131072`) on RTX 5090, with and without `FLA_USE_TMA=0`

## Test Result

### E2E on RTX 5090 with reporter's setup

Command:
```bash
FLA_USE_TMA=0 vllm serve Qwen/Qwen3.5-35B-A3B-GPTQ-Int4 \
  --quantization gptq_marlin --dtype bfloat16 --kv-cache-dtype fp8 \
  --gpu-memory-utilization 0.95 --max-model-len 131072 \
  --max-num-batched-tokens 2096 --enable-prefix-caching \
  --trust-remote-code --enforce-eager
```

| Metric | Baseline (TMA on) | FLA_USE_TMA=0 | Delta |
|---|---|---|---|
| KV cache memory | 3.03 GiB | 6.65 GiB | **+3.62 GiB** |
| KV cache tokens | 77,552 | 173,968 | **+96,416 (+124%)** |
