### PR TITLE
[CI][BugFix][MORI][AMD] Add transfer_id to kv transfer params for test

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -84,11 +84,13 @@ def mock_parallel_groups():
         yield mock_group
 
 
-def _setup_kv_transfer_request(request, remote_host="127.0.0.1", fake_port=4789):
+def _setup_kv_transfer_request(
+    request, remote_host="127.0.0.1", fake_port=4789, fake_transfer_id="0"
+):
     """Setup KV transfer parameters for a request."""
     request.kv_transfer_params.update(
         {
-            "transfer_id": "0",
+            "transfer_id": fake_transfer_id,
             "remote_notify_port": fake_port,
             "remote_block_ids": None,
             "remote_host": remote_host,

--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -88,6 +88,7 @@ def _setup_kv_transfer_request(request, remote_host="127.0.0.1", fake_port=4789)
     """Setup KV transfer parameters for a request."""
     request.kv_transfer_params.update(
         {
+            "transfer_id": 0,
             "remote_notify_port": fake_port,
             "remote_block_ids": None,
             "remote_host": remote_host,

--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -88,7 +88,7 @@ def _setup_kv_transfer_request(request, remote_host="127.0.0.1", fake_port=4789)
     """Setup KV transfer parameters for a request."""
     request.kv_transfer_params.update(
         {
-            "transfer_id": 0,
+            "transfer_id": "0",
             "remote_notify_port": fake_port,
             "remote_block_ids": None,
             "remote_host": remote_host,


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
The `test_morrio_connector.py` tests fail because the `transfer_id `is not added into the KV transfer params.
This PR adds the transfer_id into the KV transfer params so the tests pass.
## Test Plan
` pytest -sv v1/kv_connector/unit/test_moriio_connector.py`
## Test Result
`3 passed, 2 skipped, 3 warnings in 4.45s`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

