### PR TITLE
[Scheduler][WIP] Try to reduce preemption

### DIFF
--- a/tests/v1/engine/test_init_error_messaging.py
+++ b/tests/v1/engine/test_init_error_messaging.py
@@ -38,7 +38,7 @@ def test_kv_cache_oom_insufficient_memory(monkeypatch):
 
     monkeypatch.setattr(
         "vllm.v1.core.kv_cache_utils.max_memory_usage_bytes",
-        lambda c, s: 100 * 1024**3,  # 100 GiB
+        lambda c, s, m: 100 * 1024**3,  # 100 GiB
     )
 
     spec = {

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -146,6 +146,12 @@ class SchedulerConfig:
     while a larger value (e.g., 10) reduces host overhead and may increase throughput
     by batching multiple tokens before sending."""
 
+    min_free_block_ratio: float = Field(default=0.0, ge=0.0, le=1.0)
+    """Minimum ratio of free KV cache blocks required to schedule new requests.
+    When the ratio of free blocks after allocating for a new request would fall
+    below this threshold, the scheduler stops admitting new requests to avoid
+    preemption. Set to 0.0 to disable this check (default)."""
+
     @staticmethod
     def default_factory(**kwargs):
         """

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -598,6 +598,7 @@ class EngineArgs:
     async_scheduling: bool | None = SchedulerConfig.async_scheduling
 
     stream_interval: int = SchedulerConfig.stream_interval
+    min_free_block_ratio: float = SchedulerConfig.min_free_block_ratio
 
     kv_sharing_fast_prefill: bool = CacheConfig.kv_sharing_fast_prefill
     optimization_level: OptimizationLevel = VllmConfig.optimization_level
@@ -1789,6 +1790,7 @@ class EngineArgs:
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,
+            min_free_block_ratio=self.min_free_block_ratio,
         )
 
         if not model_config.is_multimodal_model and self.default_mm_loras:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -651,12 +651,17 @@ def _check_enough_kv_cache_memory(
 
 
 def max_memory_usage_bytes(
-    vllm_config: VllmConfig, kv_cache_specs: Iterable[KVCacheSpec]
+    vllm_config: VllmConfig,
+    kv_cache_specs: Iterable[KVCacheSpec],
+    max_model_len: int,
 ) -> int:
     """
     Get the maximum memory usage in bytes for the given KV cache specs.
     """
-    return sum(spec.max_memory_usage_bytes(vllm_config) for spec in kv_cache_specs)
+    return sum(
+        spec.max_memory_usage_bytes(vllm_config, max_model_len)
+        for spec in kv_cache_specs
+    )
 
 
 def estimate_max_model_len(
@@ -679,38 +684,31 @@ def estimate_max_model_len(
     Returns:
         The estimated maximum model length that can fit in the available memory.
     """
-    # Save the original max_model_len to restore after estimation
-    original_max_model_len = vllm_config.model_config.max_model_len
 
     # Define a function to check if a given model length fits in memory
     def fits_in_memory(model_len: int) -> bool:
-        # Temporarily modify the max_model_len for this calculation
-        vllm_config.model_config.max_model_len = model_len
-        # Calculate memory needed for the given model length
-        memory_needed = max_memory_usage_bytes(vllm_config, kv_cache_spec.values())
+        memory_needed = max_memory_usage_bytes(
+            vllm_config, kv_cache_spec.values(), model_len
+        )
         return memory_needed <= available_memory
 
-    try:
-        # Binary search for the maximum model length
-        left, right = 1, original_max_model_len
+    # Binary search for the maximum model length
+    left, right = 1, vllm_config.model_config.max_model_len
 
-        # If even the smallest model length doesn't fit, return 0
-        if not fits_in_memory(left):
-            return 0
+    # If even the smallest model length doesn't fit, return 0
+    if not fits_in_memory(left):
+        return 0
 
-        # Binary search for the maximum model length that fits
-        result = 1
-        while left <= right:
-            mid = (left + right) // 2
-            if fits_in_memory(mid):
-                result = mid
-                left = mid + 1
-            else:
-                right = mid - 1
-        return result
-    finally:
-        # Always restore the original max_model_len to avoid side effects
-        vllm_config.model_config.max_model_len = original_max_model_len
+    # Binary search for the maximum model length that fits
+    result = 1
+    while left <= right:
+        mid = (left + right) // 2
+        if fits_in_memory(mid):
+            result = mid
+            left = mid + 1
+        else:
+            right = mid - 1
+    return result
 
 
 def check_enough_kv_cache_memory(
@@ -735,7 +733,11 @@ def check_enough_kv_cache_memory(
     if kv_cache_spec:
         _check_enough_kv_cache_memory(
             available_memory,
-            lambda: max_memory_usage_bytes(vllm_config, kv_cache_spec.values()),
+            lambda: max_memory_usage_bytes(
+                vllm_config,
+                kv_cache_spec.values(),
+                vllm_config.model_config.max_model_len,
+            ),
             vllm_config.model_config.max_model_len,
             lambda am: estimate_max_model_len(vllm_config, kv_cache_spec, am),
         )
@@ -806,7 +808,9 @@ def get_max_concurrency_for_kv_cache_config(
         len(group.layer_names) for group in kv_cache_config.kv_cache_groups
     )
     max_memory_usage_per_request = num_layer_per_group * max_memory_usage_bytes(
-        vllm_config, (group.kv_cache_spec for group in kv_cache_config.kv_cache_groups)
+        vllm_config,
+        (group.kv_cache_spec for group in kv_cache_config.kv_cache_groups),
+        vllm_config.model_config.max_model_len,
     )
     memory_per_block = (
         kv_cache_config.kv_cache_groups[0].kv_cache_spec.page_size_bytes
@@ -1329,6 +1333,7 @@ def _report_kv_cache_config(
 def _max_memory_usage_bytes_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
+    max_model_len: int,
 ) -> int:
     """
     Calculate maximum memory usage in bytes from KV cache groups.
@@ -1346,7 +1351,7 @@ def _max_memory_usage_bytes_from_groups(
     ):
         per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
         return sum(
-            spec.max_memory_usage_bytes(vllm_config)
+            spec.max_memory_usage_bytes(vllm_config, max_model_len)
             for spec in per_layer_specs.values()
         )
 
@@ -1357,7 +1362,10 @@ def _max_memory_usage_bytes_from_groups(
         [group.kv_cache_spec for group in kv_cache_groups]
     )
     blocks_needed = sum(
-        cdiv(group.kv_cache_spec.max_memory_usage_bytes(vllm_config), page_size)
+        cdiv(
+            group.kv_cache_spec.max_memory_usage_bytes(vllm_config, max_model_len),
+            page_size,
+        )
         for group in kv_cache_groups
     )
 
@@ -1373,30 +1381,25 @@ def _estimate_max_model_len_from_groups(
     Binary search for the maximum model length that fits in available memory.
     Returns 0 if even 1 token doesn't fit.
     """
-    original_max = vllm_config.model_config.max_model_len
 
     def fits(model_len: int) -> bool:
-        vllm_config.model_config.max_model_len = model_len
         return (
-            _max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
+            _max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups, model_len)
             <= available_memory
         )
 
-    try:
-        left, right = 1, original_max
-        if not fits(left):
-            return 0
-        result = 1
-        while left <= right:
-            mid = (left + right) // 2
-            if fits(mid):
-                result = mid
-                left = mid + 1
-            else:
-                right = mid - 1
-        return result
-    finally:
-        vllm_config.model_config.max_model_len = original_max
+    left, right = 1, vllm_config.model_config.max_model_len
+    if not fits(left):
+        return 0
+    result = 1
+    while left <= right:
+        mid = (left + right) // 2
+        if fits(mid):
+            result = mid
+            left = mid + 1
+        else:
+            right = mid - 1
+    return result
 
 
 def _auto_fit_max_model_len(
@@ -1575,7 +1578,12 @@ def get_kv_cache_configs(
             continue
         _check_enough_kv_cache_memory(
             avail_mem,
-            partial(_max_memory_usage_bytes_from_groups, vllm_config, groups),
+            partial(
+                _max_memory_usage_bytes_from_groups,
+                vllm_config,
+                groups,
+                vllm_config.model_config.max_model_len,
+            ),
             vllm_config.model_config.max_model_len,
             partial(_estimate_max_model_len_from_groups, vllm_config, groups),
         )
@@ -1688,3 +1696,13 @@ class BlockHashListWithBlockSize:
 
 
 BlockHashList = list[BlockHash] | BlockHashListWithBlockSize
+
+
+def get_max_num_blocks(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig, num_tokens: int
+) -> int:
+    return sum(
+        group.kv_cache_spec.max_memory_usage_bytes(vllm_config, num_tokens)
+        // group.kv_cache_spec.page_size_bytes
+        for group in kv_cache_config.kv_cache_groups
+    )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -38,6 +38,7 @@ from vllm.v1.core.encoder_cache_manager import (
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
+from vllm.v1.core.kv_cache_utils import get_max_num_blocks
 from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
 from vllm.v1.core.sched.output import (
     CachedRequestData,
@@ -563,6 +564,22 @@ class Scheduler(SchedulerInterface):
 
                 request = request_queue.peek_request()
                 request_id = request.request_id
+
+                if self.scheduler_config.min_free_block_ratio > 0:
+                    num_blocks_new_req = get_max_num_blocks(
+                        self.vllm_config, self.kv_cache_config, request.num_tokens
+                    )
+                    if (
+                        (
+                            self.kv_cache_manager.block_pool.get_num_free_blocks()
+                            - num_blocks_new_req
+                        )
+                        / self.kv_cache_manager.block_pool.num_gpu_blocks
+                        < self.scheduler_config.min_free_block_ratio
+                    ):
+                        # avoid scheduling new requests when kv cache usage is high.
+                        # This is to avoid preemption
+                        break
 
                 # try to promote blocked statuses while traversing skipped queue.
                 if self._is_blocked_waiting_status(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -35,9 +35,15 @@ class KVCacheSpec:
         """
         raise NotImplementedError
 
-    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+    def max_memory_usage_bytes(
+        self, vllm_config: VllmConfig, max_model_len: int
+    ) -> int:
         """
         The maximum possible memory usage of this KV cache in bytes.
+
+        Args:
+            vllm_config: The global VllmConfig.
+            max_model_len: The maximum sequence length to compute usage for.
 
         Returns:
             The KV cache size in bytes
@@ -110,8 +116,9 @@ class FullAttentionSpec(AttentionSpec):
         if self.head_size_v is None:
             object.__setattr__(self, "head_size_v", self.head_size)
 
-    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
-        max_model_len = vllm_config.model_config.max_model_len
+    def max_memory_usage_bytes(
+        self, vllm_config: VllmConfig, max_model_len: int
+    ) -> int:
         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
         pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
         # Note(hc): each dcp rank only need save
@@ -229,8 +236,9 @@ class MLAAttentionSpec(FullAttentionSpec):
 class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
 
-    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
-        max_model_len = vllm_config.model_config.max_model_len
+    def max_memory_usage_bytes(
+        self, vllm_config: VllmConfig, max_model_len: int
+    ) -> int:
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
 
         # During chunked prefill, we allocate KV cache for at most
@@ -248,11 +256,12 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
 class SlidingWindowSpec(AttentionSpec):
     sliding_window: int
 
-    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+    def max_memory_usage_bytes(
+        self, vllm_config: VllmConfig, max_model_len: int
+    ) -> int:
         assert vllm_config.parallel_config.decode_context_parallel_size == 1, (
             "DCP not support sliding window."
         )
-        max_model_len = vllm_config.model_config.max_model_len
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
 
         # During chunked prefill, we allocate KV cache for the last
@@ -290,9 +299,10 @@ class MambaSpec(KVCacheSpec):
             return self.page_size_padded
         return page_size
 
-    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+    def max_memory_usage_bytes(
+        self, vllm_config: VllmConfig, max_model_len: int
+    ) -> int:
         if vllm_config.cache_config.mamba_cache_mode == "all":
-            max_model_len = vllm_config.model_config.max_model_len
             return cdiv(max_model_len, self.block_size) * self.page_size_bytes
         elif vllm_config.cache_config.mamba_cache_mode == "align":
             return self.page_size_bytes * (2 + self.num_speculative_blocks)
@@ -302,7 +312,9 @@ class MambaSpec(KVCacheSpec):
 
 @dataclass(frozen=True)
 class EncoderOnlyAttentionSpec(AttentionSpec):
-    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+    def max_memory_usage_bytes(
+        self, vllm_config: VllmConfig, max_model_len: int
+    ) -> int:
         # Encoder-only layers do not need KV cache
         return 0
 
@@ -313,7 +325,9 @@ class CrossAttentionSpec(AttentionSpec):
     KV cache spec for cross-attention layers in encoder-decoder models.
     """
 
-    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+    def max_memory_usage_bytes(
+        self, vllm_config: VllmConfig, max_model_len: int
+    ) -> int:
         # For cross-attention, we need to cache encoder states
         # Get encoder length (e.g., 1500 for Whisper).
         max_encoder_len = vllm_config.scheduler_config.max_num_encoder_input_tokens
@@ -386,9 +400,14 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
     def page_size_bytes(self) -> int:
         return sum(spec.page_size_bytes for spec in self.kv_cache_specs.values())
 
-    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+    def max_memory_usage_bytes(
+        self, vllm_config: VllmConfig, max_model_len: int
+    ) -> int:
         max_num_pages = max(
-            cdiv(spec.max_memory_usage_bytes(vllm_config), spec.page_size_bytes)
+            cdiv(
+                spec.max_memory_usage_bytes(vllm_config, max_model_len),
+                spec.page_size_bytes,
+            )
             for spec in self.kv_cache_specs.values()
         )
         return max_num_pages * self.page_size_bytes


### PR DESCRIPTION

## Purpose
Reduce preemption by
* making schedule decision on whether to schedule a new request from the full prompt length rather than tokens of this step
* add rooms for decode tokens  

Core logic

```
if (
    (
    self.kv_cache_manager.block_pool.get_num_free_blocks()
    - num_blocks_new_req
    )
    / self.kv_cache_manager.block_pool.num_gpu_blocks
    < self.scheduler_config.min_free_block_ratio
 ):
    # avoid scheduling new requests when kv cache usage is high.
    # This is to avoid preemption
    break
```
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

