### PR TITLE
WIP: [Feature] KVCACHE NVFP4

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -175,7 +175,7 @@ Priority is **1 = highest** (tried first).
 | `ROCM_AITER_UNIFIED_ATTN` | | fp16, bf16 | `auto` | %16 | Any | ✅ | ✅ | ❌ | All | N/A |
 | `ROCM_ATTN` | | fp16, bf16, fp32 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | 32, 64, 80, 96, 128, 160, 192, 224, 256 | ✅ | ✅ | ❌ | All | N/A |
 | `TREE_ATTN` | | fp16, bf16 | `auto` | %16 | 32, 64, 96, 128, 160, 192, 224, 256 | ❌ | ❌ | ❌ | Decoder | Any |
-| `TRITON_ATTN` | | fp16, bf16, fp32 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | Any | ✅ | ✅ | ❌ | All | Any |
+| `TRITON_ATTN` | | fp16, bf16, fp32 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2`, `nvfp4` | %16 | Any | ✅ | ✅ | ❌ | All | Any |
 
 > **†** FlashInfer uses TRTLLM attention on Blackwell (SM100), which supports sinks. Disable via `--attention-config.use_trtllm_attention=0`.
 >

--- a/tests/models/quantization/test_nvfp4_kv_cache.py
+++ b/tests/models/quantization/test_nvfp4_kv_cache.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""End-to-end accuracy tests for NVFP4 KV cache quantization.
+
+Compares logprobs between a baseline bf16 model and the same model with
+kv_cache_dtype="nvfp4" using the Triton attention backend. Since no
+pre-calibrated NVFP4 KV scale checkpoints exist yet, we test with
+calculate_kv_scales=True (dynamic global scale from the first batch).
+
+Run: pytest tests/models/quantization/test_nvfp4_kv_cache.py -v -s
+"""
+
+import pytest
+
+from vllm.platforms import current_platform
+
+from ..utils import check_logprobs_close
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="NVFP4 KV cache requires CUDA GPU.",
+)
+@pytest.mark.parametrize(
+    "base_model,test_model",
+    [
+        # BF16 model with dynamic NVFP4 KV cache quantization
+        (
+            "meta-llama/Llama-3.2-1B-Instruct",
+            "meta-llama/Llama-3.2-1B-Instruct",
+        ),
+    ],
+)
+@pytest.mark.parametrize("max_tokens", [4])
+@pytest.mark.parametrize("enforce_eager", [True])
+@pytest.mark.parametrize("backend", ["TRITON_ATTN"])
+@pytest.mark.parametrize("tensor_parallel_size", [1])
+def test_nvfp4_kv_cache_accuracy(
+    vllm_runner,
+    example_prompts,
+    base_model: str,
+    test_model: str,
+    max_tokens: int,
+    enforce_eager: bool,
+    backend: str,
+    tensor_parallel_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compare logprobs between bf16 baseline and NVFP4 KV cache.
+
+    Uses calculate_kv_scales (dynamic global scale computation) since there
+    are no NVFP4-calibrated checkpoints available yet. NVFP4 is a very
+    coarse quantization (4-bit with 8 representable magnitudes), so we
+    expect larger divergence than FP8 or INT8.
+    """
+    with monkeypatch.context() as m:
+        m.setenv("TOKENIZERS_PARALLELISM", "true")
+
+        MAX_MODEL_LEN = 1024
+        NUM_LOG_PROBS = 8
+
+        with vllm_runner(
+            base_model,
+            max_model_len=MAX_MODEL_LEN,
+            tensor_parallel_size=tensor_parallel_size,
+            enforce_eager=enforce_eager,
+            kv_cache_dtype="auto",
+            attention_config={"backend": backend},
+        ) as vllm_model:
+            baseline_outputs = vllm_model.generate_greedy_logprobs(
+                example_prompts, max_tokens, NUM_LOG_PROBS
+            )
+
+        with vllm_runner(
+            test_model,
+            max_model_len=MAX_MODEL_LEN,
+            tensor_parallel_size=tensor_parallel_size,
+            enforce_eager=enforce_eager,
+            kv_cache_dtype="nvfp4",
+            calculate_kv_scales=True,
+            attention_config={"backend": backend},
+        ) as vllm_model:
+            test_outputs = vllm_model.generate_greedy_logprobs(
+                example_prompts, max_tokens, NUM_LOG_PROBS
+            )
+
+        check_logprobs_close(
+            outputs_0_lst=baseline_outputs,
+            outputs_1_lst=test_outputs,
+            name_0="bf16_kv_cache",
+            name_1="nvfp4_kv_cache",
+        )

--- a/tests/quantization/test_nvfp4_kv_cache.py
+++ b/tests/quantization/test_nvfp4_kv_cache.py
@@ -75,14 +75,31 @@ def _nvfp4_dequant_ref(
     """
     # FP4 E2M1 LUT
     lut = torch.tensor(
-        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
-         -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
-        dtype=torch.float32, device=packed.device,
+        [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ],
+        dtype=torch.float32,
+        device=packed.device,
     )
 
     # Unpack nibbles
-    lo = (packed.to(torch.int32) & 0xF)
-    hi = ((packed.to(torch.int32) >> 4) & 0xF)
+    lo = packed.to(torch.int32) & 0xF
+    hi = (packed.to(torch.int32) >> 4) & 0xF
 
     # Decode via LUT
     lo_val = lut[lo]
@@ -98,20 +115,22 @@ def _nvfp4_dequant_ref(
 
     # Expand scales to match packed data
     batch_shape = packed.shape[:-1]
-    result_even = torch.zeros(*batch_shape, head_size // 2,
-                              dtype=torch.float32, device=packed.device)
+    result_even = torch.zeros(
+        *batch_shape, head_size // 2, dtype=torch.float32, device=packed.device
+    )
     result_odd = torch.zeros_like(result_even)
 
     for g in range(num_groups):
         start = g * packed_per_group
         end = start + packed_per_group
-        s = scales_f32[..., g:g+1] * global_scale
+        s = scales_f32[..., g : g + 1] * global_scale
         result_even[..., start:end] = lo_val[..., start:end] * s
         result_odd[..., start:end] = hi_val[..., start:end] * s
 
     # Interleave even/odd
-    result = torch.zeros(*batch_shape, head_size,
-                         dtype=torch.float32, device=packed.device)
+    result = torch.zeros(
+        *batch_shape, head_size, dtype=torch.float32, device=packed.device
+    )
     result[..., 0::2] = result_even
     result[..., 1::2] = result_odd
     return result
@@ -142,21 +161,30 @@ class TestNvfp4CacheSpec:
         from vllm.v1.kv_cache_interface import AttentionSpec
 
         spec = AttentionSpec(
-            block_size=16, num_kv_heads=8, head_size=128,
-            dtype=torch.uint8, cache_dtype_str="nvfp4",
+            block_size=16,
+            num_kv_heads=8,
+            head_size=128,
+            dtype=torch.uint8,
+            cache_dtype_str="nvfp4",
         )
         assert spec.is_nvfp4
         assert not AttentionSpec(
-            block_size=16, num_kv_heads=8, head_size=128,
-            dtype=torch.uint8, cache_dtype_str="fp8",
+            block_size=16,
+            num_kv_heads=8,
+            head_size=128,
+            dtype=torch.uint8,
+            cache_dtype_str="fp8",
         ).is_nvfp4
 
     def test_nvfp4_head_size_bytes(self):
         from vllm.v1.kv_cache_interface import AttentionSpec
 
         spec = AttentionSpec(
-            block_size=16, num_kv_heads=8, head_size=128,
-            dtype=torch.uint8, cache_dtype_str="nvfp4",
+            block_size=16,
+            num_kv_heads=8,
+            head_size=128,
+            dtype=torch.uint8,
+            cache_dtype_str="nvfp4",
         )
         # 128 // 2 + 128 // 16 = 64 + 8 = 72
         assert spec.nvfp4_head_size_bytes == 72
@@ -165,8 +193,11 @@ class TestNvfp4CacheSpec:
         from vllm.v1.kv_cache_interface import AttentionSpec
 
         spec = AttentionSpec(
-            block_size=16, num_kv_heads=8, head_size=128,
-            dtype=torch.uint8, cache_dtype_str="nvfp4",
+            block_size=16,
+            num_kv_heads=8,
+            head_size=128,
+            dtype=torch.uint8,
+            cache_dtype_str="nvfp4",
         )
         # 2 * 16 * 8 * 72 = 18432
         assert spec.page_size_bytes == 2 * 16 * 8 * 72
@@ -175,8 +206,11 @@ class TestNvfp4CacheSpec:
         from vllm.v1.kv_cache_interface import FullAttentionSpec
 
         spec = FullAttentionSpec(
-            block_size=16, num_kv_heads=8, head_size=128,
-            dtype=torch.uint8, cache_dtype_str="nvfp4",
+            block_size=16,
+            num_kv_heads=8,
+            head_size=128,
+            dtype=torch.uint8,
+            cache_dtype_str="nvfp4",
         )
         assert spec.is_nvfp4
         # FullAttentionSpec should also compute NVFP4 page size correctly
@@ -186,11 +220,16 @@ class TestNvfp4CacheSpec:
         from vllm.v1.kv_cache_interface import AttentionSpec
 
         nvfp4 = AttentionSpec(
-            block_size=16, num_kv_heads=8, head_size=128,
-            dtype=torch.uint8, cache_dtype_str="nvfp4",
+            block_size=16,
+            num_kv_heads=8,
+            head_size=128,
+            dtype=torch.uint8,
+            cache_dtype_str="nvfp4",
         )
         bf16 = AttentionSpec(
-            block_size=16, num_kv_heads=8, head_size=128,
+            block_size=16,
+            num_kv_heads=8,
+            head_size=128,
             dtype=torch.bfloat16,
         )
         ratio = bf16.page_size_bytes / nvfp4.page_size_bytes
@@ -202,8 +241,10 @@ class TestNvfp4CacheSpec:
         from vllm.v1.attention.backends.triton_attn import TritonAttentionBackend
 
         shape = TritonAttentionBackend.get_kv_cache_shape(
-            num_blocks=100, block_size=16,
-            num_kv_heads=8, head_size=128,
+            num_blocks=100,
+            block_size=16,
+            num_kv_heads=8,
+            head_size=128,
             cache_dtype_str="nvfp4",
         )
         assert shape == (100, 2, 16, 8, 72)
@@ -256,8 +297,13 @@ def test_reshape_and_cache_nvfp4(
     v_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
 
     triton_reshape_and_cache_nvfp4(
-        key, value, key_cache, value_cache,
-        slot_mapping, k_scale, v_scale,
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        k_scale,
+        v_scale,
     )
 
     # Verify non-zero data was written for valid slots
@@ -271,17 +317,15 @@ def test_reshape_and_cache_nvfp4(
 
         # At least some packed bytes should be non-zero (unless input was zero)
         if key[i].abs().max() > 0:
-            assert k_data[:packed_head].any(), (
-                f"Key packed data all zeros at token {i}"
-            )
+            assert k_data[:packed_head].any(), f"Key packed data all zeros at token {i}"
         if value[i].abs().max() > 0:
             assert v_data[:packed_head].any(), (
                 f"Value packed data all zeros at token {i}"
             )
 
         # Block scales should be non-zero for non-zero inputs
-        k_scales = k_data[packed_head:packed_head + scale_head]
-        v_scales = v_data[packed_head:packed_head + scale_head]
+        k_scales = k_data[packed_head : packed_head + scale_head]
+        v_scales = v_data[packed_head : packed_head + scale_head]
         if key[i].abs().max() > 0:
             assert k_scales.any(), f"Key scales all zeros at token {i}"
         if value[i].abs().max() > 0:
@@ -328,8 +372,13 @@ def test_nvfp4_round_trip_accuracy(head_size: int, num_heads: int):
 
     # Quantize
     triton_reshape_and_cache_nvfp4(
-        key, value, key_cache, value_cache,
-        slot_mapping, k_scale, v_scale,
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        k_scale,
+        v_scale,
     )
 
     # Dequantize
@@ -401,8 +450,13 @@ def test_nvfp4_negative_slot_skipped():
     v_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
 
     triton_reshape_and_cache_nvfp4(
-        key, value, key_cache, value_cache,
-        slot_mapping, k_scale, v_scale,
+        key,
+        value,
+        key_cache,
+        value_cache,
+        slot_mapping,
+        k_scale,
+        v_scale,
     )
 
     # Slots 0 and 1 should have been written
@@ -429,12 +483,8 @@ class TestProcessWeightsAfterLoadingNvfp4:
         layer.v_scale = torch.nn.Parameter(
             torch.tensor(v_scale_val, dtype=torch.float32), requires_grad=False
         )
-        layer.q_scale = torch.nn.Parameter(
-            torch.tensor(-1.0), requires_grad=False
-        )
-        layer.prob_scale = torch.nn.Parameter(
-            torch.tensor(-1.0), requires_grad=False
-        )
+        layer.q_scale = torch.nn.Parameter(torch.tensor(-1.0), requires_grad=False)
+        layer.prob_scale = torch.nn.Parameter(torch.tensor(-1.0), requires_grad=False)
         layer._k_scale = torch.tensor(0.0)
         layer._v_scale = torch.tensor(0.0)
         layer._q_scale = torch.tensor(0.0)
@@ -511,12 +561,8 @@ def test_calc_kv_scales_nvfp4():
     expected_k = k_absmax / (6.0 * 448.0)
     expected_v = v_absmax / (6.0 * 448.0)
 
-    torch.testing.assert_close(
-        layer._k_scale, expected_k, atol=1e-6, rtol=1e-5
-    )
-    torch.testing.assert_close(
-        layer._v_scale, expected_v, atol=1e-6, rtol=1e-5
-    )
+    torch.testing.assert_close(layer._k_scale, expected_k, atol=1e-6, rtol=1e-5)
+    torch.testing.assert_close(layer._v_scale, expected_v, atol=1e-6, rtol=1e-5)
     assert layer.calculate_kv_scales is False
 
 
@@ -534,7 +580,6 @@ def test_nvfp4_unified_attention_integration(
 ):
     """End-to-end: quantize KV to NVFP4, run attention with fused dequant,
     compare to BF16 reference."""
-    from vllm.utils.math_utils import next_power_of_2
     from vllm.utils.torch_utils import set_random_seed
     from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
         triton_reshape_and_cache_nvfp4,
@@ -558,12 +603,18 @@ def test_nvfp4_unified_attention_integration(
     query = torch.randn(total_q, num_query_heads, head_size, dtype=torch.bfloat16)
 
     # Create BF16 KV data and quantize to NVFP4
-    key_bf16 = torch.randn(
-        num_blocks * block_size, num_kv_heads, head_size, dtype=torch.bfloat16
-    ) * 0.3
-    value_bf16 = torch.randn(
-        num_blocks * block_size, num_kv_heads, head_size, dtype=torch.bfloat16
-    ) * 0.3
+    key_bf16 = (
+        torch.randn(
+            num_blocks * block_size, num_kv_heads, head_size, dtype=torch.bfloat16
+        )
+        * 0.3
+    )
+    value_bf16 = (
+        torch.randn(
+            num_blocks * block_size, num_kv_heads, head_size, dtype=torch.bfloat16
+        )
+        * 0.3
+    )
 
     # NVFP4 cache
     key_cache_nvfp4 = torch.zeros(
@@ -578,15 +629,18 @@ def test_nvfp4_unified_attention_integration(
     value_cache_bf16 = torch.zeros_like(key_cache_bf16)
 
     # Fill both caches with the same data
-    all_slots = torch.arange(
-        num_blocks * block_size, dtype=torch.long, device="cuda"
-    )
+    all_slots = torch.arange(num_blocks * block_size, dtype=torch.long, device="cuda")
     k_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
     v_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
 
     triton_reshape_and_cache_nvfp4(
-        key_bf16, value_bf16, key_cache_nvfp4, value_cache_nvfp4,
-        all_slots, k_scale, v_scale,
+        key_bf16,
+        value_bf16,
+        key_cache_nvfp4,
+        value_cache_nvfp4,
+        all_slots,
+        k_scale,
+        v_scale,
     )
 
     # Fill BF16 cache directly
@@ -623,7 +677,7 @@ def test_nvfp4_unified_attention_integration(
         seqused_k=kv_lens,
         max_seqlen_q=query_len,
         max_seqlen_k=seq_len,
-        softmax_scale=head_size ** -0.5,
+        softmax_scale=head_size**-0.5,
         causal=True,
         window_size=(-1, -1),
         block_table=block_tables,
@@ -645,7 +699,7 @@ def test_nvfp4_unified_attention_integration(
         seqused_k=kv_lens,
         max_seqlen_q=query_len,
         max_seqlen_k=seq_len,
-        softmax_scale=head_size ** -0.5,
+        softmax_scale=head_size**-0.5,
         causal=True,
         window_size=(-1, -1),
         block_table=block_tables,

--- a/tests/quantization/test_nvfp4_kv_cache.py
+++ b/tests/quantization/test_nvfp4_kv_cache.py
@@ -1,0 +1,659 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for NVFP4 KV cache quantization.
+
+Covers:
+- is_quantized_kv_cache for "nvfp4"
+- AttentionSpec / FullAttentionSpec NVFP4 page size and shape
+- Triton reshape_and_cache_nvfp4 kernel correctness
+- NVFP4 round-trip quantize/dequantize accuracy
+- Negative slot mapping (padding tokens skipped)
+- process_weights_after_loading NVFP4 paths
+- calc_kv_scales NVFP4 path
+- Triton unified_attention with fused NVFP4 dequant
+
+Run: pytest tests/quantization/test_nvfp4_kv_cache.py -v -s
+"""
+
+import random
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.backend import is_quantized_kv_cache
+from vllm.v1.kv_cache_interface import NVFP4_QUANT_BLOCK_SIZE
+
+# Skip entire module if no CUDA GPU available (NVFP4 uses tl.float8e4nv)
+pytestmark = [
+    pytest.mark.skipif(
+        not current_platform.is_cuda(),
+        reason="NVFP4 KV cache tests require CUDA GPU.",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Test parameters
+# ---------------------------------------------------------------------------
+NUM_TOKENS = [1, 7, 32]
+NUM_KV_HEADS = [4, 8]
+HEAD_SIZES = [64, 128]
+BLOCK_SIZES = [16]
+SEEDS = [0]
+
+# FP4 E2M1 representable magnitudes
+FP4_E2M1_VALUES = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+FP4_E2M1_MAX = 6.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _nvfp4_effective_head_size(head_size: int) -> int:
+    """Compute the effective head size in bytes for NVFP4 cache."""
+    return head_size // 2 + head_size // NVFP4_QUANT_BLOCK_SIZE
+
+
+def _nvfp4_dequant_ref(
+    packed: torch.Tensor,
+    scales: torch.Tensor,
+    global_scale: float,
+    head_size: int,
+) -> torch.Tensor:
+    """Reference NVFP4 dequantization.
+
+    Args:
+        packed: uint8 tensor of shape [..., head_size // 2]
+        scales: uint8 tensor of shape [..., head_size // NVFP4_QUANT_BLOCK_SIZE]
+            (FP8 E4M3 bitcast)
+        global_scale: second-level scale factor
+        head_size: original head dimension
+
+    Returns:
+        float32 tensor of shape [..., head_size]
+    """
+    # FP4 E2M1 LUT
+    lut = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+         -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        dtype=torch.float32, device=packed.device,
+    )
+
+    # Unpack nibbles
+    lo = (packed.to(torch.int32) & 0xF)
+    hi = ((packed.to(torch.int32) >> 4) & 0xF)
+
+    # Decode via LUT
+    lo_val = lut[lo]
+    hi_val = lut[hi]
+
+    # Decode FP8 E4M3 scales
+    scales_f32 = scales.view(torch.float8_e4m3fn).to(torch.float32)
+
+    # Apply per-group scales
+    group_size = NVFP4_QUANT_BLOCK_SIZE
+    packed_per_group = group_size // 2
+    num_groups = head_size // group_size
+
+    # Expand scales to match packed data
+    batch_shape = packed.shape[:-1]
+    result_even = torch.zeros(*batch_shape, head_size // 2,
+                              dtype=torch.float32, device=packed.device)
+    result_odd = torch.zeros_like(result_even)
+
+    for g in range(num_groups):
+        start = g * packed_per_group
+        end = start + packed_per_group
+        s = scales_f32[..., g:g+1] * global_scale
+        result_even[..., start:end] = lo_val[..., start:end] * s
+        result_odd[..., start:end] = hi_val[..., start:end] * s
+
+    # Interleave even/odd
+    result = torch.zeros(*batch_shape, head_size,
+                         dtype=torch.float32, device=packed.device)
+    result[..., 0::2] = result_even
+    result[..., 1::2] = result_odd
+    return result
+
+
+# ===========================================================================
+# 1. is_quantized_kv_cache
+# ===========================================================================
+class TestIsQuantizedKvCache:
+    def test_nvfp4(self):
+        assert is_quantized_kv_cache("nvfp4")
+
+    def test_fp8(self):
+        assert is_quantized_kv_cache("fp8")
+
+    def test_auto(self):
+        assert not is_quantized_kv_cache("auto")
+
+    def test_bfloat16(self):
+        assert not is_quantized_kv_cache("bfloat16")
+
+
+# ===========================================================================
+# 2. AttentionSpec / FullAttentionSpec NVFP4 page size
+# ===========================================================================
+class TestNvfp4CacheSpec:
+    def test_attention_spec_is_nvfp4(self):
+        from vllm.v1.kv_cache_interface import AttentionSpec
+
+        spec = AttentionSpec(
+            block_size=16, num_kv_heads=8, head_size=128,
+            dtype=torch.uint8, cache_dtype_str="nvfp4",
+        )
+        assert spec.is_nvfp4
+        assert not AttentionSpec(
+            block_size=16, num_kv_heads=8, head_size=128,
+            dtype=torch.uint8, cache_dtype_str="fp8",
+        ).is_nvfp4
+
+    def test_nvfp4_head_size_bytes(self):
+        from vllm.v1.kv_cache_interface import AttentionSpec
+
+        spec = AttentionSpec(
+            block_size=16, num_kv_heads=8, head_size=128,
+            dtype=torch.uint8, cache_dtype_str="nvfp4",
+        )
+        # 128 // 2 + 128 // 16 = 64 + 8 = 72
+        assert spec.nvfp4_head_size_bytes == 72
+
+    def test_nvfp4_page_size_bytes(self):
+        from vllm.v1.kv_cache_interface import AttentionSpec
+
+        spec = AttentionSpec(
+            block_size=16, num_kv_heads=8, head_size=128,
+            dtype=torch.uint8, cache_dtype_str="nvfp4",
+        )
+        # 2 * 16 * 8 * 72 = 18432
+        assert spec.page_size_bytes == 2 * 16 * 8 * 72
+
+    def test_full_attention_spec_nvfp4(self):
+        from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+        spec = FullAttentionSpec(
+            block_size=16, num_kv_heads=8, head_size=128,
+            dtype=torch.uint8, cache_dtype_str="nvfp4",
+        )
+        assert spec.is_nvfp4
+        # FullAttentionSpec should also compute NVFP4 page size correctly
+        assert spec.page_size_bytes == 2 * 16 * 8 * 72
+
+    def test_compression_ratio(self):
+        from vllm.v1.kv_cache_interface import AttentionSpec
+
+        nvfp4 = AttentionSpec(
+            block_size=16, num_kv_heads=8, head_size=128,
+            dtype=torch.uint8, cache_dtype_str="nvfp4",
+        )
+        bf16 = AttentionSpec(
+            block_size=16, num_kv_heads=8, head_size=128,
+            dtype=torch.bfloat16,
+        )
+        ratio = bf16.page_size_bytes / nvfp4.page_size_bytes
+        # BF16: 2 * 16 * 8 * 128 * 2 = 65536
+        # NVFP4: 2 * 16 * 8 * 72 = 18432
+        assert ratio == pytest.approx(65536 / 18432, rel=1e-3)
+
+    def test_get_kv_cache_shape_nvfp4(self):
+        from vllm.v1.attention.backends.triton_attn import TritonAttentionBackend
+
+        shape = TritonAttentionBackend.get_kv_cache_shape(
+            num_blocks=100, block_size=16,
+            num_kv_heads=8, head_size=128,
+            cache_dtype_str="nvfp4",
+        )
+        assert shape == (100, 2, 16, 8, 72)
+
+
+# ===========================================================================
+# 3. Triton reshape_and_cache_nvfp4 kernel
+# ===========================================================================
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_heads", NUM_KV_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("seed", SEEDS)
+@torch.inference_mode()
+def test_reshape_and_cache_nvfp4(
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    block_size: int,
+    seed: int,
+):
+    """Test triton_reshape_and_cache_nvfp4 stores packed FP4 data + scales."""
+    from vllm.utils.torch_utils import set_random_seed
+    from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+        triton_reshape_and_cache_nvfp4,
+    )
+
+    set_random_seed(seed)
+    torch.set_default_device("cuda")
+
+    eff_head_size = _nvfp4_effective_head_size(head_size)
+    num_blocks = (num_tokens + block_size - 1) // block_size + 4
+
+    key = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16)
+    value = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16)
+
+    key_cache = torch.zeros(
+        num_blocks, block_size, num_heads, eff_head_size, dtype=torch.uint8
+    )
+    value_cache = torch.zeros(
+        num_blocks, block_size, num_heads, eff_head_size, dtype=torch.uint8
+    )
+
+    num_slots = block_size * num_blocks
+    slot_mapping = torch.tensor(
+        random.sample(range(num_slots), num_tokens), dtype=torch.long
+    )
+
+    k_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+    v_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+
+    triton_reshape_and_cache_nvfp4(
+        key, value, key_cache, value_cache,
+        slot_mapping, k_scale, v_scale,
+    )
+
+    # Verify non-zero data was written for valid slots
+    packed_head = head_size // 2
+    scale_head = head_size // NVFP4_QUANT_BLOCK_SIZE
+    for i, slot in enumerate(slot_mapping.tolist()):
+        blk = slot // block_size
+        off = slot % block_size
+        k_data = key_cache[blk, off]
+        v_data = value_cache[blk, off]
+
+        # At least some packed bytes should be non-zero (unless input was zero)
+        if key[i].abs().max() > 0:
+            assert k_data[:packed_head].any(), (
+                f"Key packed data all zeros at token {i}"
+            )
+        if value[i].abs().max() > 0:
+            assert v_data[:packed_head].any(), (
+                f"Value packed data all zeros at token {i}"
+            )
+
+        # Block scales should be non-zero for non-zero inputs
+        k_scales = k_data[packed_head:packed_head + scale_head]
+        v_scales = v_data[packed_head:packed_head + scale_head]
+        if key[i].abs().max() > 0:
+            assert k_scales.any(), f"Key scales all zeros at token {i}"
+        if value[i].abs().max() > 0:
+            assert v_scales.any(), f"Value scales all zeros at token {i}"
+
+
+# ===========================================================================
+# 4. NVFP4 round-trip accuracy
+# ===========================================================================
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("num_heads", [4])
+@torch.inference_mode()
+def test_nvfp4_round_trip_accuracy(head_size: int, num_heads: int):
+    """Verify NVFP4 round-trip: quantize via kernel → dequant via kernel,
+    compare to original with expected FP4 tolerance."""
+    from vllm.utils.torch_utils import set_random_seed
+    from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+        triton_reshape_and_cache_nvfp4,
+    )
+    from vllm.v1.attention.ops.triton_unified_attention import (
+        nvfp4_dequant_kv_cache,
+    )
+
+    set_random_seed(42)
+    torch.set_default_device("cuda")
+
+    num_tokens = 16
+    block_size = 16
+    eff_head_size = _nvfp4_effective_head_size(head_size)
+    num_blocks = (num_tokens + block_size - 1) // block_size + 2
+
+    # Use moderate values so quantization isn't too lossy
+    key = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16) * 0.5
+    value = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16) * 0.5
+
+    key_cache = torch.zeros(
+        num_blocks, block_size, num_heads, eff_head_size, dtype=torch.uint8
+    )
+    value_cache = torch.zeros_like(key_cache)
+
+    slot_mapping = torch.arange(num_tokens, dtype=torch.long, device="cuda")
+    k_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+    v_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+
+    # Quantize
+    triton_reshape_and_cache_nvfp4(
+        key, value, key_cache, value_cache,
+        slot_mapping, k_scale, v_scale,
+    )
+
+    # Dequantize
+    key_deq = nvfp4_dequant_kv_cache(key_cache, k_scale, head_size)
+    value_deq = nvfp4_dequant_kv_cache(value_cache, v_scale, head_size)
+
+    # Compare: FP4 E2M1 has only 8 representable magnitudes, so we expect
+    # relatively coarse quantization. Relative error can be 20-30%.
+    for i in range(num_tokens):
+        blk = i // block_size
+        off = i % block_size
+
+        k_orig = key[i].float()
+        k_rt = key_deq[blk, off].float()
+        v_orig = value[i].float()
+        v_rt = value_deq[blk, off].float()
+
+        # Absolute error should be bounded by the quantization step size
+        # For global_scale=1.0, the max value is 6.0 * block_scale
+        # Allow generous tolerance for FP4
+        k_err = (k_orig - k_rt).abs()
+        v_err = (v_orig - v_rt).abs()
+        k_range = k_orig.abs().max()
+        v_range = v_orig.abs().max()
+
+        # Error should be within ~50% of the range (FP4 is very coarse)
+        if k_range > 0.01:
+            assert k_err.max() < k_range * 0.6, (
+                f"Key round-trip error too large at token {i}: "
+                f"max_err={k_err.max():.4f}, range={k_range:.4f}"
+            )
+        if v_range > 0.01:
+            assert v_err.max() < v_range * 0.6, (
+                f"Value round-trip error too large at token {i}: "
+                f"max_err={v_err.max():.4f}, range={v_range:.4f}"
+            )
+
+
+# ===========================================================================
+# 5. Negative slot mapping
+# ===========================================================================
+@torch.inference_mode()
+def test_nvfp4_negative_slot_skipped():
+    """Tokens with slot_mapping=-1 should leave the cache unchanged."""
+    from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+        triton_reshape_and_cache_nvfp4,
+    )
+
+    torch.set_default_device("cuda")
+    num_tokens = 4
+    num_heads = 2
+    head_size = 64
+    block_size = 16
+    num_blocks = 2
+    eff_head_size = _nvfp4_effective_head_size(head_size)
+
+    key = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16)
+    value = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16)
+
+    key_cache = torch.zeros(
+        num_blocks, block_size, num_heads, eff_head_size, dtype=torch.uint8
+    )
+    value_cache = torch.zeros_like(key_cache)
+    key_cache_before = key_cache.clone()
+    val_cache_before = value_cache.clone()
+
+    slot_mapping = torch.tensor([0, -1, 1, -1], dtype=torch.long, device="cuda")
+    k_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+    v_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+
+    triton_reshape_and_cache_nvfp4(
+        key, value, key_cache, value_cache,
+        slot_mapping, k_scale, v_scale,
+    )
+
+    # Slots 0 and 1 should have been written
+    assert not torch.equal(key_cache[0, 0], key_cache_before[0, 0])
+    assert not torch.equal(key_cache[0, 1], key_cache_before[0, 1])
+
+    # All other slots should be unchanged
+    assert torch.equal(key_cache[0, 2:], key_cache_before[0, 2:])
+    assert torch.equal(key_cache[1], key_cache_before[1])
+    assert torch.equal(value_cache[0, 2:], val_cache_before[0, 2:])
+
+
+# ===========================================================================
+# 6. process_weights_after_loading — NVFP4 paths
+# ===========================================================================
+class TestProcessWeightsAfterLoadingNvfp4:
+    def _make_layer(self, k_scale_val, v_scale_val):
+        layer = MagicMock()
+        layer.kv_cache_dtype = "nvfp4"
+        layer.calculate_kv_scales = False
+        layer.k_scale = torch.nn.Parameter(
+            torch.tensor(k_scale_val, dtype=torch.float32), requires_grad=False
+        )
+        layer.v_scale = torch.nn.Parameter(
+            torch.tensor(v_scale_val, dtype=torch.float32), requires_grad=False
+        )
+        layer.q_scale = torch.nn.Parameter(
+            torch.tensor(-1.0), requires_grad=False
+        )
+        layer.prob_scale = torch.nn.Parameter(
+            torch.tensor(-1.0), requires_grad=False
+        )
+        layer._k_scale = torch.tensor(0.0)
+        layer._v_scale = torch.tensor(0.0)
+        layer._q_scale = torch.tensor(0.0)
+        layer._prob_scale = torch.tensor(0.0)
+        layer._k_scale_float = 0.0
+        layer._v_scale_float = 0.0
+        layer._q_scale_float = 0.0
+        return layer
+
+    def test_nvfp4_positive_scales(self):
+        """NVFP4 with positive scales should store them."""
+        from vllm.model_executor.layers.quantization.kv_cache import (
+            BaseKVCacheMethod,
+        )
+
+        layer = self._make_layer(2.5, 1.5)
+        method = BaseKVCacheMethod.__new__(BaseKVCacheMethod)
+        method.quant_config = MagicMock()
+        method.process_weights_after_loading(layer)
+
+        assert abs(layer._k_scale_float - 2.5) < 1e-6
+        assert abs(layer._v_scale_float - 1.5) < 1e-6
+
+    def test_nvfp4_no_scales_defaults_to_1(self):
+        """NVFP4 with no checkpoint scales should default to 1.0."""
+        from vllm.model_executor.layers.quantization.kv_cache import (
+            BaseKVCacheMethod,
+        )
+
+        layer = self._make_layer(-1.0, -1.0)
+        method = BaseKVCacheMethod.__new__(BaseKVCacheMethod)
+        method.quant_config = MagicMock()
+        method.process_weights_after_loading(layer)
+
+        assert abs(layer._k_scale_float - 1.0) < 1e-6
+        assert abs(layer._v_scale_float - 1.0) < 1e-6
+
+
+# ===========================================================================
+# 7. calc_kv_scales — NVFP4 path
+# ===========================================================================
+@torch.inference_mode()
+def test_calc_kv_scales_nvfp4():
+    """Test that calc_kv_scales produces correct global scales for NVFP4."""
+    num_tokens = 8
+    num_kv_heads = 4
+    head_size = 64
+
+    layer = MagicMock()
+    layer.kv_cache_dtype = "nvfp4"
+    layer.num_kv_heads = num_kv_heads
+    layer._k_scale = torch.tensor(0.0, device="cuda")
+    layer._v_scale = torch.tensor(0.0, device="cuda")
+    layer._q_scale = torch.tensor(0.0, device="cuda")
+    layer._k_scale_float = 0.0
+    layer._v_scale_float = 0.0
+    layer._q_scale_float = 0.0
+    layer.q_range = torch.tensor(127.0, device="cuda")
+    layer.k_range = torch.tensor(127.0, device="cuda")
+    layer.v_range = torch.tensor(127.0, device="cuda")
+    layer.calculate_kv_scales = True
+
+    query = torch.randn(num_tokens, num_kv_heads, head_size, device="cuda")
+    key = torch.randn(num_tokens, num_kv_heads, head_size, device="cuda")
+    value = torch.randn(num_tokens, num_kv_heads, head_size, device="cuda")
+
+    from vllm.model_executor.layers.attention.attention import Attention
+
+    Attention.calc_kv_scales(layer, query, key, value)
+
+    # Verify scale = absmax / (FP4_MAX * FP8_E4M3_MAX) = absmax / (6 * 448)
+    k_absmax = torch.abs(key).max()
+    v_absmax = torch.abs(value).max()
+    expected_k = k_absmax / (6.0 * 448.0)
+    expected_v = v_absmax / (6.0 * 448.0)
+
+    torch.testing.assert_close(
+        layer._k_scale, expected_k, atol=1e-6, rtol=1e-5
+    )
+    torch.testing.assert_close(
+        layer._v_scale, expected_v, atol=1e-6, rtol=1e-5
+    )
+    assert layer.calculate_kv_scales is False
+
+
+# ===========================================================================
+# 8. Triton unified_attention with NVFP4 fused dequant
+# ===========================================================================
+@pytest.mark.parametrize("num_heads", [(4, 4), (8, 2)])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("block_size", [16])
+@torch.inference_mode()
+def test_nvfp4_unified_attention_integration(
+    num_heads: tuple[int, int],
+    head_size: int,
+    block_size: int,
+):
+    """End-to-end: quantize KV to NVFP4, run attention with fused dequant,
+    compare to BF16 reference."""
+    from vllm.utils.math_utils import next_power_of_2
+    from vllm.utils.torch_utils import set_random_seed
+    from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+        triton_reshape_and_cache_nvfp4,
+    )
+    from vllm.v1.attention.ops.triton_unified_attention import (
+        unified_attention,
+    )
+
+    set_random_seed(0)
+    torch.set_default_device("cuda")
+
+    num_query_heads, num_kv_heads = num_heads
+    eff_head_size = _nvfp4_effective_head_size(head_size)
+    num_blocks = 64
+    seq_len = 64
+    num_seqs = 2
+    query_len = 1
+
+    # Create query
+    total_q = num_seqs * query_len
+    query = torch.randn(total_q, num_query_heads, head_size, dtype=torch.bfloat16)
+
+    # Create BF16 KV data and quantize to NVFP4
+    key_bf16 = torch.randn(
+        num_blocks * block_size, num_kv_heads, head_size, dtype=torch.bfloat16
+    ) * 0.3
+    value_bf16 = torch.randn(
+        num_blocks * block_size, num_kv_heads, head_size, dtype=torch.bfloat16
+    ) * 0.3
+
+    # NVFP4 cache
+    key_cache_nvfp4 = torch.zeros(
+        num_blocks, block_size, num_kv_heads, eff_head_size, dtype=torch.uint8
+    )
+    value_cache_nvfp4 = torch.zeros_like(key_cache_nvfp4)
+
+    # BF16 cache (for reference)
+    key_cache_bf16 = torch.zeros(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=torch.bfloat16
+    )
+    value_cache_bf16 = torch.zeros_like(key_cache_bf16)
+
+    # Fill both caches with the same data
+    all_slots = torch.arange(
+        num_blocks * block_size, dtype=torch.long, device="cuda"
+    )
+    k_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+    v_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+
+    triton_reshape_and_cache_nvfp4(
+        key_bf16, value_bf16, key_cache_nvfp4, value_cache_nvfp4,
+        all_slots, k_scale, v_scale,
+    )
+
+    # Fill BF16 cache directly
+    for i in range(num_blocks * block_size):
+        blk = i // block_size
+        off = i % block_size
+        key_cache_bf16[blk, off] = key_bf16[i]
+        value_cache_bf16[blk, off] = value_bf16[i]
+
+    # Attention metadata
+    cu_query_lens = torch.tensor(
+        [0] + [query_len] * num_seqs, dtype=torch.int32
+    ).cumsum(dim=0, dtype=torch.int32)
+    kv_lens = torch.tensor([seq_len] * num_seqs, dtype=torch.int32)
+
+    max_blocks_per_seq = (seq_len + block_size - 1) // block_size
+    block_tables = torch.zeros(
+        num_seqs, max_blocks_per_seq, dtype=torch.int32, device="cuda"
+    )
+    for s in range(num_seqs):
+        for b in range(max_blocks_per_seq):
+            block_tables[s, b] = s * max_blocks_per_seq + b
+
+    descale_shape = (num_seqs, num_kv_heads)
+
+    # Run NVFP4 attention (fused dequant)
+    output_nvfp4 = torch.empty_like(query)
+    unified_attention(
+        q=query,
+        k=key_cache_nvfp4,
+        v=value_cache_nvfp4,
+        out=output_nvfp4,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens,
+        max_seqlen_q=query_len,
+        max_seqlen_k=seq_len,
+        softmax_scale=head_size ** -0.5,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=k_scale.expand(descale_shape),
+        v_descale=v_scale.expand(descale_shape),
+        nvfp4_head_size=head_size,
+    )
+
+    # Run BF16 reference attention
+    output_bf16 = torch.empty_like(query)
+    unified_attention(
+        q=query,
+        k=key_cache_bf16,
+        v=value_cache_bf16,
+        out=output_bf16,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens,
+        max_seqlen_q=query_len,
+        max_seqlen_k=seq_len,
+        softmax_scale=head_size ** -0.5,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+    )
+
+    # FP4 quantization is very coarse — generous tolerance
+    torch.testing.assert_close(output_nvfp4, output_bf16, atol=0.15, rtol=0.15)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -19,6 +19,7 @@ CacheDType = Literal[
     "fp8_e5m2",
     "fp8_inc",
     "fp8_ds_mla",
+    "nvfp4",
 ]
 MambaDType = Literal["auto", "float32", "float16"]
 MambaCacheMode = Literal["all", "align", "none"]
@@ -213,5 +214,11 @@ class CacheConfig:
                 "memory footprint and boosts the performance. "
                 "Meanwhile, it may cause accuracy drop without a proper "
                 "scaling factor."
+            )
+        elif cache_dtype == "nvfp4":
+            logger.info(
+                "Using nvfp4 data type to store kv cache. It reduces the GPU "
+                "memory footprint significantly. Meanwhile, it may cause "
+                "accuracy drop without proper scaling factors."
             )
         return cache_dtype

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -360,9 +360,11 @@ class Attention(nn.Module, AttentionLayerBase):
         _init_kv_cache_quant(self, quant_config, prefix)
 
         # for attn backends supporting query quantization
+        # Only FP8 KV cache benefits from FP8 query quantization.
+        # NVFP4 dequantizes to BF16 inline, so queries stay in BF16.
         self.query_quant = None
-        if self.impl.supports_quant_query_input and is_quantized_kv_cache(
-            self.kv_cache_dtype
+        if self.impl.supports_quant_query_input and self.kv_cache_dtype.startswith(
+            "fp8"
         ):
             is_per_head = (
                 hasattr(self, "q_scale") and self.q_scale.numel() == self.num_kv_heads

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -480,12 +480,32 @@ class Attention(nn.Module, AttentionLayerBase):
                 )
 
     def calc_kv_scales(self, query, key, value):
+        if self.kv_cache_dtype == "nvfp4":
+            # NVFP4 global scale: maps data range so block scales (FP8 E4M3,
+            # max ~448) can handle the remaining dynamic range.
+            # global_sf = absmax / (FP4_MAX * FP8_E4M3_MAX)
+            FP4_MAX = 6.0
+            FP8_E4M3_MAX = 448.0
+            k_absmax = torch.abs(key).max()
+            v_absmax = torch.abs(value).max()
+            k_sf = torch.where(k_absmax > 0,
+                               k_absmax / (FP4_MAX * FP8_E4M3_MAX),
+                               torch.ones_like(k_absmax))
+            v_sf = torch.where(v_absmax > 0,
+                               v_absmax / (FP4_MAX * FP8_E4M3_MAX),
+                               torch.ones_like(v_absmax))
+            self._k_scale.copy_(k_sf)
+            self._v_scale.copy_(v_sf)
+            self._k_scale_float = self._k_scale.item()
+            self._v_scale_float = self._v_scale.item()
+        else:
+            # FP8 / INT8: original per-tensor scale behaviour
+            self._k_scale.copy_(torch.abs(key).max() / self.k_range)
+            self._v_scale.copy_(torch.abs(value).max() / self.v_range)
+            self._k_scale_float = self._k_scale.item()
+            self._v_scale_float = self._v_scale.item()
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
-        self._k_scale.copy_(torch.abs(key).max() / self.k_range)
-        self._v_scale.copy_(torch.abs(value).max() / self.v_range)
         self._q_scale_float = self._q_scale.item()
-        self._k_scale_float = self._k_scale.item()
-        self._v_scale_float = self._v_scale.item()
         # We only calculate the scales once
         self.calculate_kv_scales = False
 

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -32,6 +32,7 @@ from vllm.utils.torch_utils import (
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionType,
+    is_quantized_kv_cache,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import get_attn_backend
@@ -360,8 +361,8 @@ class Attention(nn.Module, AttentionLayerBase):
 
         # for attn backends supporting query quantization
         self.query_quant = None
-        if self.impl.supports_quant_query_input and self.kv_cache_dtype.startswith(
-            "fp8"
+        if self.impl.supports_quant_query_input and is_quantized_kv_cache(
+            self.kv_cache_dtype
         ):
             is_per_head = (
                 hasattr(self, "q_scale") and self.q_scale.numel() == self.num_kv_heads
@@ -528,6 +529,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 head_size=self.head_size,
                 dtype=self.kv_cache_torch_dtype,
                 sliding_window=self.sliding_window,
+                cache_dtype_str=self.kv_cache_dtype,
             )
         else:
             return FullAttentionSpec(
@@ -536,6 +538,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 head_size=self.head_size,
                 head_size_v=self.head_size_v,
                 dtype=self.kv_cache_torch_dtype,
+                cache_dtype_str=self.kv_cache_dtype,
             )
 
 

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -32,7 +32,6 @@ from vllm.utils.torch_utils import (
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionType,
-    is_quantized_kv_cache,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import get_attn_backend
@@ -490,12 +489,16 @@ class Attention(nn.Module, AttentionLayerBase):
             FP8_E4M3_MAX = 448.0
             k_absmax = torch.abs(key).max()
             v_absmax = torch.abs(value).max()
-            k_sf = torch.where(k_absmax > 0,
-                               k_absmax / (FP4_MAX * FP8_E4M3_MAX),
-                               torch.ones_like(k_absmax))
-            v_sf = torch.where(v_absmax > 0,
-                               v_absmax / (FP4_MAX * FP8_E4M3_MAX),
-                               torch.ones_like(v_absmax))
+            k_sf = torch.where(
+                k_absmax > 0,
+                k_absmax / (FP4_MAX * FP8_E4M3_MAX),
+                torch.ones_like(k_absmax),
+            )
+            v_sf = torch.where(
+                v_absmax > 0,
+                v_absmax / (FP4_MAX * FP8_E4M3_MAX),
+                torch.ones_like(v_absmax),
+            )
             self._k_scale.copy_(k_sf)
             self._v_scale.copy_(v_sf)
             self._k_scale_float = self._k_scale.item()

--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -61,33 +61,50 @@ class BaseKVCacheMethod(QuantizeMethodBase):
             is_quantized_kv_cache(layer.kv_cache_dtype)
             and not layer.calculate_kv_scales
         ):
-            if layer.k_scale > 0.0 and layer.v_scale > 0.0:
+            is_nvfp4 = layer.kv_cache_dtype == "nvfp4"
+            is_fp8 = layer.kv_cache_dtype.startswith("fp8")
+
+            # Use .all() so comparisons work for both scalar and per-head tensors
+            k_all_pos = bool((layer.k_scale > 0.0).all())
+            v_all_pos = bool((layer.v_scale > 0.0).all())
+            k_all_neg = bool((layer.k_scale < 0.0).all())
+            v_all_neg = bool((layer.v_scale < 0.0).all())
+
+            if k_all_pos and v_all_pos:
                 # We prefer to use separate k_scale and v_scale if present
                 k_scale = layer.k_scale.to("cpu").tolist()
                 v_scale = layer.v_scale.to("cpu").tolist()
-                if current_platform.is_fp8_fnuz():
+                if current_platform.is_fp8_fnuz() and is_fp8:
                     k_scale *= 2
                     v_scale *= 2
-            elif layer.k_scale < 0.0 and layer.v_scale < 0.0:
-                # If no scales were loaded (both scales are invalid negative
-                # values), use the default value of 1.0
+            elif k_all_neg and v_all_neg:
+                # No scales in checkpoint
+                if is_nvfp4:
+                    # NVFP4 with scale=1.0 is acceptable: block-level FP8
+                    # scales handle the primary quantization. The global scale
+                    # just provides a second-level range adjustment.
+                    logger.warning_once(
+                        "NVFP4 KV cache: no calibrated k/v_scale found in "
+                        "checkpoint. Using default global scale 1.0. "
+                        "Block-level FP8 scales will still be computed "
+                        "dynamically per quantization group."
+                    )
                 k_scale = 1.0
                 v_scale = 1.0
             else:
-                # If we find a single kv_scale in the checkpoint, we remap
-                # kv_scale to k_scale during weight loading, and duplicate
-                # k_scale to v_scale here
-                assert layer.k_scale > 0.0
+                # Single shared kv_scale — duplicate to k and v
+                assert k_all_pos
                 scale_to_duplicate = max(layer.k_scale, layer.v_scale)
                 k_scale = scale_to_duplicate.to("cpu").tolist()
                 v_scale = scale_to_duplicate.to("cpu").tolist()
-                if current_platform.is_fp8_fnuz():
+                if current_platform.is_fp8_fnuz() and is_fp8:
                     k_scale *= 2
                     v_scale *= 2
 
             if not isinstance(k_scale, float) or not isinstance(v_scale, float):
                 raise ValueError(
-                    "Only support per-tensor scaling factor for fp8 KV cache"
+                    "Only support per-tensor scaling factor "
+                    "for fp8/nvfp4 KV cache"
                 )
 
             if layer.q_scale < 0.0:
@@ -105,11 +122,19 @@ class BaseKVCacheMethod(QuantizeMethodBase):
             layer._k_scale_float = k_scale
             layer._v_scale_float = v_scale
             if k_scale == 1.0 and v_scale == 1.0 and "e5m2" not in layer.kv_cache_dtype:
-                logger.warning_once(
-                    "Using KV cache scaling factor 1.0 for fp8_e4m3. "
-                    "If this is unintended, verify that k/v_scale "
-                    "scaling factors are properly set in the checkpoint."
-                )
+                if is_nvfp4:
+                    logger.warning_once(
+                        "Using KV cache global scaling factor 1.0 for nvfp4. "
+                        "Block-level FP8 scales will handle primary "
+                        "quantization. If a global scale was expected, verify "
+                        "k/v_scale in the checkpoint."
+                    )
+                else:
+                    logger.warning_once(
+                        "Using KV cache scaling factor 1.0 for fp8_e4m3. "
+                        "If this is unintended, verify that k/v_scale "
+                        "scaling factors are properly set in the checkpoint."
+                    )
 
         if layer.q_scale > 0.0:
             q_scale = layer.q_scale

--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -103,8 +103,7 @@ class BaseKVCacheMethod(QuantizeMethodBase):
 
             if not isinstance(k_scale, float) or not isinstance(v_scale, float):
                 raise ValueError(
-                    "Only support per-tensor scaling factor "
-                    "for fp8/nvfp4 KV cache"
+                    "Only support per-tensor scaling factor for fp8/nvfp4 KV cache"
                 )
 
             if layer.q_scale < 0.0:

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -118,12 +118,28 @@ QUANT_ALGOS = [
     # MIXED_PRECISION,
     "MIXED_PRECISION",
 ]
-KV_CACHE_QUANT_ALGOS = ["FP8"]
+KV_CACHE_QUANT_ALGOS = ["FP8", "NVFP4"]
 
 
 class ModelOptFp8KVCacheMethod(BaseKVCacheMethod):
     """
     Supports loading kv-cache scaling factors from FP8 checkpoints.
+    """
+
+    def __init__(self, quant_config: "ModelOptQuantConfigBase"):
+        super().__init__(quant_config)
+
+
+class ModelOptNvFp4KVCacheMethod(BaseKVCacheMethod):
+    """
+    Supports loading kv-cache scaling factors for NVFP4 KV cache.
+
+    NVFP4 uses a two-level quantization scheme:
+      - Level 1 (block scale): FP8 E4M3, one per group of 16 FP4 elements
+      - Level 2 (global scale): per-tensor K and V scales from checkpoint
+
+    The k_scale and v_scale loaded from checkpoint serve as the global
+    (second-level) scale factors used during quantization and dequantization.
     """
 
     def __init__(self, quant_config: "ModelOptQuantConfigBase"):
@@ -1459,7 +1475,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
 
 ModelOptNvFp4Config.LinearMethodCls = ModelOptNvFp4LinearMethod
 ModelOptNvFp4Config.FusedMoEMethodCls = ModelOptNvFp4FusedMoE
-ModelOptNvFp4Config.KVCacheMethodCls = ModelOptFp8KVCacheMethod
+ModelOptNvFp4Config.KVCacheMethodCls = ModelOptNvFp4KVCacheMethod
 
 
 class ModelOptMxFp8Config(ModelOptQuantConfigBase):

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -41,6 +41,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "int8": torch.int8,
     "fp8_inc": torch.float8_e4m3fn,
     "fp8_ds_mla": torch.uint8,
+    "nvfp4": torch.uint8,
 }
 
 TORCH_DTYPE_TO_NUMPY_DTYPE = {
@@ -54,10 +55,8 @@ TORCH_DTYPE_TO_NUMPY_DTYPE = {
 
 
 MODELOPT_TO_VLLM_KV_CACHE_DTYPE_MAP = {
-    # TODO: Add more modelopt kv cache dtype
-    # mappings here when it supported by some attention backend
-    # (for example supports nvfp4).
     "fp8": "fp8_e4m3",
+    "nvfp4": "nvfp4",
 }
 
 T = TypeVar("T")

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -927,7 +927,7 @@ class SparseMLAAttentionImpl(AttentionImplBase[T], Generic[T]):
 
 
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
-    return kv_cache_dtype.startswith("fp8")
+    return kv_cache_dtype.startswith("fp8") or kv_cache_dtype == "nvfp4"
 
 
 def subclass_attention_backend(

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -31,6 +31,7 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.ops.triton_prefill_attention import context_attention_fwd
 from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
     triton_reshape_and_cache_flash,
+    triton_reshape_and_cache_nvfp4,
 )
 from vllm.v1.attention.ops.triton_unified_attention import unified_attention
 from vllm.v1.kv_cache_interface import AttentionSpec
@@ -267,6 +268,7 @@ class TritonAttentionBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
         "fp8_e5m2",
+        "nvfp4",
     ]
 
     @staticmethod
@@ -299,6 +301,15 @@ class TritonAttentionBackend(AttentionBackend):
     ) -> tuple[int, ...]:
         if block_size % 16 != 0:
             raise ValueError("Block size must be a multiple of 16.")
+        if cache_dtype_str == "nvfp4":
+            from vllm.v1.kv_cache_interface import NVFP4_QUANT_BLOCK_SIZE
+
+            assert head_size % NVFP4_QUANT_BLOCK_SIZE == 0
+            # Packed FP4 data + FP8 block scales per head
+            effective_head_size = (
+                head_size // 2 + head_size // NVFP4_QUANT_BLOCK_SIZE
+            )
+            return (num_blocks, 2, block_size, num_kv_heads, effective_head_size)
         return (num_blocks, 2, block_size, num_kv_heads, head_size)
 
     @staticmethod
@@ -471,7 +482,10 @@ class TritonAttentionImpl(AttentionImpl):
 
         # For decoder and cross-attention, use KV cache as before
         key_cache, value_cache = kv_cache.unbind(1)
-        if self.kv_cache_dtype.startswith("fp8"):
+
+        nvfp4_mode = self.kv_cache_dtype == "nvfp4"
+
+        if not nvfp4_mode and self.kv_cache_dtype.startswith("fp8"):
             if key_cache.dtype != self.fp8_dtype:
                 key_cache = key_cache.view(self.fp8_dtype)
                 value_cache = value_cache.view(self.fp8_dtype)
@@ -521,6 +535,8 @@ class TritonAttentionImpl(AttentionImpl):
             sinks=self.sinks,
             output_scale=output_scale,
             mm_prefix_range=mm_prefix_range_tensor,
+            # NVFP4: kernel does inline dequant using packed cache + scales
+            nvfp4_head_size=self.head_size if nvfp4_mode else 0,
         )
 
         return output
@@ -585,6 +601,19 @@ class TritonAttentionImpl(AttentionImpl):
             return
         # For decoder and cross-attention, use KV cache as before
         key_cache, value_cache = kv_cache.unbind(1)
+
+        if self.kv_cache_dtype == "nvfp4":
+            # NVFP4 quantization: pack FP4 data + block scales into cache
+            triton_reshape_and_cache_nvfp4(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                slot_mapping,
+                layer._k_scale,
+                layer._v_scale,
+            )
+            return
 
         # Reshape the input keys and values and store them in the cache.
         if self.kv_cache_dtype.startswith("fp8"):

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -306,9 +306,7 @@ class TritonAttentionBackend(AttentionBackend):
 
             assert head_size % NVFP4_QUANT_BLOCK_SIZE == 0
             # Packed FP4 data + FP8 block scales per head
-            effective_head_size = (
-                head_size // 2 + head_size // NVFP4_QUANT_BLOCK_SIZE
-            )
+            effective_head_size = head_size // 2 + head_size // NVFP4_QUANT_BLOCK_SIZE
             return (num_blocks, 2, block_size, num_kv_heads, effective_head_size)
         return (num_blocks, 2, block_size, num_kv_heads, head_size)
 

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -424,26 +424,26 @@ def _fp4_e2m1_quantize(val):
 
     # Round to nearest representable value using midpoint thresholds
     code = (abs_val * 0).to(tl.int32)  # zeros with same shape
-    code = tl.where(abs_val >= 0.25, 1, code)   # 0.5
-    code = tl.where(abs_val >= 0.75, 2, code)   # 1.0
-    code = tl.where(abs_val >= 1.25, 3, code)   # 1.5
-    code = tl.where(abs_val >= 1.75, 4, code)   # 2.0
-    code = tl.where(abs_val >= 2.5, 5, code)    # 3.0
-    code = tl.where(abs_val >= 3.5, 6, code)    # 4.0
-    code = tl.where(abs_val >= 5.0, 7, code)    # 6.0
+    code = tl.where(abs_val >= 0.25, 1, code)  # 0.5
+    code = tl.where(abs_val >= 0.75, 2, code)  # 1.0
+    code = tl.where(abs_val >= 1.25, 3, code)  # 1.5
+    code = tl.where(abs_val >= 1.75, 4, code)  # 2.0
+    code = tl.where(abs_val >= 2.5, 5, code)  # 3.0
+    code = tl.where(abs_val >= 3.5, 6, code)  # 4.0
+    code = tl.where(abs_val >= 5.0, 7, code)  # 6.0
 
     return sign | code
 
 
 @triton.jit
 def reshape_and_cache_nvfp4_kernel(
-    key_ptr,             # [num_tokens, num_heads, head_size] in bf16/fp16
-    value_ptr,           # [num_tokens, num_heads, head_size] in bf16/fp16
-    key_cache_ptr,       # [num_blocks, block_size, num_heads, eff_head_size] uint8
-    value_cache_ptr,     # [num_blocks, block_size, num_heads, eff_head_size] uint8
-    slot_mapping_ptr,    # [num_tokens]
-    k_scale_ptr,         # global K scale (float32 tensor, scalar)
-    v_scale_ptr,         # global V scale (float32 tensor, scalar)
+    key_ptr,  # [num_tokens, num_heads, head_size] in bf16/fp16
+    value_ptr,  # [num_tokens, num_heads, head_size] in bf16/fp16
+    key_cache_ptr,  # [num_blocks, block_size, num_heads, eff_head_size] uint8
+    value_cache_ptr,  # [num_blocks, block_size, num_heads, eff_head_size] uint8
+    slot_mapping_ptr,  # [num_tokens]
+    k_scale_ptr,  # global K scale (float32 tensor, scalar)
+    v_scale_ptr,  # global V scale (float32 tensor, scalar)
     # strides (for source tensors, in elements)
     key_stride: tl.int64,
     value_stride: tl.int64,
@@ -456,8 +456,8 @@ def reshape_and_cache_nvfp4_kernel(
     head_size: tl.constexpr,
     block_size: tl.constexpr,
     QUANT_GROUP_SIZE: tl.constexpr,
-    packed_head_size: tl.constexpr,    # head_size // 2
-    scale_head_size: tl.constexpr,     # head_size // QUANT_GROUP_SIZE
+    packed_head_size: tl.constexpr,  # head_size // 2
+    scale_head_size: tl.constexpr,  # head_size // QUANT_GROUP_SIZE
 ):
     """Reshape, quantize to NVFP4, and cache K/V vectors.
 
@@ -480,20 +480,24 @@ def reshape_and_cache_nvfp4_kernel(
     block_offset = slot_idx % block_size
 
     # Source offset for this head's group
-    src_key_base = (token_idx * key_stride
-                    + head_idx * head_size
-                    + group_idx * QUANT_GROUP_SIZE)
-    src_val_base = (token_idx * value_stride
-                    + head_idx * head_size
-                    + group_idx * QUANT_GROUP_SIZE)
+    src_key_base = (
+        token_idx * key_stride + head_idx * head_size + group_idx * QUANT_GROUP_SIZE
+    )
+    src_val_base = (
+        token_idx * value_stride + head_idx * head_size + group_idx * QUANT_GROUP_SIZE
+    )
 
     # Cache base offset for this token's head
-    cache_base_k = (block_idx * cache_block_stride
-                    + block_offset * cache_page_stride
-                    + head_idx * cache_head_stride)
-    cache_base_v = (block_idx * cache_block_stride
-                    + block_offset * cache_page_stride
-                    + head_idx * cache_head_stride)
+    cache_base_k = (
+        block_idx * cache_block_stride
+        + block_offset * cache_page_stride
+        + head_idx * cache_head_stride
+    )
+    cache_base_v = (
+        block_idx * cache_block_stride
+        + block_offset * cache_page_stride
+        + head_idx * cache_head_stride
+    )
 
     # Load global scale factors
     global_k_sf = tl.load(k_scale_ptr)
@@ -534,29 +538,31 @@ def reshape_and_cache_nvfp4_kernel(
 
     # Store packed FP4 data
     packed_offset = group_idx * (QUANT_GROUP_SIZE // 2)
-    tl.store(key_cache_ptr + cache_base_k + packed_offset + pair_offs,
-             k_packed)
-    tl.store(value_cache_ptr + cache_base_v + packed_offset + pair_offs,
-             v_packed)
+    tl.store(key_cache_ptr + cache_base_k + packed_offset + pair_offs, k_packed)
+    tl.store(value_cache_ptr + cache_base_v + packed_offset + pair_offs, v_packed)
 
     # Store block scales as FP8 E4M3 (bitcast to uint8)
     scale_offset = packed_head_size + group_idx
     k_scale_fp8 = k_block_scale.to(tl.float8e4nv)
     v_scale_fp8 = v_block_scale.to(tl.float8e4nv)
-    tl.store(key_cache_ptr + cache_base_k + scale_offset,
-             k_scale_fp8.to(tl.uint8, bitcast=True))
-    tl.store(value_cache_ptr + cache_base_v + scale_offset,
-             v_scale_fp8.to(tl.uint8, bitcast=True))
+    tl.store(
+        key_cache_ptr + cache_base_k + scale_offset,
+        k_scale_fp8.to(tl.uint8, bitcast=True),
+    )
+    tl.store(
+        value_cache_ptr + cache_base_v + scale_offset,
+        v_scale_fp8.to(tl.uint8, bitcast=True),
+    )
 
 
 def triton_reshape_and_cache_nvfp4(
-    key: torch.Tensor,         # [num_tokens, num_heads, head_size]
-    value: torch.Tensor,       # [num_tokens, num_heads, head_size]
-    key_cache: torch.Tensor,   # [num_blocks, block_size, num_heads, eff_head_size]
-    value_cache: torch.Tensor, # [num_blocks, block_size, num_heads, eff_head_size]
+    key: torch.Tensor,  # [num_tokens, num_heads, head_size]
+    value: torch.Tensor,  # [num_tokens, num_heads, head_size]
+    key_cache: torch.Tensor,  # [num_blocks, block_size, num_heads, eff_head_size]
+    value_cache: torch.Tensor,  # [num_blocks, block_size, num_heads, eff_head_size]
     slot_mapping: torch.Tensor,  # [num_tokens]
-    k_scale: torch.Tensor,    # global K scale (float32)
-    v_scale: torch.Tensor,    # global V scale (float32)
+    k_scale: torch.Tensor,  # global K scale (float32)
+    v_scale: torch.Tensor,  # global V scale (float32)
 ):
     """Quantize K/V to NVFP4 and store in paged KV cache.
 

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -5,6 +5,7 @@ import torch
 
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.v1.kv_cache_interface import NVFP4_QUANT_BLOCK_SIZE
 
 
 @triton.jit
@@ -392,4 +393,219 @@ def triton_reshape_and_cache_flash_diffkv(
         TILE_SIZE=TILE_SIZE,
         num_warps=num_warps,
         num_stages=num_stages,
+    )
+
+
+# ===================== NVFP4 KV Cache Support =====================
+# NVFP4 (E2M1) uses 4 bits per element, packed 2 per byte as uint8.
+# Block scales are FP8 (E4M3), one per NVFP4_QUANT_BLOCK_SIZE elements.
+#
+# Cache layout per head per token (contiguous in the last dim):
+#   [packed_fp4_data (head_size // 2 bytes)] [block_scales (head_size // 16 bytes)]
+#
+# FP4 E2M1 encoding (4 bits): [sign(1) | exponent(2) | mantissa(1)]
+#   Representable magnitudes: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
+
+FP4_E2M1_MAX = 6.0
+
+
+@triton.jit
+def _fp4_e2m1_quantize(val):
+    """Quantize a float value to FP4 E2M1 (4-bit), returning 4-bit codes.
+
+    E2M1 format: [sign | exp(2) | mantissa(1)]
+    Representable magnitudes: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
+    """
+    sign = tl.where(val < 0, 8, 0).to(tl.int32)
+    abs_val = tl.abs(val)
+
+    # Clamp to representable range
+    abs_val = tl.minimum(abs_val, 6.0)
+
+    # Round to nearest representable value using midpoint thresholds
+    code = tl.zeros_like(abs_val, dtype=tl.int32)
+    code = tl.where(abs_val >= 0.25, 1, code)   # 0.5
+    code = tl.where(abs_val >= 0.75, 2, code)   # 1.0
+    code = tl.where(abs_val >= 1.25, 3, code)   # 1.5
+    code = tl.where(abs_val >= 1.75, 4, code)   # 2.0
+    code = tl.where(abs_val >= 2.5, 5, code)    # 3.0
+    code = tl.where(abs_val >= 3.5, 6, code)    # 4.0
+    code = tl.where(abs_val >= 5.0, 7, code)    # 6.0
+
+    return sign | code
+
+
+@triton.jit
+def reshape_and_cache_nvfp4_kernel(
+    key_ptr,             # [num_tokens, num_heads, head_size] in bf16/fp16
+    value_ptr,           # [num_tokens, num_heads, head_size] in bf16/fp16
+    key_cache_ptr,       # [num_blocks, block_size, num_heads, eff_head_size] uint8
+    value_cache_ptr,     # [num_blocks, block_size, num_heads, eff_head_size] uint8
+    slot_mapping_ptr,    # [num_tokens]
+    k_scale_ptr,         # global K scale (float32 tensor, scalar)
+    v_scale_ptr,         # global V scale (float32 tensor, scalar)
+    # strides (for source tensors, in elements)
+    key_stride: tl.int64,
+    value_stride: tl.int64,
+    # strides (for cache tensors, in bytes since uint8)
+    cache_block_stride: tl.int64,
+    cache_page_stride: tl.int64,
+    cache_head_stride: tl.int64,
+    # constexpr
+    num_heads: tl.constexpr,
+    head_size: tl.constexpr,
+    block_size: tl.constexpr,
+    QUANT_GROUP_SIZE: tl.constexpr,
+    packed_head_size: tl.constexpr,    # head_size // 2
+    scale_head_size: tl.constexpr,     # head_size // QUANT_GROUP_SIZE
+):
+    """Reshape, quantize to NVFP4, and cache K/V vectors.
+
+    For each head, the cache stores (contiguously):
+      - packed FP4 data: head_size // 2 bytes (2 elements per byte)
+      - block scales: head_size // QUANT_GROUP_SIZE bytes (FP8 E4M3)
+
+    Each program instance handles one token and one quantization group
+    (QUANT_GROUP_SIZE elements) across all heads.
+    """
+    token_idx = tl.program_id(axis=0)
+    head_idx = tl.program_id(axis=1)
+    group_idx = tl.program_id(axis=2)
+
+    slot_idx = tl.load(slot_mapping_ptr + token_idx).to(tl.int64)
+    if slot_idx < 0:
+        return
+
+    block_idx = slot_idx // block_size
+    block_offset = slot_idx % block_size
+
+    # Source offset for this head's group
+    src_key_base = (token_idx * key_stride
+                    + head_idx * head_size
+                    + group_idx * QUANT_GROUP_SIZE)
+    src_val_base = (token_idx * value_stride
+                    + head_idx * head_size
+                    + group_idx * QUANT_GROUP_SIZE)
+
+    # Cache base offset for this token's head
+    cache_base_k = (block_idx * cache_block_stride
+                    + block_offset * cache_page_stride
+                    + head_idx * cache_head_stride)
+    cache_base_v = (block_idx * cache_block_stride
+                    + block_offset * cache_page_stride
+                    + head_idx * cache_head_stride)
+
+    # Load global scale factors
+    global_k_sf = tl.load(k_scale_ptr)
+    global_v_sf = tl.load(v_scale_ptr)
+
+    # Load the group of elements
+    group_offs = tl.arange(0, QUANT_GROUP_SIZE)
+    k_vals = tl.load(key_ptr + src_key_base + group_offs).to(tl.float32)
+    v_vals = tl.load(value_ptr + src_val_base + group_offs).to(tl.float32)
+
+    # Compute per-group absmax
+    k_absmax = tl.max(tl.abs(k_vals))
+    v_absmax = tl.max(tl.abs(v_vals))
+
+    # Compute block scales: scale = absmax / (FP4_MAX * global_sf)
+    # Dequant formula: value = fp4_code * block_scale * global_sf
+    k_block_scale = k_absmax / (6.0 * global_k_sf + 1e-12)
+    v_block_scale = v_absmax / (6.0 * global_v_sf + 1e-12)
+
+    # Scale values to FP4 range
+    k_scaled = k_vals / (k_block_scale * global_k_sf + 1e-12)
+    v_scaled = v_vals / (v_block_scale * global_v_sf + 1e-12)
+
+    # Quantize to FP4 E2M1
+    k_codes = _fp4_e2m1_quantize(k_scaled)
+    v_codes = _fp4_e2m1_quantize(v_scaled)
+
+    # Pack pairs of FP4 values into uint8: byte[i] = code[2i] | (code[2i+1] << 4)
+    pair_offs = tl.arange(0, QUANT_GROUP_SIZE // 2)
+    k_lo = k_codes[pair_offs * 2] & 0xF
+    k_hi = (k_codes[pair_offs * 2 + 1] & 0xF) << 4
+    k_packed = (k_lo | k_hi).to(tl.uint8)
+
+    v_lo = v_codes[pair_offs * 2] & 0xF
+    v_hi = (v_codes[pair_offs * 2 + 1] & 0xF) << 4
+    v_packed = (v_lo | v_hi).to(tl.uint8)
+
+    # Store packed FP4 data
+    packed_offset = group_idx * (QUANT_GROUP_SIZE // 2)
+    tl.store(key_cache_ptr + cache_base_k + packed_offset + pair_offs,
+             k_packed)
+    tl.store(value_cache_ptr + cache_base_v + packed_offset + pair_offs,
+             v_packed)
+
+    # Store block scales as FP8 E4M3 (bitcast to uint8)
+    scale_offset = packed_head_size + group_idx
+    k_scale_fp8 = k_block_scale.to(tl.float8e4nv)
+    v_scale_fp8 = v_block_scale.to(tl.float8e4nv)
+    tl.store(key_cache_ptr + cache_base_k + scale_offset,
+             k_scale_fp8.to(tl.uint8, bitcast=True))
+    tl.store(value_cache_ptr + cache_base_v + scale_offset,
+             v_scale_fp8.to(tl.uint8, bitcast=True))
+
+
+def triton_reshape_and_cache_nvfp4(
+    key: torch.Tensor,         # [num_tokens, num_heads, head_size]
+    value: torch.Tensor,       # [num_tokens, num_heads, head_size]
+    key_cache: torch.Tensor,   # [num_blocks, block_size, num_heads, eff_head_size]
+    value_cache: torch.Tensor, # [num_blocks, block_size, num_heads, eff_head_size]
+    slot_mapping: torch.Tensor,  # [num_tokens]
+    k_scale: torch.Tensor,    # global K scale (float32)
+    v_scale: torch.Tensor,    # global V scale (float32)
+):
+    """Quantize K/V to NVFP4 and store in paged KV cache.
+
+    The cache layout per head per token is:
+      [packed_fp4_data (head_size//2 bytes)] [block_scales (head_size//16 bytes)]
+
+    Args:
+        key: Input key tensor in BF16/FP16.
+        value: Input value tensor in BF16/FP16.
+        key_cache: Pre-allocated key cache (uint8).
+        value_cache: Pre-allocated value cache (uint8).
+        slot_mapping: Maps token index to cache slot.
+        k_scale: Global key scale factor (second-level SF).
+        v_scale: Global value scale factor (second-level SF).
+    """
+    num_tokens = key.shape[0]
+    num_heads = key.shape[1]
+    head_size = key.shape[2]
+
+    assert head_size % NVFP4_QUANT_BLOCK_SIZE == 0
+    packed_head_size = head_size // 2
+    scale_head_size = head_size // NVFP4_QUANT_BLOCK_SIZE
+    num_groups = head_size // NVFP4_QUANT_BLOCK_SIZE
+
+    block_size = key_cache.shape[1]
+    cache_block_stride = key_cache.stride(0)
+    cache_page_stride = key_cache.stride(1)
+    cache_head_stride = key_cache.stride(2)
+
+    grid = (num_tokens, num_heads, num_groups)
+
+    reshape_and_cache_nvfp4_kernel[grid](
+        key_ptr=key,
+        value_ptr=value,
+        key_cache_ptr=key_cache,
+        value_cache_ptr=value_cache,
+        slot_mapping_ptr=slot_mapping,
+        k_scale_ptr=k_scale,
+        v_scale_ptr=v_scale,
+        key_stride=key.stride(0),
+        value_stride=value.stride(0),
+        cache_block_stride=cache_block_stride,
+        cache_page_stride=cache_page_stride,
+        cache_head_stride=cache_head_stride,
+        num_heads=num_heads,
+        head_size=head_size,
+        block_size=block_size,
+        QUANT_GROUP_SIZE=NVFP4_QUANT_BLOCK_SIZE,
+        packed_head_size=packed_head_size,
+        scale_head_size=scale_head_size,
+        num_warps=4,
+        num_stages=2,
     )

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -423,7 +423,7 @@ def _fp4_e2m1_quantize(val):
     abs_val = tl.minimum(abs_val, 6.0)
 
     # Round to nearest representable value using midpoint thresholds
-    code = tl.zeros_like(abs_val, dtype=tl.int32)
+    code = (abs_val * 0).to(tl.int32)  # zeros with same shape
     code = tl.where(abs_val >= 0.25, 1, code)   # 0.5
     code = tl.where(abs_val >= 0.75, 2, code)   # 1.0
     code = tl.where(abs_val >= 1.25, 3, code)   # 1.5
@@ -499,37 +499,38 @@ def reshape_and_cache_nvfp4_kernel(
     global_k_sf = tl.load(k_scale_ptr)
     global_v_sf = tl.load(v_scale_ptr)
 
-    # Load the group of elements
-    group_offs = tl.arange(0, QUANT_GROUP_SIZE)
-    k_vals = tl.load(key_ptr + src_key_base + group_offs).to(tl.float32)
-    v_vals = tl.load(value_ptr + src_val_base + group_offs).to(tl.float32)
+    # Load even and odd elements separately to avoid fancy indexing
+    # even_offs = [0, 2, 4, ...], odd_offs = [1, 3, 5, ...]
+    pair_offs = tl.arange(0, QUANT_GROUP_SIZE // 2)
+    even_offs = pair_offs * 2
+    odd_offs = even_offs + 1
 
-    # Compute per-group absmax
-    k_absmax = tl.max(tl.abs(k_vals))
-    v_absmax = tl.max(tl.abs(v_vals))
+    k_even = tl.load(key_ptr + src_key_base + even_offs).to(tl.float32)
+    k_odd = tl.load(key_ptr + src_key_base + odd_offs).to(tl.float32)
+    v_even = tl.load(value_ptr + src_val_base + even_offs).to(tl.float32)
+    v_odd = tl.load(value_ptr + src_val_base + odd_offs).to(tl.float32)
+
+    # Compute per-group absmax (over all elements in the group)
+    k_absmax = tl.maximum(tl.max(tl.abs(k_even)), tl.max(tl.abs(k_odd)))
+    v_absmax = tl.maximum(tl.max(tl.abs(v_even)), tl.max(tl.abs(v_odd)))
 
     # Compute block scales: scale = absmax / (FP4_MAX * global_sf)
     # Dequant formula: value = fp4_code * block_scale * global_sf
     k_block_scale = k_absmax / (6.0 * global_k_sf + 1e-12)
     v_block_scale = v_absmax / (6.0 * global_v_sf + 1e-12)
 
-    # Scale values to FP4 range
-    k_scaled = k_vals / (k_block_scale * global_k_sf + 1e-12)
-    v_scaled = v_vals / (v_block_scale * global_v_sf + 1e-12)
+    # Scale values to FP4 range and quantize
+    k_denom = k_block_scale * global_k_sf + 1e-12
+    v_denom = v_block_scale * global_v_sf + 1e-12
 
-    # Quantize to FP4 E2M1
-    k_codes = _fp4_e2m1_quantize(k_scaled)
-    v_codes = _fp4_e2m1_quantize(v_scaled)
+    k_even_codes = _fp4_e2m1_quantize(k_even / k_denom)
+    k_odd_codes = _fp4_e2m1_quantize(k_odd / k_denom)
+    v_even_codes = _fp4_e2m1_quantize(v_even / v_denom)
+    v_odd_codes = _fp4_e2m1_quantize(v_odd / v_denom)
 
-    # Pack pairs of FP4 values into uint8: byte[i] = code[2i] | (code[2i+1] << 4)
-    pair_offs = tl.arange(0, QUANT_GROUP_SIZE // 2)
-    k_lo = k_codes[pair_offs * 2] & 0xF
-    k_hi = (k_codes[pair_offs * 2 + 1] & 0xF) << 4
-    k_packed = (k_lo | k_hi).to(tl.uint8)
-
-    v_lo = v_codes[pair_offs * 2] & 0xF
-    v_hi = (v_codes[pair_offs * 2 + 1] & 0xF) << 4
-    v_packed = (v_lo | v_hi).to(tl.uint8)
+    # Pack: byte[i] = even_code[i] | (odd_code[i] << 4)
+    k_packed = ((k_even_codes & 0xF) | ((k_odd_codes & 0xF) << 4)).to(tl.uint8)
+    v_packed = ((v_even_codes & 0xF) | ((v_odd_codes & 0xF) << 4)).to(tl.uint8)
 
     # Store packed FP4 data
     packed_offset = group_idx * (QUANT_GROUP_SIZE // 2)

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -39,7 +39,7 @@ def _nvfp4_decode_magnitude(mag_idx):
 
     Magnitude LUT: [0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
     """
-    mag = tl.zeros_like(mag_idx, dtype=tl.float32)
+    mag = (mag_idx * 0).to(tl.float32)  # zeros with same shape
     mag = tl.where(mag_idx == 1, 0.5, mag)
     mag = tl.where(mag_idx == 2, 1.0, mag)
     mag = tl.where(mag_idx == 3, 1.5, mag)

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -23,8 +23,22 @@ float8_info = torch.finfo(current_platform.fp8_dtype())
 # Format: [sign(1) | exp(2) | mantissa(1)]
 # Magnitudes: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
 FP4_E2M1_DEQUANT_TABLE = [
-    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,       # positive
-    0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,  # negative
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,  # positive
+    0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,  # negative
 ]
 
 
@@ -56,7 +70,7 @@ def _nvfp4_dequant_page_kernel(
     src_cache_ptr,
     # Output dequantized cache: [num_blocks, block_size, num_kv_heads, head_size]
     dst_cache_ptr,
-    global_scale_ptr,      # float32 scalar
+    global_scale_ptr,  # float32 scalar
     src_stride_0: tl.int64,  # block stride
     src_stride_1: tl.int64,  # page (token-in-block) stride
     src_stride_2: tl.int64,  # head stride (= effective_head_size)
@@ -67,9 +81,9 @@ def _nvfp4_dequant_page_kernel(
     HEAD_SIZE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     QUANT_GROUP_SIZE: tl.constexpr,
-    PACKED_HEAD_SIZE: tl.constexpr,   # HEAD_SIZE // 2
-    SCALE_HEAD_SIZE: tl.constexpr,    # HEAD_SIZE // QUANT_GROUP_SIZE
-    PAIRS_PER_GROUP: tl.constexpr,    # QUANT_GROUP_SIZE // 2
+    PACKED_HEAD_SIZE: tl.constexpr,  # HEAD_SIZE // 2
+    SCALE_HEAD_SIZE: tl.constexpr,  # HEAD_SIZE // QUANT_GROUP_SIZE
+    PAIRS_PER_GROUP: tl.constexpr,  # QUANT_GROUP_SIZE // 2
 ):
     """Dequantize one token-slot of one head in the NVFP4 paged KV cache.
 
@@ -82,14 +96,18 @@ def _nvfp4_dequant_page_kernel(
     token_in_block = slot_idx % BLOCK_SIZE
 
     # Source offset: beginning of this token's head data
-    src_base = (block_idx * src_stride_0
-                + token_in_block * src_stride_1
-                + head_idx * src_stride_2)
+    src_base = (
+        block_idx * src_stride_0
+        + token_in_block * src_stride_1
+        + head_idx * src_stride_2
+    )
 
     # Destination offset
-    dst_base = (block_idx * dst_stride_0
-                + token_in_block * dst_stride_1
-                + head_idx * dst_stride_2)
+    dst_base = (
+        block_idx * dst_stride_0
+        + token_in_block * dst_stride_1
+        + head_idx * dst_stride_2
+    )
 
     global_scale = tl.load(global_scale_ptr)
 
@@ -104,7 +122,7 @@ def _nvfp4_dequant_page_kernel(
     packed = tl.load(src_cache_ptr + src_base + pair_offs)
 
     # Extract low and high nibbles
-    lo_codes = (packed.to(tl.int32)) & 0xF   # even elements
+    lo_codes = (packed.to(tl.int32)) & 0xF  # even elements
     hi_codes = (packed.to(tl.int32) >> 4) & 0xF  # odd elements
 
     # Decode sign and magnitude
@@ -417,7 +435,7 @@ def kernel_unified_attention_2d(
     # Pre-compute NVFP4 index helpers (outside tile loop, constant across tiles)
     if USE_NVFP4:
         packed_byte_pos = offs_d // 2
-        is_high = ((offs_d % 2) == 1)
+        is_high = (offs_d % 2) == 1
         scale_group_idx = offs_d // QUANT_GROUP_SIZE
 
     # iterate through tiles (now limited to the sliding window range)
@@ -438,11 +456,12 @@ def kernel_unified_attention_2d(
                 + packed_byte_pos[:, None] * stride_k_cache_3
                 + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
             )
-            k_packed = tl.load(key_cache_ptr + k_packed_off,
-                               mask=dim_mask[:, None] & tile_mask[None, :],
-                               other=0).to(tl.int32)
-            k_codes = tl.where(is_high[:, None],
-                               (k_packed >> 4) & 0xF, k_packed & 0xF)
+            k_packed = tl.load(
+                key_cache_ptr + k_packed_off,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0,
+            ).to(tl.int32)
+            k_codes = tl.where(is_high[:, None], (k_packed >> 4) & 0xF, k_packed & 0xF)
             k_sign = tl.where(k_codes & 8, -1.0, 1.0)
             k_mag = _nvfp4_decode_magnitude(k_codes & 0x7)
 
@@ -452,9 +471,11 @@ def kernel_unified_attention_2d(
                 + (PACKED_HEAD_SIZE + scale_group_idx)[:, None] * stride_k_cache_3
                 + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
             )
-            k_sf = tl.load(key_cache_ptr + k_sf_off,
-                           mask=dim_mask[:, None] & tile_mask[None, :],
-                           other=0)
+            k_sf = tl.load(
+                key_cache_ptr + k_sf_off,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0,
+            )
             k_sf = k_sf.to(tl.float8e4nv, bitcast=True).to(tl.float32)
             K = (k_sign * k_mag * k_sf * tl.load(k_scale)).to(Q.dtype)
 
@@ -465,11 +486,12 @@ def kernel_unified_attention_2d(
                 + packed_byte_pos[None, :] * stride_v_cache_3
                 + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
             )
-            v_packed = tl.load(value_cache_ptr + v_packed_off,
-                               mask=dim_mask[None, :] & tile_mask[:, None],
-                               other=0).to(tl.int32)
-            v_codes = tl.where(is_high[None, :],
-                               (v_packed >> 4) & 0xF, v_packed & 0xF)
+            v_packed = tl.load(
+                value_cache_ptr + v_packed_off,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0,
+            ).to(tl.int32)
+            v_codes = tl.where(is_high[None, :], (v_packed >> 4) & 0xF, v_packed & 0xF)
             v_sign = tl.where(v_codes & 8, -1.0, 1.0)
             v_mag = _nvfp4_decode_magnitude(v_codes & 0x7)
 
@@ -479,9 +501,11 @@ def kernel_unified_attention_2d(
                 + (PACKED_HEAD_SIZE + scale_group_idx)[None, :] * stride_v_cache_3
                 + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
             )
-            v_sf = tl.load(value_cache_ptr + v_sf_off,
-                           mask=dim_mask[None, :] & tile_mask[:, None],
-                           other=0)
+            v_sf = tl.load(
+                value_cache_ptr + v_sf_off,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0,
+            )
             v_sf = v_sf.to(tl.float8e4nv, bitcast=True).to(tl.float32)
             V = (v_sign * v_mag * v_sf * tl.load(v_scale)).to(Q.dtype)
         else:
@@ -831,7 +855,7 @@ def kernel_unified_attention_3d(
     # Pre-compute NVFP4 index helpers (3D kernel)
     if USE_NVFP4:
         packed_byte_pos = offs_d // 2
-        is_high = ((offs_d % 2) == 1)
+        is_high = (offs_d % 2) == 1
         scale_group_idx = offs_d // QUANT_GROUP_SIZE
 
     # iterate through tiles (now limited to the sliding window range)
@@ -854,11 +878,12 @@ def kernel_unified_attention_3d(
                 + packed_byte_pos[:, None] * stride_k_cache_3
                 + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
             )
-            k_packed = tl.load(key_cache_ptr + k_packed_off,
-                               mask=dim_mask[:, None] & tile_mask[None, :],
-                               other=0).to(tl.int32)
-            k_codes = tl.where(is_high[:, None],
-                               (k_packed >> 4) & 0xF, k_packed & 0xF)
+            k_packed = tl.load(
+                key_cache_ptr + k_packed_off,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0,
+            ).to(tl.int32)
+            k_codes = tl.where(is_high[:, None], (k_packed >> 4) & 0xF, k_packed & 0xF)
             k_sign = tl.where(k_codes & 8, -1.0, 1.0)
             k_mag = _nvfp4_decode_magnitude(k_codes & 0x7)
             k_sf_off = (
@@ -867,9 +892,11 @@ def kernel_unified_attention_3d(
                 + (PACKED_HEAD_SIZE + scale_group_idx)[:, None] * stride_k_cache_3
                 + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
             )
-            k_sf = tl.load(key_cache_ptr + k_sf_off,
-                           mask=dim_mask[:, None] & tile_mask[None, :],
-                           other=0)
+            k_sf = tl.load(
+                key_cache_ptr + k_sf_off,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0,
+            )
             k_sf = k_sf.to(tl.float8e4nv, bitcast=True).to(tl.float32)
             K = (k_sign * k_mag * k_sf * tl.load(k_scale)).to(Q.dtype)
 
@@ -880,11 +907,12 @@ def kernel_unified_attention_3d(
                 + packed_byte_pos[None, :] * stride_v_cache_3
                 + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
             )
-            v_packed = tl.load(value_cache_ptr + v_packed_off,
-                               mask=dim_mask[None, :] & tile_mask[:, None],
-                               other=0).to(tl.int32)
-            v_codes = tl.where(is_high[None, :],
-                               (v_packed >> 4) & 0xF, v_packed & 0xF)
+            v_packed = tl.load(
+                value_cache_ptr + v_packed_off,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0,
+            ).to(tl.int32)
+            v_codes = tl.where(is_high[None, :], (v_packed >> 4) & 0xF, v_packed & 0xF)
             v_sign = tl.where(v_codes & 8, -1.0, 1.0)
             v_mag = _nvfp4_decode_magnitude(v_codes & 0x7)
             v_sf_off = (
@@ -893,9 +921,11 @@ def kernel_unified_attention_3d(
                 + (PACKED_HEAD_SIZE + scale_group_idx)[None, :] * stride_v_cache_3
                 + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
             )
-            v_sf = tl.load(value_cache_ptr + v_sf_off,
-                           mask=dim_mask[None, :] & tile_mask[:, None],
-                           other=0)
+            v_sf = tl.load(
+                value_cache_ptr + v_sf_off,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0,
+            )
             v_sf = v_sf.to(tl.float8e4nv, bitcast=True).to(tl.float32)
             V = (v_sign * v_mag * v_sf * tl.load(v_scale)).to(Q.dtype)
         else:
@@ -912,9 +942,11 @@ def kernel_unified_attention_3d(
                 + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
             )
 
-            K_load = tl.load(key_cache_ptr + k_offset,
-                             mask=dim_mask[:, None] & tile_mask[None, :],
-                             other=0.0)
+            K_load = tl.load(
+                key_cache_ptr + k_offset,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0.0,
+            )
             if K_load.dtype.is_fp8():
                 if Q.dtype.is_fp8():
                     K = K_load
@@ -923,9 +955,11 @@ def kernel_unified_attention_3d(
             else:
                 K = K_load
 
-            V_load = tl.load(value_cache_ptr + v_offset,
-                             mask=dim_mask[None, :] & tile_mask[:, None],
-                             other=0.0)
+            V_load = tl.load(
+                value_cache_ptr + v_offset,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0.0,
+            )
             if V_load.dtype.is_fp8():
                 if Q.dtype.is_fp8():
                     V = V_load

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -13,15 +13,197 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.batch_invariant import vllm_is_batch_invariant
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.v1.kv_cache_interface import NVFP4_QUANT_BLOCK_SIZE
 
 logger = init_logger(__name__)
 is_batch_invariant = vllm_is_batch_invariant()
 float8_info = torch.finfo(current_platform.fp8_dtype())
 
+# FP4 E2M1 dequantization lookup table (16 entries, indexed by 4-bit code)
+# Format: [sign(1) | exp(2) | mantissa(1)]
+# Magnitudes: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
+FP4_E2M1_DEQUANT_TABLE = [
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,       # positive
+    0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,  # negative
+]
+
 
 @triton.jit
 def cdiv_fn(x, y):
     return (x + y - 1) // y
+
+
+@triton.jit
+def _nvfp4_decode_magnitude(mag_idx):
+    """Decode FP4 E2M1 magnitude from 3-bit index to float.
+
+    Magnitude LUT: [0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+    """
+    mag = tl.zeros_like(mag_idx, dtype=tl.float32)
+    mag = tl.where(mag_idx == 1, 0.5, mag)
+    mag = tl.where(mag_idx == 2, 1.0, mag)
+    mag = tl.where(mag_idx == 3, 1.5, mag)
+    mag = tl.where(mag_idx == 4, 2.0, mag)
+    mag = tl.where(mag_idx == 5, 3.0, mag)
+    mag = tl.where(mag_idx == 6, 4.0, mag)
+    mag = tl.where(mag_idx == 7, 6.0, mag)
+    return mag
+
+
+@triton.jit
+def _nvfp4_dequant_page_kernel(
+    # NVFP4 packed cache: [num_blocks, block_size, num_kv_heads, eff_head_size]
+    src_cache_ptr,
+    # Output dequantized cache: [num_blocks, block_size, num_kv_heads, head_size]
+    dst_cache_ptr,
+    global_scale_ptr,      # float32 scalar
+    src_stride_0: tl.int64,  # block stride
+    src_stride_1: tl.int64,  # page (token-in-block) stride
+    src_stride_2: tl.int64,  # head stride (= effective_head_size)
+    dst_stride_0: tl.int64,
+    dst_stride_1: tl.int64,
+    dst_stride_2: tl.int64,
+    num_kv_heads: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    QUANT_GROUP_SIZE: tl.constexpr,
+    PACKED_HEAD_SIZE: tl.constexpr,   # HEAD_SIZE // 2
+    SCALE_HEAD_SIZE: tl.constexpr,    # HEAD_SIZE // QUANT_GROUP_SIZE
+    PAIRS_PER_GROUP: tl.constexpr,    # QUANT_GROUP_SIZE // 2
+):
+    """Dequantize one token-slot of one head in the NVFP4 paged KV cache.
+
+    Grid: (num_used_blocks * BLOCK_SIZE, num_kv_heads)
+    """
+    slot_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    block_idx = slot_idx // BLOCK_SIZE
+    token_in_block = slot_idx % BLOCK_SIZE
+
+    # Source offset: beginning of this token's head data
+    src_base = (block_idx * src_stride_0
+                + token_in_block * src_stride_1
+                + head_idx * src_stride_2)
+
+    # Destination offset
+    dst_base = (block_idx * dst_stride_0
+                + token_in_block * dst_stride_1
+                + head_idx * dst_stride_2)
+
+    global_scale = tl.load(global_scale_ptr)
+
+    # Load block scales (SCALE_HEAD_SIZE uint8 values, FP8 E4M3 bitcast)
+    scale_offs = tl.arange(0, SCALE_HEAD_SIZE)
+    raw_scales = tl.load(src_cache_ptr + src_base + PACKED_HEAD_SIZE + scale_offs)
+    scales_fp8 = raw_scales.to(tl.float8e4nv, bitcast=True)
+    scales_f32 = scales_fp8.to(tl.float32)
+
+    # Load packed FP4 data and dequantize
+    pair_offs = tl.arange(0, PACKED_HEAD_SIZE)
+    packed = tl.load(src_cache_ptr + src_base + pair_offs)
+
+    # Extract low and high nibbles
+    lo_codes = (packed.to(tl.int32)) & 0xF   # even elements
+    hi_codes = (packed.to(tl.int32) >> 4) & 0xF  # odd elements
+
+    # Decode sign and magnitude
+    lo_sign = tl.where(lo_codes & 8, -1.0, 1.0)
+    hi_sign = tl.where(hi_codes & 8, -1.0, 1.0)
+    lo_mag = _nvfp4_decode_magnitude(lo_codes & 0x7)
+    hi_mag = _nvfp4_decode_magnitude(hi_codes & 0x7)
+
+    lo_val = lo_sign * lo_mag
+    hi_val = hi_sign * hi_mag
+
+    # Apply per-group scales: each group of PAIRS_PER_GROUP packed bytes
+    # shares one scale factor
+    group_idx = pair_offs // PAIRS_PER_GROUP
+
+    # Gather scale for each pair position
+    # Since we can't dynamically index a register tensor, we use
+    # static unrolling over groups
+    lo_result = tl.zeros([PACKED_HEAD_SIZE], dtype=tl.float32)
+    hi_result = tl.zeros([PACKED_HEAD_SIZE], dtype=tl.float32)
+
+    for g in tl.static_range(0, SCALE_HEAD_SIZE):
+        g_mask = group_idx == g
+        g_scale = scales_f32[g] * global_scale
+        lo_result = tl.where(g_mask, lo_val * g_scale, lo_result)
+        hi_result = tl.where(g_mask, hi_val * g_scale, hi_result)
+
+    # Interleave even/odd back to original element order:
+    # element[2i] = lo_result[i], element[2i+1] = hi_result[i]
+    # Store interleaved
+    even_dst_offs = pair_offs * 2
+    odd_dst_offs = pair_offs * 2 + 1
+    tl.store(dst_cache_ptr + dst_base + even_dst_offs, lo_result.to(tl.bfloat16))
+    tl.store(dst_cache_ptr + dst_base + odd_dst_offs, hi_result.to(tl.bfloat16))
+
+
+def nvfp4_dequant_kv_cache(
+    nvfp4_cache: torch.Tensor,
+    global_scale: torch.Tensor,
+    head_size: int,
+    num_blocks_used: int | None = None,
+) -> torch.Tensor:
+    """Dequantize an NVFP4 paged KV cache to BF16.
+
+    Args:
+        nvfp4_cache: Paged cache tensor of shape
+            [num_blocks, block_size, num_kv_heads, effective_head_size] as uint8.
+        global_scale: Scalar float32 tensor (second-level scale factor).
+        head_size: Original (unpacked) head dimension.
+        num_blocks_used: If given, only dequantize this many blocks.
+
+    Returns:
+        BF16 tensor of shape [num_blocks, block_size, num_kv_heads, head_size].
+    """
+    num_blocks = nvfp4_cache.shape[0]
+    block_size = nvfp4_cache.shape[1]
+    num_kv_heads = nvfp4_cache.shape[2]
+
+    if num_blocks_used is None:
+        num_blocks_used = num_blocks
+
+    packed_head_size = head_size // 2
+    scale_head_size = head_size // NVFP4_QUANT_BLOCK_SIZE
+    pairs_per_group = NVFP4_QUANT_BLOCK_SIZE // 2
+
+    # Allocate output
+    out = torch.empty(
+        (num_blocks, block_size, num_kv_heads, head_size),
+        dtype=torch.bfloat16,
+        device=nvfp4_cache.device,
+    )
+
+    total_slots = num_blocks_used * block_size
+    if total_slots == 0:
+        return out
+
+    grid = (total_slots, num_kv_heads)
+
+    _nvfp4_dequant_page_kernel[grid](
+        src_cache_ptr=nvfp4_cache,
+        dst_cache_ptr=out,
+        global_scale_ptr=global_scale,
+        src_stride_0=nvfp4_cache.stride(0),
+        src_stride_1=nvfp4_cache.stride(1),
+        src_stride_2=nvfp4_cache.stride(2),
+        dst_stride_0=out.stride(0),
+        dst_stride_1=out.stride(1),
+        dst_stride_2=out.stride(2),
+        num_kv_heads=num_kv_heads,
+        HEAD_SIZE=head_size,
+        BLOCK_SIZE=block_size,
+        QUANT_GROUP_SIZE=NVFP4_QUANT_BLOCK_SIZE,
+        PACKED_HEAD_SIZE=packed_head_size,
+        SCALE_HEAD_SIZE=scale_head_size,
+        PAIRS_PER_GROUP=pairs_per_group,
+        num_warps=4,
+        num_stages=2,
+    )
+    return out
 
 
 @triton.jit
@@ -105,6 +287,9 @@ def kernel_unified_attention_2d(
     num_seqs: tl.int32,
     BLOCK_M: tl.constexpr,  # int
     USE_FP8: tl.constexpr,  # bool
+    USE_NVFP4: tl.constexpr = False,  # bool
+    PACKED_HEAD_SIZE: tl.constexpr = 0,  # HEAD_SIZE // 2
+    QUANT_GROUP_SIZE: tl.constexpr = 16,  # elements per block scale
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
 ):
@@ -229,6 +414,12 @@ def kernel_unified_attention_2d(
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
 
+    # Pre-compute NVFP4 index helpers (outside tile loop, constant across tiles)
+    if USE_NVFP4:
+        packed_byte_pos = offs_d // 2
+        is_high = ((offs_d % 2) == 1)
+        scale_group_idx = offs_d // QUANT_GROUP_SIZE
+
     # iterate through tiles (now limited to the sliding window range)
     for j in range(tile_start, tile_end):
         seq_offset = j * TILE_SIZE + offs_t
@@ -238,49 +429,102 @@ def kernel_unified_attention_2d(
             block_tables_ptr + block_table_offset + seq_offset // BLOCK_SIZE
         ).to(tl.int64)
 
-        v_offset = (
-            physical_block_idx[:, None] * stride_v_cache_0
-            + kv_head_idx * stride_v_cache_2
-            + offs_d[None, :] * stride_v_cache_3
-            + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
-        )
+        if USE_NVFP4:
+            # --- NVFP4 fused dequant: load packed bytes + scales, decode inline ---
+            # K: (HEAD_SIZE_PADDED, TILE_SIZE)
+            k_packed_off = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + packed_byte_pos[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
+            k_packed = tl.load(key_cache_ptr + k_packed_off,
+                               mask=dim_mask[:, None] & tile_mask[None, :],
+                               other=0).to(tl.int32)
+            k_codes = tl.where(is_high[:, None],
+                               (k_packed >> 4) & 0xF, k_packed & 0xF)
+            k_sign = tl.where(k_codes & 8, -1.0, 1.0)
+            k_mag = _nvfp4_decode_magnitude(k_codes & 0x7)
 
-        k_offset = (
-            physical_block_idx[None, :] * stride_k_cache_0
-            + kv_head_idx * stride_k_cache_2
-            + offs_d[:, None] * stride_k_cache_3
-            + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-        )
+            k_sf_off = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + (PACKED_HEAD_SIZE + scale_group_idx)[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
+            k_sf = tl.load(key_cache_ptr + k_sf_off,
+                           mask=dim_mask[:, None] & tile_mask[None, :],
+                           other=0)
+            k_sf = k_sf.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+            K = (k_sign * k_mag * k_sf * tl.load(k_scale)).to(Q.dtype)
 
-        # K : (HEAD_SIZE, TILE_SIZE)
-        K_load = tl.load(
-            key_cache_ptr + k_offset,
-            mask=dim_mask[:, None] & tile_mask[None, :],
-            other=0.0,
-        )
+            # V: (TILE_SIZE, HEAD_SIZE_PADDED)
+            v_packed_off = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + packed_byte_pos[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
+            v_packed = tl.load(value_cache_ptr + v_packed_off,
+                               mask=dim_mask[None, :] & tile_mask[:, None],
+                               other=0).to(tl.int32)
+            v_codes = tl.where(is_high[None, :],
+                               (v_packed >> 4) & 0xF, v_packed & 0xF)
+            v_sign = tl.where(v_codes & 8, -1.0, 1.0)
+            v_mag = _nvfp4_decode_magnitude(v_codes & 0x7)
 
-        if K_load.dtype.is_fp8():
-            if Q.dtype.is_fp8():
+            v_sf_off = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + (PACKED_HEAD_SIZE + scale_group_idx)[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
+            v_sf = tl.load(value_cache_ptr + v_sf_off,
+                           mask=dim_mask[None, :] & tile_mask[:, None],
+                           other=0)
+            v_sf = v_sf.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+            V = (v_sign * v_mag * v_sf * tl.load(v_scale)).to(Q.dtype)
+        else:
+            # --- Standard BF16/FP16/FP8 load ---
+            v_offset = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + offs_d[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
+
+            k_offset = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + offs_d[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
+
+            K_load = tl.load(
+                key_cache_ptr + k_offset,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0.0,
+            )
+            if K_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    K = K_load
+                else:
+                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+            else:
                 K = K_load
+
+            V_load = tl.load(
+                value_cache_ptr + v_offset,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0.0,
+            )
+            if V_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    V = V_load
+                else:
+                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
             else:
-                K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
-        else:
-            K = K_load
-
-        # V : (TILE_SIZE, HEAD_SIZE)
-        V_load = tl.load(
-            value_cache_ptr + v_offset,
-            mask=dim_mask[None, :] & tile_mask[:, None],
-            other=0.0,
-        )
-
-        if V_load.dtype.is_fp8():
-            if Q.dtype.is_fp8():
                 V = V_load
-            else:
-                V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
-        else:
-            V = V_load
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -453,6 +697,9 @@ def kernel_unified_attention_3d(
     USE_MM_PREFIX: tl.constexpr,  # bool
     MAX_MM_RANGES: tl.constexpr,  # int
     mm_prefix_range_ptr,  # [num_seqs] - prefix length for each sequence
+    USE_NVFP4: tl.constexpr = False,  # bool
+    PACKED_HEAD_SIZE: tl.constexpr = 0,  # HEAD_SIZE // 2
+    QUANT_GROUP_SIZE: tl.constexpr = 16,  # elements per block scale
 ):
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -581,6 +828,12 @@ def kernel_unified_attention_3d(
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
 
+    # Pre-compute NVFP4 index helpers (3D kernel)
+    if USE_NVFP4:
+        packed_byte_pos = offs_d // 2
+        is_high = ((offs_d % 2) == 1)
+        scale_group_idx = offs_d // QUANT_GROUP_SIZE
+
     # iterate through tiles (now limited to the sliding window range)
     for j in range(
         max(segm_idx * tiles_per_segment, tile_start),
@@ -593,49 +846,93 @@ def kernel_unified_attention_3d(
             block_tables_ptr + block_table_offset + seq_offset // BLOCK_SIZE
         ).to(tl.int64)
 
-        v_offset = (
-            physical_block_idx[:, None] * stride_v_cache_0
-            + kv_head_idx * stride_v_cache_2
-            + offs_d[None, :] * stride_v_cache_3
-            + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
-        )
+        if USE_NVFP4:
+            # K: fused NVFP4 dequant
+            k_packed_off = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + packed_byte_pos[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
+            k_packed = tl.load(key_cache_ptr + k_packed_off,
+                               mask=dim_mask[:, None] & tile_mask[None, :],
+                               other=0).to(tl.int32)
+            k_codes = tl.where(is_high[:, None],
+                               (k_packed >> 4) & 0xF, k_packed & 0xF)
+            k_sign = tl.where(k_codes & 8, -1.0, 1.0)
+            k_mag = _nvfp4_decode_magnitude(k_codes & 0x7)
+            k_sf_off = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + (PACKED_HEAD_SIZE + scale_group_idx)[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
+            k_sf = tl.load(key_cache_ptr + k_sf_off,
+                           mask=dim_mask[:, None] & tile_mask[None, :],
+                           other=0)
+            k_sf = k_sf.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+            K = (k_sign * k_mag * k_sf * tl.load(k_scale)).to(Q.dtype)
 
-        k_offset = (
-            physical_block_idx[None, :] * stride_k_cache_0
-            + kv_head_idx * stride_k_cache_2
-            + offs_d[:, None] * stride_k_cache_3
-            + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
-        )
+            # V: fused NVFP4 dequant
+            v_packed_off = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + packed_byte_pos[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
+            v_packed = tl.load(value_cache_ptr + v_packed_off,
+                               mask=dim_mask[None, :] & tile_mask[:, None],
+                               other=0).to(tl.int32)
+            v_codes = tl.where(is_high[None, :],
+                               (v_packed >> 4) & 0xF, v_packed & 0xF)
+            v_sign = tl.where(v_codes & 8, -1.0, 1.0)
+            v_mag = _nvfp4_decode_magnitude(v_codes & 0x7)
+            v_sf_off = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + (PACKED_HEAD_SIZE + scale_group_idx)[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
+            v_sf = tl.load(value_cache_ptr + v_sf_off,
+                           mask=dim_mask[None, :] & tile_mask[:, None],
+                           other=0)
+            v_sf = v_sf.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+            V = (v_sign * v_mag * v_sf * tl.load(v_scale)).to(Q.dtype)
+        else:
+            v_offset = (
+                physical_block_idx[:, None] * stride_v_cache_0
+                + kv_head_idx * stride_v_cache_2
+                + offs_d[None, :] * stride_v_cache_3
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+            )
+            k_offset = (
+                physical_block_idx[None, :] * stride_k_cache_0
+                + kv_head_idx * stride_k_cache_2
+                + offs_d[:, None] * stride_k_cache_3
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+            )
 
-        # K : (HEAD_SIZE, TILE_SIZE)
-        K_load = tl.load(
-            key_cache_ptr + k_offset,
-            mask=dim_mask[:, None] & tile_mask[None, :],
-            other=0.0,
-        )
-
-        if K_load.dtype.is_fp8():
-            if Q.dtype.is_fp8():
+            K_load = tl.load(key_cache_ptr + k_offset,
+                             mask=dim_mask[:, None] & tile_mask[None, :],
+                             other=0.0)
+            if K_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    K = K_load
+                else:
+                    K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+            else:
                 K = K_load
+
+            V_load = tl.load(value_cache_ptr + v_offset,
+                             mask=dim_mask[None, :] & tile_mask[:, None],
+                             other=0.0)
+            if V_load.dtype.is_fp8():
+                if Q.dtype.is_fp8():
+                    V = V_load
+                else:
+                    V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
             else:
-                K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
-        else:
-            K = K_load
-
-        # V : (TILE_SIZE, HEAD_SIZE)
-        V_load = tl.load(
-            value_cache_ptr + v_offset,
-            mask=dim_mask[None, :] & tile_mask[:, None],
-            other=0.0,
-        )
-
-        if V_load.dtype.is_fp8():
-            if Q.dtype.is_fp8():
                 V = V_load
-            else:
-                V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
-        else:
-            V = V_load
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -911,9 +1208,13 @@ def unified_attention(
     # Optional tensor for prefix lengths (PrefixLM support)
     mm_prefix_range=None,
     use_alibi_sqrt=False,
+    # NVFP4 KV cache mode
+    nvfp4_head_size=0,
 ):
     assert causal, "Only causal attention is supported"
     assert q_descale is None, "Q scales not supported"
+
+    use_nvfp4 = nvfp4_head_size > 0
 
     if sinks is not None:
         assert sinks.shape[0] == q.shape[1], "Sinks must be num_query_heads size"
@@ -1040,6 +1341,9 @@ def unified_attention(
             num_seqs=num_seqs,
             BLOCK_M=BLOCK_M,
             USE_FP8=output_scale is not None,
+            USE_NVFP4=use_nvfp4,
+            PACKED_HEAD_SIZE=nvfp4_head_size // 2 if use_nvfp4 else 0,
+            QUANT_GROUP_SIZE=NVFP4_QUANT_BLOCK_SIZE,
         )
     else:
         kernel_unified_attention_3d[
@@ -1092,6 +1396,9 @@ def unified_attention(
             num_seqs=num_seqs,
             BLOCK_M=BLOCK_M,
             NUM_SEGMENTS_PER_SEQ=num_par_softmax_segments,
+            USE_NVFP4=use_nvfp4,
+            PACKED_HEAD_SIZE=nvfp4_head_size // 2 if use_nvfp4 else 0,
+            QUANT_GROUP_SIZE=NVFP4_QUANT_BLOCK_SIZE,
         )
         reduce_segments[(q.shape[0], num_query_heads)](
             output_ptr=out,

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -184,6 +184,7 @@ class FullAttentionSpec(AttentionSpec):
             head_size_v=specs[0].head_size_v,
             dtype=specs[0].dtype,
             page_size_padded=specs[0].page_size_padded,
+            cache_dtype_str=specs[0].cache_dtype_str,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
         )
@@ -191,7 +192,9 @@ class FullAttentionSpec(AttentionSpec):
             for f in fields(AttentionSpec):
                 assert getattr(spec, f.name) == getattr(merged_spec, f.name), (
                     "All attention layers in the same KV cache group must have "
-                    "the same attention spec."
+                    f"the same attention spec. Field '{f.name}' differs: "
+                    f"{getattr(spec, f.name)!r} != "
+                    f"{getattr(merged_spec, f.name)!r}"
                 )
         assert (merged_spec.sliding_window is not None) + (
             merged_spec.attention_chunk_size is not None
@@ -387,7 +390,9 @@ class SinkFullAttentionSpec(FullAttentionSpec):
             for f in fields(AttentionSpec):
                 assert getattr(spec, f.name) == getattr(merged_spec, f.name), (
                     "All attention layers in the same KV cache group must have "
-                    "the same attention spec."
+                    f"the same attention spec. Field '{f.name}' differs: "
+                    f"{getattr(spec, f.name)!r} != "
+                    f"{getattr(merged_spec, f.name)!r}"
                 )
         assert (merged_spec.sliding_window is not None) + (
             merged_spec.attention_chunk_size is not None

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -61,12 +61,33 @@ class KVCacheSpec:
         return copy.deepcopy(specs[0])
 
 
+# NVFP4 quantization block size (number of FP4 elements per scale factor)
+NVFP4_QUANT_BLOCK_SIZE = 16
+
+
 @dataclass(frozen=True, kw_only=True)
 class AttentionSpec(KVCacheSpec):
     num_kv_heads: int
     head_size: int
     dtype: torch.dtype
     page_size_padded: int | None = None
+    # The KV cache dtype string (e.g., "auto", "fp8", "nvfp4").
+    # Needed to distinguish NVFP4 from FP8 since both use torch.uint8.
+    cache_dtype_str: str | None = None
+
+    @property
+    def is_nvfp4(self) -> bool:
+        return self.cache_dtype_str == "nvfp4"
+
+    @property
+    def nvfp4_head_size_bytes(self) -> int:
+        """Number of bytes per head per token for NVFP4 cache.
+
+        Includes packed FP4 data (head_size // 2 bytes) and
+        FP8 block scales (head_size // NVFP4_QUANT_BLOCK_SIZE bytes).
+        """
+        assert self.head_size % NVFP4_QUANT_BLOCK_SIZE == 0
+        return self.head_size // 2 + self.head_size // NVFP4_QUANT_BLOCK_SIZE
 
     @property
     def page_size_bytes(self) -> int:
@@ -78,6 +99,14 @@ class AttentionSpec(KVCacheSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
+        if self.is_nvfp4:
+            # NVFP4: packed FP4 data + FP8 block scales
+            return (
+                2
+                * self.block_size
+                * self.num_kv_heads
+                * self.nvfp4_head_size_bytes
+            )
         return (
             2
             * self.block_size

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -101,12 +101,7 @@ class AttentionSpec(KVCacheSpec):
     def real_page_size_bytes(self) -> int:
         if self.is_nvfp4:
             # NVFP4: packed FP4 data + FP8 block scales
-            return (
-                2
-                * self.block_size
-                * self.num_kv_heads
-                * self.nvfp4_head_size_bytes
-            )
+            return 2 * self.block_size * self.num_kv_heads * self.nvfp4_head_size_bytes
         return (
             2
             * self.block_size
@@ -210,12 +205,7 @@ class FullAttentionSpec(AttentionSpec):
     def real_page_size_bytes(self) -> int:
         if self.is_nvfp4:
             # NVFP4: packed FP4 data + FP8 block scales for K and V
-            return (
-                2
-                * self.block_size
-                * self.num_kv_heads
-                * self.nvfp4_head_size_bytes
-            )
+            return 2 * self.block_size * self.num_kv_heads * self.nvfp4_head_size_bytes
         return (
             self.block_size
             * self.num_kv_heads

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -208,6 +208,14 @@ class FullAttentionSpec(AttentionSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
+        if self.is_nvfp4:
+            # NVFP4: packed FP4 data + FP8 block scales for K and V
+            return (
+                2
+                * self.block_size
+                * self.num_kv_heads
+                * self.nvfp4_head_size_bytes
+            )
         return (
             self.block_size
             * self.num_kv_heads

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -117,7 +117,9 @@ def _reshape_kv_cache(
             num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
 
             attn_backend = attn_backends[layer_name]
-            cache_dtype_str = getattr(kv_cache_spec, "cache_dtype_str", "auto") or "auto"
+            cache_dtype_str = (
+                getattr(kv_cache_spec, "cache_dtype_str", "auto") or "auto"
+            )
             kv_cache_shape = attn_backend.get_kv_cache_shape(
                 num_blocks,
                 kv_cache_spec.block_size,

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -117,11 +117,13 @@ def _reshape_kv_cache(
             num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
 
             attn_backend = attn_backends[layer_name]
+            cache_dtype_str = getattr(kv_cache_spec, "cache_dtype_str", "auto") or "auto"
             kv_cache_shape = attn_backend.get_kv_cache_shape(
                 num_blocks,
                 kv_cache_spec.block_size,
                 kv_cache_spec.num_kv_heads,
                 kv_cache_spec.head_size,
+                cache_dtype_str=cache_dtype_str,
             )
 
             # FIXME(woosuk): Add kv_cache_stride_order to all attention backends.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -118,6 +118,7 @@ from vllm.v1.attention.backend import (
     AttentionMetadataBuilder,
     AttentionType,
     CommonAttentionMetadata,
+    is_quantized_kv_cache,
 )
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
@@ -857,7 +858,7 @@ class GPUModelRunner(
           If these are left at 0.0 (default after wake_up), all KV cache values
           become effectively zero, causing gibberish output.
         """
-        if not self.cache_config.cache_dtype.startswith("fp8"):
+        if not is_quantized_kv_cache(self.cache_config.cache_dtype):
             return
 
         kv_caches = getattr(self, "kv_caches", [])


### PR DESCRIPTION
Working on it

## Add NVFP4 KV cache quantization support (Triton attention backend)

### Summary

This PR adds full support for NVFP4 (FP4 E2M1) KV cache quantization in vLLM's Triton attention backend. NVFP4 uses a two-level quantization scheme that significantly reduces GPU memory footprint without requiring pre-calibrated checkpoints.

### Motivation

NVFP4 (E2M1, 4 bits per element) achieves ~3.5× compression over BF16 for the KV cache (`65536 / 18432` bytes per page at head_size=128, 8 heads, block_size=16). Precision loss is bounded by a two-level scaling scheme:

- **Level 1 (block scale):** FP8 E4M3, one per group of 16 FP4 elements — captures local distribution variance
- **Level 2 (global scale):** per-tensor K/V scale, loaded from checkpoint or derived dynamically — anchors the global range

### Changes

#### Configuration and types

- `vllm/config/cache.py`: adds `"nvfp4"` to `CacheDType` and logs an informational warning when it is selected.
- `vllm/utils/torch_utils.py`: adds `"nvfp4" → torch.uint8` to `STR_DTYPE_TO_TORCH_DTYPE` and a corresponding entry in `MODELOPT_TO_VLLM_KV_CACHE_DTYPE_MAP`.

#### Quantization detection

- `vllm/v1/attention/backend.py`: `is_quantized_kv_cache()` now returns `True` for `"nvfp4"` in addition to `fp8*`.
- `vllm/v1/worker/gpu_model_runner.py`: `init_fp8_kv_scales()` reuses the same guard via `is_quantized_kv_cache()`.

#### KV cache interface

- `vllm/v1/kv_cache_interface.py`: introduces `NVFP4_QUANT_BLOCK_SIZE = 16` and adds `cache_dtype_str` to `AttentionSpec` / `FullAttentionSpec`. New properties `is_nvfp4`, `nvfp4_head_size_bytes`, and `real_page_size_bytes` compute the correct NVFP4 page size (`2 × block_size × num_kv_heads × (head_size // 2 + head_size // 16)`).

#### Triton backend — reshape & cache

- `vllm/v1/attention/ops/triton_reshape_and_cache_flash.py`: adds the `reshape_and_cache_nvfp4_kernel` Triton kernel and the `triton_reshape_and_cache_nvfp4` Python launcher. The kernel quantizes groups in parallel (one instance per token × head × group), computes a per-group FP8 block scale, packs two FP4 elements per byte, and stores packed data plus scales contiguously in the same uint8 tensor.
- `vllm/v1/attention/backends/triton_attn.py`: `get_kv_cache_shape()` returns the correct shape for NVFP4; `do_kv_cache_update()` dispatches to `triton_reshape_and_cache_nvfp4` when `kv_cache_dtype == "nvfp4"`; the FP8 path is guarded with `not nvfp4_mode`.

#### Triton backend — fused dequantization in attention

- `vllm/v1/attention/ops/triton_unified_attention.py`: adds `USE_NVFP4`, `PACKED_HEAD_SIZE`, and `QUANT_GROUP_SIZE` parameters to both 2D and 3D kernels. When `USE_NVFP4=True`, inside the tile loop the kernel loads packed bytes and FP8 scales, decodes FP4 E2M1 nibbles inline via `_nvfp4_decode_magnitude` (8-entry LUT), applies block scale × global scale, and produces K/V in Q's dtype without materializing an intermediate BF16 tensor. `nvfp4_dequant_kv_cache()` is also exposed for use outside the attention loop (tests, prefill). `unified_attention()` accepts the new `nvfp4_head_size` parameter.

#### Scale loading

- `vllm/model_executor/layers/quantization/kv_cache.py`: `process_weights_after_loading()` handles three cases for both FP8 and NVFP4 — positive checkpoint scales, no scales (defaults to 1.0 with a warning), and a single shared scale duplicated to K and V — with differentiated log messages per dtype.
- `vllm/model_executor/layers/attention/attention.py`: `calc_kv_scales()` adds an NVFP4 path that computes `global_sf = absmax / (FP4_MAX × FP8_E4M3_MAX)` = `absmax / (6.0 × 448.0)`, ensuring the full data range is representable as FP4 × FP8 block scale.

#### ModelOpt integration

- `vllm/model_executor/layers/quantization/modelopt.py`: adds `ModelOptNvFp4KVCacheMethod` (subclass of `BaseKVCacheMethod`), assigns it to `ModelOptNvFp4Config.KVCacheMethodCls` replacing the previously reused FP8 method, and adds `"NVFP4"` to `KV_CACHE_QUANT_ALGOS`.

### Tests

- `tests/quantization/test_nvfp4_kv_cache.py`: eight unit test suites covering `is_quantized_kv_cache`, `AttentionSpec` / `FullAttentionSpec` page shape, `reshape_and_cache_nvfp4` kernel correctness, quantize→dequantize round-trip accuracy (FP4 tolerance ≤60% of range), negative slot skipping, `process_weights_after_loading` with and without checkpoint scales, `calc_kv_scales` for NVFP4, and end-to-end NVFP4 attention vs BF16 (atol/rtol=0.15).
- `tests/models/quantization/test_nvfp4_kv_cache.py`: E2E accuracy test comparing BF16 vs NVFP4 logprobs using `calculate_kv_scales=True` on Llama-3.2-1B-Instruct.

### Known limitations

- NVFP4 requires CUDA (uses `tl.float8e4nv`); not available on ROCm.
- Without pre-calibrated NVFP4 checkpoints, only `calculate_kv_scales=True` is supported (dynamic global scale derived from the first batch).
- End-to-end accuracy tolerance is larger than FP8 or INT8, as FP4 E2M1 has only 8 representable magnitudes.

https://github.com/vllm-project/vllm/issues/32220

vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct --gpu-memory-utilization 0.95 --max_model_len 65536 -tp 1 --served-model-name QWEN3VL --port 8000 --limit-mm-per-prompt '{"image":6, "video":0, "audio": 0}' --dtype float16 --enable-log-requests --tool-call-parser hermes --attention-backend TRITON_ATTN --enable-auto-tool-choice --attention-config.use_prefill_decode_attention false --structured-outputs-config '{"backend": "xgrammar", "disable_any_whitespace": true}' --mm-encoder-tp-mode data --default-chat-template-kwargs '{"enable_thinking": false}' --kv-cache-dtype nvfp4