### PR TITLE
[Superseded] Early FlashInfer MLA wrapper bring-up for SM120

### DIFF
--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -1,19 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# FlashInfer MLA backend - plan() in builder, run() in forward (SGLang pattern)
+# CG support: UNIFORM_BATCH — per-batch-size wrappers with use_cuda_graph=True
+# ensure plan() copies into fixed-address buffers for safe CUDA graph replay.
 
-from typing import ClassVar
+from dataclasses import dataclass
+from typing import ClassVar, Optional
 
 import torch
-from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+from flashinfer import BatchMLAPagedAttentionWrapper
 
+from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonBackend,
+    MLACommonDecodeMetadata,
     MLACommonImpl,
     MLACommonMetadata,
     MLACommonMetadataBuilder,
     QueryLenSupport,
+    get_mla_dims,
 )
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backend import (
@@ -21,33 +27,122 @@ from vllm.v1.attention.backend import (
     AttentionLayer,
     AttentionType,
     MultipleOf,
-    is_quantized_kv_cache,
 )
-from vllm.v1.attention.backends.utils import KVCacheLayoutType
+from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
 FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE = 128 * 1024 * 1024
 
 
-class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
-    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+def _create_wrapper(device, batch_size, max_pages_per_req, tpr=1):
+    """Create a BatchMLAPagedAttentionWrapper with use_cuda_graph=True
+    and pre-allocated buffers sized for exactly batch_size requests."""
+    workspace = torch.zeros(
+        FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE, dtype=torch.uint8, device=device)
+    num_tokens = batch_size * tpr
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indices = torch.zeros(batch_size * max_pages_per_req, dtype=torch.int32, device=device)
+    kv_len_arr = torch.zeros(batch_size, dtype=torch.int32, device=device)
+    return workspace, BatchMLAPagedAttentionWrapper(
+        workspace,
+        use_cuda_graph=True,
+        qo_indptr=qo_indptr,
+        kv_indptr=kv_indptr,
+        kv_indices=kv_indices,
+        kv_len_arr=kv_len_arr,
+        backend="auto",
+    )
+
+
+@dataclass
+class FlashInferMLADecodeMetadata(MLACommonDecodeMetadata):
+    wrapper: Optional[BatchMLAPagedAttentionWrapper] = None
+
+
+class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder["FlashInferMLAMetadata"]):
+    _cudagraph_support: ClassVar[AttentionCGSupport] = (
+        AttentionCGSupport.UNIFORM_BATCH
+    )
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+
+    def __init__(self, kv_cache_spec, layer_names, vllm_config, device, **kwargs):
+        max_model_len = vllm_config.model_config.max_model_len
+        block_size = kv_cache_spec.block_size
+        self._max_pages_per_req = (max_model_len + block_size - 1) // block_size
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device, supports_dcp_with_varlen=True,
+                         metadata_cls=FlashInferMLAMetadata, **kwargs)
+
+        mla_dims = get_mla_dims(self.model_config)
+        self._kv_lora_rank = mla_dims.kv_lora_rank
+        self._qk_nope_head_dim = mla_dims.qk_nope_head_dim
+        self._qk_rope_head_dim = mla_dims.qk_rope_head_dim
+        self._page_size = kv_cache_spec.block_size
+        self._device = device
+
+        # Per-batch-size wrappers: created lazily on first use.
+        # Key = (num_reqs, tokens_per_req), value = (workspace, wrapper).
+        self._wrappers: dict[tuple[int, int], tuple[torch.Tensor, BatchMLAPagedAttentionWrapper]] = {}
+
+    def _get_wrapper(self, num_reqs, tpr=1):
+        """Get or create a wrapper for the given batch size."""
+        key = (num_reqs, tpr)
+        if key not in self._wrappers:
+            logger.info("Creating FlashInfer MLA wrapper for batch=%d tpr=%d",
+                        num_reqs, tpr)
+            self._wrappers[key] = _create_wrapper(self._device, num_reqs, self._max_pages_per_req, tpr)
+        return self._wrappers[key][1]
+
+    def _build_decode(self, block_table_tensor, seq_lens_device,
+                      max_seq_len, query_start_loc_cpu, query_start_loc_device,
+                      num_decode_tokens, dcp_tot_seq_lens_device=None):
+        num_reqs = seq_lens_device.shape[0]
+        page_size = self._page_size
+        dev = seq_lens_device.device
+
+        num_pages_per_req = (seq_lens_device + page_size - 1) // page_size
+        kv_indptr = torch.zeros(num_reqs + 1, dtype=torch.int32, device=dev)
+        torch.cumsum(num_pages_per_req, dim=0, out=kv_indptr[1:])
+        max_blk = block_table_tensor.shape[1]
+        blk_idx = torch.arange(max_blk, device=dev)
+        mask = blk_idx.unsqueeze(0) < num_pages_per_req.unsqueeze(1)
+        kv_indices = block_table_tensor[mask].to(torch.int32)
+
+        tpr = num_decode_tokens // num_reqs if num_reqs > 0 else 1
+        qo_indptr = torch.arange(0, num_reqs * tpr + 1, tpr,
+                                 dtype=torch.int32, device=dev)
+
+        wrapper = self._get_wrapper(num_reqs, tpr)
+        wrapper.plan(
+            qo_indptr, kv_indptr, kv_indices,
+            seq_lens_device.to(torch.int32),
+            num_heads=self.num_heads * self.dcp_world_size,
+            head_dim_ckv=self._kv_lora_rank,
+            head_dim_kpe=self._qk_rope_head_dim,
+            page_size=page_size, causal=False,
+            sm_scale=1.0 / (self._qk_nope_head_dim + self._qk_rope_head_dim) ** 0.5,
+            q_data_type=self.model_config.dtype,
+            kv_data_type=self.model_config.dtype)
+
+        return FlashInferMLADecodeMetadata(
+            block_table=block_table_tensor, seq_lens=seq_lens_device,
+            dcp_tot_seq_lens=dcp_tot_seq_lens_device, wrapper=wrapper)
+
+
+@dataclass
+class FlashInferMLAMetadata(MLACommonMetadata[FlashInferMLADecodeMetadata]):
+    pass
 
 
 class FlashInferMLABackend(MLACommonBackend):
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
     supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
