### PR TITLE
[MoE][Offload] Run MoE models exceeding VRAM via expert CPU offloading with GPU cache (--moe-expert-cache-size)

### DIFF
--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -10,12 +10,14 @@ steps:
   - vllm/
   - tests/basic_correctness/test_basic_correctness
   - tests/basic_correctness/test_cpu_offload
+  - tests/basic_correctness/test_moe_expert_cache
   - tests/basic_correctness/test_mem.py
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s basic_correctness/test_mem.py
   - pytest -v -s basic_correctness/test_basic_correctness.py
   - pytest -v -s basic_correctness/test_cpu_offload.py
+  - pytest -v -s basic_correctness/test_moe_expert_cache.py
   mirror:
     amd:
       dind: false

--- a/docs/features/moe_cache_policies.md
+++ b/docs/features/moe_cache_policies.md
@@ -89,7 +89,7 @@ startup.
 
 The cache is compatible with piecewise CUDA graphs, which is the default
 when `--moe-expert-cache-size` is set without `--enforce-eager`. vLLM adds
-the MoE op (`vllm.moe_forward`) to `splitting_ops` and caps
+the MoE op (`vllm::moe_forward`) to `splitting_ops` and caps
 `cudagraph_mode` at `PIECEWISE`: every non-MoE segment of the model is
 captured and replayed, while the MoE layer — routing, cache management,
 H2D copies, and the grouped GEMM — runs eagerly between segments. The

--- a/docs/features/moe_cache_policies.md
+++ b/docs/features/moe_cache_policies.md
@@ -10,10 +10,6 @@ experts in a fixed-size GPU scratch buffer.
 | `--moe-expert-cache-split` | `token` | How to evaluate a forward that needs more experts than the cache holds: `token` or `expert` |
 
 !!! note
-    Expert caching requires `--enforce-eager`. CUDA graph capture is
-    incompatible with the dynamic Python bookkeeping in `prepare()`.
-
-!!! note
     Expert caching is not compatible with expert parallelism (EP > 1),
     data parallelism, or sequence parallelism.
 
@@ -22,8 +18,7 @@ experts in a fixed-size GPU scratch buffer.
 ```bash
 # OLMoE-1B-7B: 64 experts, fits on 8 GB GPU with 16 cached per layer
 vllm serve allenai/OLMoE-1B-7B-0924 \
-    --moe-expert-cache-size 16 \
-    --enforce-eager
+    --moe-expert-cache-size 16
 ```
 
 ### Python API
@@ -37,7 +32,6 @@ llm = LLM(
     model="allenai/OLMoE-1B-7B-0924",
     moe_expert_cache_size=16,
     moe_expert_cache_split="token",  # or "expert"
-    enforce_eager=True,
 )
 ```
 
@@ -91,12 +85,35 @@ Either way the cache must hold at least `top_k` experts — one token's experts
 have to be resident together, which no split can avoid. That is checked at
 startup.
 
+## CUDA graphs
+
+The cache is compatible with piecewise CUDA graphs, which is the default
+when `--moe-expert-cache-size` is set without `--enforce-eager`. vLLM adds
+the MoE op (`vllm.moe_forward`) to `splitting_ops` and caps
+`cudagraph_mode` at `PIECEWISE`: every non-MoE segment of the model is
+captured and replayed, while the MoE layer — routing, cache management,
+H2D copies, and the grouped GEMM — runs eagerly between segments. The
+cache's GPU buffers and its `expert_map` are allocated once and updated
+in place, so captured segments never observe a stale address.
+
+Full-graph capture (`FULL`, `FULL_AND_PIECEWISE`) is not supported: a
+capture would freeze one forward's cache state into every replay.
+`--enforce-eager` remains available and is required when compilation is
+disabled (`-O0`).
+
+## Known costs
+
+Each MoE layer performs one device sync per forward to read the routing
+decision onto the host (`topk_ids.unique()`); this is the latency floor of
+the current design. Overlapping it with a routing-ahead prefetch is
+planned as a follow-up (see RFC #38256).
+
 ## Observability
 
 ### DEBUG-level hit/miss log
 
 Set `VLLM_LOGGING_LEVEL=DEBUG` to get a per-layer running hit/miss total,
-logged on every `prepare()` call:
+logged every 1000 `prepare()` calls:
 
 ```text
 DEBUG vllm...expert_weight_provider: Expert cache: 1234 hits, 56 misses (95.7% hit rate)

--- a/docs/features/moe_cache_policies.md
+++ b/docs/features/moe_cache_policies.md
@@ -1,0 +1,140 @@
+# MoE Expert Weight Caching
+
+vLLM can run MoE models that exceed available GPU memory by keeping all expert
+weights in CPU pinned memory and caching only the most-recently-used
+experts in a fixed-size GPU scratch buffer.
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `--moe-expert-cache-size N` | `0` (disabled) | Number of expert slots to allocate in the GPU buffer per layer |
+| `--moe-expert-cache-split` | `token` | How to evaluate a forward that needs more experts than the cache holds: `token` or `expert` |
+
+!!! note
+    Expert caching requires `--enforce-eager`. CUDA graph capture is
+    incompatible with the dynamic Python bookkeeping in `prepare()`.
+
+!!! note
+    Expert caching is not compatible with expert parallelism (EP > 1),
+    data parallelism, or sequence parallelism.
+
+## Quick start
+
+```bash
+# OLMoE-1B-7B: 64 experts, fits on 8 GB GPU with 16 cached per layer
+vllm serve allenai/OLMoE-1B-7B-0924 \
+    --moe-expert-cache-size 16 \
+    --enforce-eager
+```
+
+### Python API
+
+`moe_expert_cache_size` is exposed as a direct `LLM` constructor parameter:
+
+```python
+from vllm import LLM, SamplingParams
+
+llm = LLM(
+    model="allenai/OLMoE-1B-7B-0924",
+    moe_expert_cache_size=16,
+    moe_expert_cache_split="token",  # or "expert"
+    enforce_eager=True,
+)
+```
+
+## Architecture (RFC #38256)
+
+The cache is implemented as a `CachedWeightProvider` — the kernel does not
+know or care where weights came from.
+
+### How it works
+
+```text
+Everything fits (the common case, including every decode step):
+  topk_ids -> provider.prepare():
+    hit  -> bump the expert's frequency and recency
+    miss -> evict the lowest-scoring expert, H2D copy into its slot
+  -> kernel.apply(result.w1, result.w2, expert_map=result.expert_map)
+```
+
+Eviction is LFRU rather than plain LRU: an entry scores `freq / age`, so a
+rarely used expert loses to a frequently used one even if the latter was
+touched longer ago. Pure LRU behaves badly here, because MoE layers run in
+sequence and early layers always look recently used.
+
+The provider hands the kernel an `expert_map` — global expert id to buffer
+slot, or `-1` for experts that are not resident — which is the same convention
+expert parallelism uses, so `topk_ids` is passed through untouched. The map
+lives in a GPU `int32` tensor with a pinned host mirror, rebuilt per call and
+uploaded once.
+
+### When the cache is smaller than a forward needs
+
+A single forward can route to more distinct experts than the cache holds; a
+batched prefill routinely routes to nearly all of them. `--moe-expert-cache-split`
+picks how that forward is evaluated.
+
+`token` (default) splits the batch by rows into chunks that fit, and
+concatenates. Each token's full sum still happens inside one kernel call, so
+**output is identical to running without the cache**. The cost is one kernel
+launch per chunk, and as the cache approaches `top_k` no two tokens can share a
+chunk — a long prefill can end up with one launch per token.
+
+`expert` splits the expert set instead: run the whole batch once per group of
+at most `--moe-expert-cache-size` experts, with the map hiding the rest, and
+sum the results. That is `ceil(experts_used / cache_size)` launches whatever
+the batch size, and each expert is fetched at most once per forward instead of
+being refetched as the cache thrashes. **Output differs from the uncached path
+at rounding level**, because each group's partial sum is rounded to the model
+dtype before being accumulated.
+
+Either way the cache must hold at least `top_k` experts — one token's experts
+have to be resident together, which no split can avoid. That is checked at
+startup.
+
+## Observability
+
+### DEBUG-level hit/miss log
+
+Set `VLLM_LOGGING_LEVEL=DEBUG` to get a per-layer running hit/miss total,
+logged on every `prepare()` call:
+
+```text
+DEBUG vllm...expert_weight_provider: Expert cache: 1234 hits, 56 misses (95.7% hit rate)
+```
+
+Read the hit rate as a locality signal only under `--moe-expert-cache-split
+token`. Under `expert`, a forward wider than the cache walks the whole expert
+set group by group, so the rate mostly reports how often that happened rather
+than how well the cache is sized — and the eviction policy has little to do
+either, since each group displaces the last.
+
+## Sizing guidance
+
+Set `--moe-expert-cache-size` to the number of experts that must fit on
+GPU simultaneously per layer. For a model with `E` experts and `top_k`
+routing:
+
+- **Minimum useful**: `top_k` (one slot per active expert per token, no
+  eviction during decode)
+- **Typical decode**: `2 * top_k` – `4 * top_k` gives headroom for
+  locality without wasting VRAM
+- **Maximum** (no-op): `E` (all experts on GPU, equivalent to normal mode)
+
+Below roughly `E / 2` a batched prefill will start needing more experts than
+fit, and `--moe-expert-cache-split` starts to matter. Keep the default `token`
+unless prefill latency is the problem; switch to `expert` when it is, and
+verify the quality impact for your model rather than assuming it is negligible.
+
+## GPU memory note
+
+Expert weights in CPU pinned memory are invisible to the `--gpu-memory-utilization`
+profiler. The profiler will underestimate available KV cache headroom by the
+expert weight footprint (a safe margin, not a hazard), but exact
+`gpu-memory-utilization`-based sizing will be off.
+
+## Tests
+
+```bash
+# Unit tests: CachedWeightProvider
+pytest tests/kernels/moe/test_expert_lru_cache.py -v
+```

--- a/tests/basic_correctness/test_moe_expert_cache.py
+++ b/tests/basic_correctness/test_moe_expert_cache.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for the MoE expert LRU cache (--moe-expert-cache-size).
+
+Runs two vllm serve instances side-by-side via compare_two_settings:
+  - baseline: standard MoE (all experts on GPU)
+  - cache:    expert LRU cache enabled with a small GPU buffer
+
+Token outputs must match exactly.
+"""
+
+import pytest
+
+from ..utils import compare_two_settings
+
+_MOE_MODEL = "RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8"
+
+# The model routes each token to 6 of its 64 experts, so 8 is just above the
+# floor (a forward is split into row chunks, but one token's experts always
+# have to be resident together) and 16 exercises steady eviction.
+_CACHE_SIZES = [8, 16]
+
+
+@pytest.mark.parametrize("cache_size", _CACHE_SIZES)
+def test_moe_expert_cache_correctness(cache_size: int) -> None:
+    """Output tokens from the cache path must match the no-cache baseline."""
+    compare_two_settings(
+        model=_MOE_MODEL,
+        arg1=["--enforce-eager"],
+        arg2=[
+            "--enforce-eager",
+            "--moe-expert-cache-size",
+            str(cache_size),
+        ],
+    )
+
+
+def test_moe_expert_cache_disabled_by_default() -> None:
+    """Verify that the default (cache_size=0) leaves the existing path intact."""
+    compare_two_settings(
+        model=_MOE_MODEL,
+        arg1=["--enforce-eager"],
+        arg2=["--enforce-eager", "--moe-expert-cache-size", "0"],
+    )

--- a/tests/basic_correctness/test_moe_expert_cache.py
+++ b/tests/basic_correctness/test_moe_expert_cache.py
@@ -62,6 +62,21 @@ def test_moe_expert_cache_with_enforce_eager() -> None:
     )
 
 
+def test_moe_expert_cache_piecewise_vs_eager() -> None:
+    """Piecewise CUDA graphs must match enforce-eager with cache enabled.
+
+    Validates the address-stability fix: MoE output is copied to a persistent
+    buffer on PIECEWISE passes so captured graph segments replay against the
+    same address. Without the fix, the workspace buffer relocates during
+    capture and downstream pieces read stale memory.
+    """
+    compare_two_settings(
+        model=_TINY_MOE_MODEL,
+        arg1=_COMMON_ARGS + ["--enforce-eager", "--moe-expert-cache-size", "4"],
+        arg2=_COMMON_ARGS + ["--moe-expert-cache-size", "4"],
+    )
+
+
 @pytest.mark.skipif(
     not _HAS_LARGE_GPU,
     reason="FP8 MoE e2e needs ~16 GB of weights plus KV for two servers; "

--- a/tests/basic_correctness/test_moe_expert_cache.py
+++ b/tests/basic_correctness/test_moe_expert_cache.py
@@ -6,39 +6,71 @@ Runs two vllm serve instances side-by-side via compare_two_settings:
   - baseline: standard MoE (all experts on GPU)
   - cache:    expert LRU cache enabled with a small GPU buffer
 
-Token outputs must match exactly.
+Token outputs must match exactly (the default ``token`` split is bit-exact).
+
+The tiny Qwen3-MoE checkpoint (8 experts, top-2, 6 layers) keeps the main
+cases runnable on small CI devices and covers the unquantized path; the FP8
+case needs the full DeepSeek-Coder-V2-Lite checkpoint (~16 GB weights plus a
+baseline server), so it runs only where a large device is available.
 """
 
 import pytest
