### PR TITLE
fix: re-record prepare_inputs_event after sample_tokens for spec decode

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3824,6 +3824,22 @@ class GPUModelRunner(
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
+        try:
+            return self._sample_tokens_impl(grammar_output)
+        finally:
+            # Re-record the prepare_inputs_event AFTER sample_tokens
+            # (which includes the spec-decode proposer) so the NEXT
+            # batch's execute_model waits for ALL GPU work from this
+            # step -- not just execute_model but also the proposer.
+            # Without this, the batch queue allows the next batch's
+            # _update_states to modify block tables while the current
+            # batch's proposer is still reading them on the GPU.
+            if self.prepare_inputs_event is not None:
+                self.prepare_inputs_event.record()
+
+    def _sample_tokens_impl(
+        self, grammar_output: "GrammarOutput | None"
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
         if self.execute_model_state is None:
             kv_connector_output = self.kv_connector_output
             self.kv_connector_output = None


### PR DESCRIPTION
## Summary

Fixes a race condition in the batch queue where the next batch's `execute_model` can begin modifying block tables while the current batch's speculative decode proposer (running inside `sample_tokens`) still has GPU work in flight.

- `prepare_inputs_event` is recorded in `execute_model`'s finally block
- But `sample_tokens` (which runs the MTP/EAGLE proposer) executes **after** `execute_model` returns
- The next batch's `synchronize_input_prep` only waits for the `execute_model` event, not the proposer's GPU work
- Under sustained concurrent load with MTP speculative decoding, this causes illegal memory access crashes

**Fix**: Re-record the event after `sample_tokens` completes so the next batch waits for ALL GPU work.

Related to https://github.com/vllm-project/vllm/issues/37113

## Test plan

- [x] Tested with GLM-5 NVFP4 MTP:3 on 8x RTX PRO 6000 (SM 120)
- [x] Without fix: crashes at ~30 concurrent requests with 512 max_tokens
- [x] With fix: survives 5 rounds of 30 concurrent x 512 tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)