-        "auto",
-        "float16",
-        "bfloat16",
-        "fp8",
-        "fp8_e4m3",
-    ]
+        "auto", "bfloat16", "fp8", "fp8_e4m3"]
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
-        return [32, 64]
+        return [MultipleOf(1)]
 
     @staticmethod
     def get_name() -> str:
@@ -63,190 +158,56 @@ class FlashInferMLABackend(MLACommonBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        return capability.major == 10
+        return capability.major >= 10
 
     @classmethod
-    def supports_combination(
-        cls,
-        head_size: int,
-        dtype: torch.dtype,
-        kv_cache_dtype: CacheDType | None,
-        block_size: int | None,
-        use_mla: bool,
-        has_sink: bool,
-        use_sparse: bool,
-        device_capability: DeviceCapability,
-    ) -> str | None:
-        # FlashInfer MLA kernel requires qk_nope_head_dim in [64, 128, 192]
-        from vllm.config import get_current_vllm_config
-
-        vllm_config = get_current_vllm_config()
-        if vllm_config.model_config is not None:
-            hf_text_config = vllm_config.model_config.hf_text_config
-            qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 1)
-            if qk_nope_head_dim not in [64, 128, 192]:
-                return (
-                    "FlashInfer MLA kernel requires qk_nope_head_dim "
-                    f"in [64, 128, 192], but got {qk_nope_head_dim}"
-                )
+    def supports_combination(cls, head_size, dtype, kv_cache_dtype, block_size,
+                             use_mla, has_sink, use_sparse,
+                             device_capability) -> str | None:
         return None
 
-    @classmethod
-    def get_required_kv_cache_layout(cls) -> "KVCacheLayoutType | None":
-        return "HND"
 
