### PR TITLE
[Bugfix] Fix render server crash for quantized models on CPU-only hosts

### DIFF
--- a/vllm/entrypoints/cli/launch.py
+++ b/vllm/entrypoints/cli/launch.py
@@ -116,6 +116,11 @@ async def run_launch_fastapi(args: argparse.Namespace) -> None:
     # 2. Build and serve the API server
     engine_args = AsyncEngineArgs.from_cli_args(args)
     model_config = engine_args.create_model_config()
+
+    # Render servers preprocess data only — no inference, no quantized kernels.
+    # Clear quantization so VllmConfig skips quant dtype/capability validation.
+    model_config.quantization = None
+
     vllm_config = VllmConfig(model_config=model_config)
     shutdown_task = await build_and_serve_renderer(
         vllm_config, listen_address, sock, args


### PR DESCRIPTION
**Description:**

Currently, running `vllm launch render` with a quantized model (like `openai/gpt-oss-120b` using `mxfp4`) crashes on CPU-only hosts that lack native `bfloat16` support. 

This happens because the system auto-detects the `mxfp4` quantization and tries to validate it. On hardware without `bfloat16` support, the system automatically falls back to `float16`. However, `float16` isn't a supported data type for `mxfp4`, which triggers a validation error during startup.

Since the render server is strictly for preprocessing and postprocessing (handling token IDs and multimodal placeholders) and doesn't run any actual model inference, it doesn't need the quantization config at all. 

This PR fixes the issue by simply setting `model_config.quantization = None` in the render path before constructing the config. This safely bypasses the unnecessary validation check without affecting functionality.

**Testing:**

- Ran `vllm launch render --model openai/gpt-oss-120b`. The server now starts up correctly instead of throwing the Pydantic validation error.
- `tests/entrypoints/openai/test_launch_render.py` passed
- `tests/entrypoints/test_launch_cli.py` passed


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

