### PR TITLE
[Bugfix] Fix mock.patch resolution failure for standalone_compile.FakeTensorMode on Python <= 3.10

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -373,8 +373,15 @@ class InductorStandaloneAdaptor(CompilerInterface):
                 break
 
         if input_fake_mode is not None:
-            fake_mode_ctx: Any = patch(
-                "torch._inductor.standalone_compile.FakeTensorMode",
+            # Use patch.object on the actual module from sys.modules
+            # because in Python <=3.10 the string-based patch() resolves
+            # torch._inductor.standalone_compile to the wrapper function
+            # (defined in __init__.py) instead of the module.
+            import sys
+
+            fake_mode_ctx: Any = patch.object(
+                sys.modules["torch._inductor.standalone_compile"],
+                "FakeTensorMode",
                 lambda *a, **kw: input_fake_mode,
             )
         else:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR fixes an `AttributeError: <function standalone_compile at 0x7b8cf83c40d0> does not have the attribute 'FakeTensorMode'` crash introduced by #36093 when running with Python <= 3.10.

<details>
<summary> Stacktrace </summary>

```
[...]
(EngineCore pid=842) INFO 03-16 08:18:10 [backends.py:1048] Dynamo bytecode transform time: 5.43 s
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099] EngineCore failed to start.
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099] Traceback (most recent call last):
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/engine/core.py", line 1073, in run_engine_core
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/engine/core.py", line 839, in __init__
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     super().__init__(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/engine/core.py", line 122, in __init__
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     kv_cache_config = self._initialize_kv_caches(vllm_config)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/engine/core.py", line 245, in _initialize_kv_caches
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     available_gpu_memory = self.model_executor.determine_available_memory()
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/executor/abstract.py", line 136, in determine_available_memory
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return self.collective_rpc("determine_available_memory")
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/executor/uniproc_executor.py", line 78, in collective_rpc
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/serial_utils.py", line 459, in run_method
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/worker/gpu_worker.py", line 388, in determine_available_memory
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     self.model_runner.profile_run()
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/worker/gpu_model_runner.py", line 5527, in profile_run
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     hidden_states, last_hidden_states = self._dummy_run(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/v1/worker/gpu_model_runner.py", line 5221, in _dummy_run
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     outputs = self.model(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/cuda_graph.py", line 241, in __call__
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return self.runnable(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return self._call_impl(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return forward_call(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/model_executor/models/pixtral.py", line 381, in forward
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     hidden_states = self.language_model.model(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/decorators.py", line 583, in __call__
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     self.aot_compiled_fn = self.aot_compile(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/wrapper.py", line 206, in aot_compile
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return self._compiled_callable.aot_compile((args, kwargs))
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/.venv/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 832, in aot_compile
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return aot_compile_fullgraph(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/.venv/lib/python3.10/site-packages/torch/_dynamo/aot_compile.py", line 239, in aot_compile_fullgraph
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     compiled_fn = backend(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/.venv/lib/python3.10/site-packages/torch/__init__.py", line 2509, in __call__
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return self.compiler_fn(model_, inputs_, **self.kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/usr/lib/python3.10/contextlib.py", line 79, in inner
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return func(*args, **kwds)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/backends.py", line 1114, in __call__
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     PiecewiseCompileInterpreter(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/backends.py", line 640, in run
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return super().run(*args)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/.venv/lib/python3.10/site-packages/torch/fx/interpreter.py", line 200, in run
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     self.env[node] = self.run_node(node)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/.venv/lib/python3.10/site-packages/torch/fx/interpreter.py", line 295, in run_node
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return getattr(self, n.op)(n.target, args, kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/backends.py", line 667, in call_module
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     piecewise_backend = PiecewiseBackend(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/piecewise_backend.py", line 189, in __init__
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     self.compile_all_ranges()
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/piecewise_backend.py", line 265, in compile_all_ranges
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     range_entry.runnable = self.vllm_backend.compiler_manager.compile(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/backends.py", line 346, in compile
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     compiled_graph, handle = self.compiler.compile(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/scratch/code/vllm/vllm/compilation/compiler_interface.py", line 383, in compile
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     with pregrad_ctx, fake_mode_ctx, _patch_constrain_to_fx_strides():
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/usr/lib/python3.10/unittest/mock.py", line 1447, in __enter__
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     original, local = self.get_original()
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]   File "/usr/lib/python3.10/unittest/mock.py", line 1420, in get_original
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099]     raise AttributeError(
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099] AttributeError: <function standalone_compile at 0x7b8cf83c40d0> does not have the attribute 'FakeTensorMode'
```

</details>

The string-based `patch("torch._inductor.standalone_compile.FakeTensorMode", ...)` resolves `torch._inductor.standalone_compile` to the wrapper function defined in `torch/_inductor/__init__.py` rather than the module, because in Python 3.10 the  `mock._importer` uses `getattr`. In Python 3.11+, `mock.patch` switched to `pkgutil.resolve_name` ([cpython#18544](https://github.com/python/cpython/pull/18544)) which correctly resolves to the module.

## Test Plan

Test by loading a model before and after the fix in a Python 3.10 environment.

## Test Result

Before:
```
[...]
(EngineCore pid=842) INFO 03-16 08:18:10 [backends.py:1048] Dynamo bytecode transform time: 5.43 s
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099] EngineCore failed to start.
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099] Traceback (most recent call last):
[...]
(EngineCore pid=842) ERROR 03-16 08:18:11 [core.py:1099] AttributeError: <function standalone_compile at 0x7b8cf83c40d0> does not have the attribute 'FakeTensorMode'
```

After:
```
[...]
(EngineCore pid=211) INFO 03-16 08:12:00 [backends.py:1048] Dynamo bytecode transform time: 17.36 s
(EngineCore pid=211) INFO 03-16 08:12:01 [backends.py:284] Directly load the compiled graph(s) for compile range (1, 8192) from the cache, took 1.586 s
(EngineCore pid=211) INFO 03-16 08:12:01 [monitor.py:48] torch.compile took 19.36 s in total
[...]
(APIServer pid=102) INFO:     Started server process [102]
(APIServer pid=102) INFO:     Waiting for application startup.
(APIServer pid=102) INFO:     Application startup complete.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

