### PR TITLE
[WIP][Hardware] replace `torch.cuda.Stream` with `torch.Stream`

### DIFF
--- a/benchmarks/kernels/benchmark_cutlass_moe_fp8.py
+++ b/benchmarks/kernels/benchmark_cutlass_moe_fp8.py
@@ -157,7 +157,7 @@ def bench_run(
     )
 
     # Create CUDA graphs for CUTLASS (match benchmark_moe.py pattern exactly)
-    cutlass_stream = torch.cuda.Stream()
+    cutlass_stream = torch.Stream()
     cutlass_graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(cutlass_graph, stream=cutlass_stream):
         # Capture 10 invocations like benchmark_moe.py
@@ -174,7 +174,7 @@ def bench_run(
     torch.accelerator.synchronize()
 
     # Create CUDA graphs for Triton (match benchmark_moe.py pattern exactly)
-    triton_stream = torch.cuda.Stream()
+    triton_stream = torch.Stream()
     triton_graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(triton_graph, stream=triton_stream):
         # Capture 10 invocations like benchmark_moe.py

--- a/benchmarks/kernels/benchmark_cutlass_moe_nvfp4.py
+++ b/benchmarks/kernels/benchmark_cutlass_moe_nvfp4.py
@@ -309,7 +309,7 @@ def bench_run(
             graph.replay()
         torch.accelerator.synchronize()
 
-    cutlass_stream = torch.cuda.Stream()
+    cutlass_stream = torch.Stream()
     cutlass_graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(cutlass_graph, stream=cutlass_stream):
         run_cutlass_from_graph(
@@ -332,7 +332,7 @@ def bench_run(
         )
     torch.accelerator.synchronize()
 
-    triton_stream = torch.cuda.Stream()
+    triton_stream = torch.Stream()
     triton_graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(triton_graph, stream=triton_stream):
         run_triton_from_graph(

--- a/benchmarks/kernels/benchmark_device_communicators.py
+++ b/benchmarks/kernels/benchmark_device_communicators.py
@@ -343,7 +343,7 @@ class CommunicatorBenchmark:
                 return None
 
             torch.accelerator.synchronize()
-            stream = torch.cuda.Stream()
+            stream = torch.Stream()
             with torch.cuda.stream(stream):
                 graph_input = tensor.clone()
 

--- a/benchmarks/kernels/benchmark_grouped_gemm_cutlass.py
+++ b/benchmarks/kernels/benchmark_grouped_gemm_cutlass.py
@@ -226,7 +226,7 @@ def bench_run(
             graph.replay()
         torch.accelerator.synchronize()
 
-    cutlass_stream = torch.cuda.Stream()
+    cutlass_stream = torch.Stream()
     cutlass_graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(cutlass_graph, stream=cutlass_stream):
         run_cutlass_from_graph(
@@ -241,7 +241,7 @@ def bench_run(
         )
     torch.accelerator.synchronize()
 
-    triton_stream = torch.cuda.Stream()
+    triton_stream = torch.Stream()
     triton_graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(triton_graph, stream=triton_stream):
         run_triton_from_graph(

--- a/benchmarks/kernels/utils.py
+++ b/benchmarks/kernels/utils.py
@@ -132,7 +132,7 @@ class Bench:
 
         self.args_iterator.reset()
         args_it = self.args_iterator.__next__()
-        stream = torch.cuda.Stream()
+        stream = torch.Stream()
         with torch.cuda.stream(stream):
             g = torch.cuda.CUDAGraph()
             with torch.cuda.graph(g):

--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -124,7 +124,7 @@ If GPU/CPU communication cannot be established, you can use the following Python
     # prefer to read the latest documentation.
     pynccl.disabled = False
 
-    s = torch.cuda.Stream()
+    s = torch.Stream()
     with torch.cuda.stream(s):
         data.fill_(1)
         out = pynccl.all_reduce(data, stream=s)

--- a/tests/distributed/test_eplb_events.py
+++ b/tests/distributed/test_eplb_events.py
@@ -11,8 +11,8 @@ from vllm.distributed.eplb.eplb_utils import CpuGpuEvent
 
 def test_wait_blocks_until_record():
     event = CpuGpuEvent()
-    record_stream = torch.cuda.Stream()
-    wait_stream = torch.cuda.Stream()
+    record_stream = torch.Stream()
+    wait_stream = torch.Stream()
     wait_returned = threading.Event()
 
     def waiter():
@@ -33,8 +33,8 @@ def test_wait_blocks_until_record():
 
 def test_reuse_across_multiple_cycles():
     wrapper = CpuGpuEvent()
-    record_stream = torch.cuda.Stream()
-    wait_stream = torch.cuda.Stream()
+    record_stream = torch.Stream()
+    wait_stream = torch.Stream()
     NUM_CYCLES = 8
     completed_cycles = []
     barriers = [threading.Barrier(2) for _ in range(NUM_CYCLES)]
@@ -61,7 +61,7 @@ def test_producer_consumer():
     This test uses the CpuGpuEvent to synchronize reads and writes to/from a shared GPU
     tensor on multiple CPU threads.
     """
-    worker_stream = torch.cuda.Stream()
+    worker_stream = torch.Stream()
     # Create a single element counter that will be shared between two threads
     buf = torch.zeros(1, device="cuda")
     NUM_ROUNDS = 5

--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -353,7 +353,7 @@ def _test_async_transfer_layer_without_mtp_worker(
         new_indices_cpu = new_indices.cpu()
 
         expert_buffer = [torch.empty_like(w) for w in expert_weights[0]]
-        cuda_stream = torch.cuda.Stream(device=device)
+        cuda_stream = torch.Stream(device=device)
 
         communicator = create_eplb_communicator_or_raise(
             group_coordinator=ep_group_coordinator,

--- a/tests/kernels/moe/test_block_fp8.py
+++ b/tests/kernels/moe/test_block_fp8.py
@@ -304,7 +304,7 @@ def test_w8a8_block_fp8_deep_gemm_fused_moe(M, N, K, E, topk, seed, monkeypatch)
 
         if use_cudagraph:
             out.fill_(0)
-            stream = torch.cuda.Stream()
+            stream = torch.Stream()
             graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(graph, stream=stream):
                 out = deep_gemm_moe_fp8_fn(

--- a/tests/kernels/moe/test_cutlass_moe.py
+++ b/tests/kernels/moe/test_cutlass_moe.py
@@ -402,7 +402,7 @@ def test_cutlass_moe_8_bit_cuda_graph(
             mt.a_d, mt.w1_d, mt.w2_d, topk_weights, topk_ids, quant_config=quant_config
         )
 
-        stream = torch.cuda.Stream()
+        stream = torch.Stream()
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph, stream=stream):
             cutlass_output = run_8_bit(

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -262,7 +262,7 @@ def run_moe_test(
 
     if use_cudagraph:
         test_output.fill_(0)
-        stream = torch.cuda.Stream()
+        stream = torch.Stream()
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph, stream=stream):
             test_output = moe_fn(

--- a/tests/kernels/quantization/test_cutlass_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutlass_scaled_mm.py
@@ -613,7 +613,7 @@ def test_cutlass_cuda_graph(per_act_token: bool, per_out_ch: bool):
     model = CutlassLayer(b, scale_a, scale_b, torch.bfloat16)
 
     # Run the model with a cuda graph
-    stream = torch.cuda.Stream()
+    stream = torch.Stream()
     with torch.cuda.stream(stream):
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):

--- a/tests/kernels/quantization/test_cutlass_w4a8.py
+++ b/tests/kernels/quantization/test_cutlass_w4a8.py
@@ -283,7 +283,7 @@ def test_w4a8_cuda_graph():
     )
 
     # Run the model with a cuda graph
-    stream = torch.cuda.Stream()
+    stream = torch.Stream()
     with torch.cuda.stream(stream):
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):

--- a/tests/kernels/quantization/test_cutlass_w4a8_moe.py
+++ b/tests/kernels/quantization/test_cutlass_w4a8_moe.py
@@ -331,7 +331,7 @@ def test_cutlass_w4a8_moe_mm_cuda_graph():
     # Capture and run the model in a CUDA graph.
     a_static = setup.a.clone()  # static input tensor for graph replay
 
-    stream = torch.cuda.Stream()
+    stream = torch.Stream()
     with torch.cuda.stream(stream):
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):

--- a/tests/kernels/quantization/test_machete_mm.py
+++ b/tests/kernels/quantization/test_machete_mm.py
@@ -434,7 +434,7 @@ def test_machete_cuda_graph():
     output_ref = torch.matmul(a, w_ref)
 
     # Run the model with a cuda graph
-    stream = torch.cuda.Stream()
+    stream = torch.Stream()
     with torch.cuda.stream(stream):
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):

--- a/tests/utils_/test_torch_utils.py
+++ b/tests/utils_/test_torch_utils.py
@@ -104,7 +104,7 @@ def test_current_stream_multithread():
 
     main_dedicated_stream = current_stream()
 
-    assert main_dedicated_stream.cuda_stream != 0, (
+    assert main_dedicated_stream.native_handle != 0, (
         "ROCm/CUDA should create a dedicated stream, not use default stream (0x0)"
     )
 

--- a/tests/utils_/test_torch_utils.py
+++ b/tests/utils_/test_torch_utils.py
@@ -60,10 +60,10 @@ def test_common_broadcastable_dtype(dtypes, expected_result):
     assert common_broadcastable_dtype(dtypes) == expected_result
 
 
-def _test_stream_thread(main_expected_stream: torch.cuda.Stream):
+def _test_stream_thread(main_expected_stream: torch.Stream):
     import threading
 
-    child_stream = torch.cuda.Stream()
+    child_stream = torch.Stream()
     thread_stream_ready = threading.Event()
     thread_can_exit = threading.Event()
 

--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -36,7 +36,7 @@ def cuda_capture_stream():
     """
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
-    stream = torch.cuda.Stream()
+    stream = torch.Stream()
     with torch.cuda.stream(stream):
         yield stream
     torch.cuda.current_stream().wait_stream(stream)

--- a/tests/v1/kv_connector/unit/test_hf3fs_client.py
+++ b/tests/v1/kv_connector/unit/test_hf3fs_client.py
@@ -101,7 +101,7 @@ class TestHf3fsClientResourceManagement:
             patch("os.ftruncate"),
             patch("os.close"),
             patch("os.fsync"),
-            patch("torch.cuda.Stream", return_value=MagicMock()),
+            patch("torch.Stream", return_value=MagicMock()),
             patch("torch.frombuffer", return_value=MagicMock()),
             patch("torch.empty", return_value=MagicMock()),
         ]
@@ -183,7 +183,7 @@ class TestHf3fsClientResourceManagement:
             patch("os.open", return_value=55),
             patch("os.ftruncate"),
             patch("os.close") as mock_os_close,
-            patch("torch.cuda.Stream", return_value=MagicMock()),
+            patch("torch.Stream", return_value=MagicMock()),
             pytest.raises(RuntimeError, match="mount point not found"),
         ):
             Hf3fsClient(
@@ -219,7 +219,7 @@ class TestHf3fsClientResourceManagement:
                 side_effect=RuntimeError("ioring init failed"),
             ),
             patch(f"{self._MOD}.make_iovec", return_value=MagicMock()),
-            patch("torch.cuda.Stream", return_value=MagicMock()),
+            patch("torch.Stream", return_value=MagicMock()),
             pytest.raises(RuntimeError, match="ioring init failed"),
         ):
             Hf3fsClient(
@@ -250,7 +250,7 @@ class TestHf3fsClientResourceManagement:
             patch("os.open", return_value=77),
             patch("os.ftruncate"),
             patch("os.close"),
-            patch("torch.cuda.Stream", return_value=MagicMock()),
+            patch("torch.Stream", return_value=MagicMock()),
             pytest.raises(RuntimeError, match="early failure"),
         ):
             Hf3fsClient(

--- a/tests/v1/kv_offload/cpu/test_swap_blocks_batch.py
+++ b/tests/v1/kv_offload/cpu/test_swap_blocks_batch.py
@@ -38,5 +38,5 @@ def test_swap_blocks_batch_default_stream():
 )
 def test_swap_blocks_batch_dedicated_stream():
     # A dedicated non-default stream exercises the cuMemcpyBatchAsync fast path.
-    with torch.cuda.stream(torch.cuda.Stream()):
+    with torch.cuda.stream(torch.Stream()):
         _run_batch([8, 4096, 8192])

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -41,14 +41,14 @@ def _make_backend() -> tuple[DmaCopyBackend, torch.Tensor, torch.Tensor]:
     gpu = {"k": torch.zeros((NUM_BLOCKS, BLOCK_BYTES), dtype=torch.int8, device="cuda")}
     cpu = {"k": torch.zeros((NUM_BLOCKS, BLOCK_BYTES), dtype=torch.int8, device="cpu")}
     pin_tensor(cpu["k"])
-    low_pri, _ = torch.cuda.Stream.priority_range()
+    low_pri, _ = torch.Stream.priority_range()
     backend = DmaCopyBackend()
     backend.init(
         gpu,
         cpu,
         gpu["k"].device,
-        torch.cuda.Stream(priority=low_pri),
-        torch.cuda.Stream(priority=low_pri),
+        torch.Stream(priority=low_pri),
+        torch.Stream(priority=low_pri),
     )
     return backend, gpu["k"], cpu["k"]
 
@@ -69,7 +69,7 @@ def _drive_store(
     happens-before edge.
     """
     block_ids = list(range(gpu.shape[0]))
-    compute_stream = torch.cuda.Stream()
+    compute_stream = torch.Stream()
     corrupt = 0
     for it in range(ITERS):
         val = (it % 126) + 1  # 1..126; distinct from the zero-initialized pool
@@ -172,7 +172,7 @@ def test_build_params_src_access_order():
     """build_params defaults to ANY and honors an explicit STREAM override."""
     gpu = {"k": torch.zeros((4, 64), dtype=torch.int8, device="cuda")}
     cpu = {"k": torch.zeros((4, 64), dtype=torch.int8, device="cpu")}
-    stream = torch.cuda.Stream()
+    stream = torch.Stream()
 
     default = build_params(gpu, cpu, stream)
     assert default.attrs.srcAccessOrder == CU_MEMCPY_SRC_ACCESS_ORDER_ANY

--- a/tools/pre_commit/check_torch_cuda.py
+++ b/tools/pre_commit/check_torch_cuda.py
@@ -8,7 +8,7 @@ import regex as re
 # Regex: match `torch.cuda.xxx` but allow `torch.accelerator.xxx`
 # --------------------------------------------------------------------------- #
 _TORCH_CUDA_PATTERNS = [
-    r"\btorch\.cuda\.(empty_cache|synchronize|device_count|current_device|memory_reserved|memory_allocated|max_memory_allocated|max_memory_reserved|reset_peak_memory_stats|memory_stats|set_device|device\()\b",
+    r"\btorch\.cuda\.(empty_cache|synchronize|device_count|current_device|memory_reserved|memory_allocated|max_memory_allocated|max_memory_reserved|reset_peak_memory_stats|memory_stats|set_device|Stream|device\()\b",
     r"\btorch\.cuda\.(manual_seed|manual_seed_all)\b",
     r"\bwith\storch\.cuda\.device\b",
     # Calls torch.cuda.{_is_compiled/_device_count_amdsmi/_device_count_nvml} internally

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -192,7 +192,7 @@ class PyNcclCommunicator:
             ncclDataTypeEnum.from_torch(in_tensor.dtype),
             ncclRedOpTypeEnum.from_torch(op),
             self.comm,
-            cudaStream_t(stream.cuda_stream),
+            cudaStream_t(stream.native_handle),
         )
         return out_tensor
 
@@ -216,7 +216,7 @@ class PyNcclCommunicator:
             input_tensor.numel(),
             ncclDataTypeEnum.from_torch(input_tensor.dtype),
             self.comm,
-            cudaStream_t(stream.cuda_stream),
+            cudaStream_t(stream.native_handle),
         )
 
     def all_gatherv(
@@ -249,7 +249,7 @@ class PyNcclCommunicator:
                 ncclDataTypeEnum.from_torch(input_tensor.dtype),
                 root,
                 self.comm,
-                cudaStream_t(stream.cuda_stream),
+                cudaStream_t(stream.native_handle),
             )
             split_offset += split_size
         self.nccl.ncclGroupEnd()
@@ -279,7 +279,7 @@ class PyNcclCommunicator:
             ncclDataTypeEnum.from_torch(input_tensor.dtype),
             ncclRedOpTypeEnum.from_torch(op),
             self.comm,
-            cudaStream_t(stream.cuda_stream),
+            cudaStream_t(stream.native_handle),
         )
 
     def reduce_scatterv(
@@ -314,7 +314,7 @@ class PyNcclCommunicator:
                 ncclRedOpTypeEnum.from_torch(op),
                 root,
                 self.comm,
-                cudaStream_t(stream.cuda_stream),
+                cudaStream_t(stream.native_handle),
             )
             split_offset += split_size
         self.nccl.ncclGroupEnd()
@@ -343,7 +343,7 @@ class PyNcclCommunicator:
             nccl_dtype,
             dst,
             self.comm,
-            cudaStream_t(stream.cuda_stream),
+            cudaStream_t(stream.native_handle),
         )
 
     def recv(self, tensor: torch.Tensor, src: int, stream=None):
@@ -370,7 +370,7 @@ class PyNcclCommunicator:
             nccl_dtype,
             src,
             self.comm,
-            cudaStream_t(stream.cuda_stream),
+            cudaStream_t(stream.native_handle),
         )
 
     def broadcast(self, tensor: torch.Tensor, src: int, stream=None):
@@ -396,7 +396,7 @@ class PyNcclCommunicator:
             ncclDataTypeEnum.from_torch(tensor.dtype),
             src,
             self.comm,
-            cudaStream_t(stream.cuda_stream),
+            cudaStream_t(stream.native_handle),
         )
 
     def group_start(self):

--- a/vllm/distributed/device_communicators/ray_communicator.py
+++ b/vllm/distributed/device_communicators/ray_communicator.py
@@ -35,7 +35,7 @@ class RayPPCommunicator(Communicator):
         comm_id: Any,
         rank: int | None,
         actor_handles: list["ray.actor.ActorHandle"],
-        cuda_stream: torch.cuda.Stream | None,
+        cuda_stream: torch.Stream | None,
         use_communication_streams: bool = False,
     ):
         """

--- a/vllm/distributed/device_communicators/ray_communicator.py
+++ b/vllm/distributed/device_communicators/ray_communicator.py
@@ -14,6 +14,7 @@ from vllm.distributed.device_communicators.base_device_communicator import (
 )
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import current_stream
 
 logger = init_logger(__name__)
@@ -240,11 +241,11 @@ class RayPPCommunicator(Communicator):
 
     @property
     def recv_stream(self):
-        return torch.cuda.StreamContext(current_stream())
+        return current_platform.stream(current_stream())
 
     @property
     def send_stream(self):
-        return torch.cuda.StreamContext(current_stream())
+        return current_platform.stream(current_stream())
 
     def destroy(self) -> None:
         # Just sets a flag, vLLM manages the lifecycle of the underlying

--- a/vllm/distributed/eplb/async_worker.py
+++ b/vllm/distributed/eplb/async_worker.py
@@ -32,7 +32,7 @@ def start_async_worker(
     def thread_target() -> None:
         assert device_index is not None
         torch.accelerator.set_device_index(device_index)
-        cuda_stream = torch.cuda.Stream(device=device_index)
+        cuda_stream = torch.Stream(device=device_index)
         try:
             transfer_run_periodically(
                 state=state,
@@ -51,7 +51,7 @@ def run_rebalance_experts(
     model_state: "EplbModelState",
     eplb_state: "EplbState",
     physical_to_logical_map_cpu: torch.Tensor,
-    cuda_stream: torch.cuda.Stream,
+    cuda_stream: torch.Stream,
 ) -> torch.Tensor:
     assert model_state.eplb_stats is not None
     eplb_stats = model_state.eplb_stats
@@ -75,7 +75,7 @@ def run_rebalance_experts(
 
 def transfer_run_periodically(
     state: "EplbState",
-    cuda_stream: torch.cuda.Stream,
+    cuda_stream: torch.Stream,
     is_profile: bool = False,
 ) -> None:
     while True:

--- a/vllm/distributed/eplb/eplb_communicator.py
+++ b/vllm/distributed/eplb/eplb_communicator.py
@@ -87,7 +87,7 @@ class EplbCommunicator(ABC):
         communication buffers."""
         return True
 
-    def set_stream(self, cuda_stream: torch.cuda.Stream | None) -> None:
+    def set_stream(self, cuda_stream: torch.Stream | None) -> None:
         self._cuda_stream = cuda_stream
 
     def _log_initialized(self) -> None:
@@ -101,7 +101,7 @@ class TorchDistNcclEplbCommunicator(EplbCommunicator):
     def __init__(
         self,
         ep_group: ProcessGroup,
-        cuda_stream: torch.cuda.Stream | None = None,
+        cuda_stream: torch.Stream | None = None,
     ) -> None:
         self._ep_group = ep_group
         self._cuda_stream = cuda_stream
@@ -158,7 +158,7 @@ class TorchDistGlooStagedEplbCommunicator(EplbCommunicator):
     def __init__(
         self,
         cpu_group: ProcessGroup,
-        cuda_stream: torch.cuda.Stream | None = None,
+        cuda_stream: torch.Stream | None = None,
     ) -> None:
         self._cpu_group = cpu_group
         self._cuda_stream = cuda_stream
@@ -617,7 +617,7 @@ class PyNcclEplbCommunicator(EplbCommunicator):
     def __init__(
         self,
         pynccl_comm: PyNcclCommunicator,
-        cuda_stream: torch.cuda.Stream | None = None,
+        cuda_stream: torch.Stream | None = None,
     ) -> None:
         self._pynccl_comm = pynccl_comm
         self._cuda_stream = cuda_stream

--- a/vllm/distributed/eplb/eplb_communicator.py
+++ b/vllm/distributed/eplb/eplb_communicator.py
@@ -357,7 +357,7 @@ class NixlEplbCommunicator(EplbCommunicator):
         uid = uuid.uuid4().hex[:8]
         return f"eplb-{self._rank}{pp_suffix}-{uid}"
 
-    def set_stream(self, cuda_stream: torch.cuda.Stream | None) -> None:
+    def set_stream(self, cuda_stream: torch.Stream | None) -> None:
         pass
 
     def add_send(

--- a/vllm/distributed/eplb/eplb_utils.py
+++ b/vllm/distributed/eplb/eplb_utils.py
@@ -34,7 +34,7 @@ class CpuGpuEvent:
         self._event = torch.cuda.Event()
         self._recorded = threading.Event()
 
-    def wait(self, stream: torch.cuda.Stream | None = None):
+    def wait(self, stream: torch.Stream | None = None):
         """
         Blocks the calling thread until record finishes. Used to guarantee that the
         record kernel is called before wait.
@@ -45,7 +45,7 @@ class CpuGpuEvent:
         self._event.wait(stream)
         self._recorded.clear()
 
-    def record(self, stream: torch.cuda.Stream | None = None):
+    def record(self, stream: torch.Stream | None = None):
         """
         Unblocks the waiting thread after calling event.record().
 

--- a/vllm/distributed/eplb/rebalance_execute.py
+++ b/vllm/distributed/eplb/rebalance_execute.py
@@ -175,7 +175,7 @@ def move_to_buffer(
     new_indices: np.ndarray,
     expert_weights: Sequence[torch.Tensor],
     expert_weights_buffers: Sequence[torch.Tensor],
-    cuda_stream: torch.cuda.Stream | None,
+    cuda_stream: torch.Stream | None,
     ep_rank: int,
     communicator: EplbCommunicator,
     layer_idx: int = 0,
@@ -432,7 +432,7 @@ def transfer_layer(
     ep_group: ProcessGroup,
     communicator: EplbCommunicator,
     is_profile: bool = False,
-    cuda_stream: torch.cuda.Stream | None = None,
+    cuda_stream: torch.Stream | None = None,
     rank_mapping: dict[int, int] | None = None,
     layer_idx: int = 0,
 ) -> TransferMetadata:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -165,7 +165,7 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         # Async write infrastructure (worker-side).
         # Dedicated CUDA stream for DtoH copies so they don't block
         # the default stream (model forward). Thread pool for disk writes.
-        self._copy_stream: torch.cuda.Stream | None = None  # lazy init
+        self._copy_stream: torch.Stream | None = None  # lazy init
         self._executor = ThreadPoolExecutor(
             max_workers=self._kv_transfer_config.get_from_extra_config(
                 "num_writer_threads", 8
@@ -203,10 +203,10 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         # accumulated across get_finished calls.
         self._accumulated_finished_req_ids: set[str] = set()
 
-    def _get_copy_stream(self) -> torch.cuda.Stream:
+    def _get_copy_stream(self) -> torch.Stream:
         """Lazily create the copy stream (CUDA must be initialized)."""
         if self._copy_stream is None:
-            self._copy_stream = torch.cuda.Stream()
+            self._copy_stream = torch.Stream()
         return self._copy_stream
 
     # ==============================

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_client.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_client.py
@@ -142,7 +142,7 @@ class Hf3fsClient:
             self.rlock = threading.RLock()
             self.wlock = threading.RLock()
 
-            self.stream = torch.cuda.Stream()
+            self.stream = torch.Stream()
             self.stream_ptr_int = self.stream.cuda_stream
 
         except Exception:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_client.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_client.py
@@ -143,7 +143,7 @@ class Hf3fsClient:
             self.wlock = threading.RLock()
 
             self.stream = torch.Stream()
-            self.stream_ptr_int = self.stream.cuda_stream
+            self.stream_ptr_int = self.stream.native_handle
 
         except Exception:
             self._release_resources()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
@@ -131,8 +131,8 @@ class AsyncOperationManager:
     def _init_cuda_resources(self) -> None:
         """Initialize CUDA streams, events and buffer allocators."""
         # CUDA streams for async operations
-        self._save_stream = torch.cuda.Stream()
-        self._load_stream = torch.cuda.Stream()
+        self._save_stream = torch.Stream()
+        self._load_stream = torch.Stream()
         self._save_event = torch.cuda.Event()
 
         # Buffer allocators for data copying

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class GraphCaptureContext:
-    stream: torch.cuda.Stream
+    stream: torch.Stream
 
 
 TensorMetadata = namedtuple("TensorMetadata", ["device", "dtype", "size"])
@@ -578,7 +578,7 @@ class GroupCoordinator:
     @contextmanager
     def graph_capture(self, graph_capture_context: GraphCaptureContext | None = None):
         if graph_capture_context is None:
-            stream = torch.cuda.Stream()
+            stream = torch.Stream()
             graph_capture_context = GraphCaptureContext(stream)
         else:
             stream = graph_capture_context.stream
@@ -1422,7 +1422,7 @@ def graph_capture(device: torch.device):
     in order to explicitly distinguish the kernels to capture
     from other kernels possibly launched on background in the default stream.
     """
-    context = GraphCaptureContext(torch.cuda.Stream(device=device))
+    context = GraphCaptureContext(torch.Stream(device=device))
     with get_tp_group().graph_capture(context), get_pp_group().graph_capture(context):
         yield context
 

--- a/vllm/distributed/weight_transfer/nccl_engine.py
+++ b/vllm/distributed/weight_transfer/nccl_engine.py
@@ -51,7 +51,7 @@ class NCCLTrainerSendWeightsArgs:
     """Whether to use packed tensor broadcasting for efficiency.
     When True, multiple tensors are batched together before broadcasting
     to reduce NCCL communication overhead."""
-    stream: torch.cuda.Stream | None = None
+    stream: torch.Stream | None = None
     """CUDA stream to use for broadcasting if packed is False.
     If packed is True, new streams will be created for each buffer."""
     packed_buffer_size_bytes: int = DEFAULT_PACKED_BUFFER_SIZE_BYTES

--- a/vllm/distributed/weight_transfer/packed_tensor.py
+++ b/vllm/distributed/weight_transfer/packed_tensor.py
@@ -155,7 +155,7 @@ def packed_nccl_broadcast_producer(
                     Both producer and consumer must use the same value.
 
     """
-    streams = [torch.cuda.Stream() for _ in range(num_buffers)]
+    streams = [torch.Stream() for _ in range(num_buffers)]
     # Keep references to in-flight chunks so their packed_tensors
     # aren't freed while an async broadcast is still reading them.
     in_flight: list[PackedChunk | None] = [None] * num_buffers
@@ -203,7 +203,7 @@ def packed_nccl_broadcast_consumer(
     """
     target_packed_tensor_size = buffer_size_bytes
 
-    streams = [torch.cuda.Stream() for _ in range(num_buffers)]
+    streams = [torch.Stream() for _ in range(num_buffers)]
     buffer_idx = 0
 
     packing_tensor_meta_data: list[list[tuple[str, list[int], torch.dtype, int]]] = [

--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -116,7 +116,7 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         return self.moe_config.intermediate_size_per_partition
 
     def _init_lora_stream_context(self) -> None:
-        self._lora_stream: torch.cuda.Stream | None = None
+        self._lora_stream: torch.Stream | None = None
         self._events: tuple[torch.cuda.Event, ...] | None = None
         if not self._enable_aux_cuda_stream:
             return

--- a/vllm/lora/layers/utils.py
+++ b/vllm/lora/layers/utils.py
@@ -12,15 +12,15 @@ from vllm.model_executor.layers.fused_moe.fused_moe import try_get_optimal_moe_c
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import next_power_of_2
 
-_lora_aux_cuda_stream: torch.cuda.Stream | None = None
+_lora_aux_cuda_stream: torch.Stream | None = None
 
 
-def _get_lora_aux_cuda_stream() -> torch.cuda.Stream | None:
+def _get_lora_aux_cuda_stream() -> torch.Stream | None:
     if not envs.VLLM_LORA_ENABLE_DUAL_STREAM:
         return None
     global _lora_aux_cuda_stream
     if _lora_aux_cuda_stream is None and current_platform.is_cuda_alike():
-        _lora_aux_cuda_stream = torch.cuda.Stream()
+        _lora_aux_cuda_stream = torch.Stream()
     return _lora_aux_cuda_stream
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/lora_context.py
+++ b/vllm/model_executor/layers/fused_moe/experts/lora_context.py
@@ -50,7 +50,7 @@ class MoELoRAContext:
     # aux_stream, which the default stream sums in afterwards.
     # Events are paired one-per-overlap-pair: events[0,1] for w13,
     # events[2,3] for w2, so the two pairs do not race on the same event.
-    aux_stream: torch.cuda.Stream | None = None
+    aux_stream: torch.Stream | None = None
     events: tuple[torch.cuda.Event, ...] | None = None
 
     # Per-rank token→LoRA mapping after EP dispatch. Set by

--- a/vllm/model_executor/layers/fused_moe/experts/xpu_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/xpu_moe.py
@@ -180,6 +180,7 @@ class XPUExperts(mk.FusedMoEExpertsModular):
                 gemm1_clamp_limit=self.gemm1_clamp_limit,
             )
         assert self.fused_moe_impl is not None
+
         self.fused_moe_impl.apply(
             output=output,
             hidden_states=hidden_states,
@@ -260,6 +261,42 @@ class XPUExpertsBlockFp8(XPUExperts):
             num_dispatchers,
         )
         self.is_block_fp8 = True
+
+    def apply(
+        self,
+        output,
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        activation,
+        global_num_experts,
+        expert_map,
+        a1q_scale,
+        a2_scale,
+        workspace13,
+        workspace2,
+        expert_tokens_meta,
+        apply_router_weight_on_input,
+    ):
+        return super().apply(
+            output,
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            activation,
+            global_num_experts,
+            expert_map,
+            a1q_scale,
+            a2_scale,
+            workspace13,
+            workspace2,
+            expert_tokens_meta,
+            apply_router_weight_on_input,
+        )
 
     @staticmethod
     def _supports_quant_scheme(

--- a/vllm/model_executor/offloader/prefetch.py
+++ b/vllm/model_executor/offloader/prefetch.py
@@ -153,7 +153,7 @@ class PrefetchOffloader(BaseOffloader):
         self.mode = mode
 
         # Copy stream for async H2D transfers
-        self.copy_stream = torch.cuda.Stream()
+        self.copy_stream = torch.Stream()
 
         # Module offloaders and buffer pool (populated in wrap_modules/post_init)
         self.module_offloaders: list[_ModuleOffloader] = []
@@ -375,7 +375,7 @@ class _ModuleOffloader:
         self,
         mode: str,
         module: nn.Module,
-        copy_stream: torch.cuda.Stream,
+        copy_stream: torch.Stream,
         whitelist_param_names: list[str],
         layer_idx: int,
     ):

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -230,7 +230,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         vllm_config,
         prefix,
         topk_indices_buffer: torch.Tensor | None = None,
-        aux_stream_list: list[torch.cuda.Stream] | None = None,
+        aux_stream_list: list[torch.Stream] | None = None,
     ):
         super().__init__()
 
@@ -453,9 +453,7 @@ class DeepseekV4Model(nn.Module):
         # kv_score). fused_wqa_wkv stays on the default stream.
         # Disable them on ROCm because of hang issues.
         aux_stream_list = (
-            None
-            if current_platform.is_rocm()
-            else [torch.cuda.Stream() for _ in range(3)]
+            None if current_platform.is_rocm() else [torch.Stream() for _ in range(3)]
         )
 
         self.device = current_platform.device_type

--- a/vllm/models/deepseek_v4/amd/mtp.py
+++ b/vllm/models/deepseek_v4/amd/mtp.py
@@ -64,7 +64,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         vllm_config: VllmConfig,
         topk_indices_buffer: torch.Tensor,
         prefix: str,
-        aux_stream_list: list[torch.cuda.Stream] | None = None,
+        aux_stream_list: list[torch.Stream] | None = None,
     ) -> None:
         super().__init__()
 
@@ -185,9 +185,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         # Three aux streams shared across all MTP layers, mirroring
         # DeepseekV4Model. ROCm runs the same work serially for now.
         aux_stream_list = (
-            None
-            if current_platform.is_rocm()
-            else [torch.cuda.Stream() for _ in range(3)]
+            None if current_platform.is_rocm() else [torch.Stream() for _ in range(3)]
         )
 
         # to map the exact layer index from weights

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -155,7 +155,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         vllm_config: VllmConfig,
         prefix: str,
         topk_indices_buffer: torch.Tensor | None = None,
-        aux_stream_list: list[torch.cuda.Stream] | None = None,
+        aux_stream_list: list[torch.Stream] | None = None,
     ) -> None:
         super().__init__()
         config = vllm_config.model_config.hf_config
@@ -672,7 +672,7 @@ class DeepseekV4Indexer(nn.Module):
         topk_indices_buffer: torch.Tensor | None,
         compress_ratio: int = 1,
         prefix: str = "",
-        aux_stream: torch.cuda.Stream | None = None,
+        aux_stream: torch.Stream | None = None,
     ):
         super().__init__()
         self.vllm_config = vllm_config

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -791,7 +791,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         vllm_config,
         prefix,
         topk_indices_buffer: torch.Tensor | None = None,
-        aux_stream_list: list[torch.cuda.Stream] | None = None,
+        aux_stream_list: list[torch.Stream] | None = None,
     ):
         super().__init__()
 
@@ -961,7 +961,7 @@ class DeepseekV4Model(nn.Module):
         # DeepseekV4Attention.attn_gemm_parallel_execute
         # (compressor kv_score, indexer.weights_proj, indexer.compressor
         # kv_score). fused_wqa_wkv stays on the default stream.
-        aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
+        aux_stream_list = [torch.Stream() for _ in range(3)]
 
         # Reserved topk indices buffer for all Indexer layers to reuse.
         self.topk_indices_buffer = torch.empty(

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -71,7 +71,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         vllm_config: VllmConfig,
         topk_indices_buffer: torch.Tensor,
         prefix: str,
-        aux_stream_list: list[torch.cuda.Stream] | None = None,
+        aux_stream_list: list[torch.Stream] | None = None,
     ) -> None:
         super().__init__()
 
@@ -182,7 +182,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         )
 
         # Three aux streams shared across all MTP layers, mirroring DeepseekV4Model.
-        aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
+        aux_stream_list = [torch.Stream() for _ in range(3)]
 
         # to map the exact layer index from weights
         self.layers = torch.nn.ModuleDict(

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -576,7 +576,7 @@ class PyNvVideoCodecVideoBackendMixin:
     def _create_decoder_slot(cls) -> PyNvVideoCodecDecoderSlot:
         import torch
 
-        return PyNvVideoCodecDecoderSlot(torch.cuda.Stream(device=cls._DEVICE_INDEX))
+        return PyNvVideoCodecDecoderSlot(torch.Stream(device=cls._DEVICE_INDEX))
 
     @staticmethod
     @contextmanager

--- a/vllm/utils/multi_stream_utils.py
+++ b/vllm/utils/multi_stream_utils.py
@@ -22,7 +22,7 @@ def maybe_execute_in_parallel(
     fn1: Callable[[], Any],
     event0: torch.cuda.Event,
     event1: torch.cuda.Event,
-    aux_stream: torch.cuda.Stream | None = None,
+    aux_stream: torch.Stream | None = None,
 ) -> tuple[Any, Any]:
     """Run two functions potentially in parallel on separate CUDA streams.
 

--- a/vllm/utils/multi_stream_utils.py
+++ b/vllm/utils/multi_stream_utils.py
@@ -63,7 +63,7 @@ def execute_in_parallel(
     aux_fns: list[Callable[[], Any] | None],
     start_event: torch.cuda.Event,
     done_events: list[torch.cuda.Event],
-    aux_streams: list[torch.cuda.Stream] | None = None,
+    aux_streams: list[torch.Stream] | None = None,
     enable: bool = False,
 ) -> tuple[Any, list[Any]]:
     """Run default_fn on the current stream and aux_fns concurrently on

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -680,7 +680,7 @@ prev_set_stream = torch.cuda.set_stream
 _current_stream_tls = threading.local()
 
 
-def _patched_set_stream(stream: torch.cuda.Stream) -> None:
+def _patched_set_stream(stream: torch.Stream) -> None:
     _current_stream_tls.value = stream
     prev_set_stream(stream)
 
@@ -693,7 +693,7 @@ class _StreamPlaceholder:
         self.synchronize = lambda: None
 
 
-def current_stream() -> torch.cuda.Stream:
+def current_stream() -> torch.Stream:
     """
     replace `torch.cuda.current_stream()` with `vllm.utils.current_stream()`.
     it turns out that `torch.cuda.current_stream()` is quite expensive,
@@ -718,7 +718,7 @@ def current_stream() -> torch.cuda.Stream:
         # for more details. Therefore, we create a dedicated stream per process.
         if current_platform.is_rocm() or current_platform.is_cuda():
             # torch.cuda.set_stream here is the alias of _pathed_set_stream
-            torch.cuda.set_stream(torch.cuda.Stream())
+            torch.cuda.set_stream(torch.Stream())
         elif current_platform.is_cpu():
             _current_stream_tls.value = _StreamPlaceholder()
         else:
@@ -739,10 +739,10 @@ def current_stream() -> torch.cuda.Stream:
 #
 # aux_stream() is currently used for:
 #   - MoE shared_expert overlap with router
-_aux_stream: torch.cuda.Stream | None = None
+_aux_stream: torch.Stream | None = None
 
 
-def aux_stream() -> torch.cuda.Stream | None:
+def aux_stream() -> torch.Stream | None:
     """
     Ensures aux_stream is initialized only once
     """
@@ -751,7 +751,7 @@ def aux_stream() -> torch.cuda.Stream | None:
     from vllm.platforms import current_platform
 
     if _aux_stream is None and current_platform.is_cuda_alike():
-        _aux_stream = torch.cuda.Stream()
+        _aux_stream = torch.Stream()
 
     return _aux_stream
 

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -62,7 +62,7 @@ def _select_swap_blocks_fn(
 @dataclass
 class Transfer:
     job_id: int
-    stream: torch.cuda.Stream
+    stream: torch.Stream
     start_event: torch.Event
     end_event: torch.Event
     num_bytes: int
@@ -206,7 +206,7 @@ class SingleDirectionOffloadingHandler:
         # queue of transfers (job_id, stream, event)
         self._transfers: deque[Transfer] = deque()
         # list of CUDA streams available for re-use
-        self._stream_pool: list[torch.cuda.Stream] = []
+        self._stream_pool: list[torch.Stream] = []
         # list of CUDA events available for re-use
         self._event_pool: list[torch.Event] = []
         # list of pinned descriptor buffer sets available for re-use

--- a/vllm/v1/simple_kv_offload/copy_backend.py
+++ b/vllm/v1/simple_kv_offload/copy_backend.py
@@ -28,8 +28,8 @@ class DmaCopyBackend:
     def __init__(self) -> None:
         self._store_params: BatchMemcpyParams | None = None
         self._load_params: BatchMemcpyParams | None = None
-        self._load_stream: torch.cuda.Stream | None = None
-        self._store_stream: torch.cuda.Stream | None = None
+        self._load_stream: torch.Stream | None = None
+        self._store_stream: torch.Stream | None = None
         self._queue: queue.SimpleQueue | None = None
         self._thread: threading.Thread | None = None
         self._shutdown: bool = False
@@ -39,8 +39,8 @@ class DmaCopyBackend:
         gpu_caches: dict[str, torch.Tensor],
         cpu_caches: dict[str, torch.Tensor],
         device: torch.device,
-        load_stream: torch.cuda.Stream,
-        store_stream: torch.cuda.Stream,
+        load_stream: torch.Stream,
+        store_stream: torch.Stream,
     ) -> None:
         self._load_stream = load_stream
         self._store_stream = store_stream
@@ -104,8 +104,8 @@ class DmaCopyBackend:
     def _copy_loop(
         q: queue.SimpleQueue,
         device: torch.device,
-        load_stream: torch.cuda.Stream,
-        store_stream: torch.cuda.Stream,
+        load_stream: torch.Stream,
+        store_stream: torch.Stream,
     ) -> None:
         current_platform.set_device(device)
         while True:

--- a/vllm/v1/simple_kv_offload/cuda_mem_ops.py
+++ b/vllm/v1/simple_kv_offload/cuda_mem_ops.py
@@ -125,7 +125,7 @@ class BatchMemcpyParams(NamedTuple):
 def build_params(
     src_caches: dict[str, torch.Tensor],
     dst_caches: dict[str, torch.Tensor],
-    stream: torch.cuda.Stream,
+    stream: torch.Stream,
     src_access_order: int = CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
 ) -> BatchMemcpyParams:
     global _batch_memcpy_fn

--- a/vllm/v1/simple_kv_offload/cuda_mem_ops.py
+++ b/vllm/v1/simple_kv_offload/cuda_mem_ops.py
@@ -154,7 +154,7 @@ def build_params(
         attrs=attrs,
         attrs_idx=ctypes.c_size_t(0),
         fail_idx=ctypes.c_size_t(0),
-        stream_handle=stream.cuda_stream,
+        stream_handle=stream.native_handle,
     )
 
 

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -41,8 +41,8 @@ class SimpleCPUOffloadWorker:
         self.num_cpu_blocks: int = 0
 
         # CUDA streams for the async transfers
-        self.load_stream: torch.cuda.Stream | None = None
-        self.store_stream: torch.cuda.Stream | None = None
+        self.load_stream: torch.Stream | None = None
+        self.store_stream: torch.Stream | None = None
 
         self._backend = DmaCopyBackend()
 
@@ -172,9 +172,9 @@ class SimpleCPUOffloadWorker:
             self.cpu_kv_caches[name] = tensor
 
         # Use lowest priority so KV cache I/O yields to compute streams.
-        low_pri, _ = torch.cuda.Stream.priority_range()
-        self.load_stream = torch.cuda.Stream(priority=low_pri)
-        self.store_stream = torch.cuda.Stream(priority=low_pri)
+        low_pri, _ = torch.Stream.priority_range()
+        self.load_stream = torch.Stream(priority=low_pri)
+        self.store_stream = torch.Stream(priority=low_pri)
 
         # Initialize copy backend with caches and streams.
         self._backend.init(

--- a/vllm/v1/spec_decode/ngram_proposer_gpu.py
+++ b/vllm/v1/spec_decode/ngram_proposer_gpu.py
@@ -642,7 +642,7 @@ def _sync_num_tokens(
 
 def copy_num_valid_draft_tokens(
     num_valid_draft_tokens_cpu: torch.Tensor,
-    num_valid_draft_tokens_copy_stream: torch.cuda.Stream,
+    num_valid_draft_tokens_copy_stream: torch.Stream,
     num_valid_draft_tokens_event: torch.cuda.Event,
     num_valid_draft_tokens: torch.Tensor | None,
     batch_size: int,

--- a/vllm/v1/worker/cpu/shm.py
+++ b/vllm/v1/worker/cpu/shm.py
@@ -40,7 +40,7 @@ class _StreamPlaceholder:
 
 torch.Event = _EventPlaceholder
 torch.cuda.Event = _EventPlaceholder
-torch.cuda.Stream = _StreamPlaceholder
+torch.Stream = _StreamPlaceholder
 torch.cuda.set_stream = noop
 torch.cuda.current_stream = lambda *args, **kwargs: _StreamPlaceholder()
 torch.accelerator.synchronize = noop

--- a/vllm/v1/worker/cpu_model_runner.py
+++ b/vllm/v1/worker/cpu_model_runner.py
@@ -267,14 +267,14 @@ def _torch_cuda_wrapper():
             pass
 
     cuda_event = torch.Event
-    cuda_stream = torch.cuda.Stream
+    cuda_stream = torch.Stream
     try:
         torch.Event = _EventPlaceholder
-        torch.cuda.Stream = _StreamPlaceholder
+        torch.Stream = _StreamPlaceholder
         yield
     finally:
         torch.Event = cuda_event
-        torch.cuda.Stream = cuda_stream
+        torch.Stream = cuda_stream
 
 
 @contextmanager

--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -15,8 +15,8 @@ class AsyncOutput(AsyncModelRunnerOutput):
         model_runner_output: ModelRunnerOutput,
         sampler_output: SamplerOutput,
         num_sampled_tokens: torch.Tensor,
-        main_stream: torch.cuda.Stream,
-        copy_stream: torch.cuda.Stream,
+        main_stream: torch.Stream,
+        copy_stream: torch.Stream,
     ):
         # NOTE(woosuk): We must retain references to the GPU tensors,
         # as the copy operations are performed on a different CUDA stream than
@@ -75,8 +75,8 @@ class AsyncPoolingOutput(AsyncModelRunnerOutput):
         model_runner_output: ModelRunnerOutput,
         pooler_output: torch.Tensor,
         is_valid: torch.Tensor | None,
-        main_stream: torch.cuda.Stream,
-        copy_stream: torch.cuda.Stream,
+        main_stream: torch.Stream,
+        copy_stream: torch.Stream,
     ):
         self.model_runner_output = model_runner_output
         self.pooler_output = pooler_output
@@ -109,7 +109,7 @@ def async_copy_to_np(x: torch.Tensor) -> np.ndarray:
 
 
 @contextlib.contextmanager
-def stream(to_stream: torch.cuda.Stream, from_stream: torch.cuda.Stream):
+def stream(to_stream: torch.Stream, from_stream: torch.Stream):
     """Lightweight version of torch.cuda.stream() context manager which
     avoids current_stream and device lookups.
     """

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -149,7 +149,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.max_num_reqs = self.scheduler_config.max_num_seqs
         self.is_encoder_decoder = self.model_config.is_encoder_decoder
 
-        self.output_copy_stream = torch.cuda.Stream(self.device)
+        self.use_async_scheduling = self.scheduler_config.async_scheduling
+        self.output_copy_stream = torch.Stream(self.device)
 
         # Pipeline parallelism.
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
@@ -402,7 +403,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.vllm_config.load_config = self.load_config
 
     @functools.cached_property
-    def main_stream(self) -> torch.cuda.Stream:
+    def main_stream(self) -> torch.Stream:
         # Cache the default CUDA stream to avoid lookup overhead.
         return torch.cuda.current_stream(self.device)
 

--- a/vllm/v1/worker/gpu/pp_utils.py
+++ b/vllm/v1/worker/gpu/pp_utils.py
@@ -66,7 +66,7 @@ class PPHandler:
         self.max_sample_len = num_speculative_steps + 1
         self.device = device
         self.main_stream = torch.cuda.current_stream(device)
-        self.broadcast_stream = torch.cuda.Stream(device)
+        self.broadcast_stream = torch.Stream(device)
 
         # On non-last ranks, a FIFO with one entry per in-flight step: the entry
         # pushed by step T's `receive` is consumed pp_size steps later. Pre-seeded

--- a/vllm/v1/worker/gpu/spec_decode/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/utils.py
@@ -11,7 +11,7 @@ from vllm.v1.worker.gpu.input_batch import InputBatch
 class DraftTokensHandler:
     def __init__(self, device: torch.device | None = None):
         self.device = device
-        self.copy_stream = torch.cuda.Stream(device)
+        self.copy_stream = torch.Stream(device)
         self.copy_event = torch.cuda.Event()
 
         self.req_ids: list[str] = []

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -18,7 +18,7 @@ class StructuredOutputsWorker:
             (max_num_logits, cdiv(vocab_size, 32)), dtype=torch.int32, device=device
         )
         self.device = device
-        self.copy_stream = torch.cuda.Stream()
+        self.copy_stream = torch.Stream()
 
     def apply_grammar_bitmask(
         self,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -246,7 +246,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         sampled_token_ids: torch.Tensor,
         logprobs_tensors: LogprobsTensors | None,
         invalid_req_indices: list[int],
-        async_output_copy_stream: torch.cuda.Stream,
+        async_output_copy_stream: torch.Stream,
         vocab_size: int,
         routed_experts: RoutedExpertsTensors | None = None,
     ):
@@ -370,7 +370,7 @@ class AsyncGPUPoolingModelRunnerOutput(AsyncModelRunnerOutput):
         model_runner_output: ModelRunnerOutput,
         raw_pooler_output: PoolerOutput,
         finished_mask: list[bool],
-        async_output_copy_stream: torch.cuda.Stream,
+        async_output_copy_stream: torch.Stream,
     ):
         self._model_runner_output = model_runner_output
 
@@ -691,12 +691,12 @@ class GPUModelRunner(
 
         # Separate cuda stream for overlapping transfer of sampled token ids from
         # GPU to CPU when async scheduling is enabled.
-        self.async_output_copy_stream: torch.cuda.Stream | None = None
+        self.async_output_copy_stream: torch.Stream | None = None
         # cuda event to synchronize use of reused CPU tensors between steps
         # when async scheduling is enabled.
         self.prepare_inputs_event: torch.Event | None = None
         if self.use_async_scheduling:
-            self.async_output_copy_stream = torch.cuda.Stream()
+            self.async_output_copy_stream = torch.Stream()
             self.prepare_inputs_event = torch.Event()
 
         # self.cudagraph_batch_sizes sorts in ascending order.
@@ -840,7 +840,7 @@ class GPUModelRunner(
         self._num_valid_draft_tokens: torch.Tensor | None = None
         self._num_valid_draft_tokens_cpu: torch.Tensor | None = None
         self._num_valid_draft_tokens_event: torch.cuda.Event | None = None
-        self._num_valid_draft_tokens_copy_stream: torch.cuda.Stream | None = None
+        self._num_valid_draft_tokens_copy_stream: torch.Stream | None = None
         if (
             self.speculative_config is not None
             and self.speculative_config.use_ngram_gpu()
@@ -849,7 +849,7 @@ class GPUModelRunner(
                 self.max_num_reqs, dtype=torch.int32, pin_memory=PIN_MEMORY
             )
             self._num_valid_draft_tokens_event = torch.cuda.Event()
-            self._num_valid_draft_tokens_copy_stream = torch.cuda.Stream()
+            self._num_valid_draft_tokens_copy_stream = torch.Stream()
 
         self._draft_token_req_ids: list[str] | None = None
         self.transfer_event = torch.Event()
@@ -863,18 +863,18 @@ class GPUModelRunner(
         # Pre-allocated tensor for copying valid sampled token counts to CPU,
         # with dedicated stream for overlapping and event for coordination.
         self.valid_sampled_token_count_event: torch.Event | None = None
-        self.valid_sampled_token_count_copy_stream: torch.cuda.Stream | None = None
+        self.valid_sampled_token_count_copy_stream: torch.Stream | None = None
         # We also copy the drafted tokens to the CPU asynchronously,
         # in case we need them for structured outputs.
         self.draft_token_ids_event: torch.Event | None = None
-        self.draft_token_ids_copy_stream: torch.cuda.Stream | None = None
+        self.draft_token_ids_copy_stream: torch.Stream | None = None
         self.valid_sampled_token_count_cpu: torch.Tensor | None = None
         self.draft_token_ids_cpu: torch.Tensor | None = None
         self.num_accepted_tokens_event: torch.Event | None = None
         if self.num_spec_tokens:
             self.draft_token_ids_event = torch.Event()
             self.num_accepted_tokens_event = torch.Event()
-            self.draft_token_ids_copy_stream = torch.cuda.Stream()
+            self.draft_token_ids_copy_stream = torch.Stream()
             self.draft_token_ids_cpu = torch.empty(
                 (self.max_num_reqs, self.num_spec_tokens),
                 dtype=torch.int64,
@@ -883,7 +883,7 @@ class GPUModelRunner(
             )
             if self.use_async_scheduling:
                 self.valid_sampled_token_count_event = torch.Event()
-                self.valid_sampled_token_count_copy_stream = torch.cuda.Stream()
+                self.valid_sampled_token_count_copy_stream = torch.Stream()
                 self.valid_sampled_token_count_cpu = torch.empty(
                     self.max_num_reqs,
                     dtype=torch.int32,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1117,10 +1117,10 @@ class GPUModelRunner(
     def _sync_device(self) -> None:
         torch.accelerator.synchronize()
 
-    def _get_or_create_async_output_copy_stream(self) -> torch.cuda.Stream:
+    def _get_or_create_async_output_copy_stream(self) -> torch.Stream:
         stream = self.async_output_copy_stream
         if stream is None:
-            stream = torch.cuda.Stream()
+            stream = torch.Stream()
             self.async_output_copy_stream = stream
         return stream
 

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -121,7 +121,7 @@ class UBatchWrapper:
         self.runnable = runnable
         self.vllm_config = vllm_config
         self.compilation_config = vllm_config.compilation_config
-        self.comm_stream = torch.cuda.Stream(device=device)
+        self.comm_stream = torch.Stream(device=device)
         # Ubatch threads plus the main thread
         self.ready_barrier = threading.Barrier(
             self.vllm_config.parallel_config.num_ubatches + 1

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -25,8 +25,8 @@ class UBatchContext:
     def __init__(
         self,
         id: int,
-        comm_stream: torch.cuda.Stream,
-        compute_stream: torch.cuda.Stream,
+        comm_stream: torch.Stream,
+        compute_stream: torch.Stream,
         forward_context: ForwardContext,
         ready_barrier: threading.Barrier,
         cpu_wait_event: threading.Event,
@@ -201,8 +201,8 @@ def dbo_get_previous_event(func, *args, **kwargs):
 
 def make_ubatch_contexts(
     num_micro_batches: int,
-    compute_stream: torch.cuda.Stream,
-    comm_stream: torch.cuda.Stream,
+    compute_stream: torch.Stream,
+    comm_stream: torch.Stream,
     forward_contexts: list[ForwardContext],
     ready_barrier: threading.Barrier,
     schedule: str = "default",

--- a/vllm/v1/worker/xpu_model_runner.py
+++ b/vllm/v1/worker/xpu_model_runner.py
@@ -41,8 +41,6 @@ class XPUModelRunnerV2(GPUModelRunnerV2):
 @contextmanager
 def _torch_cuda_wrapper():
     # replace cuda APIs with xpu APIs, this should work by default
-    torch.cuda.Stream = torch.xpu.Stream
-    torch.cuda.default_stream = torch.xpu.current_stream
     torch.cuda.current_stream = torch.xpu.current_stream
     torch.cuda.stream = torch.xpu.stream
     torch.cuda.mem_get_info = torch.xpu.mem_get_info


### PR DESCRIPTION

## Purpose
part of #30679
update on March 18th:
there are some places use `Stream.cuda_stream` for some cuda specific 3rd party library like pynccl. torch 2.10 can not handle it properly.
torch add `torch.Stream.native_handle` in 2.11 see https://github.com/pytorch/pytorch/pull/171040 

I will evaluate we should ignore such cases for now, or wait until 2.11 upgrade done. 

## Test Plan
test full CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

