### PR TITLE
[BUGFIX][Mamba] Use uint64 for address in KVBlockZeroer

### DIFF
--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -180,7 +180,7 @@ class KVBlockZeroer:
         )
         self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
         self._meta = (
-            torch.tensor(seg_addrs, dtype=torch.int64, device=self.device),
+            torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
             page_size_el,
             blk_size,
             len(seg_addrs),


### PR DESCRIPTION

## Purpose
a bug fix for https://github.com/vllm-project/vllm/pull/35219/changes#diff-645d58630d5acf3a0b07226bfef1e890a584c32502ab97c3d4642070f39a783cR183 , 
for any address related data, we should use uint64 instead of int64.

see previous discussion https://github.com/vllm-project/vllm/pull/25266#discussion_r2377349541

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

