### PR TITLE
[BugFix] Ensure num_cached_tokens is non-negative for kv transfer failed requests

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1470,7 +1470,7 @@ class Scheduler(SchedulerInterface):
                         finish_reason=request.get_finished_reason(),
                         events=request.take_events(),
                         trace_headers=request.trace_headers,
-                        num_cached_tokens=request.num_cached_tokens,
+                        num_cached_tokens=max(0, request.num_cached_tokens),
                     )
                 )
 


### PR DESCRIPTION


<!-- markdownlint-disable -->

## Purpose

BugFix for failure kv load requests handling
For requests failing KV load in decode side, since it's still in WAITING_REMOTE_KV state, its num_cached_tokens are still the default -1, and it was never updated, when we do metrics logging on local_cache_hit, -1 will be used and will crash engine due to:

ValueError: Counters can only be incremented by non-negative amounts.

## Test Plan
Tested with stress testing and intentionally fail random kv transfer to surface the bug.


## Test Result
### Before:
logger will crash with ValueError: Counters can only be incremented by non-negative amounts.

### After:
No crash observed
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

