### PR TITLE
[Feature] Support loading LoRA from memory

### DIFF
--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Literal
 
 import msgspec
 
@@ -20,6 +21,11 @@ class LoRARequest(
         with the same lora_int_id already exists in the cache. This replaces
         the existing adapter in-place. If False (default), only loads if the
         adapter is not already loaded.
+
+    source: Selects how the adapter is loaded.
+        - "path": load from lora_path.
+        - "memory": load from peft_config and lora_tensors.
+          In this mode, lora_path is ignored.
     """
 
     lora_name: str
@@ -28,13 +34,23 @@ class LoRARequest(
     base_model_name: str | None = msgspec.field(default=None)
     tensorizer_config_dict: dict | None = None
     load_inplace: bool = False
+    source: Literal["path", "memory"] = "path"
+    peft_config: dict | None = None
+    lora_tensors: dict | None = None
 
     def __post_init__(self):
         if self.lora_int_id < 1:
             raise ValueError(f"id must be > 0, got {self.lora_int_id}")
 
-        # Ensure lora_path is not empty
-        assert self.lora_path, "lora_path cannot be empty"
+        if self.source == "path":
+            if not self.lora_path:
+                raise ValueError("LoRA source 'path' requires a non-empty lora_path.")
+            return
+
+        if self.peft_config is None or self.lora_tensors is None:
+            raise ValueError(
+                "LoRA source 'memory' requires peft_config and lora_tensors."
+            )
 
     @property
     def adapter_id(self):

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -98,24 +98,27 @@ class WorkerLoRAManager:
 
     def _load_adapter(self, lora_request: LoRARequest) -> LoRAModel:
         try:
-            supported_lora_modules = self._adapter_manager.supported_lora_modules
-            packed_modules_mapping = self._adapter_manager.packed_modules_mapping
-            expected_lora_lst: list[str] = []
-            for module in supported_lora_modules:
-                if module in packed_modules_mapping:
-                    expected_lora_lst.extend(packed_modules_mapping[module])
-                else:
-                    expected_lora_lst.append(module)
-                if module == "experts":
-                    expected_lora_lst.append(module)
-            expected_lora_modules = set(expected_lora_lst)
-            lora_path = get_adapter_absolute_path(lora_request.lora_path)
+            if lora_request.source == "path":
+                supported_lora_modules = self._adapter_manager.supported_lora_modules
+                packed_modules_mapping = self._adapter_manager.packed_modules_mapping
+                expected_lora_lst: list[str] = []
+                for module in supported_lora_modules:
+                    if module in packed_modules_mapping:
+                        expected_lora_lst.extend(packed_modules_mapping[module])
+                    else:
+                        expected_lora_lst.append(module)
+                    if module == "experts":
+                        expected_lora_lst.append(module)
+                expected_lora_modules = set(expected_lora_lst)
+                lora_path = get_adapter_absolute_path(lora_request.lora_path)
 
-            peft_helper = PEFTHelper.from_local_dir(
-                lora_path,
-                self.max_position_embeddings,
-                lora_request.tensorizer_config_dict,
-            )
+                peft_helper = PEFTHelper.from_local_dir(
+                    lora_path,
+                    self.max_position_embeddings,
+                    lora_request.tensorizer_config_dict,
+                )
+            else:
+                peft_helper = PEFTHelper.from_dict(lora_request.peft_config)
 
             # Validates the LoRA configuration against requirements before
             # loading weights, throwing an exception if validation fails.
@@ -129,18 +132,30 @@ class WorkerLoRAManager:
             # Get model-defined prefixes to skip during LoRA loading.
             lora_skip_prefixes = getattr(model, "lora_skip_prefixes", None)
 
-            lora = self._lora_model_cls.from_local_checkpoint(
-                lora_path,
-                expected_lora_modules,
-                peft_helper=peft_helper,
-                lora_model_id=lora_request.lora_int_id,
-                device="cpu",
-                dtype=self.lora_config.lora_dtype,
-                model_vocab_size=self.vocab_size,
-                tensorizer_config_dict=lora_request.tensorizer_config_dict,
-                weights_mapper=hf_to_vllm_mapper,
-                skip_prefixes=lora_skip_prefixes,
-            )
+            if lora_request.source == "path":
+                lora = self._lora_model_cls.from_local_checkpoint(
+                    lora_path,
+                    expected_lora_modules,
+                    peft_helper=peft_helper,
+                    lora_model_id=lora_request.lora_int_id,
+                    device="cpu",
+                    dtype=self.lora_config.lora_dtype,
+                    model_vocab_size=self.vocab_size,
+                    tensorizer_config_dict=lora_request.tensorizer_config_dict,
+                    weights_mapper=hf_to_vllm_mapper,
+                    skip_prefixes=lora_skip_prefixes,
+                )
+            else:
+                lora = self._lora_model_cls.from_lora_tensors(
+                    lora_model_id=lora_request.lora_int_id,
+                    tensors=lora_request.lora_tensors,
+                    peft_helper=peft_helper,
+                    device="cpu",
+                    dtype=self.lora_config.lora_dtype,
+                    model_vocab_size=self.vocab_size,
+                    weights_mapper=hf_to_vllm_mapper,
+                    skip_prefixes=lora_skip_prefixes,
+                )
 
         except FileNotFoundError as e:
             # FileNotFoundError should be raised if both

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -118,6 +118,7 @@ class WorkerLoRAManager:
                     lora_request.tensorizer_config_dict,
                 )
             else:
+                assert lora_request.peft_config is not None
                 peft_helper = PEFTHelper.from_dict(lora_request.peft_config)
 
             # Validates the LoRA configuration against requirements before
@@ -146,6 +147,7 @@ class WorkerLoRAManager:
                     skip_prefixes=lora_skip_prefixes,
                 )
             else:
+                assert lora_request.lora_tensors is not None
                 lora = self._lora_model_cls.from_lora_tensors(
                     lora_model_id=lora_request.lora_int_id,
                     tensors=lora_request.lora_tensors,


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

This PR adds support for loading LoRA adapters from memory in vLLM.

The main reason is that `verl` needs this capability when using vLLM LoRA. Right now, `verl` carries a patch to support this behavior:
https://github.com/verl-project/verl/blob/227acc76/verl/utils/vllm/utils.py#L36-L124

Adding this support to vLLM makes the behavior available upstream and removes the need for that patch in `verl`.

## Test Plan

Tested in `verl`.

## Test Result

Passed in `verl`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

