### PR TITLE
fix: Add missing k_scale attribute to Attention for weight offloading

### DIFF
--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -151,7 +151,9 @@ class BaseKVCacheMethod(QuantizeMethodBase):
                 "available in the fp8 checkpoint."
             )
 
-        del layer.k_scale
-        del layer.v_scale
-        del layer.q_scale
-        del layer.prob_scale
+        # Note: We intentionally do NOT delete k_scale, v_scale, q_scale, and
+        # prob_scale here. These are nn.Parameter objects that may be needed
+        # by weight offloading mechanisms. The values are copied to _k_scale,
+        # _v_scale, etc. for use in the forward pass, but the original
+        # parameters must be preserved for offloading compatibility.
+        # See: https://github.com/vllm-project/vllm/issues/37176


### PR DESCRIPTION
## Description

Fixes #37176

The `BaseKVCacheMethod.create_weights()` creates `k_scale`, `v_scale`, `q_scale`, and `prob_scale` as nn.Parameter objects for weight loading. However, `process_weights_after_loading()` was deleting these parameters with `del layer.k_scale`, etc.

This caused weight offloading to fail with:
```
AttributeError: 'Attention' object has no attribute 'k_scale'. Did you mean: '_k_scale'?
```

The offloader captures all parameters during module initialization, then fails when trying to access them after they've been deleted in `process_weights_after_loading()`.

## Fix

Remove the `del` statements for `k_scale`, `v_scale`, `q_scale`, and `prob_scale`. The values are still copied to `_k_scale`, `_v_scale`, etc. for use in the forward pass, but the original parameters are now preserved for offloading compatibility.

## Testing

- Verified that the fix preserves the parameters needed by weight offloading
- The fix is minimal and only removes the problematic `del` statements