+import torch
 
 from ..utils import compare_two_settings
 
-_MOE_MODEL = "RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8"
+# 8 experts, top-2: cache 3 sits just above the one-token floor and forces
+# splitting plus steady eviction; cache 4 (50%) exercises plain eviction.
+_TINY_MOE_MODEL = "nm-testing/tinysmokeqwen3moe"
 
-# The model routes each token to 6 of its 64 experts, so 8 is just above the
-# floor (a forward is split into row chunks, but one token's experts always
-# have to be resident together) and 16 exercises steady eviction.
-_CACHE_SIZES = [8, 16]
+# fp8 quant_method with shared experts; routes top-6 of 64.
+_FP8_MOE_MODEL = "RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8"
+
+_COMMON_ARGS = ["--max-model-len", "2048", "--dtype", "bfloat16"]
+
+_HAS_LARGE_GPU = (
+    torch.cuda.is_available()
+    and torch.cuda.get_device_properties(0).total_memory >= 40 * 2**30
+)
 
 
-@pytest.mark.parametrize("cache_size", _CACHE_SIZES)
+@pytest.mark.parametrize("cache_size", [3, 4])
 def test_moe_expert_cache_correctness(cache_size: int) -> None:
     """Output tokens from the cache path must match the no-cache baseline."""
     compare_two_settings(
-        model=_MOE_MODEL,
-        arg1=["--enforce-eager"],
-        arg2=[
-            "--enforce-eager",
-            "--moe-expert-cache-size",
-            str(cache_size),
-        ],
+        model=_TINY_MOE_MODEL,
+        arg1=_COMMON_ARGS,
+        arg2=_COMMON_ARGS + ["--moe-expert-cache-size", str(cache_size)],
     )
 
 
 def test_moe_expert_cache_disabled_by_default() -> None:
     """Verify that the default (cache_size=0) leaves the existing path intact."""
     compare_two_settings(
-        model=_MOE_MODEL,
-        arg1=["--enforce-eager"],
-        arg2=["--enforce-eager", "--moe-expert-cache-size", "0"],
+        model=_TINY_MOE_MODEL,
+        arg1=_COMMON_ARGS,
+        arg2=_COMMON_ARGS + ["--moe-expert-cache-size", "0"],
+    )
+
+
+def test_moe_expert_cache_with_enforce_eager() -> None:
+    """Cache with explicit --enforce-eager (no CUDA graphs)."""
+    compare_two_settings(
+        model=_TINY_MOE_MODEL,
+        arg1=_COMMON_ARGS + ["--enforce-eager"],
+        arg2=_COMMON_ARGS + ["--enforce-eager", "--moe-expert-cache-size", "4"],
+    )
+
+
+@pytest.mark.skipif(
+    not _HAS_LARGE_GPU,
+    reason="FP8 MoE e2e needs ~16 GB of weights plus KV for two servers; "
+    "requires a >=40 GiB device",
+)
+def test_moe_expert_cache_fp8_correctness() -> None:
+    """FP8 path: slot-indexed scales must reproduce baseline tokens exactly."""
+    compare_two_settings(
+        model=_FP8_MOE_MODEL,
+        arg1=_COMMON_ARGS,
+        arg2=_COMMON_ARGS + ["--moe-expert-cache-size", "16"],
     )

