### PR TITLE
[Bugfix] Handle inaccessible GPUs in CudaPlatform.log_warnings()

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -579,8 +579,11 @@ class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
     def _get_physical_device_name(cls, device_id: int = 0) -> str:
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
-        return pynvml.nvmlDeviceGetName(handle)
+        try:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
+            return pynvml.nvmlDeviceGetName(handle)
+        except pynvml.NVMLError:
+            return f"GPU{device_id}(unavailable)"
 
     @classmethod
     @with_nvml_context


### PR DESCRIPTION
## Purpose

Fix `CudaPlatform._get_physical_device_name()` crashing on machines with physically faulty or inaccessible GPUs.

`_get_physical_device_name()` calls `nvmlDeviceGetHandleByIndex()` without error handling. In vllm 0.17.0, `CudaPlatform.log_warnings()` is invoked at module import time and enumerates **all physical GPUs** via pynvml — regardless of `CUDA_VISIBLE_DEVICES`, which pynvml ignores. On machines where one GPU is hardware-faulted, pynvml raises `NVMLError_Unknown` for that device, causing the entire vllm import chain to fail before any user code runs:

```
vllm.third_party.pynvml.NVMLError_Unknown: Unknown Error
  File "vllm/platforms/cuda.py", line 644, in <module>
    CudaPlatform.log_warnings()
  File "vllm/platforms/cuda.py", line 590, in log_warnings
    device_names = [cls._get_physical_device_name(i) for i in range(device_ids)]
  File "vllm/platforms/cuda.py", line 582, in _get_physical_device_name
    handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
```

This makes `from vllm import LLM` completely unusable even when the target GPU (e.g. `CUDA_VISIBLE_DEVICES=2`) is healthy.

Fix: wrap `_get_physical_device_name` in a `try/except` so that unreachable devices are reported as `"GPU{id}(unavailable)"` rather than raising.

## Test Plan

Reproduce on a machine with a faulted GPU visible to NVML:

```python
# Before fix — raises NVMLError_Unknown at import time
from vllm import LLM

# After fix — imports cleanly, warning includes "GPU3(unavailable)"
from vllm import LLM
```

Unit test (no special hardware needed) — mock `nvmlDeviceGetHandleByIndex` to raise:

```python
from unittest.mock import patch
import vllm.third_party.pynvml as pynvml

def test_log_warnings_with_faulty_gpu():
    original_count = pynvml.nvmlDeviceGetCount

    def mock_count():
        return 2

    def mock_get_handle(i):
        if i == 1:
            raise pynvml.NVMLError(pynvml.NVML_ERROR_UNKNOWN)
        return original_get_handle(i)

    from vllm.platforms.cuda import CudaPlatform
    original_get_handle = pynvml.nvmlDeviceGetHandleByIndex
    with patch.object(pynvml, "nvmlDeviceGetCount", mock_count), \
         patch.object(pynvml, "nvmlDeviceGetHandleByIndex", mock_get_handle):
        # Should not raise
        name = CudaPlatform._get_physical_device_name(1)
        assert name == "GPU1(unavailable)"
```

## Test Result

Before: `from vllm import LLM` raises `NVMLError_Unknown` at module load on affected machines.

After: import succeeds; `log_warnings()` logs device names with faulted devices shown as `GPU{id}(unavailable)`.
