### PR TITLE
[Bugfix] dtype mismatch in ngram gpu propose

### DIFF
--- a/vllm/v1/spec_decode/ngram_proposer_gpu.py
+++ b/vllm/v1/spec_decode/ngram_proposer_gpu.py
@@ -364,7 +364,9 @@ class NgramProposerGPU:
         )
         token_ids_gpu.scatter_(1, write_positions_long, tokens_to_scatter)
 
-        num_tokens_tmp = num_tokens_no_spec + valid_sampled_tokens_count
+        num_tokens_tmp = (num_tokens_no_spec + valid_sampled_tokens_count).to(
+            torch.int32
+        )
 
         # Compute validity masks.
         sampled_flags = valid_sampled_tokens_count > 0
@@ -437,7 +439,7 @@ class NgramProposerGPU:
         )
 
         # Count valid tokens per request.
-        valid_sampled_tokens_count = valid_mask.sum(dim=1)
+        valid_sampled_tokens_count = valid_mask.sum(dim=1).to(torch.int32)
 
         # Rightmost valid index per row.
         last_valid_indices = valid_sampled_tokens_count - 1


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Related to https://github.com/vllm-project/vllm/issues/37150

The GPU ngram proposer produces incorrect draft tokens when running under VLLM_COMPILE mode (i.e., torch.compile with drop_guards).

The root cause is a dtype mismatch between the warmup/tracing phase and actual runtime:

During warmup, NgramGPUKernel.forward() is traced with num_tokens as int32 (created in _generate_dummy_data at line 354).

At runtime, num_tokens_tmp is computed as:

num_tokens_tmp = num_tokens_no_spec + valid_sampled_tokens_count 
where num_tokens_no_spec is int32 (from gpu_model_runner.py:528), but valid_sampled_tokens_count is int64 — because torch.Tensor.sum() on a bool tensor returns int64 by default in PyTorch.

Due to PyTorch's type promotion rules, int32 + int64 = int64, so num_tokens_tmp becomes int64.

Under drop_guards mode, Inductor does not recompile when the input dtype changes from int32 to int64. It reuses the int32-compiled kernel to process int64 data.

Since int64 elements are 8 bytes while the compiled kernel assumes 4-byte (int32) stride, Inductor reads every other element from the int64 tensor. The interleaved reads hit the upper 4 bytes of each int64 (which are all zeros for small values), producing 0 - ngram_len = -2 as the suffix start position.

This causes the suffix extraction to read from completely wrong positions, leading to incorrect ngram matching and wrong draft tokens.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

