### PR TITLE
[Bugfix](xpu): prevent “selected index k out of range” in TP decode path

### DIFF
--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -426,7 +426,8 @@ class xpu_ops:
         mask = positions <= index_end_pos
         # mask: [B * N, L]
         logits = logits.masked_fill(~mask, float("-inf"))
-        topk_indices = logits.topk(topk_tokens, dim=-1)[1].to(torch.int32)  # [B * N, K]
+        real_topk = min(topk_tokens, logits.shape[-1])
+        topk_indices = logits.topk(real_topk, dim=-1)[1].to(torch.int32)  # [B * N, K]
         # ensure we don't set indices for the top k
         # that is out of range(masked already)
         # this will happen if context length is shorter than K


### PR DESCRIPTION
### Purpose

This PR fixes a runtime failure on XPU when running tensor parallel inference with TP=2 in the decode path.

### Root cause:
The decode top-k selection could request a k value larger than the available logits dimension on a TP shard, which caused:
RuntimeError: selected index k out of range

### Fix:
Clamp the effective decode top-k value to the logits width before calling top-k. This matches the defensive behavior already used in the prefill path and prevents out-of-range access under TP sharding.
