### PR TITLE
[ROCm] Add `torch.cuda` fallback for amdsmi-dependent methods on WSL2

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -124,7 +124,29 @@ def rocm_platform_plugin() -> str | None:
         finally:
             amdsmi.amdsmi_shut_down()
     except Exception as e:
-        logger.debug("ROCm platform is not available because: %s", str(e))
+        logger.debug(
+            "amdsmi not available: %s. Trying torch.version.hip fallback.", str(e)
+        )
+        # Fallback: on WSL2, amdsmi is unavailable but ROCm works
+        # via torch HIP backend. Check torch.version.hip instead.
+        try:
+            import torch
+
+            if torch.version.hip is not None and torch.cuda.is_available():
+                is_rocm = True
+                logger.debug(
+                    "Confirmed ROCm platform via torch.version.hip "
+                    "(amdsmi unavailable, e.g. WSL2)."
+                )
+            else:
+                logger.debug(
+                    "ROCm platform is not available: "
+                    "torch.version.hip=%s, cuda.is_available=%s",
+                    torch.version.hip,
+                    torch.cuda.is_available() if hasattr(torch, "cuda") else False,
+                )
+        except Exception as e2:
+            logger.debug("ROCm platform fallback also failed: %s", str(e2))
 
     return "vllm.platforms.rocm.RocmPlatform" if is_rocm else None
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -35,8 +35,11 @@ try:
         amdsmi_topo_get_link_type,
         amdsmi_topo_get_numa_node_number,
     )
+
+    _amdsmi_available = True
 except ImportError as e:
     logger.warning("Failed to import from amdsmi with %r", e)
+    _amdsmi_available = False
 
 try:
     import vllm._C  # noqa: F401
