### PR TITLE
fix(cpu_worker): Fix list index out of range in omp_cpuids_list for multi-node distributed inference

### DIFF
--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -99,7 +99,12 @@ class CPUWorker(Worker):
                 omp_cpuids_list = omp_cpuids_list[
                     local_dp_rank * world_size : (local_dp_rank + 1) * world_size
                 ]
-            self.local_omp_cpuid = omp_cpuids_list[self.rank]
+                # In multi-node setups, self.rank is the global rank, but after
+                # slicing we only have world_size entries for this DP group.
+                # Use modulo to get the correct local index within the slice.
+                self.local_omp_cpuid = omp_cpuids_list[self.rank % world_size]
+            else:
+                self.local_omp_cpuid = omp_cpuids_list[self.rank]
 
         if self.local_omp_cpuid != "nobind":
             ret = torch.ops._C.init_cpu_threads_env(self.local_omp_cpuid)


### PR DESCRIPTION
## Purpose

Fixes #37255 - In multi-node distributed setups with tensor parallelism, the CPU worker fails to start on secondary nodes with an IndexError: list index out of range when accessing "omp_cpuids_list[self.rank]".

## Root Cause

In a multi-node setup with tensor_parallel_size=2 and 2 nodes:
- Node 0 has workers with global ranks 0, 1
- Node 1 has workers with global ranks 2, 3
- The VLLM_CPU_OMP_THREADS_BIND environment variable contains entries for all workers (e.g., "0,1|2,3|4,5|6,7")
- After slicing for the data parallel group, the list only has world_size entries
- The old code used self.rank (global rank, e.g., 2 or 3) to index into this sliced list, causing IndexError

## Fix

Use self.rank % world_size to get the correct local index within the sliced list when local_dp_rank is not None.

## Test Plan

- Verified the indexing logic with unit tests simulating multi-node scenarios
- Tested both single data parallel group and multiple data parallel group configurations

## Test Result

The fix correctly maps global ranks to local indices:
- Node 0: rank 0 -> index 0, rank 1 -> index 1
- Node 1: rank 2 -> index 0, rank 3 -> index 1

---

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results