### PR TITLE
[Frontend] Fix Hermes streaming for parameterless tool args

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py
@@ -395,6 +395,39 @@ def test_hermes_parser_streaming(
     )
 
 
+def test_hermes_parser_streaming_parameterless_tool(
+    qwen_tokenizer: TokenizerLike,
+    hermes_parser: Hermes2ProToolParser,
+    any_chat_request: ChatCompletionRequest,
+) -> None:
+    text = '<tool_call>{"name": "switch_led_on", "arguments": {}}</tool_call>'
+
+    tokens = qwen_tokenizer.encode(text)
+    previous_text = ""
+    delta_messages = []
+    for token in tokens:
+        delta_text = qwen_tokenizer.decode([token])
+        current_text = previous_text + delta_text
+        delta = hermes_parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=any_chat_request,
+        )
+        previous_text = current_text
+        if delta is not None:
+            delta_messages.append(delta)
+
+    assert delta_messages[0].tool_calls[0].function.name == "switch_led_on"
+    tool_call_args = "".join(
+        delta.tool_calls[0].function.arguments or "" for delta in delta_messages
+    )
+    assert tool_call_args == "{}"
+
+
 def test_hermes_parser_non_streaming_no_tool_call(
     hermes_parser: Hermes2ProToolParser,
     any_chat_request: ChatCompletionRequest,

--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -387,18 +387,20 @@ class Hermes2ProToolParser(ToolParser):
             )
             assert current_tool_call is not None
             cur_arguments = current_tool_call.get("arguments")
+            prev_arguments_missing = prev_arguments is None
+            cur_arguments_missing = cur_arguments is None
 
             logger.debug("diffing old arguments: %s", prev_arguments)
             logger.debug("against new ones: %s", cur_arguments)
 
             # case -- no arguments have been created yet. skip sending a delta.
-            if not cur_arguments and not prev_arguments:
+            if cur_arguments_missing and prev_arguments_missing:
                 logger.debug("Skipping text %s - no arguments", delta_text)
                 delta = None
 
             # case -- prev arguments are defined, but non are now.
             #   probably impossible, but not a fatal error - just keep going
-            elif not cur_arguments and prev_arguments:
+            elif cur_arguments_missing and not prev_arguments_missing:
                 logger.error(
                     "should be impossible to have arguments reset "
                     "mid-call. skipping streaming anything."
@@ -407,55 +409,73 @@ class Hermes2ProToolParser(ToolParser):
 
             # case -- we now have the first info about arguments available from
             #   autocompleting the JSON
-            elif cur_arguments and not prev_arguments:
-                # extract the content after {"name": ..., "arguments":
-                #   directly from tool_call_portion as cur_arguments_json,
-                #   since cur_arguments may differ from the original text
-                #   due to partial JSON parsing
-                #   for example, tool_call_portion =
-                #     {"name": "search", "arguments": {"search_request": {"
-                #   but cur_arguments =
-                #     {"search_request": {}}
-                function_name = current_tool_call.get("name")
-                match = re.search(
-                    r'\{"name":\s*"'
-                    + re.escape(function_name)
-                    + r'"\s*,\s*"arguments":\s*(.*)',
-                    tool_call_portion.strip(),
-                    re.DOTALL,
-                )
-                if match:
-                    cur_arguments_json = match.group(1)
+            elif not cur_arguments_missing and prev_arguments_missing:
+                if cur_arguments == {}:
+                    arguments_delta = "{}"
+                    delta = DeltaMessage(
+                        tool_calls=[
+                            DeltaToolCall(
+                                index=self.current_tool_id,
+                                function=DeltaFunctionCall(
+                                    arguments=arguments_delta
+                                ).model_dump(exclude_none=True),
+                            )
+                        ]
+                    )
+                    self.streamed_args_for_tool[self.current_tool_id] += arguments_delta
                 else:
-                    cur_arguments_json = json.dumps(cur_arguments, ensure_ascii=False)
-
-                logger.debug("finding %s in %s", delta_text, cur_arguments_json)
-
-                # get the location where previous args differ from current.
-                if delta_text not in cur_arguments_json:
-                    return None
-                args_delta_start_loc = cur_arguments_json.rindex(delta_text) + len(
-                    delta_text
-                )
-
-                # use that to find the actual delta
-                arguments_delta = cur_arguments_json[:args_delta_start_loc]
-                logger.debug("First tokens in arguments received: %s", arguments_delta)
-
-                delta = DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.current_tool_id,
-                            function=DeltaFunctionCall(
-                                arguments=arguments_delta
-                            ).model_dump(exclude_none=True),
+                    # extract the content after {"name": ..., "arguments":
+                    # directly from tool_call_portion as cur_arguments_json,
+                    # since cur_arguments may differ from the original text
+                    # due to partial JSON parsing. for example,
+                    # tool_call_portion =
+                    #   {"name": "search", "arguments": {"search_request": {"
+                    # but cur_arguments =
+                    #   {"search_request": {}}
+                    function_name = current_tool_call.get("name")
+                    match = re.search(
+                        r'\{"name":\s*"'
+                        + re.escape(function_name)
+                        + r'"\s*,\s*"arguments":\s*(.*)',
+                        tool_call_portion.strip(),
+                        re.DOTALL,
+                    )
+                    if match:
+                        cur_arguments_json = match.group(1)
+                    else:
+                        cur_arguments_json = json.dumps(
+                            cur_arguments, ensure_ascii=False
                         )
-                    ]
-                )
-                self.streamed_args_for_tool[self.current_tool_id] += arguments_delta
+
+                    logger.debug("finding %s in %s", delta_text, cur_arguments_json)
+
+                    # get the location where previous args differ from current.
+                    if delta_text not in cur_arguments_json:
+                        return None
+                    args_delta_start_loc = cur_arguments_json.rindex(delta_text) + len(
+                        delta_text
+                    )
+
+                    # use that to find the actual delta
+                    arguments_delta = cur_arguments_json[:args_delta_start_loc]
+                    logger.debug(
+                        "First tokens in arguments received: %s", arguments_delta
+                    )
+
+                    delta = DeltaMessage(
+                        tool_calls=[
+                            DeltaToolCall(
+                                index=self.current_tool_id,
+                                function=DeltaFunctionCall(
+                                    arguments=arguments_delta
+                                ).model_dump(exclude_none=True),
+                            )
+                        ]
+                    )
+                    self.streamed_args_for_tool[self.current_tool_id] += arguments_delta
 
             # last case -- we have an update to existing arguments.
-            elif cur_arguments and prev_arguments:
+            elif not cur_arguments_missing and not prev_arguments_missing:
                 # judge whether the tool_call_portion is a complete JSON
                 try:
                     json.loads(tool_call_portion)


### PR DESCRIPTION
## Summary
Fix Hermes streaming tool parsing when a tool has an empty argument object ({}).

## Related
- Fixes #28806

## Problem
The streaming parser currently uses truthiness checks for cur_arguments / prev_arguments. That treats {} the same as a missing value, so parameterless tool calls can lose their streamed arguments entirely. In practice, the function name is emitted but the reconstructed arguments string ends up empty instead of {}.

## What changed
- distinguish None from an empty dict when diffing streamed Hermes tool-call arguments
- emit "{}" as the first argument delta when the parsed arguments object is empty
- add a regression test for a streamed parameterless tool call

## Notes
I was not able to run the full upstream test suite in this environment because the local checkout was missing some test/runtime dependencies. I did syntax-check the touched files and added a focused regression test.