@@ -143,6 +146,12 @@ _sync_hip_cuda_env_vars()
 def with_amdsmi_context(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
+        if not _amdsmi_available:
+            raise RuntimeError(
+                f"amdsmi is not available (e.g. WSL2 environment). "
+                f"Cannot call {fn.__name__}. "
+                f"Caller should handle this gracefully."
+            )
         amdsmi_init()
         try:
             return fn(*args, **kwargs)
@@ -666,36 +675,63 @@ class RocmPlatform(Platform):
         return DeviceCapability(major=major, minor=minor)
 
     @classmethod
-    @with_amdsmi_context
     def is_fully_connected(cls, physical_device_ids: list[int]) -> bool:
         """
         Query if the set of gpus are fully connected by xgmi (1 hop)
         """
-        handles = [amdsmi_get_processor_handles()[i] for i in physical_device_ids]
-        for i, handle in enumerate(handles):
-            for j, peer_handle in enumerate(handles):
-                if i < j:
-                    try:
-                        link_type = amdsmi_topo_get_link_type(handle, peer_handle)
-                        # type is 2 for XGMI
-                        if link_type["hops"] != 1 or link_type["type"] != 2:
+        if not _amdsmi_available:
+            logger.warning_once(
+                "amdsmi is not available (e.g. WSL2 environment). "
+                "Cannot determine GPU topology. "
+                "Assuming GPUs are NOT fully connected."
+            )
+            return False
+        amdsmi_init()
+        try:
+            handles = [amdsmi_get_processor_handles()[i] for i in physical_device_ids]
+            for i, handle in enumerate(handles):
+                for j, peer_handle in enumerate(handles):
+                    if i < j:
+                        try:
+                            link_type = amdsmi_topo_get_link_type(handle, peer_handle)
+                            # type is 2 for XGMI
+                            if link_type["hops"] != 1 or link_type["type"] != 2:
+                                return False
+                        except AmdSmiException as error:
+                            logger.error(
+                                "AMD 1 hop XGMI detection failed.", exc_info=error
+                            )
                             return False
-                    except AmdSmiException as error:
-                        logger.error("AMD 1 hop XGMI detection failed.", exc_info=error)
-                        return False
-        return True
+            return True
+        finally:
+            amdsmi_shut_down()
 
     @classmethod
-    @with_amdsmi_context
     @lru_cache(maxsize=8)
     def get_device_name(cls, device_id: int = 0) -> str:
-        physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        handle = amdsmi_get_processor_handles()[physical_device_id]
-        asic_info = amdsmi_get_gpu_asic_info(handle)
-        asic_info_device_id: str = asic_info["device_id"]
-        if asic_info_device_id in _ROCM_DEVICE_ID_NAME_MAP:
-            return _ROCM_DEVICE_ID_NAME_MAP[asic_info_device_id]
-        return asic_info["market_name"]
+        # Try amdsmi first (no CUDA init), fallback to torch.cuda
+        if _amdsmi_available:
+            try:
+                amdsmi_init()
+                try:
+                    physical_device_id = cls.device_id_to_physical_device_id(device_id)
+                    handle = amdsmi_get_processor_handles()[physical_device_id]
+                    asic_info = amdsmi_get_gpu_asic_info(handle)
+                    asic_info_device_id: str = asic_info["device_id"]
+                    if asic_info_device_id in _ROCM_DEVICE_ID_NAME_MAP:
+                        return _ROCM_DEVICE_ID_NAME_MAP[asic_info_device_id]
+                    return asic_info["market_name"]
+                finally:
+                    amdsmi_shut_down()
+            except Exception as e:
+                logger.debug("Failed to get device name via amdsmi: %s", e)
+        # Fallback: use torch.cuda (works on WSL2 and other
+        # environments where amdsmi is not available)
+        logger.warning_once(
+            "Using torch.cuda fallback for get_device_name(). "
+            "This may return a less specific device name."
+        )
+        return torch.cuda.get_device_name(device_id)
 
     @classmethod
     @with_amdsmi_context


### PR DESCRIPTION
## Problem

On WSL2, `amdsmi` is unavailable because the AMD GPU is exposed via `dxgkrnl` (DirectX paravirtualization) rather than the native `amdgpu` driver — `/dev/kfd` does not exist and UKI is not supported ([AMD docs](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/limitations/limitationsrad.html)).

As a result, `import amdsmi` fails, causing two categories of failures:

1. **Platform detection**: `rocm_platform_plugin()` in `__init__.py` relies solely on amdsmi to detect ROCm — fails to identify the platform entirely
2. **Runtime methods**: `get_device_name()` / `is_fully_connected()` crash at startup with no fallback

> PR #35069 added torch fallbacks for `get_device_capability()` and `_get_gcn_arch()`, but missed these methods and the platform detection path.

## Solution

### 1. Platform detection fallback (`vllm/platforms/__init__.py`)

`rocm_platform_plugin()` now falls back to `torch.version.hip` + `torch.cuda.is_available()` when amdsmi import fails, enabling ROCm platform detection on WSL2.

### 2. Runtime fallbacks (`vllm/platforms/rocm.py`)

- **`_amdsmi_available` flag**: Track whether `amdsmi` was successfully imported
- **`with_amdsmi_context`**: Early check — raises descriptive `RuntimeError` instead of `NameError` when amdsmi is unavailable
- **`get_device_name()`**: Try amdsmi first, fall back to `torch.cuda.get_device_name()` (works on WSL2 via `hipGetDeviceProperties` → `dxgkrnl`)
- **`is_fully_connected()`**: When amdsmi is unavailable, return `False` with warning (safe — WSL2 is typically single-GPU, XGMI topology irrelevant)

## Test

Verified end-to-end on WSL2 + AMD Radeon 8060S (Strix Halo, gfx1151) + ROCm 7.2 + PyTorch 2.10:

```python
# Platform detection
from vllm.platforms import current_platform
assert type(current_platform).__name__ == "RocmPlatform"  # detected via torch.version.hip

# Runtime fallbacks
from vllm.platforms.rocm import RocmPlatform, _amdsmi_available, _GCN_ARCH
assert not _amdsmi_available                          # amdsmi correctly unavailable
assert _GCN_ARCH == "gfx1151"                         # torch fallback works
assert RocmPlatform.get_device_name(0) == "AMD Radeon(TM) 8060S Graphics"
assert RocmPlatform.get_device_capability(0).major == 11
assert RocmPlatform.is_fully_connected([0]) == False  # safe degradation

# End-to-end: vllm serve + inference
import vllm  # no crash
# Qwen2.5-7B-Instruct served successfully, GSM8K accuracy normal
```

- **WSL2 + ROCm**: Platform detection, model loading, and inference all pass
- **Native Linux + ROCm**: No behavior change — amdsmi path used as before

## Related

- PR #35069 — torch fallbacks for `get_device_capability()` / `_get_gcn_arch()` (merged, this PR completes coverage)
- PR #34108 — Dynamo-safe arch detection refactor (merged)
