### PR TITLE
[Bugfix] Fix OOM caused by cumem allocator inflating memory_reserved()

### DIFF
--- a/tests/utils_/test_mem_utils.py
+++ b/tests/utils_/test_mem_utils.py
@@ -58,6 +58,93 @@ def test_memory_profiling():
     non_torch_ratio = result.non_torch_increase / (256 * 1024 * 1024)  # noqa
     assert abs(non_torch_ratio - 1) <= 0.05
     assert result.torch_peak_increase == 1024 * 1024 * 1024
+
+    # total_consumed should reflect all GPU memory used between baseline and
+    # after profiling, measured via mem_get_info(). This includes weights
+    # (512 MiB) + non-torch (256 MiB) = 768 MiB.
+    expected_total_consumed = (256 + 512) * 1024 * 1024  # 768 MiB
+    total_consumed_ratio = result.total_consumed / expected_total_consumed
+    assert abs(total_consumed_ratio - 1) <= 0.05, (
+        f"total_consumed={result.total_consumed}, "
+        f"expected={expected_total_consumed}, "
+        f"ratio={total_consumed_ratio}"
+    )
+
+    # non_kv_cache_memory = total_consumed + transient_peak_headroom
+    # transient_peak_headroom = torch_peak - torch_allocated (after profiling)
+    # In this test no persistent torch allocations are created during
+    # profiling (spike is deleted), so transient_headroom == torch_peak_increase
+    # = 768 MiB + 1 GiB = 1.75 GiB
+    expected_non_kv = expected_total_consumed + 1024 * 1024 * 1024
+    non_kv_ratio = result.non_kv_cache_memory / expected_non_kv
+    assert abs(non_kv_ratio - 1) <= 0.05, (
+        f"non_kv_cache_memory={result.non_kv_cache_memory}, "
+        f"expected={expected_non_kv}, "
+        f"ratio={non_kv_ratio}"
+    )
+
     del weights
     lib.cudaFree(handle1)
     lib.cudaFree(handle2)
+
+
+@create_new_process_for_each_test()
+def test_memory_profiling_persistent_torch():
+    """Test that persistent torch allocations during profiling are not
+    double-counted. transient_peak_headroom should only capture the
+    transient spike, not persistent allocations already in total_consumed."""
+    from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
+
+    lib = CudaRTLibrary()
+    handle1 = lib.cudaMalloc(512 * 1024 * 1024)  # 512 MiB external
+
+    baseline_snapshot = MemorySnapshot()
+
+    # load weights: 512 MiB
+    weights = torch.randn(128, 1024, 1024, device="cuda", dtype=torch.float32)
+    weights_memory = 128 * 1024 * 1024 * 4  # 512 MiB
+
+    with memory_profiling(
+        baseline_snapshot=baseline_snapshot, weights_memory=weights_memory
+    ) as result:
+        # Transient spike: 1 GiB (freed before persistent is created)
+        spike = torch.randn(256, 1024, 1024, device="cuda", dtype=torch.float32)
+        del spike
+
+        # Persistent torch allocation: 256 MiB (NOT freed during profiling)
+        persistent = torch.randn(  # noqa: F841
+            64, 1024, 1024, device="cuda", dtype=torch.float32
+        )
+
+    persistent_size = 64 * 1024 * 1024 * 4  # 256 MiB
+
+    # transient_peak_headroom = torch_peak - torch_allocated (after profiling)
+    # torch_peak = weights(512) + spike(1024) = 1536 MiB (peak during profiling)
+    # torch_allocated = weights(512) + persistent(256) = 768 MiB (after profiling)
+    # transient_peak_headroom = 1536 - 768 = 768 MiB
+    transient_peak_headroom = (
+        result.after_profile.torch_peak - result.after_profile.torch_allocated
+    )
+
+    # Key assertion: transient_peak_headroom < torch_peak_increase by exactly
+    # the persistent allocation size. This proves persistent torch allocations
+    # (already in total_consumed) are correctly excluded from the headroom.
+    assert result.torch_peak_increase - transient_peak_headroom == persistent_size, (
+        f"torch_peak_increase={result.torch_peak_increase}, "
+        f"transient_peak_headroom={transient_peak_headroom}, "
+        f"diff={result.torch_peak_increase - transient_peak_headroom}, "
+        f"expected_persistent={persistent_size}"
+    )
+
+    # Verify non_kv_cache_memory uses transient_peak_headroom, not
+    # torch_peak_increase (which would double-count persistent by 256 MiB).
+    assert result.non_kv_cache_memory == (
+        result.total_consumed + transient_peak_headroom
+    ), (
+        f"non_kv_cache_memory={result.non_kv_cache_memory}, "
+        f"expected={result.total_consumed + transient_peak_headroom}"
+    )
+
+    del persistent
+    del weights
+    lib.cudaFree(handle1)

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -68,6 +68,7 @@ class MemorySnapshot:
     """Memory snapshot."""
 
     torch_peak: int = 0