--- a/tests/kernels/moe/test_expert_lru_cache.py
+++ b/tests/kernels/moe/test_expert_lru_cache.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for CachedWeightProvider (LFRU expert cache)."""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.expert_weight_provider import (
+    CachedWeightProvider,
+    ExpertWeightResult,
+)
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+
+NUM_EXPERTS = [8, 64]
+DTYPES = [torch.bfloat16, torch.float16]
+CAPACITIES = [1, 4]
+HIDDEN = 16
+INTERMEDIATE = 32
+
+
+def _make_weights(num_experts: int, dtype: torch.dtype):
+    # Generate in BF16 then cast - torch.randn doesn't support FP8 dtypes
+    w13 = torch.randn(num_experts, 2 * INTERMEDIATE, HIDDEN, dtype=torch.bfloat16)
+    w2 = torch.randn(num_experts, HIDDEN, INTERMEDIATE, dtype=torch.bfloat16)
+    return w13.to(dtype), w2.to(dtype)
+
+
+def _make_scales(num_experts: int):
+    w13_s = torch.rand(num_experts, 1, dtype=torch.float32)
+    w2_s = torch.rand(num_experts, 1, dtype=torch.float32)
+    return w13_s, w2_s
+
+
+def _make_provider(
+    num_experts: int = 8,
+    capacity: int = 4,
+    dtype: torch.dtype = torch.bfloat16,
+    with_scales: bool = False,
+    split: str = "token",
+):
+    set_random_seed(42)
+    w13, w2 = _make_weights(num_experts, dtype)
+    kwargs: dict = dict(capacity=capacity, w13_weight=w13, w2_weight=w2, split=split)
+    scales = None
+    if with_scales:
+        w13_s, w2_s = _make_scales(num_experts)
+        kwargs.update(w13_scale=w13_s, w2_scale=w2_s)
+        scales = (w13_s, w2_s)
+    return CachedWeightProvider(**kwargs), w13, w2, scales
+
+
+def _topk(ids: list[int]) -> torch.Tensor:
+    return torch.tensor(ids, dtype=torch.int32, device="cuda").unsqueeze(0)
+
+
+# -- Core cache behavior --
+
+
+@pytest.mark.parametrize("num_experts", NUM_EXPERTS)
+@pytest.mark.parametrize("capacity", CAPACITIES)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_cold_miss_and_warm_hit(num_experts: int, capacity: int, dtype: torch.dtype):
+    """Cold access misses, repeat access hits. GPU buffer matches source."""
+    provider, w13, w2, _ = _make_provider(num_experts, capacity, dtype)
+    expert_ids = list(range(min(capacity, num_experts)))
+
+    # Cold miss
+    result = provider.prepare(_topk(expert_ids))
+    assert provider.misses == len(expert_ids)
+    assert provider.hits == 0
+    assert isinstance(result, ExpertWeightResult)
+    assert result.w1 is provider.buf_w13
+    assert result.w2 is provider.buf_w2
+    assert result.expert_map.shape == (num_experts,)
+
+    # Verify GPU buffer contents match source weights
+    for eid in expert_ids:
+        slot = provider._lru[eid][0]
+        torch.testing.assert_close(result.w1[slot].cpu(), w13[eid])
+        torch.testing.assert_close(result.w2[slot].cpu(), w2[eid])
+
+    # Warm hit
+    prev_misses = provider.misses
+    provider.prepare(_topk(expert_ids))
+    assert provider.hits == len(expert_ids)
+    assert provider.misses == prev_misses
+
+
+@pytest.mark.parametrize("num_experts", NUM_EXPERTS)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_cache_full_equals_num_experts(num_experts: int, dtype: torch.dtype):
+    """When capacity == num_experts, all fit with zero evictions."""
+    provider, _, _, _ = _make_provider(num_experts, capacity=num_experts, dtype=dtype)
+    all_ids = list(range(num_experts))
+    provider.prepare(_topk(all_ids))
+    assert provider.misses == num_experts
+    assert len(provider._free_slots) == 0
+
+    provider.prepare(_topk(all_ids))
+    assert provider.hits == num_experts
+
+
+@pytest.mark.parametrize("capacity", CAPACITIES)
+def test_expert_map_points_at_slots(capacity: int):
+    """expert_map sends resident experts to their slot and the rest to -1."""
+    provider, _, _, _ = _make_provider(capacity=capacity)
+    ids = list(range(min(capacity, 8)))
+    result = provider.prepare(_topk(ids))
+
+    mapping = result.expert_map.tolist()
+    for eid in ids:
+        assert mapping[eid] == provider._lru[eid][0]
+    for eid in range(len(mapping)):
+        if eid not in provider._lru:
+            assert mapping[eid] == -1
+
+
+@pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
+def test_accepts_either_topk_dtype(dtype: torch.dtype):
+    """topk_ids may be int32 or int64; the map is always int32."""
+    provider, *_ = _make_provider()
+    ids = torch.tensor([[0, 1]], dtype=dtype, device="cuda")
+    result = provider.prepare(ids)
+    assert result.expert_map.dtype == torch.int32
+
+
+# -- LFRU eviction semantics --
+
+
+def test_lfru_prefers_evicting_low_frequency():
+    """LFRU evicts the expert with lowest freq/age score, not pure LRU.
+    A accessed 5x, B accessed 1x. When C arrives, B is evicted, not A.
+    """
+    provider, w13, _, _ = _make_provider(capacity=2)
+    provider.prepare(_topk([0, 1]))
+    for _ in range(4):
+        provider.prepare(_topk([0]))  # A freq=5
+    provider.prepare(_topk([1]))  # touch B for recency parity
+
+    provider.prepare(_topk([2]))  # evicts B (lower freq/age score)
+    assert 0 in provider._lru, "High-frequency expert A should survive"
+    assert 2 in provider._lru, "New expert C should be cached"
+    assert 1 not in provider._lru, "Low-frequency expert B should be evicted"
+    slot_c = provider._lru[2][0]
+    torch.testing.assert_close(provider.buf_w13[slot_c].cpu(), w13[2])
+
+
+def test_lfru_evicts_stale_high_freq_expert():
+    """High historical freq but old last-access loses to recent low-freq.
+    Distinguishes LFRU (score=freq/age) from pure frequency-based caching.
+    """
+    provider, _, _, _ = _make_provider(capacity=2)
+
+    # Expert 0: accessed 11x early, then becomes stale
+    provider.prepare(_topk([0]))
+    for _ in range(10):
+        provider.prepare(_topk([0]))
+    # Expert 1: loaded later, accessed 51x (0 becomes very stale)
+    provider.prepare(_topk([1]))
+    for _ in range(50):
+        provider.prepare(_topk([1]))
+
+    # Expert 0: freq=11, age~62 -> score~0.18. Expert 1: freq=51, age=1 -> 51
+    provider.prepare(_topk([2]))
+    assert 1 in provider._lru, "Recent high-freq expert should survive"
+    assert 0 not in provider._lru, "Stale expert should be evicted"
+
+
+def test_capacity_one_always_evicts():
+    """With capacity=1, every new expert evicts the previous."""
+    provider, *_ = _make_provider(capacity=1)
+    for eid in range(5):
+        provider.prepare(_topk([eid]))
+    assert provider.misses == 5
+    assert provider.hits == 0
+    assert len(provider._lru) == 1
+    assert 4 in provider._lru
+
+
+# -- GPU buffer correctness under eviction --
+
+
+def test_gpu_buffer_correct_after_eviction():
+    """After eviction, the reused slot contains the new expert's weights."""
+    provider, w13, w2, _ = _make_provider(capacity=4)
+    provider.prepare(_topk([0, 1, 2, 3]))
+
+    # Make 0 the eviction candidate (least recently used, lowest freq)
+    provider.prepare(_topk([1, 2, 3]))
+    slot_for_0 = provider._lru[0][0]
+
+    provider.prepare(_topk([7]))
+    assert provider._lru[7][0] == slot_for_0
+    torch.testing.assert_close(provider.buf_w13[slot_for_0].cpu(), w13[7])
+    torch.testing.assert_close(provider.buf_w2[slot_for_0].cpu(), w2[7])
+
+
+def test_batch_experts_survive_intra_batch_eviction():
+    """Every expert in a batch maps to a slot holding its own weights.
+
+    A miss loads the expert with freq=1, the lowest possible LFRU score, so a
+    later miss in the same batch would evict it and reuse its slot while
+    _mapping still points there — feeding the kernel another expert's weights
+    with no error raised.
+    """
+    provider, w13, w2, _ = _make_provider(num_experts=8, capacity=4)
+
+    # Warm every slot with high-frequency experts so the buffer is full and
+    # each resident entry outscores a freshly loaded one.
+    for _ in range(50):
+        provider.prepare(_topk([0, 1, 2, 3]))
+
+    batch = [4, 5, 6, 7]
+    result = provider.prepare(_topk(batch))
+
+    for expert_id in batch:
+        slot = provider._lru[expert_id][0]
+        torch.testing.assert_close(provider.buf_w13[slot].cpu(), w13[expert_id])
+        torch.testing.assert_close(provider.buf_w2[slot].cpu(), w2[expert_id])
+
+    # Every batch expert must be resident, not mapped away.
+    assert all(result.expert_map[e].item() >= 0 for e in batch)
+
+
+# -- Scale buffer handling --
+
+
+def test_scale_lifecycle():
+    """Scales are allocated, copied on load, and updated on eviction."""
+    if not current_platform.has_device_capability(89):
+        pytest.skip("FP8 requires CUDA capability >= 89")
+
+    provider, _, _, scales = _make_provider(
+        capacity=4, dtype=torch.float8_e4m3fn, with_scales=True
+    )
+    w13_s, w2_s = scales
+
+    # Buffers allocated on GPU
+    assert provider.buf_w13_scale is not None
+    assert provider.buf_w2_scale is not None
+    assert provider.buf_w13_scale.device.type == "cuda"
+
+    # Scales copied correctly on load
+    result = provider.prepare(_topk([3, 6]))
+    for eid in [3, 6]:
+        slot = provider._lru[eid][0]
+        torch.testing.assert_close(result.w1_scale[slot].cpu(), w13_s[eid])
+        torch.testing.assert_close(result.w2_scale[slot].cpu(), w2_s[eid])
+
+    # Fill cache and evict: scales must be updated in evicted slot
+    provider.prepare(_topk([0, 1]))  # cache now full: [3, 6, 0, 1]
+    provider.prepare(_topk([3, 6, 0]))  # boost freq on 3,6,0; expert 1 stale
+
+    result = provider.prepare(_topk([7]))  # evicts 1
+    assert 1 not in provider._lru
+    slot_7 = provider._lru[7][0]
+    torch.testing.assert_close(provider.buf_w13_scale[slot_7].cpu(), w13_s[7])
+    torch.testing.assert_close(provider.buf_w2_scale[slot_7].cpu(), w2_s[7])
+
+
+def test_no_scales_when_not_provided():
+    """Without scale inputs, scale buffers remain None."""
+    provider, *_ = _make_provider()
+    assert provider.buf_w13_scale is None
+    assert provider.buf_w2_scale is None
+    result = provider.prepare(_topk([0]))
+    assert result.w1_scale is None
+    assert result.w2_scale is None
+
+
+# -- Invalidation --
+
+
+def test_invalidate_frees_slot():
+    """invalidate() removes an expert and returns its slot to the free list."""
+    provider, *_ = _make_provider()
+    provider.prepare(_topk([0, 1, 2, 3]))
+    old_slot = provider._lru[2][0]
+    provider.invalidate(2)
+    assert 2 not in provider._lru
+    assert old_slot in provider._free_slots
+
+
+def test_invalidate_noop_when_absent():
+    """invalidate() on an uncached expert is a no-op."""
+    provider, *_ = _make_provider()
+    provider.invalidate(99)  # must not raise
+
+
+# -- Overflow (unique experts > capacity) --
+
+
+def test_overflow_raises():
+    """When unique experts exceed capacity, raise RuntimeError immediately."""
+    provider, *_ = _make_provider(capacity=2)
+    with pytest.raises(RuntimeError, match="unique experts"):
+        provider.prepare(_topk([0, 1, 2, 3]))
+
+
+# -- CPU pinned memory --
+
+
+def test_cpu_backing_is_pinned():
+    """CPU weight tensors must be pinned for async H2D copies."""
+    provider, *_ = _make_provider()
+    assert provider._cpu_w13.is_pinned()
+    assert provider._cpu_w2.is_pinned()
+
+
+# -- Expert-group execution --
+
+
+def _rows(rows: list[list[int]]) -> torch.Tensor:
+    return torch.tensor(rows, dtype=torch.int32, device="cuda")
+
+
+def test_single_group_when_experts_fit():
+    """A forward within capacity runs as one group."""
+    provider, *_ = _make_provider(num_experts=8, capacity=4, split="expert")
+    groups = provider.plan_expert_groups(_rows([[0, 1], [1, 2], [2, 3]]))
+    assert groups == [[0, 1, 2, 3]]
+
+
+def test_groups_partition_all_experts():
+    """Every expert appears in exactly one group, and no group overflows."""
+    provider, *_ = _make_provider(num_experts=8, capacity=3, split="expert")
+    topk = _rows([[0, 1], [2, 3], [4, 5], [6, 7]])
+
+    groups = provider.plan_expert_groups(topk)
+
+    assert len(groups) > 1
+    flat = [e for g in groups for e in g]
+    assert sorted(flat) == sorted(topk.unique().tolist())
+    assert len(flat) == len(set(flat)), "an expert landed in two groups"
+    for g in groups:
+        assert len(g) <= provider.capacity
+
+
+def test_group_count_is_independent_of_token_count():
+    """Group count follows the expert set, not the batch size."""
+    provider, *_ = _make_provider(num_experts=8, capacity=4, split="expert")
+    few = _rows([[0, 1], [2, 3], [4, 5], [6, 7]])
+    many = _rows([[0, 1], [2, 3], [4, 5], [6, 7]] * 50)
+    assert len(provider.plan_expert_groups(few)) == len(
+        provider.plan_expert_groups(many)
+    )
+
+
+def test_expert_map_hides_other_groups():
+    """Within a group only that group's experts are resident."""
+    provider, w13, _, _ = _make_provider(num_experts=8, capacity=3, split="expert")
+    topk = _rows([[0, 1], [2, 3], [4, 5], [6, 7]])
+
+    for group in provider.plan_expert_groups(topk):
+        result = provider.prepare(topk, group)
+        mapping = result.expert_map.tolist()
+        for eid in group:
+            slot = mapping[eid]
+            assert slot >= 0
+            torch.testing.assert_close(result.w1[slot].cpu(), w13[eid])
+        resident = {e for e, slot in enumerate(mapping) if slot >= 0}
+        assert resident == set(group)
+
+
+def test_group_execution_covers_every_pair():
+    """Summing over groups touches each (token, expert) pair exactly once."""
+    from vllm.model_executor.layers.fused_moe.expert_weight_provider import (
+        run_with_expert_cache,
+    )
+
+    provider, *_ = _make_provider(num_experts=8, capacity=3, split="expert")
+    topk = _rows([[0, 1], [2, 3], [4, 5], [6, 7]])
+
+    seen: list[int] = []
+    firsts: list[bool] = []
+
+    def run(result, rows, include_shared):
+        firsts.append(include_shared)
+        seen.extend(e for e, slot in enumerate(result.expert_map.tolist()) if slot >= 0)
+        return torch.zeros(topk.size(0), 4, device="cuda")
+
+    out = run_with_expert_cache(provider, topk, run)
+
+    assert sorted(seen) == sorted(topk.unique().tolist())
+    assert firsts[0] is True and not any(firsts[1:]), "first flag must fire once"
+    assert out.shape == (topk.size(0), 4)
+
+
+# -- Token-split execution --
+
+
+def test_token_split_single_chunk_when_batch_fits():
+    """A batch within capacity is evaluated in one piece."""
+    provider, *_ = _make_provider(num_experts=8, capacity=4)
+    plan = provider.plan_chunks(_rows([[0, 1], [1, 2], [2, 3]]))
+    assert [rows for rows, _ in plan] == [slice(0, 3)]
+    assert plan[0][1] == [0, 1, 2, 3]
+
+
+def test_token_split_covers_every_row_once():
+    """Chunks tile the batch, and each fits the cache."""
+    provider, *_ = _make_provider(num_experts=8, capacity=4)
+    topk = _rows([[0, 1], [2, 3], [4, 5], [6, 7]])
+
+    plan = provider.plan_chunks(topk)
+    chunks = [rows for rows, _ in plan]
+
+    assert len(chunks) > 1
+    assert chunks[0].start == 0
+    assert chunks[-1].stop == topk.size(0)
+    for prev, nxt in zip(chunks, chunks[1:]):
+        assert prev.stop == nxt.start
+    for rows, unique_ids in plan:
+        assert topk[rows].unique().numel() <= provider.capacity
+        assert unique_ids == sorted(topk[rows].unique().tolist())
+
+
+def test_token_split_rejects_single_row_over_capacity():
+    """No split helps when one token alone exceeds capacity."""
+    provider, *_ = _make_provider(num_experts=8, capacity=2)
+    with pytest.raises(RuntimeError, match="one token routes to"):
+        provider.plan_chunks(_rows([[0, 1, 2, 3]]))
+
+
+@pytest.mark.parametrize("split", ["token", "expert"])
+def test_both_splits_reach_every_expert(split: str):
+    """Whatever the split, every expert the batch needs gets loaded."""
+    from vllm.model_executor.layers.fused_moe.expert_weight_provider import (
+        run_with_expert_cache,
+    )
+
+    provider, *_ = _make_provider(num_experts=8, capacity=3, split=split)
+    topk = _rows([[0, 1], [2, 3], [4, 5], [6, 7]])
+
+    seen: set[int] = set()
+
+    def run(result, rows, include_shared):
+        seen.update(e for e, s in enumerate(result.expert_map.tolist()) if s >= 0)
+        return torch.zeros(topk[rows].size(0), 4, device="cuda")
+
+    out = run_with_expert_cache(provider, topk, run)
+
+    assert seen == set(topk.unique().tolist())
+    assert out.shape == (topk.size(0), 4)

--- a/vllm/config/offload.py
+++ b/vllm/config/offload.py
@@ -10,6 +10,7 @@ from pydantic import Field, model_validator
 from vllm.config.utils import config
 
 OffloadBackend = Literal["auto", "uva", "prefetch"]
+MoECacheSplit = Literal["token", "expert"]
 
 
 @config
@@ -93,6 +94,20 @@ class OffloadConfig:
 
     prefetch: PrefetchOffloadConfig = Field(default_factory=PrefetchOffloadConfig)
     """Parameters for prefetch offloading backend."""
