### PR TITLE
[Perf] Support Flashinfer trtllm tinygemm_bf16 router gemm for GPT-OSS

### DIFF
--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -15,25 +15,34 @@ if has_flashinfer():
         x: torch.Tensor,
         weight: torch.Tensor,
         bias: torch.Tensor | None,
-        out: torch.Tensor,
-    ) -> None:
+    ) -> torch.Tensor:
         from flashinfer.gemm.routergemm import tinygemm_bf16
 
-        tinygemm_bf16(x, weight, out, bias)
+        output = torch.empty(
+            x.shape[0],
+            weight.shape[0],
+            dtype=torch.bfloat16,
+            device=x.device,
+        )
+        tinygemm_bf16(x, weight, output, bias)
+        return output
 
     def flashinfer_tinygemm_router_gemm_fake(
         x: torch.Tensor,
         weight: torch.Tensor,
         bias: torch.Tensor | None,
-        out: torch.Tensor,
-    ) -> None:
-        return
+    ) -> torch.Tensor:
+        return torch.empty(
+            x.shape[0],
+            weight.shape[0],
+            dtype=torch.bfloat16,
+            device=x.device,
+        )
 
     direct_register_custom_op(
         op_name="flashinfer_tinygemm_router_gemm",
         op_func=flashinfer_tinygemm_router_gemm_impl,
         fake_impl=flashinfer_tinygemm_router_gemm_fake,
-        mutates_args=["out"],
     )
 
 
@@ -65,12 +74,11 @@ class GateLinear(ReplicatedLinear):
         force_fp32_compute: bool = False,
         prefix: str = "",
     ):
-        is_hopper_or_blackwell = current_platform.is_device_capability(
-            (9, 0)
-        ) or current_platform.is_device_capability_family(100)
-        can_use_specialized_kernels = (
-            current_platform.is_cuda() and is_hopper_or_blackwell
+        is_hopper_or_blackwell = current_platform.is_cuda() and (
+            current_platform.is_device_capability((9, 0))
+            or current_platform.is_device_capability_family(100)
         )
+        can_use_specialized_kernels = is_hopper_or_blackwell and not bias
 
         # If fp32 compute is required and no specialized kernel is available,
         # store weights in fp32 so Tier 3 computes in fp32 natively.
@@ -87,33 +95,29 @@ class GateLinear(ReplicatedLinear):
         )
         self.out_dtype = out_dtype
 
+        # DSV3 specialized kernel eligibility (SM90+, exact dims)
         self.allow_specialized_router_gemm = can_use_specialized_kernels
-        self.allow_specialized_router_gemm_no_bias = (
-            can_use_specialized_kernels and not bias
-        )
-
-        # DSV3 specialized kernel eligibility (SM90+, exact dims, no bias)
         self.allow_dsv3_router_gemm = (
-            self.allow_specialized_router_gemm_no_bias
+            self.allow_specialized_router_gemm
             and output_size in self.DSV3_SUPPORTED_NUM_EXPERTS
             and input_size in self.DSV3_SUPPORTED_HIDDEN_SIZES
         )
 
-        # cuBLAS bf16→fp32 eligibility (no bias)
+        # cuBLAS bf16→fp32 eligibility
         self.allow_cublas_router_gemm = (
-            self.allow_specialized_router_gemm_no_bias
+            self.allow_specialized_router_gemm
             and self.weight.dtype == torch.bfloat16
             and self.out_dtype == torch.float32
         )
 
         # Flashinfer tinygemm_bf16 (SM90+, aligned dims, supports bias)
