### PR TITLE
[Bugfix] Fix prompt_embeds precision divergence with MTP speculative …

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -628,6 +628,13 @@ class ModelConfig:
                 "repo name or path using the --tokenizer argument."
             )
 
+        if self.enable_prompt_embeds and self.is_multimodal_model:
+            raise ValueError(
+                "Cannot use --enable-prompt-embeds with multimodal models. "
+                "Multimodal models have their own embedding pipeline that "
+                "is incompatible with prompt_embeds input."
+            )
+
         if self.disable_sliding_window:
             # Set after get_and_verify_max_len to ensure that max_model_len
             # can be correctly capped to sliding window size

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -112,6 +112,8 @@ class SpecDecodeBaseProposer:
             vllm_config.model_config
         )
 
+        self.supports_prompt_embeds = vllm_config.model_config.enable_prompt_embeds
+
         self.draft_attn_groups: list[AttentionGroup] = []
         self.kv_cache_gid: int = -1
         self.eagle3_use_aux_hidden_state: bool = (
@@ -177,6 +179,7 @@ class SpecDecodeBaseProposer:
         if self.needs_extra_input_slots:
             self._raise_if_padded_drafter_batch_disabled()
             self._raise_if_multimodal()
+            self._raise_if_prompt_embeds()
             self._raise_if_mrope()
 
         self.is_rejected_token_mask: torch.Tensor | None = None
@@ -293,6 +296,13 @@ class SpecDecodeBaseProposer:
                 "does not support multimodal models yet"
             )
 
+    def _raise_if_prompt_embeds(self):
+        if self.supports_prompt_embeds:
+            raise NotImplementedError(
+                "Speculative Decoding with draft models or parallel drafting "
+                "does not support prompt embeds yet"
+            )
+
     def _raise_if_mrope(self):
         if self.draft_model_config.uses_mrope:
             raise NotImplementedError(
@@ -400,6 +410,7 @@ class SpecDecodeBaseProposer:
         slot_mappings: dict[str, torch.Tensor]
         | list[dict[str, torch.Tensor]]
         | None = None,
+        target_inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor:
         batch_size = common_attn_metadata.batch_size()
 
@@ -421,6 +432,7 @@ class SpecDecodeBaseProposer:
                 token_indices_to_sample=token_indices_to_sample,
                 cad=common_attn_metadata,
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+                target_inputs_embeds=target_inputs_embeds,
             )
         )
 
@@ -448,6 +460,11 @@ class SpecDecodeBaseProposer:
             )
 
             input_ids = None
+            inputs_embeds = self.inputs_embeds[:num_input_tokens]
+        elif self.supports_prompt_embeds:
+            # inputs_embeds prepared in set_inputs_first_pass.
+            # Keep input_ids for models that require it (e.g. DeepSeekMTP).
+            input_ids = self.input_ids[:num_input_tokens]
             inputs_embeds = self.inputs_embeds[:num_input_tokens]
         else:
             input_ids = self.input_ids[:num_input_tokens]
@@ -612,6 +629,12 @@ class SpecDecodeBaseProposer:
 
                 input_ids = None
                 inputs_embeds = self.inputs_embeds[:input_batch_size]
+            elif self.supports_prompt_embeds:
+                # Keep input_ids for models that require it (e.g. DeepSeekMTP).
+                self.inputs_embeds[:batch_size] = self.model.embed_input_ids(input_ids)
+
+                input_ids = self.input_ids[:input_batch_size]
+                inputs_embeds = self.inputs_embeds[:input_batch_size]
             else:
                 input_ids = self.input_ids[:input_batch_size]
                 inputs_embeds = None
@@ -657,6 +680,7 @@ class SpecDecodeBaseProposer:
         token_indices_to_sample: torch.Tensor | None,
         cad: CommonAttentionMetadata,
         num_rejected_tokens_gpu: torch.Tensor | None,
+        target_inputs_embeds: torch.Tensor | None = None,
     ) -> tuple[int, torch.Tensor, CommonAttentionMetadata]:
         if not self.needs_extra_input_slots:
             # Default EAGLE pathway: no reshaping of input tensors needed.
@@ -672,6 +696,13 @@ class SpecDecodeBaseProposer:
             # Replace the last token with the next token.
             # E.g., [b1, b2, c1, c2, c3, c3] -> [a2, b2, b3, c2, c3, c4]
             self.input_ids[token_indices_to_sample] = next_token_ids
+
+            # Apply the same shift to inputs_embeds using the target
+            # model's embeddings rather than re-embedding from token ids.
+            if self.supports_prompt_embeds and target_inputs_embeds is not None:
+                self.inputs_embeds[: num_tokens - 1] = target_inputs_embeds[1:]
+                next_token_embeds = self.model.embed_input_ids(next_token_ids)
+                self.inputs_embeds[token_indices_to_sample] = next_token_embeds
 
             # copy inputs to buffer for cudagraph
             if self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim == 0:
@@ -1509,6 +1540,9 @@ class SpecDecodeBaseProposer:
             ):
                 if self.supports_mm_inputs:
                     input_ids = None
