### PR TITLE
[WIP][Bugfix] Clamp -1 async placeholders to fix CUDA assert in multimodal+EAGLE3

### DIFF
--- a/tests/v1/worker/test_prepare_input_ids_clamp.py
+++ b/tests/v1/worker/test_prepare_input_ids_clamp.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Regression test for issue #36906: EAGLE3 + multimodal + async scheduling
+crashes with CUDA error in F.embedding() due to -1 placeholder token IDs
+reaching the embedding layer.
+
+This test directly exercises the _prepare_input_ids scatter path to verify
+that -1 spec token placeholders from async scheduling are clamped to valid
+values before reaching the model.
+"""
+
+import pytest
+import torch
+
+
+def test_prepare_input_ids_clamps_negative_placeholders():
+    """Simulate the async scatter path and verify -1 values are clamped.
+
+    Reproduces the exact scenario where -1 leaks through:
+    1. A request transitions from prefill to decode (not in prev_req_id_to_index)
+    2. Async scheduler writes -1 spec token placeholders to token_ids_cpu
+    3. _prepare_input_ids copies input_ids.cpu (containing -1) to GPU
+    4. Scatter only covers "common" requests, leaving -1 for the new request
+
+    Without the fix, input_ids.gpu would contain -1, causing F.embedding()
+    to crash with CUDA device-side assert.
+    """
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Simulate a batch with 3 requests, each with 1 sampled + 2 spec tokens = 3 tokens
+    total_num_scheduled_tokens = 9  # 3 requests * 3 tokens each
+
+    # Create input_ids buffer (like CpuGpuBuffer)
+    input_ids_cpu = torch.zeros(total_num_scheduled_tokens, dtype=torch.int32)
+    input_ids_gpu = torch.zeros(
+        total_num_scheduled_tokens, dtype=torch.int32, device=device
+    )
+
+    # Request 0: common request (was decoding in prev step) - valid tokens
+    input_ids_cpu[0] = 100  # sampled token (will be overwritten by scatter)
+    input_ids_cpu[1] = 200  # spec token 1 (will be overwritten by scatter)
+    input_ids_cpu[2] = 300  # spec token 2 (will be overwritten by scatter)
+
+    # Request 1: TRANSITIONING request (was prefilling, now decoding)
+    # NOT in prev_req_id_to_index, so scatter won't touch it
+    input_ids_cpu[3] = 0  # sampled token position (0 from token_ids_cpu init)
+    input_ids_cpu[4] = -1  # spec token placeholder from async scheduler
+    input_ids_cpu[5] = -1  # spec token placeholder from async scheduler
+
+    # Request 2: common request - valid tokens
+    input_ids_cpu[6] = 400  # sampled token
+    input_ids_cpu[7] = 500  # spec token 1
+    input_ids_cpu[8] = 600  # spec token 2
+
+    # Step 1: Copy CPU -> GPU (simulates copy_to_gpu)
+    input_ids_gpu.copy_(input_ids_cpu)
+
+    # Verify -1 values ARE present before clamp (the bug condition)
+    assert (input_ids_gpu == -1).any(), (
+        "Test setup error: -1 values should be present before clamp"
+    )
+
+    # Step 2: Apply the fix - clamp negative values
+    # This is the exact line added by the fix in _prepare_input_ids
+    input_ids_gpu[:total_num_scheduled_tokens].clamp_(min=0)
+
+    # Step 3: Simulate scatter for common requests (requests 0 and 2)
+    # In the real code, scatter overwrites sampled + spec positions
+    # for requests in prev_req_id_to_index
+    prev_sampled_token_ids = torch.tensor([[42], [99]], device=device)
+    sampled_indices = torch.tensor([0, 6], dtype=torch.int64, device=device)
+    input_ids_gpu.scatter_(
+        0, sampled_indices, prev_sampled_token_ids[:, 0].to(torch.int32)
+    )
+
+    draft_token_ids = torch.tensor([50, 51, 80, 81], dtype=torch.int32, device=device)
+    draft_indices = torch.tensor([1, 2, 7, 8], dtype=torch.int64, device=device)
+    input_ids_gpu.scatter_(0, draft_indices, draft_token_ids)
+
+    # VERIFICATION: No -1 values should remain anywhere
+    assert input_ids_gpu.min().item() >= 0, (
+        f"Bug: input_ids_gpu still contains negative values: {input_ids_gpu}"
+    )
+
+    # Verify the transitioning request (request 1) has clamped values
+    assert input_ids_gpu[3].item() == 0, "Sampled position should be 0"
+    assert input_ids_gpu[4].item() == 0, "Spec position should be clamped to 0"
+    assert input_ids_gpu[5].item() == 0, "Spec position should be clamped to 0"
+
+    # Verify common requests have correct scattered values
+    assert input_ids_gpu[0].item() == 42, "Req 0 sampled should be scattered"
+    assert input_ids_gpu[1].item() == 50, "Req 0 spec 1 should be scattered"
+    assert input_ids_gpu[2].item() == 51, "Req 0 spec 2 should be scattered"
+    assert input_ids_gpu[6].item() == 99, "Req 2 sampled should be scattered"
+    assert input_ids_gpu[7].item() == 80, "Req 2 spec 1 should be scattered"
+    assert input_ids_gpu[8].item() == 81, "Req 2 spec 2 should be scattered"
+
+    # Verify that F.embedding would NOT crash with these values
+    vocab_size = 1000
+    embedding = torch.nn.Embedding(vocab_size, 16).to(device)
+    # This would crash with "CUDA error: device-side assert triggered"
+    # if any input_ids_gpu values were -1
+    result = embedding(input_ids_gpu.to(torch.int64))
+    assert result.shape == (total_num_scheduled_tokens, 16)
+
+
+def test_no_clamp_needed_when_all_common():
+    """Verify the fast path: when all requests are common, no clamp needed.
+
+    This tests the code path where num_common_tokens == total_without_spec,
+    meaning the copy_to_gpu block (and thus the clamp) is skipped entirely.
+    """
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # All tokens are from common requests - scatter handles everything
+    total_tokens = 6
+    input_ids_gpu = torch.zeros(total_tokens, dtype=torch.int32, device=device)
+
+    # Scatter puts correct values for all positions
+    prev_sampled = torch.tensor([[10], [20]], device=device, dtype=torch.int32)
+    sampled_idx = torch.tensor([0, 3], dtype=torch.int64, device=device)
+    input_ids_gpu.scatter_(0, sampled_idx, prev_sampled[:, 0])
+
+    draft = torch.tensor([11, 12, 21, 22], dtype=torch.int32, device=device)
+    draft_idx = torch.tensor([1, 2, 4, 5], dtype=torch.int64, device=device)
+    input_ids_gpu.scatter_(0, draft_idx, draft)
+
+    # All values should be valid without any clamp
+    assert input_ids_gpu.min().item() >= 0
+    expected = torch.tensor([10, 11, 12, 20, 21, 22], dtype=torch.int32, device=device)
+    assert torch.equal(input_ids_gpu, expected)
+
+
+def test_negative_token_ids_crash_embedding():
+    """Demonstrate that F.embedding crashes on -1 input (the bug).
+
+    Uses CPU to avoid poisoning the CUDA context with a device-side assert.
+    On GPU, this same error manifests as the CUDA device-side assert
+    reported in issue #36906.
+    """
+    vocab_size = 1000
+    embedding = torch.nn.Embedding(vocab_size, 16)
+
+    # F.embedding with -1 should raise IndexError on CPU
+    bad_input_ids = torch.tensor([100, -1, 200], dtype=torch.int64)
+    with pytest.raises(IndexError):
+        embedding(bad_input_ids)
+
+    # After clamping, embedding succeeds
+    fixed_input_ids = bad_input_ids.clamp(min=0)
+    result = embedding(fixed_input_ids)
+    assert result.shape == (3, 16), "Clamped input should embed successfully"

--- a/tests/v1/worker/test_prepare_input_ids_clamp.py
+++ b/tests/v1/worker/test_prepare_input_ids_clamp.py
@@ -5,131 +5,89 @@ Regression test for issue #36906: EAGLE3 + multimodal + async scheduling
 crashes with CUDA error in F.embedding() due to -1 placeholder token IDs
 reaching the embedding layer.
 
-This test directly exercises the _prepare_input_ids scatter path to verify
-that -1 spec token placeholders from async scheduling are clamped to valid
-values before reaching the model.
+The actual crash path is in the EAGLE draft model's propose() method:
+1. get_token_id(seq_lens[i]) returns -1 when async scheduling's seq_lens
+   exceeds known tokens
+2. -1 propagates through prepare_next_token_ids_padded() as a backup token
+3. The Triton kernel stores -1 when valid_count == 0 (discarded request)
+4. -1 enters self.input_ids via set_inputs_first_pass()
+5. propose() calls self.model.embed_input_ids(self.input_ids[:num_tokens])
+6. F.embedding(-1) triggers CUDA device-side assert
+
+The fix clamps self.input_ids[:num_tokens] to min=0 in propose() before
+the embed_input_ids call.
 """
 
 import pytest
 import torch
 
 
