### PR TITLE
[V1] Fix jump-forward decoding correctness and add tests (follow-up to #36142)

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4140,3 +4140,205 @@ def test_eagle3_mm_encoder_cache_with_shift():
         f"shifted_end={scheduled_end_with_shift}) overlapping MM at "
         f"{start_pos}. The fix must schedule encoder inputs."
     )
+
+
+# ---------------------------------------------------------------------------
+# Jump-forward decoding tests
+# ---------------------------------------------------------------------------
+
+
+def _setup_jump_forward_request(scheduler, request):
+    """Helper: put a request into RUNNING state with prefill done."""
+    request.num_computed_tokens = request.num_tokens
+    request.status = RequestStatus.RUNNING
+    scheduler.requests[request.request_id] = request
+    scheduler.running.append(request)
+
+
+def _make_mock_grammar(ff_tokens: list[int]):
+    """Create a mock grammar that returns the given ff_tokens."""
+    grammar = Mock()
+    grammar.accept_tokens = Mock(return_value=True)
+    grammar.is_terminated = Mock(return_value=False)
+    grammar.advance_ff_tokens = Mock(return_value=ff_tokens)
+    return grammar
+
+
+def _make_structured_output_request(grammar):
+    """Create a mock StructuredOutputRequest with the given grammar."""
+    sor = Mock()
+    sor.grammar = grammar
+    sor.reasoning_ended = None
+    return sor
+
+
+def test_jump_forward_tokens_injected():
+    """ff_tokens from grammar are appended to the request and stored in
+    pending_ff_tokens."""
+    scheduler = create_scheduler(enable_jump_decoding=True)
+    # Mock should_advance to return True for structured output requests.
+    scheduler.structured_output_manager.should_advance = Mock(return_value=True)
+
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    _setup_jump_forward_request(scheduler, req)
+
+    # Attach mock grammar that produces ff_tokens [100, 101, 102].
+    ff = [100, 101, 102]
+    grammar = _make_mock_grammar(ff)
+    req.structured_output_request = _make_structured_output_request(grammar)
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={req.request_id: 1},
+        total_num_scheduled_tokens=1,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[7]],  # normal token from model
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    # The output should contain the sampled token + all ff_tokens.
+    assert list(req.output_token_ids) == [7, 100, 101, 102]
+    # ff_tokens should be stored for the next schedule step.
+    assert scheduler.pending_ff_tokens[req.request_id] == [100, 101, 102]
+    # Request should still be running.
+    assert not req.is_finished()
+
+
+def test_jump_forward_tokens_stop_eos():
+    """ff_tokens containing an EOS token should truncate the sequence and
+    stop the request."""
+    scheduler = create_scheduler(enable_jump_decoding=True)
+    scheduler.structured_output_manager.should_advance = Mock(return_value=True)
+
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    _setup_jump_forward_request(scheduler, req)
+
+    # ff_tokens: 100, EOS, 102 — should truncate after EOS.
+    ff = [100, EOS_TOKEN_ID, 102]
+    grammar = _make_mock_grammar(ff)
+    req.structured_output_request = _make_structured_output_request(grammar)
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={req.request_id: 1},
+        total_num_scheduled_tokens=1,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[7]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    # Should stop at EOS — token 102 must NOT appear.
+    assert list(req.output_token_ids) == [7, 100, EOS_TOKEN_ID]
+    assert req.status == RequestStatus.FINISHED_STOPPED
+    # Stored ff_tokens should be truncated to what was actually used.
+    assert scheduler.pending_ff_tokens[req.request_id] == [100, EOS_TOKEN_ID]
+
+
+def test_jump_forward_tokens_stop_max_tokens():
+    """ff_tokens that would exceed max_tokens should be truncated."""
+    scheduler = create_scheduler(enable_jump_decoding=True)
+    scheduler.structured_output_manager.should_advance = Mock(return_value=True)
+
+    # max_tokens=3: the sampled token (7) counts as 1, so only 2 ff_tokens
+    # should fit.
+    requests = create_requests(num_requests=1, max_tokens=3)
+    req = requests[0]
+    _setup_jump_forward_request(scheduler, req)
+
+    ff = [100, 101, 102, 103]
+    grammar = _make_mock_grammar(ff)
+    req.structured_output_request = _make_structured_output_request(grammar)
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={req.request_id: 1},
+        total_num_scheduled_tokens=1,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[7]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    # 1 sampled + 2 ff = 3 = max_tokens → length capped.
+    assert list(req.output_token_ids) == [7, 100, 101]
+    assert req.status == RequestStatus.FINISHED_LENGTH_CAPPED
+    assert scheduler.pending_ff_tokens[req.request_id] == [100, 101]
+
+
+def test_jump_forward_tokens_retained_for_unscheduled_requests():
+    """pending_ff_tokens for requests NOT scheduled in a step must be
+    preserved (Bug 1 fix).
+
+    Uses max_num_batched_tokens=1 so that only the first running request
+    gets scheduled, while the second is skipped due to budget exhaustion.
+    """
+    scheduler = create_scheduler(
+        max_num_batched_tokens=1,
+        max_model_len=100,
+        enable_jump_decoding=True,
+    )
+
+    requests = create_requests(num_requests=2, max_tokens=20)
+    for req in requests:
+        _setup_jump_forward_request(scheduler, req)
+
+    req_a, req_b = requests
+
+    # Simulate: both requests have pending ff_tokens from a previous step.
+    scheduler.pending_ff_tokens[req_a.request_id] = [10, 11]
+    scheduler.pending_ff_tokens[req_b.request_id] = [20, 21]
+
+    # Call the real schedule() — budget=1 means only req_a (first in
+    # running list) gets scheduled; req_b is skipped.
+    output = scheduler.schedule()
+
+    # req_a was scheduled, so its ff_tokens should appear in the output.
+    assert req_a.request_id in output.num_scheduled_tokens
+    assert output.jump_forward_tokens == {req_a.request_id: [10, 11]}
+
+    # req_b was NOT scheduled, so its ff_tokens must still be pending.
+    assert req_b.request_id not in output.num_scheduled_tokens
+    assert scheduler.pending_ff_tokens == {req_b.request_id: [20, 21]}

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4148,8 +4148,13 @@ def test_eagle3_mm_encoder_cache_with_shift():
 
 
 def _setup_jump_forward_request(scheduler, request):
