### PR TITLE
[CI][Bugfix] Fix 500 errors from priority overflow and TemplateError subclasses in schema fuzz tests

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -45,6 +45,8 @@ pystemmer==3.0.0
     # via mteb
 
 # Multi-modal processing
+av==16.1.0
+    # required for audio_in_video tests
 blobfile==3.0.0
     # Multi-Modal Models Test
 decord==0.6.0

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -7,7 +7,6 @@ import json
 import time
 from typing import Annotated, Any, ClassVar, Literal
 
-import torch
 from openai.types.chat.chat_completion_audio import (
     ChatCompletionAudio as OpenAIChatCompletionAudio,
 )
@@ -48,7 +47,8 @@ from vllm.utils import random_uuid
 logger = init_logger(__name__)
 
 
-_LONG_INFO = torch.iinfo(torch.long)
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
 
 
 class ChatMessage(OpenAIBaseModel):
@@ -165,7 +165,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     n: int | None = 1
     presence_penalty: float | None = 0.0
     response_format: AnyResponseFormat | None = None
-    seed: int | None = Field(None, ge=_LONG_INFO.min, le=_LONG_INFO.max)
+    seed: int | None = Field(None, ge=_INT64_MIN, le=_INT64_MAX)
     stop: str | list[str] | None = []
     stream: bool | None = False
     stream_options: StreamOptions | None = None
@@ -198,9 +198,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     min_tokens: int = 0
     skip_special_tokens: bool = True
     spaces_between_special_tokens: bool = True
-    truncate_prompt_tokens: Annotated[int, Field(ge=-1, le=_LONG_INFO.max)] | None = (
-        None
-    )
+    truncate_prompt_tokens: Annotated[int, Field(ge=-1, le=_INT64_MAX)] | None = None
     prompt_logprobs: int | None = None
     allowed_token_ids: list[int] | None = None
     bad_words: list[str] = Field(default_factory=list)
