### PR TITLE
fix: combine content/reasoning with tool calls in responses API (#37167)

### DIFF
--- a/tests/entrypoints/test_responses_utils.py
+++ b/tests/entrypoints/test_responses_utils.py
@@ -646,11 +646,11 @@ class TestMaybeCombineReasoningAndToolCall:
 
         assert result is None
 
-    def test_returns_none_when_id_does_not_start_with_mcp_prefix(self):
-        """Test that non-MCP tool calls are not combined."""
+    def test_combines_non_mcp_tool_call_with_reasoning(self):
+        """Test that non-MCP tool calls are combined with reasoning (fixes #37167)."""
         item = ResponseFunctionToolCall(
             type="function_call",
-            id="regular_id",  # Does not start with MCP_PREFIX
+            id="regular_id",
             call_id="call_123",
             name="test_function",
             arguments="{}",
@@ -659,13 +659,17 @@ class TestMaybeCombineReasoningAndToolCall:
 
         result = _maybe_combine_reasoning_and_tool_call(item, messages)
 
-        assert result is None
+        assert result is not None
+        assert result["role"] == "assistant"
+        assert result["reasoning"] == "some reasoning"
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["id"] == "call_123"
 
     def test_returns_none_when_last_message_is_not_assistant(self):
         """Test that non-assistant last message returns None."""
         item = ResponseFunctionToolCall(
             type="function_call",
-            id=f"{MCP_PREFIX}tool_id",
+            id="fc_123",
             call_id="call_123",
             name="test_function",
             arguments="{}",
@@ -676,23 +680,70 @@ class TestMaybeCombineReasoningAndToolCall:
 
         assert result is None
 
-    def test_returns_none_when_last_message_has_no_reasoning(self):
-        """Test that assistant message without reasoning returns None."""
+    def test_returns_none_when_last_message_has_no_reasoning_or_content(self):
+        """Test that assistant message without reasoning or content returns None."""
         item = ResponseFunctionToolCall(
             type="function_call",
-            id=f"{MCP_PREFIX}tool_id",
+            id="fc_123",
             call_id="call_123",
             name="test_function",
             arguments="{}",
         )
-        messages = [{"role": "assistant", "content": "some content"}]
+        messages = [{"role": "assistant", "tool_calls": []}]
 
         result = _maybe_combine_reasoning_and_tool_call(item, messages)
 
         assert result is None
 
+    def test_combines_content_and_tool_call(self):
+        """Test that content message + tool call are combined (fixes #37167)."""
+        item = ResponseFunctionToolCall(
+            type="function_call",
+            id="fc_123",
+            call_id="call_456",
+            name="get_weather",
+            arguments='{"location": "Paris"}',
+        )
+        messages = [{"role": "assistant", "content": "Let me check the weather."}]
+
+        result = _maybe_combine_reasoning_and_tool_call(item, messages)
+
+        assert result is not None
+        assert result["role"] == "assistant"
+        assert result["content"] == "Let me check the weather."
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    def test_combines_parallel_tool_calls(self):
+        """Test that multiple tool calls append to the same message."""
+        messages = [{"role": "assistant", "reasoning": "I need both."}]
+        item1 = ResponseFunctionToolCall(
+            type="function_call",
+            id="fc_1",
+            call_id="call_1",
+            name="get_weather",
+            arguments='{"location": "Paris"}',
+        )
+        item2 = ResponseFunctionToolCall(
+            type="function_call",
+            id="fc_2",
+            call_id="call_2",
+            name="get_weather",
+            arguments='{"location": "London"}',
+        )
+
+        result1 = _maybe_combine_reasoning_and_tool_call(item1, messages)
+        assert result1 is not None
+        messages[-1] = result1
+        result2 = _maybe_combine_reasoning_and_tool_call(item2, messages)
+
+        assert result2 is not None
+        assert len(result2["tool_calls"]) == 2
+        assert result2["tool_calls"][0]["id"] == "call_1"
+        assert result2["tool_calls"][1]["id"] == "call_2"
+
     def test_combines_reasoning_and_mcp_tool_call(self):
-        """Test successful combination of reasoning message and MCP tool call."""
+        """Test successful combination of reasoning message and tool call."""
         item = ResponseFunctionToolCall(
             type="function_call",
             id=f"{MCP_PREFIX}tool_id",
@@ -724,11 +775,11 @@ class TestMaybeCombineReasoningAndToolCall:
 
         assert result is None
 
-    def test_returns_none_when_id_is_empty_string(self):
-        """Test that empty string id returns None (falsy check)."""
+    def test_combines_when_item_id_is_empty_string(self):
+        """Test that tool call with empty id is still combined (id not required)."""
         item = ResponseFunctionToolCall(
             type="function_call",
-            id="",  # Empty string is falsy
+            id="",
             call_id="call_123",
             name="test_function",
             arguments="{}",
@@ -737,4 +788,5 @@ class TestMaybeCombineReasoningAndToolCall:
 
         result = _maybe_combine_reasoning_and_tool_call(item, messages)
 
-        assert result is None
+        assert result is not None
+        assert len(result["tool_calls"]) == 1

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -21,7 +21,6 @@ from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 from openai.types.responses.tool import Tool
 
 from vllm import envs
-from vllm.entrypoints.constants import MCP_PREFIX
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionMessageParam
 from vllm.entrypoints.openai.responses.protocol import ResponseInputOutputItem
 from vllm.logger import init_logger
@@ -122,34 +121,39 @@ def construct_input_messages(
 def _maybe_combine_reasoning_and_tool_call(
     item: ResponseInputOutputItem, messages: list[ChatCompletionMessageParam]
 ) -> ChatCompletionMessageParam | None:
-    """Many models treat MCP calls and reasoning as a single message.
-    This function checks if the last message is a reasoning message and
-    the current message is a tool call"""
-    if not (
-        isinstance(item, ResponseFunctionToolCall)
-        and item.id
-        and item.id.startswith(MCP_PREFIX)
-    ):
+    """Combine tool calls with preceding assistant messages (reasoning or content).
+
+    Many models (Qwen3, Qwen3.5, etc.) expect content/reasoning and tool calls
+    in a single message, matching the chat completions API. This function merges
+    ResponseFunctionToolCall items into the preceding assistant message when
+    it has reasoning or content, and appends to existing tool_calls for parallel
+    tool calls.
+    """
+    if not isinstance(item, ResponseFunctionToolCall):
         return None
     if len(messages) == 0:
         return None
     last_message = messages[-1]
     if not (
         last_message.get("role") == "assistant"
-        and last_message.get("reasoning") is not None
+        and (
+            last_message.get("reasoning") is not None
+            or last_message.get("content") is not None
+        )
     ):
         return None
 
-    last_message["tool_calls"] = [
-        ChatCompletionMessageToolCallParam(
-            id=item.call_id,
-            function=FunctionCallTool(
-                name=item.name,
-                arguments=item.arguments,
-            ),
-            type="function",
-        )
-    ]
+    new_tool_call = ChatCompletionMessageToolCallParam(
+        id=item.call_id,
+        function=FunctionCallTool(
+            name=item.name,
+            arguments=item.arguments,
+        ),
+        type="function",
+    )
+    existing_tool_calls = list(last_message.get("tool_calls", []))
+    existing_tool_calls.append(new_tool_call)
+    last_message["tool_calls"] = existing_tool_calls
     return last_message
 
 


### PR DESCRIPTION
## Summary

Fixes #37167.

**Root cause:** `_maybe_combine_reasoning_and_tool_call` only merged MCP-prefixed tool calls with reasoning messages. Non-harmony models (Qwen3, Qwen3.5) expect content/reasoning and tool calls in a single message. Keeping them separate caused each to render in its own `<|im_start|>assistant` block, biasing the model toward producing a final text-only response and prematurely ending agent turns.

**Fix:** 
- Drop MCP prefix guard: combine all `ResponseFunctionToolCall` items with preceding assistant messages
- Extend preceding-message check to `content` OR `reasoning` (not just reasoning)
- Append to existing `tool_calls` for parallel tool calls instead of overwriting

## Changes

- `vllm/entrypoints/openai/responses/utils.py`: Updated `_maybe_combine_reasoning_and_tool_call`, removed unused `MCP_PREFIX` import
- `tests/entrypoints/test_responses_utils.py`: Updated and added tests for content+tool_call, non-MCP combination, parallel tool calls

## Testing

- Verified fix addresses reported scenario (content/reasoning + tool call combined)
- Added tests: `test_combines_content_and_tool_call`, `test_combines_non_mcp_tool_call_with_reasoning`, `test_combines_parallel_tool_calls`
- Updated existing tests for new behavior

Made with [Cursor](https://cursor.com)