### PR TITLE
[Core] Use contiguous arrays for request token histories

### DIFF
--- a/tests/v1/core/test_request.py
+++ b/tests/v1/core/test_request.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from array import array
+
+import pytest
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.request import Request
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_request_token_histories_use_contiguous_arrays():
+    request = Request(
+        request_id="req-1",
+        prompt_token_ids=[1, 2, 3],
+        sampling_params=SamplingParams(max_tokens=8),
+        pooling_params=None,
+    )
+
+    request.append_output_token_ids(4)
+    request.append_output_token_ids([5, 6])
+
+    assert isinstance(request._output_token_ids, array)
+    assert isinstance(request._all_token_ids, array)
+    assert list(request.output_token_ids) == [4, 5, 6]
+    assert list(request.all_token_ids) == [1, 2, 3, 4, 5, 6]
+    assert request.all_token_ids.copy() == [1, 2, 3, 4, 5, 6]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -856,7 +856,7 @@ class Scheduler(SchedulerInterface):
                 NewRequestData.from_request(
                     req,
                     req_to_new_blocks[req.request_id].get_block_ids(),
-                    req._all_token_ids,
+                    req.all_token_ids.copy(),
                 )
                 for req in scheduled_new_reqs
             ]

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -3,6 +3,7 @@
 
 import enum
 import time
+from array import array
 from collections import deque
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -119,11 +120,15 @@ class Request:
         self.num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
             prompt_token_ids, prompt_embeds
         )
-        self._output_token_ids: list[int] = []
-        self._all_token_ids: list[int] = (
+        # Request-local token histories grow with each generated token.
+        # Keep them in contiguous integer arrays to reduce Python object
+        # overhead while preserving list-like mutation semantics.
+        self._output_token_ids = array("i")
+        self._all_token_ids = array(
+            "i",
             self.prompt_token_ids.copy()
             if self.prompt_token_ids is not None
-            else [0] * self.num_prompt_tokens
+            else [0] * self.num_prompt_tokens,
         )
 
         # Used in async scheduling.

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -41,7 +41,7 @@ T = TypeVar("T")
 
 
 class ConstantList(Generic[T], Sequence):
-    def __init__(self, x: list[T]) -> None:
+    def __init__(self, x: Sequence[T]) -> None:
         self._x = x
 
     def append(self, item):
@@ -72,6 +72,8 @@ class ConstantList(Generic[T], Sequence):
     def __getitem__(self, s: slice, /) -> list[T]: ...
 
     def __getitem__(self, item: int | slice) -> T | list[T]:
+        if isinstance(item, slice):
+            return list(self._x[item])
         return self._x[item]
 
     @overload
@@ -99,7 +101,7 @@ class ConstantList(Generic[T], Sequence):
         return f"ConstantList({self._x})"
 
     def copy(self) -> list[T]:
-        return self._x.copy()
+        return list(self._x)
 
 
 class CpuGpuBuffer:


### PR DESCRIPTION
## Summary
This takes a small slice of the data-structure cleanup roadmap work by replacing the append-heavy per-request token history lists in `vllm/v1/request.py` with contiguous integer arrays.

## Related
- Roadmap: #32455
- Tracking issue: #37077

## What changed
- store `Request._output_token_ids` and `Request._all_token_ids` as `array("i")` instead of Python `list[int]`
- widen `ConstantList` so it can wrap generic sequences while preserving list-like slices for downstream callers
- add a regression test that verifies the request token histories still behave like the existing public read-only views while using contiguous storage internally

## Why this seems worthwhile
These histories grow with every generated token and exist per request, so they are on the hot path for the exact kind of Python-object overhead called out in the roadmap issue. This keeps the change local and low risk while moving one of the token-growth structures away from boxed Python ints.

## Notes
- I kept prompt token IDs unchanged in this PR to avoid broad API churn.
- I was not able to run the full vLLM test suite in this environment because the local checkout is missing the upstream test/runtime dependencies (for example `torch` / `tblib`). I did verify the edited files parse successfully.