### PR TITLE
[Misc] Use VLLMValidationError for user-facing errors in Responses harmony

### DIFF
--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -37,6 +37,7 @@ from vllm.entrypoints.openai.responses.protocol import (
     ResponseInputOutputItem,
     ResponsesRequest,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.utils import random_uuid
 
@@ -85,7 +86,10 @@ def _parse_chat_format_message(chat_msg: dict) -> list[Message]:
     """Parse an OpenAI chat-format dict into Harmony messages."""
     role = chat_msg.get("role")
     if role is None:
-        raise ValueError(f"Message has no 'role' key: {chat_msg}")
+        raise VLLMValidationError(
+            f"Message has no 'role' key: {chat_msg}",
+            parameter="messages",
+        )
 
     # Assistant message with tool calls
     tool_calls = chat_msg.get("tool_calls")
@@ -170,7 +174,10 @@ def response_input_to_harmony(
                 call_response = prev_response
                 break
         if call_response is None:
-            raise ValueError(f"No call message found for {call_id}")
+            raise VLLMValidationError(
+                f"No call message found for {call_id}",
+                parameter="input",
+            )
         msg = Message.from_author_and_content(
             Author.new(Role.TOOL, f"functions.{call_response.name}"),
             response_msg["output"],
@@ -189,7 +196,10 @@ def response_input_to_harmony(
         msg = msg.with_recipient(f"functions.{response_msg['name']}")
         msg = msg.with_content_type("json")
     else:
-        raise ValueError(f"Unknown input type: {response_msg['type']}")
+        raise VLLMValidationError(
+            f"Unknown input type: {response_msg['type']}",
+            parameter="input",
+        )
     return msg
 
 


### PR DESCRIPTION
## Summary

Replace `ValueError` with `VLLMValidationError` for three user-input validation errors in the Responses API Harmony conversion layer. This adds the `parameter` field to error responses, helping API clients identify which part of their request is invalid.

### Changed
- Missing `role` key in chat-format message → `parameter: "messages"`
- Invalid `call_id` reference in `function_call_output` → `parameter: "input"`
- Unknown input type in previous response → `parameter: "input"`

### Not changed
Internal processing errors (browser message parsing, unknown channel) are kept as `ValueError` since they indicate server-side issues rather than invalid user input.

This continues the effort from #36256, #35531, #35510 to use `VLLMValidationError` consistently across the frontend layer.