-    """Helper: put a request into RUNNING state with prefill done."""
+    """Helper: put a request into RUNNING state with prefill done and
+    one decode token already generated (so the scheduler sees
+    num_new_tokens=1 and schedules the request)."""
     request.num_computed_tokens = request.num_tokens
+    # Append a dummy output token so that num_tokens_with_spec >
+    # num_computed_tokens, giving the scheduler 1 new token to schedule.
+    request.append_output_token_ids(0)
     request.status = RequestStatus.RUNNING
     scheduler.requests[request.request_id] = request
     scheduler.running.append(request)
@@ -4211,8 +4216,8 @@ def test_jump_forward_tokens_injected():
 
     scheduler.update_from_output(scheduler_output, model_output)
 
-    # The output should contain the sampled token + all ff_tokens.
-    assert list(req.output_token_ids) == [7, 100, 101, 102]
+    # The output should contain the setup token + sampled token + all ff_tokens.
+    assert list(req.output_token_ids) == [0, 7, 100, 101, 102]
     # ff_tokens should be stored for the next schedule step.
     assert scheduler.pending_ff_tokens[req.request_id] == [100, 101, 102]
     # Request should still be running.
@@ -4258,7 +4263,7 @@ def test_jump_forward_tokens_stop_eos():
     scheduler.update_from_output(scheduler_output, model_output)
 
     # Should stop at EOS — token 102 must NOT appear.
-    assert list(req.output_token_ids) == [7, 100, EOS_TOKEN_ID]
+    assert list(req.output_token_ids) == [0, 7, 100, EOS_TOKEN_ID]
     assert req.status == RequestStatus.FINISHED_STOPPED
     # Stored ff_tokens should be truncated to what was actually used.
     assert scheduler.pending_ff_tokens[req.request_id] == [100, EOS_TOKEN_ID]
@@ -4302,37 +4307,39 @@ def test_jump_forward_tokens_stop_max_tokens():
 
     scheduler.update_from_output(scheduler_output, model_output)
 
-    # 1 sampled + 2 ff = 3 = max_tokens → length capped.
-    assert list(req.output_token_ids) == [7, 100, 101]
+    # 1 setup + 1 sampled + 2 ff = 4, but max_tokens=3 so only 2 ff fit.
+    # output_token_ids: [0 (setup), 7 (sampled), 100, 101] — but
+    # max_tokens counts only output tokens, and we have setup(0) + 7
+    # + 100 = 3 output tokens already at that point → length capped.
+    assert list(req.output_token_ids) == [0, 7, 100]
     assert req.status == RequestStatus.FINISHED_LENGTH_CAPPED
