### PR TITLE
[ROCm] Fix AttributeError for torch.compiler.skip_all_guards_unsafe on older PyTorch

### DIFF
--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -112,11 +112,12 @@ class TorchCompileWithNoGuardsWrapper:
                     entry.guard_type == "SHAPE_ENV" for entry in x
                 ]
             else:
-                options["guard_filter_fn"] = getattr(
-                    torch.compiler,
-                    "skip_all_guards_unsafe",
-                    lambda x: [False for _ in x],
-                )
+                if hasattr(torch.compiler, "skip_all_guards_unsafe"):
+                    # Torch 2.10+ provides skip_all_guards_unsafe
+                    options["guard_filter_fn"] = torch.compiler.skip_all_guards_unsafe
+                else:
+                    # Equivalent fallback for older PyTorch: skip all guards
+                    options["guard_filter_fn"] = lambda x: [False for _ in x]
 
         compiled_ptr: Any = self.forward
         # Validate that unbacked dynamic shapes require VLLM_USE_BYTECODE_HOOK=False

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -112,10 +112,11 @@ class TorchCompileWithNoGuardsWrapper:
                     entry.guard_type == "SHAPE_ENV" for entry in x
                 ]
             else:
-                if hasattr(torch.compiler, "skip_all_guards_unsafe"):
-                    options["guard_filter_fn"] = torch.compiler.skip_all_guards_unsafe
-                else:
-                    options["guard_filter_fn"] = lambda x: [False for _ in x]
+                options["guard_filter_fn"] = getattr(
+                    torch.compiler,
+                    "skip_all_guards_unsafe",
+                    lambda x: [False for _ in x],
+                )
 
         compiled_ptr: Any = self.forward
         # Validate that unbacked dynamic shapes require VLLM_USE_BYTECODE_HOOK=False

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -112,7 +112,10 @@ class TorchCompileWithNoGuardsWrapper:
                     entry.guard_type == "SHAPE_ENV" for entry in x
                 ]
             else:
-                options["guard_filter_fn"] = torch.compiler.skip_all_guards_unsafe
+                if hasattr(torch.compiler, "skip_all_guards_unsafe"):
+                    options["guard_filter_fn"] = torch.compiler.skip_all_guards_unsafe
+                else:
+                    options["guard_filter_fn"] = lambda x: [False for _ in x]
 
         compiled_ptr: Any = self.forward
         # Validate that unbacked dynamic shapes require VLLM_USE_BYTECODE_HOOK=False


### PR DESCRIPTION
- #36204 replaced the guard filter lambda with `torch.compiler.skip_all_guards_unsafe`, which doesn't exist in PyTorch < 2.10
- Adds a `hasattr` check to fall back to the equivalent `lambda x: [False for _ in x]` on older versions
- Fixes `AttributeError: module 'torch.compiler' has no attribute 'skip_all_guards_unsafe'` when running any model inference

## Test plan
- [ ] `pytest -s-v tests/test_regression.py::test_max_tokens_none`
- [ ] `pytest -s -v tests/v1/entrypoints/llm/test_struct_output_generate.py`

cc @kenroche 