+    torch_allocated: int = 0
     free_memory: int = 0
     total_memory: int = 0
     cuda_memory: int = 0
@@ -97,9 +98,9 @@ class MemorySnapshot:
         # After `torch.accelerator.reset_peak_memory_stats()`,
         # `torch.accelerator.memory_reserved()` will keep growing, and only shrink
         # when we call `torch.accelerator.empty_cache()` or OOM happens.
-        self.torch_peak = torch.accelerator.memory_stats(device).get(
-            "allocated_bytes.all.peak", 0
-        )
+        stats = torch.accelerator.memory_stats(device)
+        self.torch_peak = stats.get("allocated_bytes.all.peak", 0)
+        self.torch_allocated = stats.get("allocated_bytes.all.current", 0)
 
         self.free_memory, self.total_memory = current_platform.mem_get_info(device)
         shared_sysmem_device_mem_sms = ((8, 7), (11, 0), (12, 1))  # Orin, Thor, Spark
@@ -140,6 +141,7 @@ class MemorySnapshot:
 
         return MemorySnapshot(
             torch_peak=self.torch_peak - other.torch_peak,
+            torch_allocated=self.torch_allocated - other.torch_allocated,
             free_memory=self.free_memory - other.free_memory,
             total_memory=self.total_memory - other.total_memory,
             cuda_memory=self.cuda_memory - other.cuda_memory,
@@ -153,6 +155,7 @@ class MemorySnapshot:
     def __repr__(self) -> str:
         return (
             f"torch_peak={format_gib(self.torch_peak)}GiB, "
+            f"torch_allocated={format_gib(self.torch_allocated)}GiB, "
             f"free_memory={format_gib(self.free_memory)}GiB, "
             f"total_memory={format_gib(self.total_memory)}GiB, "
             f"{current_platform.device_name}_memory={format_gib(self.cuda_memory)}GiB, "
@@ -170,6 +173,7 @@ class MemoryProfilingResult:
     non_kv_cache_memory: int = 0
     torch_peak_increase: int = 0
     non_torch_increase: int = 0
+    total_consumed: int = 0
     weights_memory: int = 0
     before_create: MemorySnapshot = field(default_factory=MemorySnapshot)
     profile_time: float = 0.0
@@ -187,8 +191,8 @@ class MemoryProfilingResult:
             f"{format_gib(self.non_kv_cache_memory)}GiB; "
             f"torch peak memory increase: "
             f"{format_gib(self.torch_peak_increase)}GiB; "
-            f"non-torch forward increase memory: "
-            f"{format_gib(self.non_torch_increase)}GiB; "
+            f"total consumed (from mem_get_info): "
+            f"{format_gib(self.total_consumed)}GiB; "
             f"weights memory: {format_gib(self.weights_memory)}GiB."
         )
 
@@ -274,8 +278,20 @@ def memory_profiling(
     result.non_torch_increase = diff_from_create.non_torch_memory
     result.profile_time = diff_profile.timestamp
 
-    non_torch_memory = result.non_torch_increase
-    peak_activation_memory = result.torch_peak_increase
-    result.non_kv_cache_memory = (
-        non_torch_memory + peak_activation_memory + result.weights_memory
+    # total_consumed measures all GPU memory used between before_create and
+    # after_profile via the CUDA driver's mem_get_info(). This is reliable
+    # even when pluggable allocators (e.g. cumem) bypass PyTorch's
+    # memory_reserved() tracking, which can make non_torch_memory negative.
+    result.total_consumed = (
+        result.before_create.free_memory - result.after_profile.free_memory
     )
+
+    # total_consumed already includes persistent torch allocations still alive
+    # at after_profile. The transient peak headroom is the extra memory needed
+    # at peak above the current persistent level: torch_peak - torch_allocated
+    # (both from after_profile). Using torch_peak_increase (peak - before)
+    # would double-count persistent torch allocations created during profiling.
+    transient_peak_headroom = (
+        result.after_profile.torch_peak - result.after_profile.torch_allocated
+    )
+    result.non_kv_cache_memory = result.total_consumed + transient_peak_headroom

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -387,9 +387,12 @@ class Worker(WorkerBase):
         ) as profile_result:
             self.model_runner.profile_run()
 
-            profile_torch_peak = torch.accelerator.memory_stats(self.device).get(
-                "allocated_bytes.all.peak", 0
-            )
+            # Capture both peak and current allocation at the same point
+            # (after profile_run, before cudagraph) so transient headroom
+            # is measured consistently without cudagraph interference.
+            stats = torch.accelerator.memory_stats(self.device)
+            profile_torch_peak = stats.get("allocated_bytes.all.peak", 0)
+            profile_torch_allocated = stats.get("allocated_bytes.all.current", 0)
 
             # Profile CUDA graph memory if graphs will be captured.
             # Skip on ROCm/HIP as graph pool handles and mem_get_info behave
@@ -402,10 +405,13 @@ class Worker(WorkerBase):
         profile_result.torch_peak_increase = (
             profile_torch_peak - profile_result.before_profile.torch_peak
         )
+        # transient_peak_headroom = peak - current (both pre-cudagraph).
+        # This is the extra memory needed at peak above the persistent level.
+        # Using torch_peak_increase (peak - before_profile) would double-count
+        # persistent torch allocations already included in total_consumed.
+        transient_peak_headroom = profile_torch_peak - profile_torch_allocated
         profile_result.non_kv_cache_memory = (
-            profile_result.non_torch_increase
-            + profile_result.torch_peak_increase
-            + profile_result.weights_memory
+            profile_result.total_consumed + transient_peak_headroom
         )
 
         # On ROCm, cudagraph_memory_estimate is always 0 so this is a no-op.
@@ -416,9 +422,9 @@ class Worker(WorkerBase):
             else 0
         )
 
-        self.non_torch_memory = profile_result.non_torch_increase
+        self.total_consumed = profile_result.total_consumed
         self.peak_activation_memory = (
-            profile_result.torch_peak_increase + cudagraph_memory_estimate_applied
+            transient_peak_headroom + cudagraph_memory_estimate_applied
         )
         self.cudagraph_memory_estimate = cudagraph_memory_estimate
 
@@ -639,9 +645,8 @@ class Worker(WorkerBase):
             # So leave a small buffer (=150MiB) to avoid OOM.
             redundancy_buffer_memory = 150 * (1 << 20)
             non_kv_cache_memory = (
-                self.model_runner.model_memory_usage
+                self.total_consumed
                 + self.peak_activation_memory
-                + self.non_torch_memory
                 + cuda_graph_memory_bytes
             )
             kv_cache_memory_bytes_to_gpu_limit = (
@@ -662,10 +667,10 @@ class Worker(WorkerBase):
                 f"Desired GPU memory utilization is "
                 f"({self.cache_config.gpu_memory_utilization}, "
                 f"{format_gib(self.requested_memory)} GiB). "
-                f"Actual usage is {format_gib(self.model_runner.model_memory_usage)} "
-                f"GiB for weight, {format_gib(self.peak_activation_memory)} GiB "
-                f"for peak activation, {format_gib(self.non_torch_memory)} GiB "
-                f"for non-torch memory, and {format_gib(cuda_graph_memory_bytes)} "
+                f"Actual usage is {format_gib(self.total_consumed)} "
+                f"GiB for consumed memory (weights + non-torch), "
+                f"{format_gib(self.peak_activation_memory)} GiB "
+                f"for peak activation, and {format_gib(cuda_graph_memory_bytes)} "
                 f"GiB for CUDAGraph memory. Replace gpu_memory_utilization "
                 f"config with `--kv-cache-memory="
                 f"{kv_cache_memory_bytes_to_requested_limit}` "


### PR DESCRIPTION
## Purpose

When the cumem allocator's cleanup (`use_memory_pool()` exit in `cumem.py`) manually calls `unmap_and_release()` to free cached blocks, it bypasses PyTorch's allocator tracking. This inflates `torch.cuda.memory_reserved()`, making `non_torch_memory` (`cuda_memory - memory_reserved()`) go deeply negative. The downstream effect is that `non_kv_cache_memory` is underestimated, causing vLLM to over-allocate KV cache and OOM on large models.

This was exposed after #32947 when a Python syntax bug fix (`with A and B:` → `with (A, B):`) properly enabled the cumem allocator for model weight loading.

The fix replaces the `memory_reserved()`-based formula with a `mem_get_info()`-based measurement (`total_consumed = before_create.free_memory - after_profile.free_memory`). The CUDA driver's `mem_get_info()` always returns accurate physical free/total memory regardless of which allocator is used. Additionally, uses `transient_peak_headroom` (`torch_peak - torch_allocated`) instead of `torch_peak_increase` to avoid double-counting persistent torch allocations already included in `total_consumed`.

Fixes #37096

## Test Plan

- Added `test_memory_profiling_persistent_torch` to verify persistent torch allocations are not double-counted in `non_kv_cache_memory`.
- E2E verification with cumem allocator on NVIDIA GB10:

| Metric | Without Fix | With Fix |
|---|---|---|
| `non_torch_increase` | -496.1 MiB (negative!) | N/A (not used) |
| `total_consumed` (mem_get_info) | N/A | 527.9 MiB (accurate) |
| `non_kv_cache_memory` | 15.9 MiB (underestimates ~49x) | 783.9 MiB (correct) |
| Result | Over-allocates KV cache → OOM | Safe |

## Test Result

```
tests/utils_/test_mem_utils.py::test_memory_profiling_persistent_torch PASSED
```