### PR TITLE
Fix EagleMistralLarge3Model initialization

### DIFF
--- a/vllm/model_executor/models/mistral_large_3_eagle.py
+++ b/vllm/model_executor/models/mistral_large_3_eagle.py
@@ -74,6 +74,7 @@ class EagleMistralLarge3Model(DeepseekV2Model):
             prefix=maybe_prefix(prefix, "fc"),
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.aux_hidden_state_layers: tuple[int, ...] = ()
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
         )


### PR DESCRIPTION
## Purpose

This PR fixes initialization of `EagleMistralLarge3Model` due to #36361 that added `aux_hidden_state_layers` init requirement.

## Test Plan

ran an inference

## Test Result

on main it raises error, now it works :)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

