### PR TITLE
[Bugfix] Fix incorrect int8 dtype cast for kv_c_normed in MLA prefill

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2503,8 +2503,7 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 else self.kv_b_proj.params_dtype
             )
             if (
-                use_fp8_prefill
-                or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
+                use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
             ) and _kv_b_proj_w_dtype != torch.int8:
                 kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2502,7 +2502,10 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 if hasattr(self.kv_b_proj, "weight")
                 else self.kv_b_proj.params_dtype
             )
-            if use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype():
+            if (
+                use_fp8_prefill
+                or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
+            ) and _kv_b_proj_w_dtype != torch.int8:
                 kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
 
             k_pe = workspace[:toks][..., self.kv_lora_rank :].unsqueeze(1)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix a runtime error in MLA (Multi-head Latent Attention) prefill path when using W8A8 INT8 quantized models.

Reproduced with [kakaocorp/kanana-2-30b-a3b-instruct-2601](https://huggingface.co/kakaocorp/kanana-2-30b-a3b-instruct-2601) (DeepSeek V3 architecture) quantized to W8A8 INT8 via [llm-compressor](https://github.com/vllm-project/llm-compressor).

When `kv_b_proj` uses INT8 weights, the existing logic incorrectly casts `kv_c_normed` to `torch.int8` before passing it to `kv_b_proj`. This causes `dynamic_scaled_int8_quant_kernel` to fail with:

NotImplementedError: "dynamic_scaled_int8_quant_kernel" not implemented for 'Char'

INT8 quantized linear layers expect **model-dtype input** (e.g., `bfloat16`) and handle quantization internally — the same way FP8 quantized layers work when `use_fp8_prefill` is disabled.

**Root cause:** The condition `_kv_b_proj_w_dtype != current_platform.fp8_dtype()` evaluates to `True` for INT8 weights, triggering an unintended `.to(torch.int8)` cast on `kv_c_normed`.

**Fix:** Add an `and _kv_b_proj_w_dtype != torch.int8` guard to skip the dtype cast when the weight dtype is INT8.

## Test Plan

- **Serving benchmark** — Verify the model serves correctly under concurrent load:

```bash
# Start server
vllm serve <model> --port 8000

# Run benchmark (32 concurrent users, 2k input tokens)
vllm bench serve \
  --model <model> \
  --dataset-name random \
  --random-input-len 2048 \
  --random-output-len 512 \
  --num-prompts 128 \
  --max-concurrency 32 \
  --request-rate inf \
  --base-url http://localhost:8000
```

## Test Result
- **Environment:** NVIDIA A100-SXM4-80GB x 1

Before fix — 126/128 requests fail during prefill:
```
NotImplementedError: "dynamic_scaled_int8_quant_kernel" not implemented for 'Char'
  at mla_attention.py:2443 → kv_b_proj(kv_c_normed)
  → compressed_tensors_w8a8_int8.py → cutlass.py → ops.scaled_int8_quant

Successful requests:   2
Failed requests:       126
```
After fix — All 128 requests succeed with no errors:
```
============ Serving Benchmark Result ============
Successful requests:                     128
Failed requests:                         0
Maximum request concurrency:             32
Benchmark duration (s):                  73.60
Total input tokens:                      262016
Total generated tokens:                  65536
Request throughput (req/s):              1.74
Output token throughput (tok/s):         890.43
Peak output token throughput (tok/s):    1251.00
Total token throughput (tok/s):          4450.39
---------------Time to First Token----------------
Mean TTFT (ms):                          1238.18
Median TTFT (ms):                        612.78
P99 TTFT (ms):                           5265.88
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          33.41
Median TPOT (ms):                        34.40
P99 TPOT (ms):                           34.96
---------------Inter-token Latency----------------
Mean ITL (ms):                           33.41
Median ITL (ms):                         27.47
P99 ITL (ms):                            155.75
==================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

