### PR TITLE
[Bugfix] Add error handling for FINISHED_ERROR in OpenAIServing

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -29,11 +29,13 @@ from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.launcher import serve_http
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
+from vllm.entrypoints.openai.engine.protocol import GenerationError
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.server_utils import (
     engine_error_handler,
     exception_handler,
+    generation_error_handler,
     get_uvicorn_log_config,
     http_exception_handler,
     lifespan,
@@ -263,6 +265,7 @@ def build_app(
     app.exception_handler(RequestValidationError)(validation_exception_handler)
     app.exception_handler(EngineGenerateError)(engine_error_handler)
     app.exception_handler(EngineDeadError)(engine_error_handler)
+    app.exception_handler(GenerationError)(generation_error_handler)
     app.exception_handler(Exception)(exception_handler)
 
     # Ensure --api-key option from CLI takes precedence over VLLM_API_KEY

--- a/vllm/entrypoints/openai/server_utils.py
+++ b/vllm/entrypoints/openai/server_utils.py
@@ -21,7 +21,11 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from vllm import envs
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.launcher import terminate_if_errored
-from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
+from vllm.entrypoints.openai.engine.protocol import (
+    ErrorInfo,
+    ErrorResponse,
+    GenerationError,
+)
 from vllm.entrypoints.utils import create_error_response, sanitize_message
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
@@ -350,6 +354,17 @@ async def engine_error_handler(
         server=req.app.state.server,
         engine=req.app.state.engine_client,
     )
+    err = create_error_response(exc)
+    return JSONResponse(err.model_dump(), status_code=err.error.code)
+
+
+async def generation_error_handler(req: Request, exc: GenerationError):
+    """Handle GenerationError without logging stack traces.
+
+    GenerationError is a known, expected error (e.g. KV cache load failure)
+    that should be returned to the client as a 500 response without polluting
+    server logs with stack traces.
+    """
     err = create_error_response(exc)
     return JSONResponse(err.model_dump(), status_code=err.error.code)
 


### PR DESCRIPTION


## Purpose
PR #26813 introduced a **`FINISHED_ERROR`** error for P/D and converted it into a **500 HTTP error**. However, PR #31164 removed this handling, which caused a large number of logs like the following to appear. This may lead users to mistakenly believe that **vLLM has encountered an error**.
```
(APIServer pid=134834) ERROR:    Exception in ASGI application
(APIServer pid=134834) Traceback (most recent call last):
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/uvicorn/protocols/http/httptools_impl.py", line 416, in run_asgi
(APIServer pid=134834)     result = await app(  # type: ignore[func-returns-value]
(APIServer pid=134834)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
(APIServer pid=134834)     return await self.app(scope, receive, send)
(APIServer pid=134834)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/fastapi/applications.py", line 1160, in __call__
(APIServer pid=134834)     await super().__call__(scope, receive, send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/applications.py", line 107, in __call__
(APIServer pid=134834)     await self.middleware_stack(scope, receive, send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 186, in __call__
(APIServer pid=134834)     raise exc
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
(APIServer pid=134834)     await self.app(scope, receive, _send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/middleware/cors.py", line 87, in __call__
(APIServer pid=134834)     await self.app(scope, receive, send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/prometheus_fastapi_instrumentator/middleware.py", line 177, in __call__
(APIServer pid=134834)     raise exc
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/prometheus_fastapi_instrumentator/middleware.py", line 175, in __call__
(APIServer pid=134834)     await self.app(scope, receive, send_wrapper)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
(APIServer pid=134834)     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
(APIServer pid=134834)     raise exc
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
(APIServer pid=134834)     await app(scope, receive, sender)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
(APIServer pid=134834)     await self.app(scope, receive, send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/routing.py", line 716, in __call__
(APIServer pid=134834)     await self.middleware_stack(scope, receive, send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/routing.py", line 736, in app
(APIServer pid=134834)     await route.handle(scope, receive, send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/routing.py", line 290, in handle
(APIServer pid=134834)     await self.app(scope, receive, send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/fastapi/routing.py", line 130, in app
(APIServer pid=134834)     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
(APIServer pid=134834)     raise exc
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
(APIServer pid=134834)     await app(scope, receive, sender)
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/fastapi/routing.py", line 116, in app
(APIServer pid=134834)     response = await f(request)
(APIServer pid=134834)                ^^^^^^^^^^^^^^^^
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/fastapi/routing.py", line 670, in app
(APIServer pid=134834)     raw_response = await run_endpoint_function(
(APIServer pid=134834)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=134834)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/fastapi/routing.py", line 324, in run_endpoint_function
(APIServer pid=134834)     return await dependant.call(**values)
(APIServer pid=134834)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=134834)   File "/mnt/data4/jxy/vllm/vllm/entrypoints/utils.py", line 95, in wrapper
(APIServer pid=134834)     return handler_task.result()
(APIServer pid=134834)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=134834)   File "/mnt/data4/jxy/vllm/vllm/entrypoints/utils.py", line 116, in wrapper
(APIServer pid=134834)     return await func(*args, **kwargs)
(APIServer pid=134834)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=134834)   File "/mnt/data4/jxy/vllm/vllm/entrypoints/openai/chat_completion/api_router.py", line 55, in create_chat_completion
(APIServer pid=134834)     generator = await handler.create_chat_completion(request, raw_request)
(APIServer pid=134834)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=134834)   File "/mnt/data4/jxy/vllm/vllm/entrypoints/openai/chat_completion/serving.py", line 346, in create_chat_completion
(APIServer pid=134834)     return await self.chat_completion_full_generator(
(APIServer pid=134834)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=134834)   File "/mnt/data4/jxy/vllm/vllm/entrypoints/openai/chat_completion/serving.py", line 1304, in chat_completion_full_generator
(APIServer pid=134834)     self._raise_if_error(output.finish_reason, request_id)
(APIServer pid=134834)   File "/mnt/data4/jxy/vllm/vllm/entrypoints/openai/engine/serving.py", line 601, in _raise_if_error
(APIServer pid=134834)     raise GenerationError("Internal server error")
(APIServer pid=134834) vllm.entrypoints.openai.engine.protocol.GenerationError: Internal server error

```
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

