### PR TITLE
[Profiling] Add optional stage-level NVTX annotations for Nsight Systems

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -132,6 +132,7 @@ To profile the server, you will want to prepend your `vllm serve` command with `
 nsys profile \
     --trace-fork-before-exec=true \
     --cuda-graph-trace=node \
+    --trace=cuda,nvtx \
     --capture-range=cudaProfilerApi \
     --capture-range-end repeat \
     vllm serve meta-llama/Llama-3.1-8B-Instruct --profiler-config.profiler cuda
@@ -147,6 +148,38 @@ vllm bench serve \
 ```
 
 With `--profile`, vLLM will capture a profile for each run of `vllm bench serve`. Once the server is killed, the profiles will all be saved.
+
+#### Stage-level NVTX scopes (optional)
+
+For high-level serving phases in the timeline, enable vLLM's env-gated NVTX
+scopes:
+
+- `scheduler_step`
+- `prefill_batch`
+- `decode_batch`
+- `mixed_batch`
+- `empty_batch`
+- `sampling`
+
+```bash
+# server
+VLLM_NVTX_SCOPES_FOR_PROFILING=1 \
+nsys profile \
+    --trace-fork-before-exec=true \
+    --cuda-graph-trace=node \
+    --trace=cuda,nvtx \
+    --capture-range=cudaProfilerApi \
+    --capture-range-end repeat \
+    vllm serve meta-llama/Llama-3.1-8B-Instruct --profiler-config.profiler cuda
+```
+
+Use the same client flow shown above (`vllm bench serve --profile ...`) to drive
+`/start_profile` and `/stop_profile`.
+
+!!! note
+    In Nsight Systems, `--nvtx-capture` is only applicable when
+    `--capture-range=nvtx` is set. The command above uses vLLM's existing
+    `cudaProfilerApi` capture workflow for consistency with `/start_profile`.
 
 #### Analysis
 