-def test_prepare_input_ids_clamps_negative_placeholders():
-    """Simulate the async scatter path and verify -1 values are clamped.
+def test_eagle_input_ids_clamp_prevents_negative_embedding():
+    """Verify that -1 token IDs in EAGLE's input_ids are clamped before
+    embedding, preventing F.embedding() crashes.
 
-    Reproduces the exact scenario where -1 leaks through:
-    1. A request transitions from prefill to decode (not in prev_req_id_to_index)
-    2. Async scheduler writes -1 spec token placeholders to token_ids_cpu
-    3. _prepare_input_ids copies input_ids.cpu (containing -1) to GPU
-    4. Scatter only covers "common" requests, leaving -1 for the new request
-
-    Without the fix, input_ids.gpu would contain -1, causing F.embedding()
-    to crash with CUDA device-side assert.
+    Simulates the exact scenario:
+    - next_token_ids contains -1 from get_token_id() returning -1
+    - set_inputs_first_pass() writes -1 into self.input_ids
+    - The fix clamps self.input_ids before embed_input_ids
     """
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-    # Simulate a batch with 3 requests, each with 1 sampled + 2 spec tokens = 3 tokens
-    total_num_scheduled_tokens = 9  # 3 requests * 3 tokens each
-
-    # Create input_ids buffer (like CpuGpuBuffer)
-    input_ids_cpu = torch.zeros(total_num_scheduled_tokens, dtype=torch.int32)
-    input_ids_gpu = torch.zeros(
-        total_num_scheduled_tokens, dtype=torch.int32, device=device
-    )
-
-    # Request 0: common request (was decoding in prev step) - valid tokens
-    input_ids_cpu[0] = 100  # sampled token (will be overwritten by scatter)
-    input_ids_cpu[1] = 200  # spec token 1 (will be overwritten by scatter)
-    input_ids_cpu[2] = 300  # spec token 2 (will be overwritten by scatter)
-
-    # Request 1: TRANSITIONING request (was prefilling, now decoding)
-    # NOT in prev_req_id_to_index, so scatter won't touch it
-    input_ids_cpu[3] = 0  # sampled token position (0 from token_ids_cpu init)
-    input_ids_cpu[4] = -1  # spec token placeholder from async scheduler
-    input_ids_cpu[5] = -1  # spec token placeholder from async scheduler
-
-    # Request 2: common request - valid tokens
-    input_ids_cpu[6] = 400  # sampled token
-    input_ids_cpu[7] = 500  # spec token 1
-    input_ids_cpu[8] = 600  # spec token 2
-
-    # Step 1: Copy CPU -> GPU (simulates copy_to_gpu)
-    input_ids_gpu.copy_(input_ids_cpu)
-
-    # Verify -1 values ARE present before clamp (the bug condition)
-    assert (input_ids_gpu == -1).any(), (
-        "Test setup error: -1 values should be present before clamp"
-    )
-
-    # Step 2: Apply the fix - clamp negative values
-    # This is the exact line added by the fix in _prepare_input_ids
-    input_ids_gpu[:total_num_scheduled_tokens].clamp_(min=0)
-
-    # Step 3: Simulate scatter for common requests (requests 0 and 2)
-    # In the real code, scatter overwrites sampled + spec positions
-    # for requests in prev_req_id_to_index
-    prev_sampled_token_ids = torch.tensor([[42], [99]], device=device)
-    sampled_indices = torch.tensor([0, 6], dtype=torch.int64, device=device)
-    input_ids_gpu.scatter_(
-        0, sampled_indices, prev_sampled_token_ids[:, 0].to(torch.int32)
-    )
-
-    draft_token_ids = torch.tensor([50, 51, 80, 81], dtype=torch.int32, device=device)
-    draft_indices = torch.tensor([1, 2, 7, 8], dtype=torch.int64, device=device)
-    input_ids_gpu.scatter_(0, draft_indices, draft_token_ids)
-
-    # VERIFICATION: No -1 values should remain anywhere
-    assert input_ids_gpu.min().item() >= 0, (
-        f"Bug: input_ids_gpu still contains negative values: {input_ids_gpu}"
-    )
-
-    # Verify the transitioning request (request 1) has clamped values
-    assert input_ids_gpu[3].item() == 0, "Sampled position should be 0"
-    assert input_ids_gpu[4].item() == 0, "Spec position should be clamped to 0"
-    assert input_ids_gpu[5].item() == 0, "Spec position should be clamped to 0"
-
-    # Verify common requests have correct scattered values
-    assert input_ids_gpu[0].item() == 42, "Req 0 sampled should be scattered"
-    assert input_ids_gpu[1].item() == 50, "Req 0 spec 1 should be scattered"
-    assert input_ids_gpu[2].item() == 51, "Req 0 spec 2 should be scattered"
-    assert input_ids_gpu[6].item() == 99, "Req 2 sampled should be scattered"
-    assert input_ids_gpu[7].item() == 80, "Req 2 spec 1 should be scattered"
-    assert input_ids_gpu[8].item() == 81, "Req 2 spec 2 should be scattered"
-
-    # Verify that F.embedding would NOT crash with these values
+    num_tokens = 6
     vocab_size = 1000
+
+    # Simulate EAGLE's self.input_ids after set_inputs_first_pass()
+    # Positions 2 and 5 have -1 from next_token_ids (backup tokens
+    # from get_token_id returning -1 for async scheduling)
+    input_ids = torch.tensor(
+        [100, 200, -1, 300, 400, -1], dtype=torch.int32, device=device
+    )
+
+    # Verify -1 values are present (the bug condition)
+    assert (input_ids == -1).any(), "Test setup error: -1 values should be present"
+
+    # Apply the fix: clamp before embed_input_ids
+    input_ids[:num_tokens].clamp_(min=0)
+
+    # Verify no -1 values remain
+    assert input_ids.min().item() >= 0, (
+        f"Bug: input_ids still contains negative values: {input_ids}"
+    )
+
+    # Verify F.embedding succeeds (would crash on -1)
     embedding = torch.nn.Embedding(vocab_size, 16).to(device)
-    # This would crash with "CUDA error: device-side assert triggered"
-    # if any input_ids_gpu values were -1
-    result = embedding(input_ids_gpu.to(torch.int64))
-    assert result.shape == (total_num_scheduled_tokens, 16)
+    result = embedding(input_ids.to(torch.int64))
+    assert result.shape == (num_tokens, 16)
 
 
-def test_no_clamp_needed_when_all_common():
-    """Verify the fast path: when all requests are common, no clamp needed.
+def test_get_token_id_returns_negative_one_for_out_of_bounds():
+    """Verify get_token_id returns -1 when index exceeds known tokens.
 
-    This tests the code path where num_common_tokens == total_without_spec,
-    meaning the copy_to_gpu block (and thus the clamp) is skipped entirely.
+    This is the root source of -1 values in the crash path. When async
+    scheduling sets seq_lens beyond the known prompt + output tokens,
+    get_token_id() returns -1 as a fallback.
     """
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    from vllm.v1.worker.gpu_input_batch import CachedRequestState
 