+
+    moe_expert_cache_size: int = Field(default=0, ge=0)
+    """Number of MoE expert weight rows to keep in a GPU cache buffer."""
+
+    moe_expert_cache_split: MoECacheSplit = "token"
+    """How a forward needing more experts than the cache holds is broken up.
+    - "token": split the batch by rows. Output matches the uncached path
+      exactly, but costs one kernel launch per chunk, approaching one per token
+      as the cache approaches top_k.
+    - "expert": split the expert set and sum the parts. Costs
+      ceil(experts/cache size) launches whatever the batch size, and fetches
+      each expert at most once per forward, but each part is rounded to the
+      model dtype before being summed, so results differ from the uncached
+      path at rounding level."""
 
     @model_validator(mode="after")
     def validate_offload_config(self) -> "OffloadConfig":

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1549,7 +1549,7 @@ class VllmConfig:
                 )
             if cc.splitting_ops is None:
                 cc.splitting_ops = []
-            for op in ("vllm.moe_forward", "vllm.moe_forward_shared"):
+            for op in ("vllm::moe_forward", "vllm::moe_forward_shared"):
                 if op not in cc.splitting_ops:
                     cc.splitting_ops.append(op)
             if cc.cudagraph_mode.has_full_cudagraphs():

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2379,6 +2379,21 @@ class VllmConfig:
             )
         return self
 
+    @model_validator(mode="after")
+    def validate_moe_expert_cache(self) -> "VllmConfig":
+        if self.model_config is None:
+            return self
+        if (
+            self.offload_config.moe_expert_cache_size > 0
+            and not self.model_config.enforce_eager
+        ):
+            raise ValueError(
+                "--moe-expert-cache-size requires --enforce-eager. "
+                "The expert LRU cache uses dynamic Python state in prepare() "
+                "that is incompatible with CUDA graph capture."
+            )
+        return self
+
 
 _current_vllm_config: VllmConfig | None = None
 _current_prefix: str | None = None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1532,6 +1532,35 @@ class VllmConfig:
             data_parallel_size=effective_dp_size,
         )
 
+        # Expert LRU cache: run MoE ops eagerly between piecewise graph segments.
+        # The cache's prepare() is dynamic host code (LFRU bookkeeping, D2H
+        # routing sync, H2D weight copies) and must never be captured.
+        if (
+            self.model_config is not None
+            and self.offload_config.moe_expert_cache_size > 0
+            and not self.model_config.enforce_eager
+        ):
+            cc = self.compilation_config
+            if cc.mode != CompilationMode.VLLM_COMPILE:
+                raise ValueError(
+                    "--moe-expert-cache-size without --enforce-eager requires "
+                    "compilation mode VLLM_COMPILE (piecewise CUDA graphs). "
+                    "Pass --enforce-eager or remove -O overrides."
+                )
+            if cc.splitting_ops is None:
+                cc.splitting_ops = []
+            for op in ("vllm.moe_forward", "vllm.moe_forward_shared"):
+                if op not in cc.splitting_ops:
+                    cc.splitting_ops.append(op)
+            if cc.cudagraph_mode.has_full_cudagraphs():
+                logger.info(
+                    "MoE expert cache: downgrading cudagraph_mode %s -> "
+                    "PIECEWISE; the cache's prepare() must run eagerly "
+                    "between graph segments.",
+                    cc.cudagraph_mode,
+                )
+                cc.cudagraph_mode = CUDAGraphMode.PIECEWISE
+
         if self.compilation_config.pass_config.enable_sp:
             # With pipeline parallelism, native rms norm tracing errors due to
             # incorrect residual shape.
@@ -2376,21 +2405,6 @@ class VllmConfig:
             raise ValueError(
                 "--use-replayssm is incompatible with KV connectors "
                 "(P/D disaggregation, KV cache offload)"
-            )
-        return self
-
-    @model_validator(mode="after")
-    def validate_moe_expert_cache(self) -> "VllmConfig":
-        if self.model_config is None:
-            return self
-        if (
-            self.offload_config.moe_expert_cache_size > 0
-            and not self.model_config.enforce_eager
-        ):
-            raise ValueError(
-                "--moe-expert-cache-size requires --enforce-eager. "
-                "The expert LRU cache uses dynamic Python state in prepare() "
-                "that is incompatible with CUDA graph capture."
             )
         return self
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1532,6 +1532,19 @@ class VllmConfig:
             data_parallel_size=effective_dp_size,
         )
 
+        # Expert cache + LoRA: incompatible due to indexing mismatch.
+        # LoRA adapters index by global expert id; the cache serves slot-indexed
+        # weights. moe_lora_align_block_size would apply wrong adapters.
+        if (
+            self.lora_config is not None
+            and self.offload_config.moe_expert_cache_size > 0
+        ):
+            raise ValueError(
+                "MoE expert caching (--moe-expert-cache-size) is incompatible "
+                "with LoRA. LoRA adapters index by global expert id, but the "
+                "cache serves slot-indexed weights. Disable one or the other."
+            )
+
         # Expert LRU cache: run MoE ops eagerly between piecewise graph segments.
         # The cache's prepare() is dynamic host code (LFRU bookkeeping, D2H
         # routing sync, H2D weight copies) and must never be captured.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -528,6 +528,8 @@ class EngineArgs:
     offload_num_in_group: int = PrefetchOffloadConfig.offload_num_in_group
     offload_prefetch_step: int = PrefetchOffloadConfig.offload_prefetch_step
     offload_params: set[str] = get_field(PrefetchOffloadConfig, "offload_params")
+    moe_expert_cache_size: int = OffloadConfig.moe_expert_cache_size
+    moe_expert_cache_split: str = OffloadConfig.moe_expert_cache_split
     gpu_memory_utilization: float = CacheConfig.gpu_memory_utilization
     kv_cache_memory_bytes: int | None = CacheConfig.kv_cache_memory_bytes
     max_num_batched_tokens: int | None = None
@@ -1274,6 +1276,12 @@ class EngineArgs:
         )
         offload_group.add_argument(
             "--offload-params", **prefetch_kwargs["offload_params"]
+        )
+        offload_group.add_argument(
+            "--moe-expert-cache-size", **offload_kwargs["moe_expert_cache_size"]
+        )
+        offload_group.add_argument(
+            "--moe-expert-cache-split", **offload_kwargs["moe_expert_cache_split"]
         )
 
         # Multimodal related configs
@@ -2449,6 +2457,8 @@ class EngineArgs:
                 offload_prefetch_step=self.offload_prefetch_step,
                 offload_params=self.offload_params,
             ),
+            moe_expert_cache_size=self.moe_expert_cache_size,
+            moe_expert_cache_split=self.moe_expert_cache_split,
         )
 
         if self.gdn_prefill_backend is not None:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -137,6 +137,15 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             these segments will be offloaded (e.g., {"gate_up_proj", "down_proj"}
             for MLP weights, or {"w13_weight", "w2_weight"} for MoE expert
             weights). If None or empty, all parameters are offloaded.
+        moe_expert_cache_size: Number of MoE expert weight rows to keep in a
+            GPU LRU buffer. When greater than zero, expert weights are stored in
+            CPU pinned memory and only the N most-recently-used experts are
+            mirrored onto the GPU on each forward pass. Requires
+            ``enforce_eager=True``. Default is 0 (disabled).
+        moe_expert_cache_split: How a forward wider than the cache is split:
+            "token" (default) reproduces the uncached output exactly;
+            "expert" is much cheaper at small cache sizes but differs at
+            rounding level.
         enforce_eager: Whether to enforce eager execution. If True, we will
             disable CUDA graph and always execute the model in eager mode.
             If False, we will use CUDA graph and eager execution in hybrid.
@@ -199,6 +208,8 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
         offload_num_in_group: int = 1,
         offload_prefetch_step: int = 1,
         offload_params: set[str] | None = None,
+        moe_expert_cache_size: int = 0,
+        moe_expert_cache_split: str = "token",
         enforce_eager: bool = False,
         enable_return_routed_experts: bool = False,
         disable_custom_all_reduce: bool = False,
@@ -315,6 +326,8 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             offload_num_in_group=offload_num_in_group,
             offload_prefetch_step=offload_prefetch_step,
             offload_params=offload_params or set(),
+            moe_expert_cache_size=moe_expert_cache_size,
+            moe_expert_cache_split=moe_expert_cache_split,
             enforce_eager=enforce_eager,
             enable_return_routed_experts=enable_return_routed_experts,
             disable_custom_all_reduce=disable_custom_all_reduce,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -140,8 +140,8 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
         moe_expert_cache_size: Number of MoE expert weight rows to keep in a
             GPU LRU buffer. When greater than zero, expert weights are stored in
             CPU pinned memory and only the N most-recently-used experts are
-            mirrored onto the GPU on each forward pass. Requires
-            ``enforce_eager=True``. Default is 0 (disabled).
+            mirrored onto the GPU on each forward pass. Compatible with
+            piecewise CUDA graphs (the default). Default is 0 (disabled).
         moe_expert_cache_split: How a forward wider than the cache is split:
             "token" (default) reproduces the uncached output exactly;
             "expert" is much cheaper at small cache sizes but differs at

