### PR TITLE
[Bugfix] Fix TOCTOU race in KV block allocator causing prefix-cache block theft

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2306,3 +2306,105 @@ def test_block_lookup_cache_multi_blocks_per_key():
     assert cache.pop(key1, 11) is block11
     assert cache.get_one_block(key1) is None
     assert cache.pop(key1, 12) is None
+
+
+def test_prefix_cache_block_not_stolen_between_get_and_alloc():
+    """Regression test for the TOCTOU use-after-free bug in the KV block
+    allocator (GitHub issue #37076).
+
+    Scenario (simulating the scheduler's waiting-request loop):
+      1. req_A shares a common prefix with a previously-freed request.
+         get_computed_blocks(req_A) returns the prefix block (ref_cnt==0,
+         sitting in the free/eviction queue).
+      2. Before allocate_slots(req_A) is called, req_B needs a fresh block
+         and its allocate_new_blocks() call would steal the same eviction
+         candidate from the free queue.
+      3. Without the fix, req_A's computed_blocks would point to a block that
+         now belongs to req_B, causing KV data corruption (token bleed).
+      4. With the fix, get_computed_blocks() immediately pins (touches) the
+         returned blocks so that req_B's allocation cannot steal them.
+    """
+    block_size = 4
+    # 4 usable blocks (plus the null block at index 0):
+    #   block 1: req0's prefix block (will be cached)
+    #   block 2: req0's second block
+    #   block 3: req_B's first new block
+    #   block 4: req_B's second new block
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, 5),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    hash_fn = sha256
+
+    # ── Step 1: warm the cache with a request that fills exactly 1 block ─
+    # Use 2*block_size tokens so req0 fills one full block (gets cached)
+    # plus one more full block, and then call cache_blocks explicitly to
+    # ensure the prefix block is stored under the right hash.
+    prefix_token_ids = list(range(block_size))  # block 0: tokens 0-3
+    suffix_token_ids = list(range(block_size, 2 * block_size))  # block 1: tokens 4-7
+    req0 = make_request("0", prefix_token_ids + suffix_token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    blocks0 = manager.allocate_slots(req0, 2 * block_size, 0, computed_blocks)
+    assert blocks0 is not None
+    # cache_blocks is called inside allocate_slots; 2 full blocks are cached.
+    prefix_block = manager.block_pool.blocks[1]  # first allocated block
+    assert prefix_block.ref_cnt == 1
+    assert prefix_block.block_hash is not None, (
+        "Prefix block must be cached after allocating 2 full blocks"
+    )
+    manager.free(req0)
+    # After free, prefix_block has ref_cnt==0 and is an eviction candidate.
+    assert prefix_block.ref_cnt == 0
+
+    # ── Step 2: simulate the scheduler loop ───────────────────────────────
+    # req_A hits the cached prefix. get_computed_blocks() should pin it.
+    req_a = make_request(
+        "A", prefix_token_ids + [42], block_size, hash_fn
+    )  # 5 tokens: 1 full cached block + 1 partial
+    computed_blocks_a, num_computed_a = manager.get_computed_blocks(req_a)
+    assert num_computed_a == block_size, (
+        "req_A should get a prefix cache hit for the 1 full block"
+    )
+    assert computed_blocks_a.blocks[0][0] is prefix_block
+
+    # The fix: prefix_block must be pinned (ref_cnt > 0) so that a
+    # subsequent allocate_new_blocks() for another request cannot steal it.
+    assert prefix_block.ref_cnt == 1, (
+        "Prefix block must be pre-touched by get_computed_blocks() "
+        "to prevent it being stolen before allocate_slots() is called "
+        "(TOCTOU / use-after-free, issue #37076)"
+    )
+
+    # req_B has no cache hit. It needs 2 fresh blocks; these should come from
+    # the unallocated pool, NOT from the pinned prefix_block.
+    req_b = make_request("B", [10, 11, 12, 13, 20, 21, 22, 23], block_size, hash_fn)
+    computed_blocks_b, num_computed_b = manager.get_computed_blocks(req_b)
+    assert num_computed_b == 0
+    blocks_b = manager.allocate_slots(req_b, 2 * block_size, 0, computed_blocks_b)
+    assert blocks_b is not None
+
+    # ── Step 3: verify the prefix block was NOT stolen by req_B ──────────
+    req_b_block_ids = {b.block_id for b in blocks_b.blocks[0]}
+    assert prefix_block.block_id not in req_b_block_ids, (
+        "Prefix block was stolen by req_B's allocation (use-after-free bug)"
+    )
+
+    # ── Step 4: complete req_A allocation ────────────────────────────────
+    blocks_a = manager.allocate_slots(req_a, 1, num_computed_a, computed_blocks_a)
+    assert blocks_a is not None
+    # req_A's block list must include the cached prefix block.
+    prefix_still_tracked = any(
+        b is prefix_block
+        for b in manager.coordinator.single_type_managers[0].req_to_blocks[
+            req_a.request_id
+        ]
+    )
+    assert prefix_still_tracked, (
+        "Prefix block should still be tracked in req_A's block list"
+    )
+
+    manager.free(req_a)
+    manager.free(req_b)

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -239,6 +239,50 @@ class KVCacheCoordinator(ABC):
             for manager in self.single_type_managers
         )
 