@@ -285,6 +283,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
     )
     priority: int = Field(
         default=0,
+        ge=_INT64_MIN,
+        le=_INT64_MAX,
         description=(
             "The priority of the request (lower means earlier handling; "
             "default: 0). Any priority other than 0 will raise an error "

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -6,6 +6,7 @@ import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Final
 
 import partial_json_parser
@@ -1289,7 +1290,12 @@ class OpenAIServingChat(OpenAIServing):
         except asyncio.CancelledError:
             return self.create_error_response("Client disconnected")
 
-        assert final_res is not None
+        if final_res is None:
+            return self.create_error_response(
+                "No output received from the engine.",
+                err_type="InternalServerError",
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
 
         choices: list[ChatCompletionResponseChoice] = []
         if self.tool_call_id_type == "kimi_k2":

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -7,7 +7,6 @@ import json
 import time
 from typing import Annotated, Any, Literal
 
-import torch
 from pydantic import Field, model_validator
 
 from vllm.config import ModelConfig
@@ -36,7 +35,8 @@ from vllm.utils import random_uuid
 logger = init_logger(__name__)
 
 
-_LONG_INFO = torch.iinfo(torch.long)
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
 
 
 class CompletionRequest(OpenAIBaseModel):
@@ -57,7 +57,7 @@ class CompletionRequest(OpenAIBaseModel):
     max_tokens: int | None = 16
     n: int = 1
     presence_penalty: float | None = 0.0
-    seed: int | None = Field(None, ge=_LONG_INFO.min, le=_LONG_INFO.max)
+    seed: int | None = Field(None, ge=_INT64_MIN, le=_INT64_MAX)
     stop: str | list[str] | None = []
     stream: bool | None = False
     stream_options: StreamOptions | None = None
@@ -78,9 +78,7 @@ class CompletionRequest(OpenAIBaseModel):
     min_tokens: int = 0
     skip_special_tokens: bool = True
     spaces_between_special_tokens: bool = True
-    truncate_prompt_tokens: Annotated[int, Field(ge=-1, le=_LONG_INFO.max)] | None = (
-        None
-    )
+    truncate_prompt_tokens: Annotated[int, Field(ge=-1, le=_INT64_MAX)] | None = None
     allowed_token_ids: list[int] | None = None
     prompt_logprobs: int | None = None
     # --8<-- [end:completion-sampling-params]
@@ -108,6 +106,8 @@ class CompletionRequest(OpenAIBaseModel):
     )
     priority: int = Field(
         default=0,
+        ge=_INT64_MIN,
+        le=_INT64_MAX,
         description=(
             "The priority of the request (lower means earlier handling; "
             "default: 0). Any priority other than 0 will raise an error "

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -6,7 +6,6 @@
 import time
 from typing import Any, Literal, TypeAlias
 
-import torch
 from openai.types.responses import (
     ResponseCodeInterpreterCallCodeDeltaEvent,
     ResponseCodeInterpreterCallCodeDoneEvent,
@@ -78,7 +77,8 @@ from vllm.utils import random_uuid
 
 logger = init_logger(__name__)
 
-_LONG_INFO = torch.iinfo(torch.long)
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
 
 
 class InputTokensDetails(OpenAIBaseModel):
@@ -210,6 +210,8 @@ class ResponsesRequest(OpenAIBaseModel):
     )
     priority: int = Field(
         default=0,
+        ge=_INT64_MIN,
+        le=_INT64_MAX,
         description=(
             "The priority of the request (lower means earlier handling; "
             "default: 0). Any priority other than 0 will raise an error "
@@ -246,7 +248,7 @@ class ResponsesRequest(OpenAIBaseModel):
     )
 
     repetition_penalty: float | None = None
-    seed: int | None = Field(None, ge=_LONG_INFO.min, le=_LONG_INFO.max)
+    seed: int | None = Field(None, ge=_INT64_MIN, le=_INT64_MAX)
     stop: str | list[str] | None = []
     ignore_eos: bool = False
     vllm_xargs: dict[str, str | int | float | list[str | int | float]] | None = Field(

--- a/vllm/entrypoints/pooling/base/protocol.py
+++ b/vllm/entrypoints/pooling/base/protocol.py
@@ -34,6 +34,8 @@ class PoolingBasicRequestMixin(OpenAIBaseModel):
     )
     priority: int = Field(
         default=0,
+        ge=-(2**63),
+        le=2**63 - 1,
         description=(
             "The priority of the request (lower means earlier handling; "
             "default: 0). Any priority other than 0 will raise an error "

--- a/vllm/entrypoints/serve/disagg/protocol.py
+++ b/vllm/entrypoints/serve/disagg/protocol.py
@@ -93,6 +93,8 @@ class GenerateRequest(BaseModel):
     )
     priority: int = Field(
         default=0,
+        ge=-(2**63),
+        le=2**63 - 1,
         description=(
             "The priority of the request (lower means earlier handling; "
             "default: 0). Any priority other than 0 will raise an error "

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -331,8 +331,8 @@ def create_error_response(
             err_type = "InternalServerError"
             status_code = exc.status_code
             param = None
-        elif exc.__class__.__name__ == "TemplateError":
-            # jinja2.TemplateError (avoid importing jinja2)
+        elif any(cls.__name__ == "TemplateError" for cls in type(exc).__mro__):
+            # jinja2.TemplateError and its subclasses (avoid importing jinja2)
             err_type = "BadRequestError"
             status_code = HTTPStatus.BAD_REQUEST
             param = None


### PR DESCRIPTION
The `test_openapi_stateless` schemathesis fuzz test is failing on AMD CI ([BuildKite #6544, entrypoints server api 1, mi325 and mi355](https://buildkite.com/vllm/amd-ci/builds/6544/steps/canvas?sid=019cf015-1cfd-445d-b66c-88374d4dc1cb&tab=output)). Schemathesis generates schema-valid inputs that trigger 500s from the server. This PR fixes three independent issues found during that investigation.

1. `priority` field has no int64 bounds

`priority` is defined as a plain `int` with no constraints. Values outside `[-2^63, 2^63 - 1]` cause `msgspec.msgpack` to raise `OverflowError` when serializing the request for the engine. That error gets swallowed by the broad `except Exception` in `AsyncLLM.generate()`, re-raised as `EngineGenerateError()` with no message, and the client gets back `{"message": "", "type": "InternalServerError"}`. The fix is to validate at the HTTP boundary with Pydantic `ge`/`le` constraints — the same approach already used for `seed` and `truncate_prompt_tokens`.

2. jinja2 `TemplateError` subclasses incorrectly return 500

`create_error_response` in `entrypoints/utils.py` identified jinja2 errors by checking `exc.__class__.__name__ == "TemplateError"`. That only matches the base class. Subclasses like `UndefinedError` and `TemplateRuntimeError` fall through to the default `else` branch and come back as 500 instead of 400.

3. Bare `assert` produces an empty 500

`assert final_res is not None` in `chat_completion_full_generator` raises `AssertionError` with no message if the generator yields nothing, which again produces `{"message": ""}`. Replaced with an explicit error response.

### Changes

Priority bounds: adds `ge=-(2**63), le=2**63-1` to the `priority` field across all five endpoint protocol files: `chat_completion`, `completion`, `responses`, `disagg`, and `pooling`.

Torch cleanup: while adding those bounds, also follows through on the TODO left in #34468: removes `import torch` and `_LONG_INFO = torch.iinfo(torch.long)` from the three protocol files that had it (`chat_completion`, `completion`, `responses`). These are pure Pydantic files and torch doesn't belong there. All usages are replaced with plain `_INT64_MIN = -(2**63)` / `_INT64_MAX = 2**63 - 1` constants.

Error handling: fixes the `TemplateError` subclass check in `utils.py` with an MRO walk, and replaces the bare assert in `chat_completion/serving.py` with a proper error response.

### Related

- #34468: int64 bounds on `DetokenizeRequest.tokens`; introduced the `torch.iinfo` TODO
- #35231: `ge=0` bounds on `CompletionRequest.prompt` token IDs

### Test plan

- `pytest tests/entrypoints/openai/test_openai_schema.py -v -s`
- `pytest tests/entrypoints/openai/chat_completion/test_chat_error.py -v -s`

cc @kenroche 