-    assert scheduler.pending_ff_tokens[req.request_id] == [100, 101]
+    assert scheduler.pending_ff_tokens[req.request_id] == [100]
 
 
 def test_jump_forward_tokens_retained_for_unscheduled_requests():
     """pending_ff_tokens for requests NOT scheduled in a step must be
     preserved (Bug 1 fix).
 
-    Uses max_num_batched_tokens=1 so that only the first running request
-    gets scheduled, while the second is skipped due to budget exhaustion.
+    req_a is in RUNNING and gets scheduled normally.  req_b is NOT in
+    the running list (e.g. it was preempted or is still waiting), but
+    it has pending ff_tokens from an earlier step.  After schedule(),
+    req_b's ff_tokens must still be in pending_ff_tokens.
     """
     scheduler = create_scheduler(
-        max_num_batched_tokens=1,
         max_model_len=100,
         enable_jump_decoding=True,
     )
 
     requests = create_requests(num_requests=2, max_tokens=20)
-    for req in requests:
-        _setup_jump_forward_request(scheduler, req)
-
     req_a, req_b = requests
 
-    # Simulate: both requests have pending ff_tokens from a previous step.
+    # Only req_a goes into RUNNING.
+    _setup_jump_forward_request(scheduler, req_a)
+
+    # Both have pending ff_tokens from a previous step.
     scheduler.pending_ff_tokens[req_a.request_id] = [10, 11]
     scheduler.pending_ff_tokens[req_b.request_id] = [20, 21]
 