--- a/tests/v1/test_profiling_scopes.py
+++ b/tests/v1/test_profiling_scopes.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1 import utils as v1_utils
+from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
+
+
+@pytest.fixture
+def should_do_global_cleanup_after_test() -> bool:
+    # These tests do not initialize distributed state.
+    # Skip the global teardown fixture to stay hermetic on CPU-only hosts.
+    return False
+
+
+def _make_scheduler_output(
+    num_scheduled_tokens: dict[str, int],
+    new_req_ids: list[str] | None = None,
+    cached_context_req_ids: list[str] | None = None,
+    cached_generation_req_ids: list[str] | None = None,
+) -> SchedulerOutput:
+    new_req_ids = new_req_ids or []
+    cached_context_req_ids = cached_context_req_ids or []
+    cached_generation_req_ids = cached_generation_req_ids or []
+
+    cached_req_ids = cached_context_req_ids + cached_generation_req_ids
+    cached_num_output_tokens = (
+        [0] * len(cached_context_req_ids) + [1] * len(cached_generation_req_ids)
+    )
+    cached_reqs = CachedRequestData(
+        req_ids=cached_req_ids,
+        resumed_req_ids=set(),
+        new_token_ids=[[] for _ in cached_req_ids],
+        all_token_ids={},
+        new_block_ids=[None for _ in cached_req_ids],
+        num_computed_tokens=[0 for _ in cached_req_ids],
+        num_output_tokens=cached_num_output_tokens,
+    )
+
+    return SchedulerOutput(
+        scheduled_new_reqs=[
+            SimpleNamespace(req_id=req_id) for req_id in new_req_ids
+        ],
+        scheduled_cached_reqs=cached_reqs,
+        num_scheduled_tokens=num_scheduled_tokens,
+        total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+
+@pytest.mark.parametrize(
+    "scheduler_output,expected",
+    [
+        (
+            _make_scheduler_output(
+                num_scheduled_tokens={"new_req": 4},
+                new_req_ids=["new_req"],
+            ),
+            "prefill_batch",
+        ),
+        (
+            _make_scheduler_output(
+                num_scheduled_tokens={"decode_req": 2},
+                cached_generation_req_ids=["decode_req"],
+            ),
+            "decode_batch",
+        ),
+        (
+            _make_scheduler_output(
+                num_scheduled_tokens={"new_req": 3, "decode_req": 2},
+                new_req_ids=["new_req"],
+                cached_generation_req_ids=["decode_req"],
+            ),
+            "mixed_batch",
+        ),
+        (
+            _make_scheduler_output(num_scheduled_tokens={}),
+            "empty_batch",
+        ),
+    ],
+)
+def test_classify_batch_stage(scheduler_output: SchedulerOutput, expected: str):
+    assert v1_utils.classify_batch_stage(scheduler_output) == expected
+
+
+def test_get_batch_stage_scope_name_disabled(monkeypatch):
+    scheduler_output = _make_scheduler_output(
+        num_scheduled_tokens={"new_req": 1},
+        new_req_ids=["new_req"],
+    )
+    monkeypatch.setattr(v1_utils.envs, "VLLM_CUSTOM_SCOPES_FOR_PROFILING", False)
+    monkeypatch.setattr(v1_utils.envs, "VLLM_NVTX_SCOPES_FOR_PROFILING", False)
+
+    assert v1_utils.get_batch_stage_scope_name(scheduler_output) is None
+
+
+def test_get_batch_stage_scope_name_enabled(monkeypatch):
+    scheduler_output = _make_scheduler_output(
+        num_scheduled_tokens={"decode_req": 1},
+        cached_generation_req_ids=["decode_req"],
+    )
+    monkeypatch.setattr(v1_utils.envs, "VLLM_CUSTOM_SCOPES_FOR_PROFILING", False)
+    monkeypatch.setattr(v1_utils.envs, "VLLM_NVTX_SCOPES_FOR_PROFILING", True)
+
+    assert v1_utils.get_batch_stage_scope_name(scheduler_output) == "decode_batch"

--- a/tests/v1/test_profiling_scopes.py
+++ b/tests/v1/test_profiling_scopes.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import importlib
+import sys
+import types
+from collections.abc import Callable
+from concurrent.futures import Future
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -10,8 +16,6 @@ from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 
 @pytest.fixture
 def should_do_global_cleanup_after_test() -> bool:
-    # These tests do not initialize distributed state.
-    # Skip the global teardown fixture to stay hermetic on CPU-only hosts.
     return False
 
 
@@ -54,6 +58,41 @@ def _make_scheduler_output(
     )
 
 
+def _recorded_scope_factory(scope_names: list[str]) -> Callable[[str], object]:
+    @contextmanager
+    def _record_scope(name: str):
+        scope_names.append(name)
+        yield
+
+    return _record_scope
+
+
+def _import_gpu_worker(monkeypatch):
+    stub_module = types.ModuleType("vllm.model_executor.warmup.kernel_warmup")
+    stub_module.kernel_warmup = lambda *args, **kwargs: None
+    worker_utils_stub = types.ModuleType("vllm.v1.worker.utils")
+    worker_utils_stub.is_residual_scattered_for_sp = lambda *args, **kwargs: False
+    worker_utils_stub.request_memory = lambda *args, **kwargs: None
+    model_loader_stub = types.ModuleType("vllm.model_executor.model_loader")
+    model_loader_stub.TensorizerLoader = object
+    gpu_warmup_stub = types.ModuleType("vllm.v1.worker.gpu.warmup")
+    gpu_warmup_stub.warmup_kernels = lambda *args, **kwargs: None
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.warmup.kernel_warmup",
+        stub_module,
+    )
+    monkeypatch.setitem(sys.modules, "vllm.v1.worker.utils", worker_utils_stub)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.model_loader",
+        model_loader_stub,
+    )
+    monkeypatch.setitem(sys.modules, "vllm.v1.worker.gpu.warmup", gpu_warmup_stub)
+    sys.modules.pop("vllm.v1.worker.gpu_worker", None)
+    return importlib.import_module("vllm.v1.worker.gpu_worker")
+
+
 @pytest.mark.parametrize(
     "scheduler_output,expected",
     [
@@ -89,23 +128,119 @@ def test_classify_batch_stage(scheduler_output: SchedulerOutput, expected: str):
     assert v1_utils.classify_batch_stage(scheduler_output) == expected
 
 
-def test_get_batch_stage_scope_name_disabled(monkeypatch):
+def test_engine_core_step_emits_scheduler_scope(monkeypatch):
+    import vllm.v1.engine.core as engine_core_mod
+
     scheduler_output = _make_scheduler_output(
-        num_scheduled_tokens={"new_req": 1},
-        new_req_ids=["new_req"],
+        num_scheduled_tokens={"req": 1},
+        new_req_ids=["req"],
     )
-    monkeypatch.setattr(v1_utils.envs, "VLLM_CUSTOM_SCOPES_FOR_PROFILING", False)
-    monkeypatch.setattr(v1_utils.envs, "VLLM_NVTX_SCOPES_FOR_PROFILING", False)
+    scope_names: list[str] = []
+    future: Future[None] = Future()
+    future.set_result(None)
 
-    assert v1_utils.get_batch_stage_scope_name(scheduler_output) is None
-
-
-def test_get_batch_stage_scope_name_enabled(monkeypatch):
-    scheduler_output = _make_scheduler_output(
-        num_scheduled_tokens={"decode_req": 1},
-        cached_generation_req_ids=["decode_req"],
+    monkeypatch.setattr(
+        engine_core_mod,
+        "record_function_or_nullcontext",
+        _recorded_scope_factory(scope_names),
     )
-    monkeypatch.setattr(v1_utils.envs, "VLLM_CUSTOM_SCOPES_FOR_PROFILING", False)
-    monkeypatch.setattr(v1_utils.envs, "VLLM_NVTX_SCOPES_FOR_PROFILING", True)
 
-    assert v1_utils.get_batch_stage_scope_name(scheduler_output) == "decode_batch"
+    scheduler = SimpleNamespace(
+        has_requests=lambda: True,
+        schedule=lambda: scheduler_output,
+        get_grammar_bitmask=lambda _: None,
+        update_from_output=lambda _, model_output: {"model_output": model_output},
+    )
+    model_executor = SimpleNamespace(
+        execute_model=lambda _, non_block=True: future,
+        sample_tokens=lambda _: "sampled",
+    )
+    engine = SimpleNamespace(
+        scheduler=scheduler,
+        model_executor=model_executor,
+        log_error_detail=lambda _: nullcontext(),
+        log_iteration_details=lambda _: nullcontext(),
+        _process_aborts_queue=lambda: None,
+    )
+
+    outputs, model_executed = engine_core_mod.EngineCore.step(engine)
+
+    assert outputs == {"model_output": "sampled"}
+    assert model_executed is True
+    assert scope_names == ["scheduler_step"]
+
+
+def test_worker_sample_tokens_emits_sampling_scope(monkeypatch):
+    gpu_worker_mod = _import_gpu_worker(monkeypatch)
+
+    scope_names: list[str] = []
+    monkeypatch.setattr(
+        gpu_worker_mod,
+        "record_function_or_nullcontext",
+        _recorded_scope_factory(scope_names),
+    )
+
+    worker = SimpleNamespace(
+        model_runner=SimpleNamespace(sample_tokens=lambda _: "sampled")
+    )
+
+    assert gpu_worker_mod.Worker.sample_tokens(worker, None) == "sampled"
+    assert scope_names == ["sampling"]
+
+
+@pytest.mark.parametrize(
+    "scheduler_output,expected",
+    [
+        (
+            _make_scheduler_output(
+                num_scheduled_tokens={"req": 2},
+                new_req_ids=["req"],
+            ),
+            "prefill_batch",
+        ),
+        (
+            _make_scheduler_output(
+                num_scheduled_tokens={"req": 1},
+                cached_generation_req_ids=["req"],
+            ),
+            "decode_batch",
+        ),
+    ],
+)
+def test_worker_execute_model_emits_batch_stage_scope(
+    monkeypatch,
+    scheduler_output: SchedulerOutput,
+    expected: str,
+):
+    gpu_worker_mod = _import_gpu_worker(monkeypatch)
+
+    scope_names: list[str] = []
+    monkeypatch.setattr(
+        gpu_worker_mod,
+        "record_function_or_nullcontext",
+        _recorded_scope_factory(scope_names),
+    )
+    monkeypatch.setattr(
+        gpu_worker_mod,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True),
+    )
+
+    worker = SimpleNamespace(
+        _pp_send_work=[],
+        vllm_config=SimpleNamespace(
+            compilation_config=SimpleNamespace(
+                pass_config=SimpleNamespace(enable_sp=False)
+            ),
+            parallel_config=SimpleNamespace(
+                pipeline_parallel_size=1,
+                distributed_executor_backend="mp",
+            ),
+        ),
+        use_v2_model_runner=False,
+        annotate_profile=lambda _: nullcontext(),
+        model_runner=SimpleNamespace(execute_model=lambda *_: None),
+    )
+
+    assert gpu_worker_mod.Worker.execute_model(worker, scheduler_output) is None
+    assert scope_names == [expected]

--- a/tests/v1/test_profiling_scopes.py
+++ b/tests/v1/test_profiling_scopes.py
@@ -31,8 +31,8 @@ def _make_scheduler_output(
     cached_generation_req_ids = cached_generation_req_ids or []
 
     cached_req_ids = cached_context_req_ids + cached_generation_req_ids
-    cached_num_output_tokens = (
-        [0] * len(cached_context_req_ids) + [1] * len(cached_generation_req_ids)
+    cached_num_output_tokens = [0] * len(cached_context_req_ids) + [1] * len(
+        cached_generation_req_ids
     )
     cached_reqs = CachedRequestData(
         req_ids=cached_req_ids,
@@ -45,9 +45,7 @@ def _make_scheduler_output(
     )
 
     return SchedulerOutput(
-        scheduled_new_reqs=[
-            SimpleNamespace(req_id=req_id) for req_id in new_req_ids
-        ],
+        scheduled_new_reqs=[SimpleNamespace(req_id=req_id) for req_id in new_req_ids],
         scheduled_cached_reqs=cached_reqs,
         num_scheduled_tokens=num_scheduled_tokens,
         total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
@@ -74,9 +72,7 @@ def _import_gpu_worker(monkeypatch):
     )
     stub_module.kernel_warmup = lambda *args, **kwargs: None
     worker_utils_stub = cast(Any, types.ModuleType("vllm.v1.worker.utils"))
-    worker_utils_stub.is_residual_scattered_for_sp = (
-        lambda *args, **kwargs: False
-    )
+    worker_utils_stub.is_residual_scattered_for_sp = lambda *args, **kwargs: False
     worker_utils_stub.request_memory = lambda *args, **kwargs: None
     model_loader_stub = cast(Any, types.ModuleType("vllm.model_executor.model_loader"))
     model_loader_stub.TensorizerLoader = object

--- a/tests/v1/test_profiling_scopes.py
+++ b/tests/v1/test_profiling_scopes.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from concurrent.futures import Future
 from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -68,14 +69,18 @@ def _recorded_scope_factory(scope_names: list[str]) -> Callable[[str], object]:
 
 
 def _import_gpu_worker(monkeypatch):
-    stub_module = types.ModuleType("vllm.model_executor.warmup.kernel_warmup")
+    stub_module = cast(
+        Any, types.ModuleType("vllm.model_executor.warmup.kernel_warmup")
+    )
     stub_module.kernel_warmup = lambda *args, **kwargs: None
-    worker_utils_stub = types.ModuleType("vllm.v1.worker.utils")
-    worker_utils_stub.is_residual_scattered_for_sp = lambda *args, **kwargs: False
+    worker_utils_stub = cast(Any, types.ModuleType("vllm.v1.worker.utils"))
+    worker_utils_stub.is_residual_scattered_for_sp = (
+        lambda *args, **kwargs: False
+    )
     worker_utils_stub.request_memory = lambda *args, **kwargs: None
-    model_loader_stub = types.ModuleType("vllm.model_executor.model_loader")
+    model_loader_stub = cast(Any, types.ModuleType("vllm.model_executor.model_loader"))
     model_loader_stub.TensorizerLoader = object
-    gpu_warmup_stub = types.ModuleType("vllm.v1.worker.gpu.warmup")
+    gpu_warmup_stub = cast(Any, types.ModuleType("vllm.v1.worker.gpu.warmup"))
     gpu_warmup_stub.warmup_kernels = lambda *args, **kwargs: None
     monkeypatch.setitem(
         sys.modules,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -8,7 +8,7 @@ import time
 from collections import defaultdict, deque
 from collections.abc import Callable, Generator
 from concurrent.futures import Future
-from contextlib import ExitStack, contextmanager, nullcontext
+from contextlib import ExitStack, contextmanager
 from enum import IntEnum
 from functools import partial
 from inspect import isclass, signature
@@ -74,7 +74,6 @@ from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import (
     compute_iteration_details,
-    profiling_scopes_enabled,
     record_function_or_nullcontext,
 )
 from vllm.version import __version__ as VLLM_VERSION
@@ -390,12 +389,7 @@ class EngineCore:
         # or finished and not yet removed from the batch.
         if not self.scheduler.has_requests():
             return {}, False
-        scheduler_ctx = (
-            record_function_or_nullcontext("scheduler_step")
-            if profiling_scopes_enabled()
-            else nullcontext()
-        )
-        with scheduler_ctx:
+        with record_function_or_nullcontext("scheduler_step"):
             scheduler_output = self.scheduler.schedule()
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
@@ -454,12 +448,7 @@ class EngineCore:
         model_executed = False
         deferred_scheduler_output = None
         if self.scheduler.has_requests():
-            scheduler_ctx = (
-                record_function_or_nullcontext("scheduler_step")
-                if profiling_scopes_enabled()
-                else nullcontext()
-            )
-            with scheduler_ctx:
+            with record_function_or_nullcontext("scheduler_step"):
                 scheduler_output = self.scheduler.schedule()
             with self.log_error_detail(scheduler_output):
                 exec_future = self.model_executor.execute_model(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -8,7 +8,7 @@ import time
 from collections import defaultdict, deque
 from collections.abc import Callable, Generator
 from concurrent.futures import Future
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, contextmanager, nullcontext
 from enum import IntEnum
 from functools import partial
 from inspect import isclass, signature
@@ -72,7 +72,11 @@ from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.structured_output import StructuredOutputManager
-from vllm.v1.utils import compute_iteration_details
+from vllm.v1.utils import (
+    compute_iteration_details,
+    profiling_scopes_enabled,
+    record_function_or_nullcontext,
+)
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
@@ -386,7 +390,13 @@ class EngineCore:
         # or finished and not yet removed from the batch.
         if not self.scheduler.has_requests():
             return {}, False
-        scheduler_output = self.scheduler.schedule()
+        scheduler_ctx = (
+            record_function_or_nullcontext("scheduler_step")
+            if profiling_scopes_enabled()
+            else nullcontext()
+        )
+        with scheduler_ctx:
+            scheduler_output = self.scheduler.schedule()
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         with (
@@ -444,7 +454,13 @@ class EngineCore:
         model_executed = False
         deferred_scheduler_output = None
         if self.scheduler.has_requests():
-            scheduler_output = self.scheduler.schedule()
+            scheduler_ctx = (
+                record_function_or_nullcontext("scheduler_step")
+                if profiling_scopes_enabled()
+                else nullcontext()
+            )
+            with scheduler_ctx:
+                scheduler_output = self.scheduler.schedule()
             with self.log_error_detail(scheduler_output):
                 exec_future = self.model_executor.execute_model(
                     scheduler_output, non_block=True

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -472,14 +472,6 @@ def compute_iteration_details(scheduler_output: SchedulerOutput) -> IterationDet
     )
 
 
-def profiling_scopes_enabled() -> bool:
-    """Return whether env-gated profiling scopes are enabled."""
-    return (
-        envs.VLLM_CUSTOM_SCOPES_FOR_PROFILING
-        or envs.VLLM_NVTX_SCOPES_FOR_PROFILING
-    )
-
-
 def classify_batch_stage(scheduler_output: SchedulerOutput) -> str:
     """Classify the current scheduler output into a serving-stage label."""
     if scheduler_output.total_num_scheduled_tokens == 0:
@@ -496,10 +488,3 @@ def classify_batch_stage(scheduler_output: SchedulerOutput) -> str:
     if has_generation:
         return "decode_batch"
     return "unknown_batch"
-
-
-def get_batch_stage_scope_name(scheduler_output: SchedulerOutput) -> str | None:
-    """Return a stage scope name when env-gated profiling scopes are enabled."""
-    if not profiling_scopes_enabled():
-        return None
-    return classify_batch_stage(scheduler_output)

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -470,3 +470,36 @@ def compute_iteration_details(scheduler_output: SchedulerOutput) -> IterationDet
         num_generation_requests,
         num_generation_tokens,
     )
+
+
+def profiling_scopes_enabled() -> bool:
+    """Return whether env-gated profiling scopes are enabled."""
+    return (
+        envs.VLLM_CUSTOM_SCOPES_FOR_PROFILING
+        or envs.VLLM_NVTX_SCOPES_FOR_PROFILING
+    )
+
+
+def classify_batch_stage(scheduler_output: SchedulerOutput) -> str:
+    """Classify the current scheduler output into a serving-stage label."""
+    if scheduler_output.total_num_scheduled_tokens == 0:
+        return "empty_batch"
+
+    details = compute_iteration_details(scheduler_output)
+    has_context = details.num_ctx_tokens > 0
+    has_generation = details.num_generation_tokens > 0
+
+    if has_context and has_generation:
+        return "mixed_batch"
+    if has_context:
+        return "prefill_batch"
+    if has_generation:
+        return "decode_batch"
+    return "unknown_batch"
+
+
+def get_batch_stage_scope_name(scheduler_output: SchedulerOutput) -> str | None:
+    """Return a stage scope name when env-gated profiling scopes are enabled."""
+    if not profiling_scopes_enabled():
+        return None
+    return classify_batch_stage(scheduler_output)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -55,9 +55,8 @@ from vllm.v1.outputs import (
     ModelRunnerOutput,
 )
 from vllm.v1.utils import (
+    classify_batch_stage,
     compute_iteration_details,
-    get_batch_stage_scope_name,
-    profiling_scopes_enabled,
     record_function_or_nullcontext,
     report_usage_stats,
 )
@@ -759,9 +758,6 @@ class Worker(WorkerBase):
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
-        if not profiling_scopes_enabled():
-            return self.model_runner.sample_tokens(grammar_output)
-
         with record_function_or_nullcontext("sampling"):
             return self.model_runner.sample_tokens(grammar_output)
 
@@ -825,14 +821,12 @@ class Worker(WorkerBase):
                 comm_postprocess=comm_postprocess,
             )
 
-        batch_stage_scope_name = get_batch_stage_scope_name(scheduler_output)
-        batch_stage_scope = (
-            record_function_or_nullcontext(batch_stage_scope_name)
-            if batch_stage_scope_name is not None
-            else nullcontext()
-        )
-
-        with self.annotate_profile(scheduler_output), batch_stage_scope:
+        with (
+            self.annotate_profile(scheduler_output),
+            record_function_or_nullcontext(
+                classify_batch_stage(scheduler_output)
+            ),
+        ):
             output = self.model_runner.execute_model(
                 scheduler_output, intermediate_tensors
             )

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -54,7 +54,13 @@ from vllm.v1.outputs import (
     DraftTokenIds,
     ModelRunnerOutput,
 )
-from vllm.v1.utils import compute_iteration_details, report_usage_stats
+from vllm.v1.utils import (
+    compute_iteration_details,
+    get_batch_stage_scope_name,
+    profiling_scopes_enabled,
+    record_function_or_nullcontext,
+    report_usage_stats,
+)
 from vllm.v1.worker.utils import is_residual_scattered_for_sp
 from vllm.v1.worker.worker_base import WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
@@ -753,7 +759,11 @@ class Worker(WorkerBase):
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
-        return self.model_runner.sample_tokens(grammar_output)
+        if not profiling_scopes_enabled():
+            return self.model_runner.sample_tokens(grammar_output)
+
+        with record_function_or_nullcontext("sampling"):
+            return self.model_runner.sample_tokens(grammar_output)
 
     @torch.inference_mode()
     def execute_model(
@@ -815,7 +825,14 @@ class Worker(WorkerBase):
                 comm_postprocess=comm_postprocess,
             )
 
-        with self.annotate_profile(scheduler_output):
+        batch_stage_scope_name = get_batch_stage_scope_name(scheduler_output)
+        batch_stage_scope = (
+            record_function_or_nullcontext(batch_stage_scope_name)
+            if batch_stage_scope_name is not None
+            else nullcontext()
+        )
+
+        with self.annotate_profile(scheduler_output), batch_stage_scope:
             output = self.model_runner.execute_model(
                 scheduler_output, intermediate_tensors
             )

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -823,9 +823,7 @@ class Worker(WorkerBase):
 
         with (
             self.annotate_profile(scheduler_output),
-            record_function_or_nullcontext(
-                classify_batch_stage(scheduler_output)
-            ),
+            record_function_or_nullcontext(classify_batch_stage(scheduler_output)),
         ):
             output = self.model_runner.execute_model(
                 scheduler_output, intermediate_tensors


### PR DESCRIPTION
## Motivation
vLLM already supports multiple profiling modes, but Nsight timelines still lack a clean, stable stage-level view of serving phases at orchestration boundaries.

## What already exists today
- `--profiler-config.profiler={torch,cuda}` with `/start_profile` and `/stop_profile`
- CUDA profiler annotations via `GpuWorker.annotate_profile(...)`
- Env-gated scope annotations via:
  - `VLLM_CUSTOM_SCOPES_FOR_PROFILING=1` for `torch.profiler.record_function`
  - `VLLM_NVTX_SCOPES_FOR_PROFILING=1` for `nvtx.annotate`
- Layerwise NVTX tracing via `--enable-layerwise-nvtx-tracing`

## What this adds beyond existing tracing
This adds optional high-level stage scopes:
- `scheduler_step`
- `prefill_batch`
- `decode_batch`
- `mixed_batch`
- `empty_batch`
- `sampling`

This complements existing lower-level spans and avoids duplicating layerwise tracing.

## Why these call sites were chosen
- `EngineCore.scheduler.schedule()` is the stable scheduler orchestration boundary.
- `Worker.execute_model(...)` is the stable worker boundary shared by modern V1 execution paths, so stage labels remain useful even as internals change.
- `Worker.sample_tokens(...)` is the stable top-level sampling boundary.

## How to enable
Set:
- `VLLM_NVTX_SCOPES_FOR_PROFILING=1`

## Verified profiling command
```bash
VLLM_NVTX_SCOPES_FOR_PROFILING=1 nsys profile   --trace-fork-before-exec=true   --cuda-graph-trace=node   --trace=cuda,nvtx   --capture-range=cudaProfilerApi   --capture-range-end repeat   vllm serve <model> --profiler-config.profiler cuda
```

Use `vllm bench serve --profile ...` to trigger `/start_profile` and `/stop_profile`.

## Overhead / disabled behavior
- Disabled by default.
- Stage classification work is skipped unless env-gated scopes are enabled.
- No behavior change when profiling scopes are disabled.

## Risks and limitations
- Spans are inserted at host orchestration boundaries, not inside fragile compiled or graph-captured kernels, minimizing risk to CUDA graphs and torch.compile paths.
- This change is intentionally surgical and does not attempt broad instrumentation across all internals.

## Screenshot placeholder for Nsight timeline
Screenshot to be added after capture.