+                    inputs_embeds = self.inputs_embeds[:num_input_tokens]
+                elif self.supports_prompt_embeds:
+                    input_ids = self.input_ids[:num_input_tokens]
                     inputs_embeds = self.inputs_embeds[:num_input_tokens]
                 else:
                     input_ids = self.input_ids[:num_input_tokens]

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1596,6 +1596,12 @@ class GPUModelRunner(
                 prev_common_req_indices_tensor, 0
             ],
         )
+        if self.enable_prompt_embeds:
+            self.is_token_ids.gpu.scatter_(
+                dim=0,
+                index=sampled_tokens_index_tensor,
+                src=torch.ones_like(sampled_tokens_index_tensor, dtype=torch.bool),
+            )
 
         # Scatter the draft tokens after the sampled tokens are scattered.
         if self._draft_token_ids is None or not spec_flattened_indices:
@@ -1618,6 +1624,12 @@ class GPUModelRunner(
             index=draft_tokens_index_tensor,
             src=draft_token_ids.flatten()[prev_draft_token_indices_tensor],
         )
+        if self.enable_prompt_embeds:
+            self.is_token_ids.gpu.scatter_(
+                dim=0,
+                index=draft_tokens_index_tensor,
+                src=torch.ones_like(draft_tokens_index_tensor, dtype=torch.bool),
+            )
 
     def _get_encoder_seq_lens(
         self,
@@ -4398,6 +4410,7 @@ class GPUModelRunner(
                 )
 
             num_rejected_tokens_gpu = None
+            target_inputs_embeds = None
             if spec_decode_metadata is None:
                 token_indices_to_sample = None
                 # input_ids can be None for multimodal models.
@@ -4410,6 +4423,8 @@ class GPUModelRunner(
                     )
                 else:
                     target_hidden_states = hidden_states[:num_scheduled_tokens]
+                if self.enable_prompt_embeds:
+                    target_inputs_embeds = self.inputs_embeds.gpu[:num_scheduled_tokens]
             else:
                 if spec_config.disable_padded_drafter_batch:
                     token_indices_to_sample = None
@@ -4427,6 +4442,8 @@ class GPUModelRunner(
                         )
                     else:
                         target_hidden_states = hidden_states[token_indices]
+                    if self.enable_prompt_embeds:
+                        target_inputs_embeds = self.inputs_embeds.gpu[token_indices]
                 else:
                     (
                         common_attn_metadata,
@@ -4448,6 +4465,8 @@ class GPUModelRunner(
                         )
                     else:
                         target_hidden_states = hidden_states[:total_num_tokens]
+                    if self.enable_prompt_embeds:
+                        target_inputs_embeds = self.inputs_embeds.gpu[:total_num_tokens]
 
             if self.supports_mm_inputs and self.drafter.supports_mm_inputs:
                 mm_embed_inputs = self._gather_mm_embeddings(
@@ -4468,6 +4487,7 @@ class GPUModelRunner(
                 mm_embed_inputs=mm_embed_inputs,
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
                 slot_mappings=slot_mappings,
+                target_inputs_embeds=target_inputs_embeds,
             )
 
         return draft_token_ids


### PR DESCRIPTION
Hi from [novita.ai](https://novita.ai/) team 👋

When --enable-prompt-embeds and --speculative-config.method mtp are both enabled, logits from prompt_embeds input diverge from text input starting at the 2nd generated token. Two root causes:

1. Async scheduling scatter paths update input_ids.gpu but not is_token_ids.gpu, causing the target model to use stale embeddings instead of re-embedding from token ids for decode positions.

2. MTP drafter re-embeds from token ids instead of using the target model's actual inputs_embeds, producing inconsistent embeddings for prompt_embeds inputs.

Also adds a startup validation rejecting --enable-prompt-embeds with multimodal models, as they have incompatible embedding pipelines.


## Purpose

## Test Plan
test on [glm5-fp8](https://huggingface.co/zai-org/GLM-5-FP8), vllm serve

```
nohup vllm serve /path/to/GLM-5-FP8/ \
     --port 33333  \
     --tensor-parallel-size 8  \
     --runner generate   \
     --max-model-len 8192 \
     --enable-prompt-embeds \
     --speculative-config.method mtp \
     --speculative-config.num_speculative_tokens 1 \
     --tool-call-parser glm47 \
     --reasoning-parser glm45 \
     --enable-auto-tool-choice \
     --served-model-name glm5 > serve.log &
```

## Test Result
Test from [this example](https://github.com/vllm-project/vllm/blob/main/examples/online_serving/prompt_embed_inference_with_openai_client.py)
main branch：
```
------------------------------
11.
------------------------------
```

My branch has fixed the accuracy issue
```
------------------------------
1.  **Analyze the Request:** The user is asking for information about the capital of France.

2.  **Identify the Subject:** The capital of France is Paris.

3.  **Determine Key Information Categories:** To provide a comprehensive answer, I should cover several aspects of Paris
------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

