### PR TITLE
Fix Qwen3.5-Next RMSNormGated Initialization Error on TPU

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -501,7 +501,6 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             eps=self.layer_norm_epsilon,
             group_size=None,
             norm_before_gate=True,
-            device=current_platform.current_device(),
         )
 
         self.out_proj = RowParallelLinear(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Similar to https://github.com/vllm-project/vllm/pull/33501 -- fixes the following error seen on TPU:

```
# CMD
vllm serve Qwen/Qwen3.5-397B-A17B-FP8 --tensor-parallel-size=8 --kv-cache-dtype=fp8 --limit-mm-per-prompt '{"image": 0, "video": 0}'

# Error
(EngineCore pid=3259063) ERROR 03-16 20:56:27 [core.py:1099]   File "/mnt/disks/jacobplatin/vllm/vllm/model_executor/models/qwen3_5.py", line 245, in __init__
(EngineCore pid=3259063) ERROR 03-16 20:56:27 [core.py:1099]     self.linear_attn = Qwen3_5GatedDeltaNet(
(EngineCore pid=3259063) ERROR 03-16 20:56:27 [core.py:1099]                        ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3259063) ERROR 03-16 20:56:27 [core.py:1099]   File "/mnt/disks/jacobplatin/vllm/vllm/model_executor/models/qwen3_next.py", line 504, in __init__
(EngineCore pid=3259063) ERROR 03-16 20:56:27 [core.py:1099]     device=current_platform.current_device(),
(EngineCore pid=3259063) ERROR 03-16 20:56:27 [core.py:1099]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=3259063) ERROR 03-16 20:56:27 [core.py:1099] TypeError: 'NoneType' object is not callable
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

