### PR TITLE
[Kernel] Add Llama4 Router GEMM kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1000,6 +1000,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     "csrc/moe/moe_wna16.cu"
     "csrc/moe/grouped_topk_kernels.cu"
     "csrc/moe/gpt_oss_router_gemm.cu"
+    "csrc/moe/llama4_router_gemm.cu"
     "csrc/moe/router_gemm.cu")
 endif()
 

--- a/benchmarks/kernels/benchmark_router_gemm.py
+++ b/benchmarks/kernels/benchmark_router_gemm.py
@@ -18,6 +18,10 @@ DSV3_SUPPORTED_HIDDEN_SIZES = [7168]
 GPT_OSS_SUPPORTED_NUM_EXPERTS = [32, 128]
 GPT_OSS_SUPPORTED_HIDDEN_SIZES = [2880]
 
+# Dimensions supported by the Llama4 specialized kernel
+LLAMA4_SUPPORTED_NUM_EXPERTS = [128]
+LLAMA4_SUPPORTED_HIDDEN_SIZES = [5120]
+
 
 def get_batch_size_range(max_batch_size):
     return [2**x for x in range(14) if 2**x <= max_batch_size]
@@ -32,6 +36,10 @@ def get_model_params(config):
         num_experts = config.n_routed_experts
         hidden_size = config.hidden_size
     elif config.architectures[0] in ("GptOssForCausalLM",):
+        num_experts = config.num_local_experts
+        hidden_size = config.hidden_size
+    elif config.architectures[0] in ("Llama4ForConditionalGeneration",):
+        config = config.get_text_config()
         num_experts = config.num_local_experts
         hidden_size = config.hidden_size
     else:
@@ -84,6 +92,11 @@ def get_benchmark(model, max_batch_size, trust_remote_code):
             and num_experts in GPT_OSS_SUPPORTED_NUM_EXPERTS
             and hidden_size in GPT_OSS_SUPPORTED_HIDDEN_SIZES
         )
+        allow_llama4_router_gemm = (
+            is_hopper_or_blackwell
+            and num_experts in LLAMA4_SUPPORTED_NUM_EXPERTS
+            and hidden_size in LLAMA4_SUPPORTED_HIDDEN_SIZES
+        )
 
         has_bias = False
         if allow_gpt_oss_router_gemm:
@@ -105,6 +118,8 @@ def get_benchmark(model, max_batch_size, trust_remote_code):
                     ops.dsv3_router_gemm(mat_a, mat_b, torch.bfloat16)
                 elif allow_gpt_oss_router_gemm:
                     ops.gpt_oss_router_gemm(mat_a, mat_b, bias)
+                elif allow_llama4_router_gemm:
+                    ops.llama4_router_gemm(mat_a, mat_b)
                 else:
                     raise ValueError("Unsupported router gemm")
 

