### PR TITLE
fix(lmcache): handle KeyError in layerwise mode

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -921,7 +921,13 @@ class LMCacheConnectorV1Impl:
 
         # Wait for the layer to be loaded
         for layerwise_retriever in self.layerwise_retrievers:
-            ret_token_mask = next(layerwise_retriever)
+            try:
+                ret_token_mask = next(layerwise_retriever)
+            except StopIteration:
+                ret_token_mask = None
+            except KeyError as e:
+                logger.warning("LMCache KeyError during wait_for_layer_load: %s", e)
+                ret_token_mask = None
 
             if self.current_layer == self.num_layers - 1:
                 assert ret_token_mask is not None
@@ -1027,7 +1033,12 @@ class LMCacheConnectorV1Impl:
                     is_first = False
 
         for layerwise_storer in self.layerwise_storers:
-            next(layerwise_storer)
+            try:
+                next(layerwise_storer)
+            except StopIteration:
+                pass
+            except KeyError as e:
+                logger.warning("LMCache KeyError during save_kv_layer: %s", e)
 
         self.current_layer += 1
 
@@ -1048,7 +1059,12 @@ class LMCacheConnectorV1Impl:
 
         if self.use_layerwise:
             for layerwise_storer in self.layerwise_storers:
-                next(layerwise_storer)
+                try:
+                    next(layerwise_storer)
+                except StopIteration:
+                    pass
+                except KeyError as e:
+                    logger.warning("LMCache KeyError during wait_for_save: %s", e)
             return
 
         assert len(self.kv_caches) > 0


### PR DESCRIPTION
## Problem
When using LMCache with layerwise mode enabled (`LMCACHE_USE_LAYERWISE=True`), vLLM can crash with a KeyError from LMCache's internal hot_cache lookup:

```
KeyError: LayerCacheEngineKey(model_name='...', world_size=1, worker_id=0, ...)
```

This error originates from LMCache's `local_cpu_backend.py` during layerwise KV cache operations.

## Solution
Add error handling in vLLM's LMCache adapter to catch and gracefully handle KeyError exceptions raised by LMCache during:
- `wait_for_layer_load()` - loading KV cache layers
- `save_kv_layer()` - saving KV cache layers  
- `wait_for_save()` - waiting for save operations

The fix catches `KeyError` and `StopIteration` exceptions, logs a warning, and allows vLLM to continue operating instead of crashing.

## Changes
- Added try-except blocks around `next()` calls on LMCache generators in three methods
- Log warnings when KeyError exceptions occur for debugging purposes

Fixes #37261