### PR TITLE
refactor hardcoded device strings in vllm tests 

### DIFF
--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -26,13 +26,17 @@ def test_python_error():
     tensors = []
     with allocator.use_memory_pool():
         # allocate 70% of the total memory
-        x = torch.empty(alloc_bytes, dtype=torch.uint8, device="cuda")
+        x = torch.empty(
+            alloc_bytes,
+            dtype=torch.uint8,
+            device=current_platform.device_type,
+        )
         tensors.append(x)
     # release the memory
     allocator.sleep()
 
     # allocate more memory than the total memory
-    y = torch.empty(alloc_bytes, dtype=torch.uint8, device="cuda")
+    y = torch.empty(alloc_bytes, dtype=torch.uint8, device=current_platform.device_type)
     tensors.append(y)
     with pytest.raises(RuntimeError):
         # when the allocator is woken up, it should raise an error
@@ -44,17 +48,17 @@ def test_python_error():
 def test_basic_cumem():
     # some tensors from default memory pool
     shape = (1024, 1024)
-    x = torch.empty(shape, device="cuda")
+    x = torch.empty(shape, device=current_platform.device_type)
     x.zero_()
 
     # some tensors from custom memory pool
     allocator = CuMemAllocator.get_instance()
     with allocator.use_memory_pool():
         # custom memory pool
-        y = torch.empty(shape, device="cuda")
+        y = torch.empty(shape, device=current_platform.device_type)
         y.zero_()
         y += 1
-        z = torch.empty(shape, device="cuda")
+        z = torch.empty(shape, device=current_platform.device_type)
         z.zero_()
         z += 2
 
@@ -77,16 +81,16 @@ def test_basic_cumem():
 def test_cumem_with_cudagraph():
     allocator = CuMemAllocator.get_instance()
     with allocator.use_memory_pool():
-        weight = torch.eye(1024, device="cuda")
+        weight = torch.eye(1024, device=current_platform.device_type)
     with allocator.use_memory_pool(tag="discard"):
-        cache = torch.empty(1024, 1024, device="cuda")
+        cache = torch.empty(1024, 1024, device=current_platform.device_type)
 
     def model(x):
         out = x @ weight
         cache[: out.size(0)].copy_(out)
         return out + 1
 
-    x = torch.empty(128, 1024, device="cuda")
+    x = torch.empty(128, 1024, device=current_platform.device_type)
 
     # warmup
     model(x)

--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -13,6 +13,8 @@ from vllm.utils.mem_constants import GiB_bytes
 
 from ..utils import create_new_process_for_each_test, requires_fp8
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @create_new_process_for_each_test("fork" if not current_platform.is_rocm() else "spawn")
 def test_python_error():
@@ -29,14 +31,14 @@ def test_python_error():
         x = torch.empty(
             alloc_bytes,
             dtype=torch.uint8,
-            device=current_platform.device_type,
+            device=DEVICE_TYPE,
         )
         tensors.append(x)
     # release the memory
     allocator.sleep()
 
     # allocate more memory than the total memory
-    y = torch.empty(alloc_bytes, dtype=torch.uint8, device=current_platform.device_type)
+    y = torch.empty(alloc_bytes, dtype=torch.uint8, device=DEVICE_TYPE)
     tensors.append(y)
     with pytest.raises(RuntimeError):
         # when the allocator is woken up, it should raise an error
@@ -48,17 +50,17 @@ def test_python_error():
 def test_basic_cumem():
     # some tensors from default memory pool
     shape = (1024, 1024)
-    x = torch.empty(shape, device=current_platform.device_type)
+    x = torch.empty(shape, device=DEVICE_TYPE)
     x.zero_()
 
     # some tensors from custom memory pool
     allocator = CuMemAllocator.get_instance()
     with allocator.use_memory_pool():
         # custom memory pool
-        y = torch.empty(shape, device=current_platform.device_type)
+        y = torch.empty(shape, device=DEVICE_TYPE)
         y.zero_()
         y += 1
-        z = torch.empty(shape, device=current_platform.device_type)
+        z = torch.empty(shape, device=DEVICE_TYPE)
         z.zero_()
         z += 2
 
@@ -81,16 +83,16 @@ def test_basic_cumem():
 def test_cumem_with_cudagraph():
     allocator = CuMemAllocator.get_instance()
     with allocator.use_memory_pool():
-        weight = torch.eye(1024, device=current_platform.device_type)
+        weight = torch.eye(1024, device=DEVICE_TYPE)
     with allocator.use_memory_pool(tag="discard"):
-        cache = torch.empty(1024, 1024, device=current_platform.device_type)
+        cache = torch.empty(1024, 1024, device=DEVICE_TYPE)
 
     def model(x):
         out = x @ weight
         cache[: out.size(0)].copy_(out)
         return out + 1
 
-    x = torch.empty(128, 1024, device=current_platform.device_type)
+    x = torch.empty(128, 1024, device=DEVICE_TYPE)
 
     # warmup
     model(x)

--- a/tests/compile/passes/distributed/test_async_tp.py
+++ b/tests/compile/passes/distributed/test_async_tp.py
@@ -40,6 +40,8 @@ prompts = [
     "The future of AI is",
 ]
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class TestMMRSModel(torch.nn.Module):
     def __init__(self, hidden_size=16, dtype=torch.float16):
@@ -299,7 +301,7 @@ def async_tp_pass_on_test_model(
 ):
     set_random_seed(0)
 
-    device = torch.device(f"{current_platform.device_type}:{local_rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)
@@ -325,7 +327,7 @@ def async_tp_pass_on_test_model(
         ),
     )
     vllm_config.device_config = DeviceConfig(
-        device=torch.device(current_platform.device_type)
+        device=torch.device(DEVICE_TYPE)
     )
 
     # this is a fake model name to construct the model config

--- a/tests/compile/passes/distributed/test_async_tp.py
+++ b/tests/compile/passes/distributed/test_async_tp.py
@@ -299,7 +299,7 @@ def async_tp_pass_on_test_model(
 ):
     set_random_seed(0)
 
-    device = torch.device(f"cuda:{local_rank}")
+    device = torch.device(f"{current_platform.device_type}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)
@@ -324,7 +324,9 @@ def async_tp_pass_on_test_model(
             fuse_gemm_comms=True,
         ),
     )
-    vllm_config.device_config = DeviceConfig(device=torch.device("cuda"))
+    vllm_config.device_config = DeviceConfig(
+        device=torch.device(current_platform.device_type)
+    )
 
     # this is a fake model name to construct the model config
     # in the vllm_config, it's not really used.

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -261,7 +261,7 @@ def all_reduce_fusion_pass_on_test_model(
 ):
     set_random_seed(0)
 