--- a/csrc/moe/llama4_router_gemm.cu
+++ b/csrc/moe/llama4_router_gemm.cu
@@ -1,0 +1,179 @@
+/*
+ * Adapted from
+ * https://github.com/NVIDIA/TensorRT-LLM/blob/v1.3.0rc7/cpp/tensorrt_llm/kernels/llama4MinLatencyKernels/llama4Bf16Bf16Gemm.cu
+ * Copyright (c) 2026, The vLLM team.
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * All rights reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <torch/all.h>
+
+template <int VEC_SIZE>
+struct __align__(8) aligned_bf16x4 {
+  __align__(8) __nv_bfloat16 data[VEC_SIZE];
+};
+
+__device__ __forceinline__ float2 ffma2(float2 x, float2 y, float2 acc) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 1000))
+  return __ffma2_rn(x, y, acc);
+#else
+  return make_float2(x.x * y.x + acc.x, x.y * y.y + acc.y);
+#endif
+}
+
+template <int VEC_SIZE, int BLOCK_SIZE, int GEMM_K, int NUM_EXPERTS>
+__global__ void llama4_router_gemm_kernel(
+    int num_tokens,
+    __nv_bfloat16 const* __restrict__ A,  // Input vector
+                                          // [num_tokens][hidden_size]
+    __nv_bfloat16 const* __restrict__ B,  // Input matrix
+                                          // [num_experts][hidden_size]
+    __nv_bfloat16* __restrict__ C  // Output vector [num_tokens][num_experts]
+) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900) && (__CUDA_ARCH__ < 1200))
+  // Shared memory for block reduction
+  __shared__ float reduce_buffer[BLOCK_SIZE];
+
+  // Each thread accumulates its partial sum
+  float2 thread_sum;
+  thread_sum.x = 0.0f;
+  thread_sum.y = 0.0f;
+
+  // Each thread processes 4 elements at a time, 5 times
+  int const token_idx = blockIdx.x / NUM_EXPERTS;
+  int const row =
+      blockIdx.x % NUM_EXPERTS;  // Matrix row / Output element index
+  int const tid = threadIdx.x;   // Thread ID within the block
+
+  // PDL prefetch all B data
+  aligned_bf16x4<VEC_SIZE> b_vec[GEMM_K / BLOCK_SIZE / VEC_SIZE];
+  #pragma unroll
+  for (int chunk = 0; chunk < GEMM_K / BLOCK_SIZE / VEC_SIZE; chunk++) {
+    // Base index for this chunk
+    int base_idx = chunk * BLOCK_SIZE + tid;
+
+    // Load 4 elements at once
+    b_vec[chunk] = reinterpret_cast<aligned_bf16x4<VEC_SIZE> const*>(
+        B)[row * GEMM_K / VEC_SIZE + base_idx];
+  }
+
+  cudaGridDependencySynchronize();
+
+  // Process 5 chunks of 4 elements each
+  #pragma unroll
+  for (int chunk = 0; chunk < GEMM_K / BLOCK_SIZE / VEC_SIZE; chunk++) {
+    // Base index for this chunk
+    int base_idx = chunk * BLOCK_SIZE + tid;
+
+    // Load 4 elements at once
+    aligned_bf16x4<VEC_SIZE> a_vec =
+        reinterpret_cast<aligned_bf16x4<VEC_SIZE> const*>(
+            A)[token_idx * GEMM_K / VEC_SIZE + base_idx];
+  #pragma unroll
+    for (int i = 0; i < VEC_SIZE; i += 2) {
+      float2 a_val = make_float2(a_vec.data[i], a_vec.data[i + 1]);
+      float2 b_val =
+          make_float2(b_vec[chunk].data[i], b_vec[chunk].data[i + 1]);
+
+      thread_sum = ffma2(a_val, b_val, thread_sum);
+    }
+  }
+
+  // Warp-level reduction
+  float warp_sum = thread_sum.x + thread_sum.y;
+  for (int offset = warpSize / 2; offset > 0; offset >>= 1) {
+    warp_sum += __shfl_down_sync(0xffffffff, warp_sum, offset);
+  }
+
+  // First thread in each warp writes to shared memory
+  if (tid % warpSize == 0) {
+    reduce_buffer[tid / warpSize] = warp_sum;
+  }
+  __syncthreads();
+
+  // Final thread reduces across warps and writes the result
+  if (tid == 0) {
+    float block_sum = 0.0f;
+    for (int i = 0; i < BLOCK_SIZE / warpSize; i++) {
+      block_sum += reduce_buffer[i];
+    }
+    C[token_idx * NUM_EXPERTS + row] = __float2bfloat16(block_sum);
+  }
+#endif
+}
+
+void llama4_router_gemm_launcher(int num_tokens, __nv_bfloat16 const* A,
+                                 __nv_bfloat16 const* B, __nv_bfloat16* C,
+                                 cudaStream_t stream) {
+  constexpr int BLOCK_SIZE = 256;
+  constexpr int NUM_EXPERTS = 128;
+  constexpr int GEMM_K = 5120;
+  constexpr int VEC_SIZE = 4;
+
+  int const grid_size = NUM_EXPERTS * num_tokens;
+
+  cudaLaunchConfig_t config;
+  config.gridDim = dim3(grid_size);
+  config.blockDim = dim3(BLOCK_SIZE);
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+
+  cudaLaunchAttribute attrs[1];
+  config.attrs = attrs;
+  config.numAttrs = 0;
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+
+  cudaLaunchKernelEx(
+      &config,
+      &llama4_router_gemm_kernel<VEC_SIZE, BLOCK_SIZE, GEMM_K, NUM_EXPERTS>,
+      num_tokens, A, B, C);
+}
+
+void llama4_router_gemm_op(int num_tokens, void const* A, void const* B,
+                           void* C, cudaStream_t stream) {
+  __nv_bfloat16 const* A_bf16 = static_cast<__nv_bfloat16 const*>(A);
+  __nv_bfloat16 const* B_bf16 = static_cast<__nv_bfloat16 const*>(B);
+  __nv_bfloat16* C_bf16 = static_cast<__nv_bfloat16*>(C);
+
+  llama4_router_gemm_launcher<16>(num_tokens, A_bf16, B_bf16, C_bf16, stream);
+}
+
+void llama4_router_gemm(torch::Tensor& output, torch::Tensor const& inputA,
+                        torch::Tensor const& inputB) {
+  TORCH_CHECK(inputA.scalar_type() == at::ScalarType::BFloat16,
+              "inputA tensor must be bfloat16");
+  TORCH_CHECK(inputB.scalar_type() == at::ScalarType::BFloat16,
+              "inputB tensor must be bfloat16");
+
+  TORCH_CHECK(inputA.dim() == 2, "inputA must be 2D.");
+  TORCH_CHECK(inputB.dim() == 2, "inputB must be 2D.");
+  TORCH_CHECK(inputA.sizes()[1] == 5120, "inputA.size(1) must be 5120");
+  TORCH_CHECK(inputB.sizes()[0] == 128, "inputB.size(0) must be 128");
+  TORCH_CHECK(inputB.sizes()[1] == 5120, "inputB.size(1) must be 5120");
+
+  auto const num_tokens = inputA.sizes()[0];
+  auto const num_experts = inputB.sizes()[0];
+
+  auto stream = at::cuda::getCurrentCUDAStream(inputA.get_device());
+
+  llama4_router_gemm_op(num_tokens, num_experts, inputA.data_ptr(),
+                        inputB.data_ptr(), output.mutable_data_ptr(), stream);
+}

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -74,4 +74,8 @@ void dsv3_router_gemm(torch::Tensor& output, const torch::Tensor& mat_a,
 // gpt-oss optimized router GEMM kernel for SM90+
 void gpt_oss_router_gemm(torch::Tensor& output, torch::Tensor input,
                          torch::Tensor weight, torch::Tensor bias);
+
+// Llama4 optimized router GEMM kernel for SM90+
+void llama4_router_gemm(torch::Tensor& output, const torch::Tensor& input,
+                        const torch::Tensor& weight);
 #endif

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -138,6 +138,11 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "gpt_oss_router_gemm(Tensor! output, Tensor input, Tensor weights, "
       "Tensor bias) -> ()");
   m.impl("gpt_oss_router_gemm", torch::kCUDA, &gpt_oss_router_gemm);
+
+  // Llama 4 optimized router GEMM kernel for SM90+
+  m.def(
+      "llama4_router_gemm(Tensor! output, Tensor input, Tensor weight) -> ()");
+  m.impl("llama4_router_gemm", torch::kCUDA, &llama4_router_gemm);
 #endif
 }
 

--- a/tests/kernels/moe/test_router_gemm.py
+++ b/tests/kernels/moe/test_router_gemm.py
@@ -35,3 +35,26 @@ def test_gpt_oss_router_gemm(batch_size, input_dim, output_dim):
     output = ops.gpt_oss_router_gemm(x, weight, bias)
     output_ref = torch.nn.functional.linear(x, weight, bias)
     torch.testing.assert_close(output, output_ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(
+    not (
+        current_platform.is_cuda()
+        and (
+            current_platform.is_device_capability(90)
+            or current_platform.is_device_capability_family(100)
+        )
+    ),
+    reason="This test only runs on Hopper or Blackwell GPUs.",
+)
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("input_dim", [5120])
+@pytest.mark.parametrize("output_dim", [128])
+def test_llama4_router_gemm(batch_size, input_dim, output_dim):
+    set_random_seed(0)
+    x = torch.randn(batch_size, input_dim, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(output_dim, input_dim, device="cuda", dtype=torch.bfloat16)
+
+    output = ops.llama4_router_gemm(x, weight)
+    output_ref = torch.nn.functional.linear(x, weight)
+    torch.testing.assert_close(output, output_ref, atol=1e-2, rtol=1e-2)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2375,6 +2375,19 @@ def gpt_oss_router_gemm(
     return output
 
 
+def llama4_router_gemm(
+    hidden_states: torch.Tensor, weight: torch.Tensor
+) -> torch.Tensor:
+    output = torch.empty(
+        hidden_states.shape[0],
+        weight.shape[0],
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
+    torch.ops._moe_C.llama4_router_gemm(output, hidden_states, weight)
+    return output
+
+
 def topk_softmax(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -12,12 +12,13 @@ from vllm.utils.torch_utils import direct_register_custom_op
 
 @PluggableLayer.register("gate_linear")
 class GateLinear(ReplicatedLinear):
-    """MoE gate linear layer with three-tier GEMM dispatch:
+    """MoE gate linear layer with five-tier GEMM dispatch:
 
     1. DSV3 specialized kernel (SM90+, batch<=16, supported dims)
     2. gpt-oss specialized kernel (SM90+, batch<=128, supported dims)
-    3. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 + fp32 out_dtype)
-    4. F.linear via ReplicatedLinear (ultimate fallback)
+    3. Llama4 specialized kernel (SM90+, batch<=8, supported dims)
+    4. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 + fp32 out_dtype)
+    5. F.linear via ReplicatedLinear (ultimate fallback)
 
     The ``out_dtype`` attribute is mutable and can be set after init
     (e.g. when the required dtype depends on the expert quantization
@@ -31,6 +32,10 @@ class GateLinear(ReplicatedLinear):
     # Dimensions supported by the gpt-oss specialized kernel
     GPT_OSS_SUPPORTED_NUM_EXPERTS = [32, 128]
     GPT_OSS_SUPPORTED_HIDDEN_SIZES = [2880]
+
+    # Dimensions supported by the Llama4 specialized kernel
+    LLAMA4_SUPPORTED_NUM_EXPERTS = [128]
+    LLAMA4_SUPPORTED_HIDDEN_SIZES = [5120]
 
     def __init__(
         self,
@@ -74,11 +79,21 @@ class GateLinear(ReplicatedLinear):
 
         # gpt-oss specialized kernel eligibility (SM90+, exact dims)
         self.allow_gpt_oss_router_gemm = (
-            self.weight.dtype == torch.bfloat16
-            and current_platform.is_cuda()
+            current_platform.is_cuda()
             and is_hopper_or_blackwell
+            and self.weight.dtype == torch.bfloat16
+            and (self.out_dtype is None or self.out_dtype == torch.bfloat16)
             and output_size in self.GPT_OSS_SUPPORTED_NUM_EXPERTS
             and input_size in self.GPT_OSS_SUPPORTED_HIDDEN_SIZES
+        )
+
+        # Llama4 specialized kernel eligibility (SM90+, exact dims)
+        self.allow_llama4_router_gemm = (
+            self.allow_specialized_router_gemm
+            and self.weight.dtype == torch.bfloat16
+            and (self.out_dtype is None or self.out_dtype == torch.bfloat16)
+            and output_size in self.LLAMA4_SUPPORTED_NUM_EXPERTS
+            and input_size in self.LLAMA4_SUPPORTED_HIDDEN_SIZES
         )
 
         # cuBLAS bf16→fp32 eligibility
@@ -118,16 +133,21 @@ class GateLinear(ReplicatedLinear):
             return output, None
 
         # Tier 2: gpt-oss specialized kernel
-        if self.allow_gpt_oss_router_gemm:
+        if self.allow_gpt_oss_router_gemm and x.dtype == torch.bfloat16:
             output = torch.ops.vllm.gpt_oss_router_gemm(x, self.weight, self.bias)
             return output, None
 
-        # Tier 3: cuBLAS bf16→fp32
+        # Tier 3: Llama4 specialized kernel
+        if self.allow_llama4_router_gemm and x.dtype == torch.bfloat16:
+            output = torch.ops.vllm.llama4_router_gemm(x, self.weight)
+            return output, None
+
+        # Tier 4: cuBLAS bf16→fp32
         if self.allow_cublas_router_gemm and x.dtype == torch.bfloat16:
             output = ops.router_gemm_bf16_fp32(x, self.weight)
             return output, None
 
-        # Tier 4: F.linear (ReplicatedLinear)
+        # Tier 5: F.linear (ReplicatedLinear)
         if self.out_dtype is not None and x.dtype != self.weight.dtype:
             x = x.to(self.weight.dtype)
         output, output_bias = super().forward(x)
@@ -156,8 +176,29 @@ def gpt_oss_router_gemm_fake(
     return x.new_empty((x.shape[0], weight.shape[0]))
 
 
+def llama4_router_gemm_impl(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """
+    Dynamically run min-latency gemm if num_tokens <= 8.
+    This must be wrapped in a custom op because our torch.compile integration
+    does not support runtime dispatching on num_tokens.
+    """
+    if x.shape[0] <= 8:
+        return ops.llama4_router_gemm(x, weight)
+    else:
+        return torch.nn.functional.linear(x, weight)
+
+
+def llama4_router_gemm_fake(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    return x.new_empty((x.shape[0], weight.shape[0]))
+
+
 direct_register_custom_op(
     op_name="gpt_oss_router_gemm",
     op_func=gpt_oss_router_gemm_impl,
     fake_impl=gpt_oss_router_gemm_fake,
+)
+direct_register_custom_op(
+    op_name="llama4_router_gemm",
+    op_func=llama4_router_gemm_impl,
+    fake_impl=llama4_router_gemm_fake,
 )

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -36,11 +36,10 @@ from vllm.model_executor.layers.attention import (
     Attention,
     ChunkedLocalAttention,
 )
-from vllm.model_executor.layers.fused_moe import SharedFusedMoE
+from vllm.model_executor.layers.fused_moe import GateLinear, SharedFusedMoE
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
-    ReplicatedLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
@@ -94,11 +93,10 @@ class Llama4MoE(nn.Module):
         self.ep_size = self.ep_group.size()
 
         intermediate_size_moe = config.intermediate_size
-        self.router = ReplicatedLinear(
+        self.router = GateLinear(
             config.hidden_size,
             config.num_local_experts,
             bias=False,
-            quant_config=None,
             prefix=f"{prefix}.router",
         )
 


### PR DESCRIPTION

This PR add Llama4 optimized Router GEMM kernel

1% output token throughput improvement.

## Test Plan

Added unit test.

```
pytest -s -v tests/kernels/moe/test_router_gemm.py
```

## Test Result

Unit test passed.

## Micro bench

```
python3 benchmarks/kernels/benchmark_router_gemm.py --model nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8
```

```
   batch_size  PyTorch (TFLOPs)  vLLM (TFLOPs)
0         1.0          0.237382       0.640395
1         2.0          0.447103       1.148474
2         4.0          0.882551       1.938261
3         8.0          1.753988       2.980509
4        16.0          3.430678       3.925008
```
 
## Benchmark

```
vllm serve nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8 \
  --tensor-parallel-size 8 \
  --max-num-seqs 8 \
  --kv-cache-dtype fp8_e4m3 \
  --no-enable-prefix-caching
```

```
vllm bench serve \
        --model nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8 \
        --dataset-name sharegpt \
        --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
        --sharegpt-output-len 300 \
        --num-prompts ${num_prompts} \
        --max-concurrency 8 \
        --num-warmups 50 \
        --ignore-eos \
        --temperature 0
```

Main:

```
============ Serving Benchmark Result ============
Successful requests:                     480       
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  206.45    
Total input tokens:                      103499    
Total generated tokens:                  144000    
Request throughput (req/s):              2.33      
Output token throughput (tok/s):         697.51    
Peak output token throughput (tok/s):    768.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          1198.84   
---------------Time to First Token----------------
Mean TTFT (ms):                          112.93    
Median TTFT (ms):                        124.73    
P99 TTFT (ms):                           175.98    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.13     
Median TPOT (ms):                        11.10     
P99 TPOT (ms):                           11.59     
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.13     
Median ITL (ms):                         10.62     
P99 ITL (ms):                            30.30     
==================================================
```

PR:

```
============ Serving Benchmark Result ============
Successful requests:                     480       
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  204.33    
Total input tokens:                      103499    
Total generated tokens:                  144000    
Request throughput (req/s):              2.35      
Output token throughput (tok/s):         704.75    
Peak output token throughput (tok/s):    768.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          1211.29   
---------------Time to First Token----------------
Mean TTFT (ms):                          117.21    
Median TTFT (ms):                        124.49    
P99 TTFT (ms):                           186.96    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.99     
Median TPOT (ms):                        11.03     
P99 TPOT (ms):                           11.39     
---------------Inter-token Latency----------------
Mean ITL (ms):                           10.99     
Median ITL (ms):                         10.54     
P99 ITL (ms):                            15.72     
==================================================
```

## Accuracy Testing

```
python3 -m lm_eval --model local-completions \
  --model_args model=nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=8 \
  --tasks gsm8k
```

Main:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9219|±  |0.0074|
|     |       |strict-match    |     5|exact_match|↑  |0.9219|±  |0.0074|
```

PR:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9219|±  |0.0074|
|     |       |strict-match    |     5|exact_match|↑  |0.9219|±  |0.0074|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

