### PR TITLE
[Bugfix] Fix unreachable structured_outputs + tool_choice conflict check

### DIFF
--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -61,3 +61,68 @@ def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
                 "tools": None,
             }
         )
+
+
+SAMPLE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+        },
+    },
+}
+
+
+def test_structured_outputs_with_named_tool_choice_rejected():
+    """structured_outputs cannot be combined with a named tool_choice."""
+    with pytest.raises(
+        ValueError,
+        match="structured outputs or tools, not both",
+    ):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tools": [SAMPLE_TOOL],
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                },
+                "structured_outputs": {"json": {"type": "object"}},
+            }
+        )
+
+
+def test_structured_outputs_with_auto_tool_choice_allowed():
+    """structured_outputs with tool_choice 'auto' should be allowed."""
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "tools": [SAMPLE_TOOL],
+            "tool_choice": "auto",
+            "structured_outputs": {"json": {"type": "object"}},
+        }
+    )
+    assert request.tool_choice == "auto"
+
+
+def test_multiple_structured_outputs_rejected():
+    """Only one kind of structured output constraint is allowed."""
+    with pytest.raises(
+        ValueError,
+        match="You can only use one kind of constraints",
+    ):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "structured_outputs": {
+                    "json": {"type": "object"},
+                    "regex": ".*",
+                },
+            }
+        )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -621,7 +621,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 "outputs ('json', 'regex' or 'choice')."
             )
         # you can only either use structured outputs or tools, not both
-        if count > 1 and data.get("tool_choice", "none") not in (
+        if count > 0 and data.get("tool_choice", "none") not in (
             "none",
             "auto",
             "required",


### PR DESCRIPTION
## Summary

The second condition in `check_structured_outputs_count` is unreachable dead code. It checks `count > 1` to reject combining `structured_outputs` with a named `tool_choice`, but the first condition already raises when `count > 1` (multiple constraint types).

### Before (bug)
```python
# raises when count > 1
if count > 1:
    raise ValueError("only one kind of constraints")

# DEAD CODE: count > 1 was already caught above
if count > 1 and tool_choice is named:
    raise ValueError("structured outputs or tools, not both")
```

**Result:** `structured_outputs={"json": ...}` + `tool_choice={"function": {"name": "foo"}}` silently passes validation (`count == 1`, so `1 > 1` is `False`).

### After (fix)
```python
if count > 1:
    raise ValueError("only one kind of constraints")

if count > 0 and tool_choice is named:
    raise ValueError("structured outputs or tools, not both")
```

### Tests
Added three test cases:
- `structured_outputs` + named `tool_choice` → rejected ✅
- `structured_outputs` + `tool_choice="auto"` → allowed ✅
- Multiple `structured_outputs` constraints → rejected ✅