-    device = torch.device(f"cuda:{local_rank}")
+    device = torch.device(f"{current_platform.device_type}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)
@@ -293,7 +293,9 @@ def all_reduce_fusion_pass_on_test_model(
     vllm_config.compilation_config.pass_config = PassConfig(
         fuse_allreduce_rms=True, eliminate_noops=True
     )
-    vllm_config.device_config = DeviceConfig(device=torch.device("cuda"))
+    vllm_config.device_config = DeviceConfig(
+        device=torch.device(current_platform.device_type)
+    )
     vllm_config.parallel_config.rank = local_rank  # Setup rank for debug path
 
     # this is a fake model name to construct the model config

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -37,6 +37,8 @@ from vllm.platforms import current_platform
 from vllm.utils.system_utils import update_environment_variables
 from vllm.utils.torch_utils import set_random_seed
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class TestAllReduceRMSNormModel(torch.nn.Module):
     def __init__(self, hidden_size=16, token_num=16, eps=1e-6):
@@ -261,7 +263,7 @@ def all_reduce_fusion_pass_on_test_model(
 ):
     set_random_seed(0)
 
-    device = torch.device(f"{current_platform.device_type}:{local_rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)
@@ -294,7 +296,7 @@ def all_reduce_fusion_pass_on_test_model(
         fuse_allreduce_rms=True, eliminate_noops=True
     )
     vllm_config.device_config = DeviceConfig(
-        device=torch.device(current_platform.device_type)
+        device=torch.device(DEVICE_TYPE)
     )
     vllm_config.parallel_config.rank = local_rank  # Setup rank for debug path
 

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -227,7 +227,7 @@ def sequence_parallelism_pass_on_test_model(
 ):
     set_random_seed(0)
 
-    device = torch.device(f"cuda:{local_rank}")
+    device = torch.device(f"{current_platform.device_type}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)
@@ -257,7 +257,7 @@ def sequence_parallelism_pass_on_test_model(
             eliminate_noops=True,
         ),
     )  # NoOp needed for fusion
-    device_config = DeviceConfig(device=torch.device("cuda"))
+    device_config = DeviceConfig(device=torch.device(current_platform.device_type))
 
     # this is a fake model name to construct the model config
     # in the vllm_config, it's not really used.

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -46,6 +46,8 @@ prompts = [
     "The future of AI is",
 ]
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class TestAllReduceRMSNormModel(torch.nn.Module):
     def __init__(self, hidden_size=16, eps=1e-6):
@@ -227,7 +229,7 @@ def sequence_parallelism_pass_on_test_model(
 ):
     set_random_seed(0)
 
-    device = torch.device(f"{current_platform.device_type}:{local_rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)
@@ -257,7 +259,7 @@ def sequence_parallelism_pass_on_test_model(
             eliminate_noops=True,
         ),
     )  # NoOp needed for fusion
-    device_config = DeviceConfig(device=torch.device(current_platform.device_type))
+    device_config = DeviceConfig(device=torch.device(DEVICE_TYPE))
 
     # this is a fake model name to construct the model config
     # in the vllm_config, it's not really used.

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -37,6 +37,8 @@ from vllm.utils.torch_utils import direct_register_custom_op
 TEST_FP8 = current_platform.supports_fp8()
 FP8_DTYPE = current_platform.fp8_dtype()
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class TestSiluMul(torch.nn.Module):
     quant_key = kFp8StaticTensorSym
@@ -273,7 +275,7 @@ MODELS_AND_DO_FUSION = {
 def test_fix_functionalization(
     model_class: torch.nn.Module, do_fusion: bool, dtype: torch.dtype
 ):
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -273,7 +273,7 @@ MODELS_AND_DO_FUSION = {
 def test_fix_functionalization(
     model_class: torch.nn.Module, do_fusion: bool, dtype: torch.dtype
 ):
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/passes/test_fuse_act_padding.py
+++ b/tests/compile/passes/test_fuse_act_padding.py
@@ -21,6 +21,8 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.utils import rocm_unquantized_gemm
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class TestModel(torch.nn.Module):
     def __init__(
@@ -99,7 +101,7 @@ def test_fuse_act_padding(
             RocmAiterTritonAddRMSNormPadFusionPass,
         )
 
-        torch.set_default_device(current_platform.device_type)
+        torch.set_default_device(DEVICE_TYPE)
         torch.set_default_dtype(dtype)
         torch.manual_seed(1)
 

--- a/tests/compile/passes/test_fuse_act_padding.py
+++ b/tests/compile/passes/test_fuse_act_padding.py
@@ -19,6 +19,7 @@ from vllm.config import (
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.utils import rocm_unquantized_gemm
+from vllm.platforms import current_platform
 
 
 class TestModel(torch.nn.Module):
@@ -98,7 +99,7 @@ def test_fuse_act_padding(
             RocmAiterTritonAddRMSNormPadFusionPass,
         )
 
-        torch.set_default_device("cuda")
+        torch.set_default_device(current_platform.device_type)
         torch.set_default_dtype(dtype)
         torch.manual_seed(1)
 

--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -51,6 +51,8 @@ from vllm.utils.deep_gemm import (
 
 FP8_DTYPE = current_platform.fp8_dtype()
 
+DEVICE_TYPE = current_platform.device_type
+
 RMS_OP = torch.ops._C.rms_norm.default
 RMS_ADD_OP = torch.ops._C.fused_add_rms_norm.default
 
@@ -342,7 +344,7 @@ def test_fusion_rmsnorm_quant(
 
     with vllm.config.set_current_vllm_config(vllm_config):
         # Setup device before model creation
-        torch.set_default_device(current_platform.device_type)
+        torch.set_default_device(DEVICE_TYPE)
         torch.set_default_dtype(dtype)
         torch.manual_seed(1)
 
@@ -413,7 +415,7 @@ def test_aiter_fusion_rmsnorm_quant(
 
         rocm_aiter_ops.refresh_env_variables()
 
-        torch.set_default_device(current_platform.device_type)
+        torch.set_default_device(DEVICE_TYPE)
         torch.set_default_dtype(dtype)
         torch.manual_seed(1)
 

--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -342,7 +342,7 @@ def test_fusion_rmsnorm_quant(
 
     with vllm.config.set_current_vllm_config(vllm_config):
         # Setup device before model creation
-        torch.set_default_device("cuda")
+        torch.set_default_device(current_platform.device_type)
         torch.set_default_dtype(dtype)
         torch.manual_seed(1)
 
@@ -413,7 +413,7 @@ def test_aiter_fusion_rmsnorm_quant(
 
         rocm_aiter_ops.refresh_env_variables()
 
-        torch.set_default_device("cuda")
+        torch.set_default_device(current_platform.device_type)
         torch.set_default_dtype(dtype)
         torch.manual_seed(1)
 

--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -295,7 +295,7 @@ def test_attention_quant_pattern(
 
     custom_ops_list = custom_ops.split(",") if custom_ops else []
 
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     torch.set_default_dtype(dtype)
     torch.manual_seed(42)
 

--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -41,6 +41,8 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class AttentionQuantPatternModel(torch.nn.Module):
     """Base model for AttentionQuantPattern fusion."""
@@ -295,7 +297,7 @@ def test_attention_quant_pattern(
 
     custom_ops_list = custom_ops.split(",") if custom_ops else []
 
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     torch.set_default_dtype(dtype)
     torch.manual_seed(42)
 

--- a/tests/compile/passes/test_noop_elimination.py
+++ b/tests/compile/passes/test_noop_elimination.py
@@ -8,6 +8,7 @@ import vllm
 from tests.compile.backend import TestBackend
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
 from vllm.config import CompilationConfig, CompilationMode, PassConfig, VllmConfig
+from vllm.platforms import current_platform
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
@@ -17,7 +18,7 @@ from vllm.config import CompilationConfig, CompilationMode, PassConfig, VllmConf
 )
 @pytest.mark.parametrize("hidden_size", [64, 4096])
 def test_noop_elimination(dtype, num_tokens, hidden_size, buffer_size):
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     torch.set_default_dtype(dtype)
     torch.manual_seed(1)
 
@@ -88,7 +89,7 @@ def test_non_noop_slice_preserved():
     Regression test for a bug where end=-1 was treated like an inferred
     dimension (reshape semantics) leading to incorrect elimination.
     """
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     x = torch.randn(16, 16)
 
     class SliceModel(torch.nn.Module):

--- a/tests/compile/passes/test_noop_elimination.py
+++ b/tests/compile/passes/test_noop_elimination.py
@@ -10,6 +10,8 @@ from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
 from vllm.config import CompilationConfig, CompilationMode, PassConfig, VllmConfig
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
 # Important edge case is when `num_tokens == buffer_size`
@@ -18,7 +20,7 @@ from vllm.platforms import current_platform
 )
 @pytest.mark.parametrize("hidden_size", [64, 4096])
 def test_noop_elimination(dtype, num_tokens, hidden_size, buffer_size):
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     torch.set_default_dtype(dtype)
     torch.manual_seed(1)
 
@@ -89,7 +91,7 @@ def test_non_noop_slice_preserved():
     Regression test for a bug where end=-1 was treated like an inferred
     dimension (reshape semantics) leading to incorrect elimination.
     """
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     x = torch.randn(16, 16)
 
     class SliceModel(torch.nn.Module):

--- a/tests/compile/passes/test_qk_norm_rope_fusion.py
+++ b/tests/compile/passes/test_qk_norm_rope_fusion.py
@@ -141,7 +141,7 @@ def test_qk_norm_rope_fusion(
     if not hasattr(torch.ops._C, "fused_qk_norm_rope"):
         pytest.skip("fused_qk_norm_rope custom op not available")
 
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/passes/test_qk_norm_rope_fusion.py
+++ b/tests/compile/passes/test_qk_norm_rope_fusion.py
@@ -34,6 +34,8 @@ from vllm.v1.attention.backend import AttentionType
 RSQRT_OP = torch.ops.aten.rsqrt.default
 INDEX_SELECT_OP = torch.ops.aten.index.Tensor
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class QKNormRoPETestModel(torch.nn.Module):
     def __init__(
@@ -141,7 +143,7 @@ def test_qk_norm_rope_fusion(
     if not hasattr(torch.ops._C, "fused_qk_norm_rope"):
         pytest.skip("fused_qk_norm_rope custom op not available")
 
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/passes/test_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rope_kvcache_fusion.py
@@ -225,7 +225,7 @@ def test_rope_kvcache_fusion(
     kv_cache_dtype: str,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/passes/test_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rope_kvcache_fusion.py
@@ -39,6 +39,8 @@ INDEX_SELECT_OP = torch.ops.aten.index.Tensor
 VLLM_UNIFIED_KV_CACHE_UPDATE_OP = torch.ops.vllm.unified_kv_cache_update
 FP8_DTYPE = current_platform.fp8_dtype()
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class QKRoPEKVCacheTestModel(torch.nn.Module):
     def __init__(
@@ -225,7 +227,7 @@ def test_rope_kvcache_fusion(
     kv_cache_dtype: str,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/passes/test_scatter_split_replace.py
+++ b/tests/compile/passes/test_scatter_split_replace.py
@@ -13,6 +13,7 @@ from vllm.compilation.passes.utility.scatter_split_replace import (
 from vllm.compilation.passes.utility.split_coalescing import SplitCoalescingPass
 from vllm.config import CompilationConfig, CompilationMode, VllmConfig
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
+from vllm.platforms import current_platform
 
 
 class ScatterSplitReplacementModel(nn.Module):
@@ -61,7 +62,7 @@ class ScatterSplitReplacementModel(nn.Module):
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_scatter_split_replace(dtype):
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/passes/test_scatter_split_replace.py
+++ b/tests/compile/passes/test_scatter_split_replace.py
@@ -15,6 +15,8 @@ from vllm.config import CompilationConfig, CompilationMode, VllmConfig
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class ScatterSplitReplacementModel(nn.Module):
     """Model with a rope+getitem+slice_scatter+split_with_sizes sequence."""
@@ -62,7 +64,7 @@ class ScatterSplitReplacementModel(nn.Module):
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_scatter_split_replace(dtype):
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/passes/test_silu_mul_quant_fusion.py
+++ b/tests/compile/passes/test_silu_mul_quant_fusion.py
@@ -45,6 +45,8 @@ from vllm.platforms import current_platform
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def is_nvfp4_supported():
     return current_platform.has_device_capability(100)
@@ -224,7 +226,7 @@ def test_fusion_silu_and_mul_quant(
     if model_class is TestSiluMulGroupFp8QuantModel and not IS_AITER_FOUND:
         pytest.skip("AITER is not supported on this GPU.")
 
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     torch.set_default_dtype(dtype)
 
     x = torch.rand(num_tokens, hidden_size * 2)

--- a/tests/compile/passes/test_silu_mul_quant_fusion.py
+++ b/tests/compile/passes/test_silu_mul_quant_fusion.py
@@ -224,7 +224,7 @@ def test_fusion_silu_and_mul_quant(
     if model_class is TestSiluMulGroupFp8QuantModel and not IS_AITER_FOUND:
         pytest.skip("AITER is not supported on this GPU.")
 
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     torch.set_default_dtype(dtype)
 
     x = torch.rand(num_tokens, hidden_size * 2)

--- a/tests/compile/passes/test_split_coalescing.py
+++ b/tests/compile/passes/test_split_coalescing.py
@@ -8,6 +8,7 @@ import vllm
 from tests.compile.backend import TestBackend
 from vllm.compilation.passes.utility.split_coalescing import SplitCoalescingPass
 from vllm.config import CompilationConfig, CompilationMode, PassConfig, VllmConfig
+from vllm.platforms import current_platform
 
 
 class SplitCoalescingModel(torch.nn.Module):
@@ -28,7 +29,7 @@ class SplitCoalescingModel(torch.nn.Module):
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_split_coalescing(dtype):
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/passes/test_split_coalescing.py
+++ b/tests/compile/passes/test_split_coalescing.py
@@ -10,6 +10,8 @@ from vllm.compilation.passes.utility.split_coalescing import SplitCoalescingPass
 from vllm.config import CompilationConfig, CompilationMode, PassConfig, VllmConfig
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class SplitCoalescingModel(torch.nn.Module):
     """Model with 3 separate split_with_sizes calls on the same input,
@@ -29,7 +31,7 @@ class SplitCoalescingModel(torch.nn.Module):
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_split_coalescing(dtype):
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 

--- a/tests/compile/test_compile_ranges.py
+++ b/tests/compile/test_compile_ranges.py
@@ -22,6 +22,7 @@ from vllm.config.compilation import CompilationConfig, CompilationMode
 from vllm.config.scheduler import SchedulerConfig
 from vllm.config.utils import Range
 from vllm.forward_context import set_forward_context
+from vllm.platforms import current_platform
 
 BATCH_SIZE = 64
 MLP_SIZE = 128
@@ -77,7 +78,7 @@ def test_compile_ranges(use_fresh_inductor_cache):
             Range(start=33, end=8192),
         ]
     )
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     vllm_config = VllmConfig(
         scheduler_config=SchedulerConfig(
             max_num_batched_tokens=8192,
@@ -172,7 +173,7 @@ def test_compile_sizes_produce_static_shapes(use_fresh_inductor_cache):
     """Verify that compile_sizes entries are compiled with fully concrete
     shapes (no SymInts), while compile_ranges entries retain dynamic shapes."""
     checker = PostGradStaticShapeChecker()
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
     vllm_config = VllmConfig(
         scheduler_config=SchedulerConfig(
             max_num_batched_tokens=8192,
@@ -224,7 +225,7 @@ def test_inductor_cache_compile_ranges(monkeypatch, use_fresh_inductor_cache):
         max_model_len=8192,
         is_encoder_decoder=False,
     )
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
 
     def create_vllm_config():
         return VllmConfig(

--- a/tests/compile/test_compile_ranges.py
+++ b/tests/compile/test_compile_ranges.py
@@ -27,6 +27,8 @@ from vllm.platforms import current_platform
 BATCH_SIZE = 64
 MLP_SIZE = 128
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @support_torch_compile
 class TestModel(nn.Module):
@@ -78,7 +80,7 @@ def test_compile_ranges(use_fresh_inductor_cache):
             Range(start=33, end=8192),
         ]
     )
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     vllm_config = VllmConfig(
         scheduler_config=SchedulerConfig(
             max_num_batched_tokens=8192,
@@ -173,7 +175,7 @@ def test_compile_sizes_produce_static_shapes(use_fresh_inductor_cache):
     """Verify that compile_sizes entries are compiled with fully concrete
     shapes (no SymInts), while compile_ranges entries retain dynamic shapes."""
     checker = PostGradStaticShapeChecker()
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
     vllm_config = VllmConfig(
         scheduler_config=SchedulerConfig(
             max_num_batched_tokens=8192,
@@ -225,7 +227,7 @@ def test_inductor_cache_compile_ranges(monkeypatch, use_fresh_inductor_cache):
         max_model_len=8192,
         is_encoder_decoder=False,
     )
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
 
     def create_vllm_config():
         return VllmConfig(

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -30,6 +30,8 @@ from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 # This import automatically registers `torch.ops.silly.attention`
 from . import silly_attention  # noqa: F401
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def test_version():
     # Test the version comparison logic using the private function
@@ -449,7 +451,7 @@ def test_cached_compilation_config(default_vllm_config):
     from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 
     dtype = torch.bfloat16
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     batch_size, num_qo_heads, head_size = 8, 16, 128
 
     # access and cache default compilation config
@@ -472,7 +474,7 @@ def test_cached_compilation_config(default_vllm_config):
         query_quant = torch.compile(query_quant)
 
         _q_scale = torch.tensor(
-            1.0, dtype=torch.float32, device=current_platform.device_type
+            1.0, dtype=torch.float32, device=DEVICE_TYPE
         )
         query = torch.randn(
             batch_size, num_qo_heads * head_size, dtype=dtype, device=device

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -449,7 +449,7 @@ def test_cached_compilation_config(default_vllm_config):
     from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 
     dtype = torch.bfloat16
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     batch_size, num_qo_heads, head_size = 8, 16, 128
 
     # access and cache default compilation config
@@ -471,7 +471,9 @@ def test_cached_compilation_config(default_vllm_config):
         query_quant = QuantFP8(static=True, group_shape=GroupShape.PER_TENSOR)
         query_quant = torch.compile(query_quant)
 
-        _q_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+        _q_scale = torch.tensor(
+            1.0, dtype=torch.float32, device=current_platform.device_type
+        )
         query = torch.randn(
             batch_size, num_qo_heads * head_size, dtype=dtype, device=device
         )

--- a/tests/compile/test_graph_partition.py
+++ b/tests/compile/test_graph_partition.py
@@ -9,6 +9,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 
 from vllm.compilation.backends import _is_empty_allocation_node, split_graph
 from vllm.compilation.passes.fx_utils import find_op_nodes
+from vllm.platforms import current_platform
 
 # This import automatically registers `torch.ops.silly.attention`
 from . import silly_attention  # noqa: F401
@@ -145,7 +146,7 @@ def test_consecutive_ops_in_split():
         final_result = torch.sigmoid(attn_inout)
         return final_result
 
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
 
     # Create the traced FX graph for the model
     x = torch.randn(8, 4)
@@ -323,7 +324,7 @@ def test_builtin_empty_only_partition_is_merged():
         "Expected two builtin empty_like nodes in merged non-splitting subgraph"
     )
 
-    x = torch.randn(2, 3, device="cuda")
+    x = torch.randn(2, 3, device=current_platform.device_type)
     output_original = gm(x)
     output_split = split_gm(x)
     assert torch.allclose(output_original, output_split), "Output mismatch after split"

--- a/tests/compile/test_graph_partition.py
+++ b/tests/compile/test_graph_partition.py
@@ -14,6 +14,8 @@ from vllm.platforms import current_platform
 # This import automatically registers `torch.ops.silly.attention`
 from . import silly_attention  # noqa: F401
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def test_getitem_moved_to_producer_subgraph():
     """
@@ -146,7 +148,7 @@ def test_consecutive_ops_in_split():
         final_result = torch.sigmoid(attn_inout)
         return final_result
 
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
 
     # Create the traced FX graph for the model
     x = torch.randn(8, 4)
@@ -324,7 +326,7 @@ def test_builtin_empty_only_partition_is_merged():
         "Expected two builtin empty_like nodes in merged non-splitting subgraph"
     )
 
-    x = torch.randn(2, 3, device=current_platform.device_type)
+    x = torch.randn(2, 3, device=DEVICE_TYPE)
     output_original = gm(x)
     output_split = split_gm(x)
     assert torch.allclose(output_original, output_split), "Output mismatch after split"

--- a/tests/compile/test_rotary_embedding_compile.py
+++ b/tests/compile/test_rotary_embedding_compile.py
@@ -16,6 +16,8 @@ from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @support_torch_compile
 class RotaryEmbeddingCompileModule(torch.nn.Module):
@@ -45,7 +47,7 @@ def test_rotary_embedding_torch_compile_with_custom_op(monkeypatch):
     monkeypatch.setenv("VLLM_USE_BYTECODE_HOOK", "1")
     monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "0")
 
-    device = current_platform.device_type
+    device = DEVICE_TYPE
     positions = torch.arange(16, device=device)
     query = torch.randn(16, 32, device=device, dtype=torch.bfloat16)
     key = torch.randn(16, 32, device=device, dtype=torch.bfloat16)

--- a/tests/compile/test_rotary_embedding_compile.py
+++ b/tests/compile/test_rotary_embedding_compile.py
@@ -45,7 +45,7 @@ def test_rotary_embedding_torch_compile_with_custom_op(monkeypatch):
     monkeypatch.setenv("VLLM_USE_BYTECODE_HOOK", "1")
     monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "0")
 
-    device = "cuda"
+    device = current_platform.device_type
     positions = torch.arange(16, device=device)
     query = torch.randn(16, 32, device=device, dtype=torch.bfloat16)
     key = torch.randn(16, 32, device=device, dtype=torch.bfloat16)

--- a/tests/compile/test_structured_logging.py
+++ b/tests/compile/test_structured_logging.py
@@ -21,6 +21,8 @@ from vllm.platforms import current_platform
 
 MLP_SIZE = 64
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @support_torch_compile
 class SimpleModel(nn.Module):
@@ -72,7 +74,7 @@ class TraceStructuredCapture:
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_vllm_structured_logging_artifacts(use_fresh_inductor_cache):
     """Test that all expected vLLM artifacts are logged during compilation."""
-    torch.set_default_device(current_platform.device_type)
+    torch.set_default_device(DEVICE_TYPE)
 
     capture = TraceStructuredCapture()
 

--- a/tests/compile/test_structured_logging.py
+++ b/tests/compile/test_structured_logging.py
@@ -17,6 +17,7 @@ from vllm.config.compilation import (
 )
 from vllm.config.scheduler import SchedulerConfig
 from vllm.forward_context import set_forward_context
+from vllm.platforms import current_platform
 
 MLP_SIZE = 64
 
@@ -71,7 +72,7 @@ class TraceStructuredCapture:
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_vllm_structured_logging_artifacts(use_fresh_inductor_cache):
     """Test that all expected vLLM artifacts are logged during compilation."""
-    torch.set_default_device("cuda")
+    torch.set_default_device(current_platform.device_type)
 
     capture = TraceStructuredCapture()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ from vllm.logprobs import Logprob
 from vllm.multimodal.media import MediaWithBytes
 from vllm.multimodal.utils import fetch_image
 from vllm.outputs import RequestOutput
+from vllm.platforms import current_platform
 from vllm.sampling_params import BeamSearchParams
 from vllm.transformers_utils.utils import maybe_model_redirect
 from vllm.utils.collection_utils import is_list_of
@@ -236,7 +237,7 @@ def workspace_init():
     )
 
     if torch.cuda.is_available():
-        device = torch.device("cuda:0")
+        device = torch.device(f"{current_platform.device_type}:0")
         init_workspace_manager(device)
     yield
     reset_workspace_manager()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,8 @@ PromptImageInput = _PromptMultiModalInput[Image.Image]
 PromptAudioInput = _PromptMultiModalInput[tuple[np.ndarray, int]]
 PromptVideoInput = _PromptMultiModalInput[np.ndarray]
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def _read_prompts(filename: str) -> list[str]:
     with open(filename) as f:
@@ -237,7 +239,7 @@ def workspace_init():
     )
 
     if torch.cuda.is_available():
-        device = torch.device(f"{current_platform.device_type}:0")
+        device = torch.device(f"{DEVICE_TYPE}:0")
         init_workspace_manager(device)
     yield
     reset_workspace_manager()
@@ -296,7 +298,7 @@ class HfRunner:
     def get_default_device(self):
         from vllm.platforms import current_platform
 
-        return "cpu" if current_platform.is_cpu() else current_platform.device_type
+        return "cpu" if current_platform.is_cpu() else DEVICE_TYPE
 
     def wrap_device(self, x: _T, device: str | None = None) -> _T:
         if x is None or isinstance(x, (bool,)):

--- a/tests/distributed/eplb_utils.py
+++ b/tests/distributed/eplb_utils.py
@@ -11,6 +11,7 @@ from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.distributed.parallel_state import (
     init_distributed_environment,
 )
+from vllm.platforms import current_platform
 from vllm.utils.system_utils import update_environment_variables
 
 mp.set_start_method("spawn", force=True)
@@ -41,7 +42,7 @@ def distributed_run(fn, world_size, *args):
 def set_env_vars_and_device(env: dict[str, str]) -> None:
     update_environment_variables(env)
     local_rank = os.environ["LOCAL_RANK"]
-    device = torch.device(f"cuda:{local_rank}")
+    device = torch.device(f"{current_platform.device_type}:{local_rank}")
     torch.accelerator.set_device_index(device)
 
     # Create a minimal vllm config for init_distributed_environment

--- a/tests/distributed/eplb_utils.py
+++ b/tests/distributed/eplb_utils.py
@@ -14,6 +14,8 @@ from vllm.distributed.parallel_state import (
 from vllm.platforms import current_platform
 from vllm.utils.system_utils import update_environment_variables
 
+DEVICE_TYPE = current_platform.device_type
+
 mp.set_start_method("spawn", force=True)
 
 
@@ -42,7 +44,7 @@ def distributed_run(fn, world_size, *args):
 def set_env_vars_and_device(env: dict[str, str]) -> None:
     update_environment_variables(env)
     local_rank = os.environ["LOCAL_RANK"]
-    device = torch.device(f"{current_platform.device_type}:{local_rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{local_rank}")
     torch.accelerator.set_device_index(device)
 
     # Create a minimal vllm config for init_distributed_environment

--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -20,6 +20,7 @@ from vllm.distributed import (
     tensor_model_parallel_reduce_scatter,
 )
 from vllm.distributed.parallel_state import GroupCoordinator, TensorMetadata
+from vllm.platforms import current_platform
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
 
 from ..utils import (
@@ -41,13 +42,16 @@ def all_reduce_test_worker(
     # so that each worker can see all the GPUs
     # they will be able to set the device to the correct GPU
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-
-    device = torch.device(f"cuda:{rank}")
+    monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
+    device = torch.device(f"{current_platform.device_type}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
     num_elements = 8
     all_tensors = [
-        torch.arange(num_elements, dtype=torch.float32, device="cuda") * (r + 1)
+        torch.arange(
+            num_elements, dtype=torch.float32, device=current_platform.device_type
+        )
+        * (r + 1)
         for r in range(tp_size)
     ]
     expected = torch.sum(torch.stack(all_tensors, dim=0), dim=0)
@@ -68,13 +72,17 @@ def reduce_scatter_test_worker(
     # so that each worker can see all the GPUs
     # they will be able to set the device to the correct GPU
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-    device = torch.device(f"cuda:{rank}")
+    monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
+    device = torch.device(f"{current_platform.device_type}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
 
     num_elements = 8
     all_tensors = [
-        torch.arange(num_elements, dtype=torch.float32, device="cuda") * (r + 1)
+        torch.arange(
+            num_elements, dtype=torch.float32, device=current_platform.device_type
+        )
+        * (r + 1)
         for r in range(tp_size)
     ]
 
@@ -99,7 +107,8 @@ def all_gather_test_worker(
     # so that each worker can see all the GPUs
     # they will be able to set the device to the correct GPU
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-    device = torch.device(f"cuda:{rank}")
+    monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
+    device = torch.device(f"{current_platform.device_type}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
     num_dimensions = 3
@@ -109,9 +118,9 @@ def all_gather_test_worker(
         total_size *= s
     for all_gather_dimension in range(num_dimensions):
         all_tensors = [
-            torch.arange(total_size, dtype=torch.float32, device="cuda").reshape(
-                tensor_size
-            )
+            torch.arange(
+                total_size, dtype=torch.float32, device=current_platform.device_type
+            ).reshape(tensor_size)
             * (r + 1)
             for r in range(tp_size)
         ]
@@ -133,19 +142,20 @@ def broadcast_tensor_dict_test_worker(
     # so that each worker can see all the GPUs
     # they will be able to set the device to the correct GPU
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-    device = torch.device(f"cuda:{rank}")
+    monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
+    device = torch.device(f"{current_platform.device_type}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
     test_dict = {
         # device tensor
-        "a": torch.arange(8, dtype=torch.float32, device="cuda"),
+        "a": torch.arange(8, dtype=torch.float32, device=current_platform.device_type),
         # CPU tensor
         "b": torch.arange(16, dtype=torch.int8, device="cpu"),
         "c": "test",
         "d": [1, 2, 3],
         "e": {"a": 1, "b": 2},
         # empty tensor
-        "f": torch.tensor([], dtype=torch.float32, device="cuda"),
+        "f": torch.tensor([], dtype=torch.float32, device=current_platform.device_type),
     }
 
     if (rank % tp_size) == 0:
@@ -170,20 +180,21 @@ def send_recv_tensor_dict_test_worker(
     distributed_init_port: str,
 ):
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-    device = torch.device(f"cuda:{rank}")
+    monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
+    device = torch.device(f"{current_platform.device_type}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
 
     test_dict = {
         # device tensor
-        "a": torch.arange(8, dtype=torch.float32, device="cuda"),
+        "a": torch.arange(8, dtype=torch.float32, device=current_platform.device_type),
         # CPU tensor
         "b": torch.arange(16, dtype=torch.int8, device="cpu"),
         "c": "test",
         "d": [1, 2, 3],
         "e": {"a": 1, "b": 2},
         # empty tensor
-        "f": torch.tensor([], dtype=torch.float32, device="cuda"),
+        "f": torch.tensor([], dtype=torch.float32, device=current_platform.device_type),
     }
 
     if not get_pp_group().is_first_rank:
@@ -316,12 +327,15 @@ def send_recv_test_worker(
     distributed_init_port: str,
 ):
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-    device = torch.device(f"cuda:{rank}")
+    monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
+    device = torch.device(f"{current_platform.device_type}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
 
     size = 64
-    test_tensor = torch.arange(64, dtype=torch.float32, device="cuda")
+    test_tensor = torch.arange(
+        64, dtype=torch.float32, device=current_platform.device_type
+    )
 
     if not get_pp_group().is_first_rank:
         recv_tensor = get_pp_group().recv(size, dtype=torch.float32)

--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -29,6 +29,8 @@ from ..utils import (
     multi_process_parallel,
 )
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @ray.remote(num_gpus=1, max_calls=1)
 def all_reduce_test_worker(
@@ -43,13 +45,13 @@ def all_reduce_test_worker(
     # they will be able to set the device to the correct GPU
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
-    device = torch.device(f"{current_platform.device_type}:{rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
     num_elements = 8
     all_tensors = [
         torch.arange(
-            num_elements, dtype=torch.float32, device=current_platform.device_type
+            num_elements, dtype=torch.float32, device=DEVICE_TYPE
         )
         * (r + 1)
         for r in range(tp_size)
@@ -73,14 +75,14 @@ def reduce_scatter_test_worker(
     # they will be able to set the device to the correct GPU
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
-    device = torch.device(f"{current_platform.device_type}:{rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
 
     num_elements = 8
     all_tensors = [
         torch.arange(
-            num_elements, dtype=torch.float32, device=current_platform.device_type
+            num_elements, dtype=torch.float32, device=DEVICE_TYPE
         )
         * (r + 1)
         for r in range(tp_size)
@@ -108,7 +110,7 @@ def all_gather_test_worker(
     # they will be able to set the device to the correct GPU
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
-    device = torch.device(f"{current_platform.device_type}:{rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
     num_dimensions = 3
@@ -119,7 +121,7 @@ def all_gather_test_worker(
     for all_gather_dimension in range(num_dimensions):
         all_tensors = [
             torch.arange(
-                total_size, dtype=torch.float32, device=current_platform.device_type
+                total_size, dtype=torch.float32, device=DEVICE_TYPE
             ).reshape(tensor_size)
             * (r + 1)
             for r in range(tp_size)
@@ -143,19 +145,19 @@ def broadcast_tensor_dict_test_worker(
     # they will be able to set the device to the correct GPU
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
-    device = torch.device(f"{current_platform.device_type}:{rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
     test_dict = {
         # device tensor
-        "a": torch.arange(8, dtype=torch.float32, device=current_platform.device_type),
+        "a": torch.arange(8, dtype=torch.float32, device=DEVICE_TYPE),
         # CPU tensor
         "b": torch.arange(16, dtype=torch.int8, device="cpu"),
         "c": "test",
         "d": [1, 2, 3],
         "e": {"a": 1, "b": 2},
         # empty tensor
-        "f": torch.tensor([], dtype=torch.float32, device=current_platform.device_type),
+        "f": torch.tensor([], dtype=torch.float32, device=DEVICE_TYPE),
     }
 
     if (rank % tp_size) == 0:
@@ -181,20 +183,20 @@ def send_recv_tensor_dict_test_worker(
 ):
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
-    device = torch.device(f"{current_platform.device_type}:{rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
 
     test_dict = {
         # device tensor
-        "a": torch.arange(8, dtype=torch.float32, device=current_platform.device_type),
+        "a": torch.arange(8, dtype=torch.float32, device=DEVICE_TYPE),
         # CPU tensor
         "b": torch.arange(16, dtype=torch.int8, device="cpu"),
         "c": "test",
         "d": [1, 2, 3],
         "e": {"a": 1, "b": 2},
         # empty tensor
-        "f": torch.tensor([], dtype=torch.float32, device=current_platform.device_type),
+        "f": torch.tensor([], dtype=torch.float32, device=DEVICE_TYPE),
     }
 
     if not get_pp_group().is_first_rank:
@@ -328,13 +330,13 @@ def send_recv_test_worker(
 ):
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
-    device = torch.device(f"{current_platform.device_type}:{rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{rank}")
     torch.accelerator.set_device_index(device)
     init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
 
     size = 64
     test_tensor = torch.arange(
-        64, dtype=torch.float32, device=current_platform.device_type
+        64, dtype=torch.float32, device=DEVICE_TYPE
     )
 
     if not get_pp_group().is_first_rank:

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -18,6 +18,8 @@ from ..utils import (
     multi_process_parallel,
 )
 
+DEVICE_TYPE = current_platform.device_type
+
 random.seed(42)
 test_sizes = [random.randint(1024, 2048 * 1024) for _ in range(8)]
 for i, v in enumerate(test_sizes):
@@ -36,7 +38,7 @@ def graph_allreduce(
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         m.delenv("HIP_VISIBLE_DEVICES", raising=False)
         m.delenv("ZE_AFFINITY_MASK", raising=False)
-        device = torch.device(f"{current_platform.device_type}:{rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{rank}")
         torch.accelerator.set_device_index(device)
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
         ensure_model_parallel_initialized(tp_size, pp_size)
@@ -95,7 +97,7 @@ def eager_allreduce(
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         m.delenv("HIP_VISIBLE_DEVICES", raising=False)
         m.delenv("ZE_AFFINITY_MASK", raising=False)
-        device = torch.device(f"{current_platform.device_type}:{rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{rank}")
         torch.accelerator.set_device_index(device)
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
 

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -10,6 +10,7 @@ import torch.distributed as dist
 
 from vllm.distributed.communication_op import tensor_model_parallel_all_reduce  # noqa
 from vllm.distributed.parallel_state import get_tp_group, graph_capture
+from vllm.platforms import current_platform
 
 from ..utils import (
     ensure_model_parallel_initialized,
@@ -34,7 +35,8 @@ def graph_allreduce(
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         m.delenv("HIP_VISIBLE_DEVICES", raising=False)
-        device = torch.device(f"cuda:{rank}")
+        m.delenv("ZE_AFFINITY_MASK", raising=False)
+        device = torch.device(f"{current_platform.device_type}:{rank}")
         torch.accelerator.set_device_index(device)
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
         ensure_model_parallel_initialized(tp_size, pp_size)
@@ -92,7 +94,8 @@ def eager_allreduce(
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         m.delenv("HIP_VISIBLE_DEVICES", raising=False)
-        device = torch.device(f"cuda:{rank}")
+        m.delenv("ZE_AFFINITY_MASK", raising=False)
+        device = torch.device(f"{current_platform.device_type}:{rank}")
         torch.accelerator.set_device_index(device)
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
 

--- a/tests/distributed/test_eplb_algo.py
+++ b/tests/distributed/test_eplb_algo.py
@@ -8,6 +8,8 @@ import torch
 from vllm.distributed.eplb.policy.default import DefaultEplbPolicy
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def test_basic_rebalance():
     """Test basic rebalancing functionality"""
@@ -236,7 +238,7 @@ def test_global_load_balance_fallback():
     assert torch.sum(logcnt) == num_replicas
 
 
-@pytest.mark.parametrize("device", ["cpu", current_platform.device_type])
+@pytest.mark.parametrize("device", ["cpu", DEVICE_TYPE])
 def test_device_compatibility(device):
     """Test device compatibility"""
     if device == "cuda" and not torch.cuda.is_available():

--- a/tests/distributed/test_eplb_algo.py
+++ b/tests/distributed/test_eplb_algo.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from vllm.distributed.eplb.policy.default import DefaultEplbPolicy
+from vllm.platforms import current_platform
 
 
 def test_basic_rebalance():
@@ -235,7 +236,7 @@ def test_global_load_balance_fallback():
     assert torch.sum(logcnt) == num_replicas
 
 
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("device", ["cpu", current_platform.device_type])
 def test_device_compatibility(device):
     """Test device compatibility"""
     if device == "cuda" and not torch.cuda.is_available():

--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -18,6 +18,7 @@ from vllm.distributed.parallel_state import (
     ensure_model_parallel_initialized,
     get_tp_group,
 )
+from vllm.platforms import current_platform
 
 from .eplb_utils import distributed_run, set_env_vars_and_device
 
@@ -257,7 +258,7 @@ def _test_async_transfer_layer_without_mtp_worker(
         tp_group = get_tp_group()
         ep_group = tp_group.device_group
         ep_rank = torch.distributed.get_rank()
-        device = torch.device(f"cuda:{ep_rank}")
+        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
 
         total_physical_experts = world_size * num_local_experts
         hidden_sizes = [16, 32]
@@ -353,7 +354,7 @@ def _test_rearrange_expert_weights_with_redundancy(
 
         ep_group = get_tp_group().cpu_group
         ep_rank = torch.distributed.get_rank()
-        device = torch.device(f"cuda:{ep_rank}")
+        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
 
         # Test parameters
         total_physical_experts = world_size * num_local_experts
@@ -466,7 +467,7 @@ def _test_rearrange_expert_weights_no_change(env, world_size) -> None:
 
         ep_group = get_tp_group().cpu_group
         ep_rank = torch.distributed.get_rank()
-        device = torch.device(f"cuda:{ep_rank}")
+        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
 
         num_layers = 2
         num_local_experts = 2
@@ -565,7 +566,7 @@ def _test_rearrange_expert_weights_profile_mode(env, world_size) -> None:
 
         ep_group = get_tp_group().cpu_group
         ep_rank = torch.distributed.get_rank()
-        device = torch.device(f"cuda:{ep_rank}")
+        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
 
         num_layers = 1
         num_local_experts = 2

--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -22,10 +22,12 @@ from vllm.platforms import current_platform
 
 from .eplb_utils import distributed_run, set_env_vars_and_device
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def create_expert_indices_with_redundancy(
     num_layers: int,
-    num_logical_experts: int,
+    num_logical_experts: int
     total_physical_experts: int,
     redundancy_config: list[int],  # redundancy for each logical expert
 ) -> torch.Tensor:
@@ -258,7 +260,7 @@ def _test_async_transfer_layer_without_mtp_worker(
         tp_group = get_tp_group()
         ep_group = tp_group.device_group
         ep_rank = torch.distributed.get_rank()
-        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{ep_rank}")
 
         total_physical_experts = world_size * num_local_experts
         hidden_sizes = [16, 32]
@@ -354,7 +356,7 @@ def _test_rearrange_expert_weights_with_redundancy(
 
         ep_group = get_tp_group().cpu_group
         ep_rank = torch.distributed.get_rank()
-        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{ep_rank}")
 
         # Test parameters
         total_physical_experts = world_size * num_local_experts
@@ -467,7 +469,7 @@ def _test_rearrange_expert_weights_no_change(env, world_size) -> None:
 
         ep_group = get_tp_group().cpu_group
         ep_rank = torch.distributed.get_rank()
-        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{ep_rank}")
 
         num_layers = 2
         num_local_experts = 2
@@ -566,7 +568,7 @@ def _test_rearrange_expert_weights_profile_mode(env, world_size) -> None:
 
         ep_group = get_tp_group().cpu_group
         ep_rank = torch.distributed.get_rank()
-        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{ep_rank}")
 
         num_layers = 1
         num_local_experts = 2

--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -27,7 +27,7 @@ DEVICE_TYPE = current_platform.device_type
 
 def create_expert_indices_with_redundancy(
     num_layers: int,
-    num_logical_experts: int
+    num_logical_experts: int,
     total_physical_experts: int,
     redundancy_config: list[int],  # redundancy for each logical expert
 ) -> torch.Tensor:

--- a/tests/distributed/test_eplb_fused_moe_layer.py
+++ b/tests/distributed/test_eplb_fused_moe_layer.py
@@ -15,6 +15,7 @@ from vllm.distributed.parallel_state import (
     get_tp_group,
 )
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.platforms import current_platform
 
 from .eplb_utils import distributed_run, set_env_vars_and_device
 
@@ -79,7 +80,7 @@ def make_fused_moe_layer(
         params_dtype=test_config.weight_dtype,
     )
 
-    device = torch.device(f"cuda:{rank}")
+    device = torch.device(f"{current_platform.device_type}:{rank}")
 
     from functools import partial
 

--- a/tests/distributed/test_eplb_fused_moe_layer.py
+++ b/tests/distributed/test_eplb_fused_moe_layer.py
@@ -19,6 +19,8 @@ from vllm.platforms import current_platform
 
 from .eplb_utils import distributed_run, set_env_vars_and_device
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @dataclass
 class TestConfig:
@@ -80,7 +82,7 @@ def make_fused_moe_layer(
         params_dtype=test_config.weight_dtype,
     )
 
-    device = torch.device(f"{current_platform.device_type}:{rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{rank}")
 
     from functools import partial
 

--- a/tests/distributed/test_eplb_fused_moe_layer_dep_nvfp4.py
+++ b/tests/distributed/test_eplb_fused_moe_layer_dep_nvfp4.py
@@ -21,6 +21,7 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptNvFp4Config,
     ModelOptNvFp4FusedMoE,
 )
+from vllm.platforms import current_platform
 
 from .eplb_utils import distributed_run, set_env_vars_and_device
 
@@ -43,7 +44,7 @@ def make_fused_moe_layer(
 ) -> FusedMoE:
     quant_config = None
 
-    device = torch.device(f"cuda:{rank}")
+    device = torch.device(f"{current_platform.device_type}:{rank}")
 
     quant_config = ModelOptNvFp4Config(
         is_checkpoint_nvfp4_serialized=True,
@@ -120,7 +121,7 @@ def _test_eplb_fml(env, world_size: int, test_config: TestConfig):
         ep_group = get_dp_group().cpu_group
         ep_rank = torch.distributed.get_rank()
 
-        device = torch.device(f"cuda:{ep_rank}")
+        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
 
         fml_layers = [
             make_fused_moe_layer(ep_rank, layer_idx, test_config).to(device)

--- a/tests/distributed/test_eplb_fused_moe_layer_dep_nvfp4.py
+++ b/tests/distributed/test_eplb_fused_moe_layer_dep_nvfp4.py
@@ -25,6 +25,8 @@ from vllm.platforms import current_platform
 
 from .eplb_utils import distributed_run, set_env_vars_and_device
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @dataclass
 class TestConfig:
@@ -44,7 +46,7 @@ def make_fused_moe_layer(
 ) -> FusedMoE:
     quant_config = None
 
-    device = torch.device(f"{current_platform.device_type}:{rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{rank}")
 
     quant_config = ModelOptNvFp4Config(
         is_checkpoint_nvfp4_serialized=True,
@@ -121,7 +123,7 @@ def _test_eplb_fml(env, world_size: int, test_config: TestConfig):
         ep_group = get_dp_group().cpu_group
         ep_rank = torch.distributed.get_rank()
 
-        device = torch.device(f"{current_platform.device_type}:{ep_rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{ep_rank}")
 
         fml_layers = [
             make_fused_moe_layer(ep_rank, layer_idx, test_config).to(device)

--- a/tests/distributed/test_nccl_symm_mem_allreduce.py
+++ b/tests/distributed/test_nccl_symm_mem_allreduce.py
@@ -26,6 +26,8 @@ from vllm.distributed.parallel_state import (
 from vllm.platforms import current_platform
 from vllm.utils.system_utils import update_environment_variables
 
+DEVICE_TYPE = current_platform.device_type
+
 torch.manual_seed(42)
 random.seed(44)
 
@@ -37,7 +39,7 @@ def nccl_symm_mem_allreduce_worker(local_rank: int, world_size: int):
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         dtype = torch.bfloat16
-        device = torch.device(f"{current_platform.device_type}:{local_rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{local_rank}")
         torch.accelerator.set_device_index(device)
         torch.set_default_device(device)
         torch.set_default_dtype(dtype)

--- a/tests/distributed/test_nccl_symm_mem_allreduce.py
+++ b/tests/distributed/test_nccl_symm_mem_allreduce.py
@@ -37,7 +37,7 @@ def nccl_symm_mem_allreduce_worker(local_rank: int, world_size: int):
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         dtype = torch.bfloat16
-        device = torch.device(f"cuda:{local_rank}")
+        device = torch.device(f"{current_platform.device_type}:{local_rank}")
         torch.accelerator.set_device_index(device)
         torch.set_default_device(device)
         torch.set_default_dtype(dtype)

--- a/tests/distributed/test_packed_tensor.py
+++ b/tests/distributed/test_packed_tensor.py
@@ -16,6 +16,8 @@ from vllm.distributed.weight_transfer.packed_tensor import (
 )
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class MockCommunicationGroup:
     """Mock communication group for testing producer broadcast operations."""
@@ -23,7 +25,7 @@ class MockCommunicationGroup:
     def __init__(self):
         self.broadcasted_tensors: list[torch.Tensor] = []
         self.broadcast_count = 0
-        self.device = torch.device(f"{current_platform.device_type}:0")
+        self.device = torch.device(f"{DEVICE_TYPE}:0")
 
     def broadcast(self, tensor, src):
         """Mock broadcast that stores the tensor for later verification."""
@@ -37,7 +39,7 @@ class MockConsumerCommunicationGroup:
     def __init__(self, tensors_to_return: list[torch.Tensor]):
         self.tensors_to_return = tensors_to_return
         self.current_index = 0
-        self.device = torch.device(f"{current_platform.device_type}:0")
+        self.device = torch.device(f"{DEVICE_TYPE}:0")
 
     def broadcast(self, tensor, src):
         """Mock broadcast that fills the tensor with pre-stored data."""

--- a/tests/distributed/test_packed_tensor.py
+++ b/tests/distributed/test_packed_tensor.py
@@ -14,6 +14,7 @@ from vllm.distributed.weight_transfer.packed_tensor import (
     packed_broadcast_consumer,
     packed_broadcast_producer,
 )
+from vllm.platforms import current_platform
 
 
 class MockCommunicationGroup:
@@ -22,7 +23,7 @@ class MockCommunicationGroup:
     def __init__(self):
         self.broadcasted_tensors: list[torch.Tensor] = []
         self.broadcast_count = 0
-        self.device = torch.device("cuda:0")
+        self.device = torch.device(f"{current_platform.device_type}:0")
 
     def broadcast(self, tensor, src):
         """Mock broadcast that stores the tensor for later verification."""
@@ -36,7 +37,7 @@ class MockConsumerCommunicationGroup:
     def __init__(self, tensors_to_return: list[torch.Tensor]):
         self.tensors_to_return = tensors_to_return
         self.current_index = 0
-        self.device = torch.device("cuda:0")
+        self.device = torch.device(f"{current_platform.device_type}:0")
 
     def broadcast(self, tensor, src):
         """Mock broadcast that fills the tensor with pre-stored data."""

--- a/tests/distributed/test_pynccl.py
+++ b/tests/distributed/test_pynccl.py
@@ -22,6 +22,8 @@ from vllm.distributed.parallel_state import (
 from vllm.platforms import current_platform
 from vllm.utils.system_utils import update_environment_variables
 
+DEVICE_TYPE = current_platform.device_type
+
 mp.set_start_method("spawn", force=True)
 
 
@@ -54,7 +56,7 @@ def worker_fn_wrapper(fn):
     def wrapped_fn(env):
         update_environment_variables(env)
         local_rank = os.environ["LOCAL_RANK"]
-        device = torch.device(f"{current_platform.device_type}:{local_rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{local_rank}")
         torch.accelerator.set_device_index(device)
         init_distributed_environment()
         fn()
@@ -83,7 +85,7 @@ def test_pynccl():
 @worker_fn_wrapper
 def multiple_allreduce_worker_fn():
     device = torch.device(
-        f"{current_platform.device_type}:{torch.distributed.get_rank()}"
+        f"{DEVICE_TYPE}:{torch.distributed.get_rank()}"
     )
     groups = [
         torch.distributed.new_group(ranks=[0, 1], backend="gloo"),
@@ -116,7 +118,7 @@ def test_pynccl_multiple_allreduce():
 @worker_fn_wrapper
 def multiple_allreduce_with_vllm_worker_fn():
     device = torch.device(
-        f"{current_platform.device_type}:{torch.distributed.get_rank()}"
+        f"{DEVICE_TYPE}:{torch.distributed.get_rank()}"
     )
     with ensure_current_vllm_config():
         ensure_model_parallel_initialized(2, 2)
@@ -152,7 +154,7 @@ def worker_fn_with_cudagraph():
         )
         # run something in the default stream to initialize torch engine
         a = torch.ones(
-            (4, 4), device=f"{current_platform.device_type}:{pynccl_comm.rank}"
+            (4, 4), device=f"{DEVICE_TYPE}:{pynccl_comm.rank}"
         )
         torch.accelerator.synchronize()
         with torch.cuda.graph(graph):
@@ -171,7 +173,7 @@ def all_gather_worker_fn():
 
     rank = pynccl_comm.rank
     world_size = pynccl_comm.world_size
-    device = f"{current_platform.device_type}:{pynccl_comm.rank}"
+    device = f"{DEVICE_TYPE}:{pynccl_comm.rank}"
 
     num_elems = 1000
     tensor = (
@@ -206,7 +208,7 @@ def all_gatherv_worker_fn():
 
     rank = pynccl_comm.rank
     world_size = pynccl_comm.world_size
-    device = f"{current_platform.device_type}:{pynccl_comm.rank}"
+    device = f"{DEVICE_TYPE}:{pynccl_comm.rank}"
 
     assert world_size <= 8
     sizes = [81, 20, 57, 52, 81, 5, 49, 49][:world_size]
@@ -241,7 +243,7 @@ def reduce_scatter_worker_fn():
 
     rank = pynccl_comm.rank
     world_size = pynccl_comm.world_size
-    device = f"{current_platform.device_type}:{pynccl_comm.rank}"
+    device = f"{DEVICE_TYPE}:{pynccl_comm.rank}"
 
     num_elems = 1000
     tensor = (
@@ -281,7 +283,7 @@ def reduce_scatterv_worker_fn():
 
     rank = pynccl_comm.rank
     world_size = pynccl_comm.world_size
-    device = f"{current_platform.device_type}:{pynccl_comm.rank}"
+    device = f"{DEVICE_TYPE}:{pynccl_comm.rank}"
 
     assert world_size <= 8
     sizes = [81, 20, 57, 52, 81, 5, 49, 49][:world_size]
@@ -346,7 +348,7 @@ def test_pynccl_send_recv():
 @worker_fn_wrapper
 def multiple_send_recv_worker_fn():
     device = torch.device(
-        f"{current_platform.device_type}:{torch.distributed.get_rank()}"
+        f"{DEVICE_TYPE}:{torch.distributed.get_rank()}"
     )
     groups = [
         torch.distributed.new_group(ranks=[0, 2], backend="gloo"),

--- a/tests/distributed/test_pynccl.py
+++ b/tests/distributed/test_pynccl.py
@@ -19,6 +19,7 @@ from vllm.distributed.parallel_state import (
     graph_capture,
     init_distributed_environment,
 )
+from vllm.platforms import current_platform
 from vllm.utils.system_utils import update_environment_variables
 
 mp.set_start_method("spawn", force=True)
@@ -53,7 +54,7 @@ def worker_fn_wrapper(fn):
     def wrapped_fn(env):
         update_environment_variables(env)
         local_rank = os.environ["LOCAL_RANK"]
-        device = torch.device(f"cuda:{local_rank}")
+        device = torch.device(f"{current_platform.device_type}:{local_rank}")
         torch.accelerator.set_device_index(device)
         init_distributed_environment()
         fn()
@@ -81,7 +82,9 @@ def test_pynccl():
 
 @worker_fn_wrapper
 def multiple_allreduce_worker_fn():
-    device = torch.device(f"cuda:{torch.distributed.get_rank()}")
+    device = torch.device(
+        f"{current_platform.device_type}:{torch.distributed.get_rank()}"
+    )
     groups = [
         torch.distributed.new_group(ranks=[0, 1], backend="gloo"),
         torch.distributed.new_group(ranks=[2, 3], backend="gloo"),
@@ -112,7 +115,9 @@ def test_pynccl_multiple_allreduce():
 
 @worker_fn_wrapper
 def multiple_allreduce_with_vllm_worker_fn():
-    device = torch.device(f"cuda:{torch.distributed.get_rank()}")
+    device = torch.device(
+        f"{current_platform.device_type}:{torch.distributed.get_rank()}"
+    )
     with ensure_current_vllm_config():
         ensure_model_parallel_initialized(2, 2)
     tensor = torch.ones(16, 1024, 1024, dtype=torch.float32, device=device)
@@ -146,7 +151,9 @@ def worker_fn_with_cudagraph():
             get_world_group().cpu_group, device=get_world_group().device
         )
         # run something in the default stream to initialize torch engine
-        a = torch.ones((4, 4), device=f"cuda:{pynccl_comm.rank}")
+        a = torch.ones(
+            (4, 4), device=f"{current_platform.device_type}:{pynccl_comm.rank}"
+        )
         torch.accelerator.synchronize()
         with torch.cuda.graph(graph):
             a_out = pynccl_comm.all_reduce(a)
@@ -164,7 +171,7 @@ def all_gather_worker_fn():
 
     rank = pynccl_comm.rank
     world_size = pynccl_comm.world_size
-    device = f"cuda:{pynccl_comm.rank}"
+    device = f"{current_platform.device_type}:{pynccl_comm.rank}"
 
     num_elems = 1000
     tensor = (
@@ -199,7 +206,7 @@ def all_gatherv_worker_fn():
 
     rank = pynccl_comm.rank
     world_size = pynccl_comm.world_size
-    device = f"cuda:{pynccl_comm.rank}"
+    device = f"{current_platform.device_type}:{pynccl_comm.rank}"
 
     assert world_size <= 8
     sizes = [81, 20, 57, 52, 81, 5, 49, 49][:world_size]
@@ -234,7 +241,7 @@ def reduce_scatter_worker_fn():
 
     rank = pynccl_comm.rank
     world_size = pynccl_comm.world_size
-    device = f"cuda:{pynccl_comm.rank}"
+    device = f"{current_platform.device_type}:{pynccl_comm.rank}"
 
     num_elems = 1000
     tensor = (
@@ -274,7 +281,7 @@ def reduce_scatterv_worker_fn():
 
     rank = pynccl_comm.rank
     world_size = pynccl_comm.world_size
-    device = f"cuda:{pynccl_comm.rank}"
+    device = f"{current_platform.device_type}:{pynccl_comm.rank}"
 
     assert world_size <= 8
     sizes = [81, 20, 57, 52, 81, 5, 49, 49][:world_size]
@@ -338,7 +345,9 @@ def test_pynccl_send_recv():
 
 @worker_fn_wrapper
 def multiple_send_recv_worker_fn():
-    device = torch.device(f"cuda:{torch.distributed.get_rank()}")
+    device = torch.device(
+        f"{current_platform.device_type}:{torch.distributed.get_rank()}"
+    )
     groups = [
         torch.distributed.new_group(ranks=[0, 2], backend="gloo"),
         torch.distributed.new_group(ranks=[1, 3], backend="gloo"),

--- a/tests/distributed/test_quick_all_reduce.py
+++ b/tests/distributed/test_quick_all_reduce.py
@@ -38,7 +38,8 @@ def graph_quickreduce(
 ):
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-        device = torch.device(f"cuda:{rank}")
+        m.delenv("ZE_AFFINITY_MASK", raising=False)
+        device = torch.device(f"{current_platform.device_type}:{rank}")
         torch.accelerator.set_device_index(device)
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
         ensure_model_parallel_initialized(tp_size, pp_size)
@@ -92,7 +93,8 @@ def eager_quickreduce(
 ):
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-        device = torch.device(f"cuda:{rank}")
+        m.delenv("ZE_AFFINITY_MASK", raising=False)
+        device = torch.device(f"{current_platform.device_type}:{rank}")
         torch.accelerator.set_device_index(device)
 
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
@@ -142,7 +144,7 @@ def qr_variable_input(rank, world_size):
     in the input shape can cause QuickReduce to hang (this issue
     has been observed with the gpt_oss model).
     """
-    device = torch.device(f"cuda:{rank}")
+    device = torch.device(f"{current_platform.device_type}:{rank}")
     torch.accelerator.set_device_index(device)
     qr_max_size = None  # MB
     _ptr = ops.init_custom_qr(rank, world_size, qr_max_size)

--- a/tests/distributed/test_quick_all_reduce.py
+++ b/tests/distributed/test_quick_all_reduce.py
@@ -20,6 +20,8 @@ from ..utils import (
     multi_process_parallel,
 )
 
+DEVICE_TYPE = current_platform.device_type
+
 torch.manual_seed(42)
 random.seed(44)
 # Size over 8MB is sufficient for custom quick allreduce.
@@ -39,7 +41,7 @@ def graph_quickreduce(
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         m.delenv("ZE_AFFINITY_MASK", raising=False)
-        device = torch.device(f"{current_platform.device_type}:{rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{rank}")
         torch.accelerator.set_device_index(device)
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
         ensure_model_parallel_initialized(tp_size, pp_size)
@@ -94,7 +96,7 @@ def eager_quickreduce(
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         m.delenv("ZE_AFFINITY_MASK", raising=False)
-        device = torch.device(f"{current_platform.device_type}:{rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{rank}")
         torch.accelerator.set_device_index(device)
 
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
@@ -144,7 +146,7 @@ def qr_variable_input(rank, world_size):
     in the input shape can cause QuickReduce to hang (this issue
     has been observed with the gpt_oss model).
     """
-    device = torch.device(f"{current_platform.device_type}:{rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{rank}")
     torch.accelerator.set_device_index(device)
     qr_max_size = None  # MB
     _ptr = ops.init_custom_qr(rank, world_size, qr_max_size)

--- a/tests/distributed/test_symm_mem_allreduce.py
+++ b/tests/distributed/test_symm_mem_allreduce.py
@@ -38,7 +38,7 @@ def symm_mem_allreduce_worker(local_rank: int, world_size: int, q: mp.Queue):
     with monkeypatch.context() as m, set_current_vllm_config(config):
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         dtype = torch.bfloat16
-        device = torch.device(f"cuda:{local_rank}")
+        device = torch.device(f"{current_platform.device_type}:{local_rank}")
         torch.accelerator.set_device_index(device)
         torch.set_default_device(device)
         torch.set_default_dtype(dtype)

--- a/tests/distributed/test_symm_mem_allreduce.py
+++ b/tests/distributed/test_symm_mem_allreduce.py
@@ -25,6 +25,8 @@ from vllm.engine.llm_engine import LLMEngine
 from vllm.platforms import current_platform
 from vllm.utils.system_utils import update_environment_variables
 
+DEVICE_TYPE = current_platform.device_type
+
 torch.manual_seed(42)
 random.seed(44)
 
@@ -38,7 +40,7 @@ def symm_mem_allreduce_worker(local_rank: int, world_size: int, q: mp.Queue):
     with monkeypatch.context() as m, set_current_vllm_config(config):
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         dtype = torch.bfloat16
-        device = torch.device(f"{current_platform.device_type}:{local_rank}")
+        device = torch.device(f"{DEVICE_TYPE}:{local_rank}")
         torch.accelerator.set_device_index(device)
         torch.set_default_device(device)
         torch.set_default_dtype(dtype)

--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -31,6 +31,7 @@ from vllm.distributed.weight_transfer.nccl_engine import (
 from vllm.platforms import current_platform
 from vllm.utils.network_utils import get_open_port
 
+DEVICE_TYPE = current_platform.device_type
 
 def create_mock_parallel_config(
     rank: int = 0,
@@ -251,7 +252,7 @@ def trainer_broadcast_tensor(
     # Create and broadcast the tensor
     dtype = getattr(torch, tensor_dtype)
     tensor_to_send = torch.ones(
-        tensor_shape, dtype=dtype, device=f"{current_platform.device_type}:0"
+        tensor_shape, dtype=dtype, device=f"{DEVICE_TYPE}:0"
     )
     comm.broadcast(tensor_to_send, src=0, stream=torch.cuda.current_stream())
     torch.accelerator.synchronize()
@@ -389,7 +390,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
             pytest.skip("Need at least 1 GPU for this test")
 
         # Create a dummy tensor and IPC handle
-        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{DEVICE_TYPE}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}]
@@ -410,7 +411,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
         if torch.accelerator.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
 
-        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{DEVICE_TYPE}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}, {gpu_uuid: ipc_handle}]
@@ -428,7 +429,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
         if torch.accelerator.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
 
-        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{DEVICE_TYPE}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}, {gpu_uuid: ipc_handle}]
@@ -446,7 +447,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
         if torch.accelerator.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
 
-        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{DEVICE_TYPE}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}]  # Only one handle
@@ -466,7 +467,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
 
         monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
-        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{DEVICE_TYPE}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}]
@@ -499,7 +500,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
         if torch.accelerator.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
 
-        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{DEVICE_TYPE}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}]
@@ -551,8 +552,8 @@ class TestIPCEngineParsing:
         engine = IPCWeightTransferEngine(config, parallel_config)
 
         # Create dummy IPC handles
-        dummy_tensor1 = torch.ones(100, 100, device=f"{current_platform.device_type}:0")
-        dummy_tensor2 = torch.ones(50, device=f"{current_platform.device_type}:0")
+        dummy_tensor1 = torch.ones(100, 100, device=f"{DEVICE_TYPE}:0")
+        dummy_tensor2 = torch.ones(50, device=f"{DEVICE_TYPE}:0")
         ipc_handle1 = reduce_tensor(dummy_tensor1)
         ipc_handle2 = reduce_tensor(dummy_tensor2)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
@@ -584,8 +585,8 @@ class TestIPCEngineParsing:
         parallel_config = create_mock_parallel_config()
         engine = IPCWeightTransferEngine(config, parallel_config)
 
-        dummy_tensor1 = torch.ones(100, 100, device=f"{current_platform.device_type}:0")
-        dummy_tensor2 = torch.ones(50, device=f"{current_platform.device_type}:0")
+        dummy_tensor1 = torch.ones(100, 100, device=f"{DEVICE_TYPE}:0")
+        dummy_tensor2 = torch.ones(50, device=f"{DEVICE_TYPE}:0")
         ipc_handle1 = reduce_tensor(dummy_tensor1)
         ipc_handle2 = reduce_tensor(dummy_tensor2)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
@@ -627,7 +628,7 @@ class TrainerActor:
         # Create tensor on GPU and keep it alive
         dtype = getattr(torch, tensor_dtype)
         self.tensor = torch.ones(
-            tensor_shape, dtype=dtype, device=f"{current_platform.device_type}:0"
+            tensor_shape, dtype=dtype, device=f"{DEVICE_TYPE}:0"
         )
         self.tensor.fill_(42.0)  # Fill with 42 to verify correct transfer
 
@@ -802,7 +803,7 @@ def test_ipc_receive_weights_missing_gpu_uuid_raises():
     engine = IPCWeightTransferEngine(config, parallel_config)
 
     # Create IPC handle with wrong GPU UUID
-    dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
+    dummy_tensor = torch.ones(10, 10, device=f"{DEVICE_TYPE}:0")
     ipc_handle = reduce_tensor(dummy_tensor)
     wrong_uuid = "wrong-uuid-12345"
     ipc_handles = [{wrong_uuid: ipc_handle}]

--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -28,6 +28,7 @@ from vllm.distributed.weight_transfer.nccl_engine import (
     NCCLWeightTransferInitInfo,
     NCCLWeightTransferUpdateInfo,
 )
+from vllm.platforms import current_platform
 from vllm.utils.network_utils import get_open_port
 
 
@@ -249,7 +250,9 @@ def trainer_broadcast_tensor(
 
     # Create and broadcast the tensor
     dtype = getattr(torch, tensor_dtype)
-    tensor_to_send = torch.ones(tensor_shape, dtype=dtype, device="cuda:0")
+    tensor_to_send = torch.ones(
+        tensor_shape, dtype=dtype, device=f"{current_platform.device_type}:0"
+    )
     comm.broadcast(tensor_to_send, src=0, stream=torch.cuda.current_stream())
     torch.accelerator.synchronize()
 
@@ -386,7 +389,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
             pytest.skip("Need at least 1 GPU for this test")
 
         # Create a dummy tensor and IPC handle
-        dummy_tensor = torch.ones(10, 10, device="cuda:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}]
@@ -407,7 +410,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
         if torch.accelerator.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
 
-        dummy_tensor = torch.ones(10, 10, device="cuda:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}, {gpu_uuid: ipc_handle}]
@@ -425,7 +428,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
         if torch.accelerator.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
 
-        dummy_tensor = torch.ones(10, 10, device="cuda:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}, {gpu_uuid: ipc_handle}]
@@ -443,7 +446,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
         if torch.accelerator.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
 
-        dummy_tensor = torch.ones(10, 10, device="cuda:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}]  # Only one handle
@@ -463,7 +466,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
 
         monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
-        dummy_tensor = torch.ones(10, 10, device="cuda:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}]
@@ -496,7 +499,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
         if torch.accelerator.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
 
-        dummy_tensor = torch.ones(10, 10, device="cuda:0")
+        dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
         ipc_handle = reduce_tensor(dummy_tensor)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
         ipc_handles = [{gpu_uuid: ipc_handle}]
@@ -548,8 +551,8 @@ class TestIPCEngineParsing:
         engine = IPCWeightTransferEngine(config, parallel_config)
 
         # Create dummy IPC handles
-        dummy_tensor1 = torch.ones(100, 100, device="cuda:0")
-        dummy_tensor2 = torch.ones(50, device="cuda:0")
+        dummy_tensor1 = torch.ones(100, 100, device=f"{current_platform.device_type}:0")
+        dummy_tensor2 = torch.ones(50, device=f"{current_platform.device_type}:0")
         ipc_handle1 = reduce_tensor(dummy_tensor1)
         ipc_handle2 = reduce_tensor(dummy_tensor2)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
@@ -581,8 +584,8 @@ class TestIPCEngineParsing:
         parallel_config = create_mock_parallel_config()
         engine = IPCWeightTransferEngine(config, parallel_config)
 
-        dummy_tensor1 = torch.ones(100, 100, device="cuda:0")
-        dummy_tensor2 = torch.ones(50, device="cuda:0")
+        dummy_tensor1 = torch.ones(100, 100, device=f"{current_platform.device_type}:0")
+        dummy_tensor2 = torch.ones(50, device=f"{current_platform.device_type}:0")
         ipc_handle1 = reduce_tensor(dummy_tensor1)
         ipc_handle2 = reduce_tensor(dummy_tensor2)
         gpu_uuid = str(torch.cuda.get_device_properties(0).uuid)
@@ -623,7 +626,9 @@ class TrainerActor:
     def __init__(self, tensor_shape: list[int], tensor_dtype: str):
         # Create tensor on GPU and keep it alive
         dtype = getattr(torch, tensor_dtype)
-        self.tensor = torch.ones(tensor_shape, dtype=dtype, device="cuda:0")
+        self.tensor = torch.ones(
+            tensor_shape, dtype=dtype, device=f"{current_platform.device_type}:0"
+        )
         self.tensor.fill_(42.0)  # Fill with 42 to verify correct transfer
 
         # Create IPC handle (tensor must stay alive for IPC to work)
@@ -797,7 +802,7 @@ def test_ipc_receive_weights_missing_gpu_uuid_raises():
     engine = IPCWeightTransferEngine(config, parallel_config)
 
     # Create IPC handle with wrong GPU UUID
-    dummy_tensor = torch.ones(10, 10, device="cuda:0")
+    dummy_tensor = torch.ones(10, 10, device=f"{current_platform.device_type}:0")
     ipc_handle = reduce_tensor(dummy_tensor)
     wrong_uuid = "wrong-uuid-12345"
     ipc_handles = [{wrong_uuid: ipc_handle}]

--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -37,7 +37,8 @@ USE_ALIBI = [False, True]
 KV_CACHE_DTYPE = ["auto", "fp8"]
 SEEDS = [0]
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 

--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -36,8 +36,9 @@ BLOCK_SIZES = [16, 32]
 USE_ALIBI = [False, True]
 KV_CACHE_DTYPE = ["auto", "fp8"]
 SEEDS = [0]
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -12,8 +12,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import scaled_deq
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
-DEVICE = current_platform.device_type
-COPYING_DIRECTION = [(DEVICE, "cpu"), (DEVICE, DEVICE), ("cpu", DEVICE)]
+DEVICE_TYPE = current_platform.device_type
+COPYING_DIRECTION = [(DEVICE_TYPE, "cpu"), (DEVICE_TYPE, DEVICE_TYPE), ("cpu", DEVICE_TYPE)]
 DTYPES = [torch.bfloat16, torch.float]
 NUM_TOKENS = [42]  # Arbitrary values for testing
 NUM_LAYERS = [1]  # Arbitrary values for testing
@@ -37,7 +37,7 @@ NUM_BLOCKS = [1024, 10000]
 NUM_MAPPINGS = [256]  # Arbitrary values for testing
 SEEDS = [0]
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 
@@ -383,8 +383,8 @@ def test_swap_blocks(
 
     set_random_seed(seed)
 
-    src_device = device if direction[0] == DEVICE else "cpu"
-    dst_device = device if direction[1] == DEVICE else "cpu"
+    src_device = device if direction[0] == DEVICE_TYPE else "cpu"
+    dst_device = device if direction[1] == DEVICE_TYPE else "cpu"
 
     src_blocks = random.sample(range(num_blocks), num_mappings)
     # For the same device, mapping must not overlap

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -13,7 +13,11 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 DEVICE_TYPE = current_platform.device_type
-COPYING_DIRECTION = [(DEVICE_TYPE, "cpu"), (DEVICE_TYPE, DEVICE_TYPE), ("cpu", DEVICE_TYPE)]
+COPYING_DIRECTION = [
+    (DEVICE_TYPE, "cpu"),
+    (DEVICE_TYPE, DEVICE_TYPE),
+    ("cpu", DEVICE_TYPE),
+]
 DTYPES = [torch.bfloat16, torch.float]
 NUM_TOKENS = [42]  # Arbitrary values for testing
 NUM_LAYERS = [1]  # Arbitrary values for testing

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -12,7 +12,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import scaled_deq
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
-COPYING_DIRECTION = [("cuda", "cpu"), ("cuda", "cuda"), ("cpu", "cuda")]
+DEVICE = current_platform.device_type
+COPYING_DIRECTION = [(DEVICE, "cpu"), (DEVICE, DEVICE), ("cpu", DEVICE)]
 DTYPES = [torch.bfloat16, torch.float]
 NUM_TOKENS = [42]  # Arbitrary values for testing
 NUM_LAYERS = [1]  # Arbitrary values for testing
@@ -36,7 +37,8 @@ NUM_BLOCKS = [1024, 10000]
 NUM_MAPPINGS = [256]  # Arbitrary values for testing
 SEEDS = [0]
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 # We assume fp8 is always enabled for testing.
@@ -381,8 +383,8 @@ def test_swap_blocks(
 
     set_random_seed(seed)
 
-    src_device = device if direction[0] == "cuda" else "cpu"
-    dst_device = device if direction[1] == "cuda" else "cpu"
+    src_device = device if direction[0] == DEVICE else "cpu"
+    dst_device = device if direction[1] == DEVICE else "cpu"
 
     src_blocks = random.sample(range(num_blocks), num_mappings)
     # For the same device, mapping must not overlap

--- a/tests/kernels/attention/test_cutlass_mla_decode.py
+++ b/tests/kernels/attention/test_cutlass_mla_decode.py
@@ -65,7 +65,7 @@ CUTLASS_MLA_UNSUPPORTED_REASON = (
 def test_cutlass_mla_decode(
     b, s_q, mean_sk, h_q, h_kv, d, dv, block_size, causal, varlen, torch_dtype
 ):
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     init_dtype = torch.bfloat16 if torch_dtype == torch.float8_e4m3fn else torch_dtype
     torch.set_default_dtype(init_dtype)
     torch.set_default_device(device)

--- a/tests/kernels/attention/test_cutlass_mla_decode.py
+++ b/tests/kernels/attention/test_cutlass_mla_decode.py
@@ -11,6 +11,8 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import triton
 from vllm.utils.platform_utils import num_compute_units
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def cal_diff(
     x: torch.Tensor,
@@ -65,7 +67,7 @@ CUTLASS_MLA_UNSUPPORTED_REASON = (
 def test_cutlass_mla_decode(
     b, s_q, mean_sk, h_q, h_kv, d, dv, block_size, causal, varlen, torch_dtype
 ):
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     init_dtype = torch.bfloat16 if torch_dtype == torch.float8_e4m3fn else torch_dtype
     torch.set_default_dtype(init_dtype)
     torch.set_default_device(device)

--- a/tests/kernels/attention/test_flashmla.py
+++ b/tests/kernels/attention/test_flashmla.py
@@ -33,6 +33,8 @@ FLASH_MLA_UNSUPPORTED_REASON = (
     else "FlashMLA is supported"
 )
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @pytest.mark.skipif(
     not is_flashmla_dense_supported()[0], reason=FLASH_MLA_UNSUPPORTED_REASON
@@ -54,7 +56,7 @@ FLASH_MLA_UNSUPPORTED_REASON = (
 def test_flash_mla(
     b, s_q, mean_sk, h_q, h_kv, d, dv, block_size, causal, varlen, torch_dtype
 ):
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     init_dtype = torch.bfloat16 if torch_dtype == torch.float8_e4m3fn else torch_dtype
     torch.set_default_dtype(init_dtype)
     torch.set_default_device(device)

--- a/tests/kernels/attention/test_flashmla.py
+++ b/tests/kernels/attention/test_flashmla.py
@@ -7,6 +7,7 @@ import random
 import pytest
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import triton
 from vllm.v1.attention.ops.flashmla import (
     flash_mla_with_kvcache,
@@ -53,7 +54,7 @@ FLASH_MLA_UNSUPPORTED_REASON = (
 def test_flash_mla(
     b, s_q, mean_sk, h_q, h_kv, d, dv, block_size, causal, varlen, torch_dtype
 ):
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     init_dtype = torch.bfloat16 if torch_dtype == torch.float8_e4m3fn else torch_dtype
     torch.set_default_dtype(init_dtype)
     torch.set_default_device(device)

--- a/tests/kernels/attention/test_prefix_prefill.py
+++ b/tests/kernels/attention/test_prefix_prefill.py
@@ -21,8 +21,9 @@ NUM_HEADS = [64]
 NUM_QUERIES_PER_KV = [1, 64]
 HEAD_SIZES = [24, 128]
 DTYPES = [torch.float16]
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 SLIDING_WINDOW = [0, 16, 2048]

--- a/tests/kernels/attention/test_prefix_prefill.py
+++ b/tests/kernels/attention/test_prefix_prefill.py
@@ -22,7 +22,8 @@ NUM_QUERIES_PER_KV = [1, 64]
 HEAD_SIZES = [24, 128]
 DTYPES = [torch.float16]
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 SLIDING_WINDOW = [0, 16, 2048]
 KV_CACHE_DTYPES = ["auto", "fp8", "fp8_e5m2"]

--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -27,8 +27,9 @@ DTYPES = [torch.half, torch.bfloat16, torch.float]
 NUM_TOKENS = [7, 83, 2048]  # Arbitrary values for testing
 D = [512, 13824]  # Arbitrary values for testing
 SEEDS = [0]
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 

--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.activation import (
     SwigluStepAndMul,
     swiglustep_and_mul_triton,
 )
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
@@ -27,7 +28,8 @@ NUM_TOKENS = [7, 83, 2048]  # Arbitrary values for testing
 D = [512, 13824]  # Arbitrary values for testing
 SEEDS = [0]
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 

--- a/tests/kernels/core/test_apply_rotary_emb.py
+++ b/tests/kernels/core/test_apply_rotary_emb.py
@@ -24,7 +24,8 @@ from vllm.config import (
 )
 from vllm.platforms import current_platform
 
-CUDA_DEVICES = [f"{current_platform.device_type}:0"]
+DEVICE_TYPE = current_platform.device_type
+CUDA_DEVICES = [f"{DEVICE_TYPE}:0"]
 
 
 @dataclass

--- a/tests/kernels/core/test_apply_rotary_emb.py
+++ b/tests/kernels/core/test_apply_rotary_emb.py
@@ -24,7 +24,7 @@ from vllm.config import (
 )
 from vllm.platforms import current_platform
 
-CUDA_DEVICES = ["cuda:0"]
+CUDA_DEVICES = [f"{current_platform.device_type}:0"]
 
 
 @dataclass

--- a/tests/kernels/core/test_fused_qk_norm_rope.py
+++ b/tests/kernels/core/test_fused_qk_norm_rope.py
@@ -15,7 +15,8 @@ IS_NEOX = [True, False]
 EPS_VALUES = [1e-5, 1e-6]
 SEEDS = [13]
 PARTIAL_ROPE = [True, False]
-CUDA_DEVICES = [f"{current_platform.device_type}:0"]
+DEVICE_TYPE = current_platform.device_type
+CUDA_DEVICES = [f"{DEVICE_TYPE}:0"]
 
 
 def _apply_qk_norm_rope(

--- a/tests/kernels/core/test_fused_qk_norm_rope.py
+++ b/tests/kernels/core/test_fused_qk_norm_rope.py
@@ -15,7 +15,7 @@ IS_NEOX = [True, False]
 EPS_VALUES = [1e-5, 1e-6]
 SEEDS = [13]
 PARTIAL_ROPE = [True, False]
-CUDA_DEVICES = ["cuda:0"]
+CUDA_DEVICES = [f"{current_platform.device_type}:0"]
 
 
 def _apply_qk_norm_rope(

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -33,8 +33,9 @@ SCALE_UBS = [True, False]
 GROUP_SIZES = [None, [1, 64], [1, 128]]
 TMA_ALIGNMENTS = [0, 4]
 SEEDS = [0]
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 
@@ -44,7 +45,7 @@ EPS = 1e-6
 
 
 def as_float32_tensor(x: float | torch.Tensor) -> torch.Tensor:
-    return torch.as_tensor(x, dtype=torch.float32, device=current_platform.device_type)
+    return torch.as_tensor(x, dtype=torch.float32, device=DEVICE_TYPE)
 
 
 def ref_rms_norm(
@@ -240,7 +241,7 @@ def test_rms_norm(
     if has_scale_ub:
         rms_x, _ = ref_rms_norm(layer, x, residual)
         scale_ub = torch.mean(rms_x).to(
-            dtype=torch.float32, device=current_platform.device_type
+            dtype=torch.float32, device=DEVICE_TYPE
         )
     else:
         scale_ub = None

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -34,7 +34,8 @@ GROUP_SIZES = [None, [1, 64], [1, 128]]
 TMA_ALIGNMENTS = [0, 4]
 SEEDS = [0]
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 EPS = 1e-6
@@ -43,7 +44,7 @@ EPS = 1e-6
 
 
 def as_float32_tensor(x: float | torch.Tensor) -> torch.Tensor:
-    return torch.as_tensor(x, dtype=torch.float32, device="cuda")
+    return torch.as_tensor(x, dtype=torch.float32, device=current_platform.device_type)
 
 
 def ref_rms_norm(
@@ -238,7 +239,9 @@ def test_rms_norm(
     )
     if has_scale_ub:
         rms_x, _ = ref_rms_norm(layer, x, residual)
-        scale_ub = torch.mean(rms_x).to(dtype=torch.float32, device="cuda")
+        scale_ub = torch.mean(rms_x).to(
+            dtype=torch.float32, device=current_platform.device_type
+        )
     else:
         scale_ub = None
 

--- a/tests/kernels/core/test_fused_rms_norm_gated.py
+++ b/tests/kernels/core/test_fused_rms_norm_gated.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from vllm.model_executor.layers.fla.ops.kda import FusedRMSNormGated
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 DTYPES = [torch.bfloat16]
@@ -37,7 +38,7 @@ def test_compiled_vs_eager(
     """forward_native decomposition matches forward_cuda triton kernel."""
     torch._dynamo.reset()
     set_random_seed(seed)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
 
     module = FusedRMSNormGated(
         hidden_size,
@@ -81,7 +82,7 @@ def test_compiled_vs_eager_multidim(
     """forward_native decomposition handles multi-dimensional inputs."""
     torch._dynamo.reset()
     set_random_seed(seed)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     head_dim = shape[-1]
 
     module = FusedRMSNormGated(

--- a/tests/kernels/core/test_fused_rms_norm_gated.py
+++ b/tests/kernels/core/test_fused_rms_norm_gated.py
@@ -12,6 +12,7 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 DTYPES = [torch.bfloat16]
+DEVICE_TYPE = current_platform.device_type
 HIDDEN_SIZES = [128, 512]
 NUM_TOKENS = [64, 128]
 ACTIVATIONS = ["swish", "sigmoid"]
@@ -38,7 +39,7 @@ def test_compiled_vs_eager(
     """forward_native decomposition matches forward_cuda triton kernel."""
     torch._dynamo.reset()
     set_random_seed(seed)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
 
     module = FusedRMSNormGated(
         hidden_size,
@@ -82,7 +83,7 @@ def test_compiled_vs_eager_multidim(
     """forward_native decomposition handles multi-dimensional inputs."""
     torch._dynamo.reset()
     set_random_seed(seed)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     head_dim = shape[-1]
 
     module = FusedRMSNormGated(

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -7,6 +7,7 @@ import torch
 from tests.kernels.quant_utils import FP8_DTYPE
 from tests.kernels.utils import opcheck
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
@@ -15,7 +16,8 @@ HIDDEN_SIZES = [8, 768, 769, 5120, 5125, 8192]  # Arbitrary values for testing
 ADD_RESIDUAL = [False, True]
 SEEDS = [0]
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -15,8 +15,9 @@ NUM_TOKENS = [7, 83, 4096]  # Arbitrary values for testing
 HIDDEN_SIZES = [8, 768, 769, 5120, 5125, 8192]  # Arbitrary values for testing
 ADD_RESIDUAL = [False, True]
 SEEDS = [0]
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 

--- a/tests/kernels/core/test_pos_encoding.py
+++ b/tests/kernels/core/test_pos_encoding.py
@@ -20,8 +20,9 @@ NUM_HEADS = [17]  # Arbitrary values for testing
 BATCH_SIZES = [5]  # Arbitrary values for testing
 SEQ_LENS = [11, 8192]  # Arbitrary values for testing
 SEEDS = [0]
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 USE_KEY = [True, False]

--- a/tests/kernels/core/test_pos_encoding.py
+++ b/tests/kernels/core/test_pos_encoding.py
@@ -9,6 +9,7 @@ import torch
 
 from tests.kernels.allclose_default import get_default_atol, get_default_rtol
 from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 IS_NEOX_STYLE = [True, False]
@@ -20,7 +21,8 @@ BATCH_SIZES = [5]  # Arbitrary values for testing
 SEQ_LENS = [11, 8192]  # Arbitrary values for testing
 SEEDS = [0]
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 USE_KEY = [True, False]
 

--- a/tests/kernels/core/test_rotary_embedding_mla_cache_fused.py
+++ b/tests/kernels/core/test_rotary_embedding_mla_cache_fused.py
@@ -29,7 +29,10 @@ from vllm.utils.torch_utils import set_random_seed
 @pytest.mark.parametrize("seed", [0])
 @pytest.mark.parametrize(
     "device",
-    [f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)],
+    [
+        f"{current_platform.device_type}:{i}"
+        for i in range(min(current_platform.device_count(), 2))
+    ],
 )
 @torch.inference_mode()
 def test_concat_and_cache_mla_rope_fused(

--- a/tests/kernels/core/test_rotary_embedding_mla_cache_fused.py
+++ b/tests/kernels/core/test_rotary_embedding_mla_cache_fused.py
@@ -16,6 +16,8 @@ from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16, torch.float])
 @pytest.mark.parametrize("is_neox_style", [False, True])
@@ -30,7 +32,7 @@ from vllm.utils.torch_utils import set_random_seed
 @pytest.mark.parametrize(
     "device",
     [
-        f"{current_platform.device_type}:{i}"
+        f"{DEVICE_TYPE}:{i}"
         for i in range(min(current_platform.device_count(), 2))
     ],
 )

--- a/tests/kernels/core/test_uva.py
+++ b/tests/kernels/core/test_uva.py
@@ -7,8 +7,9 @@ from vllm.platforms import current_platform
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
 
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 

--- a/tests/kernels/core/test_uva.py
+++ b/tests/kernels/core/test_uva.py
@@ -3,11 +3,13 @@
 import pytest
 import torch
 
+from vllm.platforms import current_platform
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
 
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 

--- a/tests/kernels/mamba/test_mamba_mixer2.py
+++ b/tests/kernels/mamba/test_mamba_mixer2.py
@@ -12,6 +12,7 @@ from vllm.distributed.parallel_state import (
     initialize_model_parallel,
 )
 from vllm.model_executor.layers.mamba.mamba_mixer2 import Mixer2RMSNormGated
+from vllm.platforms import current_platform
 from vllm.utils.system_utils import update_environment_variables
 from vllm.utils.torch_utils import set_random_seed
 
@@ -33,7 +34,7 @@ def test_mixer2_gated_norm_multi_gpu(
     seq_len: int,
     hidden_size_n_groups: tuple[int, int],
     dtype: torch.dtype,
-    device: str = "cuda",
+    device: str = current_platform.device_type,
 ):
     hidden_size, n_groups = hidden_size_n_groups
     num_processes = 2
@@ -70,7 +71,7 @@ def mixer2_gated_norm_tensor_parallel(
 ):
     set_random_seed(0)
 
-    device = torch.device(f"cuda:{local_rank}")
+    device = torch.device(f"{current_platform.device_type}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)

--- a/tests/kernels/mamba/test_mamba_mixer2.py
+++ b/tests/kernels/mamba/test_mamba_mixer2.py
@@ -16,6 +16,8 @@ from vllm.platforms import current_platform
 from vllm.utils.system_utils import update_environment_variables
 from vllm.utils.torch_utils import set_random_seed
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("batch_size", [8])
@@ -34,7 +36,7 @@ def test_mixer2_gated_norm_multi_gpu(
     seq_len: int,
     hidden_size_n_groups: tuple[int, int],
     dtype: torch.dtype,
-    device: str = current_platform.device_type,
+    device: str = DEVICE_TYPE,
 ):
     hidden_size, n_groups = hidden_size_n_groups
     num_processes = 2
@@ -71,7 +73,7 @@ def mixer2_gated_norm_tensor_parallel(
 ):
     set_random_seed(0)
 
-    device = torch.device(f"{current_platform.device_type}:{local_rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)

--- a/tests/kernels/moe/test_deepep_deepgemm_moe.py
+++ b/tests/kernels/moe/test_deepep_deepgemm_moe.py
@@ -65,6 +65,8 @@ requires_deep_gemm = pytest.mark.skipif(
 
 P = ParamSpec("P")
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @contextmanager
 def with_dp_metadata(M: int, world_size: int):
@@ -373,7 +375,7 @@ def _test_deepep_deepgemm_moe(
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
 ):
-    device = torch.device(f"{current_platform.device_type}:{pgi.local_rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{pgi.local_rank}")
     init_workspace_manager(device)
 
     set_random_seed(pgi.rank)

--- a/tests/kernels/moe/test_deepep_deepgemm_moe.py
+++ b/tests/kernels/moe/test_deepep_deepgemm_moe.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 )
 from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
 from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEKernel
+from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
     get_mk_alignment_for_contiguous_layout,
     is_deep_gemm_e8m0_used,
@@ -372,7 +373,7 @@ def _test_deepep_deepgemm_moe(
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
 ):
-    device = torch.device(f"cuda:{pgi.local_rank}")
+    device = torch.device(f"{current_platform.device_type}:{pgi.local_rank}")
     init_workspace_manager(device)
 
     set_random_seed(pgi.rank)

--- a/tests/kernels/moe/test_deepep_moe.py
+++ b/tests/kernels/moe/test_deepep_moe.py
@@ -109,12 +109,22 @@ class TestTensors:
             torch.bfloat16 if config.dtype == torch.float8_e4m3fn else config.dtype
         )
         rank_tokens = (
+            torch.randn(
+                (config.m, config.k),
+                device=DEVICE_TYPE,
+                dtype=token_dtype,
+            ) / 10
+        )
+        rank_tokens = (
             torch.randn((config.m, config.k), device=DEVICE_TYPE, dtype=token_dtype) / 10
         )
         rank_token_scales = None
 
         topk = torch.randint(
-            low=0, high=config.num_experts, size=(config.m, config.topk), device=DEVICE_TYPE
+            low=0,
+            high=config.num_experts,
+            size=(config.m, config.topk),
+            device=DEVICE_TYPE,
         ).to(dtype=torch.int64)
         topk_weights = torch.randn(topk.shape, dtype=torch.float32, device=DEVICE_TYPE)
         return TestTensors(

--- a/tests/kernels/moe/test_deepep_moe.py
+++ b/tests/kernels/moe/test_deepep_moe.py
@@ -48,7 +48,7 @@ requires_deep_ep = pytest.mark.skipif(
 )
 
 MAX_TOKENS_PER_RANK = 64
-DEVICE = current_platform.device_type
+DEVICE_TYPE = current_platform.device_type
 
 
 def make_weights(
@@ -58,21 +58,21 @@ def make_weights(
     Return weights w1, w2, w1_scale, w2_scale
     """
     if dtype in [torch.float16, torch.bfloat16]:
-        w1 = torch.randn((e, 2 * n, k), device=DEVICE, dtype=dtype) / 10
-        w2 = torch.randn((e, k, n), device=DEVICE, dtype=dtype) / 10
+        w1 = torch.randn((e, 2 * n, k), device=DEVICE_TYPE, dtype=dtype) / 10
+        w2 = torch.randn((e, k, n), device=DEVICE_TYPE, dtype=dtype) / 10
         return w1, w2, None, None
 
     # per-out-channel weight quantization
     assert dtype == torch.float8_e4m3fn
-    w1 = torch.empty((e, 2 * n, k), device=DEVICE, dtype=torch.float16)
-    w2 = torch.empty((e, k, n), device=DEVICE, dtype=torch.float16)
+    w1 = torch.empty((e, 2 * n, k), device=DEVICE_TYPE, dtype=torch.float16)
+    w2 = torch.empty((e, k, n), device=DEVICE_TYPE, dtype=torch.float16)
 
     n_b_scales = 2 * n
     k_b_scales = k
     w1_q = torch.empty_like(w1, dtype=dtype)
     w2_q = torch.empty_like(w2, dtype=dtype)
-    w1_scale = torch.empty((e, n_b_scales, 1), device=DEVICE, dtype=torch.float32)
-    w2_scale = torch.empty((e, k_b_scales, 1), device=DEVICE, dtype=torch.float32)
+    w1_scale = torch.empty((e, n_b_scales, 1), device=DEVICE_TYPE, dtype=torch.float32)
+    w2_scale = torch.empty((e, k_b_scales, 1), device=DEVICE_TYPE, dtype=torch.float32)
     for expert in range(e):
         w1_q[expert], w1_scale[expert] = ops.scaled_fp8_quant(
             w1[expert], use_per_token_if_dynamic=True
@@ -109,14 +109,14 @@ class TestTensors:
             torch.bfloat16 if config.dtype == torch.float8_e4m3fn else config.dtype
         )
         rank_tokens = (
-            torch.randn((config.m, config.k), device=DEVICE, dtype=token_dtype) / 10
+            torch.randn((config.m, config.k), device=DEVICE_TYPE, dtype=token_dtype) / 10
         )
         rank_token_scales = None
 
         topk = torch.randint(
-            low=0, high=config.num_experts, size=(config.m, config.topk), device=DEVICE
+            low=0, high=config.num_experts, size=(config.m, config.topk), device=DEVICE_TYPE
         ).to(dtype=torch.int64)
-        topk_weights = torch.randn(topk.shape, dtype=torch.float32, device=DEVICE)
+        topk_weights = torch.randn(topk.shape, dtype=torch.float32, device=DEVICE_TYPE)
         return TestTensors(
             rank_tokens=rank_tokens,
             rank_token_scales=rank_token_scales,
@@ -359,7 +359,7 @@ def _deep_ep_moe(
     use_fp8_dispatch: bool,
     per_act_token_quant: bool,
 ):
-    device = torch.device(f"{DEVICE}:{pgi.local_rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{pgi.local_rank}")
     init_workspace_manager(device)
 
     if not low_latency_mode:

--- a/tests/kernels/moe/test_deepep_moe.py
+++ b/tests/kernels/moe/test_deepep_moe.py
@@ -24,6 +24,7 @@ from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEKernel
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
 )
+from vllm.platforms import current_platform
 from vllm.utils.import_utils import has_deep_ep
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.worker.workspace import init_workspace_manager
@@ -47,6 +48,7 @@ requires_deep_ep = pytest.mark.skipif(
 )
 
 MAX_TOKENS_PER_RANK = 64
+DEVICE = current_platform.device_type
 
 
 def make_weights(
@@ -56,21 +58,21 @@ def make_weights(
     Return weights w1, w2, w1_scale, w2_scale
     """
     if dtype in [torch.float16, torch.bfloat16]:
-        w1 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 10
-        w2 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 10
+        w1 = torch.randn((e, 2 * n, k), device=DEVICE, dtype=dtype) / 10
+        w2 = torch.randn((e, k, n), device=DEVICE, dtype=dtype) / 10
         return w1, w2, None, None
 
     # per-out-channel weight quantization
     assert dtype == torch.float8_e4m3fn
-    w1 = torch.empty((e, 2 * n, k), device="cuda", dtype=torch.float16)
-    w2 = torch.empty((e, k, n), device="cuda", dtype=torch.float16)
+    w1 = torch.empty((e, 2 * n, k), device=DEVICE, dtype=torch.float16)
+    w2 = torch.empty((e, k, n), device=DEVICE, dtype=torch.float16)
 
     n_b_scales = 2 * n
     k_b_scales = k
     w1_q = torch.empty_like(w1, dtype=dtype)
     w2_q = torch.empty_like(w2, dtype=dtype)
-    w1_scale = torch.empty((e, n_b_scales, 1), device="cuda", dtype=torch.float32)
-    w2_scale = torch.empty((e, k_b_scales, 1), device="cuda", dtype=torch.float32)
+    w1_scale = torch.empty((e, n_b_scales, 1), device=DEVICE, dtype=torch.float32)
+    w2_scale = torch.empty((e, k_b_scales, 1), device=DEVICE, dtype=torch.float32)
     for expert in range(e):
         w1_q[expert], w1_scale[expert] = ops.scaled_fp8_quant(
             w1[expert], use_per_token_if_dynamic=True
@@ -107,14 +109,14 @@ class TestTensors:
             torch.bfloat16 if config.dtype == torch.float8_e4m3fn else config.dtype
         )
         rank_tokens = (
-            torch.randn((config.m, config.k), device="cuda", dtype=token_dtype) / 10
+            torch.randn((config.m, config.k), device=DEVICE, dtype=token_dtype) / 10
         )
         rank_token_scales = None
 
         topk = torch.randint(
-            low=0, high=config.num_experts, size=(config.m, config.topk), device="cuda"
+            low=0, high=config.num_experts, size=(config.m, config.topk), device=DEVICE
         ).to(dtype=torch.int64)
-        topk_weights = torch.randn(topk.shape, dtype=torch.float32, device="cuda")
+        topk_weights = torch.randn(topk.shape, dtype=torch.float32, device=DEVICE)
         return TestTensors(
             rank_tokens=rank_tokens,
             rank_token_scales=rank_token_scales,
@@ -357,7 +359,7 @@ def _deep_ep_moe(
     use_fp8_dispatch: bool,
     per_act_token_quant: bool,
 ):
-    device = torch.device(f"cuda:{pgi.local_rank}")
+    device = torch.device(f"{DEVICE}:{pgi.local_rank}")
     init_workspace_manager(device)
 
     if not low_latency_mode:

--- a/tests/kernels/moe/test_modular_kernel_combinations.py
+++ b/tests/kernels/moe/test_modular_kernel_combinations.py
@@ -79,7 +79,7 @@ def rank_worker(
     verbose: bool,
 ):
     # Initialize workspace manager in child process
-    device = torch.device(f"cuda:{pgi.local_rank}")
+    device = torch.device(f"{current_platform.device_type}:{pgi.local_rank}")
     init_workspace_manager(device)
 
     set_random_seed(pgi.rank)

--- a/tests/kernels/moe/test_modular_kernel_combinations.py
+++ b/tests/kernels/moe/test_modular_kernel_combinations.py
@@ -53,6 +53,8 @@ if current_platform.is_fp8_fnuz():
         allow_module_level=True,
     )
 
+DEVICE_TYPE = current_platform.device_type    
+
 
 def format_result(verbose, msg, ex=None):
     if ex is not None:
@@ -79,7 +81,7 @@ def rank_worker(
     verbose: bool,
 ):
     # Initialize workspace manager in child process
-    device = torch.device(f"{current_platform.device_type}:{pgi.local_rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{pgi.local_rank}")
     init_workspace_manager(device)
 
     set_random_seed(pgi.rank)

--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -504,29 +504,44 @@ def test_trtllm_gen_mxfp4_fused_moe(
     seed = 42
     torch.manual_seed(seed)
     hidden_states = torch.randn(
-        num_tokens, hidden_size, device="cuda:0", dtype=torch.bfloat16
+        num_tokens,
+        hidden_size,
+        device=f"{current_platform.device_type}:0",
+        dtype=torch.bfloat16,
     )
     w13 = torch.randn(
         num_experts,
         intermediate_size * 2,
         hidden_size,
-        device="cuda:0",
+        device=f"{current_platform.device_type}:0",
         dtype=torch.bfloat16,
     )
     w2 = torch.randn(
         num_experts,
         hidden_size,
         intermediate_size,
-        device="cuda:0",
+        device=f"{current_platform.device_type}:0",
         dtype=torch.bfloat16,
     )
-    bias13 = torch.randn(num_experts, intermediate_size * 2, device="cuda:0") * 10
-    bias2 = torch.randn(num_experts, hidden_size, device="cuda:0") * 10
+    bias13 = (
+        torch.randn(
+            num_experts,
+            intermediate_size * 2,
+            device=f"{current_platform.device_type}:0",
+        )
+        * 10
+    )
+    bias2 = (
+        torch.randn(
+            num_experts, hidden_size, device=f"{current_platform.device_type}:0"
+        )
+        * 10
+    )
     router_logits = torch.rand(num_tokens, num_experts, dtype=torch.float32).cuda()
 
     w13, w13_scale = fp4_quantize(
         w13,
-        torch.tensor(1.0, device="cuda:0"),
+        torch.tensor(1.0, device=f"{current_platform.device_type}:0"),
         32,
         sf_use_ue8m0=True,
         is_sf_swizzled_layout=False,
@@ -536,7 +551,7 @@ def test_trtllm_gen_mxfp4_fused_moe(
     )
     w2, w2_scale = fp4_quantize(
         w2,
-        torch.tensor(1.0, device="cuda:0"),
+        torch.tensor(1.0, device=f"{current_platform.device_type}:0"),
         32,
         sf_use_ue8m0=True,
         is_sf_swizzled_layout=False,
@@ -651,7 +666,7 @@ def test_flashinfer_cutlass_mxfp4_fused_moe(
     limit: float | None,
 ):
     torch.manual_seed(42)
-    device = "cuda:0"
+    device = f"{current_platform.device_type}:0"
 
     # Inputs
     hidden_states = torch.randn(
@@ -805,7 +820,7 @@ def test_flashinfer_cutlass_mxfp4_mxfp8_fused_moe(
     limit: float | None,
 ):
     torch.manual_seed(42)
-    device = "cuda:0"
+    device = f"{current_platform.device_type}:0"
 
     # Inputs
     hidden_states = torch.randn(
@@ -1002,7 +1017,7 @@ def test_trtllm_gen_mxfp8_block_scale_moe(
     is_gated: bool,
 ):
     torch.manual_seed(42)
-    device = "cuda:0"
+    device = f"{current_platform.device_type}:0"
 
     inter_size = intermediate_size * (2 if is_gated else 1)
 

--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -46,6 +46,8 @@ if TRTLLM_GEN_MXFP8_AVAILABLE:
         get_w2_permute_indices_with_cache,
     )
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @dataclass
 class ModelCase:
@@ -506,34 +508,34 @@ def test_trtllm_gen_mxfp4_fused_moe(
     hidden_states = torch.randn(
         num_tokens,
         hidden_size,
-        device=f"{current_platform.device_type}:0",
+        device=f"{DEVICE_TYPE}:0",
         dtype=torch.bfloat16,
     )
     w13 = torch.randn(
         num_experts,
         intermediate_size * 2,
         hidden_size,
-        device=f"{current_platform.device_type}:0",
+        device=f"{DEVICE_TYPE}:0",
         dtype=torch.bfloat16,
     )
     w2 = torch.randn(
         num_experts,
         hidden_size,
         intermediate_size,
-        device=f"{current_platform.device_type}:0",
+        device=f"{DEVICE_TYPE}:0",
         dtype=torch.bfloat16,
     )
     bias13 = (
         torch.randn(
             num_experts,
             intermediate_size * 2,
-            device=f"{current_platform.device_type}:0",
+            device=f"{DEVICE_TYPE}:0",
         )
         * 10
     )
     bias2 = (
         torch.randn(
-            num_experts, hidden_size, device=f"{current_platform.device_type}:0"
+            num_experts, hidden_size, device=f"{DEVICE_TYPE}:0"
         )
         * 10
     )
@@ -541,7 +543,7 @@ def test_trtllm_gen_mxfp4_fused_moe(
 
     w13, w13_scale = fp4_quantize(
         w13,
-        torch.tensor(1.0, device=f"{current_platform.device_type}:0"),
+        torch.tensor(1.0, device=f"{DEVICE_TYPE}:0"),
         32,
         sf_use_ue8m0=True,
         is_sf_swizzled_layout=False,
@@ -551,7 +553,7 @@ def test_trtllm_gen_mxfp4_fused_moe(
     )
     w2, w2_scale = fp4_quantize(
         w2,
-        torch.tensor(1.0, device=f"{current_platform.device_type}:0"),
+        torch.tensor(1.0, device=f"{DEVICE_TYPE}:0"),
         32,
         sf_use_ue8m0=True,
         is_sf_swizzled_layout=False,
@@ -666,7 +668,7 @@ def test_flashinfer_cutlass_mxfp4_fused_moe(
     limit: float | None,
 ):
     torch.manual_seed(42)
-    device = f"{current_platform.device_type}:0"
+    device = f"{DEVICE_TYPE}:0"
 
     # Inputs
     hidden_states = torch.randn(
@@ -820,7 +822,7 @@ def test_flashinfer_cutlass_mxfp4_mxfp8_fused_moe(
     limit: float | None,
 ):
     torch.manual_seed(42)
-    device = f"{current_platform.device_type}:0"
+    device = f"{DEVICE_TYPE}:0"
 
     # Inputs
     hidden_states = torch.randn(
@@ -1017,7 +1019,7 @@ def test_trtllm_gen_mxfp8_block_scale_moe(
     is_gated: bool,
 ):
     torch.manual_seed(42)
-    device = f"{current_platform.device_type}:0"
+    device = f"{DEVICE_TYPE}:0"
 
     inter_size = intermediate_size * (2 if is_gated else 1)
 

--- a/tests/kernels/quantization/test_cutlass_2of4_sparse.py
+++ b/tests/kernels/quantization/test_cutlass_2of4_sparse.py
@@ -15,8 +15,9 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 )
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 

--- a/tests/kernels/quantization/test_cutlass_2of4_sparse.py
+++ b/tests/kernels/quantization/test_cutlass_2of4_sparse.py
@@ -16,7 +16,8 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 from vllm.platforms import current_platform
 
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 capability = current_platform.get_device_capability()

--- a/tests/kernels/quantization/test_cutlass_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutlass_scaled_mm.py
@@ -40,8 +40,9 @@ MNK_FACTORS = [
     (512, 24576, 128),
 ]
 
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 

--- a/tests/kernels/quantization/test_cutlass_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutlass_scaled_mm.py
@@ -41,7 +41,8 @@ MNK_FACTORS = [
 ]
 
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 # -1 means full extent in that dimension

--- a/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
+++ b/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
@@ -35,7 +35,7 @@ PAD_SHAPES = [(150, 128, 64), (128, 128, 96), (2, 128, 64), (3, 128, 96)]
 SHAPES.extend(PAD_SHAPES)
 
 SEEDS = [42]
-CUDA_DEVICES = ["cuda:0"]
+CUDA_DEVICES = [f"{current_platform.device_type}:0"]
 
 
 def get_ref_results(

--- a/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
+++ b/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
@@ -35,7 +35,8 @@ PAD_SHAPES = [(150, 128, 64), (128, 128, 96), (2, 128, 64), (3, 128, 96)]
 SHAPES.extend(PAD_SHAPES)
 
 SEEDS = [42]
-CUDA_DEVICES = [f"{current_platform.device_type}:0"]
+DEVICE_TYPE = current_platform.device_type
+CUDA_DEVICES = [f"{DEVICE_TYPE}:0"]
 
 
 def get_ref_results(

--- a/tests/kernels/quantization/test_flashinfer_scaled_mm.py
+++ b/tests/kernels/quantization/test_flashinfer_scaled_mm.py
@@ -21,7 +21,7 @@ PAD_SHAPES = [(150, 128, 64), (128, 128, 96)]
 SHAPES.extend(PAD_SHAPES)
 
 SEEDS = [42]
-CUDA_DEVICES = ["cuda:0"]
+CUDA_DEVICES = [f"{current_platform.device_type}:0"]
 
 
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/kernels/quantization/test_flashinfer_scaled_mm.py
+++ b/tests/kernels/quantization/test_flashinfer_scaled_mm.py
@@ -21,7 +21,8 @@ PAD_SHAPES = [(150, 128, 64), (128, 128, 96)]
 SHAPES.extend(PAD_SHAPES)
 
 SEEDS = [42]
-CUDA_DEVICES = [f"{current_platform.device_type}:0"]
+DEVICE_TYPE = current_platform.device_type
+CUDA_DEVICES = [f"{DEVICE_TYPE}:0"]
 
 
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/kernels/quantization/test_machete_mm.py
+++ b/tests/kernels/quantization/test_machete_mm.py
@@ -30,7 +30,8 @@ if current_platform.is_rocm():
     )
 
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 # TODO: in future PR refactor this and `is_quant_method_supported` in the kernel

--- a/tests/kernels/quantization/test_machete_mm.py
+++ b/tests/kernels/quantization/test_machete_mm.py
@@ -29,8 +29,9 @@ if current_platform.is_rocm():
         allow_module_level=True,
     )
 
+DEVICE_TYPE = current_platform.device_type    
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 

--- a/tests/kernels/quantization/test_mxfp4_qutlass.py
+++ b/tests/kernels/quantization/test_mxfp4_qutlass.py
@@ -190,7 +190,8 @@ def _forward_quantize_ref(
 
 
 DTYPE = torch.bfloat16
-DEVICE = torch.device(f"{current_platform.device_type}:0")
+DEVICE_TYPE = current_platform.device_type
+DEVICE = torch.device(f"{DEVICE_TYPE}:0")
 
 ROT_SIZES = [32, 64, 128]
 SEEDS = [0]

--- a/tests/kernels/quantization/test_mxfp4_qutlass.py
+++ b/tests/kernels/quantization/test_mxfp4_qutlass.py
@@ -190,7 +190,7 @@ def _forward_quantize_ref(
 
 
 DTYPE = torch.bfloat16
-DEVICE = torch.device("cuda:0")
+DEVICE = torch.device(f"{current_platform.device_type}:0")
 
 ROT_SIZES = [32, 64, 128]
 SEEDS = [0]

--- a/tests/kernels/quantization/test_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_nvfp4_quant.py
@@ -35,7 +35,7 @@ PAD_SHAPES = [
     (32, 14336),
 ]
 SEEDS = [42]
-CUDA_DEVICES = ["cuda:0"]
+CUDA_DEVICES = [f"{current_platform.device_type}:0"]
 
 FLOAT4_E2M1_MAX = scalar_types.float4_e2m1f.max()
 FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
@@ -164,7 +164,7 @@ def test_quantize_to_fp4(
 def test_quantize_to_fp4_padded(pad_shape: tuple[int, int]) -> None:
     dtype = torch.float16
     set_random_seed(42)
-    torch.set_default_device("cuda:0")
+    torch.set_default_device(f"{current_platform.device_type}:0")
 
     m, n = pad_shape
 
@@ -186,7 +186,7 @@ def test_quantize_to_fp4_padded(pad_shape: tuple[int, int]) -> None:
 def test_quantize_to_fp4_padded_no_sf_swizzled(pad_shape: tuple[int, int]) -> None:
     dtype = torch.float16
     set_random_seed(42)
-    torch.set_default_device("cuda:0")
+    torch.set_default_device(f"{current_platform.device_type}:0")
 
     m, n = pad_shape
 

--- a/tests/kernels/quantization/test_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_nvfp4_quant.py
@@ -35,7 +35,8 @@ PAD_SHAPES = [
     (32, 14336),
 ]
 SEEDS = [42]
-CUDA_DEVICES = [f"{current_platform.device_type}:0"]
+DEVICE_TYPE = current_platform.device_type
+CUDA_DEVICES = [f"{DEVICE_TYPE}:0"]
 
 FLOAT4_E2M1_MAX = scalar_types.float4_e2m1f.max()
 FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
@@ -164,7 +165,7 @@ def test_quantize_to_fp4(
 def test_quantize_to_fp4_padded(pad_shape: tuple[int, int]) -> None:
     dtype = torch.float16
     set_random_seed(42)
-    torch.set_default_device(f"{current_platform.device_type}:0")
+    torch.set_default_device(f"{DEVICE_TYPE}:0")
 
     m, n = pad_shape
 
@@ -186,7 +187,7 @@ def test_quantize_to_fp4_padded(pad_shape: tuple[int, int]) -> None:
 def test_quantize_to_fp4_padded_no_sf_swizzled(pad_shape: tuple[int, int]) -> None:
     dtype = torch.float16
     set_random_seed(42)
-    torch.set_default_device(f"{current_platform.device_type}:0")
+    torch.set_default_device(f"{DEVICE_TYPE}:0")
 
     m, n = pad_shape
 

--- a/tests/kernels/quantization/test_nvfp4_qutlass.py
+++ b/tests/kernels/quantization/test_nvfp4_qutlass.py
@@ -179,8 +179,9 @@ def _forward_quantize_ref(x: torch.Tensor, h: torch.Tensor, rot_size: int):
     )
 
 
+DEVICE_TYPE = current_platform.device_type
 DTYPE = torch.bfloat16
-DEVICE = torch.device(f"{current_platform.device_type}:0")
+DEVICE = torch.device(f"{DEVICE_TYPE}:0")
 ROT_SIZES = [16, 32, 64, 128]
 GLOBAL_SCALES = [6.0]
 

--- a/tests/kernels/quantization/test_nvfp4_qutlass.py
+++ b/tests/kernels/quantization/test_nvfp4_qutlass.py
@@ -180,7 +180,7 @@ def _forward_quantize_ref(x: torch.Tensor, h: torch.Tensor, rot_size: int):
 
 
 DTYPE = torch.bfloat16
-DEVICE = torch.device("cuda:0")
+DEVICE = torch.device(f"{current_platform.device_type}:0")
 ROT_SIZES = [16, 32, 64, 128]
 GLOBAL_SCALES = [6.0]
 

--- a/tests/kernels/quantization/test_nvfp4_scaled_mm.py
+++ b/tests/kernels/quantization/test_nvfp4_scaled_mm.py
@@ -21,7 +21,8 @@ PAD_SHAPES = [(150, 128, 64), (128, 128, 96)]
 SHAPES.extend(PAD_SHAPES)
 
 SEEDS = [42]
-CUDA_DEVICES = [f"{current_platform.device_type}:0"]
+DEVICE_TYPE = current_platform.device_type
+CUDA_DEVICES = [f"{DEVICE_TYPE}:0"]
 
 
 def get_ref_results(

--- a/tests/kernels/quantization/test_nvfp4_scaled_mm.py
+++ b/tests/kernels/quantization/test_nvfp4_scaled_mm.py
@@ -21,7 +21,7 @@ PAD_SHAPES = [(150, 128, 64), (128, 128, 96)]
 SHAPES.extend(PAD_SHAPES)
 
 SEEDS = [42]
-CUDA_DEVICES = ["cuda:0"]
+CUDA_DEVICES = [f"{current_platform.device_type}:0"]
 
 
 def get_ref_results(

--- a/tests/kernels/quantization/test_silu_mul_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_silu_mul_nvfp4_quant.py
@@ -22,6 +22,7 @@ if not current_platform.has_device_capability(100):
 FP4_DTYPE = torch.uint8
 FP8_DTYPE = current_platform.fp8_dtype()
 
+DEVICE_TYPE = current_platform.device_type
 DTYPES = [torch.float16, torch.bfloat16]
 SHAPES = [(128, 256), (128, 128), (256, 256), (256, 128)]
 BLOCK_SIZE = 16
@@ -36,7 +37,7 @@ def test_silu_mul_nvfp4_quant(
     shape: tuple[int, int],
 ) -> None:
     set_random_seed(42)
-    device = f"{current_platform.device_type}:0"
+    device = f"{DEVICE_TYPE}:0"
     torch.set_default_device(device)
 
     x = torch.randn(shape, dtype=dtype)

--- a/tests/kernels/quantization/test_silu_mul_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_silu_mul_nvfp4_quant.py
@@ -36,7 +36,7 @@ def test_silu_mul_nvfp4_quant(
     shape: tuple[int, int],
 ) -> None:
     set_random_seed(42)
-    device = "cuda:0"
+    device = f"{current_platform.device_type}:0"
     torch.set_default_device(device)
 
     x = torch.randn(shape, dtype=dtype)

--- a/tests/kernels/test_apply_repetition_penalties.py
+++ b/tests/kernels/test_apply_repetition_penalties.py
@@ -40,7 +40,7 @@ def test_apply_repetition_penalties(
     against a reference implementation.
     """
     set_random_seed(seed)
-    torch.set_default_device("cuda:0")
+    torch.set_default_device(f"{current_platform.device_type}:0")
 
     # Create test data
     logits = torch.randn(num_seqs, vocab_size, dtype=dtype)
@@ -97,7 +97,7 @@ def test_apply_repetition_penalties_zero_seqs() -> None:
     seed = 0
 
     set_random_seed(seed)
-    torch.set_default_device("cuda:0")
+    torch.set_default_device(f"{current_platform.device_type}:0")
 
     # Create test data
     logits = torch.randn(num_seqs, vocab_size, dtype=dtype)

--- a/tests/kernels/test_apply_repetition_penalties.py
+++ b/tests/kernels/test_apply_repetition_penalties.py
@@ -17,6 +17,7 @@ VOCAB_SIZES = [17, 256, 1019, 151936, 202048]
 REPETITION_PENALTY_VALUES = [1.05]
 SEEDS = [0]
 DTYPES = [torch.float32, torch.float16]
+DEVICE_TYPE = current_platform.device_type
 
 
 @pytest.mark.parametrize("num_seqs", NUM_SEQS)
@@ -40,7 +41,7 @@ def test_apply_repetition_penalties(
     against a reference implementation.
     """
     set_random_seed(seed)
-    torch.set_default_device(f"{current_platform.device_type}:0")
+    torch.set_default_device(f"{DEVICE_TYPE}:0")
 
     # Create test data
     logits = torch.randn(num_seqs, vocab_size, dtype=dtype)
@@ -97,7 +98,7 @@ def test_apply_repetition_penalties_zero_seqs() -> None:
     seed = 0
 
     set_random_seed(seed)
-    torch.set_default_device(f"{current_platform.device_type}:0")
+    torch.set_default_device(f"{DEVICE_TYPE}:0")
 
     # Create test data
     logits = torch.randn(num_seqs, vocab_size, dtype=dtype)

--- a/tests/kernels/test_fla_layernorm_guard.py
+++ b/tests/kernels/test_fla_layernorm_guard.py
@@ -13,6 +13,8 @@ from vllm.model_executor.layers.fla.ops.layernorm_guard import (
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def layer_norm_ref(
     x,
@@ -116,7 +118,7 @@ def test_layer_norm_fwd_basic(
 ) -> None:
     """Test basic layer norm forward pass without z (gate) tensor."""
     set_random_seed(seed)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -158,7 +160,7 @@ def test_layer_norm_fwd_with_gate(
 ) -> None:
     """Test layer norm forward pass with z (gate) tensor."""
     set_random_seed(42)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -215,7 +217,7 @@ def test_layer_norm_fwd_with_groups(
         )
 
     set_random_seed(42)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -255,7 +257,7 @@ def test_layer_norm_rows_per_block(
 ) -> None:
     """Test that rows_per_block logic works correctly for various M sizes."""
     set_random_seed(42)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     hidden_size = 1024
 
     # Create inputs
@@ -280,7 +282,7 @@ def test_strided_input(dtype: torch.dtype) -> None:
     """Test that the kernel handles non-contiguous (strided)
     inputs correctly."""
     set_random_seed(42)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     num_tokens = 128
     hidden_size = 1024
 
@@ -320,7 +322,7 @@ def test_output_buffer_provided(
 ) -> None:
     """Test that the kernel works when an output buffer is provided."""
     set_random_seed(42)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -361,7 +363,7 @@ def test_multidimensional_input(
 ) -> None:
     """Test that the autograd function handles multidimensional inputs."""
     set_random_seed(42)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     hidden_size = shape[-1]
 
     # Create inputs
@@ -405,7 +407,7 @@ def test_rmsnorm_gated_forward_native_dtype(
 
     from vllm.model_executor.layers.layernorm import RMSNormGated
 
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     set_random_seed(42)
 
     layer = RMSNormGated(

--- a/tests/kernels/test_fla_layernorm_guard.py
+++ b/tests/kernels/test_fla_layernorm_guard.py
@@ -10,6 +10,7 @@ from vllm.model_executor.layers.fla.ops.layernorm_guard import (
     layernorm_fn,
     rms_norm_ref,
 )
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 
@@ -115,7 +116,7 @@ def test_layer_norm_fwd_basic(
 ) -> None:
     """Test basic layer norm forward pass without z (gate) tensor."""
     set_random_seed(seed)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -157,7 +158,7 @@ def test_layer_norm_fwd_with_gate(
 ) -> None:
     """Test layer norm forward pass with z (gate) tensor."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -214,7 +215,7 @@ def test_layer_norm_fwd_with_groups(
         )
 
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -254,7 +255,7 @@ def test_layer_norm_rows_per_block(
 ) -> None:
     """Test that rows_per_block logic works correctly for various M sizes."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     hidden_size = 1024
 
     # Create inputs
@@ -279,7 +280,7 @@ def test_strided_input(dtype: torch.dtype) -> None:
     """Test that the kernel handles non-contiguous (strided)
     inputs correctly."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     num_tokens = 128
     hidden_size = 1024
 
@@ -319,7 +320,7 @@ def test_output_buffer_provided(
 ) -> None:
     """Test that the kernel works when an output buffer is provided."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
 
     # Create inputs
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
@@ -360,7 +361,7 @@ def test_multidimensional_input(
 ) -> None:
     """Test that the autograd function handles multidimensional inputs."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     hidden_size = shape[-1]
 
     # Create inputs
@@ -404,7 +405,7 @@ def test_rmsnorm_gated_forward_native_dtype(
 
     from vllm.model_executor.layers.layernorm import RMSNormGated
 
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     set_random_seed(42)
 
     layer = RMSNormGated(

--- a/tests/kernels/test_fused_quant_activation.py
+++ b/tests/kernels/test_fused_quant_activation.py
@@ -13,8 +13,9 @@ QUANT_DTYPES = [current_platform.fp8_dtype()]
 NUM_TOKENS = [1, 17, 86, 1234, 3045]  # Arbitrary values for testing
 HIDDEN_SIZES = [16, 48, 128, 1562, 4096]  # Arbitrary values for testing
 SEEDS = [0]
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 

--- a/tests/kernels/test_fused_quant_activation.py
+++ b/tests/kernels/test_fused_quant_activation.py
@@ -14,7 +14,8 @@ NUM_TOKENS = [1, 17, 86, 1234, 3045]  # Arbitrary values for testing
 HIDDEN_SIZES = [16, 48, 128, 1562, 4096]  # Arbitrary values for testing
 SEEDS = [0]
 CUDA_DEVICES = [
-    f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    f"{current_platform.device_type}:{i}"
+    for i in range(min(current_platform.device_count(), 2))
 ]
 
 

--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -12,7 +12,7 @@ from vllm.model_executor.layers.fla.ops import (
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
-DEVICE = current_platform.device_type
+DEVICE_TYPE = current_platform.device_type
 
 
 @pytest.mark.parametrize("tp_size", [1])
@@ -31,7 +31,7 @@ def test_fused_sigmoid_gating_delta_rule_update_non_spec(
     head_v_dim: int,
     dtype: torch.dtype,
 ) -> None:
-    torch.set_default_device(DEVICE)
+    torch.set_default_device(DEVICE_TYPE)
     set_random_seed(0)
     key_dim = head_k_dim * num_k_heads
     value_dim = head_v_dim * num_v_heads
@@ -118,7 +118,7 @@ def test_fused_sigmoid_gating_delta_rule_update_spec(
     num_speculative_tokens: int,
     dtype: torch.dtype,
 ) -> None:
-    torch.set_default_device(DEVICE)
+    torch.set_default_device(DEVICE_TYPE)
     set_random_seed(0)
     key_dim = head_k_dim * num_k_heads
     value_dim = head_v_dim * num_v_heads

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -14,6 +14,7 @@ TOP_K_VALUES = [2048, 3000]
 BATCH_SIZE = [1, 2, 2048]
 NEXT_N = [1, 8]
 DATA_GENERATION = ["random", "10LSBits"]
+DEVICE = current_platform.device_type
 
 
 def create_random_logits(
@@ -30,7 +31,7 @@ def create_random_logits(
     # Generate logits with some structure to make testing more meaningful
     if data_generation == "random":
         logits = torch.randn(
-            row_starts.shape[0], max(row_ends), dtype=dtype, device="cuda"
+            row_starts.shape[0], max(row_ends), dtype=dtype, device=DEVICE
         )
     elif data_generation == "10LSBits":
         top_22_bits_mask = 0xFFFFFC00
@@ -42,7 +43,7 @@ def create_random_logits(
             2**10,
             (row_starts.shape[0], max(row_ends)),
             dtype=torch.int32,
-            device="cuda",
+            device=DEVICE,
         )
         # Combine: fixed top 22 bits with random last 10 bits
         logits_bits = (fixed_top_22_bits & top_22_bits_mask) | (
@@ -60,8 +61,10 @@ def create_row_boundaries(
     seq_len: int, vocab_size: int
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Create row start and end indices for testing."""
-    row_starts = torch.zeros(seq_len, dtype=torch.int32, device="cuda")
-    row_ends = torch.arange(1, seq_len + 1, device="cuda", dtype=torch.int32)
+    row_starts = torch.zeros(seq_len, dtype=torch.int32, device=DEVICE)
+    row_ends = torch.arange(
+        1, seq_len + 1, device=current_platform.device_type, dtype=torch.int32
+    )
     return row_starts, row_ends
 
 
@@ -136,7 +139,7 @@ def test_top_k_per_row(
     Test top_k_per_row.
     """
     set_random_seed(0)
-    torch.set_default_device("cuda:0")
+    torch.set_default_device(f"{DEVICE}:0")
 
     # Create test data
     vocab_size = 20000
@@ -146,7 +149,7 @@ def test_top_k_per_row(
     )
 
     # Create output tensors
-    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device="cuda")
+    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE)
 
     # Run CUDA implementation
     torch.ops._C.top_k_per_row_prefill(
@@ -161,7 +164,7 @@ def test_top_k_per_row(
     )
 
     # Run reference implementation
-    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device="cuda")
+    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE)
     for i in range(num_rows):
         row_end = int(row_ends[i])
         k_i = min(top_k, row_end)
@@ -185,7 +188,7 @@ def _run_top_k_per_row_decode_test(
     """
     Helper function to run top_k_per_row_decode test with given parameters.
     """
-    torch.set_default_device("cuda:0")
+    torch.set_default_device(f"{DEVICE}:0")
 
     # Create test data
     num_rows = batch_size * next_n
@@ -194,18 +197,18 @@ def _run_top_k_per_row_decode_test(
         high=vocab_size,
         size=(batch_size,),
         dtype=torch.int32,
-        device="cuda",
+        device=current_platform.device_type,
     )
-    row_starts = torch.zeros(num_rows, dtype=torch.int32, device="cuda")
-    row_indices = torch.arange(num_rows, device="cuda") // next_n
-    next_n_offset = torch.arange(num_rows, device="cuda") % next_n
+    row_starts = torch.zeros(num_rows, dtype=torch.int32, device=DEVICE)
+    row_indices = torch.arange(num_rows, device=DEVICE) // next_n
+    next_n_offset = torch.arange(num_rows, device=DEVICE) % next_n
     row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
     logits = create_random_logits(
         row_starts, row_ends, torch.float32, 42, clean_logits, data_generation
     )
 
     # Create output tensors
-    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device="cuda")
+    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE)
 
     # Run CUDA implementation
     torch.ops._C.top_k_per_row_decode(
@@ -222,7 +225,7 @@ def _run_top_k_per_row_decode_test(
     torch.accelerator.synchronize()
 
     # Run reference implementation
-    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device="cuda")
+    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE)
     for i in range(num_rows):
         row_end = int(row_ends[i])
         k_i = min(top_k, row_end)
@@ -281,7 +284,7 @@ def test_top_k_per_row_decode_large_vocab_size(clean_logits: bool) -> None:
 @pytest.mark.parametrize("clean_logits", [True, False])
 @torch.inference_mode()
 def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
-    torch.set_default_device("cuda:0")
+    torch.set_default_device(f"{DEVICE}:0")
 
     top_k = 2048
 
@@ -292,12 +295,12 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
 
     # Create sequences with max length < 8192
     seq_lens_short = torch.randint(
-        4000, 8000, (batch_size_short,), dtype=torch.int32, device="cuda"
+        4000, 8000, (batch_size_short,), dtype=torch.int32, device=DEVICE
     )
 
-    row_starts_short = torch.zeros(num_rows_short, dtype=torch.int32, device="cuda")
-    row_indices_short = torch.arange(num_rows_short, device="cuda") // next_n
-    next_n_offset_short = torch.arange(num_rows_short, device="cuda") % next_n
+    row_starts_short = torch.zeros(num_rows_short, dtype=torch.int32, device=DEVICE)
+    row_indices_short = torch.arange(num_rows_short, device=DEVICE) // next_n
+    next_n_offset_short = torch.arange(num_rows_short, device=DEVICE) % next_n
     row_ends_short = (
         seq_lens_short[row_indices_short] - next_n + next_n_offset_short + 1
     )
@@ -307,7 +310,7 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
     )
 
     indices_vllm = torch.empty(
-        (num_rows_short, top_k), dtype=torch.int32, device="cuda"
+        (num_rows_short, top_k), dtype=torch.int32, device=DEVICE
     )
 
     # Use vllm's kernel for short sequences
@@ -328,19 +331,19 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
 
     # Create sequences with max length >= 8192
     seq_lens_long = torch.randint(
-        8192, 16384, (batch_size_long,), dtype=torch.int32, device="cuda"
+        8192, 16384, (batch_size_long,), dtype=torch.int32, device=DEVICE
     )
 
-    row_starts_long = torch.zeros(num_rows_long, dtype=torch.int32, device="cuda")
-    row_indices_long = torch.arange(num_rows_long, device="cuda") // next_n
-    next_n_offset_long = torch.arange(num_rows_long, device="cuda") % next_n
+    row_starts_long = torch.zeros(num_rows_long, dtype=torch.int32, device=DEVICE)
+    row_indices_long = torch.arange(num_rows_long, device=DEVICE) // next_n
+    next_n_offset_long = torch.arange(num_rows_long, device=DEVICE) % next_n
     row_ends_long = seq_lens_long[row_indices_long] - next_n + next_n_offset_long + 1
 
     logits_long = create_random_logits(
         row_starts_long, row_ends_long, torch.float32, 43, clean_logits, "random"
     )
 
-    indices = torch.empty((num_rows_long, top_k), dtype=torch.int32, device="cuda")
+    indices = torch.empty((num_rows_long, top_k), dtype=torch.int32, device=DEVICE)
 
     # Use large_context_topk kernel for long sequences
     if next_n == 1:
@@ -357,7 +360,7 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
     )
 
     torch_indices_short = torch.empty(
-        (num_rows_short, top_k), dtype=torch.int32, device="cuda"
+        (num_rows_short, top_k), dtype=torch.int32, device=DEVICE
     )
     for i in range(num_rows_short):
         row_end = int(row_ends_short[i])
@@ -375,7 +378,7 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
     ), "top_k_per_row_decode kernel (short sequences) doesn't match torch.topk"
 
     torch_indices_long = torch.empty(
-        (num_rows_long, top_k), dtype=torch.int32, device="cuda"
+        (num_rows_long, top_k), dtype=torch.int32, device=DEVICE
     )
     for i in range(num_rows_long):
         row_end = int(row_ends_long[i])

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -14,7 +14,7 @@ TOP_K_VALUES = [2048, 3000]
 BATCH_SIZE = [1, 2, 2048]
 NEXT_N = [1, 8]
 DATA_GENERATION = ["random", "10LSBits"]
-DEVICE = current_platform.device_type
+DEVICE_TYPE = current_platform.device_type
 
 
 def create_random_logits(
@@ -31,7 +31,7 @@ def create_random_logits(
     # Generate logits with some structure to make testing more meaningful
     if data_generation == "random":
         logits = torch.randn(
-            row_starts.shape[0], max(row_ends), dtype=dtype, device=DEVICE
+            row_starts.shape[0], max(row_ends), dtype=dtype, device=DEVICE_TYPE
         )
     elif data_generation == "10LSBits":
         top_22_bits_mask = 0xFFFFFC00
@@ -43,7 +43,7 @@ def create_random_logits(
             2**10,
             (row_starts.shape[0], max(row_ends)),
             dtype=torch.int32,
-            device=DEVICE,
+            device=DEVICE_TYPE,
         )
         # Combine: fixed top 22 bits with random last 10 bits
         logits_bits = (fixed_top_22_bits & top_22_bits_mask) | (
@@ -61,9 +61,9 @@ def create_row_boundaries(
     seq_len: int, vocab_size: int
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Create row start and end indices for testing."""
-    row_starts = torch.zeros(seq_len, dtype=torch.int32, device=DEVICE)
+    row_starts = torch.zeros(seq_len, dtype=torch.int32, device=DEVICE_TYPE)
     row_ends = torch.arange(
-        1, seq_len + 1, device=current_platform.device_type, dtype=torch.int32
+        1, seq_len + 1, device=DEVICE_TYPE, dtype=torch.int32
     )
     return row_starts, row_ends
 
@@ -139,7 +139,7 @@ def test_top_k_per_row(
     Test top_k_per_row.
     """
     set_random_seed(0)
-    torch.set_default_device(f"{DEVICE}:0")
+    torch.set_default_device(f"{DEVICE_TYPE}:0")
 
     # Create test data
     vocab_size = 20000
@@ -149,7 +149,7 @@ def test_top_k_per_row(
     )
 
     # Create output tensors
-    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE)
+    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE_TYPE)
 
     # Run CUDA implementation
     torch.ops._C.top_k_per_row_prefill(
@@ -164,7 +164,7 @@ def test_top_k_per_row(
     )
 
     # Run reference implementation
-    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE)
+    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE_TYPE)
     for i in range(num_rows):
         row_end = int(row_ends[i])
         k_i = min(top_k, row_end)
@@ -188,7 +188,7 @@ def _run_top_k_per_row_decode_test(
     """
     Helper function to run top_k_per_row_decode test with given parameters.
     """
-    torch.set_default_device(f"{DEVICE}:0")
+    torch.set_default_device(f"{DEVICE_TYPE}:0")
 
     # Create test data
     num_rows = batch_size * next_n
@@ -197,18 +197,18 @@ def _run_top_k_per_row_decode_test(
         high=vocab_size,
         size=(batch_size,),
         dtype=torch.int32,
-        device=current_platform.device_type,
+        device=DEVICE_TYPE,
     )
-    row_starts = torch.zeros(num_rows, dtype=torch.int32, device=DEVICE)
-    row_indices = torch.arange(num_rows, device=DEVICE) // next_n
-    next_n_offset = torch.arange(num_rows, device=DEVICE) % next_n
+    row_starts = torch.zeros(num_rows, dtype=torch.int32, device=DEVICE_TYPE)
+    row_indices = torch.arange(num_rows, device=DEVICE_TYPE) // next_n
+    next_n_offset = torch.arange(num_rows, device=DEVICE_TYPE) % next_n
     row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
     logits = create_random_logits(
         row_starts, row_ends, torch.float32, 42, clean_logits, data_generation
     )
 
     # Create output tensors
-    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE)
+    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE_TYPE)
 
     # Run CUDA implementation
     torch.ops._C.top_k_per_row_decode(
@@ -225,7 +225,7 @@ def _run_top_k_per_row_decode_test(
     torch.accelerator.synchronize()
 
     # Run reference implementation
-    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE)
+    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE_TYPE)
     for i in range(num_rows):
         row_end = int(row_ends[i])
         k_i = min(top_k, row_end)
@@ -284,7 +284,7 @@ def test_top_k_per_row_decode_large_vocab_size(clean_logits: bool) -> None:
 @pytest.mark.parametrize("clean_logits", [True, False])
 @torch.inference_mode()
 def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
-    torch.set_default_device(f"{DEVICE}:0")
+    torch.set_default_device(f"{DEVICE_TYPE}:0")
 
     top_k = 2048
 
@@ -295,12 +295,12 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
 
     # Create sequences with max length < 8192
     seq_lens_short = torch.randint(
-        4000, 8000, (batch_size_short,), dtype=torch.int32, device=DEVICE
+        4000, 8000, (batch_size_short,), dtype=torch.int32, device=DEVICE_TYPE
     )
 
-    row_starts_short = torch.zeros(num_rows_short, dtype=torch.int32, device=DEVICE)
-    row_indices_short = torch.arange(num_rows_short, device=DEVICE) // next_n
-    next_n_offset_short = torch.arange(num_rows_short, device=DEVICE) % next_n
+    row_starts_short = torch.zeros(num_rows_short, dtype=torch.int32, device=DEVICE_TYPE)
+    row_indices_short = torch.arange(num_rows_short, device=DEVICE_TYPE) // next_n
+    next_n_offset_short = torch.arange(num_rows_short, device=DEVICE_TYPE) % next_n
     row_ends_short = (
         seq_lens_short[row_indices_short] - next_n + next_n_offset_short + 1
     )
@@ -310,7 +310,7 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
     )
 
     indices_vllm = torch.empty(
-        (num_rows_short, top_k), dtype=torch.int32, device=DEVICE
+        (num_rows_short, top_k), dtype=torch.int32, device=DEVICE_TYPE
     )
 
     # Use vllm's kernel for short sequences
@@ -331,19 +331,19 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
 
     # Create sequences with max length >= 8192
     seq_lens_long = torch.randint(
-        8192, 16384, (batch_size_long,), dtype=torch.int32, device=DEVICE
+        8192, 16384, (batch_size_long,), dtype=torch.int32, device=DEVICE_TYPE
     )
 
-    row_starts_long = torch.zeros(num_rows_long, dtype=torch.int32, device=DEVICE)
-    row_indices_long = torch.arange(num_rows_long, device=DEVICE) // next_n
-    next_n_offset_long = torch.arange(num_rows_long, device=DEVICE) % next_n
+    row_starts_long = torch.zeros(num_rows_long, dtype=torch.int32, device=DEVICE_TYPE)
+    row_indices_long = torch.arange(num_rows_long, device=DEVICE_TYPE) // next_n
+    next_n_offset_long = torch.arange(num_rows_long, device=DEVICE_TYPE) % next_n
     row_ends_long = seq_lens_long[row_indices_long] - next_n + next_n_offset_long + 1
 
     logits_long = create_random_logits(
         row_starts_long, row_ends_long, torch.float32, 43, clean_logits, "random"
     )
 
-    indices = torch.empty((num_rows_long, top_k), dtype=torch.int32, device=DEVICE)
+    indices = torch.empty((num_rows_long, top_k), dtype=torch.int32, device=DEVICE_TYPE)
 
     # Use large_context_topk kernel for long sequences
     if next_n == 1:
@@ -360,7 +360,7 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
     )
 
     torch_indices_short = torch.empty(
-        (num_rows_short, top_k), dtype=torch.int32, device=DEVICE
+        (num_rows_short, top_k), dtype=torch.int32, device=DEVICE_TYPE
     )
     for i in range(num_rows_short):
         row_end = int(row_ends_short[i])
@@ -378,7 +378,7 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
     ), "top_k_per_row_decode kernel (short sequences) doesn't match torch.topk"
 
     torch_indices_long = torch.empty(
-        (num_rows_long, top_k), dtype=torch.int32, device=DEVICE
+        (num_rows_long, top_k), dtype=torch.int32, device=DEVICE_TYPE
     )
     for i in range(num_rows_long):
         row_end = int(row_ends_long[i])

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -164,7 +164,11 @@ def test_top_k_per_row(
     )
 
     # Run reference implementation
-    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE_TYPE)
+    torch_indices = torch.empty(
+        (num_rows, top_k),
+        dtype=torch.int32,
+        device=DEVICE_TYPE,
+    )
     for i in range(num_rows):
         row_end = int(row_ends[i])
         k_i = min(top_k, row_end)
@@ -225,7 +229,11 @@ def _run_top_k_per_row_decode_test(
     torch.accelerator.synchronize()
 
     # Run reference implementation
-    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=DEVICE_TYPE)
+    torch_indices = torch.empty(
+        (num_rows, top_k),
+        dtype=torch.int32,
+        device=DEVICE_TYPE,
+    )
     for i in range(num_rows):
         row_end = int(row_ends[i])
         k_i = min(top_k, row_end)
@@ -298,7 +306,11 @@ def test_deepseek_hybrid_topk(clean_logits: bool) -> None:
         4000, 8000, (batch_size_short,), dtype=torch.int32, device=DEVICE_TYPE
     )
 
-    row_starts_short = torch.zeros(num_rows_short, dtype=torch.int32, device=DEVICE_TYPE)
+    row_starts_short = torch.zeros(
+        num_rows_short,
+        dtype=torch.int32,
+        device=DEVICE_TYPE,
+    )
     row_indices_short = torch.arange(num_rows_short, device=DEVICE_TYPE) // next_n
     next_n_offset_short = torch.arange(num_rows_short, device=DEVICE_TYPE) % next_n
     row_ends_short = (

--- a/tests/lora/test_fused_moe_lora_kernel.py
+++ b/tests/lora/test_fused_moe_lora_kernel.py
@@ -637,7 +637,7 @@ def use_fused_moe_lora_kernel_tensor_parallel(
 
     set_random_seed(seed)
 
-    device = torch.device(f"{current_platform.device_type}:{local_rank}")
+    device = torch.device(f"{DEVICE_TYPE}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)

--- a/tests/lora/test_fused_moe_lora_kernel.py
+++ b/tests/lora/test_fused_moe_lora_kernel.py
@@ -637,7 +637,7 @@ def use_fused_moe_lora_kernel_tensor_parallel(
 
     set_random_seed(seed)
 
-    device = torch.device(f"cuda:{local_rank}")
+    device = torch.device(f"{current_platform.device_type}:{local_rank}")
     torch.accelerator.set_device_index(device)
     torch.set_default_device(device)
     torch.set_default_dtype(dtype)

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -61,7 +61,10 @@ pytestmark = pytest.mark.skipif(
 )
 
 DEVICES = (
-    [f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)]
+    [
+        f"{current_platform.device_type}:{i}"
+        for i in range(1 if torch.accelerator.device_count() == 1 else 2)
+    ]
     if current_platform.is_cuda_alike()
     else ["cpu"]
 )
@@ -196,7 +199,7 @@ def create_random_inputs(
     input_size: tuple[int, ...],
     input_range: tuple[float, float],
     input_type: torch.dtype = torch.int,
-    device: torch.device = "cuda",
+    device: torch.device = current_platform.device_type,
 ) -> tuple[list[torch.Tensor], list[int], list[int]]:
     """Creates random inputs.
 

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -60,9 +60,10 @@ pytestmark = pytest.mark.skipif(
     reason="Backend not supported",
 )
 
+DEVICE_TYPE = current_platform.device_type
 DEVICES = (
     [
-        f"{current_platform.device_type}:{i}"
+        f"{DEVICE_TYPE}:{i}"
         for i in range(1 if torch.accelerator.device_count() == 1 else 2)
     ]
     if current_platform.is_cuda_alike()
@@ -199,7 +200,7 @@ def create_random_inputs(
     input_size: tuple[int, ...],
     input_range: tuple[float, float],
     input_type: torch.dtype = torch.int,
-    device: torch.device = current_platform.device_type,
+    device: torch.device = DEVICE_TYPE,
 ) -> tuple[list[torch.Tensor], list[int], list[int]]:
     """Creates random inputs.
 

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -35,9 +35,10 @@ EMBEDDING_MODULES = {
     "lm_head": "output_embeddings",
 }
 
+DEVICE_TYPE = current_platform.device_type
 DEVICES = (
     [
-        f"{current_platform.device_type}:{i}"
+        f"{DEVICE_TYPE}:{i}"
         for i in range(min(torch.accelerator.device_count(), 2))
     ]
     if current_platform.is_cuda_alike()

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -35,9 +35,11 @@ EMBEDDING_MODULES = {
     "lm_head": "output_embeddings",
 }
 
-
 DEVICES = (
-    [f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)]
+    [
+        f"{current_platform.device_type}:{i}"
+        for i in range(min(torch.accelerator.device_count(), 2))
+    ]
     if current_platform.is_cuda_alike()
     else ["cpu"]
 )

--- a/tests/lora/test_moe_lora_align_sum.py
+++ b/tests/lora/test_moe_lora_align_sum.py
@@ -8,6 +8,7 @@ import torch
 from vllm import _custom_ops as ops
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
 
 def round_up(x, base):
     return ((x + base - 1) // base) * base
@@ -28,8 +29,8 @@ def sample_data(num_experts, max_loras, num_tokens, topk_num):
             topk_ids[i, j] = pool[j]
         token_lora_mapping[i] = random.randint(0, max_loras - 1)
 
-    return topk_ids.to(current_platform.device_type), token_lora_mapping.to(
-        current_platform.device_type
+    return topk_ids.to(DEVICE_TYPE), token_lora_mapping.to(
+        DEVICE_TYPE
     )
 
 
@@ -59,22 +60,22 @@ def test_moe_lora_align_block_size(
         (max_loras * max_num_tokens_padded,),
         topk_ids.numel(),
         dtype=torch.int32,
-        device=current_platform.device_type,
+        device=DEVICE_TYPE,
     )
     expert_ids = torch.full(
         (max_loras * max_num_m_blocks,),
         num_experts,
         dtype=torch.int32,
-        device=current_platform.device_type,
+        device=DEVICE_TYPE,
     )
     num_tokens_post_pad = torch.zeros(
-        (max_loras,), dtype=torch.int32, device=current_platform.device_type
+        (max_loras,), dtype=torch.int32, device=DEVICE_TYPE
     )
     adapter_enabled = torch.ones(
-        (max_loras + 1,), dtype=torch.int32, device=current_platform.device_type
+        (max_loras + 1,), dtype=torch.int32, device=DEVICE_TYPE
     )
     lora_ids = torch.arange(
-        max_loras + 2, dtype=torch.int32, device=current_platform.device_type
+        max_loras + 2, dtype=torch.int32, device=DEVICE_TYPE
     )
 
     # call kernel

--- a/tests/lora/test_moe_lora_align_sum.py
+++ b/tests/lora/test_moe_lora_align_sum.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
 
 
 def round_up(x, base):
@@ -27,7 +28,9 @@ def sample_data(num_experts, max_loras, num_tokens, topk_num):
             topk_ids[i, j] = pool[j]
         token_lora_mapping[i] = random.randint(0, max_loras - 1)
 
-    return topk_ids.to("cuda"), token_lora_mapping.to("cuda")
+    return topk_ids.to(current_platform.device_type), token_lora_mapping.to(
+        current_platform.device_type
+    )
 
 
 @pytest.mark.parametrize("num_tokens", [100, 200, 1024, 4096])  # 81920
@@ -56,14 +59,23 @@ def test_moe_lora_align_block_size(
         (max_loras * max_num_tokens_padded,),
         topk_ids.numel(),
         dtype=torch.int32,
-        device="cuda",
+        device=current_platform.device_type,
     )
     expert_ids = torch.full(
-        (max_loras * max_num_m_blocks,), num_experts, dtype=torch.int32, device="cuda"
+        (max_loras * max_num_m_blocks,),
+        num_experts,
+        dtype=torch.int32,
+        device=current_platform.device_type,
     )
-    num_tokens_post_pad = torch.zeros((max_loras,), dtype=torch.int32, device="cuda")
-    adapter_enabled = torch.ones((max_loras + 1,), dtype=torch.int32, device="cuda")
-    lora_ids = torch.arange(max_loras + 2, dtype=torch.int32, device="cuda")
+    num_tokens_post_pad = torch.zeros(
+        (max_loras,), dtype=torch.int32, device=current_platform.device_type
+    )
+    adapter_enabled = torch.ones(
+        (max_loras + 1,), dtype=torch.int32, device=current_platform.device_type
+    )
+    lora_ids = torch.arange(
+        max_loras + 2, dtype=torch.int32, device=current_platform.device_type
+    )
 
     # call kernel
     ops.moe_lora_align_block_size(

--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -9,6 +9,7 @@ import vllm.lora.ops.torch_ops as torch_ops
 import vllm.lora.ops.triton_ops as triton_ops
 from vllm.lora.ops.triton_ops import LoRAKernelMeta
 from vllm.lora.ops.triton_ops.utils import _LORA_A_PTR_DICT, _LORA_B_PTR_DICT
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 from .utils import PunicaTensors, assert_close, generate_data_for_nslices
@@ -146,7 +147,9 @@ def check_lora_shrink_kernel(
 
     # Setup metadata information for the LoRA kernel.
     lora_meta = LoRAKernelMeta.make(
-        max_loras=num_loras, max_num_tokens=token_nums, device="cuda"
+        max_loras=num_loras,
+        max_num_tokens=token_nums,
+        device=current_platform.device_type,
     )
     lora_meta.prepare_tensors(data.token_lora_mapping)
 
@@ -219,7 +222,9 @@ def check_lora_expand_kernel(
 
     # Setup metadata information for the LoRA kernel.
     lora_meta = LoRAKernelMeta.make(
-        max_loras=num_loras, max_num_tokens=token_nums, device="cuda"
+        max_loras=num_loras,
+        max_num_tokens=token_nums,
+        device=current_platform.device_type,
     )
     lora_meta.prepare_tensors(data.token_lora_mapping)
 
@@ -367,7 +372,7 @@ test_params = {
 }
 
 DTYPES = [torch.float16, torch.bfloat16]
-DEVICES = [f"cuda:{0}"]
+DEVICES = [f"{current_platform.device_type}:{0}"]
 SEED = [0]
 
 

--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -14,6 +14,7 @@ from vllm.utils.torch_utils import set_random_seed
 
 from .utils import PunicaTensors, assert_close, generate_data_for_nslices
 
+DEVICE_TYPE = current_platform.device_type
 
 @pytest.fixture(autouse=True)
 def reset_device(reset_default_device):
@@ -149,7 +150,7 @@ def check_lora_shrink_kernel(
     lora_meta = LoRAKernelMeta.make(
         max_loras=num_loras,
         max_num_tokens=token_nums,
-        device=current_platform.device_type,
+        device=DEVICE_TYPE,
     )
     lora_meta.prepare_tensors(data.token_lora_mapping)
 
@@ -224,7 +225,7 @@ def check_lora_expand_kernel(
     lora_meta = LoRAKernelMeta.make(
         max_loras=num_loras,
         max_num_tokens=token_nums,
-        device=current_platform.device_type,
+        device=DEVICE_TYPE,
     )
     lora_meta.prepare_tensors(data.token_lora_mapping)
 
@@ -372,7 +373,7 @@ test_params = {
 }
 
 DTYPES = [torch.float16, torch.bfloat16]
-DEVICES = [f"{current_platform.device_type}:{0}"]
+DEVICES = [f"{DEVICE_TYPE}:{0}"]
 SEED = [0]
 
 

--- a/tests/lora/test_punica_ops_fp8.py
+++ b/tests/lora/test_punica_ops_fp8.py
@@ -31,7 +31,8 @@ from vllm.lora.ops.triton_ops.utils import _LORA_A_PTR_DICT, _LORA_B_PTR_DICT
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
-DEVICES = [f"{current_platform.device_type}:{0}"]
+DEVICE_TYPE = current_platform.device_type
+DEVICES = [f"{DEVICE_TYPE}:{0}"]
 SEED = [0]
 
 _dict_lock = Lock()

--- a/tests/lora/test_punica_ops_fp8.py
+++ b/tests/lora/test_punica_ops_fp8.py
@@ -28,9 +28,10 @@ from vllm.lora.ops.triton_ops.lora_shrink_fp8_op import (
     _SHRINK_LORA_SCALE_PTR_DICT,
 )
 from vllm.lora.ops.triton_ops.utils import _LORA_A_PTR_DICT, _LORA_B_PTR_DICT
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
-DEVICES = [f"cuda:{0}"]
+DEVICES = [f"{current_platform.device_type}:{0}"]
 SEED = [0]
 
 _dict_lock = Lock()

--- a/tests/lora/test_worker.py
+++ b/tests/lora/test_worker.py
@@ -25,6 +25,8 @@ from vllm.v1.worker.gpu_worker import Worker
 MODEL_PATH = "Qwen/Qwen3-0.6B"
 NUM_LORAS = 16
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @patch.dict(os.environ, {"RANK": "0"})
 def test_worker_apply_lora(qwen3_lora_files):
@@ -62,7 +64,7 @@ def test_worker_apply_lora(qwen3_lora_files):
             max_num_seqs=32,
             max_num_partial_prefills=32,
         ),
-        device_config=DeviceConfig(current_platform.device_type),
+        device_config=DeviceConfig(DEVICE_TYPE),
         cache_config=CacheConfig(
             block_size=16,
             cache_dtype="auto",

--- a/tests/lora/test_worker.py
+++ b/tests/lora/test_worker.py
@@ -19,6 +19,7 @@ from vllm.config.load import LoadConfig
 from vllm.config.lora import LoRAConfig
 from vllm.lora.model_manager import LoRAMapping
 from vllm.lora.request import LoRARequest
+from vllm.platforms import current_platform
 from vllm.v1.worker.gpu_worker import Worker
 
 MODEL_PATH = "Qwen/Qwen3-0.6B"
@@ -61,7 +62,7 @@ def test_worker_apply_lora(qwen3_lora_files):
             max_num_seqs=32,
             max_num_partial_prefills=32,
         ),
-        device_config=DeviceConfig("cuda"),
+        device_config=DeviceConfig(current_platform.device_type),
         cache_config=CacheConfig(
             block_size=16,
             cache_dtype="auto",

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -9,10 +9,11 @@ import torch
 from safetensors.torch import save_file
 
 from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
+from vllm.platforms import current_platform
 
 
 class DummyLoRAManager:
-    def __init__(self, device: torch.device = "cuda:0"):
+    def __init__(self, device: torch.device = f"{current_platform.device_type}:0"):
         super().__init__()
         self._loras: dict[str, LoRALayerWeights] = {}
         self._device = device
@@ -57,8 +58,10 @@ class DummyLoRAManager:
             module_name,
             rank=rank,
             lora_alpha=1,
-            lora_a=torch.rand([rank, input_dim], device="cuda"),
-            lora_b=torch.rand([output_dim, input_dim], device="cuda"),
+            lora_a=torch.rand([rank, input_dim], device=current_platform.device_type),
+            lora_b=torch.rand(
+                [output_dim, input_dim], device=current_platform.device_type
+            ),
             embeddings_tensor=embeddings_tensor,
         )
         self.set_module_lora(module_name, lora)

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -11,9 +11,11 @@ from safetensors.torch import save_file
 from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 class DummyLoRAManager:
-    def __init__(self, device: torch.device = f"{current_platform.device_type}:0"):
+    def __init__(self, device: torch.device = f"{DEVICE_TYPE}:0"):
         super().__init__()
         self._loras: dict[str, LoRALayerWeights] = {}
         self._device = device
@@ -58,9 +60,9 @@ class DummyLoRAManager:
             module_name,
             rank=rank,
             lora_alpha=1,
-            lora_a=torch.rand([rank, input_dim], device=current_platform.device_type),
+            lora_a=torch.rand([rank, input_dim], device=DEVICE_TYPE),
             lora_b=torch.rand(
-                [output_dim, input_dim], device=current_platform.device_type
+                [output_dim, input_dim], device=DEVICE_TYPE
             ),
             embeddings_tensor=embeddings_tensor,
         )

--- a/tests/model_executor/test_eagle_quantization.py
+++ b/tests/model_executor/test_eagle_quantization.py
@@ -10,9 +10,10 @@ from vllm.config import LoadConfig, ModelConfig, SpeculativeConfig, VllmConfig
 from vllm.model_executor.models.utils import get_draft_quant_config
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
 DEVICES = (
     [
-        f"{current_platform.device_type}:{i}"
+        f"{DEVICE_TYPE}:{i}"
         for i in range(min(torch.accelerator.device_count(), 2))
     ]
     if current_platform.is_cuda_alike()

--- a/tests/model_executor/test_eagle_quantization.py
+++ b/tests/model_executor/test_eagle_quantization.py
@@ -11,7 +11,10 @@ from vllm.model_executor.models.utils import get_draft_quant_config
 from vllm.platforms import current_platform
 
 DEVICES = (
-    [f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)]
+    [
+        f"{current_platform.device_type}:{i}"
+        for i in range(min(torch.accelerator.device_count(), 2))
+    ]
     if current_platform.is_cuda_alike()
     else ["cpu"]
 )

--- a/tests/models/language/pooling/test_colbert.py
+++ b/tests/models/language/pooling/test_colbert.py
@@ -74,6 +74,7 @@ TEXTS_2 = [
 ]
 
 DTYPE = "half"
+DEVICE_TYPE = current_platform.device_type
 
 
 def _load_hf_model(model_name: str, hf_spec: dict, device: torch.device):
@@ -356,7 +357,7 @@ def test_colbert_hf_comparison(vllm_runner, backend):
         vllm_outputs = vllm_model.token_embed(test_texts)
 
     device = torch.device(
-        current_platform.device_type if torch.cuda.is_available() else "cpu"
+        DEVICE_TYPE if torch.cuda.is_available() else "cpu"
     )
 
     hf_tokenizer = AutoTokenizer.from_pretrained(

--- a/tests/models/language/pooling/test_colbert.py
+++ b/tests/models/language/pooling/test_colbert.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 
 from vllm.entrypoints.pooling.score.utils import compute_maxsim_score
+from vllm.platforms import current_platform
 
 # -----------------------------------------------------------------------
 # Model definitions: (model_name, colbert_dim, extra vllm_runner kwargs)
@@ -354,7 +355,9 @@ def test_colbert_hf_comparison(vllm_runner, backend):
     ) as vllm_model:
         vllm_outputs = vllm_model.token_embed(test_texts)
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device(
+        current_platform.device_type if torch.cuda.is_available() else "cpu"
+    )
 
     hf_tokenizer = AutoTokenizer.from_pretrained(
         model_name,

--- a/tests/models/multimodal/pooling/test_intern_vit.py
+++ b/tests/models/multimodal/pooling/test_intern_vit.py
@@ -16,6 +16,8 @@ from ....conftest import ImageTestAssets
 # dynamic_module and trust_remote_code for hf_runner
 DOWNLOAD_PATTERN = ["*.json", "*.py", "*.safetensors", "*.txt", "*.model"]
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @torch.inference_mode()
 def run_intern_vit_test(
@@ -40,9 +42,9 @@ def run_intern_vit_test(
 
     hf_model = AutoModel.from_pretrained(
         model, dtype=torch_dtype, trust_remote_code=True
-    ).to(current_platform.device_type)
+    ).to(DEVICE_TYPE)
     hf_outputs_per_image = [
-        hf_model(pixel_value.to(current_platform.device_type)).last_hidden_state
+        hf_model(pixel_value.to(DEVICE_TYPE)).last_hidden_state
         for pixel_value in pixel_values
     ]
 
@@ -54,9 +56,9 @@ def run_intern_vit_test(
     del hf_model
     cleanup_dist_env_and_memory()
 
-    vllm_model = vllm_model.to(current_platform.device_type, torch_dtype)
+    vllm_model = vllm_model.to(DEVICE_TYPE, torch_dtype)
     vllm_outputs_per_image = [
-        vllm_model(pixel_values=pixel_value.to(current_platform.device_type))
+        vllm_model(pixel_values=pixel_value.to(DEVICE_TYPE))
         for pixel_value in pixel_values
     ]
     del vllm_model

--- a/tests/models/multimodal/pooling/test_intern_vit.py
+++ b/tests/models/multimodal/pooling/test_intern_vit.py
@@ -7,6 +7,7 @@ from huggingface_hub import snapshot_download
 from transformers import AutoConfig, AutoModel, CLIPImageProcessor
 
 from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 
 from ....conftest import ImageTestAssets
@@ -39,9 +40,9 @@ def run_intern_vit_test(
 
     hf_model = AutoModel.from_pretrained(
         model, dtype=torch_dtype, trust_remote_code=True
-    ).to("cuda")
+    ).to(current_platform.device_type)
     hf_outputs_per_image = [
-        hf_model(pixel_value.to("cuda")).last_hidden_state
+        hf_model(pixel_value.to(current_platform.device_type)).last_hidden_state
         for pixel_value in pixel_values
     ]
 
@@ -53,9 +54,10 @@ def run_intern_vit_test(
     del hf_model
     cleanup_dist_env_and_memory()
 
-    vllm_model = vllm_model.to("cuda", torch_dtype)
+    vllm_model = vllm_model.to(current_platform.device_type, torch_dtype)
     vllm_outputs_per_image = [
-        vllm_model(pixel_values=pixel_value.to("cuda")) for pixel_value in pixel_values
+        vllm_model(pixel_values=pixel_value.to(current_platform.device_type))
+        for pixel_value in pixel_values
     ]
     del vllm_model
     cleanup_dist_env_and_memory()

--- a/tests/models/multimodal/pooling/test_radio.py
+++ b/tests/models/multimodal/pooling/test_radio.py
@@ -8,6 +8,7 @@ from transformers import AutoConfig, AutoModel, CLIPImageProcessor
 
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.model_executor.models.radio import RadioModel
+from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.radio import RadioConfig
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 
@@ -51,7 +52,7 @@ def run_radio_test(
         config=hf_config,
         dtype=torch_dtype,
         trust_remote_code=True,
-    ).to("cuda")
+    ).to(current_platform.device_type)
     hf_model.eval()
 
     # A HF model has image normalization as a part of model's forward
@@ -62,7 +63,8 @@ def run_radio_test(
     hf_model.make_preprocessor_external()
 
     hf_outputs_per_image = [
-        hf_model(pixel_value.to("cuda")) for pixel_value in pixel_values
+        hf_model(pixel_value.to(current_platform.device_type))
+        for pixel_value in pixel_values
     ]
 
     vllm_config = RadioConfig(
@@ -71,10 +73,11 @@ def run_radio_test(
     )
     vllm_model = RadioModel(vllm_config)
     vllm_model.load_weights(hf_model.state_dict())
-    vllm_model = vllm_model.to("cuda", torch_dtype)
+    vllm_model = vllm_model.to(current_platform.device_type, torch_dtype)
 
     vllm_outputs_per_image = [
-        vllm_model(pixel_values=pixel_value.to("cuda")) for pixel_value in pixel_values
+        vllm_model(pixel_values=pixel_value.to(current_platform.device_type))
+        for pixel_value in pixel_values
     ]
     del vllm_model, hf_model
     cleanup_dist_env_and_memory()

--- a/tests/models/multimodal/pooling/test_radio.py
+++ b/tests/models/multimodal/pooling/test_radio.py
@@ -18,6 +18,8 @@ from ....conftest import ImageTestAssets
 # dynamic_module and trust_remote_code for hf_runner
 DOWNLOAD_PATTERN = ["*.json", "*.py", "*.safetensors", "*.txt", "*.model"]
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @torch.inference_mode()
 def run_radio_test(
@@ -52,7 +54,7 @@ def run_radio_test(
         config=hf_config,
         dtype=torch_dtype,
         trust_remote_code=True,
-    ).to(current_platform.device_type)
+    ).to(DEVICE_TYPE)
     hf_model.eval()
 
     # A HF model has image normalization as a part of model's forward
@@ -63,7 +65,7 @@ def run_radio_test(
     hf_model.make_preprocessor_external()
 
     hf_outputs_per_image = [
-        hf_model(pixel_value.to(current_platform.device_type))
+        hf_model(pixel_value.to(DEVICE_TYPE))
         for pixel_value in pixel_values
     ]
 
@@ -73,10 +75,10 @@ def run_radio_test(
     )
     vllm_model = RadioModel(vllm_config)
     vllm_model.load_weights(hf_model.state_dict())
-    vllm_model = vllm_model.to(current_platform.device_type, torch_dtype)
+    vllm_model = vllm_model.to(DEVICE_TYPE, torch_dtype)
 
     vllm_outputs_per_image = [
-        vllm_model(pixel_values=pixel_value.to(current_platform.device_type))
+        vllm_model(pixel_values=pixel_value.to(DEVICE_TYPE))
         for pixel_value in pixel_values
     ]
     del vllm_model, hf_model

--- a/tests/models/multimodal/processing/test_tensor_schema.py
+++ b/tests/models/multimodal/processing/test_tensor_schema.py
@@ -45,6 +45,8 @@ VideoInput: TypeAlias = (
 )
 AudioInput = list[tuple[np.ndarray, int]]
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def _resize_data(
     _data: Image.Image | np.ndarray, size_factor: float
@@ -146,7 +148,7 @@ def initialize_dummy_model(
         initialize_model_parallel(tensor_model_parallel_size=1)
 
         with set_default_torch_dtype(model_config.dtype):
-            torch.set_default_device(current_platform.device_type)
+            torch.set_default_device(DEVICE_TYPE)
             model = model_cls(vllm_config=vllm_config)
             torch.set_default_device(current_device)
         yield model

--- a/tests/models/test_vision.py
+++ b/tests/models/test_vision.py
@@ -25,6 +25,8 @@ from vllm.utils.torch_utils import set_random_seed
 
 pytestmark = pytest.mark.cpu_test
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @pytest.mark.parametrize(
     ("select_layers", "num_layers_loaded", "max_possible_layers", "expected_features"),
@@ -467,7 +469,7 @@ def run_dp_sharded_mrope_vision_model_uneven_load_worker(
 @pytest.mark.parametrize("spatial_merge_size", [2, 4])
 def test_simple_mrope_vision_model_spatial_merge(spatial_merge_size: int):
     """Test SimpleMRopeVisionModel with different spatial merge sizes."""
-    device = current_platform.device_type
+    device = DEVICE_TYPE
 
     grid_thw_list = [[1, 4, 4], [1, 6, 6]]  # Two images
     pixel_values_list = []

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -33,6 +33,7 @@ MODELS = [
     ),
 ]
 
+DEVICE_TYPE = current_platform.device_type
 
 @pytest.mark.skipif(
     not is_quant_method_supported("fp8"),
@@ -313,7 +314,7 @@ def test_scaled_fp8_quant(dtype) -> None:
 
     # Note that we use a shape % 4 != 0 to cover edge cases,
     # because scaled_fp8_quant is vectorized by 4.
-    x = (torch.randn(size=(11, 11), device=current_platform.device_type) * 13).to(dtype)
+    x = (torch.randn(size=(11, 11), device=DEVICE_TYPE) * 13).to(dtype)
 
     # Dynamic quantization
     ref_y, inv_scale = ops.scaled_fp8_quant(x, None)
@@ -338,7 +339,7 @@ def test_scaled_fp8_quant(dtype) -> None:
     # non-contiguous input with padding
     m, n, padded_stride = 975, 512, 576
     padded_tensor = (
-        torch.randn(size=(m, padded_stride), device=current_platform.device_type) * 13
+        torch.randn(size=(m, padded_stride), device=DEVICE_TYPE) * 13
     ).to(dtype)
     x_nc = padded_tensor[:, :n]  # shape (m, n) with stride (padded_stride, 1)
 
@@ -408,7 +409,7 @@ def test_fp8_reloading(
             "If this is your use case, consider using a restore function like #26327"
         )
 
-    with torch.device(f"{current_platform.device_type}:0"):
+    with torch.device(f"{DEVICE_TYPE}:0"):
         config = Fp8Config(
             is_checkpoint_fp8_serialized=is_checkpoint_fp8_serialized,
             weight_block_size=weight_block_size,

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -313,7 +313,7 @@ def test_scaled_fp8_quant(dtype) -> None:
 
     # Note that we use a shape % 4 != 0 to cover edge cases,
     # because scaled_fp8_quant is vectorized by 4.
-    x = (torch.randn(size=(11, 11), device="cuda") * 13).to(dtype)
+    x = (torch.randn(size=(11, 11), device=current_platform.device_type) * 13).to(dtype)
 
     # Dynamic quantization
     ref_y, inv_scale = ops.scaled_fp8_quant(x, None)
@@ -337,7 +337,9 @@ def test_scaled_fp8_quant(dtype) -> None:
 
     # non-contiguous input with padding
     m, n, padded_stride = 975, 512, 576
-    padded_tensor = (torch.randn(size=(m, padded_stride), device="cuda") * 13).to(dtype)
+    padded_tensor = (
+        torch.randn(size=(m, padded_stride), device=current_platform.device_type) * 13
+    ).to(dtype)
     x_nc = padded_tensor[:, :n]  # shape (m, n) with stride (padded_stride, 1)
 
     assert not x_nc.is_contiguous()
@@ -406,7 +408,7 @@ def test_fp8_reloading(
             "If this is your use case, consider using a restore function like #26327"
         )
 
-    with torch.device("cuda:0"):
+    with torch.device(f"{current_platform.device_type}:0"):
         config = Fp8Config(
             is_checkpoint_fp8_serialized=is_checkpoint_fp8_serialized,
             weight_block_size=weight_block_size,

--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -26,6 +26,8 @@ from vllm.platforms import current_platform
 
 from .reference_mxfp4 import dq_mxfp4_torch, qdq_mxfp4_torch
 
+DEVICE_TYPE = current_platform.device_type
+
 # Minimum amd-quark version for MXFP4/OCP_MX tests (single source of truth).
 QUARK_MXFP4_MIN_VERSION = "0.8.99"
 
@@ -280,7 +282,7 @@ def test_mxfp4_fused_qdq_match_quark(float_dtype: torch.dtype, scalings: list[in
     hidden_size = 64 * 32
     inp = (
         torch.rand(
-            1, hidden_size, dtype=float_dtype, device=current_platform.device_type
+            1, hidden_size, dtype=float_dtype, device=DEVICE_TYPE
         )
         - 0.5
     ) * 2
@@ -327,16 +329,16 @@ def test_mxfp4_dequant_kernel_match_quark(
         reorder=False,
         real_quantized=True,
         float_dtype=float_dtype,
-        device=current_platform.device_type,
+        device=DEVICE_TYPE,
     )
 
-    observer = qspec.observer_cls(qspec, device=current_platform.device_type)
+    observer = qspec.observer_cls(qspec, device=DEVICE_TYPE)
 
     hidden_size = 512
     shape = (11008, hidden_size)
 
     w = (
-        torch.rand(shape, device=current_platform.device_type, dtype=float_dtype) - 0.5
+        torch.rand(shape, device=DEVICE_TYPE, dtype=float_dtype) - 0.5
     ) * 2
 
     # Make it so that different groups have different scales.
@@ -350,7 +352,7 @@ def test_mxfp4_dequant_kernel_match_quark(
     weight_quantizer.scale = scale
 
     w_mxfp4 = weight_quantizer.to_real_quantize_params(w).to(
-        current_platform.device_type
+        DEVICE_TYPE
     )
     weight_quantizer.maybe_convert_and_transpose_scale()
 

--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -278,7 +278,12 @@ def test_mxfp4_fused_qdq_match_quark(float_dtype: torch.dtype, scalings: list[in
     torch.manual_seed(0)
 
     hidden_size = 64 * 32
-    inp = (torch.rand(1, hidden_size, dtype=float_dtype, device="cuda") - 0.5) * 2
+    inp = (
+        torch.rand(
+            1, hidden_size, dtype=float_dtype, device=current_platform.device_type
+        )
+        - 0.5
+    ) * 2
     for i in range(hidden_size // 32):
         inp[:, i * 32 : (i + 1) * 32] = (
             inp[:, i * 32 : (i + 1) * 32] * scalings[i % len(scalings)]
@@ -322,15 +327,17 @@ def test_mxfp4_dequant_kernel_match_quark(
         reorder=False,
         real_quantized=True,
         float_dtype=float_dtype,
-        device="cuda",
+        device=current_platform.device_type,
     )
 
-    observer = qspec.observer_cls(qspec, device="cuda")
+    observer = qspec.observer_cls(qspec, device=current_platform.device_type)
 
     hidden_size = 512
     shape = (11008, hidden_size)
 
-    w = (torch.rand(shape, device="cuda", dtype=float_dtype) - 0.5) * 2
+    w = (
+        torch.rand(shape, device=current_platform.device_type, dtype=float_dtype) - 0.5
+    ) * 2
 
     # Make it so that different groups have different scales.
     for i in range(hidden_size // 32):
@@ -342,7 +349,9 @@ def test_mxfp4_dequant_kernel_match_quark(
     scale, _ = observer._calculate_qparams()
     weight_quantizer.scale = scale
 
-    w_mxfp4 = weight_quantizer.to_real_quantize_params(w).to("cuda")
+    w_mxfp4 = weight_quantizer.to_real_quantize_params(w).to(
+        current_platform.device_type
+    )
     weight_quantizer.maybe_convert_and_transpose_scale()
 
     scale = weight_quantizer.scale

--- a/tests/quantization/test_torchao.py
+++ b/tests/quantization/test_torchao.py
@@ -33,7 +33,7 @@ def test_pre_quantized_model(vllm_runner):
 @pytest.mark.parametrize(
     "pt_load_map_location",
     [
-        "cuda:0",
+        f"{current_platform.device_type}:0",
         # {"": "cuda"},
     ],
 )
@@ -60,7 +60,7 @@ def test_qwenvl_int8wo_model_loading_with_params(vllm_runner):
         model_name=model_name,
         quantization="torchao",
         dtype="bfloat16",
-        pt_load_map_location="cuda:0",
+        pt_load_map_location=f"{current_platform.device_type}:0",
         enforce_eager=True,
     ) as llm:
         output = llm.generate_greedy(["The capital of France is"], max_tokens=4)
@@ -81,7 +81,7 @@ def test_opt_125m_awq_int4wo_model_loading_with_params(vllm_runner):
         model_name=model_name,
         quantization="torchao",
         dtype="bfloat16",
-        pt_load_map_location="cuda:0",
+        pt_load_map_location=f"{current_platform.device_type}:0",
     ) as llm:
         output = llm.generate_greedy(["The capital of France is"], max_tokens=4)
 
@@ -112,7 +112,7 @@ def test_online_quant_config_dict_json(vllm_runner, enable_pickle):
     with vllm_runner(
         model_name=model_name,
         dtype="bfloat16",
-        pt_load_map_location="cuda:0",
+        pt_load_map_location=f"{current_platform.device_type}:0",
         quantization="torchao",
         hf_overrides=hf_overrides,
         enforce_eager=True,
@@ -158,7 +158,7 @@ def test_online_quant_config_file(vllm_runner):
         with vllm_runner(
             model_name=model_name,
             dtype="bfloat16",
-            pt_load_map_location="cuda:0",
+            pt_load_map_location=f"{current_platform.device_type}:0",
             quantization="torchao",
             hf_overrides=hf_overrides,
             enforce_eager=True,
@@ -248,7 +248,9 @@ def test_opt_125m_module_fqn_to_config_regex_model(vllm_runner):
     torch._dynamo.reset()
     model_name = "torchao-testing/opt-125m-ModuleFqnToConfig-v1-regex-0.14.0.dev"
     with vllm_runner(
-        model_name=model_name, dtype="bfloat16", pt_load_map_location="cuda:0"
+        model_name=model_name,
+        dtype="bfloat16",
+        pt_load_map_location=f"{current_platform.device_type}:0",
     ) as llm:
         output = llm.generate_greedy(["The capital of France is"], max_tokens=4)
 
@@ -278,7 +280,7 @@ def test_opt_125m_int4wo_model_running_preshuffled_kernel(vllm_runner, monkeypat
         model_name=model_name,
         quantization="torchao",
         dtype="bfloat16",
-        pt_load_map_location="cuda:0",
+        pt_load_map_location=f"{current_platform.device_type}:0",
         enforce_eager=True,
     ) as llm:
 
@@ -357,7 +359,7 @@ def test_opt_125m_int4wo_model_running_preshuffled_kernel_online_quant(
         model_name=model_name,
         quantization="torchao",
         dtype="bfloat16",
-        pt_load_map_location="cuda:0",
+        pt_load_map_location=f"{current_platform.device_type}:0",
         hf_overrides=hf_overrides,
         enforce_eager=True,
     ) as llm:

--- a/tests/quantization/test_torchao.py
+++ b/tests/quantization/test_torchao.py
@@ -9,6 +9,7 @@ from vllm.model_executor.model_loader import get_model_loader
 from vllm.platforms import current_platform
 
 DTYPE = ["bfloat16"]
+DEVICE_TYPE = current_platform.device_type
 
 TORCHAO_AVAILABLE = importlib.util.find_spec("torchao") is not None
 
@@ -33,7 +34,7 @@ def test_pre_quantized_model(vllm_runner):
 @pytest.mark.parametrize(
     "pt_load_map_location",
     [
-        f"{current_platform.device_type}:0",
+        f"{DEVICE_TYPE}:0",
         # {"": "cuda"},
     ],
 )
@@ -60,7 +61,7 @@ def test_qwenvl_int8wo_model_loading_with_params(vllm_runner):
         model_name=model_name,
         quantization="torchao",
         dtype="bfloat16",
-        pt_load_map_location=f"{current_platform.device_type}:0",
+        pt_load_map_location=f"{DEVICE_TYPE}:0",
         enforce_eager=True,
     ) as llm:
         output = llm.generate_greedy(["The capital of France is"], max_tokens=4)
@@ -81,7 +82,7 @@ def test_opt_125m_awq_int4wo_model_loading_with_params(vllm_runner):
         model_name=model_name,
         quantization="torchao",
         dtype="bfloat16",
-        pt_load_map_location=f"{current_platform.device_type}:0",
+        pt_load_map_location=f"{DEVICE_TYPE}:0",
     ) as llm:
         output = llm.generate_greedy(["The capital of France is"], max_tokens=4)
 
@@ -112,7 +113,7 @@ def test_online_quant_config_dict_json(vllm_runner, enable_pickle):
     with vllm_runner(
         model_name=model_name,
         dtype="bfloat16",
-        pt_load_map_location=f"{current_platform.device_type}:0",
+        pt_load_map_location=f"{DEVICE_TYPE}:0",
         quantization="torchao",
         hf_overrides=hf_overrides,
         enforce_eager=True,
@@ -158,7 +159,7 @@ def test_online_quant_config_file(vllm_runner):
         with vllm_runner(
             model_name=model_name,
             dtype="bfloat16",
-            pt_load_map_location=f"{current_platform.device_type}:0",
+            pt_load_map_location=f"{DEVICE_TYPE}:0",
             quantization="torchao",
             hf_overrides=hf_overrides,
             enforce_eager=True,
@@ -250,7 +251,7 @@ def test_opt_125m_module_fqn_to_config_regex_model(vllm_runner):
     with vllm_runner(
         model_name=model_name,
         dtype="bfloat16",
-        pt_load_map_location=f"{current_platform.device_type}:0",
+        pt_load_map_location=f"{DEVICE_TYPE}:0",
     ) as llm:
         output = llm.generate_greedy(["The capital of France is"], max_tokens=4)
 
@@ -280,7 +281,7 @@ def test_opt_125m_int4wo_model_running_preshuffled_kernel(vllm_runner, monkeypat
         model_name=model_name,
         quantization="torchao",
         dtype="bfloat16",
-        pt_load_map_location=f"{current_platform.device_type}:0",
+        pt_load_map_location=f"{DEVICE_TYPE}:0",
         enforce_eager=True,
     ) as llm:
 
@@ -359,7 +360,7 @@ def test_opt_125m_int4wo_model_running_preshuffled_kernel_online_quant(
         model_name=model_name,
         quantization="torchao",
         dtype="bfloat16",
-        pt_load_map_location=f"{current_platform.device_type}:0",
+        pt_load_map_location=f"{DEVICE_TYPE}:0",
         hf_overrides=hf_overrides,
         enforce_eager=True,
     ) as llm:

--- a/tests/rocm/aiter/test_grouped_quant.py
+++ b/tests/rocm/aiter/test_grouped_quant.py
@@ -35,9 +35,7 @@ def test_rocm_aiter_group_fp8_quant_fake_implementation():
     N = 4096
     group_size = 128
 
-    input_tensor = torch.randn(
-        (M, N), dtype=torch.bfloat16, device=current_platform.device_type
-    )
+    input_tensor = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
 
     # Verify the op's fake implementation using torch.library.opcheck
     # This checks that the fake function returns tensors with correct shapes and dtypes
@@ -57,9 +55,7 @@ def test_rocm_aiter_group_fp8_quant_torch_compile_with_cudagraph():
     N = 4096
     group_size = 128
 
-    input_tensor = torch.randn(
-        (M, N), dtype=torch.bfloat16, device=current_platform.device_type
-    )
+    input_tensor = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
 
     # Define a function that uses the op
     def group_fp8_quant_fn(x):
@@ -99,9 +95,7 @@ def test_rocm_aiter_group_fp8_quant_torch_compile_with_cudagraph():
     assert torch.allclose(scales_compiled, scales_eager, rtol=1e-3, atol=1e-3)
 
     # Test with different input (reusing compiled graph)
-    input_tensor_2 = torch.randn(
-        (M, N), dtype=torch.bfloat16, device=current_platform.device_type
-    )
+    input_tensor_2 = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
     x_fp8_eager_2, scales_eager_2 = group_fp8_quant_fn(input_tensor_2)
     x_fp8_compiled_2, scales_compiled_2 = compiled_fn(input_tensor_2)
 
@@ -127,9 +121,7 @@ def test_rocm_aiter_group_fp8_quant_different_shapes():
     ]
 
     for M, N in test_shapes:
-        input_tensor = torch.randn(
-            (M, N), dtype=torch.bfloat16, device=current_platform.device_type
-        )
+        input_tensor = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
 
         x_fp8, scales = rocm_aiter_ops.group_fp8_quant(input_tensor, group_size)
 

--- a/tests/rocm/aiter/test_grouped_quant.py
+++ b/tests/rocm/aiter/test_grouped_quant.py
@@ -35,7 +35,9 @@ def test_rocm_aiter_group_fp8_quant_fake_implementation():
     N = 4096
     group_size = 128
 
-    input_tensor = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+    input_tensor = torch.randn(
+        (M, N), dtype=torch.bfloat16, device=current_platform.device_type
+    )
 
     # Verify the op's fake implementation using torch.library.opcheck
     # This checks that the fake function returns tensors with correct shapes and dtypes
@@ -55,7 +57,9 @@ def test_rocm_aiter_group_fp8_quant_torch_compile_with_cudagraph():
     N = 4096
     group_size = 128
 
-    input_tensor = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+    input_tensor = torch.randn(
+        (M, N), dtype=torch.bfloat16, device=current_platform.device_type
+    )
 
     # Define a function that uses the op
     def group_fp8_quant_fn(x):
@@ -95,7 +99,9 @@ def test_rocm_aiter_group_fp8_quant_torch_compile_with_cudagraph():
     assert torch.allclose(scales_compiled, scales_eager, rtol=1e-3, atol=1e-3)
 
     # Test with different input (reusing compiled graph)
-    input_tensor_2 = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+    input_tensor_2 = torch.randn(
+        (M, N), dtype=torch.bfloat16, device=current_platform.device_type
+    )
     x_fp8_eager_2, scales_eager_2 = group_fp8_quant_fn(input_tensor_2)
     x_fp8_compiled_2, scales_compiled_2 = compiled_fn(input_tensor_2)
 
@@ -121,7 +127,9 @@ def test_rocm_aiter_group_fp8_quant_different_shapes():
     ]
 
     for M, N in test_shapes:
-        input_tensor = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+        input_tensor = torch.randn(
+            (M, N), dtype=torch.bfloat16, device=current_platform.device_type
+        )
 
         x_fp8, scales = rocm_aiter_ops.group_fp8_quant(input_tensor, group_size)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -424,8 +424,8 @@ def test_generation_config_loading():
 @pytest.mark.parametrize(
     "pt_load_map_location",
     [
-        "cuda",
-        {"": "cuda"},
+        current_platform.device_type,
+        {"": current_platform.device_type},
     ],
 )
 def test_load_config_pt_load_map_location(pt_load_map_location):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,8 @@ from vllm.config.vllm import (
 )
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def test_compile_config_repr_succeeds():
     # setup: VllmBackend mutates the config object
@@ -424,8 +426,8 @@ def test_generation_config_loading():
 @pytest.mark.parametrize(
     "pt_load_map_location",
     [
-        current_platform.device_type,
-        {"": current_platform.device_type},
+        DEVICE_TYPE,
+        {"": DEVICE_TYPE},
     ],
 )
 def test_load_config_pt_load_map_location(pt_load_map_location):

--- a/tests/utils_/test_mem_utils.py
+++ b/tests/utils_/test_mem_utils.py
@@ -8,6 +8,8 @@ from vllm.utils.mem_utils import MemorySnapshot, memory_profiling
 
 from ..utils import create_new_process_for_each_test
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @create_new_process_for_each_test()
 def test_memory_profiling():
@@ -24,7 +26,7 @@ def test_memory_profiling():
     # load weights
 
     weights = torch.randn(
-        128, 1024, 1024, device=current_platform.device_type, dtype=torch.float32
+        128, 1024, 1024, device=DEVICE_TYPE, dtype=torch.float32
     )
 
     weights_memory = 128 * 1024 * 1024 * 4  # 512 MiB
@@ -44,7 +46,7 @@ def test_memory_profiling():
     ):
         # make a memory spike, 1 GiB
         spike = torch.randn(
-            256, 1024, 1024, device=current_platform.device_type, dtype=torch.float32
+            256, 1024, 1024, device=DEVICE_TYPE, dtype=torch.float32
         )
         del spike
 

--- a/tests/utils_/test_mem_utils.py
+++ b/tests/utils_/test_mem_utils.py
@@ -3,6 +3,7 @@
 import torch
 from vllm_test_utils.monitor import monitor
 
+from vllm.platforms import current_platform
 from vllm.utils.mem_utils import MemorySnapshot, memory_profiling
 
 from ..utils import create_new_process_for_each_test
@@ -22,7 +23,9 @@ def test_memory_profiling():
 
     # load weights
 
-    weights = torch.randn(128, 1024, 1024, device="cuda", dtype=torch.float32)
+    weights = torch.randn(
+        128, 1024, 1024, device=current_platform.device_type, dtype=torch.float32
+    )
 
     weights_memory = 128 * 1024 * 1024 * 4  # 512 MiB
 
@@ -40,7 +43,9 @@ def test_memory_profiling():
         monitor(measure_current_non_torch) as monitored_values,
     ):
         # make a memory spike, 1 GiB
-        spike = torch.randn(256, 1024, 1024, device="cuda", dtype=torch.float32)
+        spike = torch.randn(
+            256, 1024, 1024, device=current_platform.device_type, dtype=torch.float32
+        )
         del spike
 
         # Add some extra non-torch memory 256 MiB (simulate NCCL)

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -366,7 +366,7 @@ def _test_backend_correctness(
         num_gpu_blocks=8192,
         hf_config_override=hf_config_override,
     )
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
 
     kv_cache_spec = create_standard_kv_cache_spec(vllm_config)
 

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -40,6 +40,8 @@ BACKENDS_TO_TEST = [
     "FLEX_ATTENTION_SLOW",
 ]
 
+DEVICE_TYPE = current_platform.device_type
+
 # Remove flashinfer from the list if it's not available
 try:
     import flashinfer  # noqa: F401
@@ -366,7 +368,7 @@ def _test_backend_correctness(
         num_gpu_blocks=8192,
         hf_config_override=hf_config_override,
     )
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
 
     kv_cache_spec = create_standard_kv_cache_spec(vllm_config)
 

--- a/tests/v1/attention/test_chunked_local_attention.py
+++ b/tests/v1/attention/test_chunked_local_attention.py
@@ -22,6 +22,7 @@ class LocalAttentionTestData:
     expected_k_seqlens: list[int]
     expected_local_block_table: list[list[int]]
 
+DEVICE_TYPE = current_platform.device_type
 
 test_data_list = [
     # Same as example in docstring of make_local_attention_virtual_batches
@@ -152,7 +153,7 @@ test_data_list = [
 
 @pytest.mark.parametrize("test_data", test_data_list)
 def test_local_attention_virtual_batches(test_data: LocalAttentionTestData):
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
     batch_spec = test_data.batch_spec
     attn_chunk_size = test_data.attn_chunk_size
     block_size = test_data.block_size

--- a/tests/v1/attention/test_chunked_local_attention.py
+++ b/tests/v1/attention/test_chunked_local_attention.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from tests.v1.attention.utils import BatchSpec, create_common_attn_metadata
+from vllm.platforms import current_platform
 from vllm.v1.attention.backends.utils import make_local_attention_virtual_batches
 
 
@@ -151,7 +152,7 @@ test_data_list = [
 
 @pytest.mark.parametrize("test_data", test_data_list)
 def test_local_attention_virtual_batches(test_data: LocalAttentionTestData):
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
     batch_spec = test_data.batch_spec
     attn_chunk_size = test_data.attn_chunk_size
     block_size = test_data.block_size

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -42,6 +42,8 @@ BACKENDS_TO_TEST = [
     AttentionBackendEnum.TRITON_MLA,
 ]
 
+DEVICE_TYPE = current_platform.device_type
+
 # Remove sm100 backends from the list if not using sm100
 if not torch.cuda.is_available() or torch.cuda.get_device_properties(0).major < 10:
     BACKENDS_TO_TEST.remove(AttentionBackendEnum.CUTLASS_MLA)
@@ -763,7 +765,7 @@ def test_backend_correctness(
             method="ngram", num_speculative_tokens=query_len - 1
         )
 
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
 
     # 1. Setup
     batch_size = batch_spec.batch_size

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -763,7 +763,7 @@ def test_backend_correctness(
             method="ngram", num_speculative_tokens=query_len - 1
         )
 
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
 
     # 1. Setup
     batch_size = batch_spec.batch_size

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -24,8 +24,6 @@ from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.platforms import current_platform
 
-DEVICE_TYPE = current_platform.device_type
-
 # TODO: Integrate ROCMAiterMLASparseBackend for ROCm.
 # The ROCm sparse MLA backend (rocm_aiter_mla_sparse.py) has a compatible
 # forward_mqa interface but needs validation on ROCm hardware.
@@ -64,6 +62,8 @@ SPARSE_BACKEND_BATCH_SPECS["large_q_prefill"] = BatchSpec(
 SPARSE_BACKEND_BATCH_SPECS["large_q_pure_prefill"] = BatchSpec(
     seq_lens=[256] * 2, query_lens=[256] * 2
 )
+
+DEVICE_TYPE = current_platform.device_type
 
 
 def _float_to_e8m0_truncate(f: float) -> float:

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -218,7 +218,7 @@ def test_sparse_backend_decode_correctness(
     batch_spec = SPARSE_BACKEND_BATCH_SPECS[batch_name]
     use_fp8_ds_mla_quantization = kv_cache_dtype == "fp8_ds_mla"
 
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     dtype = torch.bfloat16
 
     # Model hyper-parameters (kept intentionally small for the unit test)
@@ -578,7 +578,7 @@ def _triton_convert_reference_impl(
 def test_triton_convert_req_index_to_global_index_decode_only(
     block_size, num_topk_tokens
 ):
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     num_tokens = 8
     num_requests = 4
     max_blocks_per_req = 10
@@ -631,7 +631,7 @@ def test_triton_convert_req_index_to_global_index_decode_only(
     reason="FlashMLASparseBackend requires CUDA 9.0 or higher",
 )
 def test_triton_convert_req_index_to_global_index_with_prefill_workspace(block_size):
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     num_requests = 4
     max_blocks_per_req = 8
     num_topk_tokens = 128
@@ -711,7 +711,7 @@ def test_split_prefill_chunks(seq_lens, max_buf, expected):
 
 def test_triton_convert_returns_valid_counts():
     """Test that return_valid_counts correctly counts non-negative indices."""
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     num_tokens = 8
     num_requests = 2
     max_blocks_per_req = 10

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -24,6 +24,8 @@ from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 # TODO: Integrate ROCMAiterMLASparseBackend for ROCm.
 # The ROCm sparse MLA backend (rocm_aiter_mla_sparse.py) has a compatible
 # forward_mqa interface but needs validation on ROCm hardware.
@@ -218,7 +220,7 @@ def test_sparse_backend_decode_correctness(
     batch_spec = SPARSE_BACKEND_BATCH_SPECS[batch_name]
     use_fp8_ds_mla_quantization = kv_cache_dtype == "fp8_ds_mla"
 
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     dtype = torch.bfloat16
 
     # Model hyper-parameters (kept intentionally small for the unit test)
@@ -578,7 +580,7 @@ def _triton_convert_reference_impl(
 def test_triton_convert_req_index_to_global_index_decode_only(
     block_size, num_topk_tokens
 ):
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     num_tokens = 8
     num_requests = 4
     max_blocks_per_req = 10
@@ -631,7 +633,7 @@ def test_triton_convert_req_index_to_global_index_decode_only(
     reason="FlashMLASparseBackend requires CUDA 9.0 or higher",
 )
 def test_triton_convert_req_index_to_global_index_with_prefill_workspace(block_size):
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     num_requests = 4
     max_blocks_per_req = 8
     num_topk_tokens = 128
@@ -711,7 +713,7 @@ def test_split_prefill_chunks(seq_lens, max_buf, expected):
 
 def test_triton_convert_returns_valid_counts():
     """Test that return_valid_counts correctly counts non-negative indices."""
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     num_tokens = 8
     num_requests = 2
     max_blocks_per_req = 10

--- a/tests/v1/attention/test_trtllm_attention_integration.py
+++ b/tests/v1/attention/test_trtllm_attention_integration.py
@@ -55,6 +55,7 @@ class MockAttentionLayer:
 MODEL = "Qwen/Qwen2.5-0.5B"
 BLOCK_SIZE = 16
 NUM_GPU_BLOCKS = 8192
+DEVICE_TYPE = current_platform.device_type
 
 BATCH_SPECS = {
     "decode_only": BatchSpec(
@@ -172,7 +173,7 @@ def _run_trtllm_integration(batch_spec):
     """Run TRTLLM attention through the full FlashInfer pipeline
     and compare against an SDPA reference."""
     set_random_seed(42)
-    device = torch.device(f"{current_platform.device_type}:0")
+    device = torch.device(f"{DEVICE_TYPE}:0")
 
     vllm_config = create_vllm_config(
         model_name=MODEL,

--- a/tests/v1/attention/test_trtllm_attention_integration.py
+++ b/tests/v1/attention/test_trtllm_attention_integration.py
@@ -172,7 +172,7 @@ def _run_trtllm_integration(batch_spec):
     """Run TRTLLM attention through the full FlashInfer pipeline
     and compare against an SDPA reference."""
     set_random_seed(42)
-    device = torch.device("cuda:0")
+    device = torch.device(f"{current_platform.device_type}:0")
 
     vllm_config = create_vllm_config(
         model_name=MODEL,

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -269,9 +269,11 @@ class TestCudagraphDispatcher:
 class TestCUDAGraphWrapper:
     def setup_method(self):
         self.vllm_config = _create_vllm_config(CompilationConfig())
-        self.model = SimpleMLP().to("cuda")
-        self.persistent_input_buffer = torch.zeros(1, 10, device="cuda")
-        self.input_tensor = torch.randn(1, 10, device="cuda")
+        self.model = SimpleMLP().to(current_platform.device_type)
+        self.persistent_input_buffer = torch.zeros(
+            1, 10, device=current_platform.device_type
+        )
+        self.input_tensor = torch.randn(1, 10, device=current_platform.device_type)
 
     def test_capture_and_replay(self):
         wrapper = CUDAGraphWrapper(
@@ -428,10 +430,12 @@ class TestCudagraphIntegration:
 
     @create_new_process_for_each_test("spawn")
     def test_capture_replay_bypass_logic(self):
-        model = SimpleMLP().to("cuda")
+        model = SimpleMLP().to(current_platform.device_type)
         full_wrapper = CUDAGraphWrapper(model, self.vllm_config, CUDAGraphMode.FULL)
         max_bs = 16
-        persistent_input_buffer = torch.zeros(max_bs, 10, device="cuda")
+        persistent_input_buffer = torch.zeros(
+            max_bs, 10, device=current_platform.device_type
+        )
         input_1 = persistent_input_buffer[:1]
         input_2 = persistent_input_buffer[:2]
         input_3 = persistent_input_buffer[:3]
@@ -486,17 +490,17 @@ class TestCudagraphIntegration:
     @create_new_process_for_each_test("spawn")
     def test_nested_wrappers(self):
         """Tests a scenario with a PIECEWISE wrapper inside a FULL one."""
-        model = SimpleMLP().to("cuda")
+        model = SimpleMLP().to(current_platform.device_type)
         full_wrapper = CUDAGraphWrapper(model, self.vllm_config, CUDAGraphMode.FULL)
-        input_1 = torch.randn(1, 10, device="cuda")
+        input_1 = torch.randn(1, 10, device=current_platform.device_type)
 
         # Setup: Inner model is wrapped with PIECEWISE, outer with FULL
-        inner_model = SimpleMLP().to("cuda")
+        inner_model = SimpleMLP().to(current_platform.device_type)
         piecewise_wrapper = CUDAGraphWrapper(
             inner_model, self.vllm_config, CUDAGraphMode.PIECEWISE
         )
         inner_model.forward = MagicMock(wraps=inner_model.forward)
-        outer_model = SimpleMLP().to("cuda")
+        outer_model = SimpleMLP().to(current_platform.device_type)
         # When outer model is called, it calls the piecewise_wrapper
         outer_model.forward = MagicMock(
             wraps=outer_model.forward, side_effect=piecewise_wrapper

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -23,6 +23,8 @@ from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.platforms import current_platform
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 
+DEVICE_TYPE = current_platform.device_type
+
 
 # Helper MLP for testing
 class SimpleMLP(nn.Module):
@@ -269,11 +271,11 @@ class TestCudagraphDispatcher:
 class TestCUDAGraphWrapper:
     def setup_method(self):
         self.vllm_config = _create_vllm_config(CompilationConfig())
-        self.model = SimpleMLP().to(current_platform.device_type)
+        self.model = SimpleMLP().to(DEVICE_TYPE)
         self.persistent_input_buffer = torch.zeros(
-            1, 10, device=current_platform.device_type
+            1, 10, device=DEVICE_TYPE
         )
-        self.input_tensor = torch.randn(1, 10, device=current_platform.device_type)
+        self.input_tensor = torch.randn(1, 10, device=DEVICE_TYPE)
 
     def test_capture_and_replay(self):
         wrapper = CUDAGraphWrapper(
@@ -430,11 +432,11 @@ class TestCudagraphIntegration:
 
     @create_new_process_for_each_test("spawn")
     def test_capture_replay_bypass_logic(self):
-        model = SimpleMLP().to(current_platform.device_type)
+        model = SimpleMLP().to(DEVICE_TYPE)
         full_wrapper = CUDAGraphWrapper(model, self.vllm_config, CUDAGraphMode.FULL)
         max_bs = 16
         persistent_input_buffer = torch.zeros(
-            max_bs, 10, device=current_platform.device_type
+            max_bs, 10, device=DEVICE_TYPE
         )
         input_1 = persistent_input_buffer[:1]
         input_2 = persistent_input_buffer[:2]
@@ -490,17 +492,17 @@ class TestCudagraphIntegration:
     @create_new_process_for_each_test("spawn")
     def test_nested_wrappers(self):
         """Tests a scenario with a PIECEWISE wrapper inside a FULL one."""
-        model = SimpleMLP().to(current_platform.device_type)
+        model = SimpleMLP().to(DEVICE_TYPE)
         full_wrapper = CUDAGraphWrapper(model, self.vllm_config, CUDAGraphMode.FULL)
-        input_1 = torch.randn(1, 10, device=current_platform.device_type)
+        input_1 = torch.randn(1, 10, device=DEVICE_TYPE)
 
         # Setup: Inner model is wrapped with PIECEWISE, outer with FULL
-        inner_model = SimpleMLP().to(current_platform.device_type)
+        inner_model = SimpleMLP().to(DEVICE_TYPE)
         piecewise_wrapper = CUDAGraphWrapper(
             inner_model, self.vllm_config, CUDAGraphMode.PIECEWISE
         )
         inner_model.forward = MagicMock(wraps=inner_model.forward)
-        outer_model = SimpleMLP().to(current_platform.device_type)
+        outer_model = SimpleMLP().to(DEVICE_TYPE)
         # When outer model is called, it calls the piecewise_wrapper
         outer_model.forward = MagicMock(
             wraps=outer_model.forward, side_effect=piecewise_wrapper

--- a/tests/v1/determinism/test_rms_norm_batch_invariant.py
+++ b/tests/v1/determinism/test_rms_norm_batch_invariant.py
@@ -15,6 +15,8 @@ from vllm.model_executor.layers.batch_invariant import rms_norm as triton_rms_no
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 @skip_unsupported
 @pytest.mark.parametrize("batch_size", [1, 4, 16, 64])
@@ -35,7 +37,7 @@ def test_rms_norm_batch_invariant_vs_standard(
     equivalent results to the standard CUDA implementation across various
     configurations.
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     # Create test input and weight
     torch.manual_seed(42)
@@ -82,7 +84,7 @@ def test_rms_norm_3d_input(
     Ensures that the batch-invariant RMS norm correctly handles multi-dimensional
     inputs that are common in transformer models.
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     dtype = torch.bfloat16
     eps = 1e-6
 
@@ -121,7 +123,7 @@ def test_rms_norm_numerical_stability(default_vllm_config):
     Ensures that both implementations handle edge cases like very small or large
     values without producing NaN or Inf.
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     dtype = torch.float16
     eps = 1e-6
     hidden_size = 2048
@@ -180,7 +182,7 @@ def test_rms_norm_formula(default_vllm_config):
 
     Verifies: output = input / sqrt(mean(input^2) + eps) * weight
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     dtype = torch.float32  # Use float32 for higher precision in formula check
     eps = 1e-6
     hidden_size = 1024
@@ -215,7 +217,7 @@ def test_rms_norm_different_hidden_sizes(default_vllm_config, hidden_size: int):
     The Triton kernel uses a fixed BLOCK_SIZE=1024, so this tests that it
     correctly handles hidden sizes both smaller and larger than the block size.
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     dtype = torch.bfloat16
     eps = 1e-6
     batch_size = 16
@@ -252,7 +254,7 @@ def test_rms_norm_determinism(default_vllm_config):
     Runs the same input through the kernel multiple times and verifies
     identical outputs.
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     dtype = torch.bfloat16
     eps = 1e-6
     hidden_size = 4096
@@ -284,7 +286,7 @@ if __name__ == "__main__":
     # Run a quick smoke test
     print("Running quick smoke test of RMS norm implementations...")
 
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     batch_size = 8
     hidden_size = 4096
     dtype = torch.bfloat16

--- a/tests/v1/determinism/test_rms_norm_batch_invariant.py
+++ b/tests/v1/determinism/test_rms_norm_batch_invariant.py
@@ -13,6 +13,7 @@ from utils import skip_unsupported
 
 from vllm.model_executor.layers.batch_invariant import rms_norm as triton_rms_norm
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.platforms import current_platform
 
 
 @skip_unsupported
@@ -34,7 +35,7 @@ def test_rms_norm_batch_invariant_vs_standard(
     equivalent results to the standard CUDA implementation across various
     configurations.
     """
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
 
     # Create test input and weight
     torch.manual_seed(42)
@@ -81,7 +82,7 @@ def test_rms_norm_3d_input(
     Ensures that the batch-invariant RMS norm correctly handles multi-dimensional
     inputs that are common in transformer models.
     """
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     dtype = torch.bfloat16
     eps = 1e-6
 
@@ -120,7 +121,7 @@ def test_rms_norm_numerical_stability(default_vllm_config):
     Ensures that both implementations handle edge cases like very small or large
     values without producing NaN or Inf.
     """
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     dtype = torch.float16
     eps = 1e-6
     hidden_size = 2048
@@ -179,7 +180,7 @@ def test_rms_norm_formula(default_vllm_config):
 
     Verifies: output = input / sqrt(mean(input^2) + eps) * weight
     """
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     dtype = torch.float32  # Use float32 for higher precision in formula check
     eps = 1e-6
     hidden_size = 1024
@@ -214,7 +215,7 @@ def test_rms_norm_different_hidden_sizes(default_vllm_config, hidden_size: int):
     The Triton kernel uses a fixed BLOCK_SIZE=1024, so this tests that it
     correctly handles hidden sizes both smaller and larger than the block size.
     """
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     dtype = torch.bfloat16
     eps = 1e-6
     batch_size = 16
@@ -251,7 +252,7 @@ def test_rms_norm_determinism(default_vllm_config):
     Runs the same input through the kernel multiple times and verifies
     identical outputs.
     """
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     dtype = torch.bfloat16
     eps = 1e-6
     hidden_size = 4096
@@ -283,7 +284,7 @@ if __name__ == "__main__":
     # Run a quick smoke test
     print("Running quick smoke test of RMS norm implementations...")
 
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     batch_size = 8
     hidden_size = 4096
     dtype = torch.bfloat16

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -16,6 +16,7 @@ from vllm import LLM, SamplingParams, TokensPrompt
 from vllm.config import CacheConfig
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
@@ -71,7 +72,7 @@ def get_fake_sample_fn() -> SamplerOutput:
             return SamplerOutput(
                 sampled_token_ids=torch.tensor(
                     [[prompt_token_ids[first_token_id_index]]],
-                    device="cuda",
+                    device=current_platform.device_type,
                     dtype=torch.int32,
                 ),
                 logprobs_tensors=None,
@@ -83,7 +84,9 @@ def get_fake_sample_fn() -> SamplerOutput:
         sampled_token_ids = accepted_tokens
         return SamplerOutput(
             sampled_token_ids=torch.tensor(
-                [sampled_token_ids], device="cuda", dtype=torch.int32
+                [sampled_token_ids],
+                device=current_platform.device_type,
+                dtype=torch.int32,
             ),
             logprobs_tensors=None,
         )
@@ -128,17 +131,23 @@ def get_fake_propose_draft_token_ids_fn():
                 - 1
                 + num_accepted_tokens
             ],
-            device="cuda",
+            device=current_platform.device_type,
             dtype=torch.int32,
         )
 
         valid_sampled_tokens_count = torch.tensor(
-            [num_accepted_tokens], device="cuda", dtype=torch.int32
+            [num_accepted_tokens],
+            device=current_platform.device_type,
+            dtype=torch.int32,
         )
 
         self._copy_valid_sampled_token_count(next_token_ids, valid_sampled_tokens_count)
 
-        return torch.tensor(proposed_draft_token_ids, device="cuda", dtype=torch.int32)
+        return torch.tensor(
+            proposed_draft_token_ids,
+            device=current_platform.device_type,
+            dtype=torch.int32,
+        )
 
     return fake_propose_draft_token_ids_fn
 

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -49,6 +49,7 @@ num_accepted_tokens = 1
 prompt_token_ids: list[int] = []
 MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"
 BLOCK_SIZE = 560
+DEVICE_TYPE = current_platform.device_type
 NUM_HIDDEN_LAYERS = 1
 cur_step_action_idx = 0
 cur_step_action: StepAction | None = None
@@ -72,7 +73,7 @@ def get_fake_sample_fn() -> SamplerOutput:
             return SamplerOutput(
                 sampled_token_ids=torch.tensor(
                     [[prompt_token_ids[first_token_id_index]]],
-                    device=current_platform.device_type,
+                    device=DEVICE_TYPE,
                     dtype=torch.int32,
                 ),
                 logprobs_tensors=None,
@@ -85,7 +86,7 @@ def get_fake_sample_fn() -> SamplerOutput:
         return SamplerOutput(
             sampled_token_ids=torch.tensor(
                 [sampled_token_ids],
-                device=current_platform.device_type,
+                device=DEVICE_TYPE,
                 dtype=torch.int32,
             ),
             logprobs_tensors=None,
@@ -131,13 +132,13 @@ def get_fake_propose_draft_token_ids_fn():
                 - 1
                 + num_accepted_tokens
             ],
-            device=current_platform.device_type,
+            device=DEVICE_TYPE,
             dtype=torch.int32,
         )
 
         valid_sampled_tokens_count = torch.tensor(
             [num_accepted_tokens],
-            device=current_platform.device_type,
+            device=DEVICE_TYPE,
             dtype=torch.int32,
         )
 
@@ -145,7 +146,7 @@ def get_fake_propose_draft_token_ids_fn():
 
         return torch.tensor(
             proposed_draft_token_ids,
-            device=current_platform.device_type,
+            device=DEVICE_TYPE,
             dtype=torch.int32,
         )
 

--- a/tests/v1/kv_offload/test_cpu_gpu.py
+++ b/tests/v1/kv_offload/test_cpu_gpu.py
@@ -33,7 +33,8 @@ NUM_HEADS = [8]
 NUM_LAYERS = [4]
 DTYPES = [torch.bfloat16]
 SEEDS = [0]
-CUDA_DEVICES = [f"{current_platform.device_type}:0"]
+DEVICE_TYPE = current_platform.device_type
+CUDA_DEVICES = [f"{DEVICE_TYPE}:0"]
 NUM_MAPPINGS = [3]
 
 

--- a/tests/v1/kv_offload/test_cpu_gpu.py
+++ b/tests/v1/kv_offload/test_cpu_gpu.py
@@ -33,7 +33,7 @@ NUM_HEADS = [8]
 NUM_LAYERS = [4]
 DTYPES = [torch.bfloat16]
 SEEDS = [0]
-CUDA_DEVICES = ["cuda:0"]
+CUDA_DEVICES = [f"{current_platform.device_type}:0"]
 NUM_MAPPINGS = [3]
 
 

--- a/tests/v1/logits_processors/test_correctness.py
+++ b/tests/v1/logits_processors/test_correctness.py
@@ -38,8 +38,9 @@ PIN_MEMORY_AVAILABLE = is_pin_memory_available()
 MAX_NUM_REQS = 256
 VOCAB_SIZE = 1024
 NUM_OUTPUT_TOKENS = 20
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(1 if current_platform.device_count() == 1 else 2)
 ]
 MAX_NUM_PROMPT_TOKENS = 64

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -19,7 +19,7 @@ from vllm.v1.sample.rejection_sampler import (
 from vllm.v1.sample.sampler import Sampler, SamplerOutput
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
-DEVICE = current_platform.device_type
+DEVICE_TYPE = current_platform.device_type
 
 
 @pytest.fixture
@@ -57,7 +57,7 @@ def create_logits_tensor(
     will produce desired token ids on argmax"""
     token_ids = [tokens[:-1] for tokens in output_token_ids]
     num_total_tokens = sum(len(tokens) for tokens in token_ids)
-    logits = torch.full((num_total_tokens, vocab_size), -100.0, device=DEVICE)
+    logits = torch.full((num_total_tokens, vocab_size), -100.0, device=DEVICE_TYPE)
     start_loc = 0
     for tokens in token_ids:
         for j, token_id in enumerate(tokens):
@@ -99,9 +99,9 @@ def create_sampling_metadata(
         assert output_token_ids
         assert len(output_token_ids) > 0
 
-        frequency_penalties = torch.tensor(frequency_penalties, device=DEVICE)
-        presence_penalties = torch.tensor(presence_penalties, device=DEVICE)
-        repetition_penalties = torch.tensor(repetition_penalties, device=DEVICE)
+        frequency_penalties = torch.tensor(frequency_penalties, device=DEVICE_TYPE)
+        presence_penalties = torch.tensor(presence_penalties, device=DEVICE_TYPE)
+        repetition_penalties = torch.tensor(repetition_penalties, device=DEVICE_TYPE)
     else:
         no_penalties = True
         frequency_penalties = torch.tensor([])
@@ -320,14 +320,14 @@ def test_deterministic_when_seeded(
     n_rep: int,
 ):
     num_tokens = batch_size * k
-    draft_probs = torch.rand(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
+    draft_probs = torch.rand(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE_TYPE)
     draft_probs = F.softmax(draft_probs, dim=-1)
     target_logits = torch.rand_like(draft_probs)
     bonus_token_ids = torch.randint(
-        low=0, high=vocab_size, size=(batch_size, 1), dtype=torch.int64, device=DEVICE
+        low=0, high=vocab_size, size=(batch_size, 1), dtype=torch.int64, device=DEVICE_TYPE
     )
     draft_token_ids = torch.randint(
-        low=0, high=vocab_size, size=(batch_size, k), dtype=torch.int64, device=DEVICE
+        low=0, high=vocab_size, size=(batch_size, k), dtype=torch.int64, device=DEVICE_TYPE
     )
 
     seeded_mask = torch.rand(batch_size, dtype=torch.float32) <= frac_seeded
@@ -335,12 +335,12 @@ def test_deterministic_when_seeded(
     results = []
     for _ in range(n_rep):
         seeded_seqs = {
-            i: torch.Generator(device=DEVICE).manual_seed(i)
+            i: torch.Generator(device=DEVICE_TYPE).manual_seed(i)
             for i in range(batch_size)
             if seeded_mask[i]
         }
 
-        temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE)
+        temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE_TYPE)
         sampling_metadata = create_sampling_metadata(
             all_greedy=False, temperature=temperature, generators=seeded_seqs
         )
@@ -387,7 +387,7 @@ def test_rejection_sampling_approximates_target_distribution():
     much more than the distance improvement between the observed
     distribution and the random distribution.
     """
-    torch.set_default_device(DEVICE)
+    torch.set_default_device(DEVICE_TYPE)
     vocab_size = 10
     k = 2
     num_reference_probs = 100
@@ -410,7 +410,7 @@ def test_rejection_sampling_approximates_target_distribution():
         rej_sample_probs = estimate_rejection_sampling_pdf(
             draft_probs, target_logits, k, vocab_size, num_samples
         )
-        rej_sample_probs = rej_sample_probs.to(DEVICE)
+        rej_sample_probs = rej_sample_probs.to(DEVICE_TYPE)
 
         # Average distance from reference probs.
         reference_vs_rejsample_dist = (
@@ -491,11 +491,11 @@ def estimate_rejection_sampling_pdf(
     draft_probs = draft_probs.view(num_tokens, vocab_size)
 
     # Bonus tokens not used but required.
-    bonus_token_ids = torch.zeros((1, 1), dtype=torch.int64, device=DEVICE).repeat(
+    bonus_token_ids = torch.zeros((1, 1), dtype=torch.int64, device=DEVICE_TYPE).repeat(
         num_samples, 1
     )
 
-    temperature = torch.ones(num_samples, dtype=torch.float32, device=DEVICE)
+    temperature = torch.ones(num_samples, dtype=torch.float32, device=DEVICE_TYPE)
     sampling_metadata = create_sampling_metadata(
         all_greedy=False, temperature=temperature
     )
@@ -600,7 +600,7 @@ def _test_masked_logits(
 
     # Create random draft probabilities.
     draft_probs = torch.rand(
-        (num_tokens, vocab_size), dtype=torch.float32, device=DEVICE
+        (num_tokens, vocab_size), dtype=torch.float32, device=DEVICE_TYPE
     )
     draft_probs = F.softmax(draft_probs, dim=-1)
 
@@ -610,7 +610,7 @@ def _test_masked_logits(
     draft_token_ids = draft_token_ids.tolist()
 
     # Bonus tokens not used but required
-    bonus_token_ids = torch.zeros((batch_size, 1), dtype=torch.int64, device=DEVICE)
+    bonus_token_ids = torch.zeros((batch_size, 1), dtype=torch.int64, device=DEVICE_TYPE)
 
     # Create spec decode metadata
     spec_decode_metadata = create_spec_decode_metadata(draft_token_ids, target_logits)
@@ -645,12 +645,12 @@ def test_top_k(rejection_sampler, top_k):
 
     # Randomly create top-k indices.
     top_k_indices = [
-        torch.randperm(vocab_size, device=DEVICE)[:top_k] for _ in range(num_tokens)
+        torch.randperm(vocab_size, device=DEVICE_TYPE)[:top_k] for _ in range(num_tokens)
     ]
     top_k_indices = torch.stack(top_k_indices)
 
     # Create logits with the uniform distribution.
-    target_logits = torch.zeros((num_tokens, vocab_size), device=DEVICE)
+    target_logits = torch.zeros((num_tokens, vocab_size), device=DEVICE_TYPE)
 
     # Increment the logits for top-k indices, a little bit more than the other
     # ones. If the masking is effective, the non-topk indices will never be
@@ -659,11 +659,11 @@ def test_top_k(rejection_sampler, top_k):
         target_logits[i, top_k_indices[i]] += 0.1
 
     # Create sampling metadata
-    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE)
+    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE_TYPE)
     sampling_metadata = create_sampling_metadata(
         all_greedy=False,
         temperature=temperature,
-        top_k=torch.tensor([top_k] * batch_size, device=DEVICE, dtype=torch.int64),
+        top_k=torch.tensor([top_k] * batch_size, device=DEVICE_TYPE, dtype=torch.int64),
     )
 
     _test_masked_logits(
@@ -686,8 +686,8 @@ def test_top_p(rejection_sampler, top_p):
     num_tokens = batch_size * num_draft_tokens
 
     # Create logits with the uniform distribution.
-    target_logits = torch.randn((num_tokens, vocab_size), device=DEVICE)
-    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE)
+    target_logits = torch.randn((num_tokens, vocab_size), device=DEVICE_TYPE)
+    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE_TYPE)
     rescaled_logits = target_logits / temperature
 
     logits_sort, logits_idx = rescaled_logits.sort(dim=-1, descending=False)
@@ -706,7 +706,7 @@ def test_top_p(rejection_sampler, top_p):
     sampling_metadata = create_sampling_metadata(
         all_greedy=False,
         temperature=temperature,
-        top_p=torch.tensor([top_p] * batch_size, device=DEVICE, dtype=torch.float32),
+        top_p=torch.tensor([top_p] * batch_size, device=DEVICE_TYPE, dtype=torch.float32),
     )
 
     _test_masked_logits(
@@ -732,7 +732,7 @@ def test_frequency_penalties(rejection_sampler):
         all_greedy=True,
         output_token_ids=[[2], [3], [4]],
         spec_token_ids=spec_tokens,
-        prompt_token_ids=torch.tensor([[5, 6, 7], [6, 7, 8], [7, 8, 9]], device=DEVICE),
+        prompt_token_ids=torch.tensor([[5, 6, 7], [6, 7, 8], [7, 8, 9]], device=DEVICE_TYPE),
         frequency_penalties=[1.5, 1.5, 0.7],
         presence_penalties=[0.0] * num_requests,
         repetition_penalties=[1.0] * num_requests,
@@ -858,21 +858,21 @@ def test_sample_recovered_tokens(
     num_tokens = batch_size * max_spec_len
 
     # Create random draft probabilities.
-    draft_probs = torch.rand(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
+    draft_probs = torch.rand(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE_TYPE)
     draft_probs = F.softmax(draft_probs, dim=-1)
 
     # Create random target probabilities.
     target_logits = torch.rand(
-        num_tokens, vocab_size, dtype=torch.float32, device=DEVICE
+        num_tokens, vocab_size, dtype=torch.float32, device=DEVICE_TYPE
     )
     target_probs = F.softmax(target_logits, dim=-1)
 
     # Randomly sample draft token ids from draft probs
     draft_token_ids = torch.multinomial(draft_probs, num_samples=1).to(torch.int32)
 
-    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE)
+    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE_TYPE)
     generators = {
-        i: torch.Generator(device=DEVICE).manual_seed(i) for i in range(batch_size)
+        i: torch.Generator(device=DEVICE_TYPE).manual_seed(i) for i in range(batch_size)
     }
     sampling_metadata = create_sampling_metadata(
         all_greedy=False, temperature=temperature, generators=generators
@@ -890,7 +890,7 @@ def test_sample_recovered_tokens(
         None if no_draft_probs else draft_probs,
         target_probs,
         sampling_metadata,
-        device=DEVICE,
+        device=DEVICE_TYPE,
     )
     recovered_token_ids = sample_recovered_tokens(
         max_spec_len,
@@ -900,6 +900,6 @@ def test_sample_recovered_tokens(
         None if no_draft_probs else draft_probs,
         target_probs,
         sampling_metadata,
-        device=DEVICE,
+        device=DEVICE_TYPE,
     )
     assert torch.equal(recovered_token_ids, ref_recovered_token_ids)

--- a/tests/v1/sample/test_sampler.py
+++ b/tests/v1/sample/test_sampler.py
@@ -17,8 +17,9 @@ PIN_MEMORY_AVAILABLE = is_pin_memory_available()
 MAX_NUM_REQS = 256
 VOCAB_SIZE = 1024
 NUM_OUTPUT_TOKENS = 20
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(1 if current_platform.device_count() == 1 else 2)
 ]
 MAX_NUM_PROMPT_TOKENS = 64

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -7,8 +7,8 @@ from torch import Generator
 from vllm.platforms import current_platform
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p_pytorch
 
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICE = "cuda" if current_platform.is_cuda() else None
-DEVICE = current_platform.device_type
 
 BATCH_SIZE = 1024
 VOCAB_SIZE = 128 * 1024
@@ -26,8 +26,8 @@ def reset_default_device():
 
 
 def test_topk_impl_equivalence():
-    torch.set_default_device(DEVICE)
-    generator = Generator(device=DEVICE).manual_seed(33)
+    torch.set_default_device(DEVICE_TYPE)
+    generator = Generator(device=DEVICE_TYPE).manual_seed(33)
 
     logits = torch.rand((BATCH_SIZE, VOCAB_SIZE), generator=generator)
 
@@ -76,8 +76,8 @@ def test_flashinfer_sampler():
     if not FLASHINFER_ENABLED:
         pytest.skip("FlashInfer not installed or not available on this platform.")
 
-    torch.set_default_device(DEVICE)
-    generator = Generator(device=DEVICE).manual_seed(42)
+    torch.set_default_device(DEVICE_TYPE)
+    generator = Generator(device=DEVICE_TYPE).manual_seed(42)
 
     # Generate random logits
     logits = torch.rand((BATCH_SIZE, VOCAB_SIZE), generator=generator)

--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -38,6 +38,7 @@ eagle3_dir = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
 ar_draft_model_dir = "amd/PARD-Llama-3.2-1B"  # Compatible with parallel and AR drafting
 
 BLOCK_SIZE = 16
+DEVICE_TYPE = current_platform.device_type
 
 
 def _create_proposer(
@@ -77,7 +78,7 @@ def _create_proposer(
         # Overwrite pard_token to avoid crash during init
         speculative_config.draft_model_config.hf_config.pard_token = 0
 
-    device = current_platform.device_type
+    device = DEVICE_TYPE
     vllm_config = VllmConfig(
         model_config=model_config,
         cache_config=CacheConfig(block_size=16),
@@ -107,7 +108,7 @@ def test_prepare_next_token_ids():
     either the GPU tensor of sampled_token_ids with -1 for rejected tokens,
     or the CPU python list[list[int]] with the rejected tokens removed.
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     num_requests = 4
     num_speculative_tokens = 4
@@ -199,7 +200,7 @@ def test_prepare_inputs():
                     a, a + 1, ..., a + b - n2 - 1,
                     a + b, a + b + 1, ..., a + b + c - n3 - 1]
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     # q1 = 4, q2 = 7, q3 = 5
     # n1 = 1, n2 = 3, n3 = 2
@@ -292,7 +293,7 @@ def test_prepare_inputs_padded():
             from the original indices to sample from.
     """
 
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     expected_token_indices_to_sample = torch.tensor(
         [1, 5, 6], dtype=torch.int32, device=device
@@ -362,7 +363,7 @@ def test_set_inputs_first_pass_default_eagle():
     - After inserting next_tokens [100, 200, 300]:
         [a2, a3, 100, b2, 200, c2, c3, c4, 300]
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     num_speculative_tokens = 3
     proposer = _create_proposer("eagle", num_speculative_tokens)
@@ -463,7 +464,7 @@ def test_set_inputs_first_pass_draft_model():
       - idx 5: token 21, pos 1
       - idx 6: token 200, pos 2 (bonus token)
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     num_speculative_tokens = 2
     block_size = BLOCK_SIZE
@@ -601,7 +602,7 @@ def test_set_inputs_first_pass_parallel_drafting():
       - idx 9: bonus token 200
       - idx 10-11: parallel_drafting_tokens, is_masked=True
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     num_speculative_tokens = 3
     block_size = BLOCK_SIZE
@@ -851,7 +852,7 @@ def test_propose(method, attn_backend, num_speculative_tokens, monkeypatch):
         monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
 
     # Use GPU device
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     # Setup test parameters
     batch_size = 2
@@ -1022,7 +1023,7 @@ def test_propose(method, attn_backend, num_speculative_tokens, monkeypatch):
 )
 def test_propose_tree(spec_token_tree):
     # Get GPU device.
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     # Setup test parameters.
     batch_size = 2

--- a/tests/v1/spec_decode/test_eagle_step_kernel.py
+++ b/tests/v1/spec_decode/test_eagle_step_kernel.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 
+from vllm.platforms import current_platform
 from vllm.v1.spec_decode.utils import (
     PADDING_SLOT_ID,
     eagle_step_update_slot_mapping_and_metadata,
@@ -47,7 +48,7 @@ def _reference_eagle_step_slot_mapping(
 
 def test_eagle_step_slot_mapping_kernel():
     """Test fused kernel matches Python reference for slot mapping and metadata."""
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     batch_size = 32
     block_size = 16
     max_model_len = 4096
@@ -93,7 +94,7 @@ def test_eagle_step_slot_mapping_kernel():
 
 def test_eagle_step_slot_mapping_kernel_exceeds_max():
     """Test fused kernel when position exceeds max_model_len."""
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     batch_size = 4
     block_size = 16
     max_model_len = 100
@@ -130,7 +131,7 @@ def test_eagle_step_slot_mapping_kernel_exceeds_max():
 def test_eagle_step_slot_mapping_kernel_cudagraph_padding():
     """Test that padding threads write PADDING_SLOT_ID when
     input_batch_size > batch_size (cudagraph padding)."""
-    device = torch.device("cuda")
+    device = torch.device(current_platform.device_type)
     batch_size = 4
     input_batch_size = 8
     block_size = 16

--- a/tests/v1/spec_decode/test_eagle_step_kernel.py
+++ b/tests/v1/spec_decode/test_eagle_step_kernel.py
@@ -11,6 +11,8 @@ from vllm.v1.spec_decode.utils import (
     eagle_step_update_slot_mapping_and_metadata,
 )
 
+DEVICE_TYPE = current_platform.device_type
+
 # Skip if no CUDA - Triton kernel requires GPU
 pytest.importorskip("triton")
 if not torch.cuda.is_available():
@@ -48,7 +50,7 @@ def _reference_eagle_step_slot_mapping(
 
 def test_eagle_step_slot_mapping_kernel():
     """Test fused kernel matches Python reference for slot mapping and metadata."""
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     batch_size = 32
     block_size = 16
     max_model_len = 4096
@@ -94,7 +96,7 @@ def test_eagle_step_slot_mapping_kernel():
 
 def test_eagle_step_slot_mapping_kernel_exceeds_max():
     """Test fused kernel when position exceeds max_model_len."""
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     batch_size = 4
     block_size = 16
     max_model_len = 100
@@ -131,7 +133,7 @@ def test_eagle_step_slot_mapping_kernel_exceeds_max():
 def test_eagle_step_slot_mapping_kernel_cudagraph_padding():
     """Test that padding threads write PADDING_SLOT_ID when
     input_batch_size > batch_size (cudagraph padding)."""
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     batch_size = 4
     input_batch_size = 8
     block_size = 16

--- a/tests/v1/spec_decode/test_extract_hidden_states.py
+++ b/tests/v1/spec_decode/test_extract_hidden_states.py
@@ -26,6 +26,7 @@ from vllm.v1.spec_decode.extract_hidden_states import ExtractHiddenStatesPropose
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
 model_dir = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+DEVICE_TYPE = current_platform.device_type
 
 
 def _create_proposer(
@@ -50,7 +51,7 @@ def _create_proposer(
         },
     )
 
-    device = current_platform.device_type
+    device = DEVICE_TYPE
     vllm_config = VllmConfig(
         model_config=model_config,
         cache_config=CacheConfig(),
@@ -100,7 +101,7 @@ def test_proposer_initialization_missing_layer_ids():
         },
     )
 
-    device = current_platform.device_type
+    device = DEVICE_TYPE
     vllm_config = VllmConfig(
         model_config=model_config,
         cache_config=CacheConfig(),
@@ -129,7 +130,7 @@ def test_prepare_next_token_ids_padded():
     For each request we either use the sampled token (if valid and not discarded)
     or a backup token from the request state.
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     num_requests = 4
     batch_spec = BatchSpec(
@@ -207,7 +208,7 @@ def test_propose():
     2. Return the sampled tokens as "draft" tokens (shape [batch_size, 1])
     3. Cache the hidden states in the model's KV cache
     """
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     # Setup test parameters
     batch_size = 2
@@ -283,7 +284,7 @@ def test_propose():
 @pytest.mark.parametrize("num_hidden_layers", [1, 4, 8])
 def test_propose_different_layer_counts(num_hidden_layers):
     """Test that propose works correctly with different numbers of hidden layers."""
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
 
     batch_size = 2
     num_tokens = 5

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -28,6 +28,7 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.spec_decode.eagle import EagleProposer
 
 mimo_7b_dir = "XiaomiMiMo/MiMo-7B-Base"
+DEVICE_TYPE = current_platform.device_type
 
 
 def _create_mtp_proposer(num_speculative_tokens: int) -> EagleProposer:
@@ -48,7 +49,7 @@ def _create_mtp_proposer(num_speculative_tokens: int) -> EagleProposer:
         model_config=model_config,
         cache_config=CacheConfig(),
         speculative_config=speculative_config,
-        device_config=DeviceConfig(device=current_platform.device_type),
+        device_config=DeviceConfig(device=DEVICE_TYPE),
         parallel_config=ParallelConfig(),
         load_config=LoadConfig(),
         scheduler_config=SchedulerConfig(
@@ -57,7 +58,7 @@ def _create_mtp_proposer(num_speculative_tokens: int) -> EagleProposer:
         ),
     )
 
-    return EagleProposer(vllm_config=vllm_config, device=current_platform.device_type)
+    return EagleProposer(vllm_config=vllm_config, device=DEVICE_TYPE)
 
 
 @mock.patch("vllm.v1.spec_decode.eagle.get_pp_group")
@@ -118,7 +119,7 @@ def test_mtp_load_model_unified(mock_get_model, mock_get_layers, mock_get_pp_gro
 def test_mtp_propose(num_speculative_tokens, monkeypatch):
     """Test that MTP's forward method returns hidden states directly"""
 
-    device = torch.device(current_platform.device_type)
+    device = torch.device(DEVICE_TYPE)
     batch_size = 2
     seq_lens = [5, 3]
     total_tokens = sum(seq_lens)

--- a/tests/v1/spec_decode/test_tree_attention.py
+++ b/tests/v1/spec_decode/test_tree_attention.py
@@ -18,6 +18,8 @@ from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.fa_utils import is_flash_attn_varlen_func_available
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
+DEVICE_TYPE = current_platform.device_type
+
 if not is_flash_attn_varlen_func_available():
     pytest.skip(
         "This test requires flash_attn_varlen_func, but it's not available.",
@@ -171,13 +173,13 @@ def _get_available_reference_backends() -> list[AttentionBackendEnum]:
 
 class MockAttentionLayer(torch.nn.Module):
     _q_scale = torch.tensor(
-        1.0, dtype=torch.float32, device=current_platform.device_type
+        1.0, dtype=torch.float32, device=DEVICE_TYPE
     )
     _k_scale = torch.tensor(
-        1.0, dtype=torch.float32, device=current_platform.device_type
+        1.0, dtype=torch.float32, device=DEVICE_TYPE
     )
     _v_scale = torch.tensor(
-        1.0, dtype=torch.float32, device=current_platform.device_type
+        1.0, dtype=torch.float32, device=DEVICE_TYPE
     )
     layer_name = "mock_layer"
 

--- a/tests/v1/spec_decode/test_tree_attention.py
+++ b/tests/v1/spec_decode/test_tree_attention.py
@@ -170,9 +170,15 @@ def _get_available_reference_backends() -> list[AttentionBackendEnum]:
 
 
 class MockAttentionLayer(torch.nn.Module):
-    _q_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
-    _k_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
-    _v_scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+    _q_scale = torch.tensor(
+        1.0, dtype=torch.float32, device=current_platform.device_type
+    )
+    _k_scale = torch.tensor(
+        1.0, dtype=torch.float32, device=current_platform.device_type
+    )
+    _v_scale = torch.tensor(
+        1.0, dtype=torch.float32, device=current_platform.device_type
+    )
     layer_name = "mock_layer"
 
     def __init__(self):

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -22,8 +22,9 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 VOCAB_SIZE = 1024
 NUM_OUTPUT_TOKENS = 20
 MAX_PROMPT_SIZE = 100
+DEVICE_TYPE = current_platform.device_type
 CUDA_DEVICES = [
-    f"{current_platform.device_type}:{i}"
+    f"{DEVICE_TYPE}:{i}"
     for i in range(min(current_platform.device_count(), 2))
 ]
 MAX_NUM_PROMPT_TOKENS = 64

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -42,7 +42,7 @@ from vllm.v1.worker.utils import select_common_block_size
 
 BLOCK_SIZE = 16
 NUM_BLOCKS = 10
-DEVICE = current_platform.device_type
+DEVICE_TYPE = current_platform.device_type
 
 
 def initialize_kv_cache(runner: GPUModelRunner):
@@ -118,7 +118,7 @@ def model_runner():
         vllm_config.compilation_config.static_forward_context["layer.0"] = Attention(
             num_heads, head_size, 0.1
         )
-        runner = GPUModelRunner(vllm_config, DEVICE)
+        runner = GPUModelRunner(vllm_config, DEVICE_TYPE)
         initialize_kv_cache(runner)
         yield runner
 
@@ -337,7 +337,7 @@ def test_get_nans_in_logits(model_runner, dist_init):
             [1.0, 2.0, 3.0],
             [3.0, 2.0, 1.0],
         ],
-        device=DEVICE,
+        device=DEVICE_TYPE,
     )
     result = model_runner._get_nans_in_logits(logits)
     assert result == {"req_0": 0, "req_1": 0}
@@ -347,7 +347,7 @@ def test_get_nans_in_logits(model_runner, dist_init):
             [1.0, float("nan"), 3.0],
             [4.0, float("nan"), float("nan")],
         ],
-        device=DEVICE,
+        device=DEVICE_TYPE,
     )
     result = model_runner._get_nans_in_logits(logits)
     assert result == {"req_0": 1, "req_1": 2}
@@ -357,7 +357,7 @@ def test_get_nans_in_logits(model_runner, dist_init):
             [1.0, 2.0, 3.0],
             [4.0, float("nan"), float("nan")],
         ],
-        device=DEVICE,
+        device=DEVICE_TYPE,
     )
     result = model_runner._get_nans_in_logits(logits)
     assert result == {"req_0": 0, "req_1": 2}
@@ -369,7 +369,7 @@ def test_get_nans_in_logits(model_runner, dist_init):
         [
             [1.0, float("nan"), 3.0],
         ],
-        device=DEVICE,
+        device=DEVICE_TYPE,
     )
     result = model_runner._get_nans_in_logits(logits)
     assert result == {"req_0": 1, "req_1": 0}
@@ -380,7 +380,7 @@ def test_get_nans_in_logits(model_runner, dist_init):
             [1.0, 2.0, 3.0],
             [float("nan"), 2.0, 3.0],
         ],
-        device=DEVICE,
+        device=DEVICE_TYPE,
     )
     result = model_runner._get_nans_in_logits(logits)
     assert result == {"req_0": 2, "req_1": 0}
@@ -640,7 +640,7 @@ def test_init_kv_cache_without_kv_sharing(default_vllm_config):
     # Set high context length to test max context length estimation
     vllm_config.model_config.max_model_len = 3_000_000
     vllm_ctx = vllm_config.compilation_config.static_forward_context
-    runner = GPUModelRunner(vllm_config, DEVICE)
+    runner = GPUModelRunner(vllm_config, DEVICE_TYPE)
     kv_cache_spec = runner.get_kv_cache_spec()
     assert len(kv_cache_spec) == 2
     assert len(runner.shared_kv_cache_layers) == 0
@@ -708,7 +708,7 @@ def test_init_kv_cache_with_kv_sharing_valid(default_vllm_config):
     # Set high context length to test max context length estimation
     vllm_config.model_config.max_model_len = 3_000_000
     vllm_ctx = vllm_config.compilation_config.static_forward_context
-    runner = GPUModelRunner(vllm_config, DEVICE)
+    runner = GPUModelRunner(vllm_config, DEVICE_TYPE)
     kv_cache_spec = runner.get_kv_cache_spec()
     assert len(kv_cache_spec) == 1
     assert layer_0 in kv_cache_spec
@@ -847,7 +847,7 @@ def test_hybrid_attention_mamba_tensor_shapes():
         assert fwd_context is not None
         vllm_ctx = vllm_config.compilation_config.static_forward_context
 
-        runner = GPUModelRunner(vllm_config, DEVICE)
+        runner = GPUModelRunner(vllm_config, DEVICE_TYPE)
         kv_cache_spec = runner.get_kv_cache_spec()
 
         available_memory = 5 * GiB_bytes
@@ -892,13 +892,13 @@ def test_hybrid_attention_mamba_tensor_shapes():
     ssm_constant_shape = ssm_shape[1:]
 
     attn_blocks_constant = torch.full(
-        (test_block_size, *attn_constant_shape), device=DEVICE, fill_value=3.33
+        (test_block_size, *attn_constant_shape), device=DEVICE_TYPE, fill_value=3.33
     )
     conv_blocks_constant = torch.full(
-        (test_block_size, *conv_constant_shape), device=DEVICE, fill_value=6.66
+        (test_block_size, *conv_constant_shape), device=DEVICE_TYPE, fill_value=6.66
     )
     ssm_blocks_constant = torch.full(
-        (test_block_size, *ssm_constant_shape), device=DEVICE, fill_value=9.99
+        (test_block_size, *ssm_constant_shape), device=DEVICE_TYPE, fill_value=9.99
     )
 
     # Fill attention blocks with constants using kv block indices
@@ -966,7 +966,7 @@ def test_hybrid_block_table_initialization():
         max_num_blocks_per_req=max_num_blocks_per_req,
         max_num_batched_tokens=max_num_batched_tokens,
         pin_memory=False,
-        device=torch.device(DEVICE),
+        device=torch.device(DEVICE_TYPE),
         kernel_block_size=kernel_block_sizes[0],
         cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
     )
@@ -1005,7 +1005,7 @@ def test_input_batch_with_kernel_block_sizes():
     max_num_reqs = 10
     max_model_len = 512
     max_num_batched_tokens = 512
-    device = torch.device(DEVICE)
+    device = torch.device(DEVICE_TYPE)
     pin_memory = False
     vocab_size = 50272
 
@@ -1052,7 +1052,7 @@ def test_hybrid_cache_integration(default_vllm_config, dist_init):
         num_heads, head_size, 0.1
     )
 
-    runner = GPUModelRunner(vllm_config, DEVICE)
+    runner = GPUModelRunner(vllm_config, DEVICE_TYPE)
 
     # Initialize KV cache with configuration
     attn_spec = FullAttentionSpec(
@@ -1275,7 +1275,7 @@ def test_cudagraph_sizes_capped_for_mamba_cache():
             )
         assert fwd_context is not None
 
-        runner = GPUModelRunner(vllm_config, DEVICE)
+        runner = GPUModelRunner(vllm_config, DEVICE_TYPE)
         kv_cache_spec = runner.get_kv_cache_spec()
 
         available_memory = 5 * GiB_bytes


### PR DESCRIPTION
## Purpose
this pr will replace hardcoded device strings in vllm tests that other accelerator can reuse the tests.

f"cuda:{rank}"  ==> f"{current_platform.device_type}:{rank}"
torch.set_default_device("cuda")  ==> torch.set_default_device(current_platform.device_type)
                                   to("cuda")  ==>  to(current_platform.device_type)
                               device=cuda  ==> device=current_platform.device_type  as function argument


## Test Plan
CI
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>