--- a/vllm/model_executor/layers/fused_moe/expert_weight_provider.py
+++ b/vllm/model_executor/layers/fused_moe/expert_weight_provider.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# How a forward too wide for the cache is broken up.
+#   "token"  -- split the rows; every token's full sum still happens inside one
+#               kernel call, so output matches the uncached path exactly. Costs
+#               one launch per chunk, which approaches one per token as
+#               capacity approaches top_k.
+#   "expert" -- split the experts; one launch per ceil(experts/capacity)
+#               regardless of batch size, and each expert is fetched at most
+#               once per forward. Each group's partial sum is rounded to the
+#               model dtype before being accumulated, so results differ from
+#               the uncached path at rounding level.
+MoECacheSplit = Literal["token", "expert"]
+
+# Every row: what the expert split passes, since it never cuts the batch.
+_ALL_ROWS = slice(None)
+
+
+@dataclass
+class ExpertWeightResult:
+    """GPU-resident expert weights ready for kernel consumption.
+
+    ``expert_map`` follows the expert-parallel convention the kernels already
+    understand: global expert id to buffer slot, or -1 for experts that are not
+    resident. Pairs routed to -1 are dropped during alignment, which is what
+    lets one forward be evaluated a group of experts at a time.
+    """
+
+    w1: torch.Tensor
+    w2: torch.Tensor
+    expert_map: torch.Tensor
+    w1_scale: torch.Tensor | None = None
+    w2_scale: torch.Tensor | None = None
+
+
+class CachedWeightProvider:
+    """GPU LRU cache backed by CPU pinned memory.
+
+    Keeps capacity expert weight tensors in a fixed-size GPU scratch
+    buffer. All expert weights reside in CPU pinned memory; only the N
+    hottest experts are mirrored into the GPU buffer.
+
+    Uses LFRU (frequency-weighted LRU) eviction: score = freq / age.
+    This prevents early layers from monopolizing the cache — a known
+    problem with pure LRU in sequential MoE execution where early
+    layers always appear "recently used."
+
+    prepare() copies any missing experts from CPU to GPU, evicting the
+    lowest-scored resident entry when the buffer is full, and returns an
+    ExpertWeightResult whose expert_map selects them. Forwards needing more
+    experts than fit are handled by run_with_expert_cache(), which splits
+    them according to ``split``.
+    """
+
+    def __init__(
+        self,
+        capacity: int,
+        w13_weight: torch.Tensor,
+        w2_weight: torch.Tensor,
+        w13_scale: torch.Tensor | None = None,
+        w2_scale: torch.Tensor | None = None,
+        split: MoECacheSplit = "token",
+    ) -> None:
+        num_experts = w13_weight.size(0)
+
+        self.capacity = capacity
+        self.split: MoECacheSplit = split
+        self._num_experts = num_experts
+        self.hits = 0
+        self.misses = 0
+
+        if w13_weight.device.type == "cpu":
+            cuda_device = torch.accelerator.current_accelerator()
+            self._cpu_w13: torch.Tensor = (
+                w13_weight if w13_weight.is_pinned() else w13_weight.pin_memory()
+            )
+            self._cpu_w2: torch.Tensor = (
+                w2_weight if w2_weight.is_pinned() else w2_weight.pin_memory()
+            )
+        else:
+            cuda_device = w13_weight.device
+            self._cpu_w13 = w13_weight.cpu().pin_memory()
+            self._cpu_w2 = w2_weight.cpu().pin_memory()
+
+        self._buf_w13: torch.Tensor = torch.empty(
+            capacity,
+            *w13_weight.shape[1:],
+            dtype=w13_weight.dtype,
+            device=cuda_device,
+        )
+        self._buf_w2: torch.Tensor = torch.empty(
+            capacity,
+            *w2_weight.shape[1:],
+            dtype=w2_weight.dtype,
+            device=cuda_device,
+        )
+
+        if w13_scale is not None and w2_scale is not None:
+            # Pinned for the same reason the weights are: these are copied on
+            # every miss, and pageable source memory forces a staging copy.
+            self._cpu_w13_scale: torch.Tensor | None = w13_scale.cpu().pin_memory()
+            self._cpu_w2_scale: torch.Tensor | None = w2_scale.cpu().pin_memory()
+            self._buf_w13_scale: torch.Tensor | None = torch.empty(
+                capacity,
+                *w13_scale.shape[1:],
+                dtype=w13_scale.dtype,
+                device=cuda_device,
+            )
+            self._buf_w2_scale: torch.Tensor | None = torch.empty(
+                capacity,
+                *w2_scale.shape[1:],
+                dtype=w2_scale.dtype,
+                device=cuda_device,
+            )
+        else:
+            self._cpu_w13_scale = None
+            self._cpu_w2_scale = None
+            self._buf_w13_scale = None
+            self._buf_w2_scale = None
+
+        # LFRU state: {expert_id: [slot, freq, last_access_clock]}
+        # Eviction score = freq / (clock - last_access + 1). Lower = evict first.
+        self._lru: dict[int, list] = {}
+        self._clock: int = 0
+        self._free_slots: list[int] = list(range(capacity))
+
+        # Expert map handed to the kernel: expert id to slot for the group
+        # being evaluated, -1 for everything else. Rebuilt each prepare() --
+        # it must expose exactly the requested group, not whatever else
+        # happens to still be resident, or experts already summed in an
+        # earlier group would be counted twice. Residency itself lives in
+        # _lru; this is only the view the kernel gets. Built in a pinned host
+        # mirror and uploaded once, rather than a transfer per entry.
+        self._mapping: torch.Tensor = torch.full(
+            (num_experts,), -1, dtype=torch.int32, device=cuda_device
+        )
+        self._mapping_host: torch.Tensor = torch.full(
+            (num_experts,), -1, dtype=torch.int32
+        ).pin_memory()
+
+    @property
+    def buf_w13(self) -> torch.Tensor:
+        return self._buf_w13
+
+    @property
+    def buf_w2(self) -> torch.Tensor:
+        return self._buf_w2
+
+    @property
+    def buf_w13_scale(self) -> torch.Tensor | None:
+        return self._buf_w13_scale
+
+    @property
+    def buf_w2_scale(self) -> torch.Tensor | None:
+        return self._buf_w2_scale
+
+    def invalidate(self, expert_id: int) -> None:
+        """Remove *expert_id* from the cache, returning its slot to the free
+        list.  No-op if the expert is not currently cached."""
+        if expert_id in self._lru:
+            entry = self._lru.pop(expert_id)
+            self._free_slots.append(entry[0])
+
+    @torch.compiler.disable
+    def plan_chunks(self, topk_ids: torch.Tensor) -> list[tuple[slice, list[int]]]:
+        """Row ranges whose combined unique expert count fits the cache.
+
+        Routing is per token, so evaluating a subset of rows and concatenating
+        the results is equivalent to evaluating the whole batch -- and every
+        token's sum still happens in a single kernel call, which is why this
+        split reproduces the uncached output exactly.
+
+        Returns a single full-width slice when the batch already fits, which is
+        the common case, so callers pay nothing extra for it. Each slice comes
+        with the expert ids it needs, computed from host data this method
+        already has, so ``prepare()`` need not synchronize again per chunk.
+
+        Args:
+            topk_ids: Shape ``[num_tokens, top_k]``, global expert IDs.
+
+        Returns:
+            ``(row slice, unique expert ids)`` pairs covering ``topk_ids``.
+
+        Raises:
+            RuntimeError: if one token alone routes to more experts than the
+                cache can hold, which no amount of splitting can fix.
+        """
+        num_rows = topk_ids.size(0)
+        if num_rows == 0:
+            return [(slice(0, 0), [])]
+
+        # The common case only needs the distinct ids, which the device can
+        # reduce far more cheaply than transferring every row.
+        unique = topk_ids.unique()
+        if unique.numel() <= self.capacity:
+            return [(slice(0, num_rows), unique.tolist())]
+
+        rows = topk_ids.tolist()
+        chunks: list[tuple[slice, list[int]]] = []
+        start = 0
+        seen: set[int] = set()
+        for i, row in enumerate(rows):
+            row_ids = set(row)
+            if len(seen | row_ids) > self.capacity:
+                if i == start:
+                    raise RuntimeError(
+                        f"CachedWeightProvider: one token routes to "
+                        f"{len(row_ids)} experts but "
+                        f"--moe-expert-cache-size={self.capacity}. "
+                        f"Set --moe-expert-cache-size >= {len(row_ids)}."
+                    )
+                chunks.append((slice(start, i), sorted(seen)))
+                start = i
+                seen = row_ids
+            else:
+                seen |= row_ids
+        chunks.append((slice(start, num_rows), sorted(seen)))
+        return chunks
+
+    @torch.compiler.disable
+    def plan_expert_groups(self, topk_ids: torch.Tensor) -> list[list[int]]:
+        """Split the forward's experts into groups the cache can hold at once.
+
+        A token's output is the weighted sum of its experts' outputs, so the
+        sum can be taken a few experts at a time and accumulated: run the
+        kernel once per group with an ``expert_map`` that hides the others,
+        then add the results. Every (token, expert) pair is still computed
+        exactly once, in whichever group owns its expert.
+
+        Cost is ``ceil(experts_used / capacity)`` kernel launches, independent
+        of how many tokens are in the batch, and each expert is fetched at most
+        once per forward. Splitting the token axis instead costs one launch per
+        chunk -- one per token once capacity approaches ``top_k`` -- and
+        refetches experts as the cache thrashes.
+
+        Args:
+            topk_ids: Shape ``[num_tokens, top_k]``, global expert IDs.
+
+        Returns:
+            Groups of global expert ids, each no larger than ``capacity``. A
+            single group when everything already fits, which is the common
+            case.
+        """
+        unique = topk_ids.unique().tolist()
+        if len(unique) <= self.capacity:
+            return [unique]
+        return [
+            unique[i : i + self.capacity] for i in range(0, len(unique), self.capacity)
+        ]
+
+    @torch.compiler.disable
+    def prepare(
+        self, topk_ids: torch.Tensor, unique_ids: list[int] | None = None
+    ) -> ExpertWeightResult:
+        """Make a set of experts resident and return the map selecting them.
+
+        Args:
+            topk_ids: Shape ``[num_tokens, top_k]``, global expert IDs. Only
+                read when ``unique_ids`` is not supplied.
+            unique_ids: The experts to make resident. Both planners already
+                know this, and passing it avoids a device synchronization --
+                which matters, because a split forward calls this once per
+                piece.
+
+        Returns:
+            ExpertWeightResult holding the GPU buffers and an ``expert_map``
+            exposing exactly these experts, everything else -1.
+
+        Raises:
+            RuntimeError: if more experts are requested than the cache holds.
+        """
+        if unique_ids is None:
+            unique_ids = topk_ids.unique().tolist()
+        if len(unique_ids) > self.capacity:
+            raise RuntimeError(
+                f"CachedWeightProvider: {len(unique_ids)} unique experts "
+                f"requested but --moe-expert-cache-size={self.capacity}. "
+                f"Set --moe-expert-cache-size >= {len(unique_ids)}."
+            )
+
+        # Experts requested here must never be evicted to make room for
+        # another one in the same call -- their slot would be handed to a
+        # different expert while they are still expected to be resident. A
+        # freshly loaded expert has freq=1, exactly the lowest LFRU score, so
+        # it is the first eviction candidate. The map built at the end reads
+        # every requested expert back out of _lru, so violating this raises
+        # rather than corrupting silently, but it must not happen at all.
+        needed = set(unique_ids)
+
+        for expert_id in unique_ids:
+            if expert_id in self._lru:
+                # Cache hit: update frequency and recency
+                self._clock += 1
+                entry = self._lru[expert_id]
+                entry[1] += 1  # freq
+                entry[2] = self._clock  # last access
+                self.hits += 1
+            else:
+                # Cache miss: need to load expert
+                if self._free_slots:
+                    slot = self._free_slots.pop()
+                else:
+                    # Evict entry with lowest freq/age score
+                    best_key = None
+                    best_score = float("inf")
+                    for k, (s, freq, last) in self._lru.items():
+                        if k in needed:
+                            continue
+                        age = self._clock - last + 1
+                        score = freq / age
+                        if score < best_score:
+                            best_score = score
+                            best_key = k
+                    # len(unique_ids) <= capacity is enforced above, so at least
+                    # one cached expert is outside `needed` whenever the buffer
+                    # is full and a miss remains to be served.
+                    assert best_key is not None
+                    slot = self._lru.pop(best_key)[0]
+
+                # Copy expert weights from CPU to GPU slot
+                self._buf_w13[slot].copy_(self._cpu_w13[expert_id], non_blocking=True)
+                self._buf_w2[slot].copy_(self._cpu_w2[expert_id], non_blocking=True)
+                if self._buf_w13_scale is not None:
+                    assert self._cpu_w13_scale is not None
+                    assert self._cpu_w2_scale is not None
+                    assert self._buf_w2_scale is not None
+                    self._buf_w13_scale[slot].copy_(
+                        self._cpu_w13_scale[expert_id], non_blocking=True
+                    )
+                    self._buf_w2_scale[slot].copy_(
+                        self._cpu_w2_scale[expert_id], non_blocking=True
+                    )
+
+                self._clock += 1
+                self._lru[expert_id] = [slot, 1, self._clock]
+                self.misses += 1
+
+        total = self.hits + self.misses
+        if total > 0:
+            logger.debug(
+                "Expert cache: %d hits, %d misses (%.1f%% hit rate)",
+                self.hits,
+                self.misses,
+                100.0 * self.hits / total,
+            )
+
+        # Expose exactly this group. Blocking on purpose: the host mirror is
+        # rewritten by the next group, so an async copy could still be reading
+        # it when that happens.
+        self._mapping_host.fill_(-1)
+        for expert_id in unique_ids:
+            self._mapping_host[expert_id] = self._lru[expert_id][0]
+        self._mapping.copy_(self._mapping_host)
+
+        return ExpertWeightResult(
+            w1=self._buf_w13,
+            w2=self._buf_w2,
+            expert_map=self._mapping,
+            w1_scale=self._buf_w13_scale,
+            w2_scale=self._buf_w2_scale,
+        )
+
+
+def run_with_expert_cache(
+    provider: CachedWeightProvider,
+    topk_ids: torch.Tensor,
+    run: Callable[[ExpertWeightResult, slice, bool], torch.Tensor],
+) -> torch.Tensor:
+    """Evaluate a MoE forward through the expert cache.
+
+    ``run`` receives the resident weights with the ``expert_map`` selecting
+    them, the rows it should evaluate, and whether it should include work that
+    belongs to the forward as a whole rather than to this call -- shared
+    experts, most importantly. It sees the original ``topk_ids``; the map is
+    what restricts each call to the resident experts.
+
+    The two splits differ only in what is cut. ``"token"`` cuts rows and
+    concatenates, so each token's sum stays inside one kernel call and the
+    result matches the uncached path exactly. ``"expert"`` cuts the expert set
+    and sums, which costs far fewer launches when capacity is small but rounds
+    each group's partial sum to the model dtype.
+
+    When everything fits -- the common case for both splits -- ``run`` is
+    called exactly once and its result returned untouched.
+    """
+    if provider.split == "expert":
+        groups = provider.plan_expert_groups(topk_ids)
+        if len(groups) == 1:
+            return run(provider.prepare(topk_ids, groups[0]), _ALL_ROWS, True)
+
+        # Accumulate in fp32. It does not recover what each group already lost
+        # rounding to the model dtype, but it keeps the sum from losing more.
+        accumulator: torch.Tensor | None = None
+        out_dtype: torch.dtype | None = None
+        for i, expert_ids in enumerate(groups):
+            part = run(provider.prepare(topk_ids, expert_ids), _ALL_ROWS, i == 0)
+            if accumulator is None:
+                accumulator, out_dtype = part.float(), part.dtype
+            else:
+                accumulator += part.float()
+        assert accumulator is not None and out_dtype is not None
+        return accumulator.to(out_dtype)
+
+    plan = provider.plan_chunks(topk_ids)
+    if len(plan) == 1:
+        rows, unique_ids = plan[0]
+        return run(provider.prepare(topk_ids, unique_ids), rows, True)
+    return torch.cat(
+        [
+            run(provider.prepare(topk_ids[rows], unique_ids), rows, True)
+            for rows, unique_ids in plan
+        ],
+        dim=0,
+    )