-        self.allow_tinygemm_router_gemm = (
-            self.allow_specialized_router_gemm
+        self.allow_flashinfer_tinygemm_router_gemm = (
+            is_hopper_or_blackwell
+            and has_flashinfer()
             and self.weight.dtype == torch.bfloat16
-            and self.out_dtype != torch.float32
+            and self.out_dtype in [None, torch.bfloat16]
             and input_size % 64 == 0
             and output_size % 16 == 0
-            and has_flashinfer()
         )
 
     def set_out_dtype(self, out_dtype: torch.dtype) -> None:
@@ -128,14 +132,14 @@ class GateLinear(ReplicatedLinear):
 
         if (
             not self.allow_cublas_router_gemm
-            and self.allow_specialized_router_gemm_no_bias
+            and self.allow_specialized_router_gemm
             and out_dtype == torch.float32
         ):
             self.allow_cublas_router_gemm = self.weight.dtype == torch.bfloat16
 
         # tinygemm outputs bf16 — disable if fp32 output is now required
         if out_dtype == torch.float32:
-            self.allow_tinygemm_router_gemm = False
+            self.allow_flashinfer_tinygemm_router_gemm = False
 
     def forward(
         self, x: torch.Tensor
@@ -157,15 +161,13 @@ class GateLinear(ReplicatedLinear):
             return output, None
 
         # Tier 3: Flashinfer tinygemm_bf16
-        if self.allow_tinygemm_router_gemm and x.dtype == torch.bfloat16:
-            output = torch.empty(
-                x.shape[0],
-                self.weight.shape[0],
-                dtype=torch.bfloat16,
-                device=x.device,
-            )
-            torch.ops.vllm.flashinfer_tinygemm_router_gemm(
-                x, self.weight, self.bias, output
+        if (
+            self.allow_flashinfer_tinygemm_router_gemm
+            and x.dtype == torch.bfloat16
+            and x.shape[0] <= 128
+        ):
+            output = torch.ops.vllm.flashinfer_tinygemm_router_gemm(
+                x, self.weight, self.bias
             )
             return output, None
 

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -14,7 +14,7 @@ if has_flashinfer():
     def flashinfer_tinygemm_router_gemm_impl(
         x: torch.Tensor,
         weight: torch.Tensor,
-        bias: torch.Tensor,
+        bias: torch.Tensor | None,
         out: torch.Tensor,
     ) -> None:
         from flashinfer.gemm.routergemm import tinygemm_bf16
@@ -24,7 +24,7 @@ if has_flashinfer():
     def flashinfer_tinygemm_router_gemm_fake(
         x: torch.Tensor,
         weight: torch.Tensor,
-        bias: torch.Tensor,
+        bias: torch.Tensor | None,
         out: torch.Tensor,
     ) -> None:
         return

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -6,15 +6,45 @@ from torch.nn.parameter import Parameter
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer
+from vllm.utils.torch_utils import direct_register_custom_op
+
+if has_flashinfer():
+
+    def flashinfer_tinygemm_router_gemm_impl(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        out: torch.Tensor,
+    ) -> None:
+        from flashinfer.gemm.routergemm import tinygemm_bf16
+
+        tinygemm_bf16(x, weight, out, bias)
+
+    def flashinfer_tinygemm_router_gemm_fake(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        out: torch.Tensor,
+    ) -> None:
+        return
+
+    direct_register_custom_op(
+        op_name="flashinfer_tinygemm_router_gemm",
+        op_func=flashinfer_tinygemm_router_gemm_impl,
+        fake_impl=flashinfer_tinygemm_router_gemm_fake,
+        mutates_args=["out"],
+    )
 
 
 @PluggableLayer.register("gate_linear")
 class GateLinear(ReplicatedLinear):
-    """MoE gate linear layer with three-tier GEMM dispatch:
+    """MoE gate linear layer with four-tier GEMM dispatch:
 
-    1. DSV3 specialized kernel (SM90+, batch<=16, supported dims)
-    2. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 + fp32 out_dtype)
-    3. F.linear via ReplicatedLinear (ultimate fallback)
+    1. DSV3 specialized kernel (SM90+, batch<=16, supported dims, no bias)
+    2. cuBLAS bf16xbf16→fp32 (SM90+ + bf16 + fp32 out_dtype, no bias)
+    3. Flashinfer tinygemm_bf16 kernel (SM90+, aligned dims, supports bias)
+    4. F.linear via ReplicatedLinear (ultimate fallback)
 
     The ``out_dtype`` attribute is mutable and can be set after init
     (e.g. when the required dtype depends on the expert quantization
@@ -39,7 +69,7 @@ class GateLinear(ReplicatedLinear):
             (9, 0)
         ) or current_platform.is_device_capability_family(100)
         can_use_specialized_kernels = (
-            current_platform.is_cuda() and is_hopper_or_blackwell and not bias
+            current_platform.is_cuda() and is_hopper_or_blackwell
         )
 
         # If fp32 compute is required and no specialized kernel is available,
@@ -57,19 +87,33 @@ class GateLinear(ReplicatedLinear):
         )
         self.out_dtype = out_dtype
 
-        # DSV3 specialized kernel eligibility (SM90+, exact dims)
         self.allow_specialized_router_gemm = can_use_specialized_kernels
+        self.allow_specialized_router_gemm_no_bias = (
+            can_use_specialized_kernels and not bias
+        )
+
+        # DSV3 specialized kernel eligibility (SM90+, exact dims, no bias)
         self.allow_dsv3_router_gemm = (
-            self.allow_specialized_router_gemm
+            self.allow_specialized_router_gemm_no_bias
             and output_size in self.DSV3_SUPPORTED_NUM_EXPERTS
             and input_size in self.DSV3_SUPPORTED_HIDDEN_SIZES
         )
 
-        # cuBLAS bf16→fp32 eligibility
+        # cuBLAS bf16→fp32 eligibility (no bias)
         self.allow_cublas_router_gemm = (
-            self.allow_specialized_router_gemm
+            self.allow_specialized_router_gemm_no_bias
             and self.weight.dtype == torch.bfloat16
             and self.out_dtype == torch.float32
+        )
+
+        # Flashinfer tinygemm_bf16 (SM90+, aligned dims, supports bias)
+        self.allow_tinygemm_router_gemm = (
+            self.allow_specialized_router_gemm
+            and self.weight.dtype == torch.bfloat16
+            and self.out_dtype != torch.float32
+            and input_size % 64 == 0
+            and output_size % 16 == 0
+            and has_flashinfer()
         )
 
     def set_out_dtype(self, out_dtype: torch.dtype) -> None:
@@ -84,10 +128,14 @@ class GateLinear(ReplicatedLinear):
 
         if (
             not self.allow_cublas_router_gemm
-            and self.allow_specialized_router_gemm
+            and self.allow_specialized_router_gemm_no_bias
             and out_dtype == torch.float32
         ):
             self.allow_cublas_router_gemm = self.weight.dtype == torch.bfloat16
+
+        # tinygemm outputs bf16 — disable if fp32 output is now required
+        if out_dtype == torch.float32:
+            self.allow_tinygemm_router_gemm = False
 
     def forward(
         self, x: torch.Tensor
@@ -108,7 +156,20 @@ class GateLinear(ReplicatedLinear):
             output = ops.router_gemm_bf16_fp32(x, self.weight)
             return output, None
 
-        # Tier 3: F.linear (ReplicatedLinear)
+        # Tier 3: Flashinfer tinygemm_bf16
+        if self.allow_tinygemm_router_gemm and x.dtype == torch.bfloat16:
+            output = torch.empty(
+                x.shape[0],
+                self.weight.shape[0],
+                dtype=torch.bfloat16,
+                device=x.device,
+            )
+            torch.ops.vllm.flashinfer_tinygemm_router_gemm(
+                x, self.weight, self.bias, output
+            )
+            return output, None
+
+        # Tier 4: F.linear (ReplicatedLinear)
         if self.out_dtype is not None and x.dtype != self.weight.dtype:
             x = x.to(self.weight.dtype)
         output, output_bias = super().forward(x)

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -20,12 +20,11 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
 )
 from vllm.model_executor.layers.attention import Attention
-from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe import FusedMoE, GateLinear
 from vllm.model_executor.layers.fused_moe.config import FusedMoEParallelConfig
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
-    ReplicatedLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -175,14 +174,13 @@ class MLPBlock(torch.nn.Module):
         self.hidden_size = config.hidden_size
         self.experts_per_token = config.num_experts_per_tok
         self.world_size = dist.get_world_size() if dist.is_initialized() else 1
-        self.router = ReplicatedLinear(
+        self.router = GateLinear(
             config.hidden_size,
             config.num_local_experts,
             bias=True,
-            quant_config=None,
             prefix=f"{prefix}.router",
-            return_bias=False,
         )
+
         assert config.intermediate_size % self.world_size == 0
         self.experts = FusedMoE(
             num_experts=config.num_local_experts,
@@ -209,7 +207,7 @@ class MLPBlock(torch.nn.Module):
                 self, x[:, : self.hidden_size], self.router.weight, self.router.bias
             )
         else:
-            g = self.router(x)
+            g, _ = self.router(x)
         x = self.experts(hidden_states=x, router_logits=g)[:, : self.hidden_size]
 
         if self.is_sequence_parallel:


### PR DESCRIPTION

## Purpose
Support Flashinfer trtllm tinygemm_bf16 router gemm for GPT-OSS.

## Test Plan && Test Result

### nsys
PR:
```
void flashinfer::trtllm_allreduce_fusion::allreduce_fusion_kernel_oneshot_lamport   5.088 μs
void tinygemm_kernel                                                                3.136 μs
void tensorrt_llm::kernels::quantize_with_block_size                                2.848 μs
```
main:
```
void flashinfer::trtllm_allreduce_fusion::allreduce_fusion_kernel_oneshot_lamport   5.344 μs
nvjet_sm100_tst_32x64_64x16_4x1_v_bz_splitK_bias_TNN                                3.904 μs
void cublasLt::splitKreduce_kernel                                                  2.816 μs
void tensorrt_llm::kernels::quantize_with_block_size                                3.360 μs
```

### Kernel perf
GPU: NVIDIA B200
```
gpt-oss-120b: hidden_size=2880, num_experts=128, bias=True
 batch  F.linear(us)  tinygemm(us)   speedup
------------------------------------------
     1      0.0057        0.0034     1.66x
     2      0.0059        0.0034     1.72x
     4      0.0059        0.0034     1.72x
     8      0.0059        0.0034     1.72x
    16      0.0061        0.0034     1.78x
    32      0.0061        0.0034     1.78x
    64      0.0059        0.0036     1.62x
   128      0.0061        0.0036     1.68x
   256      0.0061        0.0059     1.03x
   512      0.0061        0.0104     0.59x
```
GPU: NVIDIA H100 PCIe
```
gpt-oss-120b: hidden_size=2880, num_experts=128, bias=True
 batch  F.linear(us)  tinygemm(us)   speedup
------------------------------------------
     1      0.0066        0.0037     1.79x
     2      0.0066        0.0037     1.80x
     4      0.0066        0.0037     1.79x
     8      0.0066        0.0037     1.80x
    16      0.0069        0.0038     1.84x
    32      0.0070        0.0038     1.85x
    64      0.0071        0.0041     1.74x
   128      0.0073        0.0067     1.08x
   256      0.0074        0.0104     0.71x
   512      0.0073        0.0165     0.44x
```

### E2E accuracy
PR:
```
[{'eval_name': 'gpqa', 'model_name': 'gpt-oss-120b-high_temp1.0_20260316_202021', 'metric': 0.7954545454545454}]
```
main:
```
[{'eval_name': 'gpqa', 'model_name': 'gpt-oss-120b-high_temp1.0_20260315_210654', 'metric': 0.7891414141414141}]
```

### E2E perf
PR: **about 2% perf gain**
```
============ Serving Benchmark Result ============
Successful requests:                     80
Failed requests:                         0
Maximum request concurrency:             8
Benchmark duration (s):                  29.79
Total input tokens:                      81920
Total generated tokens:                  81920
Request throughput (req/s):              2.69
Output token throughput (tok/s):         2749.91
Peak output token throughput (tok/s):    153.00
Peak concurrent requests:                16.00
Total token throughput (tok/s):          5499.81
---------------Time to First Token----------------
Mean TTFT (ms):                          57.26
Median TTFT (ms):                        65.95
P99 TTFT (ms):                           70.88
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          2.85
Median TPOT (ms):                        2.85
P99 TPOT (ms):                           2.90
---------------Inter-token Latency----------------
Mean ITL (ms):                           56.15
Median ITL (ms):                         56.96
P99 ITL (ms):                            58.44
==================================================
```
main:
```
============ Serving Benchmark Result ============
Successful requests:                     80
Failed requests:                         0
Maximum request concurrency:             8
Benchmark duration (s):                  30.68
Total input tokens:                      81920
Total generated tokens:                  81920
Request throughput (req/s):              2.61
Output token throughput (tok/s):         2670.22
Peak output token throughput (tok/s):    144.00
Peak concurrent requests:                16.00
Total token throughput (tok/s):          5340.45
---------------Time to First Token----------------
Mean TTFT (ms):                          74.49
Median TTFT (ms):                        81.17
P99 TTFT (ms):                           102.37
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          2.93
Median TPOT (ms):                        2.92
P99 TPOT (ms):                           2.98
---------------Inter-token Latency----------------
Mean ITL (ms):                           57.55
Median ITL (ms):                         58.38
P99 ITL (ms):                            59.59
==================================================
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

