### PR TITLE
[ROCm][CI] Skip trtllm kvfp8 dequant tests on ROCm

### DIFF
--- a/tests/kernels/attention/test_trtllm_kvfp8_dequant.py
+++ b/tests/kernels/attention/test_trtllm_kvfp8_dequant.py
@@ -12,6 +12,12 @@ import torch
 
 from vllm.platforms import current_platform
 
+if current_platform.is_rocm():
+    pytest.skip(
+        "trtllm kvfp8 dequant is not supported on ROCm.",
+        allow_module_level=True,
+    )
+
 FP8_DTYPE = current_platform.fp8_dtype()
 
 NUM_BLOCKS = 128


### PR DESCRIPTION
- Add module-level `pytest.skip` for ROCm in `test_trtllm_kvfp8_dequant.py`
- Follows the same skip pattern used in `test_flashinfer.py`

cc @kenroche 