### PR TITLE
[Bugfix][ResponsesAPI] Fix crash when tool_choice=required exceeds max_output_tokens

### DIFF
--- a/tests/entrypoints/openai/responses/test_function_call.py
+++ b/tests/entrypoints/openai/responses/test_function_call.py
@@ -151,7 +151,7 @@ async def test_max_tokens_with_tool_choice_required(
         input=prompt,
         tools=tools,
         tool_choice="required",
-        max_output_tokens=1,
+        max_output_tokens=10,
     )
     assert len(response.output) >= 1
     for out in response.output:

--- a/tests/entrypoints/openai/responses/test_function_call.py
+++ b/tests/entrypoints/openai/responses/test_function_call.py
@@ -159,6 +159,7 @@ async def test_max_tokens_with_tool_choice_required(
         # exceed `max_output_tokens`,`function_call` should be empty.
         # This behavior should be consistent with OpenAI
         assert out.type != "function_call"
+    assert response.incomplete_details.reason == "max_output_tokens"
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/responses/test_function_call.py
+++ b/tests/entrypoints/openai/responses/test_function_call.py
@@ -135,6 +135,33 @@ async def test_function_tool_use(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_max_tokens_with_tool_choice_required(
+    client: openai.AsyncOpenAI, model_name: str
+):
+    prompt = [
+        {
+            "role": "user",
+            "content": "Can you tell me what the current weather is in Berlin and the "
+            "forecast for the next 5 days, in fahrenheit?",
+        },
+    ]
+    response = await client.responses.create(
+        model=model_name,
+        input=prompt,
+        tools=tools,
+        tool_choice="required",
+        max_output_tokens=1,
+    )
+    assert len(response.output) >= 1
+    for out in response.output:
+        # When `tool_choice="required"` and the tokens of `tools`
+        # exceed `max_output_tokens`,`function_call` should be empty.
+        # This behavior should be consistent with OpenAI
+        assert out.type != "function_call"
+
+
+@pytest.mark.asyncio
 async def test_named_tool_use(client: openai.AsyncOpenAI):
     def get_weather(latitude: float, longitude: float) -> str:
         """

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import contextlib
 import json
 from abc import abstractmethod
 from collections.abc import Sequence
@@ -18,7 +19,7 @@ from openai.types.responses.response_output_text import Logprob
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
 )
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -422,15 +423,19 @@ class DelegatingParser(Parser):
 
         if request.tool_choice == "required":
             # Required tool calls - parse JSON
-            assert content is not None
-            tool_calls = TypeAdapter(list[FunctionDefinition]).validate_json(content)
-            function_calls.extend(
-                FunctionCall(
-                    name=tool_call.name,
-                    arguments=json.dumps(tool_call.parameters, ensure_ascii=False),
+            tool_calls = []
+            with contextlib.suppress(ValidationError):
+                content = content or ""
+                tool_calls = TypeAdapter(list[FunctionDefinition]).validate_json(
+                    content
                 )
-                for tool_call in tool_calls
-            )
+            for tool_call in tool_calls:
+                function_calls.append(
+                    FunctionCall(
+                        name=tool_call.name,
+                        arguments=json.dumps(tool_call.parameters, ensure_ascii=False),
+                    )
+                )
             return function_calls, None  # Clear content since tool is called.
 
         if (


### PR DESCRIPTION
## Purpose
follow up https://github.com/vllm-project/vllm/pull/36841

FIX https://buildkite.com/vllm/ci/builds/56537?group_by=test#019cf9dc-06da-4341-aa86-6e0d6cb06ec8

```

[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]     return await self.responses_full_generator(
--
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/responses/serving.py", line 711, in responses_full_generator
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]     output = self._make_response_output_items(request, final_output, tokenizer)
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/responses/serving.py", line 904, in _make_response_output_items
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]     return parser.extract_response_outputs(
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]   File "/usr/local/lib/python3.12/dist-packages/vllm/parser/abstract_parser.py", line 325, in extract_response_outputs
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]     tool_calls, content = self._parse_tool_calls(
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]                           ^^^^^^^^^^^^^^^^^^^^^^^
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]   File "/usr/local/lib/python3.12/dist-packages/vllm/parser/abstract_parser.py", line 426, in _parse_tool_calls
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]     tool_calls = TypeAdapter(list[FunctionDefinition]).validate_json(content)
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]   File "/usr/local/lib/python3.12/dist-packages/pydantic/type_adapter.py", line 492, in validate_json
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]     return self.validator.validate_json(
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2026-03-17T04:29:59Z] (APIServer pid=2510) ERROR 03-17 04:29:59 [server_utils.py:374] pydantic_core._pydantic_core.ValidationError: 1 validation error for list[function-wrap[__log_extra_fields__()]]



```
## Test Plan
see e2e

Test gpt-5 with openai

```
response = client.responses.create(
    model="gpt-5",
    input=prompt,
    tools=tools,
    tool_choice="required",
    max_output_tokens=1,
)

```
## Test Result

gpt-5
```
{
    "id": "resp_0c59c8e31591e43d0069b8f1e2a17c8190bffa061a344becb7",
    "created_at": 1773728226.0,
    "error": null,
    "incomplete_details": {
        "reason": "max_output_tokens"
    },
    "instructions": null,
    "metadata": {},
    "model": "gpt-5",
    "object": "response",
    "output": [
        {
            "id": "rs_0c59c8e31591e43d0069b8f1e3de108190b7204a20852a1dca",
            "summary": [],
            "type": "reasoning",
            "content": null,
            "encrypted_content": null,
            "status": null
        }
    ],
    "parallel_tool_calls": true,
    "temperature": 1.0,
    "tool_choice": "required",
....
}
```

vllm
```
{
    "id": "resp_89d52120b02c63ff",
    "created_at": 1773728620.0,
    "error": null,
    "incomplete_details": {
        "reason": "max_output_tokens"
    },
    "instructions": null,
    "metadata": null,
    "model": "my-model",
    "object": "response",
    "output": [
        {
            "id": "rs_a1ff3b9137e892f3",
            "summary": [],
            "type": "reasoning",
            "content": [
                {
                    "text": "The",
                    "type": "reasoning_text"
                }
            ],
            "encrypted_content": null,
            "status": null
        }
    ],
    "parallel_tool_calls": true,
    "temperature": 1.0,
    "tool_choice": "required",
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

