### PR TITLE
[Bugfix] fix NoneType error in KV cache transfer with NCCL connector for DeepSeek

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -18,12 +18,11 @@ from vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_engine import (
 )
 from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import init_logger
-from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
-from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
 
 if TYPE_CHECKING:
     from vllm.forward_context import ForwardContext
+    from vllm.v1.attention.backend import AttentionMetadata
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
@@ -160,9 +159,7 @@ class P2pNcclConnector(KVConnectorBase_V1):
             Returns:
                 None. The function modifies `layer` in-place.
             """
-            if (
-                isinstance(attn_metadata, MLACommonMetadata) or layer.shape[1] == 2
-            ):  # MLA or FlashInfer
+            if layer.ndim == 3 or layer.shape[1] == 2:  # MLA or FlashInfer
                 num_block = kv_cache.shape[0]
                 self.check_tensors_except_dim(layer, kv_cache, 0)
                 if len(block_ids) == num_block:
@@ -216,6 +213,10 @@ class P2pNcclConnector(KVConnectorBase_V1):
 
                 layer = kv_cache[forward_context.virtual_engine]
 
+                # Skip non-standard KV caches (e.g. V3.2 Indexer
+                # uint8 cache) that should not be transferred.
+                if layer.dtype == torch.uint8:
+                    continue
                 kv_cache = self.p2p_nccl_engine.recv_tensor(
                     request.request_id + "#" + layer_name, remote_address
                 )
@@ -243,7 +244,7 @@ class P2pNcclConnector(KVConnectorBase_V1):
         self,
         layer_name: str,
         kv_layer: torch.Tensor,
-        attn_metadata: AttentionMetadata,
+        attn_metadata: "AttentionMetadata",
         **kwargs: Any,
     ) -> None:
         """Start saving the KV cache of the layer from vLLM's paged buffer