+class FlashInferMLAImpl(MLACommonImpl[FlashInferMLAMetadata]):
+    can_return_lse_for_decode: bool = True
 
-g_fi_workspace = torch.zeros(
-    FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE,
-    dtype=torch.uint8,
-    device="cuda",
-)
-
-
-class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
-    def __init__(
-        self,
-        num_heads: int,
-        head_size: int,
-        scale: float,
-        num_kv_heads: int,
-        alibi_slopes: list[float] | None,
-        sliding_window: int | None,
-        kv_cache_dtype: str,
-        logits_soft_cap: float | None,
-        attn_type: str,
-        kv_sharing_target_layer_name: str | None,
-        # MLA Specific Arguments
-        **mla_args,
-    ) -> None:
-        super().__init__(
-            num_heads,
-            head_size,
-            scale,
-            num_kv_heads,
-            alibi_slopes,
-            sliding_window,
-            kv_cache_dtype,
-            logits_soft_cap,
-            attn_type,
-            kv_sharing_target_layer_name,
-            **mla_args,
-        )
-
-        unsupported_features = [alibi_slopes, sliding_window, logits_soft_cap]
-        if any(unsupported_features):
+    def __init__(self, num_heads, head_size, scale, num_kv_heads,
+                 alibi_slopes, sliding_window, kv_cache_dtype,
+                 logits_soft_cap, attn_type, kv_sharing_target_layer_name,
+                 **mla_args):
+        super().__init__(num_heads, head_size, scale, num_kv_heads,
+                         alibi_slopes, sliding_window, kv_cache_dtype,
+                         logits_soft_cap, attn_type, kv_sharing_target_layer_name,
+                         **mla_args)
+        if any([alibi_slopes, sliding_window, logits_soft_cap]):
             raise NotImplementedError(
-                "FlashInferMLAImpl does not support one of the following: "
-                "alibi_slopes, sliding_window, logits_soft_cap"
-            )
-
+                "FlashInferMLAImpl does not support "
+                "alibi/sliding_window/logits_soft_cap")
         if attn_type != AttentionType.DECODER:
-            raise NotImplementedError(
-                "Encoder self-attention and "
-                "encoder/decoder cross-attention "
-                "are not implemented for "
-                "FlashInferMLAImpl"
-            )
+            raise NotImplementedError("Only decoder attention supported")
 
