### PR TITLE
[BugFix] PyTorch Compilation Tests should error if any test fails

### DIFF
--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -35,7 +35,7 @@ steps:
   # as it is a heavy test that is covered in other steps.
   # Use `find` to launch multiple instances of pytest so that
   # they do not suffer from https://github.com/vllm-project/vllm/issues/28965
-  - "find compile/fullgraph/ -name 'test_*.py' -not -name 'test_full_graph.py' -exec pytest -s -v {} \\;"
+  - "find compile/fullgraph/ -name 'test_*.py' -not -name 'test_full_graph.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}'"
 
 - label: PyTorch Fullgraph
   timeout_in_minutes: 30


### PR DESCRIPTION
This is the same fix as
https://github.com/vllm-project/vllm/pull/30277/changes#diff-2fe466060a88bb6a57175df8ca7175849db82a2cf2ba082295d481ab57e58868

We need the `-print0 | xargs` pattern.
Here's a simple demonstration:

```sh

set -u

TMPDIR=$(mktemp -d)
trap 'rm -rf "$TMPDIR"' EXIT

printf '#!/bin/bash\necho "PASS: $0"; exit 0\n' > "$TMPDIR/test_a.sh"
printf '#!/bin/bash\necho "FAIL: $0"; exit 1\n' > "$TMPDIR/test_b.sh"
chmod +x "$TMPDIR"/test_*.sh

echo "=== OLD: find -exec (broken) ==="
find "$TMPDIR" -name 'test_*.sh' -exec {} \;
echo "exit code: $?"
echo

echo "=== NEW: find -print0 | xargs (fixed) ==="
find "$TMPDIR" -name 'test_*.sh' -print0 | xargs -0 -n1 -I{} {}
echo "exit code: $?"
```
