### PR TITLE
[Core] add option to schedule requests based on full ISL

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -135,6 +135,12 @@ class SchedulerConfig:
     and starting configuration.
     """
 
+    scheduler_reserve_full_isl: bool = True
+    """If True, the scheduler checks whether the full input sequence length
+    fits in the KV cache before admitting a new request, rather than only
+    checking the first chunk. Prevents over-admission and KV cache thrashing
+    with chunked prefill."""
+
     async_scheduling: bool | None = Field(default=None)
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -530,6 +530,8 @@ class EngineArgs:
     enable_chunked_prefill: bool | None = None
     disable_chunked_mm_input: bool = SchedulerConfig.disable_chunked_mm_input
 
+    scheduler_reserve_full_isl: bool = SchedulerConfig.scheduler_reserve_full_isl
+
     disable_hybrid_kv_cache_manager: bool | None = (
         SchedulerConfig.disable_hybrid_kv_cache_manager
     )
@@ -1233,6 +1235,10 @@ class EngineArgs:
             "--scheduler-cls", **scheduler_kwargs["scheduler_cls"]
         )
         scheduler_group.add_argument(
+            "--scheduler-reserve-full-isl",
+            **scheduler_kwargs["scheduler_reserve_full_isl"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -1807,6 +1813,7 @@ class EngineArgs:
             max_num_partial_prefills=self.max_num_partial_prefills,
             max_long_partial_prefills=self.max_long_partial_prefills,
             long_prefill_token_threshold=self.long_prefill_token_threshold,
+            scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -215,6 +215,45 @@ class KVCacheManager:
 
         return self.create_kv_cache_blocks(computed_blocks), num_new_computed_tokens
 
+    def can_fit_full_sequence(
+        self,
+        request: Request,
+        num_new_computed_tokens: int = 0,
+        new_computed_blocks: KVCacheBlocks | None = None,
+        num_external_computed_tokens: int = 0,
+        num_encoder_tokens: int = 0,
+    ) -> bool:
+        """Check if the KV cache has enough free blocks to hold the full
+        sequence, accounting for prefix cache hits and sliding window.
+
+        This is used as an admission gate to prevent over-admitting requests
+        when chunked prefill would otherwise only check the first chunk.
+        """
+        if new_computed_blocks is not None:
+            new_computed_block_list = new_computed_blocks.blocks
+        else:
+            new_computed_block_list = self.empty_kv_cache_blocks.blocks
+
+        num_local_computed_tokens = (
+            request.num_computed_tokens + num_new_computed_tokens
+        )
+        total_computed_tokens = min(
+            num_local_computed_tokens + num_external_computed_tokens,
+            self.max_model_len,
+        )
+        full_num_tokens = min(request.num_tokens, self.max_model_len)
+
+        num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+            request_id=request.request_id,
+            num_tokens=full_num_tokens,
+            new_computed_blocks=new_computed_block_list,
+            num_encoder_tokens=num_encoder_tokens,
+            total_computed_tokens=total_computed_tokens,
+            num_tokens_main_model=full_num_tokens,
+        )
+
+        return num_blocks_to_allocate <= self.block_pool.get_num_free_blocks()
+
     def allocate_slots(
         self,
         request: Request,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -236,6 +236,9 @@ class Scheduler(SchedulerInterface):
         )
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
         self.use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
+        self.scheduler_reserve_full_isl = (
+            self.scheduler_config.scheduler_reserve_full_isl
+        )
 
         self.has_mamba_layers = kv_cache_config.has_mamba_layers
         self.needs_kv_cache_zeroing = kv_cache_config.needs_kv_cache_zeroing
@@ -718,6 +721,20 @@ class Scheduler(SchedulerInterface):
                         request.get_num_encoder_embeds(i)
                         for i in encoder_inputs_to_schedule
                     )
+
+                if (
+                    self.scheduler_reserve_full_isl
+                    and not self.kv_cache_manager.can_fit_full_sequence(
+                        request,
+                        num_new_computed_tokens=num_new_local_computed_tokens,
+                        new_computed_blocks=new_computed_blocks,
+                        num_external_computed_tokens=num_external_computed_tokens,
+                        num_encoder_tokens=num_encoder_tokens,
+                    )
+                ):
+                    if request.has_encoder_inputs:
+                        self.encoder_cache_manager.free(request)
+                    break
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,


### PR DESCRIPTION
## Purpose
The default behaviour of vLLM is to schedule requests if the first chunk of a request fits.

Observed problematic behavior (ISL numbers are mocked because this is customer data): When 4×100k ISL requests already occupy ~90% of the KV cache, the scheduler still admits a 5th 100k ISL request. It prefills in chunks until ~50k tokens are processed and KV cache hits ~100% capacity, triggering a preemption. The preempted request re-enters the queue and gets rescheduled, repeating the cycle.
In this particularly bad case, it creates a continuous prefill overhead that starves decode requests, dropping generation throughput from ~100 tok/s/GPU to as low as 1.5 tok/s/GPU.


This MR adds the option to calculate occupancy based on full ISL via env var. **We can also make this option the default, or available via CLI params**.
It is worth noting that TRT-LLM has an option that guarantees no evictions happen, based on full ISL + assuming max_new_tokens will be hit. I do not solve that, but instead just estimate full ISL.

## Test Plan


with the following command:
```
vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
	--host 0.0.0.0 \
	--port 8080 \
	--max-model-len 41001 \
	--tensor-parallel-size 8 \
	--data-parallel-size 1 \
	--enable-expert-parallel \
	--no-enable-prefix-caching \
	--api-server-count 1 \
	--enable-chunked-prefill &
sleep 10
VLLM_LOGGING_LEVEL=ERROR vllm bench serve \
	--backend vllm \
	--model Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
	--dataset-name random \
	--random-input-len 40000 \
	--random-output-len 1000 \
	--num-prompts 100 \
	--ignore-eos \
	--ready-check-timeout-sec 600 \
	--port 8080 
```

## Test Result
the perf with VLLM_SCHEDULER_FULL_ISL_ADMISSION=0:
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  368.99    
Total input tokens:                      4000000   
Total generated tokens:                  100000    
Request throughput (req/s):              0.27      
Output token throughput (tok/s):         271.01    
Peak output token throughput (tok/s):    1100.00   
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          11111.27  
---------------Time to First Token----------------
Mean TTFT (ms):                          158613.40 
Median TTFT (ms):                        153947.23 
P99 TTFT (ms):                           315416.48 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          159.07    
Median TPOT (ms):                        177.94    
P99 TPOT (ms):                           227.13    
---------------Inter-token Latency----------------
Mean ITL (ms):                           159.07    
Median ITL (ms):                         47.52     
P99 ITL (ms):                            434.29    
==================================================
```

and the perf with VLLM_SCHEDULER_FULL_ISL_ADMISSION=1
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  258.14    
Total input tokens:                      4000000   
Total generated tokens:                  100000    
Request throughput (req/s):              0.39      
Output token throughput (tok/s):         387.39    
Peak output token throughput (tok/s):    1100.00   
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          15883.01  
---------------Time to First Token----------------
Mean TTFT (ms):                          106236.66 
Median TTFT (ms):                        105355.69 
P99 TTFT (ms):                           210607.48 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          103.50    
Median TPOT (ms):                        119.78    
P99 TPOT (ms):                           123.67    
---------------Inter-token Latency----------------
Mean ITL (ms):                           103.50    
Median ITL (ms):                         47.60     
P99 ITL (ms):                            433.86    
==================================================
```

## Misc

I also found an explicit logger warning very useful when eviction happens as for long ISLs this is costly. The logs in the problematic case now look like this:
```
(APIServer pid=11574) INFO 03-17 15:38:10 [loggers.py:259] Engine 000: Avg prompt throughput: 23998.2 tokens/s, Avg generation throughput: 18.1 tokens/s, Running: 10 reqs, Waiting: 90 reqs, GPU KV cache usage: 19.3%, Prefix cache hit rate: 0.0%
(APIServer pid=11574) INFO 03-17 15:38:20 [loggers.py:259] Engine 000: Avg prompt throughput: 23999.9 tokens/s, Avg generation throughput: 35.4 tokens/s, Running: 16 reqs, Waiting: 84 reqs, GPU KV cache usage: 30.9%, Prefix cache hit rate: 0.0%
(APIServer pid=11574) INFO 03-17 15:38:30 [loggers.py:259] Engine 000: Avg prompt throughput: 23999.8 tokens/s, Avg generation throughput: 52.6 tokens/s, Running: 22 reqs, Waiting: 78 reqs, GPU KV cache usage: 42.5%, Prefix cache hit rate: 0.0%
(APIServer pid=11574) INFO 03-17 15:38:40 [loggers.py:259] Engine 000: Avg prompt throughput: 23998.3 tokens/s, Avg generation throughput: 69.6 tokens/s, Running: 28 reqs, Waiting: 72 reqs, GPU KV cache usage: 54.2%, Prefix cache hit rate: 0.0%
(APIServer pid=11574) INFO 03-17 15:38:50 [loggers.py:259] Engine 000: Avg prompt throughput: 24000.7 tokens/s, Avg generation throughput: 83.7 tokens/s, Running: 34 reqs, Waiting: 66 reqs, GPU KV cache usage: 65.4%, Prefix cache hit rate: 0.0%
(APIServer pid=11574) INFO 03-17 15:39:00 [loggers.py:259] Engine 000: Avg prompt throughput: 19999.5 tokens/s, Avg generation throughput: 99.5 tokens/s, Running: 40 reqs, Waiting: 60 reqs, GPU KV cache usage: 76.6%, Prefix cache hit rate: 0.0%
(APIServer pid=11574) INFO 03-17 15:39:10 [loggers.py:259] Engine 000: Avg prompt throughput: 23999.0 tokens/s, Avg generation throughput: 115.7 tokens/s, Running: 45 reqs, Waiting: 55 reqs, GPU KV cache usage: 87.9%, Prefix cache hit rate: 0.0%
(APIServer pid=11574) INFO 03-17 15:39:20 [loggers.py:259] Engine 000: Avg prompt throughput: 23997.8 tokens/s, Avg generation throughput: 131.5 tokens/s, Running: 51 reqs, Waiting: 49 reqs, GPU KV cache usage: 99.1%, Prefix cache hit rate: 0.0%
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:20 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=33620, preemption_count=1) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:22 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=2) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:23 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=3) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:25 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=4) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:26 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=5) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:27 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=6) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:29 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=7) due to insufficient KV cache blocks.
(APIServer pid=11574) INFO 03-17 15:39:30 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 180.0 tokens/s, Running: 51 reqs, Waiting: 49 reqs, GPU KV cache usage: 99.5%, Prefix cache hit rate: 0.0%
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:30 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=8) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:32 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=9) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:33 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=10) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:34 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=11) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:36 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=12) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:37 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=13) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:39 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=32568, preemption_count=14) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:40 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=24426, preemption_count=15) due to insufficient KV cache blocks.
(APIServer pid=11574) INFO 03-17 15:39:40 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 175.0 tokens/s, Running: 51 reqs, Waiting: 49 reqs, GPU KV cache usage: 99.6%, Prefix cache hit rate: 0.0%
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:41 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=24426, preemption_count=16) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:42 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=24426, preemption_count=17) due to insufficient KV cache blocks.
(EngineCore_DP0 pid=11842) WARNING 03-17 15:39:43 [scheduler.py:928] Request cmpl-bench-5f83f700-51-0-bfc32831 preempted (num_tokens=40000, computed_tokens=24426, preemption_count=18) due to insufficient KV cache blocks.
```

