### PR TITLE
[compile] Enable mega aot artifact for torch 2.12+.

### DIFF
--- a/vllm/compilation/caching.py
+++ b/vllm/compilation/caching.py
@@ -307,13 +307,6 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
             num_submods = len(submod_names)
             num_artifacts = standalone_compile_artifacts.num_artifacts()
 
-            logger.info(
-                "reconstructing serializable fn from standalone compile "
-                "artifacts. num_artifacts=%d num_submods=%d",
-                num_artifacts,
-                num_submods,
-            )
-
             with functorch_ctx:
                 fn = reconstruct_serializable_fn_from_mega_artifact(
                     state=state,
@@ -324,7 +317,10 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
                 )
 
             logger.info(
-                "reconstructed serializable fn from standalone compile artifacts"
+                "reconstructed serializable fn from standalone compile "
+                "artifacts. num_artifacts=%d num_submods=%d",
+                num_artifacts,
+                num_submods,
             )
 
             return fn

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -296,6 +296,16 @@ def use_aot_compile() -> bool:
     )
 
 
+def use_mega_aot_artifact():
+    from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+    default_value = (
+        "1" if is_torch_equal_or_newer("2.12.0.dev") and use_aot_compile() else "0"
+    )
+
+    return os.environ.get("VLLM_USE_MEGA_AOT_ARTIFACT", default_value) == "1"
+
+
 def env_with_choices(
     env_name: str,
     default: str | None,
@@ -616,10 +626,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable loading compiled models directly from cached standalone compile artifacts
     # without re-splitting graph modules. This reduces overhead during model
     # loading by using reconstruct_serializable_fn_from_mega_artifact.
-    "VLLM_USE_MEGA_AOT_ARTIFACT": lambda: os.environ.get(
-        "VLLM_USE_MEGA_AOT_ARTIFACT", "0"
-    )
-    == "1",
+    "VLLM_USE_MEGA_AOT_ARTIFACT": use_mega_aot_artifact,
     # local rank of the process in the distributed setting, used to determine
     # the GPU device id
     "LOCAL_RANK": lambda: int(os.environ.get("LOCAL_RANK", "0")),


### PR DESCRIPTION
Summary:

Following up with the previous effort to bundle compiled subgraphs in one artifact, after some local
test we think this should be ready to be enabled with the latest pytorch version by default. This
PR enables the flag with torch 2.12+ and when the toplevel AOT flag is enabled.

Test Plan:


Reviewers:

Subscribers:

Tasks:

Tags:


## Purpose

## Test Plan

Build torch 2.12 locally.

pytest tests/compile/

https://github.com/zhxchen17/scripts/blob/main/vllm/compile_time_bench.py

## Test Result
Before this change (w/ Pytorch 2.12), torch.compile warm start time:
```

Model     Cold Start (s)  Warm Start Avg (s)
--------  --------------  ------------------
deepseek  64.97           15.88 
glm       65.56           12.18
gptoss    15.04           3.61
llama     27.37           7.19
qwen      25.47           3.19
```
After the change (w/ Pytorch 2.12), torch.compile warm start time:
```
Model     Cold Start (s)  Warm Start Avg (s) 
--------  --------------  ------------------
deepseek  60.42           6.23 (-61%)
glm       61.51           7.78 (-36%)
gptoss    14.82           2.07 (-43%)
llama     27.07           3.86 (-46%)
qwen      25.82           2.00 (-37%)
```
So enabling this flag will bring down torch.compile warm start time by 37%-61% measured on 5 popular oss models.

The functionality credit goes to @dolpm .

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