-        self._workspace_buffer = g_fi_workspace
-        self.bmm1_scale: float | None = None
-        self.bmm2_scale: float | None = None
-
-        # Pre-allocated output buffer, lazily sized on first call.
-        # Zero-init once to prevent NaN in padding slots (seq_lens=0)
-        # from contaminating downstream per-tensor reductions.
-        self._decode_out: torch.Tensor | None = None
-
-    def forward_mqa(
-        self,
-        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
-        kv_c_and_k_pe_cache: torch.Tensor,
-        attn_metadata: MLACommonMetadata,
-        layer: AttentionLayer,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+    def forward_mqa(self, q, kv_c_and_k_pe_cache, attn_metadata, layer):
         assert kv_c_and_k_pe_cache.numel() > 0
         assert attn_metadata.decode is not None
+        assert attn_metadata.decode.wrapper is not None
 
         if isinstance(q, tuple):
             q_nope, q_pe = q
-            q = torch.cat([q_nope, q_pe], dim=-1)
-
-        # trtllm API requires extra dimension q_len_per_request for MTP
-        if attn_metadata.num_decode_tokens % attn_metadata.num_decodes != 0:
-            logger.warning_once(
-                """FlashInferMLAImpl got a query of uneven length.
-                This usually indicates an issue in batch reordering
-                or incorrect setup in dummy_run."""
-            )
-            q = q.unsqueeze(1)
         else:
-            q = q.view(attn_metadata.num_decodes, -1, q.shape[-2], q.shape[-1])
+            q_nope = q[:, :, :self.kv_lora_rank]
+            q_pe = q[:, :, self.kv_lora_rank:]
 
-        if self.bmm1_scale is None:
-            self.bmm1_scale = self.scale
-            if self.kv_cache_dtype.startswith("fp8"):
-                self.bmm1_scale *= layer._q_scale_float * layer._k_scale_float
+        # Split KV cache: (blocks, block_size, 576) -> ckv(512) + kpe(64)
+        # No .contiguous() — SGLang also passes strided slices, flashinfer handles it
+        ckv_cache = kv_c_and_k_pe_cache[:, :, :self.kv_lora_rank].unsqueeze(2)
+        kpe_cache = kv_c_and_k_pe_cache[:, :, self.kv_lora_rank:].unsqueeze(2)
 
-        if self.bmm2_scale is None:
-            self.bmm2_scale = 1.0
-            if self.kv_cache_dtype.startswith("fp8"):
-                self.bmm2_scale *= layer._k_scale_float
+        wrapper = attn_metadata.decode.wrapper
+        o, lse = wrapper.run(
+            q_nope.contiguous(), q_pe.contiguous(),
+            ckv_cache, kpe_cache, return_lse=True, return_lse_base_on_e=True)
 
-        # Reuse pre-allocated zero-init output buffer to avoid a memset
-        # kernel on every CUDA graph replay.
-        # q is 4D: (batch, q_len_per_req, num_heads, head_dim)
-        # FlashInfer has a bug where out= validation hardcodes 3D shape
-        # (batch, num_heads, kv_lora_rank), but the kernel writes 4D
-        # (batch, q_len, num_heads, kv_lora_rank) when q_len > 1.
-        # So we can only pass out= for single-token decode (q_len == 1).
-        # For q_len > 1, we zero padding slots after the kernel returns.
-        # TODO: upstream fix to FlashInfer
-        B, q_len_per_req = q.shape[0], q.shape[1]
-        out_kwargs: dict[str, torch.Tensor] = {}
-        if q_len_per_req == 1:
-            dtype = (
-                torch.bfloat16
-                if is_quantized_kv_cache(self.kv_cache_dtype)
-                else q.dtype
-            )
-            if (
-                self._decode_out is None
-                or self._decode_out.shape[0] < B
-                or self._decode_out.dtype != dtype
-            ):
-                self._decode_out = torch.zeros(
-                    B,
-                    q.shape[2],
-                    self.kv_lora_rank,
-                    dtype=dtype,
-                    device=q.device,
-                )
-            out_kwargs["out"] = self._decode_out[:B]
+        v_scale = layer._v_scale_float
+        if v_scale != 1.0:
+            o = o * v_scale
 
-        o = trtllm_batch_decode_with_kv_cache_mla(
-            query=q,
-            kv_cache=kv_c_and_k_pe_cache.unsqueeze(1),
-            workspace_buffer=self._workspace_buffer,
-            qk_nope_head_dim=self.qk_nope_head_dim,
-            kv_lora_rank=self.kv_lora_rank,
-            qk_rope_head_dim=self.qk_rope_head_dim,
-            block_tables=attn_metadata.decode.block_table,
-            seq_lens=attn_metadata.decode.seq_lens,
-            max_seq_len=attn_metadata.max_seq_len,
-            bmm1_scale=self.bmm1_scale,
-            bmm2_scale=self.bmm2_scale,
-            **out_kwargs,
-        )
-
-        # For q_len > 1, we can't pass out= so we work around by zeroing padding slots
-        if not out_kwargs:
-            num_real = attn_metadata.num_decodes
-            if num_real < o.shape[0]:
-                o[num_real:] = 0
-
-        # Flatten the output for consistent shape
-        o = o.view(-1, o.shape[-2], o.shape[-1])
-
-        # TODO: Return LSE pending support from Flashinfer API:
-        # https://github.com/flashinfer-ai/flashinfer/pull/1566
-        return o, None
+        return o.contiguous(), lse


### PR DESCRIPTION
Superseded by #39635 and tracked in #37113.

This exploratory runtime PR has been replaced by a smaller MLA runtime PR with a narrower review surface.