@@ -284,9 +285,7 @@ class P2pNcclConnector(KVConnectorBase_V1):
                 torch.Tensor: A tensor containing the extracted KV slices.
                 Returns None if the layout is unsupported.
             """
-            if (
-                isinstance(attn_metadata, MLACommonMetadata) or layer.shape[1] == 2
-            ):  # MLA or FlashInfer
+            if layer.ndim == 3 or layer.shape[1] == 2:  # MLA or FlashInfer
                 return layer[block_ids, ...]
 
             if layer.shape[0] == 2:  # FlashAttention
@@ -302,6 +301,15 @@ class P2pNcclConnector(KVConnectorBase_V1):
             remote_address = ip + ":" + str(port + self._rank)
 
             kv_cache = extract_kv_from_layer(kv_layer, request.block_ids)
+            if kv_cache is None:
+                logger.warning(
+                    "🚧Unsupported KV cache layout for layer %s, "
+                    "request_id:%s, shape:%s",
+                    layer_name,
+                    request_id,
+                    kv_layer.shape,
+                )
+                continue
             self.p2p_nccl_engine.send_tensor(
                 request_id + "#" + layer_name, kv_cache, remote_address
             )


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fix a `NoneType` error in `P2pNcclConnector` when transferring KV cache for DeepSeek-V3.2 under PD disaggregation with the NCCL connector.

When using `P2pNcclConnector` with DeepSeek-V3.2 in a PD-disaggregated deployment, both the prefill and decode services launch successfully, but the prefill side crashes after a request arrives with:

```text
AttributeError: 'NoneType' object has no attribute 'shape'
```

Observed environment:

- vLLM version: `v0.13.0`
- vLLM commit: `72506c98349d6bcd32b4e33eec7b5513453c1502`
- hardware: 2 nodes, each with `8 x H200`
- docker image: `vllm:v0.13.0`

Root cause:

In `p2p_nccl_connector.py`, `extract_kv_from_layer()` and `inject_kv_into_layer()` currently identify MLA KV layout using:

```python
isinstance(attn_metadata, MLACommonMetadata)
```

This assumption is too narrow for DeepSeek-V3.2. In the failing setup, the model uses the `FLASHMLA_SPARSE` backend, whose metadata type is not `MLACommonMetadata`. As a result, the KV layout is not recognized, `extract_kv_from_layer()` returns `None`, and that `None` value is later passed into `send_tensor()`. Eventually `send_sync()` assumes the payload is a tensor and accesses `tensor.shape`, which causes the crash.

This PR fixes the issue by making KV layout detection rely on tensor layout rather than a specific metadata class:

- replace `isinstance(attn_metadata, MLACommonMetadata)` with `layer.ndim == 3`
- keep the existing FlashInfer path via `layer.shape[1] == 2`
- skip unsupported KV cache layouts instead of blindly sending them
- skip `torch.uint8` KV cache entries on the receive path, since these non-standard caches should not be transferred in this flow
- add warning logs when an unsupported KV cache layout is encountered

Why this fix is correct:

For vLLM KV cache tensors, the layout is determined by the attention backend like this:
<!-- obsidian -->
Attention Backend | ndim | shape | Index Medthod
-- | -- | -- | --
MLA (All variants: FlashMLA, FlashMLA_Sparse, Triton_MLA, etc.) | 3 | (num_blocks, block_size, head_size) | layer[block_ids, ...]
FlashInfer (non-MLA) | 5 | (num_blocks, 2, block_size, num_heads, head_dim) | layer[block_ids, ...] (shape[1]==2)
FlashAttention (non-MLA) | 5 | (2, num_blocks, block_size, num_heads, head_dim) | layer[:, block_ids, ...] (shape[0]== 2)
which can be summarized as follows:
- MLA variants use a 3D KV cache tensor, e.g. `(num_blocks, block_size, head_size)`
- FlashInfer (non-MLA) uses a 5D tensor with `shape[1] == 2`
- FlashAttention (non-MLA) uses a 5D tensor with `shape[0] == 2`

Using `layer.ndim == 3` is therefore a backend-agnostic way to identify MLA layouts and works for MLA variants beyond `MLACommonMetadata`, including the DeepSeek-V3.2 `FLASHMLA_SPARSE` case.

## Test Plan

Reproduction environment:

- 2 nodes, each with `8 x H200`
- docker image: `vllm:v0.13.0`
- model: `deepseek-ai/DeepSeek-V3.2`
- KV connector: `P2pNcclConnector`
- PD disaggregation:
  - prefill node configured as `kv_producer`
  - decode node configured as `kv_consumer`

Reproduction steps:

1. Launch the prefill service with `P2pNcclConnector` as KV producer.

```shell
export NCCL_SOCKET_IFNAME=bond0
export GLOO_SOCKET_IFNAME=bond0
export NCCL_DEBUG=INFO
export NCCL_IB_HCA==mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7
export NCCL_NVLS_ENABLE=0
export NCCL_IB_GID_INDEX=3
export VLLM_RPC_TIMEOUT=600000
export VLLM_ENGINE_ITERATION_TIMEOUT_S=600
unset PYTHONPATH
export PYTHONPATH=1
unset FLAGCX_PATH
export USE_FLAGGEMS=0
nohup vllm serve /inspire/hdd/global_public/public_models/deepseek-ai/DeepSeek-V3.2/ \
        --host 0.0.0.0 \
        --port 20001 \
        --tensor-parallel-size 8 \
        --seed 1024 \
        --served-model-name base_model \
        --max-model-len 10000 \
        --max-num-batched-tokens 10000 \
        --max-num-seqs 256 \
        --trust-remote-code \
        --gpu-memory-utilization 0.8 \
        --kv-transfer-config \
        '{"kv_connector":"P2pNcclConnector","kv_role":"kv_producer","kv_buffer_size":"1e10","kv_port":"21001","kv_connector_extra_config":{"proxy_ip":"10.254.11.136","proxy_port":"30002","http_port":"20001"}}' > prefill.log &
```

2. Launch the decode service with `P2pNcclConnector` as KV consumer.

```shell
export NCCL_SOCKET_IFNAME=bond0
export GLOO_SOCKET_IFNAME=bond0
export NCCL_DEBUG=INFO
export NCCL_IB_HCA==mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7
export NCCL_NVLS_ENABLE=0
export NCCL_IB_GID_INDEX=3
export VLLM_RPC_TIMEOUT=600000
export VLLM_ENGINE_ITERATION_TIMEOUT_S=600
export USE_FLAGGEMS=0
unset PYTHONPATH
export PYTHONPATH=1
unset FLAGCX_PATH
nohup vllm serve /inspire/hdd/global_public/public_models/deepseek-ai/DeepSeek-V3.2/ \
        --host 0.0.0.0 \
        --port 20002 \
        --tensor-parallel-size 8 \
        --seed 1024 \
        --served-model-name base_model \
        --max-model-len 10000 \
        --max-num-batched-tokens 10000 \
        --max-num-seqs 256 \
        --trust-remote-code \
        --gpu-memory-utilization 0.8 \
        --kv-transfer-config \
        '{"kv_connector":"P2pNcclConnector","kv_role":"kv_consumer","kv_buffer_size":"8e9","kv_port":"22001","kv_connector_extra_config":{"proxy_ip":"10.254.11.136","proxy_port":"30002","http_port":"20002"}}' > decode.log &
```

3. Start the router for PD dispatch.
This `router-nccl2.py` just is the 1P1D customized version of `examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py`.

```shell
python3 router-nccl2.py --host 0.0.0.0 --http-port 10001 --discovery-port 30002
```

4. Send a `/v1/chat/completions` request routed through the prefill/decode pair.

```shell
curl -s http://10.254.11.136:10001/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "base_model",
    "messages": [
      {"role": "user", "content": "你好，简单介绍一下你自己"}
    ],
    "max_tokens": 128,
    "temperature": 0.2,
    "stream": false
  }'
```

Additional validation:

- ran `pre-commit run -a`
- verified the bug on the target multi-node `16 x H200` environment
- verified that the request path no longer crashes with `AttributeError: 'NoneType' object has no attribute 'shape'`

## Test Result

Before this change, the prefill side crashes during KV transfer with:

```text
File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py", line 513, in send_sync
    "shape": tensor.shape,
             ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'shape'
```

Based on the code path and logs, the failure is:

1. `extract_kv_from_layer()` only handles a subset of KV layouts.
2. For DeepSeek-V3.2 `FLASHMLA_SPARSE`, the MLA layout is not recognized because the metadata type is not `MLACommonMetadata`.
3. The function returns `None`.
4. That `None` is passed into `send_tensor()`.
5. `send_sync()` later assumes the value is a tensor and reads `tensor.shape`, causing the crash.

After this change:

- the request path no longer crashes on DeepSeek-V3.2 with `P2pNcclConnector`
- MLA KV cache layout is correctly detected using tensor dimensionality instead of a specific metadata type
- unsupported KV cache layouts are skipped with warning logs instead of causing a hard failure
- non-transferable `torch.uint8` cache entries are skipped on the receive path
<img width="3016" height="589" alt="79ac4a70bb193d2a8c1b6a258ae141bb" src="https://github.com/user-attachments/assets/f87ae54c-ad68-42f9-b9da-706be1309faf" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

