### PR TITLE
Fix Phi3 test that fails with Transformers v5

### DIFF
--- a/tests/models/multimodal/pooling/test_phi3v.py
+++ b/tests/models/multimodal/pooling/test_phi3v.py
@@ -3,6 +3,7 @@
 
 import pytest
 import torch.nn.functional as F
+import transformers.utils
 from PIL import Image
 
 from vllm.assets.base import get_vllm_public_assets
@@ -11,6 +12,12 @@ from vllm.assets.image import VLM_IMAGES_DIR
 from ....conftest import IMAGE_ASSETS, HfRunner, PromptImageInput, VllmRunner
 from ....utils import large_gpu_test
 from ...utils import check_embeddings_close
+
+# BC for method that was deleted in Transformers v5.
+# Only needed for generating the HF reference.
+transformers.utils.is_flash_attn_greater_or_equal_2_10 = (
+    lambda: transformers.utils.is_flash_attn_greater_or_equal("2.1.0")
+)
 
 HF_TEXT_PROMPTS = [
     # T -> X


### PR DESCRIPTION
`is_flash_attn_greater_or_equal_2_10` was deleted in https://github.com/huggingface/transformers/pull/42435 but the custom modelling code for `TIGER-Lab/VLM2Vec-Full` imports it.

This PR patches it back in for this test only. We can do this because the custom modelling code is only used for generating the HF reference, so the model will work as normal when used with vLLM.