-    # All tokens are from common requests - scatter handles everything
-    total_tokens = 6
-    input_ids_gpu = torch.zeros(total_tokens, dtype=torch.int32, device=device)
+    req = CachedRequestState(
+        req_id="test",
+        prompt_token_ids=[10, 20, 30],  # 3 prompt tokens
+        mm_features=[],
+        sampling_params=None,
+        generator=None,
+        block_ids=(),
+        num_computed_tokens=0,
+        output_token_ids=[40, 50],  # 2 output tokens
+    )
 
-    # Scatter puts correct values for all positions
-    prev_sampled = torch.tensor([[10], [20]], device=device, dtype=torch.int32)
-    sampled_idx = torch.tensor([0, 3], dtype=torch.int64, device=device)
-    input_ids_gpu.scatter_(0, sampled_idx, prev_sampled[:, 0])
+    # Valid indices: 0-4 (3 prompt + 2 output)
+    assert req.get_token_id(0) == 10
+    assert req.get_token_id(2) == 30
+    assert req.get_token_id(3) == 40
+    assert req.get_token_id(4) == 50
 
-    draft = torch.tensor([11, 12, 21, 22], dtype=torch.int32, device=device)
-    draft_idx = torch.tensor([1, 2, 4, 5], dtype=torch.int64, device=device)
-    input_ids_gpu.scatter_(0, draft_idx, draft)
-
-    # All values should be valid without any clamp
-    assert input_ids_gpu.min().item() >= 0
-    expected = torch.tensor([10, 11, 12, 20, 21, 22], dtype=torch.int32, device=device)
-    assert torch.equal(input_ids_gpu, expected)
+    # Out-of-bounds: returns -1 (async scheduling's seq_lens can exceed this)
+    assert req.get_token_id(5) == -1
+    assert req.get_token_id(10) == -1
 
 
 def test_negative_token_ids_crash_embedding():

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -438,6 +438,12 @@ class SpecDecodeBaseProposer:
             self._determine_batch_execution_and_padding(num_tokens)
         )
 