--- a/vllm/model_executor/layers/fused_moe/expert_weight_provider.py
+++ b/vllm/model_executor/layers/fused_moe/expert_weight_provider.py
@@ -11,6 +11,23 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
+_STATS_LOG_INTERVAL = 1000
+
+
+def _pinned_cpu_copy(src: torch.Tensor) -> torch.Tensor:
+    """Pinned CPU copy of *src* with exactly one cross-device transfer.
+
+    ``src.cpu().pin_memory()`` stages GPU tensors through pageable memory,
+    copying twice; copying straight into a pinned allocation halves init
+    time and transient host RAM for multi-GB expert tensors.
+    """
+    if src.device.type == "cpu":
+        return src if src.is_pinned() else src.pin_memory()
+    dst = torch.empty_like(src, device="cpu", pin_memory=True)
+    dst.copy_(src)
+    return dst
+
+
 # How a forward too wide for the cache is broken up.
 #   "token"  -- split the rows; every token's full sum still happens inside one
 #               kernel call, so output matches the uncached path exactly. Costs
@@ -79,19 +96,14 @@ class CachedWeightProvider:
         self._num_experts = num_experts
         self.hits = 0
         self.misses = 0
+        self._prepare_calls = 0
 
         if w13_weight.device.type == "cpu":
             cuda_device = torch.accelerator.current_accelerator()
-            self._cpu_w13: torch.Tensor = (
-                w13_weight if w13_weight.is_pinned() else w13_weight.pin_memory()
-            )
-            self._cpu_w2: torch.Tensor = (
-                w2_weight if w2_weight.is_pinned() else w2_weight.pin_memory()
-            )
         else:
             cuda_device = w13_weight.device