+    def touch_computed_blocks(
+        self, computed_blocks: tuple[Sequence[KVCacheBlock], ...]
+    ) -> None:
+        """Immediately pin the cached blocks returned by find_longest_cache_hit
+        so that they cannot be evicted or re-allocated to another request
+        before allocate_new_computed_blocks() is called.
+
+        This closes the TOCTOU window that exists between get_computed_blocks()
+        and allocate_slots(): without this pre-touch, a block with ref_cnt==0
+        (an eviction candidate) could be stolen by a concurrent request's
+        allocate_new_blocks() call in the same scheduling step, causing the
+        original request to read stale KV data (token bleed).
+
+        Must be paired with either allocate_new_computed_blocks() (which will
+        see the blocks are already touched) or release_computed_blocks() if
+        the allocation cannot proceed.
+
+        Args:
+            computed_blocks: The cached hit blocks returned by
+                find_longest_cache_hit, grouped by kv cache group.
+        """
+        if not self.enable_caching:
+            return
+        for group_blocks in computed_blocks:
+            self.block_pool.touch(group_blocks)
+
+    def release_computed_blocks(
+        self, computed_blocks: tuple[Sequence[KVCacheBlock], ...]
+    ) -> None:
+        """Undo the pre-touch performed by touch_computed_blocks().
+
+        Called when allocate_slots() cannot schedule a request (returns None)
+        so that the blocks pinned by touch_computed_blocks() are released back
+        to the eviction-candidate pool instead of being held unnecessarily.
+
+        Args:
+            computed_blocks: The same block tuple that was passed to
+                touch_computed_blocks().
+        """
+        if not self.enable_caching:
+            return
+        for group_blocks in computed_blocks:
+            self.block_pool.free_blocks(group_blocks)
+
     @abstractmethod
     def find_longest_cache_hit(
         self,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -193,6 +193,18 @@ class KVCacheManager:
             )
         )
 
+        # Pre-touch the cached hit blocks immediately to pin them out of the
+        # eviction-candidate free queue.  Without this, a block with ref_cnt==0
+        # could be stolen by a subsequent request's allocate_new_blocks() call
+        # within the same scheduling step before allocate_new_computed_blocks()
+        # gets a chance to touch it, leading to KV data corruption (token bleed
+        # between requests).  allocate_new_computed_blocks() will detect that
+        # the blocks are already touched and skip the redundant touch.
+        # If allocation later fails (allocate_slots returns None), the caller
+        # must call release_computed_blocks() to undo this touch.
+        if num_new_computed_tokens > 0:
+            self.coordinator.touch_computed_blocks(computed_blocks)
+
         if self.log_stats:
             assert self.prefix_cache_stats is not None
             self.prefix_cache_stats.record(
@@ -202,6 +214,18 @@ class KVCacheManager:
             )
 
         return self.create_kv_cache_blocks(computed_blocks), num_new_computed_tokens
+
+    def release_computed_blocks(self, computed_blocks: KVCacheBlocks) -> None:
+        """Undo the pre-touch applied by get_computed_blocks().
+
+        Must be called whenever get_computed_blocks() returned a non-empty
+        result but allocate_slots() will NOT be called for this request
+        (e.g. when a KVConnector cannot determine the number of matched tokens
+        and the request is deferred back to the waiting queue).
+        """
+        if computed_blocks is self.empty_kv_cache_blocks:
+            return
+        self.coordinator.release_computed_blocks(computed_blocks.blocks)
 
     def allocate_slots(
         self,
@@ -334,7 +358,11 @@ class KVCacheManager:
         )
 
         if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
