### PR TITLE
[Perf] Optimize top-k search in apply_top_k_top_p_triton sampler

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -188,7 +188,7 @@ def _topk_topp_kernel(
                         min_larger_1 = float("inf")
                         num_min_larger_1 = tl.zeros((), dtype=tl.uint32)
 
-                        # First pass: Calculate k_pivots_num and min_larger
+                        # Single pass: k_pivots_num, min_larger, num_min_larger
                         for i in range(0, search_iters):
                             offs_n = i * BLOCK_SIZE_TRUNC + tl.arange(
                                 0, BLOCK_SIZE_TRUNC
@@ -198,28 +198,42 @@ def _topk_topp_kernel(
                                 BUFFER_ROW + offs_n, mask=mask_n_2, other=-float("inf")
                             )
 
-                            k_pivots_num_0 += tl.sum(logits_blk2 > k_pivot_0)
-                            k_pivots_num_1 += tl.sum(logits_blk2 > k_pivot_1)
+                            above_0 = logits_blk2 > k_pivot_0
+                            above_1 = logits_blk2 > k_pivot_1
+                            k_pivots_num_0 += tl.sum(above_0)
+                            k_pivots_num_1 += tl.sum(above_1)
 
-                            min_larger_0 = tl.minimum(min_larger_0, tl.min(logits_blk2))
-                            min_larger_1 = tl.minimum(min_larger_1, tl.min(logits_blk2))
+                            tile_min_0 = tl.min(
+                                tl.where(above_0, logits_blk2, float("inf"))
+                            )
+                            tile_eq_0 = above_0 & (
+                                tl.abs(logits_blk2 - tile_min_0) < 1e-9
+                            )
+                            tile_cnt_0 = tl.sum(tile_eq_0)
+                            new_0 = tile_min_0 < min_larger_0
+                            same_0 = tl.abs(tile_min_0 - min_larger_0) < 1e-9
+                            num_min_larger_0 = tl.where(
+                                new_0,
+                                tile_cnt_0,
+                                num_min_larger_0 + tile_cnt_0 * same_0,
+                            )
+                            min_larger_0 = tl.minimum(min_larger_0, tile_min_0)
 
-                        # Second pass: Calculate num_min_larger
-                        for i in range(0, search_iters):
-                            offs_n = i * BLOCK_SIZE_TRUNC + tl.arange(
-                                0, BLOCK_SIZE_TRUNC
+                            tile_min_1 = tl.min(
+                                tl.where(above_1, logits_blk2, float("inf"))
                             )
-                            mask_n_2 = offs_n < search_range
-                            logits_blk2 = tl.load(
-                                BUFFER_ROW + offs_n, mask=mask_n_2, other=-float("inf")
+                            tile_eq_1 = above_1 & (
+                                tl.abs(logits_blk2 - tile_min_1) < 1e-9
                             )
-
-                            num_min_larger_0 += tl.sum(
-                                tl.abs(logits_blk2 - min_larger_0) < 1e-9
+                            tile_cnt_1 = tl.sum(tile_eq_1)
+                            new_1 = tile_min_1 < min_larger_1
+                            same_1 = tl.abs(tile_min_1 - min_larger_1) < 1e-9
+                            num_min_larger_1 = tl.where(
+                                new_1,
+                                tile_cnt_1,
+                                num_min_larger_1 + tile_cnt_1 * same_1,
                             )
-                            num_min_larger_1 += tl.sum(
-                                tl.abs(logits_blk2 - min_larger_1) < 1e-9
-                            )
+                            min_larger_1 = tl.minimum(min_larger_1, tile_min_1)
 
                         # Check if any of the pivots satisfy termination condition
                         if (
@@ -272,7 +286,7 @@ def _topk_topp_kernel(
                         min_larger_1 = float("inf")
                         num_min_larger_1 = tl.zeros((), dtype=tl.uint32)
 
-                        # First pass: Calculate k_pivots_num and min_larger
+                        # Single pass: k_pivots_num, min_larger, num_min_larger
                         for i in range(0, NUM_TILES):
                             offs_n = i * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
                             mask_n = offs_n < VOCAB_SIZE
@@ -280,31 +294,42 @@ def _topk_topp_kernel(
                                 LOGITS_ROW + offs_n, mask=mask_n, other=-float("inf")
                             )
 
-                            k_pivots_num_0 += tl.sum(logits_blk2 > k_pivot_0)
-                            k_pivots_num_1 += tl.sum(logits_blk2 > k_pivot_1)
+                            above_0 = logits_blk2 > k_pivot_0
+                            above_1 = logits_blk2 > k_pivot_1
+                            k_pivots_num_0 += tl.sum(above_0)
+                            k_pivots_num_1 += tl.sum(above_1)
 
-                            # Exclude -inf from min_larger to avoid
-                            # poisoning the convergence check.
-                            finite_blk2 = tl.where(
-                                logits_blk2 > -float("inf"), logits_blk2, float("inf")
+                            tile_min_0 = tl.min(
+                                tl.where(above_0, logits_blk2, float("inf"))
                             )
-                            min_larger_0 = tl.minimum(min_larger_0, tl.min(finite_blk2))
-                            min_larger_1 = tl.minimum(min_larger_1, tl.min(finite_blk2))
+                            tile_eq_0 = above_0 & (
+                                tl.abs(logits_blk2 - tile_min_0) < 1e-9
+                            )
+                            tile_cnt_0 = tl.sum(tile_eq_0)
+                            new_0 = tile_min_0 < min_larger_0
+                            same_0 = tl.abs(tile_min_0 - min_larger_0) < 1e-9
+                            num_min_larger_0 = tl.where(
+                                new_0,
+                                tile_cnt_0,
+                                num_min_larger_0 + tile_cnt_0 * same_0,
+                            )
+                            min_larger_0 = tl.minimum(min_larger_0, tile_min_0)
 
-                        # Second pass: Calculate num_min_larger
-                        for i in range(0, NUM_TILES):
-                            offs_n = i * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-                            mask_n = offs_n < VOCAB_SIZE
-                            logits_blk2 = tl.load(
-                                LOGITS_ROW + offs_n, mask=mask_n, other=-float("inf")
+                            tile_min_1 = tl.min(
+                                tl.where(above_1, logits_blk2, float("inf"))
                             )
-
-                            num_min_larger_0 += tl.sum(
-                                tl.abs(logits_blk2 - min_larger_0) < 1e-9
+                            tile_eq_1 = above_1 & (
+                                tl.abs(logits_blk2 - tile_min_1) < 1e-9
                             )
-                            num_min_larger_1 += tl.sum(
-                                tl.abs(logits_blk2 - min_larger_1) < 1e-9
+                            tile_cnt_1 = tl.sum(tile_eq_1)
+                            new_1 = tile_min_1 < min_larger_1
+                            same_1 = tl.abs(tile_min_1 - min_larger_1) < 1e-9
+                            num_min_larger_1 = tl.where(
+                                new_1,
+                                tile_cnt_1,
+                                num_min_larger_1 + tile_cnt_1 * same_1,
                             )
+                            min_larger_1 = tl.minimum(min_larger_1, tile_min_1)
 
                         # Check if any of the pivots satisfy termination condition
                         if (

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -188,7 +188,20 @@ def _topk_topp_kernel(
                         min_larger_1 = float("inf")
                         num_min_larger_1 = tl.zeros((), dtype=tl.uint32)
 
-                        # Single pass: k_pivots_num, min_larger, num_min_larger
+                        # Single fused pass: compute k_pivots_num,
+                        # min_larger, and num_min_larger together to avoid
+                        # a second data scan.
+                        #
+                        # For each pivot we track:
+                        #   k_pivots_num: count of values strictly > pivot
+                        #   min_larger: smallest value among those > pivot
+                        #   num_min_larger: how many values equal min_larger
+                        #
+                        # min_larger and num_min_larger are maintained as a
+                        # running (min, count) pair across tiles:
+                        #   - new tile min < running min  → replace both
+                        #   - new tile min == running min → add to count
+                        #   - new tile min > running min  → keep as-is
                         for i in range(0, search_iters):
                             offs_n = i * BLOCK_SIZE_TRUNC + tl.arange(
                                 0, BLOCK_SIZE_TRUNC
@@ -198,18 +211,23 @@ def _topk_topp_kernel(
                                 BUFFER_ROW + offs_n, mask=mask_n_2, other=-float("inf")
                             )
 
+                            # Count values above each pivot
                             above_0 = logits_blk2 > k_pivot_0
                             above_1 = logits_blk2 > k_pivot_1
                             k_pivots_num_0 += tl.sum(above_0)
                             k_pivots_num_1 += tl.sum(above_1)
 
+                            # --- pivot 0: track (min_larger, num_min_larger) ---
+                            # Min of values > pivot (non-qualifying → +inf)
                             tile_min_0 = tl.min(
                                 tl.where(above_0, logits_blk2, float("inf"))
                             )
+                            # Count of values in this tile equal to tile min
                             tile_eq_0 = above_0 & (
                                 tl.abs(logits_blk2 - tile_min_0) < 1e-9
                             )
                             tile_cnt_0 = tl.sum(tile_eq_0)
+                            # Merge tile (min, count) into running (min, count)
                             new_0 = tile_min_0 < min_larger_0
                             same_0 = tl.abs(tile_min_0 - min_larger_0) < 1e-9
                             num_min_larger_0 = tl.where(
@@ -219,6 +237,7 @@ def _topk_topp_kernel(
                             )
                             min_larger_0 = tl.minimum(min_larger_0, tile_min_0)
 
+                            # --- pivot 1: same logic ---
                             tile_min_1 = tl.min(
                                 tl.where(above_1, logits_blk2, float("inf"))
                             )
@@ -286,7 +305,9 @@ def _topk_topp_kernel(
                         min_larger_1 = float("inf")
                         num_min_larger_1 = tl.zeros((), dtype=tl.uint32)
 
-                        # Single pass: k_pivots_num, min_larger, num_min_larger
+                        # Single fused pass — same logic as the buffer
+                        # path above: compute k_pivots_num, min_larger, and
+                        # num_min_larger together over the full vocab.
                         for i in range(0, NUM_TILES):
                             offs_n = i * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
                             mask_n = offs_n < VOCAB_SIZE
@@ -299,6 +320,7 @@ def _topk_topp_kernel(
                             k_pivots_num_0 += tl.sum(above_0)
                             k_pivots_num_1 += tl.sum(above_1)
 
+                            # --- pivot 0: track (min_larger, num_min_larger) ---
                             tile_min_0 = tl.min(
                                 tl.where(above_0, logits_blk2, float("inf"))
                             )
@@ -315,6 +337,7 @@ def _topk_topp_kernel(
                             )
                             min_larger_0 = tl.minimum(min_larger_0, tile_min_0)
 
+                            # --- pivot 1: same logic ---
                             tile_min_1 = tl.min(
                                 tl.where(above_1, logits_blk2, float("inf"))
                             )

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -68,6 +68,29 @@ _PERCENTILE_TO_STD_TABLE = [
 
 
 @triton.jit
+def _update_min_larger_stats(data, above_mask, min_larger, num_min_larger, sentinel):
+    """Update running (min, count) of values above a pivot across tiles.
+
+    Tracks the smallest value strictly above a pivot and how many times
+    it occurs.  Called once per tile per pivot; the running state is
+    carried across tiles via `min_larger` / `num_min_larger`.
+
+    Merge rule:
+      - tile min < running min  → replace both
+      - tile min == running min → accumulate count
+      - tile min > running min  → keep running values
+    """
+    tile_min = tl.min(tl.where(above_mask, data, sentinel))
+    tile_eq = above_mask & (tl.abs(data - tile_min) < 1e-9)
+    tile_cnt = tl.sum(tile_eq)
+    is_new = tile_min < min_larger
+    is_same = tl.abs(tile_min - min_larger) < 1e-9
+    num_min_larger = tl.where(is_new, tile_cnt, num_min_larger + tile_cnt * is_same)
+    min_larger = tl.minimum(min_larger, tile_min)
+    return min_larger, num_min_larger
+
+
+@triton.jit
 def _topk_topp_kernel(
     LOGITS,
     BUFFER,
@@ -190,18 +213,8 @@ def _topk_topp_kernel(
 
                         # Single fused pass: compute k_pivots_num,
                         # min_larger, and num_min_larger together to avoid
-                        # a second data scan.
-                        #
-                        # For each pivot we track:
-                        #   k_pivots_num: count of values strictly > pivot
-                        #   min_larger: smallest value among those > pivot
-                        #   num_min_larger: how many values equal min_larger
-                        #
-                        # min_larger and num_min_larger are maintained as a
-                        # running (min, count) pair across tiles:
-                        #   - new tile min < running min  → replace both
-                        #   - new tile min == running min → add to count
-                        #   - new tile min > running min  → keep as-is
+                        # a second data scan. See _update_min_larger_stats
+                        # for the tile-level merge logic.
                         for i in range(0, search_iters):
                             offs_n = i * BLOCK_SIZE_TRUNC + tl.arange(
                                 0, BLOCK_SIZE_TRUNC
@@ -211,48 +224,25 @@ def _topk_topp_kernel(
                                 BUFFER_ROW + offs_n, mask=mask_n_2, other=-float("inf")
                             )
 
-                            # Count values above each pivot
                             above_0 = logits_blk2 > k_pivot_0
                             above_1 = logits_blk2 > k_pivot_1
                             k_pivots_num_0 += tl.sum(above_0)
                             k_pivots_num_1 += tl.sum(above_1)
 
-                            # --- pivot 0: track (min_larger, num_min_larger) ---
-                            # Min of values > pivot (non-qualifying → +inf)
-                            tile_min_0 = tl.min(
-                                tl.where(above_0, logits_blk2, float("inf"))
+                            min_larger_0, num_min_larger_0 = _update_min_larger_stats(
+                                logits_blk2,
+                                above_0,
+                                min_larger_0,
+                                num_min_larger_0,
+                                float("inf"),
                             )
-                            # Count of values in this tile equal to tile min
-                            tile_eq_0 = above_0 & (
-                                tl.abs(logits_blk2 - tile_min_0) < 1e-9
+                            min_larger_1, num_min_larger_1 = _update_min_larger_stats(
+                                logits_blk2,
+                                above_1,
+                                min_larger_1,
+                                num_min_larger_1,
+                                float("inf"),
                             )
-                            tile_cnt_0 = tl.sum(tile_eq_0)
-                            # Merge tile (min, count) into running (min, count)
-                            new_0 = tile_min_0 < min_larger_0
-                            same_0 = tl.abs(tile_min_0 - min_larger_0) < 1e-9
-                            num_min_larger_0 = tl.where(
-                                new_0,
-                                tile_cnt_0,
-                                num_min_larger_0 + tile_cnt_0 * same_0,
-                            )
-                            min_larger_0 = tl.minimum(min_larger_0, tile_min_0)
-
-                            # --- pivot 1: same logic ---
-                            tile_min_1 = tl.min(
-                                tl.where(above_1, logits_blk2, float("inf"))
-                            )
-                            tile_eq_1 = above_1 & (
-                                tl.abs(logits_blk2 - tile_min_1) < 1e-9
-                            )
-                            tile_cnt_1 = tl.sum(tile_eq_1)
-                            new_1 = tile_min_1 < min_larger_1
-                            same_1 = tl.abs(tile_min_1 - min_larger_1) < 1e-9
-                            num_min_larger_1 = tl.where(
-                                new_1,
-                                tile_cnt_1,
-                                num_min_larger_1 + tile_cnt_1 * same_1,
-                            )
-                            min_larger_1 = tl.minimum(min_larger_1, tile_min_1)
 
                         # Check if any of the pivots satisfy termination condition
                         if (
@@ -305,9 +295,8 @@ def _topk_topp_kernel(
                         min_larger_1 = float("inf")
                         num_min_larger_1 = tl.zeros((), dtype=tl.uint32)
 
-                        # Single fused pass — same logic as the buffer
-                        # path above: compute k_pivots_num, min_larger, and
-                        # num_min_larger together over the full vocab.
+                        # Single fused pass over full vocab (same approach
+                        # as the buffer path above).
                         for i in range(0, NUM_TILES):
                             offs_n = i * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
                             mask_n = offs_n < VOCAB_SIZE
@@ -320,39 +309,20 @@ def _topk_topp_kernel(
                             k_pivots_num_0 += tl.sum(above_0)
                             k_pivots_num_1 += tl.sum(above_1)
 
-                            # --- pivot 0: track (min_larger, num_min_larger) ---
-                            tile_min_0 = tl.min(
-                                tl.where(above_0, logits_blk2, float("inf"))
+                            min_larger_0, num_min_larger_0 = _update_min_larger_stats(
+                                logits_blk2,
+                                above_0,
+                                min_larger_0,
+                                num_min_larger_0,
+                                float("inf"),
                             )
-                            tile_eq_0 = above_0 & (
-                                tl.abs(logits_blk2 - tile_min_0) < 1e-9
+                            min_larger_1, num_min_larger_1 = _update_min_larger_stats(
+                                logits_blk2,
+                                above_1,
+                                min_larger_1,
+                                num_min_larger_1,
+                                float("inf"),
                             )
-                            tile_cnt_0 = tl.sum(tile_eq_0)
-                            new_0 = tile_min_0 < min_larger_0
-                            same_0 = tl.abs(tile_min_0 - min_larger_0) < 1e-9
-                            num_min_larger_0 = tl.where(
-                                new_0,
-                                tile_cnt_0,
-                                num_min_larger_0 + tile_cnt_0 * same_0,
-                            )
-                            min_larger_0 = tl.minimum(min_larger_0, tile_min_0)
-
-                            # --- pivot 1: same logic ---
-                            tile_min_1 = tl.min(
-                                tl.where(above_1, logits_blk2, float("inf"))
-                            )
-                            tile_eq_1 = above_1 & (
-                                tl.abs(logits_blk2 - tile_min_1) < 1e-9
-                            )
-                            tile_cnt_1 = tl.sum(tile_eq_1)
-                            new_1 = tile_min_1 < min_larger_1
-                            same_1 = tl.abs(tile_min_1 - min_larger_1) < 1e-9
-                            num_min_larger_1 = tl.where(
-                                new_1,
-                                tile_cnt_1,
-                                num_min_larger_1 + tile_cnt_1 * same_1,
-                            )
-                            min_larger_1 = tl.minimum(min_larger_1, tile_min_1)
 
                         # Check if any of the pivots satisfy termination condition
                         if (


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Summary
- Fix `min_larger` in top-k ternary search to compute min of values above the pivot instead of the global min. This makes the termination condition converge correctly (~3-5 iterations instead of hitting the 18-iteration cap).
- Fuse the `num_min_larger` second pass into the first pass for the top-k paths, eliminating a redundant full data scan per search iteration.

## Benchmark results (benchmark_topk_topp.py)
- **top-k only: 17–28% faster** across all batch sizes and vocab sizes
- **top-k + top-p combined: 16–25% faster**
- **top-p only: unchanged** (not touched)

| Scenario | Batch | Vocab | Before (ms) | After (ms) | Δ |
|---|---|---|---|---|---|
| topk_whole | 128 | 32k | 0.071 | 0.056 | -21% |
| topk_whole | 2048 | 32k | 0.761 | 0.550 | -28% |
| topk_whole | 2048 | 128k | 2.312 | 1.891 | -18% |
| topk_topp_whole | 2048 | 32k | 1.211 | 0.907 | -25% |
| topk_topp_whole | 2048 | 128k | 3.206 | 2.652 | -17% |

## Test plan
- [x] `pytest tests/v1/sample/test_topk_topp_sampler.py -v` passes
- [x] `benchmarks/benchmark_topk_topp.py` shows no regressions

Co-authored-by: Claude <noreply@anthropic.com>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

