### PR TITLE
fix(v1/prefix-cache): prevent KV-cache pollution from same-step block registration

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -179,6 +179,7 @@ class BlockPool:
         self.kv_event_queue: list[KVCacheEvent] = []
 
         self.metrics_collector = metrics_collector
+        self._blocks_registered_this_step: set[int] = set()
 
     def get_cached_block(
         self, block_hash: BlockHash, kv_cache_group_ids: list[int]
@@ -203,6 +204,8 @@ class BlockPool:
                 block_hash_with_group_id
             )
             if not block:
+                return None
+            if block.block_id in self._blocks_registered_this_step:
                 return None
             cached_blocks.append(block)
         return cached_blocks
@@ -269,6 +272,7 @@ class BlockPool:
             )
             blk.block_hash = block_hash_with_group_id
             self.cached_block_hash_to_block.insert(block_hash_with_group_id, blk)
+            self._blocks_registered_this_step.add(blk.block_id)
             if new_hashes is not None:
                 new_hashes.append(maybe_convert_block_hash(block_hash))
 
@@ -421,6 +425,12 @@ class BlockPool:
         self.free_block_queue.append_n(
             [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
         )
+
+    def new_step_starts(self) -> None:
+        """Called at the beginning of each scheduling step.
+        to clear same-step cache-pollution guard
+        """
+        self._blocks_registered_this_step.clear()
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -249,6 +249,7 @@ class KVCacheCoordinator(ABC):
 
     def new_step_starts(self) -> None:
         """Called when a new step is started."""
+        self.block_pool.new_step_starts()
         for manager in self.single_type_managers:
             manager.new_step_starts()
 


### PR DESCRIPTION

**Problem**

When many requests sharing a common prefix are scheduled in the same step, `cache_full_blocks` inserts newly allocated blocks into the prefix-cache hash table **before** the GPU forward pass runs. A subsequent request in the same step can hit one of these blocks via `get_cached_block`, read its uninitialized GPU memory, and produce wrong output tokens — even at `temperature=0`.

**Fix**

Add `_blocks_registered_this_step: set[int]` to `BlockPool`:
- `cache_full_blocks` adds each newly registered block ID to the set
- `get_cached_block` returns `None` (cache miss) if the block is in the set
- `new_step_starts` clears the set once the previous step's GPU forward has completed

**Files changed**
- `vllm/v1/core/block_pool.py`
- `vllm/v1/core/kv_cache_coordinator.py`

**Not a duplicate**

Searched open PRs for `prefix cache pollution`, `cache_full_blocks`, `same-step` — no existing PR addresses this.

---

**Reproduction script**

```python
# test_prefix_cache_pollution.py
import requests
import threading

BASE_URL = "http://127.0.0.1:8000"
MODEL_NAME = "Qwen/Qwen2.5-0.5B-Instruct"
SHARED = " ".join(f"pre{i}" for i in range(128))

def send(rid, results):
    resp = requests.post(
        f"{BASE_URL}/v1/completions",
        json={
            "model": MODEL_NAME,
            "prompt": SHARED + f" u{rid}",
            "max_tokens": 20,
            "temperature": 0.0,
        },
        timeout=60,
    )
    results[rid] = resp.json()["choices"][0]["text"]

all_outputs = {18: []}

for run in range(20):
    results = {}
    threads = [threading.Thread(target=send, args=(i, results)) for i in range(27)]
    for t in threads: t.start()
    for t in threads: t.join()
    for rid in all_outputs:
        all_outputs[rid].append(results.get(rid, "N/A"))
    print(f"Run {run+1:2d}:  r18={repr(results.get(18,'N/A')[:25])}")

print("\n" + "=" * 60)
unique = set(all_outputs[18])
if len(unique) > 1:
    print(f"[BUG CONFIRMED] r18: {len(unique)} distinct outputs under temperature=0")
    for out in sorted(unique):
        print(f"  [{all_outputs[18].count(out):2d}/20] {repr(out[:60])}")
else:
    print("[NOT REPRODUCED] All outputs are consistent across 20 runs.")
print("=" * 60)
```

**Before fix** (12/20 runs corrupted):

```
Run  1:  r18=' u19 u20 u21 u22 u23 u24 '
Run  2:  r18=' u19 u20 u21 u22 u23 u24 '
Run  3:  r18=' u19 u20 u21 u22 u23 u24 '
Run  4:  r18='0 pre128 pre129 pre130 pr'
Run  5:  r18=' u19 u20 u21 u22 u23 u24 '
Run  6:  r18='0 pre128 pre129 pre130 pr'
...
Run 20:  r18='0 pre128 pre129 pre130 pr'

============================================================
[BUG CONFIRMED] r18: 2 distinct outputs under temperature=0 with prefix caching enabled.
  [ 8/20] ' u19 u20 u21 u22 u23 u24 u2'
  [12/20] '0 pre128 pre129 pre130 pre131 pre13'
============================================================
```
<img width="668" height="600" alt="image" src="https://github.com/user-attachments/assets/ce3b5132-7b26-4fc9-a4f5-2b70541abe24" />


**After fix** (20/20 runs correct, prefix cache hit rate 98.3%):

```
Run  1:  r18=' u19 u20 u21 u22 u23 u24 '
Run  2:  r18=' u19 u20 u21 u22 u23 u24 '
...
Run 20:  r18=' u19 u20 u21 u22 u23 u24 '

============================================================
[NOT REPRODUCED] All outputs are consistent across 20 runs.
============================================================

Engine 000: Prefix cache hit rate: 98.3%
```
<img width="624" height="602" alt="image" src="https://github.com/user-attachments/assets/8f46192d-26cf-47b9-9651-995d47cdda8d" />

And prefix cache hit rate is normal.
<img width="2560" height="124" alt="image" src="https://github.com/user-attachments/assets/4bdbb51b-faa5-4cf7-b7e5-42e39c2f8506" />