### PR TITLE
Fix minimax m2.5 nvfp4 kv scales weight loading

### DIFF
--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -439,6 +439,17 @@ class MiniMaxM2Model(nn.Module):
                 if is_pp_missing_parameter(name, self):
                     continue
 
+                # Remap qkv_proj.[kv]_scale to attn.[kv]_scale
+                if name.endswith((".k_scale", ".v_scale")):
+                    remapped_name = maybe_remap_kv_scale_name(name, params_dict)
+                    if remapped_name is not None and remapped_name in params_dict:
+                        param = params_dict[remapped_name]
+                        weight_loader = getattr(
+                            param, "weight_loader", default_weight_loader
+                        )
+                        weight_loader(param, loaded_weight)
+                        break
+
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)


### PR DESCRIPTION
## Purpose
Fix kv scale weight loading issue in minimax m2.5 nvfp4:
```
vllm serve nvidia/MiniMax-M2.5-NVFP4     --trust-remote-code   --tensor-parallel-size 2
```

```
 [multiproc_executor.py:852]   File "/vllm/vllm/model_executor/models/utils.py", line 268, in _load_module
 [multiproc_executor.py:852]     loaded_params = module_load_weights(weights)
 [multiproc_executor.py:852]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 [multiproc_executor.py:852]   File "/vllm/vllm/model_executor/models/minimax_m2.py", line 442, in load_weights
 [multiproc_executor.py:852]     param = params_dict[name]
 [multiproc_executor.py:852]             ~~~~~~~~~~~^^^^^^
 [multiproc_executor.py:852] KeyError: 'layers.0.self_attn.qkv_proj.k_scale'
```

## Test Plan
```
lm_eval --model local-completions --model_args "base_url=http://0.0.0.0:8000/v1/completions,max_length=8192,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" --tasks gsm8k --num_fewshot 5
```

## Test Result
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9310|±  |0.0070|
|     |       |strict-match    |     5|exact_match|↑  |0.9287|±  |0.0071|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

