### PR TITLE
[Pixtral] Enable Pixtral language model support Eagle3

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -401,10 +401,18 @@ class PixtralForConditionalGeneration(
 
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         self._require_language_model_eagle3()
+        assert hasattr(self.language_model, "set_aux_hidden_state_layers"), (
+            f"Language model {type(self.language_model).__name__} does not "
+            "implement 'set_aux_hidden_state_layers'."
+        )
         self.language_model.set_aux_hidden_state_layers(layers)
 
     def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
         self._require_language_model_eagle3()
+        assert hasattr(self.language_model, "get_eagle3_aux_hidden_state_layers"), (
+            f"Language model {type(self.language_model).__name__} does not "
+            "implement 'get_eagle3_aux_hidden_state_layers'."
+        )
         return self.language_model.get_eagle3_aux_hidden_state_layers()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -66,9 +66,11 @@ from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from .interfaces import (
     MultiModalEmbeddings,
+    SupportsEagle3,
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
+    supports_eagle3,
 )
 from .module_mapping import MultiModelKeys
 from .utils import StageMissingLayer, init_vllm_registered_model, maybe_prefix
@@ -262,7 +264,7 @@ class PixtralMultiModalProcessor(BaseMultiModalProcessor[PixtralProcessingInfo])
     dummy_inputs=PixtralDummyInputsBuilder,
 )
 class PixtralForConditionalGeneration(
-    nn.Module, SupportsLoRA, SupportsMultiModal, SupportsPP
+    nn.Module, SupportsLoRA, SupportsEagle3, SupportsMultiModal, SupportsPP
 ):
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
@@ -389,6 +391,21 @@ class PixtralForConditionalGeneration(
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
         return self.language_model.compute_logits(hidden_states)
+
+    def _require_language_model_eagle3(self) -> None:
+        if not supports_eagle3(self.language_model):
+            raise RuntimeError(
+                f"EAGLE-3 speculative decoding requires the language model to "
+                f"support EAGLE-3, but {type(self.language_model).__name__} does not."
+            )
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self._require_language_model_eagle3()
+        self.language_model.set_aux_hidden_state_layers(layers)
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        self._require_language_model_eagle3()
+        return self.language_model.get_eagle3_aux_hidden_state_layers()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         def is_vision_encoder_weights(weight: tuple[str, torch.Tensor]):

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -401,18 +401,10 @@ class PixtralForConditionalGeneration(
 
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         self._require_language_model_eagle3()
-        assert hasattr(self.language_model, "set_aux_hidden_state_layers"), (
-            f"Language model {type(self.language_model).__name__} does not "
-            "implement 'set_aux_hidden_state_layers'."
-        )
         self.language_model.set_aux_hidden_state_layers(layers)
 
     def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
         self._require_language_model_eagle3()
-        assert hasattr(self.language_model, "get_eagle3_aux_hidden_state_layers"), (
-            f"Language model {type(self.language_model).__name__} does not "
-            "implement 'get_eagle3_aux_hidden_state_layers'."
-        )
         return self.language_model.get_eagle3_aux_hidden_state_layers()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):


### PR DESCRIPTION
Enables the support of using an Eagle3 draft model for Pixtral, when the underlying language model supports it (i.e. returns multiple auxiliary hidden_states).