### PR TITLE
[responsesAPI][ez] add a unit test for SimpleContext logprobs

### DIFF
--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -139,6 +139,51 @@ async def test_streaming_output_consistency(client: OpenAI, model_name: str):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_streaming_logprobs(client: OpenAI, model_name: str):
+    """Test that streaming with logprobs returns valid logprob data on
+    output_text.delta events and that top_logprobs has the requested count."""
+    response = await client.responses.create(
+        model=model_name,
+        input="Say hello.",
+        stream=True,
+        top_logprobs=3,
+        include=["message.output_text.logprobs"],
+    )
+
+    events = []
+    async for event in response:
+        events.append(event)
+
+    assert len(events) > 0
+
+    # Collect all output_text.delta events that carry logprobs
+    text_delta_events = [e for e in events if e.type == "response.output_text.delta"]
+    assert len(text_delta_events) > 0, "Expected at least one text delta event"
+
+    for delta_event in text_delta_events:
+        logprobs = delta_event.logprobs
+        assert logprobs is not None, "logprobs should be present on text delta events"
+        assert len(logprobs) > 0, "logprobs list should not be empty"
+        for lp in logprobs:
+            # Each logprob entry must have a token and a logprob value
+            assert lp.token is not None
+            assert isinstance(lp.logprob, float)
+            assert lp.logprob <= 0.0, f"logprob should be <= 0, got {lp.logprob}"
+            # top_logprobs should have up to 3 entries
+            assert lp.top_logprobs is not None
+            assert len(lp.top_logprobs) <= 3
+            for tl in lp.top_logprobs:
+                assert tl.token is not None
+                assert isinstance(tl.logprob, float)
+
+    # Verify the completed event still has valid output
+    completed = events[-1]
+    assert completed.type == "response.completed"
+    assert completed.response.status == "completed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
 async def test_streaming_reasoning_tokens_e2e(client: OpenAI, model_name: str):
     """Verify final usage includes reasoning_tokens in streaming mode."""
     response = await client.responses.create(

--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -176,6 +176,14 @@ async def test_streaming_logprobs(client: OpenAI, model_name: str):
                 assert tl.token is not None
                 assert isinstance(tl.logprob, float)
 
+    # Verify that top_logprobs are actually populated, not always empty
+    all_top_logprobs = [
+        tl for e in text_delta_events for lp in e.logprobs for tl in lp.top_logprobs
+    ]
+    assert len(all_top_logprobs) > 0, (
+        "Expected at least one top_logprobs entry across all delta events"
+    )
+
     # Verify the completed event still has valid output
     completed = events[-1]
     assert completed.type == "response.completed"


### PR DESCRIPTION
## Purpose
this adds a unit test to make sure logprobs are outputted correctly, as it would look like this in streaming. no behavioral changes. Adding so I can be more confident in the migration in https://github.com/vllm-project/vllm/pull/37007.

```
event: response.output_text.delta
data: {"content_index":0,"delta":" 😊","item_id":"090bc9aa-4861-4e04-b2cc-aeb05bb9ab03","logprobs":[{"token":"","logprob":-2.622600959512056e-6,"top_logprobs":[{"token":"","logprob":-2.622600959512056e-6},{"token":"","logprob":-12.87500286102295},{"token":"","logprob":-17.625001907348633}]}],"output_index":1,"sequence_number":138,"type":"response.output_text.delta"}

event: response.output_text.delta
data: {"content_index":0,"delta":" How","item_id":"090bc9aa-4861-4e04-b2cc-aeb05bb9ab03","logprobs":[{"token":" How","logprob":0.0,"top_logprobs":[{"token":" How","logprob":0.0},{"token":"  \n","logprob":-17.0},{"token":" I","logprob":-18.375}]}],"output_index":1,"sequence_number":139,"type":"response.output_text.delta"}

event: response.output_text.delta
data: {"content_index":0,"delta":" can","item_id":"090bc9aa-4861-4e04-b2cc-aeb05bb9ab03","logprobs":[{"token":" can","logprob":0.0,"top_logprobs":[{"token":" can","logprob":0.0},{"token":" I","logprob":-18.5},{"token":" Can","logprob":-19.875}]}],"output_index":1,"sequence_number":140,"type":"response.output_text.delta"}

event: response.output_text.delta
data: {"content_index":0,"delta":" I","item_id":"090bc9aa-4861-4e04-b2cc-aeb05bb9ab03","logprobs":[{"token":" I","logprob":0.0,"top_logprobs":[{"token":" I","logprob":0.0},{"token":" assist","logprob":-18.875},{"token":"我","logprob":-21.125}]}],"output_index":1,"sequence_number":141,"type":"response.output_text.delta"}
```

## Test Plan

unit test passes 
`python -m pytest tests/entrypoints/openai/responses/test_simple.py::test_streaming_logprobs`