-            # Cannot allocate new blocks
+            # Cannot allocate new blocks. Release the pre-touch that was applied
+            # in get_computed_blocks() so these blocks return to the eviction
+            # candidate pool rather than being unnecessarily pinned.
+            if new_computed_block_list is not self.empty_kv_cache_blocks.blocks:
+                self.coordinator.release_computed_blocks(new_computed_block_list)
             return None
 
         if (

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -608,6 +608,12 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
+                            # Release the pre-touch applied by
+                            # get_computed_blocks() since allocate_slots()
+                            # will not be called for this request.
+                            self.kv_cache_manager.release_computed_blocks(
+                                new_computed_blocks
+                            )
                             self.waiting.pop_request()
                             skipped_waiting_requests.prepend_request(request)
                             continue

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -172,6 +172,12 @@ class SingleTypeKVCacheManager(ABC):
         num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
         num_skipped_blocks = num_skipped_tokens // self.block_size
         if num_skipped_blocks > 0:
+            # The blocks in the skipped prefix were pre-touched in
+            # get_computed_blocks(). Release them now since they won't be
+            # tracked in req_to_blocks and would otherwise leak.
+            if self.enable_caching:
+                num_to_release = min(num_skipped_blocks, len(new_computed_blocks))
+                self.block_pool.free_blocks(new_computed_blocks[:num_to_release])
             # It is possible that all new computed blocks are skipped when
             # num_skipped_blocks > len(new_computed_blocks).
             new_computed_blocks = new_computed_blocks[num_skipped_blocks:]
@@ -181,10 +187,12 @@ class SingleTypeKVCacheManager(ABC):
                 num_external_computed_tokens,
             )
 
-        # Touch the computed blocks to make sure they won't be evicted.
-        if self.enable_caching:
-            self.block_pool.touch(new_computed_blocks)
-        else:
+        # The computed blocks were already pinned (ref_cnt incremented) by
+        # KVCacheManager.get_computed_blocks() via touch_computed_blocks().
+        # Calling touch() again here would double-count the reference and leak
+        # blocks out of the free pool. When caching is disabled there are no
+        # computed blocks to touch, so we still assert that.
+        if not self.enable_caching:
             assert not any(new_computed_blocks), (
                 "Computed blocks should be empty when prefix caching is disabled"
             )


### PR DESCRIPTION
## Summary

Fixes #37076

When the V1 scheduler processes multiple WAITING requests in a single scheduling step, a **use-after-free / TOCTOU window** in the KV block allocator allows one request to silently steal another request's cached prefix block, causing KV data corruption (token bleed between requests).

## Root Cause

The scheduler loop calls two methods for each waiting request:

```python
for req in waiting_requests:
    computed_blocks, n = manager.get_computed_blocks(req)   # Step 1: lookup
    ...
    manager.allocate_slots(req, ..., computed_blocks)        # Step 2: pin + alloc
```

Between Step 1 and Step 2, other requests in the loop are also processed. The bug:

1. `get_computed_blocks(req_A)` finds cached `block_X` (`ref_cnt=0`, eviction candidate in the free queue)
2. Before `allocate_slots(req_A)` pins it via `touch()`, req_B's `allocate_new_blocks()` **steals** `block_X` from the free queue and erases its hash via `_maybe_evict_cached_block()`
3. `allocate_slots(req_A)` now `touch()`es a block that belongs to req_B → **req_A reads req_B's KV data**

```
Timeline (single-threaded scheduler loop):
  get_computed_blocks(A)   →  block_X found (ref_cnt=0)
                                              ← TOCTOU WINDOW OPENS
  get_computed_blocks(B)   →  no cache hit
  allocate_new_blocks(B)   →  steals block_X from free queue!
                                              ← block_X now has B's data
  allocate_slots(A)        →  touches stale block_X → TOKEN BLEED
```

## Fix

**Pre-touch (pin) cached blocks immediately inside `get_computed_blocks()`**, closing the TOCTOU window before any other request can run.

- Added `touch_computed_blocks()` and `release_computed_blocks()` to `KVCacheCoordinator`
- `get_computed_blocks()` calls `touch_computed_blocks()` right after `find_longest_cache_hit()` so `ref_cnt` goes 0→1 and blocks are removed from the free queue
- `allocate_slots()` on the **failure path** (not enough free blocks) calls `release_computed_blocks()` to undo the pin — no ref-count leak
- `allocate_new_computed_blocks()` no longer calls `touch()` (blocks already pinned); handles the sliding-window skipped-block case by freeing pre-touched skipped blocks before slicing

### Why the free-block budget check is unchanged

Before the fix: `num_blocks_to_allocate = num_new_blocks + N` (N evictable computed blocks) is compared against F free blocks (which include those N blocks). Equivalent to `num_new_blocks > F - N`.

After the fix: pre-touch removes N blocks from the free queue, so `get_num_free_blocks() = F - N`, and `_get_num_evictable_blocks() = 0`. Check becomes `num_new_blocks > F - N`. **Identical condition** — scheduling decisions are unchanged.

## Test Plan

- Added regression test `test_prefix_cache_block_not_stolen_between_get_and_alloc` that directly reproduces the TOCTOU scenario and verifies the prefix block's `ref_cnt == 1` after `get_computed_blocks()`
- All 56 unit tests pass (`test_prefix_caching.py` + `test_single_type_kv_cache_manager.py`)
- All pre-commit hooks pass (ruff, mypy, typos, SPDX, etc.)