-            self._cpu_w13 = w13_weight.cpu().pin_memory()
-            self._cpu_w2 = w2_weight.cpu().pin_memory()
+        self._cpu_w13: torch.Tensor = _pinned_cpu_copy(w13_weight)
+        self._cpu_w2: torch.Tensor = _pinned_cpu_copy(w2_weight)
 
         self._buf_w13: torch.Tensor = torch.empty(
             capacity,
@@ -109,8 +121,8 @@ class CachedWeightProvider:
         if w13_scale is not None and w2_scale is not None:
             # Pinned for the same reason the weights are: these are copied on
             # every miss, and pageable source memory forces a staging copy.
-            self._cpu_w13_scale: torch.Tensor | None = w13_scale.cpu().pin_memory()
-            self._cpu_w2_scale: torch.Tensor | None = w2_scale.cpu().pin_memory()
+            self._cpu_w13_scale: torch.Tensor | None = _pinned_cpu_copy(w13_scale)
+            self._cpu_w2_scale: torch.Tensor | None = _pinned_cpu_copy(w2_scale)
             self._buf_w13_scale: torch.Tensor | None = torch.empty(
                 capacity,
                 *w13_scale.shape[1:],
@@ -346,14 +358,16 @@ class CachedWeightProvider:
                 self._lru[expert_id] = [slot, 1, self._clock]
                 self.misses += 1
 
-        total = self.hits + self.misses
-        if total > 0:
-            logger.debug(
-                "Expert cache: %d hits, %d misses (%.1f%% hit rate)",
-                self.hits,
-                self.misses,
-                100.0 * self.hits / total,
-            )
+        self._prepare_calls += 1
+        if self._prepare_calls % _STATS_LOG_INTERVAL == 0:
+            total = self.hits + self.misses
+            if total > 0:
+                logger.debug(
+                    "Expert cache: %d hits, %d misses (%.1f%% hit rate)",
+                    self.hits,
+                    self.misses,
+                    100.0 * self.hits / total,
+                )
 
         # Expose exactly this group. Blocking on purpose: the host mirror is
         # rewritten by the next group, so an async copy could still be reading

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -36,6 +36,16 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         self.moe_kernel: mk.FusedMoEKernel | None = None
 
     @property
+    def supports_expert_lru_cache(self) -> bool:
+        """True if this quant method is compatible with expert LRU caching.
+
+        Subclasses override to True when the method allocates w13_weight /
+        w2_weight in the standard per-expert layout and does not reorder or
+        repack weights in a way that is incompatible with slot-based remapping.
+        """
+        return False
+
+    @property
     def supports_internal_mk(self) -> bool:
         # NOTE(rob): temporary attribute to indicate support for
         # completed migration to the new internal MK interface.

--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -10,6 +10,10 @@ from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
+from vllm.model_executor.layers.fused_moe.expert_weight_provider import (
+    ExpertWeightResult,
+    run_with_expert_cache,
+)
 from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
     FusedMoEMethodBase,
 )
@@ -103,6 +107,35 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
         shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
         assert self.moe_kernel is not None
+
+        provider = layer.expert_weight_provider
+        if provider is not None:
+
+            def run(
+                result: ExpertWeightResult, rows: slice, include_shared: bool
+            ) -> torch.Tensor:
+                assert self.moe_kernel is not None
+                return self.moe_kernel.apply(
+                    hidden_states=x[rows],
+                    w1=result.w1,
+                    w2=result.w2,
+                    topk_weights=topk_weights[rows],
+                    topk_ids=topk_ids[rows],
+                    activation=layer.activation,
+                    global_num_experts=layer.global_num_experts,
+                    apply_router_weight_on_input=(layer.apply_router_weight_on_input),
+                    expert_map=result.expert_map,
+                    # Shared experts belong to the forward, not to one call.
+                    shared_experts=shared_experts if include_shared else None,
+                    shared_experts_input=(
+                        shared_experts_input[rows]
+                        if include_shared and shared_experts_input is not None
+                        else None
+                    ),
+                )
+
+            return run_with_expert_cache(provider, topk_ids, run)
+
         return self.moe_kernel.apply(
             hidden_states=x,
             w1=layer.w13_weight,

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -213,12 +213,17 @@ class RoutedExperts(PluggableLayer):
                 "moe_expert_cache_size is not compatible with data parallelism "
                 "or sequence parallelism."
             )
-        if not get_current_vllm_config().model_config.enforce_eager:
-            raise ValueError(
-                "moe_expert_cache_size requires --enforce-eager; CUDA graph "
-                "capture with an active expert cache produces incorrect "
-                "results."
-            )
+        vllm_config = get_current_vllm_config()
+        if not vllm_config.model_config.enforce_eager:
+            splitting_ops = vllm_config.compilation_config.splitting_ops or []
+            if "vllm.moe_forward" not in splitting_ops:
+                raise ValueError(
+                    "moe_expert_cache_size without --enforce-eager requires "
+                    "the MoE op to run outside CUDA graphs "
+                    "(vllm.moe_forward in compilation_config.splitting_ops). "
+                    "This is configured automatically by VllmConfig; do not "
+                    "override splitting_ops to exclude it."
+                )
         # Checked before create_weights: an unsupported method would still get
         # its expert weights allocated in CPU pinned memory below and then run
         # its normal setup against them, which is not a supported combination.

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -256,7 +256,15 @@ class RoutedExperts(PluggableLayer):
                 scales (``weight_scale``, or ``weight_scale_inv`` for
                 block-quantized checkpoints).
         """
-        if self._moe_expert_cache_size == 0 or self.expert_weight_provider is not None:
+        if self.expert_weight_provider is not None:
+            # process_weights_after_loading can be re-run for RL-style weight
+            # updates; the provider's CPU mirror and the freed layer params
+            # would go stale silently. Refuse until reload support exists.
+            raise RuntimeError(
+                "Re-running weight loading with an active expert cache is "
+                "not supported (moe_expert_cache_size > 0)."
+            )
+        if self._moe_expert_cache_size == 0:
             return
         if not hasattr(self, "w13_weight") or not hasattr(self, "w2_weight"):
             raise ValueError(

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import torch
 
+from vllm.config import get_current_vllm_config
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
@@ -25,8 +26,12 @@ from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
 )
+from vllm.model_executor.utils import replace_parameter
 
 if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe.expert_weight_provider import (
+        CachedWeightProvider,
+    )
     from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
 
 
@@ -170,9 +175,154 @@ class RoutedExperts(PluggableLayer):
                 self.moe_config.intermediate_size
             )
 
+        # The provider itself is built after weights are loaded, in
+        # _maybe_init_expert_lru_cache(). The size is read here so that
+        # create_weights() can allocate expert weights in CPU pinned memory
+        # when offloading is requested.
+        self.expert_weight_provider: CachedWeightProvider | None = None
+        offload_config = get_current_vllm_config().offload_config
+        self._moe_expert_cache_size = offload_config.moe_expert_cache_size
+        self._moe_expert_cache_split = offload_config.moe_expert_cache_split
+        if self._moe_expert_cache_size > 0:
+            self._validate_expert_cache_supported()
+
         self.quant_method.create_weights(layer=self, **moe_quant_params)
 
         self.lora_base_layer_prefix = ""
+
+    def _validate_expert_cache_supported(self) -> None:
+        # A forward is split into row chunks that fit the cache, so the floor is
+        # one token's worth of experts -- below that no split helps. Check the
+        # effective capacity, which is what the cache is actually built with.
+        top_k = self.moe_config.experts_per_token
+        capacity = min(self._moe_expert_cache_size, self.local_num_experts)
+        if capacity < top_k:
+            raise ValueError(
+                f"moe_expert_cache_size={self._moe_expert_cache_size} gives a "
+                f"cache of {capacity} slots, fewer than the {top_k} experts a "
+                f"single token routes to. Set --moe-expert-cache-size >= {top_k}."
+            )
+        parallel = self.moe_config.moe_parallel_config
+        if parallel.use_ep:
+            raise ValueError(
+                "moe_expert_cache_size is not compatible with expert "
+                f"parallelism (ep_size={parallel.ep_size})."
+            )
+        if parallel.dp_size > 1 or parallel.is_sequence_parallel:
+            raise ValueError(
+                "moe_expert_cache_size is not compatible with data parallelism "
+                "or sequence parallelism."
+            )
+        if not get_current_vllm_config().model_config.enforce_eager:
+            raise ValueError(
+                "moe_expert_cache_size requires --enforce-eager; CUDA graph "
+                "capture with an active expert cache produces incorrect "
+                "results."
+            )
+        # Checked before create_weights: an unsupported method would still get
+        # its expert weights allocated in CPU pinned memory below and then run
+        # its normal setup against them, which is not a supported combination.
+        if not self.quant_method.supports_expert_lru_cache:
+            raise ValueError(
+                "moe_expert_cache_size is not supported by "
+                f"{self.quant_method.__class__.__name__} with the active "
+                "backend; its weight layout is incompatible with slot-based "
+                "expert remapping."
+            )
+
+    def _maybe_init_expert_lru_cache(self, scale_suffix: str = "weight_scale") -> None:
+        """Build the expert weight provider once weights have been loaded.
+
+        Expert weights may reside on CPU (loaded directly into pinned memory
+        when GPU capacity is insufficient) or on GPU (standard load path).
+        Allocates GPU scratch buffers of size ``moe_expert_cache_size`` and
+        releases the full weight tensors from whichever device they were on.
+
+        Per-expert weight scales are handed the same treatment: the layer's
+        scale parameters are repointed at the cache's slot-indexed buffers, so
+        a quant config built after this call reads scales that stay in sync
+        with the weights the kernel is given. Callers whose quant config is
+        already built must call this before building it.
+
+        Must be called only once, after weights are in their runtime layout.
+
+        Args:
+            scale_suffix: Parameter-name suffix for the per-expert weight
+                scales (``weight_scale``, or ``weight_scale_inv`` for
+                block-quantized checkpoints).
+        """
+        if self._moe_expert_cache_size == 0 or self.expert_weight_provider is not None:
+            return
+        if not hasattr(self, "w13_weight") or not hasattr(self, "w2_weight"):
+            raise ValueError(
+                "moe_expert_cache_size requires w13_weight and w2_weight "
+                f"parameters but they are missing on layer {self.layer_name}."
+            )
+        if self.moe_config.has_bias:
+            raise ValueError(
+                "Expert LRU cache does not support MoE layers with bias "
+                "terms (fused_experts() receives w1/w2 only, not bias). "
+                f"Layer: {self.layer_name}."
+            )
+        from vllm.model_executor.layers.fused_moe.expert_weight_provider import (
+            CachedWeightProvider,
+        )
+
+        # Only scales indexed by expert need remapping. Anything else (a global
+        # or per-tensor scale) is slot-agnostic and is left on the layer.
+        w13_scale_name = f"w13_{scale_suffix}"
+        w2_scale_name = f"w2_{scale_suffix}"
+        w13_scale = getattr(self, w13_scale_name, None)
+        w2_scale = getattr(self, w2_scale_name, None)
+        per_expert_scales = (
+            w13_scale is not None
+            and w2_scale is not None
+            and w13_scale.size(0) == self.local_num_experts
+            and w2_scale.size(0) == self.local_num_experts
+        )
+        if not per_expert_scales:
+            w13_scale = None
+            w2_scale = None
+
+        capacity = min(self._moe_expert_cache_size, self.local_num_experts)
+        provider = CachedWeightProvider(
+            capacity=capacity,
+            w13_weight=cast(torch.Tensor, self.w13_weight).data,
+            w2_weight=cast(torch.Tensor, self.w2_weight).data,
+            w13_scale=w13_scale,
+            w2_scale=w2_scale,
+            split=self._moe_expert_cache_split,
+        )
+        self.expert_weight_provider = provider
+
+        # Repoint the scale parameters at the cache's slot-indexed buffers.
+        # Without this the kernel would index full-length, expert-indexed
+        # scales with slot ids and scale every expert by whichever one happens
+        # to occupy its slot.
+        if provider.buf_w13_scale is not None:
+            assert provider.buf_w2_scale is not None
+            # A quant config that already exists captured the expert-indexed
+            # scales, and the kernel keeps whatever it captured -- repointing
+            # now would be too late and silently wrong. Callers with scales
+            # must install the cache before building their quant config.
+            assert self.quant_method.moe_quant_config is None, (
+                f"expert cache installed after {type(self.quant_method).__name__}"
+                " built its quant config; the kernel is holding expert-indexed"
+                " scales that the cache cannot keep in sync"
+            )
+            replace_parameter(self, w13_scale_name, provider.buf_w13_scale)
+            replace_parameter(self, w2_scale_name, provider.buf_w2_scale)
+
+        # Release the full weight tensors (CachedWeightProvider holds its own
+        # reference to the CPU pinned backing store).
+        replace_parameter(self, "w13_weight", torch.empty(0))
+        replace_parameter(self, "w2_weight", torch.empty(0))
+        logger.info(
+            "Expert LRU cache enabled for %s: %d/%d experts cached on GPU.",
+            self.layer_name,
+            capacity,
+            self.local_num_experts,
+        )
 
     # TODO(bnell): Temporary hack. Get rid of this.
     def _replace_quant_method(self, quant_method: FusedMoEMethodBase):

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -216,11 +216,11 @@ class RoutedExperts(PluggableLayer):
         vllm_config = get_current_vllm_config()
         if not vllm_config.model_config.enforce_eager:
             splitting_ops = vllm_config.compilation_config.splitting_ops or []
-            if "vllm.moe_forward" not in splitting_ops:
+            if "vllm::moe_forward" not in splitting_ops:
                 raise ValueError(
                     "moe_expert_cache_size without --enforce-eager requires "
                     "the MoE op to run outside CUDA graphs "
-                    "(vllm.moe_forward in compilation_config.splitting_ops). "
+                    "(vllm::moe_forward in compilation_config.splitting_ops). "
                     "This is configured automatically by VllmConfig; do not "
                     "override splitting_ops to exclude it."
                 )

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import torch
 import torch.nn.functional as F
 
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config
 from vllm.config.parallel import ExpertPlacementStrategy
 from vllm.distributed import (
     get_ep_group,
@@ -124,11 +124,13 @@ def _moe_forward(
     hidden_dim_unpadded: int,
 ) -> torch.Tensor:
     layer = get_layer_from_name(_resolve_layer_name(layer_name))
-    return layer._forward_impl(
-        hidden_states,
-        router_logits,
-        shared_experts_input,
-        input_ids,
+    return layer._maybe_stabilize_output(
+        layer._forward_impl(
+            hidden_states,
+            router_logits,
+            shared_experts_input,
+            input_ids,
+        )
     )
 
 
@@ -158,11 +160,13 @@ def _moe_forward_shared(
     hidden_dim_unpadded: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     layer = get_layer_from_name(_resolve_layer_name(layer_name))
-    return layer._forward_impl(
-        hidden_states,
-        router_logits,
-        shared_experts_input,
-        input_ids,
+    return layer._maybe_stabilize_output(
+        layer._forward_impl(
+            hidden_states,
+            router_logits,
+            shared_experts_input,
+            input_ids,
+        )
     )
 
 
@@ -289,8 +293,77 @@ class MoERunner(MoERunnerInterface):
 
         self._forward_entry = self._select_forward()
 
+        vllm_config = get_current_vllm_config()
+
+        # Piecewise CUDA graphs replay each captured piece against the input
+        # addresses recorded at capture time (see CUDAGraphWrapper) -- piece
+        # inputs are never copied. When the moe op is a splitting op (the
+        # expert cache's mode), its output feeds the next piece from eager
+        # code, so it must land at a capture-stable address on every step.
+        # The kernels return workspace views, and the workspace reallocates
+        # as capture sizes grow, so that address moves between capture and
+        # replay and the downstream piece reads stale memory. Route the
+        # output through a per-runner persistent buffer instead. Only
+        # PIECEWISE passes need it (batches above the capture limit run
+        # unreplayed with real dataflow), so the buffer is bounded by the
+        # largest capture size, not the scheduler limit.
+        cc = vllm_config.compilation_config
+        self._stable_moe_output = (
+            vllm_config.model_config is not None
+            and not vllm_config.model_config.enforce_eager
+            and cc.cudagraph_mode != CUDAGraphMode.NONE
+            and "vllm::moe_forward" in (cc.splitting_ops or [])
+        )
+        self._stable_output_rows = (
+            cc.max_cudagraph_capture_size or 0 if self._stable_moe_output else 0
+        )
+        self._stable_output_bufs: dict[tuple, torch.Tensor] = {}
+
         # For smuggling this layer into the fused moe custom op
-        register_layer_for_moe_forward_op(get_current_vllm_config(), self)
+        register_layer_for_moe_forward_op(vllm_config, self)
+
+    def _maybe_stabilize_output(
+        self, result: torch.Tensor | tuple[torch.Tensor, torch.Tensor]
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        """Return *result* at a capture-stable address on PIECEWISE passes.
+
+        See the contract note in ``__init__``. Each layer owns its own buffer
+        keyed by (role, width, dtype); the buffer is allocated lazily and
+        reused across forward calls.
+        """
+        if not self._stable_moe_output:
+            return result
+        if not is_forward_context_available():
+            return result
+        ctx = get_forward_context()
+        if ctx.cudagraph_runtime_mode != CUDAGraphMode.PIECEWISE:
+            return result
+        if isinstance(result, tuple):
+            shared_out, fused_out = result
+            return (
+                self._stable_copy(shared_out, 0),
+                self._stable_copy(fused_out, 1),
+            )
+        return self._stable_copy(result, 0)
+
+    def _stable_copy(self, t: torch.Tensor, role: int) -> torch.Tensor:
+        if t.dim() != 2 or t.size(0) > self._stable_output_rows:
+            raise RuntimeError(
+                f"MoE output shape {tuple(t.shape)} exceeds stabilization "
+                f"buffer (max rows {self._stable_output_rows}); CUDA graph "
+                f"replay would read stale addresses. This indicates a bug in "
+                f"capture-size configuration or an unsupported batch size."
+            )
+        key = (role, t.size(-1), t.dtype)
+        buf = self._stable_output_bufs.get(key)
+        if buf is None:
+            buf = torch.empty(
+                self._stable_output_rows, t.size(-1), dtype=t.dtype, device=t.device
+            )
+            self._stable_output_bufs[key] = buf
+        out = buf[: t.size(0)]
+        out.copy_(t)
+        return out
 
     def load_weights(
         self, weights: Iterable[tuple[str, torch.Tensor]]

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -52,17 +52,14 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
 
     @property
     def supports_expert_lru_cache(self) -> bool:
-        # Only backends that do not reorder or shuffle weights at load time.
-        # FLASHINFER_TRTLLM: tiled block layout, incompatible with slot remapping.
-        # FLASHINFER_CUTLASS: requires swap_w13_to_w31.
-        # AITER: requires shuffle_weights + is_shuffled flag.
-        # TPU/OOT: untested, conservative exclusion.
-        return self.unquantized_backend in (
-            UnquantizedMoeBackend.TRITON,
-            UnquantizedMoeBackend.BATCHED_TRITON,
-            UnquantizedMoeBackend.CPU,
-            UnquantizedMoeBackend.XPU,
-        )
+        # Only TRITON: it genuinely honors expert_map via moe_align_block_size.
+        # BATCHED_TRITON: expert_map is signature-only, tokens dispatched by
+        #   global id into slot-indexed weights.
+        # CPU: prepack reads layer.w13_weight which the cache empties.
+        # XPU: expert_map signature-only, snapshots w1/w2 on first call.
+        # FLASHINFER_*: tiled layouts or swap_w13_to_w31 required.
+        # AITER: requires shuffle_weights.
+        return self.unquantized_backend == UnquantizedMoeBackend.TRITON
 
     def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -14,6 +14,10 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     biased_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.expert_weight_provider import (
+    ExpertWeightResult,
+    run_with_expert_cache,
+)
 from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
     FusedMoEMethodBase,
 )
@@ -45,6 +49,12 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
     """MoE method without quantization."""
 
     # --8<-- [end:unquantized_fused_moe]
+
+    @property
+    def supports_expert_lru_cache(self) -> bool:
+        # FLASHINFER_TRTLLM reorders weights into a tiled block layout that is
+        # incompatible with the generic per-expert slot-based remapping.
+        return self.unquantized_backend != UnquantizedMoeBackend.FLASHINFER_TRTLLM
 
     def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)
@@ -88,14 +98,25 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             w13_up_dim = 2 * intermediate_size_per_partition
         else:
             w13_up_dim = intermediate_size_per_partition
+
+        # With the expert LRU cache enabled, expert weights are allocated in CPU
+        # pinned memory so checkpoint loading never needs GPU capacity for them;
+        # the cache later mirrors only moe_expert_cache_size of them onto the
+        # GPU. device="cpu" is explicit because vLLM loads under a
+        # torch.device("cuda") context, which pin_memory() alone would not
+        # override.
+        expert_weights_on_cpu = getattr(layer, "_moe_expert_cache_size", 0) > 0
+
+        def _empty_expert_weight(*shape: int) -> torch.Tensor:
+            if expert_weights_on_cpu:
+                return torch.empty(
+                    *shape, dtype=params_dtype, device="cpu"
+                ).pin_memory()
+            return torch.empty(*shape, dtype=params_dtype)
+
         # Fused gate_up_proj (column parallel)
         w13_weight = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                w13_up_dim,
-                hidden_size,
-                dtype=params_dtype,
-            ),
+            _empty_expert_weight(num_experts, w13_up_dim, hidden_size),
             requires_grad=False,
         )
         layer.register_parameter("w13_weight", w13_weight)
@@ -109,11 +130,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             set_weight_attrs(w13_bias, extra_weight_attrs)
         # down_proj (row parallel)
         w2_weight = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                hidden_size,
-                intermediate_size_per_partition,
-                dtype=params_dtype,
+            _empty_expert_weight(
+                num_experts, hidden_size, intermediate_size_per_partition
             ),
             requires_grad=False,
         )
@@ -231,6 +249,23 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                 w13=w13,
                 w2=w2,
             )
+            layer._maybe_init_expert_lru_cache()
+        elif layer._moe_expert_cache_size > 0:
+            # Expert weights sit in CPU pinned memory and may exceed GPU
+            # capacity, so _setup_kernel -- which shuffles them into runtime
+            # format on device -- is skipped. The cache allocates the small GPU
+            # scratch buffer instead, but forward still needs a kernel.
+            self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+            layer._maybe_init_expert_lru_cache()
+            if self.moe_kernel is None:  # type: ignore[has-type]
+                assert self.experts_cls is not None
+                self.moe_kernel = make_unquantized_moe_kernel(
+                    quant_config=self.moe_quant_config,
+                    moe_config=self.moe,
+                    backend=self.unquantized_backend,
+                    experts_cls=self.experts_cls,
+                    routing_tables=layer._expert_routing_tables(),
+                )
         else:
             self._setup_kernel(
                 layer=layer,
@@ -289,6 +324,35 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
         assert self.moe_kernel is not None
+
+        provider = layer.expert_weight_provider
+        if provider is not None:
+
+            def run(
+                result: ExpertWeightResult, rows: slice, include_shared: bool
+            ) -> torch.Tensor:
+                assert self.moe_kernel is not None
+                return self.moe_kernel.apply(
+                    hidden_states=x[rows],
+                    w1=result.w1,
+                    w2=result.w2,
+                    topk_weights=topk_weights[rows],
+                    topk_ids=topk_ids[rows],
+                    activation=layer.activation,
+                    apply_router_weight_on_input=(layer.apply_router_weight_on_input),
+                    global_num_experts=layer.global_num_experts,
+                    expert_map=result.expert_map,
+                    # Shared experts belong to the forward, not to one call.
+                    shared_experts=shared_experts if include_shared else None,
+                    shared_experts_input=(
+                        shared_experts_input[rows]
+                        if include_shared and shared_experts_input is not None
+                        else None
+                    ),
+                )
+
+            return run_with_expert_cache(provider, topk_ids, run)
+
         return self.moe_kernel.apply(
             hidden_states=x,
             w1=layer.w13_weight,

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -52,9 +52,17 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
 
     @property
     def supports_expert_lru_cache(self) -> bool:
-        # FLASHINFER_TRTLLM reorders weights into a tiled block layout that is
-        # incompatible with the generic per-expert slot-based remapping.
-        return self.unquantized_backend != UnquantizedMoeBackend.FLASHINFER_TRTLLM
+        # Only backends that do not reorder or shuffle weights at load time.
+        # FLASHINFER_TRTLLM: tiled block layout, incompatible with slot remapping.
+        # FLASHINFER_CUTLASS: requires swap_w13_to_w31.
+        # AITER: requires shuffle_weights + is_shuffled flag.
+        # TPU/OOT: untested, conservative exclusion.
+        return self.unquantized_backend in (
+            UnquantizedMoeBackend.TRITON,
+            UnquantizedMoeBackend.BATCHED_TRITON,
+            UnquantizedMoeBackend.CPU,
+            UnquantizedMoeBackend.XPU,
+        )
 
     def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -28,6 +28,10 @@ from vllm.model_executor.layers.fused_moe import (
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
+from vllm.model_executor.layers.fused_moe.expert_weight_provider import (
+    ExpertWeightResult,
+    run_with_expert_cache,
+)
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     Fp8MoeBackend,
     convert_to_fp8_moe_kernel_format,
@@ -471,6 +475,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         quant_config: The quantization config.
     """
 
+    @property
+    def supports_expert_lru_cache(self) -> bool:
+        # Scales reach the kernel through moe_quant_config, so the cache has to
+        # repoint the layer's scale parameters at its slot-indexed buffers
+        # before that config is built -- see _setup_kernel. That only works for
+        # backends convert_to_fp8_moe_kernel_format() passes through unchanged;
+        # the rest (DEEPGEMM, MARLIN, AITER, FLASHINFER, HUMMING) repack weights
+        # into layouts where a per-expert row is no longer a row.
+        compatible_backends = {
+            Fp8MoeBackend.TRITON,
+            Fp8MoeBackend.BATCHED_TRITON,
+            Fp8MoeBackend.VLLM_CUTLASS,
+            Fp8MoeBackend.BATCHED_VLLM_CUTLASS,
+            Fp8MoeBackend.XPU,
+        }
+        return self.fp8_backend in compatible_backends
+
     def __init__(self, quant_config: Fp8Config, layer: RoutedExperts):
         super().__init__(layer.moe_config)
         self.quant_config = quant_config
@@ -674,6 +695,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w13_weight.is_shuffled = True
             layer.w2_weight.is_shuffled = True
 
+        # Weights are in their runtime layout now, and the quant config below
+        # captures the scale tensors -- so the cache has to take over both
+        # before that happens, not after.
+        layer._maybe_init_expert_lru_cache(self.weight_scale_name)
+
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         assert self.moe_quant_config is not None
         assert self.experts_cls is not None
@@ -726,7 +752,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 w13, w13_scale, shard_size, layer.local_num_experts
             )
 
