### PR TITLE
[ROCm][CI] Add ROCM_EXTRA_ARGS to audio_in_video test server fixture

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_audio_in_video.py
+++ b/tests/entrypoints/openai/chat_completion/test_audio_in_video.py
@@ -9,7 +9,7 @@ import pytest
 import pytest_asyncio
 
 from tests.conftest import VideoTestAssets
-from tests.utils import RemoteOpenAIServer
+from tests.utils import ROCM_EXTRA_ARGS, RemoteOpenAIServer
 
 MODEL_NAME = "Qwen/Qwen2.5-Omni-3B"
 
@@ -22,6 +22,7 @@ def server():
         "--enforce-eager",
         "--limit-mm-per-prompt",
         json.dumps({"audio": 3, "video": 3}),
+        *ROCM_EXTRA_ARGS,
     ]
 
     with RemoteOpenAIServer(


### PR DESCRIPTION
- Add `ROCM_EXTRA_ARGS` to the `test_audio_in_video` server fixture
- On ROCm, this disables prefix caching and limits to 1 sequence to reduce batch variance that can cause early EOS (reason `stop` instead of `length`)

## Test plan
- [x] `pytest -s -v tests/entrypoints/openai/chat_completion/test_audio_in_video.py`

cc @kenroche 