### PR TITLE
fix: include prompt text in RequestLogItem for gpt-oss-20b

### DIFF
--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -610,7 +610,15 @@ class OpenAIServingResponses(OpenAIServing):
 
         messages = self._construct_input_messages_with_harmony(request, prev_response)
         prompt_token_ids = render_for_completion(messages)
-        engine_prompt = token_inputs(prompt_token_ids)
+
+        # Decode token IDs to text for logging purposes
+        tokenizer = self.renderer.get_tokenizer()
+        prompt_text = tokenizer.decode(prompt_token_ids) if tokenizer else None
+
+        engine_prompt = token_inputs(
+            prompt_token_ids,
+            prompt=prompt_text,
+        )
 
         # Add cache_salt if provided in the request
         if request.cache_salt is not None:

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -403,7 +403,15 @@ class OpenAIServingRender:
 
         # Render prompt token ids.
         prompt_token_ids = render_for_completion(messages)
-        engine_prompt = TokensPrompt(prompt_token_ids=prompt_token_ids)
+
+        # Decode token IDs to text for logging purposes
+        tokenizer = self.renderer.tokenizer
+        prompt_text = tokenizer.decode(prompt_token_ids) if tokenizer else None
+
+        engine_prompt = TokensPrompt(
+            prompt_token_ids=prompt_token_ids,
+            prompt=prompt_text,
+        )
 
         # Add cache_salt if provided in the request
         if request.cache_salt is not None:


### PR DESCRIPTION
When using gpt-oss-20b with the Chat Completion API, the prompt was logged as `None` in `RequestLogItem` because the Harmony parser only produced token IDs without the text representation.

This fix decodes the token IDs back to text using the tokenizer and includes it in the `TokensPrompt`/`TokenInputs`, so the prompt text is properly logged for debugging purposes.

Changes:
- `vllm/entrypoints/serve/render/serving.py`: Decode tokens and include prompt text in `TokensPrompt`
- `vllm/entrypoints/openai/responses/serving.py`: Same fix for Responses API

Fixes #37253