-        # Shuffle weights to runtime format and setup kernel.
+        # Shuffle weights to runtime format and setup kernel. The expert cache,
+        # when enabled, is installed inside _setup_kernel -- it has to precede
+        # the quant config that captures the scale tensors.
         self._setup_kernel(
             layer, w13, w2, w13_scale, w2_scale, w13_input_scale, w2_input_scale
         )
@@ -810,6 +838,35 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     ) -> torch.Tensor:
         assert not self.is_monolithic
         assert self.moe_kernel is not None
+
+        provider = layer.expert_weight_provider
+        if provider is not None:
+
+            def run(
+                result: ExpertWeightResult, rows: slice, include_shared: bool
+            ) -> torch.Tensor:
+                assert self.moe_kernel is not None
+                return self.moe_kernel.apply(
+                    x[rows],
+                    result.w1,
+                    result.w2,
+                    topk_weights[rows],
+                    topk_ids[rows],
+                    activation=layer.activation,
+                    global_num_experts=layer.global_num_experts,
+                    expert_map=result.expert_map,
+                    apply_router_weight_on_input=layer.apply_router_weight_on_input,
+                    # Shared experts belong to the forward, not to one call.
+                    shared_experts=shared_experts if include_shared else None,
+                    shared_experts_input=(
+                        shared_experts_input[rows]
+                        if include_shared and shared_experts_input is not None
+                        else None
+                    ),
+                )
+
+            return run_with_expert_cache(provider, topk_ids, run)
+
         return self.moe_kernel.apply(
             x,
             layer.w13_weight,


### PR DESCRIPTION
## Purpose

`CachedWeightProvider` — MoE expert CPU offloading with GPU LFRU cache, addressing [RFC #38256](https://github.com/vllm-project/vllm/issues/38256).

Expert weights live in CPU pinned memory; a fixed-size GPU cache holds the hottest N experts per layer using LFRU (frequency-weighted LRU) eviction. LFRU prevents early layers from monopolizing the cache — a known problem with pure LRU in sequential MoE execution. Models that exceed GPU VRAM can now run on smaller hardware.

**No runner bypass** — all paths go through `quant_method.apply()`. EP dispatch, DP chunking, and shared expert overlap work unchanged.

**References:** [RFC #38256](https://github.com/vllm-project/vllm/issues/38256) | [tinyserve](https://github.com/e1n00r/tinyserve) (production validation, 481 tests)

## Test results

**Community validation (independent):**

| Model | VRAM | tok/s | Tester |
|---|---|---|---|
| Nemotron-Cascade-2-30B-A3B (cache=8) | 7.6 GB | 15.6 | @caiovicentino |
| Gemma-4-26B-A4B-it (cache=8) | 8.6 GB | 14.8 | @caiovicentino |

**LFRU vs LRU** (Nemotron, cache=8): LFRU cache=8 exceeds LRU cache=16 in hit rate. +5.2% speed improvement.

**Unit tests:** 26 test cases (parametrized across dtypes, capacities, num_experts). Tests LFRU-specific eviction behavior (frequency-weighted, not just recency).

## Changes

**15 files, ~810 additions**

| File | What |
|---|---|
| `expert_weight_provider.py` (new) | `CachedWeightProvider` with LFRU eviction, `ExpertWeightResult` dataclass |
| `fused_moe_method_base.py` | `supports_expert_lru_cache` property (default False) |
| `fused_moe_modular_method.py` | Provider check in `apply()` |
| `layer.py` | `_maybe_init_expert_lru_cache()`, `expert_weight_provider` attribute |
| `unquantized_fused_moe_method.py` | CPU weight allocation, cache init, kernel init for cache path, XPU transpose |
| `quantization/fp8.py` | `supports_expert_lru_cache`, provider check, cache init |
| `offload.py` | `moe_expert_cache_size` config field |
| `vllm.py` | Cross-validator: enforce_eager required |
| `arg_utils.py` | CLI argument `--moe-expert-cache-size` |
| `llm.py` | `moe_expert_cache_size` parameter in `LLM.__init__` |
| `basic_correctness.yaml` | CI test area registration |
| `docs/features/moe_cache_policies.md` (new) | Feature documentation |
| `test_expert_lru_cache.py` (new) | 26 unit tests with parametrization |
| `test_moe_expert_cache.py` (new) | Integration test via `compare_two_settings` |
| `benchmarks/qwen_122b_test_20260331.txt` (new) | Benchmark raw data |

## How it works

```text
moe_expert_cache_size == 0 (default):
  No provider created. Zero overhead (one getattr per layer).

moe_expert_cache_size > 0:
  CachedWeightProvider.prepare(topk_ids):
    for each unique expert:
      hit  → update LFRU frequency + recency (O(1))
      miss → evict lowest freq/age score, H2D copy, update mapping
    remap topk_ids → slot indices via persistent GPU mapping tensor
  → kernel receives GPU buffer + remapped IDs
```

## Limitations

- `--enforce-eager` required (CUDA graph compat deferred to PR 2)
- Synchronous H2D copies (async pipeline in PR 2)
- Single eviction policy (LFRU hardcoded, no pluggable framework)
- EP > 1 not supported
- BF16 + FP8 per-tensor only

## Test plan

```bash
pytest tests/kernels/moe/test_expert_lru_cache.py -v
pytest tests/basic_correctness/test_moe_expert_cache.py -v -s
```

---

*AI-assisted development ([Claude Code](https://claude.com/claude-code)). Architecture validated in [tinyserve](https://github.com/e1n00r/tinyserve).*