+        # Async scheduling can leave -1 placeholder token IDs in
+        # self.input_ids (via next_token_ids from get_token_id() when
+        # seq_lens exceeds known tokens). Clamp to 0 to prevent
+        # out-of-bounds F.embedding() crash. (See #36906)
+        self.input_ids[:num_tokens].clamp_(min=0)
+
         if self.supports_mm_inputs:
             mm_embeds, is_mm_embed = mm_embed_inputs or (None, None)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1566,6 +1566,13 @@ class GPUModelRunner(
             if self.enable_prompt_embeds:
                 self.inputs_embeds.copy_to_gpu(total_num_scheduled_tokens)
                 self.is_token_ids.copy_to_gpu(total_num_scheduled_tokens)
+            # Clamp -1 placeholder token IDs from async scheduling.
+            # When requests transition from prefill to decode, they may
+            # not be in prev_req_id_to_index and their spec token
+            # placeholders (-1) won't be overwritten by the scatter
+            # below. Clamp to 0 to prevent out-of-bounds F.embedding()
+            # in _preprocess. (See #36906)
+            self.input_ids.gpu[:total_num_scheduled_tokens].clamp_(min=0)
         if num_common_tokens == 0:
             # No requests in common with the previous iteration
             # So input_ids.cpu will have all the input ids.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1566,6 +1566,13 @@ class GPUModelRunner(
             if self.enable_prompt_embeds:
                 self.inputs_embeds.copy_to_gpu(total_num_scheduled_tokens)
                 self.is_token_ids.copy_to_gpu(total_num_scheduled_tokens)
+            # Sanitize -1 placeholder token IDs from async scheduling.
+            # Non-common requests (new, resumed, or transitioning from
+            # prefill) may have -1 spec token placeholders in token_ids_cpu
+            # that won't be overwritten by the scatter below (they aren't
+            # in prev_req_id_to_index). Clamp to 0 to prevent
+            # out-of-bounds F.embedding(). (See #36906)
+            self.input_ids.gpu[:total_num_scheduled_tokens].clamp_(min=0)
         if num_common_tokens == 0:
             # No requests in common with the previous iteration
             # So input_ids.cpu will have all the input ids.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1566,13 +1566,6 @@ class GPUModelRunner(
             if self.enable_prompt_embeds:
                 self.inputs_embeds.copy_to_gpu(total_num_scheduled_tokens)
                 self.is_token_ids.copy_to_gpu(total_num_scheduled_tokens)
-            # Sanitize -1 placeholder token IDs from async scheduling.
-            # Non-common requests (new, resumed, or transitioning from
-            # prefill) may have -1 spec token placeholders in token_ids_cpu
-            # that won't be overwritten by the scatter below (they aren't
-            # in prev_req_id_to_index). Clamp to 0 to prevent
-            # out-of-bounds F.embedding(). (See #36906)
-            self.input_ids.gpu[:total_num_scheduled_tokens].clamp_(min=0)
         if num_common_tokens == 0:
             # No requests in common with the previous iteration
             # So input_ids.cpu will have all the input ids.


### PR DESCRIPTION
## Purpose

Fixes #36906.

When async scheduling is used with EAGLE3 speculative decoding and multimodal models (e.g., `lightonai/LightOnOCR-2-1B`), `-1` placeholder token IDs can leak into embedding layers, triggering `CUDA error: device-side assert triggered`.

## Root cause

Async scheduling uses `-1` as placeholder for speculative tokens. These `-1` values can reach `F.embedding()` via two paths:

**Path 1 (target model):** When requests transition from prefill to decode under high concurrency, they may not be in `prev_req_id_to_index`. Their `-1` spec token placeholders in `token_ids_cpu` survive `copy_to_gpu` because the scatter in `_prepare_input_ids` only covers common requests. These reach `_preprocess -> model.embed_input_ids`.

**Path 2 (draft model):** `get_token_id(seq_lens[i])` returns `-1` when async scheduling's `seq_lens` exceeds known tokens. This propagates through `prepare_next_token_ids_padded()` backup tokens -> Triton kernel -> `set_inputs_first_pass()` -> EAGLE proposer's `self.input_ids` -> `propose() -> embed_input_ids`.

## Fix

Two defensive clamps, one for each path:

1. **`gpu_model_runner.py:_prepare_input_ids`**: `self.input_ids.gpu[:total_num_scheduled_tokens].clamp_(min=0)` after `copy_to_gpu` in the async path
2. **`eagle.py:propose()`**: `self.input_ids[:num_tokens].clamp_(min=0)` before `embed_input_ids`

Both clamp `-1` to `0` (always a valid embedding index). Token `0` at placeholder positions is harmless — the rejection sampler handles wrong spec tokens, and discarded request outputs are ignored.