-    # Call the real schedule() — budget=1 means only req_a (first in
-    # running list) gets scheduled; req_b is skipped.
     output = scheduler.schedule()
 
     # req_a was scheduled, so its ff_tokens should appear in the output.

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -12,6 +12,7 @@ from vllm.config import (
     ParallelConfig,
     SchedulerConfig,
     SpeculativeConfig,
+    StructuredOutputsConfig,
     VllmConfig,
 )
 from vllm.multimodal.inputs import (
@@ -57,6 +58,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    enable_jump_decoding: bool = False,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -130,6 +132,12 @@ def create_scheduler(
         else None
     )
 
+    structured_outputs_config = StructuredOutputsConfig(
+        # Use guidance backend when jump decoding is enabled, as required.
+        backend="guidance" if enable_jump_decoding else "auto",
+        enable_jump_decoding=enable_jump_decoding,
+    )
+
     vllm_config = VllmConfig(
         scheduler_config=scheduler_config,
         model_config=model_config,
@@ -138,6 +146,7 @@ def create_scheduler(
         kv_transfer_config=kv_transfer_config,
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
+        structured_outputs_config=structured_outputs_config,
     )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -40,6 +40,11 @@ class StructuredOutputsConfig:
     loaded and registered."""
     enable_in_reasoning: bool = False
     """Whether to use structured input for reasoning."""
+    enable_jump_decoding: bool = False
+    """If True, enable jump-forward decoding for structured outputs.
+    When the grammar forces a deterministic sequence of tokens, they are
+    injected without model inference. Only supported with the guidance
+    backend."""
 
     def compute_hash(self) -> str:
         """
@@ -70,5 +75,9 @@ class StructuredOutputsConfig:
             raise ValueError(
                 "disable_additional_properties is only supported "
                 "for the guidance backend."
+            )
+        if self.enable_jump_decoding and self.backend != "guidance":
+            raise ValueError(
+                "enable_jump_decoding is only supported for the guidance backend."
             )
         return self

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -758,7 +758,7 @@ class VllmConfig:
                 "Jump-forward decoding cannot be used together with "
                 "speculative decoding."
             )
-        
+
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
             if self.scheduler_config.async_scheduling:
                 if self.parallel_config.data_parallel_size > 1 and (

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -750,6 +750,15 @@ class VllmConfig:
             "enabled" if self.scheduler_config.async_scheduling else "disabled",
         )
 
+        if (
+            self.speculative_config is not None
+            and self.structured_outputs_config.enable_jump_decoding
+        ):
+            raise ValueError(
+                "Jump-forward decoding cannot be used together with "
+                "speculative decoding."
+            )
+        
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
             if self.scheduler_config.async_scheduling:
                 if self.parallel_config.data_parallel_size > 1 and (

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -241,7 +241,7 @@ class SchedulerOutput:
     # Jump-forward decoding: grammar-forced tokens to write to the buffer.
     # req_id -> list of deterministic token IDs
     jump_forward_tokens: dict[str, list[int]] = field(default_factory=dict)
-    
+
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":
         return cls(

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -238,6 +238,10 @@ class SchedulerOutput:
     # preventing stale NaN/data from corrupting attention or SSM computation.
     new_block_ids_to_zero: list[int] | None = None
 
+    # Jump-forward decoding: grammar-forced tokens to write to the buffer.
+    # req_id -> list of deterministic token IDs
+    jump_forward_tokens: dict[str, list[int]] = field(default_factory=dict)
+    
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":
         return cls(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1447,10 +1447,9 @@ class Scheduler(SchedulerInterface):
                         for i, tok in enumerate(ff_tokens):
                             request.append_output_token_ids(tok)
                             new_token_ids.append(tok)
-                            stopped = check_stop(
-                                request, self.max_model_len)
+                            stopped = check_stop(request, self.max_model_len)
                             if stopped:
-                                ff_tokens = ff_tokens[:i + 1]
+                                ff_tokens = ff_tokens[: i + 1]
                                 break
                         self.pending_ff_tokens[req_id] = ff_tokens
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -101,6 +101,12 @@ class Scheduler(SchedulerInterface):
         )
         self.prev_step_scheduled_req_ids: set[str] = set()
 
+        # Jump-forward decoding: grammar-forced tokens pending write to buffer.
+        self.jump_decoding_enabled = (
+            vllm_config.structured_outputs_config.enable_jump_decoding
+        )
+        self.pending_ff_tokens: dict[str, list[int]] = {}
+
         # Scheduling constraints.
         self.max_num_running_reqs = self.scheduler_config.max_num_seqs
         self.max_num_scheduled_tokens = (
@@ -881,6 +887,16 @@ class Scheduler(SchedulerInterface):
         self.prev_step_scheduled_req_ids.clear()
         self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
+        # Jump-forward: pass pending ff tokens for scheduled requests only.
+        # Retain ff tokens for requests not scheduled in this step.
+        jump_forward_tokens = {
+            req_id: tokens
+            for req_id, tokens in self.pending_ff_tokens.items()
+            if req_id in num_scheduled_tokens
+        }
+        for req_id in jump_forward_tokens:
+            del self.pending_ff_tokens[req_id]
+
         new_block_ids_to_zero = (
             (self.kv_cache_manager.take_new_block_ids() or None)
             if self.needs_kv_cache_zeroing
@@ -903,6 +919,7 @@ class Scheduler(SchedulerInterface):
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
+            jump_forward_tokens=jump_forward_tokens,
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
@@ -1414,6 +1431,28 @@ class Scheduler(SchedulerInterface):
                         new_token_ids,
                         req_id,
                     )
+
+                # Jump-forward: compute deterministic tokens forced by grammar.
+                elif (
+                    self.jump_decoding_enabled
+                    and not stopped
+                    and not struct_output_request.grammar.is_terminated()
+                ):
+                    ff_tokens = struct_output_request.grammar.advance_ff_tokens()
+
+                    if ff_tokens:
+                        # Append ff_tokens one by one, checking stop
+                        # conditions after each token (matching the
+                        # behavior in _update_request_with_output).
+                        for i, tok in enumerate(ff_tokens):
+                            request.append_output_token_ids(tok)
+                            new_token_ids.append(tok)
+                            stopped = check_stop(
+                                request, self.max_model_len)
+                            if stopped:
+                                ff_tokens = ff_tokens[:i + 1]
+                                break
+                        self.pending_ff_tokens[req_id] = ff_tokens
 
             if num_nans_in_logits is not None and req_id in num_nans_in_logits:
                 request.num_nans_in_logits = num_nans_in_logits[req_id]

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -173,7 +173,23 @@ class GuidanceGrammar(StructuredOutputGrammar):
         self.check_error()
 
         return r
+    
+    def advance_ff_tokens(self) -> list[int]:
+        """Compute deterministic fast-forward tokens from the grammar.
 
+        After accepting a token, the grammar may force a sequence of
+        tokens that don't require model inference. This returns those
+        tokens and advances the matcher past them.
+        """
+        if self.ll_matcher.is_stopped():
+            return []
+
+        ff_tokens = self.ll_matcher.compute_ff_tokens()
+        if ff_tokens:
+            self.ll_matcher.consume_tokens(ff_tokens)
+            self.check_error()
+        return ff_tokens
+    
     def validate_tokens(self, tokens: list[int]) -> list[int]:
         """Checks if the list of tokens are accepted by the parser in sequence.
         Will not advance the parser.

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -173,7 +173,7 @@ class GuidanceGrammar(StructuredOutputGrammar):
         self.check_error()
 
         return r
-    
+
     def advance_ff_tokens(self) -> list[int]:
         """Compute deterministic fast-forward tokens from the grammar.
 
@@ -189,7 +189,7 @@ class GuidanceGrammar(StructuredOutputGrammar):
             self.ll_matcher.consume_tokens(ff_tokens)
             self.check_error()
         return ff_tokens
-    
+
     def validate_tokens(self, tokens: list[int]) -> list[int]:
         """Checks if the list of tokens are accepted by the parser in sequence.
         Will not advance the parser.

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -45,6 +45,14 @@ class StructuredOutputGrammar(ABC):
             bool: True if the tokens are accepted, False otherwise.
         """
 
+    def advance_ff_tokens(self) -> list[int]:
+        """Computes fast-forward (deterministic) tokens from the grammar.
+
+        Returns tokens that the grammar forces without needing model
+        inference. Default implementation returns empty list.
+        """
+        return []
+    
     @abstractmethod
     def validate_tokens(self, tokens: list[int]) -> list[int]:
         """

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -52,7 +52,7 @@ class StructuredOutputGrammar(ABC):
         inference. Default implementation returns empty list.
         """
         return []
-    
+
     @abstractmethod
     def validate_tokens(self, tokens: list[int]) -> list[int]:
         """

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1304,7 +1304,7 @@ class GPUModelRunner(
                 self.input_batch.token_ids_cpu[req_index, start_idx:end_idx] = ff_tokens
                 self.input_batch.num_tokens_no_spec[req_index] = end_idx
                 req_state.output_token_ids.extend(ff_tokens)
-                
+
         # Add the new or resumed requests to the persistent batch.
         # The smaller empty indices are filled first.
         for request in reqs_to_add:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1296,6 +1296,15 @@ class GPUModelRunner(
                 if orig != req_state.prev_num_draft_len:
                     req_state.prev_num_draft_len = orig
 
+            # Jump-forward: write grammar-forced tokens to the buffer.
+            ff_tokens = scheduler_output.jump_forward_tokens.get(req_id)
+            if ff_tokens:
+                start_idx = self.input_batch.num_tokens_no_spec[req_index]
+                end_idx = start_idx + len(ff_tokens)
+                self.input_batch.token_ids_cpu[req_index, start_idx:end_idx] = ff_tokens
+                self.input_batch.num_tokens_no_spec[req_index] = end_idx
+                req_state.output_token_ids.extend(ff_tokens)
+                
         # Add the new or resumed requests to the persistent batch.
         # The smaller empty indices are filled first.
         for request in reqs_to_add:


### PR DESCRIPTION
## Purpose

This PR builds upon #36142 by @FredericOdermatt, addressing correctness issues 
identified in the bot reviews and adding test coverage for jump-forward decoding.

## Changes

### Bug Fixes

**1. Fix `pending_ff_tokens` cleared globally each step**
Previously, all pending ff_tokens were cleared every schedule step, even for 
requests not scheduled in that step (preempted or skipped due to token budget). 
Those requests would lose their deterministic tokens permanently, corrupting 
continuation state. Fixed by only clearing tokens for requests present in 
`num_scheduled_tokens`.

**2. Fix missing stop checks after appending ff_tokens**
ff_tokens were appended without calling `check_stop`, allowing requests to bypass 
EOS/stop-token/max-token termination. Fixed by checking stop conditions during 
ff_token application, consistent with `_update_request_with_output` behavior.

### Unit Tests Added

New tests in `tests/v1/core/test_scheduler.py`:
- ff_tokens correctly injected for scheduled requests
- ff_tokens preserved for unscheduled requests across steps  
- ff_tokens truncated correctly when stop token is encountered

Updated `tests/v1/core/utils.py` to support `enable_jump_decoding` config via 
proper `StructuredOutputsConfig → VllmConfig → Scheduler.__init__` chain.

## Test Results

pytest tests/v1/core/test_scheduler.py -v -k "jump"
4 passed in 81.48s:
```
(vllm) root@autodl-container-m414yxjsh7-f3a0a1c2:~/autodl-tmp/vllm# pytest tests/v1/core/test_scheduler.py -v -s -k "jump_forward"
================================================================================= test session starts =================================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /root/miniconda3/bin/python
cachedir: .pytest_cache
rootdir: /root/autodl-tmp/vllm
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.10.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 98 items / 94 deselected / 4 selected                                                                                                                                       

tests/v1/core/test_scheduler.py::test_jump_forward_tokens_injected INFO 03-15 21:23:42 [model.py:533] Resolved architecture: OPTForCausalLM
INFO 03-15 21:23:42 [model.py:1580] Using max model len 2048
INFO 03-15 21:23:42 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 03-15 21:23:42 [vllm.py:748] Asynchronous scheduling is disabled.
PASSED
tests/v1/core/test_scheduler.py::test_jump_forward_tokens_stop_eos '(ReadTimeoutError("HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)"), '(Request ID: 32dbbb1f-9610-4428-bd8c-eca0606d7e91)')' thrown while requesting HEAD https://huggingface.co/facebook/opt-125m/resolve/main/config.json
[2026-03-15 21:23:58] WARNING _http.py:320: '(ReadTimeoutError("HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)"), '(Request ID: 32dbbb1f-9610-4428-bd8c-eca0606d7e91)')' thrown while requesting HEAD https://huggingface.co/facebook/opt-125m/resolve/main/config.json
Retrying in 1s [Retry 1/5].
[2026-03-15 21:23:58] WARNING _http.py:329: Retrying in 1s [Retry 1/5].
'(ReadTimeoutError("HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)"), '(Request ID: 50ea8229-1f5d-43e8-9d39-526ddb172b90)')' thrown while requesting HEAD https://huggingface.co/facebook/opt-125m/resolve/main/preprocessor_config.json
[2026-03-15 21:24:12] WARNING _http.py:320: '(ReadTimeoutError("HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)"), '(Request ID: 50ea8229-1f5d-43e8-9d39-526ddb172b90)')' thrown while requesting HEAD https://huggingface.co/facebook/opt-125m/resolve/main/preprocessor_config.json
Retrying in 1s [Retry 1/5].
[2026-03-15 21:24:12] WARNING _http.py:329: Retrying in 1s [Retry 1/5].
INFO 03-15 21:24:20 [model.py:533] Resolved architecture: OPTForCausalLM
INFO 03-15 21:24:20 [model.py:1580] Using max model len 2048
INFO 03-15 21:24:20 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=8192.
PASSED
tests/v1/core/test_scheduler.py::test_jump_forward_tokens_stop_max_tokens '(ReadTimeoutError("HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)"), '(Request ID: 8255237f-d720-4e77-8a08-902dc701a3ea)')' thrown while requesting HEAD https://huggingface.co/facebook/opt-125m/resolve/main/preprocessor_config.json
[2026-03-15 21:24:38] WARNING _http.py:320: '(ReadTimeoutError("HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)"), '(Request ID: 8255237f-d720-4e77-8a08-902dc701a3ea)')' thrown while requesting HEAD https://huggingface.co/facebook/opt-125m/resolve/main/preprocessor_config.json
Retrying in 1s [Retry 1/5].
[2026-03-15 21:24:38] WARNING _http.py:329: Retrying in 1s [Retry 1/5].
INFO 03-15 21:24:44 [model.py:533] Resolved architecture: OPTForCausalLM
INFO 03-15 21:24:44 [model.py:1580] Using max model len 2048
INFO 03-15 21:24:44 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=8192.
PASSED
tests/v1/core/test_scheduler.py::test_jump_forward_tokens_retained_for_unscheduled_requests INFO 03-15 21:24:52 [model.py:533] Resolved architecture: OPTForCausalLM
INFO 03-15 21:24:52 [model.py:1580] Using max model len 2048
INFO 03-15 21:24:52 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=8192.
WARNING 03-15 21:24:52 [scheduler.py:273] max_num_batched_tokens (8192) exceeds max_num_seqs * max_model_len (1600). This may lead to unexpected behavior.
PASSED

================================================================================== warnings summary ===================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../miniconda3/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
  /root/miniconda3/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================== 4 passed, 94 deselected, 16 warnings in 81.48s (0:01:21) ===============================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

## Pending / Future Work

- xGrammar support via `find_jump_forward_string()` (requires safe FF-string to 
  token conversion, non-trivial due to token boundary issues)
- E2E tests with real model inference
- Performance benchmarks

## Acknowledgements

Thanks to @FredericOdermatt for the original implementation, @benchislett for 
the thorough review, @mmoskal for the llguidance fast-forward documentation, 
and the vLLM team for the excellent v1 architecture.