### PR TITLE
[Bugfix] out-of-bounds error for routed experts capture

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -263,16 +263,12 @@ class Scheduler(SchedulerInterface):
                 if isinstance(group.kv_cache_spec, AttentionSpec):
                     self.routed_experts_attn_gid = gid
                     break
-            min_block_size = min(
-                [
-                    group.kv_cache_spec.block_size
-                    for group in kv_cache_config.kv_cache_groups
-                ]
-            )
-            num_groups = len(kv_cache_config.kv_cache_groups)
+            attn_group = kv_cache_config.kv_cache_groups[self.routed_experts_attn_gid]
+            # Routed experts are read back with the attention group's slot_mapping,
+            # so the shared-memory view must match that group's full KV address space.
             self.max_num_kv_tokens = (
-                kv_cache_config.num_blocks // num_groups
-            ) * min_block_size
+                kv_cache_config.num_blocks * attn_group.kv_cache_spec.block_size
+            )
             dcp_size = self.vllm_config.parallel_config.decode_context_parallel_size
             pcp_size = self.vllm_config.parallel_config.prefill_context_parallel_size
             if pcp_size * dcp_size > 1:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6543,16 +6543,12 @@ class GPUModelRunner(
         )
         routed_experts_capturer = RoutedExpertsCapturer.create()
         self.routed_experts_attn_gid = self._get_attention_kv_cache_gid()
-        min_block_size = min(
-            [
-                group.kv_cache_spec.block_size
-                for group in self.kv_cache_config.kv_cache_groups
-            ]
-        )
-        num_groups = len(self.kv_cache_config.kv_cache_groups)
+        attn_group = self.kv_cache_config.kv_cache_groups[self.routed_experts_attn_gid]
+        # Routed experts are indexed with the attention group's slot_mapping,
+        # so the side buffer must match that group's full KV address space.
         self.max_num_kv_tokens = (
-            self.kv_cache_config.num_blocks // num_groups
-        ) * min_block_size
+            self.kv_cache_config.num_blocks * attn_group.kv_cache_spec.block_size
+        )
         dcp_size = self.vllm_config.parallel_config.decode_context_parallel_size
         pcp_size = self.vllm_config.parallel_config.prefill_context_parallel_size
         if pcp_size * dcp_size > 1:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR fixes an out-of-bounds error in routed expert capture when
  `enable_return_routed_experts=True` is used with hybrid KV cache groups.

```logs
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/multiproc_executor.py", line 927, in worker_busy_loop
    output = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 756, in sample_tokens
    return self.model_runner.sample_tokens(grammar_output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 4060, in sample_tokens
    capturer.save_captured_experts(indices=self.slot_mapping)  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py", line 217, in save_captured_experts
    self._host_buffer_view[indices, :, :] = data
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
IndexError: index 699312 is out of bounds for axis 0 with size 699312
```

The routed-experts side buffer was sized with:

```python
(num_blocks // num_groups) * min_block_size
```

on both the worker and scheduler sides.

That formula is only a coarse aggregate/token-capacity estimate for hybrid KV
cache layouts. However, routed expert capture/readback indexes the buffer with
the selected attention group's actual slot_mapping, whose address space is
based on that attention KV group directly.

As a result, in hybrid/padded KV-cache configurations, the routed-experts
buffer can be smaller than the valid range of slot_mapping, which leads to
out-of-bounds writes/reads.

Use the routed-experts attention group's full KV address space to size the
buffer consistently on both sides:

kv_cache_config.num_blocks * attn_group.kv_cache_spec.block_size

Routed expert capture is indexed by the attention group's slot_mapping, so
the auxiliary buffer must match the full addressable range of that mapping.
Sizing it from the specific attention group keeps the writer and reader aligned
- fixes crashes when enable_return_routed_experts=True
- no behavior change when routed expert return is disabled
- no change to model weights, routing logic, or sampling semantics

## Test Plan

End to end tests

## Test Result

Now error is gone

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

