### PR TITLE
fix(distributed): resolve inference failure in cpu_worker

### DIFF
--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -99,7 +99,11 @@ class CPUWorker(Worker):
                 omp_cpuids_list = omp_cpuids_list[
                     local_dp_rank * world_size : (local_dp_rank + 1) * world_size
                 ]
-            self.local_omp_cpuid = omp_cpuids_list[self.rank]
+                # Use local rank within the DP slice to index into the sliced list
+                local_rank_in_slice = self.rank - local_dp_rank * world_size
+                self.local_omp_cpuid = omp_cpuids_list[local_rank_in_slice]
+            else:
+                self.local_omp_cpuid = omp_cpuids_list[self.rank]
 
         if self.local_omp_cpuid != "nobind":
             ret = torch.ops._C.init_cpu_threads_env(self.local_omp_cpuid)


### PR DESCRIPTION
## Description

Fixes #37255

When running distributed inference with multiple nodes, the CPU worker fails with bIndexError: list index out of rangeb when accessing .

## Root Cause

When  is not None, the code slices  to a subset based on the data parallel rank and world size. However, it then tries to index into this sliced list using  (global rank), which can be out of bounds for the sliced list.

For example, with 2 nodes and world_size=2:
- Global ranks are 0, 1, 2, 3
- For local_dp_rank=0, the slice gives indices 0-1
- For local_dp_rank=1, the slice gives indices 2-3, but the sliced list only has length 2
- When rank=2 tries to access index 2 on a list of length 2, it fails

## Fix

Calculate the local rank within the DP slice using  to correctly index into the sliced list.

## Testing

Verified the fix with a test script that simulates the distributed scenario described in the issue:
- Rank 0,1 on node 0 (local_dp_rank=0) correctly get indices 0,1
- Rank 2,3 on node 1 (local_dp_rank=1) correctly get indices 0,1 from the sliced list

This fix is minimal and only affects the code path when data_parallel_rank_local is not None (distributed inference scenarios).