### PR TITLE
 Add local-runtime CLI, launcher install flow, and easy model management

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,71 +7,77 @@
 </p>
 
 <h3 align="center">
-Easy, fast, and cheap LLM serving for everyone
+High-performance LLM inference and serving, with a simpler local runtime
 </h3>
 
 <p align="center">
 | <a href="https://docs.vllm.ai"><b>Documentation</b></a> | <a href="https://blog.vllm.ai/"><b>Blog</b></a> | <a href="https://arxiv.org/abs/2309.06180"><b>Paper</b></a> | <a href="https://x.com/vllm_project"><b>Twitter/X</b></a> | <a href="https://discuss.vllm.ai"><b>User Forum</b></a> | <a href="https://slack.vllm.ai"><b>Developer Slack</b></a> |
 </p>
 
-🔥 We have built a vllm website to help you get started with vllm. Please visit [vllm.ai](https://vllm.ai) to learn more.
-For events, please visit [vllm.ai/events](https://vllm.ai/events) to join us.
+vLLM documentation, updates, and project resources are available at [vllm.ai](https://vllm.ai).
 
 ---
 
-## About
+## Overview
 
-vLLM is a fast and easy-to-use library for LLM inference and serving.
+vLLM is a high-performance inference and serving engine for large language models. This repository also adds a more direct local-runtime experience intended to make a source checkout feel closer to a local application install.
 
-Originally developed in the [Sky Computing Lab](https://sky.cs.berkeley.edu) at UC Berkeley, vLLM has evolved into a community-driven project with contributions from both academia and industry.
+The updated workflow focuses on:
 
-vLLM is fast with:
+- one-command installation from this repository
+- a lightweight `vllm` launcher for help, model management, and local runtime commands
+- short built-in model aliases for common Hugging Face models
+- direct shell-based execution with `vllm run`
+- managed local services through `vllm serve`, `vllm ps`, `vllm stop`, and `vllm logs`
 
-- State-of-the-art serving throughput
-- Efficient management of attention key and value memory with [**PagedAttention**](https://blog.vllm.ai/2023/06/20/vllm.html)
-- Continuous batching of incoming requests
-- Fast model execution with CUDA/HIP graph
-- Quantizations: [GPTQ](https://arxiv.org/abs/2210.17323), [AWQ](https://arxiv.org/abs/2306.00978), [AutoRound](https://arxiv.org/abs/2309.05516), INT4, INT8, and FP8
-- Optimized CUDA kernels, including integration with FlashAttention and FlashInfer
-- Speculative decoding
-- Chunked prefill
+The underlying vLLM engine and server stack remain intact, including:
 
-vLLM is flexible and easy to use with:
+- [PagedAttention](https://blog.vllm.ai/2023/06/20/vllm.html)
+- continuous batching
+- OpenAI-compatible serving
+- support for popular Hugging Face models
+- quantization, scheduling, and distributed inference features from vLLM
 
-- Seamless integration with popular Hugging Face models
-- High-throughput serving with various decoding algorithms, including *parallel sampling*, *beam search*, and more
-- Tensor, pipeline, data and expert parallelism support for distributed inference
-- Streaming outputs
-- OpenAI-compatible API server
-- Support for NVIDIA GPUs, AMD CPUs and GPUs, Intel CPUs and GPUs, PowerPC CPUs, Arm CPUs, and TPU. Additionally, support for diverse hardware plugins such as Intel Gaudi, IBM Spyre and Huawei Ascend.
-- Prefix caching support
-- Multi-LoRA support
+## Key Capabilities
 
-vLLM seamlessly supports most popular open-source models on HuggingFace, including:
+This repository is designed to support both the familiar vLLM workflows and a simpler local launcher flow.
 
-- Transformer-like LLMs (e.g., Llama)
-- Mixture-of-Expert LLMs (e.g., Mixtral, Deepseek-V2 and V3)
-- Embedding Models (e.g., E5-Mistral)
-- Multi-modal LLMs (e.g., LLaVA)
+- `./scripts/install.sh` installs the checkout with a standalone `vllm` command
+- `vllm --help` and other local metadata commands start quickly without loading the full runtime stack first
+- `vllm pull`, `vllm run`, and `vllm serve` provide the primary terminal workflow
+- `vllm aliases` exposes built-in short names for commonly used models
+- local runtime state is managed with `vllm ls`, `vllm inspect`, `vllm ps`, `vllm stop`, `vllm logs`, and `vllm rm`
+- deferred parity work and planned improvements are tracked in [docs/cli/local_runtime_followups.md](./docs/cli/local_runtime_followups.md)
 
-Find the full list of supported models [here](https://docs.vllm.ai/en/latest/models/supported_models.html).
+## Installation
 
-## What's New
+The shortest installation path from this repository is:
 
-This version keeps the existing vLLM engine and serving stack, but adds a more direct local-runtime workflow on top of it.
+```bash
+./scripts/install.sh
+vllm --help
+```
 
-New local-runtime features:
+The installer supports:
 
-- A repo-local bootstrap installer via `./scripts/install.sh`
-- A simpler CLI centered on `vllm pull`, `vllm run`, and `vllm serve`
-- A lightweight launcher so `vllm`, `vllm --help`, `vllm aliases`, `vllm pull`, and local service management feel immediate
-- Built-in short model aliases such as `deepseek-r1:8b`
-- Managed local background services with `vllm ps`, `vllm stop`, and `vllm logs`
-- A tracked backlog for deferred parity work in `docs/cli/local_runtime_followups.md`
+- system install
+- user-local install
+- explicit virtualenv install
+
+Examples:
+
+```bash
+./scripts/install.sh
+./scripts/install.sh --system
+./scripts/install.sh --venv .venv
+./scripts/install.sh --recreate
+```
+
+On Linux, the intended outcome is a usable `vllm` command installed directly into your path. On macOS, the installer currently uses the CPU source-build path; future Apple GPU support is planned separately.
 
 ## Quick Start
 
-If you want the fastest path to a local vLLM workflow from this repository:
+For a terminal-first local workflow:
 
 ```bash
 ./scripts/install.sh
@@ -80,32 +86,40 @@ vllm pull deepseek-r1:8b
 vllm run deepseek-r1:8b
 ```
 
-If you want a local API server instead:
+To start a local API service:
 
 ```bash
 vllm serve deepseek-r1:8b
 vllm ps
 ```
 
-## Core Flows
+## Local Runtime Workflow
 
-### Local Runtime
+The local launcher is organized around a small set of common commands:
 
-Use the new local commands when you want an easier terminal-first experience:
-
-- `vllm pull <model>` downloads a model using a short alias or exact Hugging Face repo
-- `vllm run <model>` opens a local shell chat or runs a one-shot prompt
+- `vllm pull <model>` downloads a model from an alias, Hugging Face repo, or local path
+- `vllm run <model>` runs directly in your shell for chat or prompt-based generation
 - `vllm serve <model>` starts a managed local service
-- `vllm aliases` lists the built-in easy-model shortcuts
-- `vllm ps`, `vllm stop`, and `vllm logs` manage those local services
+- `vllm aliases` lists the built-in short model names
+- `vllm ls` and `vllm inspect <model>` show local model metadata and resolution
+- `vllm ps`, `vllm stop`, and `vllm logs` manage background services
 
-### Built-in Easy Models
+This keeps the default local path simple while preserving the full vLLM runtime and API-serving capabilities.
 
-This version ships a larger set of built-in aliases so you can pull common models without remembering full Hugging Face repo IDs.
+## Model Support
 
-Examples:
+There are two layers of model support to keep in mind:
 
-- `deepseek-r1:1.5b`, `deepseek-r1:7b`, `deepseek-r1:8b`, `deepseek-r1:14b`, `deepseek-r1:32b`, `deepseek-r1:70b`
+1. Easy aliases
+2. Broader vLLM model support
+
+### Built-in Aliases
+
+The launcher includes a built-in alias catalog so common models can be referenced with short names instead of full Hugging Face repository IDs.
+
+Current aliases include:
+
+- `deepseek-r1:1.5b`, `deepseek-r1:7b`, `deepseek-r1:8b`, `deepseek-r1:14b`, `deepseek-r1:32b`, `deepseek-r1:70b`, `deepseek-v3`
 - `llama3.2:1b-instruct`, `llama3.2:3b-instruct`, `llama3.1:8b-instruct`, `llama3.1:70b-instruct`, `llama3.3:70b-instruct`
 - `qwen2.5:0.5b-instruct`, `qwen2.5:1.5b-instruct`, `qwen2.5:3b-instruct`, `qwen2.5:7b-instruct`, `qwen2.5:14b-instruct`, `qwen2.5:32b-instruct`, `qwen2.5:72b-instruct`
 - `qwen2.5-coder:1.5b-instruct`, `qwen2.5-coder:7b-instruct`, `qwen2.5-coder:32b-instruct`
@@ -114,16 +128,27 @@ Examples:
 - `phi3.5:mini-instruct`, `phi3.5:moe-instruct`, `phi4`
 - `smollm2:360m-instruct`, `smollm2:1.7b-instruct`
 
-Use `vllm aliases` for the full installed list.
+Run `vllm aliases` to inspect the installed catalog.
 
-### Existing vLLM Paths
+### General vLLM Compatibility
 
-The existing advanced vLLM workflows still exist:
+The alias list is only a convenience layer. `vllm pull` and `vllm run` also accept:
 
-- `pip install vllm` for the standard package install path
-- `vllm serve` in foreground mode for the existing server-first workflow
-- `vllm chat`, `vllm complete`, `vllm bench`, and `vllm run-batch` for the existing advanced CLI surface
-- Python library usage via `LLM`, `AsyncLLMEngine`, and the OpenAI-compatible server stack
+- exact Hugging Face repositories such as `meta-llama/Llama-3.1-8B-Instruct`
+- local filesystem paths
+
+Broader compatibility still follows what vLLM itself supports. For the full model-compatibility matrix, see [Supported Models](https://docs.vllm.ai/en/latest/models/supported_models.html).
+
+## Existing vLLM Workflows
+
+The local launcher flow is intended to improve the default user experience, not replace the existing vLLM interfaces.
+
+You can still use:
+
+- Python library APIs such as `LLM` and `AsyncLLMEngine`
+- foreground `vllm serve`
+- `vllm chat`, `vllm complete`, `vllm bench`, and `vllm run-batch`
+- standard package installation and development workflows
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,34 @@ Visit our [documentation](https://docs.vllm.ai/en/latest/) to learn more.
 - [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html)
 - [List of Supported Models](https://docs.vllm.ai/en/latest/models/supported_models.html)
 
+## Fork Updates
+
+This fork adds a more local-runtime-focused UX on top of the existing vLLM engine and server stack.
+
+What is different in this fork:
+
+- A repo-local bootstrap installer via `./scripts/install.sh`
+- A simpler local CLI flow centered on `vllm pull`, `vllm run`, and `vllm serve`
+- Short built-in model aliases such as `deepseek-r1:8b` that resolve to Hugging Face repos
+- Managed local background services with `vllm ps`, `vllm stop`, and `vllm logs`
+- A follow-up tracker for remaining parity work in `docs/cli/local_runtime_followups.md`
+
+Example local flow:
+
+```bash
+./scripts/install.sh
+vllm pull deepseek-r1:8b
+vllm run deepseek-r1:8b
+vllm serve deepseek-r1:8b
+vllm ps
+```
+
+For more detail, see:
+
+- [CLI Guide](./docs/cli/README.md)
+- [Quickstart](./docs/getting_started/quickstart.md)
+- [Local Runtime Follow-ups](./docs/cli/local_runtime_followups.md)
+
 ## Contributing
 
 We welcome and value any contributions and collaborations.

--- a/README.md
+++ b/README.md
@@ -56,47 +56,84 @@ vLLM seamlessly supports most popular open-source models on HuggingFace, includi
 
 Find the full list of supported models [here](https://docs.vllm.ai/en/latest/models/supported_models.html).
 
-## Getting Started
+## What's New
 
-Install vLLM with `pip` or [from source](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/index.html#build-wheel-from-source):
+This version keeps the existing vLLM engine and serving stack, but adds a more direct local-runtime workflow on top of it.
+
+New local-runtime features:
+
+- A repo-local bootstrap installer via `./scripts/install.sh`
+- A simpler CLI centered on `vllm pull`, `vllm run`, and `vllm serve`
+- A lightweight launcher so `vllm`, `vllm --help`, `vllm aliases`, `vllm pull`, and local service management feel immediate
+- Built-in short model aliases such as `deepseek-r1:8b`
+- Managed local background services with `vllm ps`, `vllm stop`, and `vllm logs`
+- A tracked backlog for deferred parity work in `docs/cli/local_runtime_followups.md`
+
+## Quick Start
+
+If you want the fastest path to a local vLLM workflow from this repository:
 
 ```bash
-pip install vllm
+./scripts/install.sh
+vllm aliases
+vllm pull deepseek-r1:8b
+vllm run deepseek-r1:8b
 ```
+
+If you want a local API server instead:
+
+```bash
+vllm serve deepseek-r1:8b
+vllm ps
+```
+
+## Core Flows
+
+### Local Runtime
+
+Use the new local commands when you want an easier terminal-first experience:
+
+- `vllm pull <model>` downloads a model using a short alias or exact Hugging Face repo
+- `vllm run <model>` opens a local shell chat or runs a one-shot prompt
+- `vllm serve <model>` starts a managed local service
+- `vllm aliases` lists the built-in easy-model shortcuts
+- `vllm ps`, `vllm stop`, and `vllm logs` manage those local services
+
+### Built-in Easy Models
+
+This version ships a larger set of built-in aliases so you can pull common models without remembering full Hugging Face repo IDs.
+
+Examples:
+
+- `deepseek-r1:1.5b`, `deepseek-r1:7b`, `deepseek-r1:8b`, `deepseek-r1:14b`, `deepseek-r1:32b`, `deepseek-r1:70b`
+- `llama3.2:1b-instruct`, `llama3.2:3b-instruct`, `llama3.1:8b-instruct`, `llama3.1:70b-instruct`, `llama3.3:70b-instruct`
+- `qwen2.5:0.5b-instruct`, `qwen2.5:1.5b-instruct`, `qwen2.5:3b-instruct`, `qwen2.5:7b-instruct`, `qwen2.5:14b-instruct`, `qwen2.5:32b-instruct`, `qwen2.5:72b-instruct`
+- `qwen2.5-coder:1.5b-instruct`, `qwen2.5-coder:7b-instruct`, `qwen2.5-coder:32b-instruct`
+- `mistral:7b-instruct`, `ministral:8b-instruct`, `mistral-nemo:12b-instruct`, `mixtral:8x7b-instruct`
+- `gemma2:2b-it`, `gemma2:9b-it`, `gemma2:27b-it`
+- `phi3.5:mini-instruct`, `phi3.5:moe-instruct`, `phi4`
+- `smollm2:360m-instruct`, `smollm2:1.7b-instruct`
+
+Use `vllm aliases` for the full installed list.
+
+### Existing vLLM Paths
+
+The existing advanced vLLM workflows still exist:
+
+- `pip install vllm` for the standard package install path
+- `vllm serve` in foreground mode for the existing server-first workflow
+- `vllm chat`, `vllm complete`, `vllm bench`, and `vllm run-batch` for the existing advanced CLI surface
+- Python library usage via `LLM`, `AsyncLLMEngine`, and the OpenAI-compatible server stack
+
+## Documentation
 
 Visit our [documentation](https://docs.vllm.ai/en/latest/) to learn more.
 
 - [Installation](https://docs.vllm.ai/en/latest/getting_started/installation.html)
 - [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html)
-- [List of Supported Models](https://docs.vllm.ai/en/latest/models/supported_models.html)
-
-## Fork Updates
-
-This fork adds a more local-runtime-focused UX on top of the existing vLLM engine and server stack.
-
-What is different in this fork:
-
-- A repo-local bootstrap installer via `./scripts/install.sh`
-- A simpler local CLI flow centered on `vllm pull`, `vllm run`, and `vllm serve`
-- Short built-in model aliases such as `deepseek-r1:8b` that resolve to Hugging Face repos
-- Managed local background services with `vllm ps`, `vllm stop`, and `vllm logs`
-- A follow-up tracker for remaining parity work in `docs/cli/local_runtime_followups.md`
-
-Example local flow:
-
-```bash
-./scripts/install.sh
-vllm pull deepseek-r1:8b
-vllm run deepseek-r1:8b
-vllm serve deepseek-r1:8b
-vllm ps
-```
-
-For more detail, see:
-
 - [CLI Guide](./docs/cli/README.md)
-- [Quickstart](./docs/getting_started/quickstart.md)
 - [Local Runtime Follow-ups](./docs/cli/local_runtime_followups.md)
+- [List of Supported Models](https://docs.vllm.ai/en/latest/models/supported_models.html)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The local launcher is organized around a small set of common commands:
 - `vllm run <model>` runs directly in your shell for chat or prompt-based generation
 - `vllm serve <model>` starts a managed local service
 - `vllm aliases` lists the built-in short model names
-- `vllm ls` and `vllm inspect <model>` show local model metadata and resolution
+- `vllm ls` or `vllm list` and `vllm inspect <model>` show local model metadata and resolution
 - `vllm ps`, `vllm stop`, and `vllm logs` manage background services
 
 This keeps the default local path simple while preserving the full vLLM runtime and API-serving capabilities.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ vLLM is a high-performance inference and serving engine for large language model
 
 The updated workflow focuses on:
 
-- one-command installation from this repository
+- explicit repo-local installation from this repository
 - a lightweight `vllm` launcher for help, model management, and local runtime commands
 - short built-in model aliases for common Hugging Face models
 - direct shell-based execution with `vllm run`
+- backend diagnostics and model preflight via `vllm doctor`, `vllm status`, and `vllm preflight`
 - managed local services through `vllm serve`, `vllm ps`, `vllm stop`, and `vllm logs`
 
 The underlying vLLM engine and server stack remain intact, including:
@@ -54,9 +55,12 @@ This repository is designed to support both the familiar vLLM workflows and a si
 The shortest installation path from this repository is:
 
 ```bash
+uv --version
 ./scripts/install.sh
 vllm --help
 ```
+
+`./scripts/install.sh` expects `uv` to already be installed. If it is missing, the script exits with a link to Astral's official installation instructions rather than bootstrapping it through `curl | sh`.
 
 The installer supports:
 
@@ -81,6 +85,7 @@ For a terminal-first local workflow:
 
 ```bash
 ./scripts/install.sh
+vllm doctor
 vllm aliases
 vllm pull deepseek-r1:8b
 vllm run deepseek-r1:8b
@@ -100,11 +105,29 @@ The local launcher is organized around a small set of common commands:
 - `vllm pull <model>` downloads a model from an alias, Hugging Face repo, or local path
 - `vllm run <model>` runs directly in your shell for chat or prompt-based generation
 - `vllm serve <model>` starts a managed local service
+- `vllm doctor`, `vllm status`, and `vllm preflight` expose backend selection, Apple/plugin fallback, and fit estimation
 - `vllm aliases` lists the built-in short model names
 - `vllm ls` or `vllm list` and `vllm inspect <model>` show local model metadata and resolution
 - `vllm ps`, `vllm stop`, and `vllm logs` manage background services
 
 This keeps the default local path simple while preserving the full vLLM runtime and API-serving capabilities.
+
+## Backend Selection
+
+The local UX layer keeps backend choice inspectable instead of implicit.
+
+- Apple Silicon prefers a plugin-based Apple GPU path when available
+- otherwise the CLI falls back cleanly to CPU and explains why
+- NVIDIA, ROCm, XPU, and CPU paths continue to use the existing vLLM serving/runtime mechanisms
+- TensorRT-LLM is surfaced as optional NVIDIA interoperability, not a replacement for native vLLM CUDA execution
+
+Use:
+
+```bash
+vllm doctor
+vllm doctor deepseek-r1:8b
+vllm preflight qwen2.5:7b-instruct --profile low-memory
+```
 
 ## Model Support
 
@@ -157,6 +180,12 @@ Visit our [documentation](https://docs.vllm.ai/en/latest/) to learn more.
 - [Installation](https://docs.vllm.ai/en/latest/getting_started/installation.html)
 - [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html)
 - [CLI Guide](./docs/cli/README.md)
+- [Local Runtime Quickstart](./docs/cli/local_runtime_quickstart.md)
+- [Apple Silicon Quickstart](./docs/cli/apple_silicon.md)
+- [Backend Selection](./docs/cli/backend_selection.md)
+- [TensorRT-LLM Interoperability](./docs/cli/trtllm_interop.md)
+- [Troubleshooting](./docs/cli/troubleshooting.md)
+- [Local Runtime UX Design Note](./docs/design/local_runtime_ux.md)
 - [Local Runtime Follow-ups](./docs/cli/local_runtime_followups.md)
 - [List of Supported Models](https://docs.vllm.ai/en/latest/models/supported_models.html)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,19 +33,20 @@ Where to get started with vLLM depends on the type of user. If you are looking t
 - Build applications with vLLM, we recommend starting with the [User Guide](./usage/README.md)
 - Build vLLM, we recommend starting with [Developer Guide](./contributing/README.md)
 
-## What's Different In This Fork
+## What's New
 
-This fork adds a simpler local-runtime workflow on top of the existing vLLM architecture.
+This version adds a simpler local-runtime workflow on top of the existing vLLM architecture.
 
-Key changes:
+Highlights:
 
 - A repo bootstrap installer at `./scripts/install.sh`
 - Local model lifecycle commands such as `vllm pull`, `vllm run`, `vllm ls`, and `vllm inspect`
+- A lightweight launcher for fast `vllm`, `vllm --help`, `vllm aliases`, and metadata commands
 - Managed background services through `vllm serve`, `vllm ps`, `vllm stop`, and `vllm logs`
 - Built-in short aliases like `deepseek-r1:8b` for common Hugging Face models
 - A tracked follow-up list for deferred parity work in [Local Runtime Follow-ups](./cli/local_runtime_followups.md)
 
-Recommended fork-specific starting points:
+Recommended starting points:
 
 - [Quickstart Guide](./getting_started/quickstart.md)
 - [CLI Guide](./cli/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,24 @@ Where to get started with vLLM depends on the type of user. If you are looking t
 - Build applications with vLLM, we recommend starting with the [User Guide](./usage/README.md)
 - Build vLLM, we recommend starting with [Developer Guide](./contributing/README.md)
 
+## What's Different In This Fork
+
+This fork adds a simpler local-runtime workflow on top of the existing vLLM architecture.
+
+Key changes:
+
+- A repo bootstrap installer at `./scripts/install.sh`
+- Local model lifecycle commands such as `vllm pull`, `vllm run`, `vllm ls`, and `vllm inspect`
+- Managed background services through `vllm serve`, `vllm ps`, `vllm stop`, and `vllm logs`
+- Built-in short aliases like `deepseek-r1:8b` for common Hugging Face models
+- A tracked follow-up list for deferred parity work in [Local Runtime Follow-ups](./cli/local_runtime_followups.md)
+
+Recommended fork-specific starting points:
+
+- [Quickstart Guide](./getting_started/quickstart.md)
+- [CLI Guide](./cli/README.md)
+- [Local Runtime Follow-ups](./cli/local_runtime_followups.md)
+
 For information about the development of vLLM, see:
 
 - [Roadmap](https://roadmap.vllm.ai)

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,6 +1,8 @@
 # vLLM CLI Guide
 
-The vllm command-line tool is used to run and manage vLLM models. You can start by viewing the help message with:
+The `vllm` command-line tool is still the front door to the same high-performance vLLM engine, but this fork adds a local-runtime layer on top so common local workflows are faster to discover and easier to manage.
+
+Start by viewing the help message with:
 
 ```bash
 vllm --help
@@ -9,12 +11,12 @@ vllm --help
 Available Commands:
 
 ```bash
-vllm {pull,run,ls,list,aliases,inspect,serve,ps,stop,logs,rm,chat,complete,bench,collect-env,run-batch}
+vllm {pull,run,ls,list,aliases,inspect,doctor,status,preflight,serve,ps,stop,logs,rm,chat,complete,bench,collect-env,run-batch}
 ```
 
 ## Local Runtime
 
-The local-runtime commands are designed to make a source checkout feel more like a local model runner:
+The local-runtime commands are designed to make a source checkout feel more like a local inference runtime without replacing vLLM's serving architecture:
 
 ```bash
 ./scripts/install.sh
@@ -25,6 +27,8 @@ vllm serve deepseek-r1:8b
 vllm ps
 ```
 
+The installer intentionally requires `uv` to be installed first. It does not use `curl | sh`. If `uv` is missing, the script exits with a link to Astral's official installation instructions.
+
 ### Main Changes
 
 Compared with the older server-first CLI flow, the main additions are:
@@ -34,6 +38,9 @@ Compared with the older server-first CLI flow, the main additions are:
 - Direct shell usage with `vllm run` instead of requiring a separate running server first
 - Built-in model aliases such as `deepseek-r1:8b`
 - Background local service management through `vllm serve`, `vllm ps`, `vllm stop`, and `vllm logs`
+- Explicit backend diagnostics through `vllm doctor`, `vllm status`, and `vllm preflight`
+- Plugin-aware Apple Silicon reporting that prefers `vllm-metal` style backends when present and explains CPU fallback otherwise
+- Local performance profiles so users can choose `balanced`, `throughput`, or `low-memory` defaults without losing access to advanced vLLM flags
 
 The advanced vLLM commands still exist; this changes the default user journey rather than removing the underlying engine/server features.
 
@@ -47,6 +54,33 @@ vllm aliases
 vllm pull deepseek-r1:8b
 vllm run deepseek-r1:8b
 ```
+
+### Backend Selection and Diagnostics
+
+The local CLI keeps backend selection explicit. It does not replace vLLM's platform architecture; it inspects the environment and reports what it will use.
+
+```bash
+vllm doctor
+vllm doctor deepseek-r1:8b
+vllm status llama3.1:8b-instruct
+vllm preflight qwen2.5:7b-instruct --profile low-memory
+```
+
+The diagnostics report includes:
+
+- detected OS and architecture
+- selected backend and fallback reason
+- available platform plugins
+- model fit/preflight estimate
+- TensorRT-LLM relevance on NVIDIA systems
+
+See:
+
+- [Local Runtime Quickstart](./local_runtime_quickstart.md)
+- [Backend Selection](./backend_selection.md)
+- [Apple Silicon Quickstart](./apple_silicon.md)
+- [TensorRT-LLM Interoperability](./trtllm_interop.md)
+- [Troubleshooting](./troubleshooting.md)
 
 ### aliases
 
@@ -73,6 +107,8 @@ Run a model directly in your shell without starting a separate API server first.
 vllm run deepseek-r1:8b
 vllm run deepseek-r1:8b --prompt "Explain KV cache in one paragraph."
 vllm run meta-llama/Llama-3.1-8B-Instruct --complete --prompt "The future of inference is"
+vllm run deepseek-r1:8b --profile throughput
+vllm run llama3.2:3b-instruct --profile low-memory
 ```
 
 ### ls, list, and inspect
@@ -83,6 +119,7 @@ Show pulled model metadata and how aliases resolve.
 vllm ls
 vllm list
 vllm inspect deepseek-r1:8b
+vllm inspect deepseek-r1:8b --backend apple-metal --profile balanced --json
 ```
 
 ### Built-in Easy Models
@@ -100,7 +137,7 @@ The built-in aliases currently include:
 
 ## serve
 
-Starts the vLLM OpenAI Compatible API server.
+Starts the vLLM OpenAI Compatible API server while preserving the existing vLLM serving path.
 
 Start with a model:
 
@@ -113,13 +150,17 @@ By default, `vllm serve` now starts a managed background service. Use `--foregro
 ```bash
 vllm serve deepseek-r1:8b
 vllm serve meta-llama/Llama-3.1-8B-Instruct --foreground
+vllm serve qwen2.5:7b-instruct --profile throughput
 ```
 
 Specify the port:
 
 ```bash
 vllm serve meta-llama/Llama-2-7b-hf --port 8100
+vllm serve meta-llama/Llama-2-7b-hf --port=8100
 ```
+
+The background-service path now respects both `--port 8100` and `--port=8100` exactly. If you choose a port explicitly, the CLI does not silently replace it with a random one.
 
 Serve over a Unix domain socket:
 
@@ -158,6 +199,16 @@ vllm logs deepseek-r1-8b
 vllm stop deepseek-r1-8b
 vllm rm deepseek-r1:8b
 ```
+
+## Local Profiles
+
+The local runtime adds a small defaulting layer for common local use cases:
+
+- `balanced`: keep prefix caching on and leave graph/compile behavior close to vLLM defaults
+- `throughput`: push memory utilization higher and prefer throughput-friendly defaults
+- `low-memory`: reduce memory pressure for laptop and smaller-device workflows
+
+Profiles only fill in defaults that the user did not specify explicitly.
 
 ## chat
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -9,7 +9,7 @@ vllm --help
 Available Commands:
 
 ```bash
-vllm {pull,run,ls,inspect,serve,ps,stop,logs,rm,chat,complete,bench,collect-env,run-batch}
+vllm {pull,run,ls,aliases,inspect,serve,ps,stop,logs,rm,chat,complete,bench,collect-env,run-batch}
 ```
 
 ## Local Runtime
@@ -18,22 +18,43 @@ The local-runtime commands are designed to make a source checkout feel more like
 
 ```bash
 ./scripts/install.sh
+vllm aliases
 vllm pull deepseek-r1:8b
 vllm run deepseek-r1:8b
 vllm serve deepseek-r1:8b
 vllm ps
 ```
 
-### What's Different
+### Main Changes
 
-Compared with the older server-first CLI flow, this fork adds:
+Compared with the older server-first CLI flow, the main additions are:
 
 - A one-script repo install path via `./scripts/install.sh`
+- A lightweight launcher so help and local metadata commands do not have to pull in the full runtime stack
 - Direct shell usage with `vllm run` instead of requiring a separate running server first
 - Built-in model aliases such as `deepseek-r1:8b`
 - Background local service management through `vllm serve`, `vllm ps`, `vllm stop`, and `vllm logs`
 
-The advanced vLLM commands still exist; this fork changes the default user journey rather than removing the underlying engine/server features.
+The advanced vLLM commands still exist; this changes the default user journey rather than removing the underlying engine/server features.
+
+### Fast Path
+
+For a terminal-first workflow, the intended path is:
+
+```bash
+./scripts/install.sh
+vllm aliases
+vllm pull deepseek-r1:8b
+vllm run deepseek-r1:8b
+```
+
+### aliases
+
+List the built-in easy-model names that resolve to Hugging Face repos.
+
+```bash
+vllm aliases
+```
 
 ### pull
 
@@ -62,6 +83,19 @@ Show pulled model metadata and how aliases resolve.
 vllm ls
 vllm inspect deepseek-r1:8b
 ```
+
+### Built-in Easy Models
+
+The built-in aliases currently include:
+
+- `deepseek-r1:1.5b`, `deepseek-r1:7b`, `deepseek-r1:8b`, `deepseek-r1:14b`, `deepseek-r1:32b`, `deepseek-r1:70b`, `deepseek-v3`
+- `llama3.2:1b-instruct`, `llama3.2:3b-instruct`, `llama3.1:8b-instruct`, `llama3.1:70b-instruct`, `llama3.3:70b-instruct`
+- `qwen2.5:0.5b-instruct`, `qwen2.5:1.5b-instruct`, `qwen2.5:3b-instruct`, `qwen2.5:7b-instruct`, `qwen2.5:14b-instruct`, `qwen2.5:32b-instruct`, `qwen2.5:72b-instruct`
+- `qwen2.5-coder:1.5b-instruct`, `qwen2.5-coder:7b-instruct`, `qwen2.5-coder:32b-instruct`
+- `mistral:7b-instruct`, `ministral:8b-instruct`, `mistral-nemo:12b-instruct`, `mixtral:8x7b-instruct`
+- `gemma2:2b-it`, `gemma2:9b-it`, `gemma2:27b-it`
+- `phi3.5:mini-instruct`, `phi3.5:moe-instruct`, `phi4`
+- `smollm2:360m-instruct`, `smollm2:1.7b-instruct`
 
 ## serve
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -9,7 +9,7 @@ vllm --help
 Available Commands:
 
 ```bash
-vllm {pull,run,ls,aliases,inspect,serve,ps,stop,logs,rm,chat,complete,bench,collect-env,run-batch}
+vllm {pull,run,ls,list,aliases,inspect,serve,ps,stop,logs,rm,chat,complete,bench,collect-env,run-batch}
 ```
 
 ## Local Runtime
@@ -75,12 +75,13 @@ vllm run deepseek-r1:8b --prompt "Explain KV cache in one paragraph."
 vllm run meta-llama/Llama-3.1-8B-Instruct --complete --prompt "The future of inference is"
 ```
 
-### ls and inspect
+### ls, list, and inspect
 
 Show pulled model metadata and how aliases resolve.
 
 ```bash
 vllm ls
+vllm list
 vllm inspect deepseek-r1:8b
 ```
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -9,7 +9,47 @@ vllm --help
 Available Commands:
 
 ```bash
-vllm {chat,complete,serve,bench,collect-env,run-batch}
+vllm {pull,run,ls,inspect,serve,ps,stop,logs,rm,chat,complete,bench,collect-env,run-batch}
+```
+
+## Local Runtime
+
+The local-runtime commands are designed to make a source checkout feel more like a local model runner:
+
+```bash
+./scripts/install.sh
+vllm pull deepseek-r1:8b
+vllm run deepseek-r1:8b
+vllm serve deepseek-r1:8b
+vllm ps
+```
+
+### pull
+
+Resolve a model alias or exact Hugging Face repo and pre-download the model locally.
+
+```bash
+vllm pull deepseek-r1:8b
+vllm pull meta-llama/Llama-3.1-8B-Instruct
+```
+
+### run
+
+Run a model directly in your shell without starting a separate API server first.
+
+```bash
+vllm run deepseek-r1:8b
+vllm run deepseek-r1:8b --prompt "Explain KV cache in one paragraph."
+vllm run meta-llama/Llama-3.1-8B-Instruct --complete --prompt "The future of inference is"
+```
+
+### ls and inspect
+
+Show pulled model metadata and how aliases resolve.
+
+```bash
+vllm ls
+vllm inspect deepseek-r1:8b
 ```
 
 ## serve
@@ -20,6 +60,13 @@ Start with a model:
 
 ```bash
 vllm serve meta-llama/Llama-2-7b-hf
+```
+
+By default, `vllm serve` now starts a managed background service. Use `--foreground` to keep the previous blocking behavior:
+
+```bash
+vllm serve deepseek-r1:8b
+vllm serve meta-llama/Llama-3.1-8B-Instruct --foreground
 ```
 
 Specify the port:
@@ -54,6 +101,17 @@ vllm serve --help=page
 ```
 
 See [vllm serve](./serve.md) for the full reference of all available arguments.
+
+### ps, stop, logs, rm
+
+Manage local background services and pulled model metadata.
+
+```bash
+vllm ps
+vllm logs deepseek-r1-8b
+vllm stop deepseek-r1-8b
+vllm rm deepseek-r1:8b
+```
 
 ## chat
 
@@ -186,3 +244,5 @@ For detailed options of any subcommand, use:
 ```bash
 vllm <subcommand> --help
 ```
+
+Tracked follow-up items for the local-runtime UX live in [local_runtime_followups.md](./local_runtime_followups.md).

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -24,6 +24,17 @@ vllm serve deepseek-r1:8b
 vllm ps
 ```
 
+### What's Different
+
+Compared with the older server-first CLI flow, this fork adds:
+
+- A one-script repo install path via `./scripts/install.sh`
+- Direct shell usage with `vllm run` instead of requiring a separate running server first
+- Built-in model aliases such as `deepseek-r1:8b`
+- Background local service management through `vllm serve`, `vllm ps`, `vllm stop`, and `vllm logs`
+
+The advanced vLLM commands still exist; this fork changes the default user journey rather than removing the underlying engine/server features.
+
 ### pull
 
 Resolve a model alias or exact Hugging Face repo and pre-download the model locally.

--- a/docs/cli/apple_silicon.md
+++ b/docs/cli/apple_silicon.md
@@ -1,0 +1,49 @@
+# Apple Silicon Quickstart
+
+Apple Silicon local usage is supported through a plugin-aware workflow.
+
+## Design Direction
+
+The local CLI does not pretend that core vLLM has a built-in Apple GPU backend. Instead, it follows vLLM's hardware-plugin architecture:
+
+- if an Apple GPU plugin such as `vllm-metal` is installed and detected, the local CLI prefers that backend
+- if no Apple GPU plugin is available, the local CLI falls back to CPU and explains why
+
+This keeps Apple support aligned with upstream vLLM architecture instead of spreading Apple-specific logic through the core runtime.
+
+## Recommended Flow
+
+1. Install `uv` using Astral's official instructions.
+2. Install this checkout with `./scripts/install.sh`.
+3. Run diagnostics:
+
+```bash
+vllm doctor
+vllm doctor deepseek-r1:8b
+```
+
+## What `doctor` Tells You
+
+On Apple Silicon, the report explains:
+
+- whether the machine is `Darwin/arm64`
+- whether an Apple GPU plugin is installed
+- whether the CLI selected `apple-metal` or fell back to `cpu`
+- the fallback reason if CPU is being used
+- a rough fit estimate for the requested model
+
+## Current Expectations
+
+- Apple GPU acceleration is plugin-based, not hardwired into core CLI logic.
+- CPU fallback remains available when no Apple GPU plugin is present.
+- The local runtime can still be used for model management, service management, and diagnostics even when the backend is CPU-only.
+
+## Follow-up Direction
+
+Future work should continue to prefer:
+
+- MLX / Metal-oriented plugin paths
+- plugin-provided capability reporting
+- explicit backend selection diagnostics
+
+instead of making raw Torch MPS the primary design center.

--- a/docs/cli/backend_selection.md
+++ b/docs/cli/backend_selection.md
@@ -1,0 +1,59 @@
+# Backend Selection
+
+The local-runtime CLI adds a thin backend-selection layer for local UX. It does not replace vLLM's platform or plugin architecture.
+
+## Goals
+
+- keep backend choice explicit
+- surface fallback reasons clearly
+- remain compatible with vLLM's out-of-tree hardware plugin approach
+- avoid hidden "magic" that makes performance debugging harder
+
+## Selection Order
+
+With `--backend auto`, the local CLI currently prefers:
+
+1. `apple-metal` on Apple Silicon when an Apple GPU plugin is detected
+2. `cuda`
+3. `rocm`
+4. `xpu`
+5. `cpu`
+
+You can override this with:
+
+```bash
+vllm doctor --backend cuda
+vllm run deepseek-r1:8b --backend cpu
+vllm serve qwen2.5:7b-instruct --backend apple-metal
+```
+
+If the requested backend is unavailable, the CLI reports the reason instead of silently pretending it worked.
+
+## Profiles
+
+The local CLI also supports small defaulting profiles:
+
+- `balanced`
+- `throughput`
+- `low-memory`
+
+Profiles only fill in defaults that the user did not set explicitly.
+
+## Diagnostics
+
+Use these commands to inspect the decision:
+
+```bash
+vllm doctor
+vllm doctor deepseek-r1:8b
+vllm preflight deepseek-r1:8b --profile low-memory
+```
+
+The report includes:
+
+- selected backend
+- available backends
+- fallback reason
+- profile
+- preflight estimate
+- TensorRT-LLM relevance for NVIDIA environments

--- a/docs/cli/local_runtime_followups.md
+++ b/docs/cli/local_runtime_followups.md
@@ -1,0 +1,25 @@
+# Local Runtime Follow-ups
+
+These items are intentionally tracked so the new local vLLM UX can ship in stages without losing scope.
+
+## Remaining feature goals
+
+- Expand built-in model aliases beyond the initial curated set.
+- Add richer `vllm ls` output for alias catalog browsing, not just pulled models.
+- Add shell UX niceties for `vllm run`, such as slash commands, history persistence, and multiline editing.
+- Add better cache eviction for `vllm rm --purge-cache` so it can clean Hugging Face cache metadata and shared blobs safely.
+- Add deeper service management commands such as restart, rename, and structured status output.
+- Add optional Ollama-compatible local API endpoints if parity beyond CLI ergonomics becomes a priority.
+- Add model creation and packaging flows comparable to Ollama's `create` / modelfile workflow.
+- Add model copy and publish flows comparable to Ollama's `cp` / `push`.
+
+## Platform follow-ups
+
+- Validate and document the local installer flow on macOS.
+- Validate and document the local installer flow on Windows.
+- Add platform-specific launcher and process-management behavior where Linux assumptions are currently baked in.
+
+## Documentation follow-ups
+
+- Add dedicated docs pages for `vllm pull`, `vllm run`, `vllm ls`, `vllm ps`, `vllm stop`, `vllm logs`, and `vllm rm`.
+- Add a local-runtime quickstart separate from the broader developer/source install docs.

--- a/docs/cli/local_runtime_followups.md
+++ b/docs/cli/local_runtime_followups.md
@@ -4,7 +4,7 @@ These items are intentionally tracked so the new local vLLM UX can ship in stage
 
 ## Remaining feature goals
 
-- Expand built-in model aliases beyond the initial curated set.
+- Expand built-in model aliases beyond the current curated catalog.
 - Add richer `vllm ls` output for alias catalog browsing, not just pulled models.
 - Add shell UX niceties for `vllm run`, such as slash commands, history persistence, and multiline editing.
 - Add better cache eviction for `vllm rm --purge-cache` so it can clean Hugging Face cache metadata and shared blobs safely.
@@ -12,15 +12,17 @@ These items are intentionally tracked so the new local vLLM UX can ship in stage
 - Add optional Ollama-compatible local API endpoints if parity beyond CLI ergonomics becomes a priority.
 - Add model creation and packaging flows comparable to Ollama's `create` / modelfile workflow.
 - Add model copy and publish flows comparable to Ollama's `cp` / `push`.
+- Add a dedicated `TensorRT-LLM export` or staging workflow once the inspect/eligibility path is proven useful.
 
 ## Platform follow-ups
 
-- Validate and document the local installer flow on macOS.
+- Validate and document the local installer flow on macOS beyond the current source-build path.
 - Validate and document the local installer flow on Windows.
 - Add platform-specific launcher and process-management behavior where Linux assumptions are currently baked in.
-- Add Apple Silicon GPU support via MLX / Metal integration, instead of relying on bare Torch MPS or CPU-only local execution on macOS.
+- Add richer Apple Silicon GPU capability reporting via MLX / Metal plugins.
+- Add more backend-specific preflight heuristics once Apple GPU plugins expose more standardized capability metadata.
 
 ## Documentation follow-ups
 
-- Add dedicated docs pages for `vllm pull`, `vllm run`, `vllm ls`, `vllm ps`, `vllm stop`, `vllm logs`, and `vllm rm`.
-- Add a local-runtime quickstart separate from the broader developer/source install docs.
+- Expand command-specific docs for `vllm pull`, `vllm run`, `vllm ls`, `vllm ps`, `vllm stop`, `vllm logs`, and `vllm rm`.
+- Add more backend compatibility notes as additional hardware plugins mature.

--- a/docs/cli/local_runtime_followups.md
+++ b/docs/cli/local_runtime_followups.md
@@ -18,6 +18,7 @@ These items are intentionally tracked so the new local vLLM UX can ship in stage
 - Validate and document the local installer flow on macOS.
 - Validate and document the local installer flow on Windows.
 - Add platform-specific launcher and process-management behavior where Linux assumptions are currently baked in.
+- Add Apple Silicon GPU support via MLX / Metal integration, instead of relying on bare Torch MPS or CPU-only local execution on macOS.
 
 ## Documentation follow-ups
 

--- a/docs/cli/local_runtime_quickstart.md
+++ b/docs/cli/local_runtime_quickstart.md
@@ -1,0 +1,83 @@
+# Local Runtime Quickstart
+
+The local runtime layer is meant to make common source-checkout workflows faster without changing the underlying vLLM engine and serving architecture.
+
+## 1. Install Prerequisites
+
+Install `uv` first using Astral's official instructions:
+
+- <https://docs.astral.sh/uv/getting-started/installation/>
+
+Then install this checkout:
+
+```bash
+./scripts/install.sh
+vllm --help
+```
+
+The installer supports:
+
+- `./scripts/install.sh`
+- `./scripts/install.sh --user`
+- `./scripts/install.sh --system`
+- `./scripts/install.sh --venv .venv`
+- `./scripts/install.sh --recreate`
+
+## 2. Inspect the Runtime
+
+Check which backend the local CLI will use and whether a model looks likely to fit:
+
+```bash
+vllm doctor
+vllm doctor deepseek-r1:8b
+vllm preflight qwen2.5:7b-instruct --profile low-memory
+```
+
+## 3. Pull a Model
+
+```bash
+vllm aliases
+vllm pull deepseek-r1:8b
+```
+
+You can also use:
+
+- exact Hugging Face repositories such as `meta-llama/Llama-3.1-8B-Instruct`
+- local model paths
+
+## 4. Run in the Shell
+
+```bash
+vllm run deepseek-r1:8b
+vllm run llama3.2:3b-instruct --prompt "Summarize prefix caching."
+vllm run qwen2.5:7b-instruct --profile throughput
+```
+
+## 5. Start a Local API Service
+
+```bash
+vllm serve deepseek-r1:8b
+vllm ps
+vllm logs deepseek-r1-8b
+vllm stop deepseek-r1-8b
+```
+
+Use `--foreground` to keep the classic blocking server behavior:
+
+```bash
+vllm serve deepseek-r1:8b --foreground
+```
+
+## 6. Inspect Local State
+
+```bash
+vllm ls
+vllm list
+vllm inspect deepseek-r1:8b
+```
+
+## Notes
+
+- This UX layer does not replace the production vLLM server architecture.
+- The local commands sit on top of the same engine and OpenAI-compatible serving path.
+- Backend selection is explicit and inspectable through `doctor`, `status`, and `preflight`.

--- a/docs/cli/troubleshooting.md
+++ b/docs/cli/troubleshooting.md
@@ -1,0 +1,53 @@
+# Local Runtime Troubleshooting
+
+## `./scripts/install.sh` says `uv` is missing
+
+Install `uv` manually using Astral's official instructions:
+
+- <https://docs.astral.sh/uv/getting-started/installation/>
+
+The installer intentionally does not use `curl | sh`.
+
+## `vllm doctor` selects CPU on Apple Silicon
+
+That means the CLI did not detect an Apple GPU plugin.
+
+Run:
+
+```bash
+vllm doctor
+```
+
+and check:
+
+- `selected_backend`
+- `fallback_reason`
+- the discovered platform plugin list
+
+## `vllm serve` changed my port
+
+If you pass either:
+
+- `--port 8100`
+- `--port=8100`
+
+the managed background-service path should honor it exactly.
+
+## A model does not fit locally
+
+Use:
+
+```bash
+vllm preflight <model> --profile low-memory
+```
+
+Then try:
+
+- a smaller model
+- lower-memory profile
+- explicit quantization
+- a backend with more memory
+
+## TensorRT-LLM looks unavailable
+
+That is expected outside NVIDIA environments. The local diagnostics surface TensorRT-LLM only as an optional NVIDIA interoperability path.

--- a/docs/cli/trtllm_interop.md
+++ b/docs/cli/trtllm_interop.md
@@ -1,0 +1,34 @@
+# TensorRT-LLM Interoperability
+
+TensorRT-LLM is treated here as an optional NVIDIA interoperability path, not as a replacement for native vLLM CUDA execution.
+
+## Scope
+
+The local CLI surfaces TensorRT-LLM relevance through diagnostics:
+
+```bash
+vllm doctor
+vllm doctor deepseek-r1:8b
+vllm inspect deepseek-r1:8b --json
+```
+
+The report focuses on:
+
+- whether the current environment looks TensorRT-LLM-capable
+- whether FlashInfer is available
+- whether vLLM's existing TensorRT-LLM-related hooks are likely relevant
+- whether the requested model family is one where those hooks are meaningful
+
+## What This Is Not
+
+This local-runtime layer does not:
+
+- replace native vLLM CUDA execution with TensorRT-LLM
+- force TensorRT-LLM into CPU or Apple flows
+- claim universal model support
+
+## Expected Use
+
+Use the diagnostics output to decide when to stay on native vLLM CUDA paths and when deeper TensorRT-LLM-specific work is worth exploring.
+
+Future work can add a more explicit export or staging command, but the first step is inspectability and clear eligibility reporting.

--- a/docs/contributing/upstream_pr_plan.md
+++ b/docs/contributing/upstream_pr_plan.md
@@ -1,0 +1,58 @@
+# Upstream PR Plan for the Local Runtime Work
+
+This repository contains a larger local-runtime product layer. That full change
+set is not a realistic first upstream PR for `vllm-project/vllm`.
+
+The first PR should be intentionally narrow and non-breaking.
+
+## Recommended First PR
+
+Title direction:
+
+- `Make top-level vllm CLI help and dispatch avoid eager subcommand imports`
+
+Scope:
+
+- keep `vllm.entrypoints.cli` lightweight
+- avoid importing every subcommand module before top-level argument parsing
+- preserve existing command behavior once a specific subcommand is selected
+- add regression tests for:
+  - `vllm --help`
+  - `vllm collect-env --help`
+  - selected-command dispatch importing only the requested module
+
+Why this is a good first PR:
+
+- it is small enough to review
+- it is easy to defend technically
+- it addresses a real startup and import-safety problem
+- it does not force a product direction change on upstream
+
+## Changes That Should Not Be in the First PR
+
+These should be proposed later, and likely in multiple PRs:
+
+- repo bootstrap installer in `scripts/install.sh`
+- standalone launcher in `scripts/vllm_launcher.py`
+- local model alias catalog
+- `pull`, `run`, `ls`, `aliases`, `inspect`, `ps`, `stop`, `logs`, `rm`
+- changing `vllm serve` defaults
+- rewriting the top-level project README around the local-runtime story
+
+## Follow-up PR Sequence
+
+1. CLI startup and lazy-import improvements
+2. discussion or RFC for a local-runtime UX in upstream
+3. narrow alias support, if upstream wants short model names
+4. optional local service-management features
+5. optional installer/bootstrap workflow, if upstream wants a source-checkout installer
+
+## Before Opening the First Upstream PR
+
+- run duplicate-work checks against upstream issues and open PRs
+- run focused tests for the CLI changes
+- verify behavior on Linux with the standard vLLM install path
+- prepare a PR description that clearly states:
+  - why the change is not duplicating an open PR
+  - what tests were run
+  - that AI assistance was used

--- a/docs/design/local_runtime_ux.md
+++ b/docs/design/local_runtime_ux.md
@@ -1,0 +1,75 @@
+# Local Runtime UX Design Note
+
+## Architecture Overview
+
+The local-runtime work is intentionally layered on top of existing vLLM entrypoints instead of replacing them.
+
+The shape is:
+
+- lightweight launcher for fast help and metadata commands
+- CLI-local model alias and local-state helpers
+- CLI-local backend diagnostics and selection helpers
+- existing vLLM `LLM` and OpenAI-compatible `serve` paths underneath
+
+This keeps local UX improvements separate from the engine, scheduler, batching logic, and production serving internals.
+
+## Why the Local UX Layer Stays Thin
+
+vLLM's core identity is still:
+
+- high-throughput inference
+- continuous batching
+- production-grade serving
+- backend scalability
+- observability
+
+The local UX additions are wrappers, defaults, and diagnostics. They do not replace vLLM's execution model with a toy runner.
+
+## Apple Support Strategy
+
+Apple support is handled in a plugin-aware way.
+
+The CLI:
+
+- detects Apple Silicon hosts
+- looks for out-of-tree platform plugins
+- prefers an Apple GPU path when such a plugin is present
+- falls back to CPU with an explicit explanation otherwise
+
+This matches upstream vLLM's plugin architecture and avoids spreading Apple-specific runtime assumptions through core platform logic.
+
+## Performance and Scalability Preservation
+
+The work is designed to preserve the core performance path by:
+
+- keeping fast metadata commands on a lightweight launcher path
+- lazy-loading heavier CLI paths only when needed
+- preserving the existing OpenAI-compatible serve path
+- using small local profiles only as defaulting layers
+- exposing diagnostics instead of hiding backend decisions
+
+## TensorRT-LLM Scope
+
+TensorRT-LLM is treated as optional NVIDIA interoperability, not as a replacement for native vLLM CUDA execution.
+
+The current scope is:
+
+- inspect environment relevance
+- report likely eligibility
+- surface FlashInfer / TensorRT-LLM-related signals in diagnostics
+
+Future work can add export/staging flows separately.
+
+## Known Limitations
+
+- Apple GPU acceleration still depends on an out-of-tree plugin rather than built-in core support.
+- Model preflight is heuristic and conservative when exact model metadata is unavailable.
+- TensorRT-LLM diagnostics are intentionally environment-focused rather than a full export pipeline.
+
+## Recommended PR Split
+
+1. Local CLI hardening and correctness fixes
+2. Backend diagnostics, doctor/status, and preflight
+3. Apple plugin-aware auto-selection and docs
+4. Performance profiles and local observability polish
+5. TensorRT-LLM interoperability enhancements

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -10,6 +10,18 @@ This guide will help you quickly get started with vLLM to perform:
 - OS: Linux
 - Python: 3.10 -- 3.13
 
+## Repo Install Shortcut
+
+If you are working from a local checkout of this repository and want an easier Ollama-like install flow, you can bootstrap the local CLI directly from the repo:
+
+```bash
+./scripts/install.sh
+vllm pull deepseek-r1:8b
+vllm run deepseek-r1:8b
+```
+
+The installer also supports `--user`, `--system`, and `--venv <path>` modes.
+
 ## Installation
 
 === "NVIDIA CUDA"

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -15,12 +15,15 @@ This guide will help you quickly get started with vLLM to perform:
 If you are working from a local checkout of this repository and want an easier Ollama-like install flow, you can bootstrap the local CLI directly from the repo:
 
 ```bash
+uv --version
 ./scripts/install.sh
+vllm doctor
 vllm pull deepseek-r1:8b
 vllm run deepseek-r1:8b
 ```
 
 The installer also supports `--user`, `--system`, and `--venv <path>` modes.
+It expects `uv` to already be installed and will print official installation guidance if it is missing.
 
 ## Installation
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -88,11 +88,6 @@ if [[ "${MODE}" == "system" && "$(id -u)" -ne 0 ]]; then
   exit 1
 fi
 
-if ! command -v curl >/dev/null 2>&1; then
-  echo "curl is required to bootstrap uv." >&2
-  exit 1
-fi
-
 pick_python() {
   local candidate=""
 
@@ -141,20 +136,15 @@ ensure_uv() {
     return
   fi
 
-  echo "Installing uv..." >&2
-  curl -LsSf https://astral.sh/uv/install.sh | sh
+  cat >&2 <<'EOF'
+uv is required to install this local-runtime vLLM environment, but it was not found on PATH.
 
-  if [[ -x "${HOME}/.local/bin/uv" ]]; then
-    echo "${HOME}/.local/bin/uv"
-    return
-  fi
+Install uv first using the official instructions:
+  https://docs.astral.sh/uv/getting-started/installation/
 
-  if command -v uv >/dev/null 2>&1; then
-    command -v uv
-    return
-  fi
-
-  echo "uv installation succeeded but uv is not on PATH." >&2
+Then re-run:
+  ./scripts/install.sh
+EOF
   exit 1
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE="auto"
+TARGET_VENV=""
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+EDITABLE=0
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/install.sh [--system | --user | --venv PATH] [--editable] [--python PYTHON]
+
+Install this vLLM checkout with an Ollama-like local CLI launcher.
+
+Modes:
+  --system       Install into /opt/vllm and /usr/local/bin/vllm
+  --user         Install into ~/.local/share/vllm and ~/.local/bin/vllm
+  --venv PATH    Install into an explicit Python virtual environment
+
+Options:
+  --editable     Install the repo in editable mode
+  --python BIN   Python interpreter to use when creating the environment
+  -h, --help     Show this message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --system)
+      MODE="system"
+      shift
+      ;;
+    --user)
+      MODE="user"
+      shift
+      ;;
+    --venv)
+      MODE="venv"
+      TARGET_VENV="${2:-}"
+      if [[ -z "${TARGET_VENV}" ]]; then
+        echo "--venv requires a target path" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --editable)
+      EDITABLE=1
+      shift
+      ;;
+    --python)
+      PYTHON_BIN="${2:-}"
+      if [[ -z "${PYTHON_BIN}" ]]; then
+        echo "--python requires an interpreter path" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${MODE}" == "auto" ]]; then
+  if [[ "$(id -u)" -eq 0 ]]; then
+    MODE="system"
+  else
+    MODE="user"
+  fi
+fi
+
+if [[ "${MODE}" == "system" && "$(id -u)" -ne 0 ]]; then
+  echo "System mode writes to /opt/vllm and /usr/local/bin. Re-run with sudo or use --user/--venv." >&2
+  exit 1
+fi
+
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  echo "Python interpreter not found: ${PYTHON_BIN}" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to bootstrap uv." >&2
+  exit 1
+fi
+
+ensure_uv() {
+  if command -v uv >/dev/null 2>&1; then
+    command -v uv
+    return
+  fi
+
+  echo "Installing uv..." >&2
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+
+  if [[ -x "${HOME}/.local/bin/uv" ]]; then
+    echo "${HOME}/.local/bin/uv"
+    return
+  fi
+
+  if command -v uv >/dev/null 2>&1; then
+    command -v uv
+    return
+  fi
+
+  echo "uv installation succeeded but uv is not on PATH." >&2
+  exit 1
+}
+
+UV_BIN="$(ensure_uv)"
+
+case "${MODE}" in
+  system)
+    INSTALL_ROOT="${VLLM_INSTALL_ROOT:-/opt/vllm}"
+    BIN_DIR="${VLLM_BIN_DIR:-/usr/local/bin}"
+    VENV_DIR="${INSTALL_ROOT}/venv"
+    ;;
+  user)
+    INSTALL_ROOT="${VLLM_INSTALL_ROOT:-${HOME}/.local/share/vllm}"
+    BIN_DIR="${VLLM_BIN_DIR:-${HOME}/.local/bin}"
+    VENV_DIR="${INSTALL_ROOT}/venv"
+    ;;
+  venv)
+    INSTALL_ROOT=""
+    BIN_DIR=""
+    VENV_DIR="${TARGET_VENV}"
+    ;;
+  *)
+    echo "Unsupported mode: ${MODE}" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$(dirname "${VENV_DIR}")"
+"${UV_BIN}" venv --python "${PYTHON_BIN}" "${VENV_DIR}"
+
+INSTALL_TARGET="${ROOT_DIR}"
+export VLLM_USE_PRECOMPILED="${VLLM_USE_PRECOMPILED:-1}"
+if [[ "${EDITABLE}" -eq 1 ]]; then
+  "${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" -e "${INSTALL_TARGET}"
+else
+  "${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" "${INSTALL_TARGET}"
+fi
+
+if [[ "${MODE}" != "venv" ]]; then
+  mkdir -p "${BIN_DIR}"
+  cat > "${BIN_DIR}/vllm" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${VENV_DIR}/bin/python" -m vllm.entrypoints.cli.main "\$@"
+EOF
+  chmod +x "${BIN_DIR}/vllm"
+fi
+
+echo
+echo "vLLM install complete."
+case "${MODE}" in
+  system)
+    echo "Launcher: ${BIN_DIR}/vllm"
+    ;;
+  user)
+    echo "Launcher: ${BIN_DIR}/vllm"
+    if [[ ":${PATH}:" != *":${BIN_DIR}:"* ]]; then
+      echo "Add ${BIN_DIR} to PATH if needed."
+    fi
+    ;;
+  venv)
+    echo "Environment: ${VENV_DIR}"
+    echo "Activate with: source ${VENV_DIR}/bin/activate"
+    ;;
+esac
+echo "Try: vllm --help"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -193,28 +193,45 @@ else
   "${UV_BIN}" venv "${VENV_ARGS[@]}" "${VENV_DIR}"
 fi
 
+export PATH="${VENV_DIR}/bin:${PATH}"
+
+if [[ -x "${VENV_DIR}/bin/ninja" ]]; then
+  export CMAKE_ARGS="${CMAKE_ARGS:-} -DCMAKE_MAKE_PROGRAM=${VENV_DIR}/bin/ninja"
+fi
+
 "${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" certifi
 CERT_BUNDLE="$("${VENV_DIR}/bin/python" -c 'import certifi; print(certifi.where())')"
 export SSL_CERT_FILE="${CERT_BUNDLE}"
 export REQUESTS_CA_BUNDLE="${CERT_BUNDLE}"
 
 INSTALL_TARGET="${ROOT_DIR}"
+INSTALL_ARGS=()
 if [[ "${HOST_OS}" == "Darwin" ]]; then
   echo "macOS detected: using the Apple Silicon CPU source-build path." >&2
   "${UV_BIN}" pip install \
     --python "${VENV_DIR}/bin/python" \
     --index-strategy unsafe-best-match \
     -r "${ROOT_DIR}/requirements/cpu.txt"
+  "${UV_BIN}" pip install \
+    --python "${VENV_DIR}/bin/python" \
+    -r "${ROOT_DIR}/requirements/build.txt"
   export VLLM_TARGET_DEVICE="${VLLM_TARGET_DEVICE:-cpu}"
   export VLLM_USE_PRECOMPILED=0
+  INSTALL_ARGS+=(--no-build-isolation)
 else
   export VLLM_USE_PRECOMPILED="${VLLM_USE_PRECOMPILED:-1}"
 fi
 
 if [[ "${EDITABLE}" -eq 1 ]]; then
-  "${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" -e "${INSTALL_TARGET}"
+  "${UV_BIN}" pip install \
+    --python "${VENV_DIR}/bin/python" \
+    "${INSTALL_ARGS[@]}" \
+    -e "${INSTALL_TARGET}"
 else
-  "${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" "${INSTALL_TARGET}"
+  "${UV_BIN}" pip install \
+    --python "${VENV_DIR}/bin/python" \
+    "${INSTALL_ARGS[@]}" \
+    "${INSTALL_TARGET}"
 fi
 
 install_launcher() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -217,14 +217,20 @@ else
   "${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" "${INSTALL_TARGET}"
 fi
 
-if [[ "${MODE}" != "venv" ]]; then
-  mkdir -p "${BIN_DIR}"
-  cat > "${BIN_DIR}/vllm" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-exec "${VENV_DIR}/bin/python" "${ROOT_DIR}/scripts/vllm_launcher.py" "\$@"
-EOF
-  chmod +x "${BIN_DIR}/vllm"
+install_launcher() {
+  local target="$1"
+  mkdir -p "$(dirname "${target}")"
+  {
+    printf '#!%s\n' "${VENV_DIR}/bin/python"
+    tail -n +2 "${ROOT_DIR}/scripts/vllm_launcher.py"
+  } > "${target}"
+  chmod +x "${target}"
+}
+
+if [[ "${MODE}" == "venv" ]]; then
+  install_launcher "${VENV_DIR}/bin/vllm"
+else
+  install_launcher "${BIN_DIR}/vllm"
 fi
 
 echo

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MODE="auto"
 TARGET_VENV=""
-PYTHON_BIN="${PYTHON_BIN:-python3}"
+PYTHON_BIN="${PYTHON_BIN:-}"
 EDITABLE=0
+HOST_OS="$(uname -s)"
 
 usage() {
   cat <<'EOF'
@@ -81,15 +82,52 @@ if [[ "${MODE}" == "system" && "$(id -u)" -ne 0 ]]; then
   exit 1
 fi
 
-if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
-  echo "Python interpreter not found: ${PYTHON_BIN}" >&2
-  exit 1
-fi
-
 if ! command -v curl >/dev/null 2>&1; then
   echo "curl is required to bootstrap uv." >&2
   exit 1
 fi
+
+pick_python() {
+  local candidate=""
+
+  if [[ -n "${PYTHON_BIN}" ]]; then
+    candidate="${PYTHON_BIN}"
+    if ! command -v "${candidate}" >/dev/null 2>&1; then
+      echo "Python interpreter not found: ${candidate}" >&2
+      exit 1
+    fi
+    echo "${candidate}"
+    return
+  fi
+
+  for candidate in python3.13 python3.12 python3.11 python3.10; do
+    if command -v "${candidate}" >/dev/null 2>&1; then
+      echo "${candidate}"
+      return
+    fi
+  done
+
+  if command -v python3 >/dev/null 2>&1; then
+    echo "python3"
+    return
+  fi
+
+  echo "No supported Python interpreter found. Install Python 3.10-3.13 or pass --python." >&2
+  exit 1
+}
+
+validate_python_version() {
+  local candidate="$1"
+  if ! "${candidate}" -c 'import sys; raise SystemExit(0 if (3, 10) <= sys.version_info[:2] < (3, 14) else 1)'; then
+    local actual_version
+    actual_version="$("${candidate}" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')"
+    echo "Unsupported Python version: ${actual_version}. vLLM requires Python >=3.10,<3.14." >&2
+    exit 1
+  fi
+}
+
+PYTHON_BIN="$(pick_python)"
+validate_python_version "${PYTHON_BIN}"
 
 ensure_uv() {
   if command -v uv >/dev/null 2>&1; then
@@ -141,8 +179,24 @@ esac
 mkdir -p "$(dirname "${VENV_DIR}")"
 "${UV_BIN}" venv --python "${PYTHON_BIN}" "${VENV_DIR}"
 
+"${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" certifi
+CERT_BUNDLE="$("${VENV_DIR}/bin/python" -c 'import certifi; print(certifi.where())')"
+export SSL_CERT_FILE="${CERT_BUNDLE}"
+export REQUESTS_CA_BUNDLE="${CERT_BUNDLE}"
+
 INSTALL_TARGET="${ROOT_DIR}"
-export VLLM_USE_PRECOMPILED="${VLLM_USE_PRECOMPILED:-1}"
+if [[ "${HOST_OS}" == "Darwin" ]]; then
+  echo "macOS detected: using the Apple Silicon CPU source-build path." >&2
+  "${UV_BIN}" pip install \
+    --python "${VENV_DIR}/bin/python" \
+    --index-strategy unsafe-best-match \
+    -r "${ROOT_DIR}/requirements/cpu.txt"
+  export VLLM_TARGET_DEVICE="${VLLM_TARGET_DEVICE:-cpu}"
+  export VLLM_USE_PRECOMPILED=0
+else
+  export VLLM_USE_PRECOMPILED="${VLLM_USE_PRECOMPILED:-1}"
+fi
+
 if [[ "${EDITABLE}" -eq 1 ]]; then
   "${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" -e "${INSTALL_TARGET}"
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,10 +7,11 @@ TARGET_VENV=""
 PYTHON_BIN="${PYTHON_BIN:-}"
 EDITABLE=0
 HOST_OS="$(uname -s)"
+RECREATE_VENV=0
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/install.sh [--system | --user | --venv PATH] [--editable] [--python PYTHON]
+Usage: ./scripts/install.sh [--system | --user | --venv PATH] [--editable] [--python PYTHON] [--recreate]
 
 Install this vLLM checkout with an Ollama-like local CLI launcher.
 
@@ -22,6 +23,7 @@ Modes:
 Options:
   --editable     Install the repo in editable mode
   --python BIN   Python interpreter to use when creating the environment
+  --recreate     Recreate the managed virtual environment instead of reusing it
   -h, --help     Show this message
 EOF
 }
@@ -47,6 +49,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --editable)
       EDITABLE=1
+      shift
+      ;;
+    --recreate)
+      RECREATE_VENV=1
       shift
       ;;
     --python)
@@ -177,7 +183,15 @@ case "${MODE}" in
 esac
 
 mkdir -p "$(dirname "${VENV_DIR}")"
-"${UV_BIN}" venv --python "${PYTHON_BIN}" "${VENV_DIR}"
+if [[ -x "${VENV_DIR}/bin/python" && "${RECREATE_VENV}" -eq 0 ]]; then
+  echo "Reusing existing virtual environment at ${VENV_DIR}"
+else
+  VENV_ARGS=("--python" "${PYTHON_BIN}")
+  if [[ "${RECREATE_VENV}" -eq 1 ]]; then
+    VENV_ARGS+=("--clear")
+  fi
+  "${UV_BIN}" venv "${VENV_ARGS[@]}" "${VENV_DIR}"
+fi
 
 "${UV_BIN}" pip install --python "${VENV_DIR}/bin/python" certifi
 CERT_BUNDLE="$("${VENV_DIR}/bin/python" -c 'import certifi; print(certifi.where())')"
@@ -208,7 +222,7 @@ if [[ "${MODE}" != "venv" ]]; then
   cat > "${BIN_DIR}/vllm" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-exec "${VENV_DIR}/bin/python" -m vllm.entrypoints.cli.main "\$@"
+exec "${VENV_DIR}/bin/python" "${ROOT_DIR}/scripts/vllm_launcher.py" "\$@"
 EOF
   chmod +x "${BIN_DIR}/vllm"
 fi

--- a/scripts/vllm_launcher.py
+++ b/scripts/vllm_launcher.py
@@ -9,16 +9,12 @@ import json
 import os
 import re
 import signal
-import socket
-import subprocess
 import sys
 import time
 from pathlib import Path
 from typing import Any
 
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-ALIASES_PATH = REPO_ROOT / "vllm" / "entrypoints" / "cli" / "model_aliases.py"
+ALIASES_RELATIVE_PATH = Path("vllm") / "entrypoints" / "cli" / "model_aliases.py"
 
 
 def _config_root() -> Path:
@@ -37,6 +33,19 @@ LOCAL_USER_ALIASES = LOCAL_RUNTIME_DIR / "aliases.json"
 def ensure_runtime_dirs() -> None:
     LOCAL_RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
     (LOCAL_RUNTIME_DIR / "logs").mkdir(parents=True, exist_ok=True)
+
+
+def _find_aliases_path() -> Path:
+    repo_candidate = Path(__file__).resolve().parents[1] / ALIASES_RELATIVE_PATH
+    if repo_candidate.exists():
+        return repo_candidate
+
+    for entry in map(Path, sys.path):
+        candidate = entry / ALIASES_RELATIVE_PATH
+        if candidate.exists():
+            return candidate
+
+    raise RuntimeError("Unable to locate model_aliases.py for the vLLM launcher.")
 
 
 def _read_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
@@ -59,9 +68,10 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _load_builtin_aliases() -> dict[str, dict[str, str]]:
-    spec = importlib.util.spec_from_file_location("_vllm_aliases", ALIASES_PATH)
+    aliases_path = _find_aliases_path()
+    spec = importlib.util.spec_from_file_location("_vllm_aliases", aliases_path)
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"Unable to load aliases from {ALIASES_PATH}")
+        raise RuntimeError(f"Unable to load aliases from {aliases_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return getattr(module, "BUILTIN_MODEL_ALIASES")

--- a/scripts/vllm_launcher.py
+++ b/scripts/vllm_launcher.py
@@ -145,6 +145,7 @@ def _print_help() -> None:
         "  vllm run <model> [options]\n"
         "  vllm serve <model> [options]\n"
         "  vllm ls\n"
+        "  vllm list\n"
         "  vllm aliases\n"
         "  vllm inspect <model>\n"
         "  vllm ps\n"
@@ -435,7 +436,7 @@ def main() -> int:
 
     if command == "aliases":
         return _cmd_aliases()
-    if command == "ls":
+    if command in {"ls", "list"}:
         return _cmd_ls()
     if command == "inspect":
         return _cmd_inspect(rest)

--- a/scripts/vllm_launcher.py
+++ b/scripts/vllm_launcher.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ALIASES_PATH = REPO_ROOT / "vllm" / "entrypoints" / "cli" / "model_aliases.py"
+
+
+def _config_root() -> Path:
+    if "VLLM_CONFIG_ROOT" in os.environ:
+        return Path(os.environ["VLLM_CONFIG_ROOT"]).expanduser()
+    xdg = Path(os.environ.get("XDG_CONFIG_HOME", "~/.config")).expanduser()
+    return xdg / "vllm"
+
+
+LOCAL_RUNTIME_DIR = _config_root() / "local"
+LOCAL_MODELS_REGISTRY = LOCAL_RUNTIME_DIR / "models.json"
+LOCAL_SERVICES_REGISTRY = LOCAL_RUNTIME_DIR / "services.json"
+LOCAL_USER_ALIASES = LOCAL_RUNTIME_DIR / "aliases.json"
+
+
+def ensure_runtime_dirs() -> None:
+    LOCAL_RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+    (LOCAL_RUNTIME_DIR / "logs").mkdir(parents=True, exist_ok=True)
+
+
+def _read_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
+    if not path.exists():
+        return default
+    try:
+        with path.open() as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        return default
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    ensure_runtime_dirs()
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+    tmp_path.replace(path)
+
+
+def _load_builtin_aliases() -> dict[str, dict[str, str]]:
+    spec = importlib.util.spec_from_file_location("_vllm_aliases", ALIASES_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load aliases from {ALIASES_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, "BUILTIN_MODEL_ALIASES")
+
+
+def _load_user_aliases() -> dict[str, dict[str, str]]:
+    return _read_json(LOCAL_USER_ALIASES, {})
+
+
+def _all_aliases() -> dict[str, dict[str, str]]:
+    aliases = dict(_load_builtin_aliases())
+    for alias, value in _load_user_aliases().items():
+        if isinstance(value, dict) and "model" in value:
+            aliases[alias] = value
+    return aliases
+
+
+def _default_models_registry() -> dict[str, Any]:
+    return {"version": 1, "models": []}
+
+
+def _default_services_registry() -> dict[str, Any]:
+    return {"version": 1, "services": []}
+
+
+def _load_models_registry() -> dict[str, Any]:
+    return _read_json(LOCAL_MODELS_REGISTRY, _default_models_registry())
+
+
+def _save_models_registry(registry: dict[str, Any]) -> None:
+    _write_json(LOCAL_MODELS_REGISTRY, registry)
+
+
+def _load_services_registry() -> dict[str, Any]:
+    registry = _read_json(LOCAL_SERVICES_REGISTRY, _default_services_registry())
+    live_services = []
+    for service in registry["services"]:
+        if _is_process_running(service["pid"]):
+            live_services.append(service)
+    if len(live_services) != len(registry["services"]):
+        registry["services"] = live_services
+        _write_json(LOCAL_SERVICES_REGISTRY, registry)
+    return registry
+
+
+def _is_process_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _print_table(rows: list[dict[str, Any]], columns: list[tuple[str, str]]) -> None:
+    if not rows:
+        return
+    widths: dict[str, int] = {}
+    for key, label in columns:
+        widths[key] = max(len(label), *(len(str(row.get(key, ""))) for row in rows))
+    print("  ".join(label.ljust(widths[key]) for key, label in columns))
+    print("  ".join("-" * widths[key] for key, _ in columns))
+    for row in rows:
+        print("  ".join(str(row.get(key, "")).ljust(widths[key]) for key, _ in columns))
+
+
+def _print_help() -> None:
+    print(
+        "vLLM local runtime\n\n"
+        "Usage:\n"
+        "  vllm pull <model>\n"
+        "  vllm run <model> [options]\n"
+        "  vllm serve <model> [options]\n"
+        "  vllm ls\n"
+        "  vllm aliases\n"
+        "  vllm inspect <model>\n"
+        "  vllm ps\n"
+        "  vllm stop <service>\n"
+        "  vllm logs <service>\n"
+        "  vllm rm <model>\n\n"
+        "Advanced commands:\n"
+        "  vllm chat\n"
+        "  vllm complete\n"
+        "  vllm bench\n"
+        "  vllm collect-env\n"
+        "  vllm run-batch\n"
+        "  vllm launch\n\n"
+        "Examples:\n"
+        "  vllm pull deepseek-r1:8b\n"
+        "  vllm run llama3.2:3b-instruct\n"
+        "  vllm serve qwen2.5:7b-instruct\n"
+        "  vllm aliases\n"
+    )
+
+
+def _print_version() -> None:
+    import importlib.metadata
+
+    try:
+        print(importlib.metadata.version("vllm"))
+    except importlib.metadata.PackageNotFoundError:
+        print("vllm (not installed)")
+
+
+def _resolve_model(model_ref: str) -> dict[str, Any]:
+    path = Path(model_ref).expanduser()
+    if path.exists():
+        return {
+            "requested": model_ref,
+            "model": str(path.resolve()),
+            "source": "path",
+            "alias": None,
+        }
+
+    if "/" in model_ref:
+        return {
+            "requested": model_ref,
+            "model": model_ref,
+            "source": "hf",
+            "alias": None,
+        }
+
+    aliases = _all_aliases()
+    if model_ref in aliases:
+        return {
+            "requested": model_ref,
+            "model": aliases[model_ref]["model"],
+            "source": "alias",
+            "alias": model_ref,
+            "description": aliases[model_ref].get("description"),
+        }
+
+    raise SystemExit(
+        "Unknown model alias. Use `vllm aliases` to browse built-ins or pass an "
+        "exact Hugging Face repo like `meta-llama/Llama-3.1-8B-Instruct`."
+    )
+
+
+def _record_pulled_model(resolved: dict[str, Any], local_path: str) -> None:
+    registry = _load_models_registry()
+    record = {
+        "requested": resolved["requested"],
+        "alias": resolved.get("alias"),
+        "source": resolved["source"],
+        "model": resolved["model"],
+        "revision": None,
+        "local_path": local_path,
+        "pulled_at": int(time.time()),
+        "description": resolved.get("description"),
+    }
+    models = []
+    replaced = False
+    for existing in registry["models"]:
+        if existing["model"] == record["model"]:
+            models.append(record)
+            replaced = True
+        else:
+            models.append(existing)
+    if not replaced:
+        models.append(record)
+    registry["models"] = models
+    _save_models_registry(registry)
+
+
+def _cmd_aliases() -> int:
+    rows = []
+    for alias, value in sorted(_all_aliases().items()):
+        rows.append(
+            {
+                "alias": alias,
+                "model": value["model"],
+                "description": value.get("description", ""),
+            }
+        )
+    _print_table(
+        rows,
+        [
+            ("alias", "ALIAS"),
+            ("model", "HUGGING_FACE_REPO"),
+            ("description", "DESCRIPTION"),
+        ],
+    )
+    return 0
+
+
+def _cmd_ls() -> int:
+    registry = _load_models_registry()
+    rows = []
+    for record in sorted(registry["models"], key=lambda item: item["requested"]):
+        rows.append(
+            {
+                "requested": record["requested"],
+                "resolved": record["model"],
+                "source": record["source"],
+                "local_path": record["local_path"],
+            }
+        )
+    if not rows:
+        print("No pulled models found. Use `vllm pull <model>` first.")
+        return 0
+    _print_table(
+        rows,
+        [
+            ("requested", "REQUESTED"),
+            ("resolved", "RESOLVED"),
+            ("source", "SOURCE"),
+            ("local_path", "LOCAL_PATH"),
+        ],
+    )
+    return 0
+
+
+def _cmd_inspect(args: list[str]) -> int:
+    if not args:
+        raise SystemExit("Usage: vllm inspect <model>")
+    resolved = _resolve_model(args[0])
+    print(json.dumps(resolved, indent=2, sort_keys=True))
+    return 0
+
+
+def _cmd_pull(args: list[str]) -> int:
+    if not args:
+        raise SystemExit("Usage: vllm pull <model>")
+    resolved = _resolve_model(args[0])
+    if resolved["source"] == "path":
+        _record_pulled_model(resolved, resolved["model"])
+        print(f"Recorded local model path: {resolved['model']}")
+        return 0
+
+    from huggingface_hub import snapshot_download
+
+    local_path = snapshot_download(repo_id=resolved["model"])
+    _record_pulled_model(resolved, local_path)
+    print(f"Pulled {resolved['requested']} -> {resolved['model']}")
+    print(f"Local path: {local_path}")
+    return 0
+
+
+def _cmd_ps() -> int:
+    registry = _load_services_registry()
+    rows = []
+    for service in sorted(registry["services"], key=lambda item: item["name"]):
+        rows.append(
+            {
+                "name": service["name"],
+                "pid": service["pid"],
+                "port": service["port"],
+                "status": "running",
+                "model": service["requested_model"],
+            }
+        )
+    if not rows:
+        print("No running vLLM local services.")
+        return 0
+    _print_table(
+        rows,
+        [
+            ("name", "NAME"),
+            ("pid", "PID"),
+            ("port", "PORT"),
+            ("status", "STATUS"),
+            ("model", "MODEL"),
+        ],
+    )
+    return 0
+
+
+def _cmd_stop(args: list[str]) -> int:
+    if not args:
+        raise SystemExit("Usage: vllm stop <service>")
+    name_or_pid = args[0]
+    registry = _load_services_registry()
+    kept = []
+    target = None
+    for service in registry["services"]:
+        if service["name"] == name_or_pid or str(service["pid"]) == name_or_pid:
+            target = service
+            continue
+        kept.append(service)
+    if target is None:
+        raise SystemExit(f"Unknown service: {name_or_pid}")
+    os.kill(target["pid"], signal.SIGTERM)
+    registry["services"] = kept
+    _write_json(LOCAL_SERVICES_REGISTRY, registry)
+    print(f"Stopped {target['name']} (pid {target['pid']}).")
+    return 0
+
+
+def _cmd_logs(args: list[str]) -> int:
+    if not args:
+        raise SystemExit("Usage: vllm logs <service>")
+    name_or_pid = args[0]
+    registry = _load_services_registry()
+    target = None
+    for service in registry["services"]:
+        if service["name"] == name_or_pid or str(service["pid"]) == name_or_pid:
+            target = service
+            break
+    if target is None:
+        raise SystemExit(f"Unknown service: {name_or_pid}")
+    log_path = Path(target["log_path"])
+    if not log_path.exists():
+        raise SystemExit(f"Log file not found: {log_path}")
+    with log_path.open() as f:
+        lines = f.readlines()[-40:]
+    print("".join(lines), end="")
+    return 0
+
+
+def _cmd_rm(args: list[str]) -> int:
+    if not args:
+        raise SystemExit("Usage: vllm rm <model>")
+    resolved = _resolve_model(args[0])
+    registry = _load_models_registry()
+    new_models = []
+    removed = False
+    for record in registry["models"]:
+        if record["model"] == resolved["model"]:
+            removed = True
+            continue
+        new_models.append(record)
+    registry["models"] = new_models
+    _save_models_registry(registry)
+    if removed:
+        print("Removed local metadata entry.")
+    else:
+        print("Model metadata not found.")
+    return 0
+
+
+def _delegate_to_vllm(args: list[str]) -> int:
+    os.execv(
+        sys.executable,
+        [
+            sys.executable,
+            "-m",
+            "vllm.entrypoints.cli.main",
+            *args,
+        ],
+    )
+    return 0
+
+
+def main() -> int:
+    ensure_runtime_dirs()
+
+    argv = sys.argv[1:]
+    if not argv:
+        _print_help()
+        return 0
+
+    if argv[0] in {"-h", "--help", "help"}:
+        _print_help()
+        return 0
+
+    if argv[0] in {"-v", "--version"}:
+        _print_version()
+        return 0
+
+    command = argv[0]
+    rest = argv[1:]
+
+    if command == "aliases":
+        return _cmd_aliases()
+    if command == "ls":
+        return _cmd_ls()
+    if command == "inspect":
+        return _cmd_inspect(rest)
+    if command == "pull":
+        return _cmd_pull(rest)
+    if command == "ps":
+        return _cmd_ps()
+    if command == "stop":
+        return _cmd_stop(rest)
+    if command == "logs":
+        return _cmd_logs(rest)
+    if command == "rm":
+        return _cmd_rm(rest)
+
+    return _delegate_to_vllm(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vllm_launcher.py
+++ b/scripts/vllm_launcher.py
@@ -148,6 +148,9 @@ def _print_help() -> None:
         "  vllm list\n"
         "  vllm aliases\n"
         "  vllm inspect <model>\n"
+        "  vllm doctor [model]\n"
+        "  vllm status [model]\n"
+        "  vllm preflight <model>\n"
         "  vllm ps\n"
         "  vllm stop <service>\n"
         "  vllm logs <service>\n"
@@ -163,6 +166,8 @@ def _print_help() -> None:
         "  vllm pull deepseek-r1:8b\n"
         "  vllm run llama3.2:3b-instruct\n"
         "  vllm serve qwen2.5:7b-instruct\n"
+        "  vllm doctor deepseek-r1:8b\n"
+        "  vllm preflight llama3.1:8b-instruct --profile low-memory\n"
         "  vllm aliases\n"
     )
 

--- a/tests/entrypoints/test_local_cli.py
+++ b/tests/entrypoints/test_local_cli.py
@@ -1,10 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import argparse
+import subprocess
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 from vllm.entrypoints.cli import local as local_cli
+from vllm.entrypoints.cli import local_backends
 from vllm.entrypoints.cli import local_runtime
+from vllm.entrypoints.cli import main as main_cli
 from vllm.entrypoints.cli.serve import ServeSubcommand
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -19,6 +25,68 @@ def _set_runtime_paths(monkeypatch, root: Path) -> None:
     )
     monkeypatch.setattr(local_runtime, "LOCAL_USER_ALIASES", root / "aliases.json")
     monkeypatch.setattr(local_runtime, "LOCAL_LOG_DIR", root / "logs")
+
+
+def _fake_platform(*, memory_bytes: int = 32 * 1024**3):
+    class FakePlatform:
+        device_type = "cpu"
+        device_name = "CPU"
+        supported_dtypes: list[object] = []
+        supported_quantization: list[str] = []
+
+        def is_cuda(self) -> bool:
+            return False
+
+        def is_rocm(self) -> bool:
+            return False
+
+        def is_xpu(self) -> bool:
+            return False
+
+        def is_cpu(self) -> bool:
+            return True
+
+        def is_out_of_tree(self) -> bool:
+            return False
+
+        def get_device_total_memory(self) -> int:
+            return memory_bytes
+
+        def support_static_graph_mode(self) -> bool:
+            return False
+
+    return FakePlatform()
+
+
+def _fake_apple_platform(*, memory_bytes: int = 32 * 1024**3):
+    class FakeApplePlatform:
+        device_type = "metal"
+        device_name = "Apple Metal"
+        supported_dtypes: list[object] = []
+        supported_quantization: list[str] = []
+
+        def is_cuda(self) -> bool:
+            return False
+
+        def is_rocm(self) -> bool:
+            return False
+
+        def is_xpu(self) -> bool:
+            return False
+
+        def is_cpu(self) -> bool:
+            return False
+
+        def is_out_of_tree(self) -> bool:
+            return True
+
+        def get_device_total_memory(self) -> int:
+            return memory_bytes
+
+        def support_static_graph_mode(self) -> bool:
+            return False
+
+    return FakeApplePlatform()
 
 
 def test_resolve_builtin_alias():
@@ -110,3 +178,259 @@ def test_parse_list_alias_command():
 
     args = parser.parse_args(["list"])
     assert args.subparser == "list"
+
+
+def test_aliases_command_registered():
+    commands = {command.name for command in local_cli.cmd_init()}
+    assert "aliases" in commands
+    assert "doctor" in commands
+    assert "status" in commands
+    assert "preflight" in commands
+
+
+def test_local_command_specs_match_registered_commands():
+    advertised = {
+        spec.name
+        for spec in main_cli.COMMAND_SPECS
+        if spec.module == "vllm.entrypoints.cli.local"
+    }
+    registered = {command.name for command in local_cli.cmd_init()}
+    assert advertised <= registered
+
+
+def test_parse_aliases_command():
+    parser = FlexibleArgumentParser(description="test")
+    subparsers = parser.add_subparsers(required=False, dest="subparser")
+    local_cli.AliasesCommand().subparser_init(subparsers)
+
+    args = parser.parse_args(["aliases", "--json"])
+    assert args.subparser == "aliases"
+    assert args.json is True
+
+
+def test_background_serve_honors_port_equals_form(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.resolve_model_reference",
+        lambda model, revision=None: local_runtime.ResolvedModel(
+            requested=model,
+            model="repo/model",
+            source="alias",
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.ensure_model_available",
+        lambda resolved, download_dir=None: {"local_path": str(tmp_path / "model")},
+    )
+    monkeypatch.setattr("vllm.entrypoints.cli.serve.find_service", lambda _: None)
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.build_doctor_report",
+        lambda **_: SimpleNamespace(
+            selected_backend="cpu",
+            fallback_reason=None,
+            selection_reason="cpu fallback",
+            preflight=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.allocate_service_port",
+        lambda *args, **kwargs: (
+            _ for _ in ()
+        ).throw(AssertionError("unexpected random port allocation")),
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.spawn_service_process",
+        lambda command, log_path: captured.update(
+            {"command": command, "log_path": str(log_path)}
+        )
+        or SimpleNamespace(pid=4321),
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.register_service",
+        lambda record: captured.setdefault("record", record),
+    )
+
+    args = argparse.Namespace(
+        model="deepseek-r1:8b",
+        model_tag=None,
+        revision=None,
+        download_dir=None,
+        foreground=False,
+        service_name=None,
+        no_wait=True,
+        host="127.0.0.1",
+        port=8000,
+        profile="balanced",
+        backend="auto",
+        dtype="auto",
+        quantization=None,
+        max_model_len=None,
+        gpu_memory_utilization=0.9,
+        enable_prefix_caching=None,
+        enforce_eager=False,
+        _argv=["serve", "deepseek-r1:8b", "--port=8000"],
+    )
+
+    ServeSubcommand.cmd(args)
+
+    assert args.port == 8000
+    assert "--port=8000" in captured["command"]
+    assert captured["record"]["port"] == 8000
+
+
+def test_background_serve_honors_port_split_form(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.resolve_model_reference",
+        lambda model, revision=None: local_runtime.ResolvedModel(
+            requested=model,
+            model="repo/model",
+            source="alias",
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.ensure_model_available",
+        lambda resolved, download_dir=None: {"local_path": str(tmp_path / "model")},
+    )
+    monkeypatch.setattr("vllm.entrypoints.cli.serve.find_service", lambda _: None)
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.build_doctor_report",
+        lambda **_: SimpleNamespace(
+            selected_backend="cpu",
+            fallback_reason=None,
+            selection_reason="cpu fallback",
+            preflight=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.allocate_service_port",
+        lambda *args, **kwargs: (
+            _ for _ in ()
+        ).throw(AssertionError("unexpected random port allocation")),
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.spawn_service_process",
+        lambda command, log_path: captured.update(
+            {"command": command, "log_path": str(log_path)}
+        )
+        or SimpleNamespace(pid=4321),
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.cli.serve.register_service",
+        lambda record: captured.setdefault("record", record),
+    )
+
+    args = argparse.Namespace(
+        model="deepseek-r1:8b",
+        model_tag=None,
+        revision=None,
+        download_dir=None,
+        foreground=False,
+        service_name=None,
+        no_wait=True,
+        host="127.0.0.1",
+        port=8001,
+        profile="balanced",
+        backend="auto",
+        dtype="auto",
+        quantization=None,
+        max_model_len=None,
+        gpu_memory_utilization=0.9,
+        enable_prefix_caching=None,
+        enforce_eager=False,
+        _argv=["serve", "deepseek-r1:8b", "--port", "8001"],
+    )
+
+    ServeSubcommand.cmd(args)
+
+    assert args.port == 8001
+    assert (
+        captured["command"][-3:] == ["--port", "8001", "--foreground"]
+        or captured["command"][-3:] == ["--foreground", "--port", "8001"]
+    )
+    assert captured["record"]["port"] == 8001
+
+
+def test_select_backend_prefers_apple_plugin(monkeypatch):
+    monkeypatch.setattr(local_backends.py_platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(local_backends.py_platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(
+        local_backends,
+        "_discover_platform_plugins",
+        lambda: [{"name": "vllm-metal", "value": "vllm_metal.platform:plugin"}],
+    )
+    monkeypatch.setattr(local_backends, "_safe_import_torch", lambda: None)
+    monkeypatch.setattr(
+        local_backends,
+        "_safe_import_current_platform",
+        lambda: _fake_apple_platform(memory_bytes=64 * 1024**3),
+    )
+
+    selection, _backends, _env, _platform = local_backends.select_backend()
+    assert selection.selected_backend == "apple-metal"
+
+
+def test_select_backend_falls_back_to_cpu_without_apple_plugin(monkeypatch):
+    monkeypatch.setattr(local_backends.py_platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(local_backends.py_platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(local_backends, "_discover_platform_plugins", lambda: [])
+    monkeypatch.setattr(local_backends, "_safe_import_torch", lambda: None)
+    monkeypatch.setattr(
+        local_backends,
+        "_safe_import_current_platform",
+        lambda: _fake_platform(memory_bytes=32 * 1024**3),
+    )
+
+    selection, _backends, _env, _platform = local_backends.select_backend()
+    assert selection.selected_backend == "cpu"
+    assert "apple-metal" in selection.rejected_backends
+
+
+def test_doctor_report_includes_preflight(monkeypatch):
+    monkeypatch.setattr(local_backends.py_platform, "system", lambda: "Linux")
+    monkeypatch.setattr(local_backends.py_platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(local_backends, "_discover_platform_plugins", lambda: [])
+    monkeypatch.setattr(local_backends, "_safe_import_torch", lambda: None)
+    monkeypatch.setattr(
+        local_backends,
+        "_safe_import_current_platform",
+        lambda: _fake_platform(memory_bytes=64 * 1024**3),
+    )
+    monkeypatch.setattr(
+        local_backends,
+        "_safe_import_psutil",
+        lambda: SimpleNamespace(
+            virtual_memory=lambda: SimpleNamespace(available=64 * 1024**3)
+        ),
+    )
+
+    report = local_backends.build_doctor_report(
+        model="deepseek-r1:8b",
+        requested_backend="auto",
+    )
+    assert report.preflight is not None
+    assert report.preflight.estimated_total_bytes is not None
+    assert report.trtllm is not None
+
+
+def test_install_script_requires_manual_uv(tmp_path):
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "install.sh"
+    python_dir = Path(sys.executable).resolve().parent
+    env = {
+        "HOME": str(tmp_path),
+        "PATH": f"{python_dir}:/usr/bin:/bin:/usr/sbin:/sbin",
+    }
+    result = subprocess.run(
+        ["bash", str(script_path), "--user", "--python", sys.executable],
+        cwd=script_path.parents[1],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    combined_output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "uv is required" in combined_output
+    assert "docs.astral.sh/uv/getting-started/installation" in combined_output

--- a/tests/entrypoints/test_local_cli.py
+++ b/tests/entrypoints/test_local_cli.py
@@ -101,3 +101,12 @@ def test_parse_serve_local_service_flags():
     assert args.foreground is True
     assert args.service_name == "deepseek"
     assert args.no_wait is True
+
+
+def test_parse_list_alias_command():
+    parser = FlexibleArgumentParser(description="test")
+    subparsers = parser.add_subparsers(required=False, dest="subparser")
+    local_cli.ListAliasCommand().subparser_init(subparsers)
+
+    args = parser.parse_args(["list"])
+    assert args.subparser == "list"

--- a/tests/entrypoints/test_local_cli.py
+++ b/tests/entrypoints/test_local_cli.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+
+from vllm.entrypoints.cli import local as local_cli
+from vllm.entrypoints.cli import local_runtime
+from vllm.entrypoints.cli.serve import ServeSubcommand
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+def _set_runtime_paths(monkeypatch, root: Path) -> None:
+    monkeypatch.setattr(local_runtime, "LOCAL_RUNTIME_DIR", root)
+    monkeypatch.setattr(local_runtime, "LOCAL_MODELS_REGISTRY", root / "models.json")
+    monkeypatch.setattr(
+        local_runtime,
+        "LOCAL_SERVICES_REGISTRY",
+        root / "services.json",
+    )
+    monkeypatch.setattr(local_runtime, "LOCAL_USER_ALIASES", root / "aliases.json")
+    monkeypatch.setattr(local_runtime, "LOCAL_LOG_DIR", root / "logs")
+
+
+def test_resolve_builtin_alias():
+    resolved = local_runtime.resolve_model_reference("deepseek-r1:8b")
+    assert resolved.alias == "deepseek-r1:8b"
+    assert resolved.model == "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+    assert resolved.source == "alias"
+
+
+def test_resolve_exact_hf_repo():
+    resolved = local_runtime.resolve_model_reference("meta-llama/Llama-3.1-8B-Instruct")
+    assert resolved.model == "meta-llama/Llama-3.1-8B-Instruct"
+    assert resolved.source == "hf"
+
+
+def test_record_and_remove_pulled_model(tmp_path, monkeypatch):
+    _set_runtime_paths(monkeypatch, tmp_path)
+
+    resolved = local_runtime.resolve_model_reference("deepseek-r1:8b")
+    fake_snapshot = tmp_path / "snapshot"
+    fake_snapshot.mkdir()
+
+    record = local_runtime.record_pulled_model(resolved, str(fake_snapshot))
+    assert record["local_path"] == str(fake_snapshot)
+
+    registry = local_runtime.load_models_registry()
+    assert len(registry["models"]) == 1
+
+    removed, purged_path = local_runtime.remove_pulled_model(
+        resolved,
+        purge_cache=True,
+    )
+    assert removed is True
+    assert purged_path == str(fake_snapshot)
+    assert not fake_snapshot.exists()
+    assert local_runtime.load_models_registry()["models"] == []
+
+
+def test_parse_run_command():
+    parser = FlexibleArgumentParser(description="test")
+    subparsers = parser.add_subparsers(required=False, dest="subparser")
+    run_parser = local_cli.RunCommand().subparser_init(subparsers)
+
+    args = parser.parse_args(
+        [
+            "run",
+            "deepseek-r1:8b",
+            "--prompt",
+            "hello",
+            "--complete",
+            "--max-tokens",
+            "32",
+        ]
+    )
+    assert args.subparser == "run"
+    assert args.model == "deepseek-r1:8b"
+    assert args.prompt == "hello"
+    assert args.complete is True
+    assert args.max_tokens == 32
+    assert isinstance(run_parser, FlexibleArgumentParser)
+
+
+def test_parse_serve_local_service_flags():
+    parser = FlexibleArgumentParser(description="test")
+    subparsers = parser.add_subparsers(required=False, dest="subparser")
+    ServeSubcommand().subparser_init(subparsers)
+
+    args = parser.parse_args(
+        [
+            "serve",
+            "deepseek-r1:8b",
+            "--foreground",
+            "--service-name",
+            "deepseek",
+            "--no-wait",
+        ]
+    )
+    assert args.subparser == "serve"
+    assert args.model_tag == "deepseek-r1:8b"
+    assert args.foreground is True
+    assert args.service_name == "deepseek"
+    assert args.no_wait is True

--- a/tests/entrypoints/test_main_cli.py
+++ b/tests/entrypoints/test_main_cli.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.entrypoints.cli import main as cli_main
+
+
+class _FakeCommand:
+    name = "collect-env"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        return None
+
+    def validate(self, args: argparse.Namespace) -> None:
+        return None
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> argparse.ArgumentParser:
+        return subparsers.add_parser(
+            self.name,
+            help="Collect environment information.",
+            description="Collect environment information.",
+        )
+
+
+def test_requested_subcommand_skips_global_flags():
+    assert cli_main._requested_subcommand(["--help"]) is None
+    assert cli_main._requested_subcommand(["--version"]) is None
+    assert cli_main._requested_subcommand(["collect-env", "--help"]) == "collect-env"
+
+
+def test_root_help_does_not_import_subcommand_modules(monkeypatch, capsys):
+    imported_modules: list[str] = []
+
+    def fail_import(name: str):
+        imported_modules.append(name)
+        raise AssertionError(f"unexpected subcommand import: {name}")
+
+    monkeypatch.setattr(cli_main.importlib, "import_module", fail_import)
+    monkeypatch.setattr(cli_main.sys, "argv", ["vllm", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main()
+
+    assert exc_info.value.code == 0
+    assert imported_modules == []
+    assert "collect-env" in capsys.readouterr().out
+
+
+def test_selected_subcommand_only_imports_requested_module(monkeypatch):
+    imported_modules: list[str] = []
+
+    def fake_import(name: str):
+        imported_modules.append(name)
+        if name != "vllm.entrypoints.cli.collect_env":
+            raise AssertionError(f"unexpected subcommand import: {name}")
+        return SimpleNamespace(cmd_init=lambda: [_FakeCommand()])
+
+    monkeypatch.setattr(cli_main.importlib, "import_module", fake_import)
+    monkeypatch.setattr(cli_main.sys, "argv", ["vllm", "collect-env", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main()
+
+    assert exc_info.value.code == 0
+    assert imported_modules == ["vllm.entrypoints.cli.collect_env"]

--- a/vllm/entrypoints/cli/__init__.py
+++ b/vllm/entrypoints/cli/__init__.py
@@ -1,19 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from vllm.entrypoints.cli.benchmark.latency import BenchmarkLatencySubcommand
-from vllm.entrypoints.cli.benchmark.mm_processor import (
-    BenchmarkMMProcessorSubcommand,
-)
-from vllm.entrypoints.cli.benchmark.serve import BenchmarkServingSubcommand
-from vllm.entrypoints.cli.benchmark.startup import BenchmarkStartupSubcommand
-from vllm.entrypoints.cli.benchmark.sweep import BenchmarkSweepSubcommand
-from vllm.entrypoints.cli.benchmark.throughput import BenchmarkThroughputSubcommand
 
-__all__: list[str] = [
-    "BenchmarkLatencySubcommand",
-    "BenchmarkMMProcessorSubcommand",
-    "BenchmarkServingSubcommand",
-    "BenchmarkStartupSubcommand",
-    "BenchmarkSweepSubcommand",
-    "BenchmarkThroughputSubcommand",
-]
+"""CLI package for vLLM.
+
+Keep this module intentionally light so importing `vllm.entrypoints.cli.main`
+does not eagerly pull in benchmark modules before argument parsing.
+"""
+
+__all__: list[str] = []

--- a/vllm/entrypoints/cli/local.py
+++ b/vllm/entrypoints/cli/local.py
@@ -9,11 +9,16 @@ import sys
 from typing import TYPE_CHECKING
 from pathlib import Path
 
+from vllm.entrypoints.cli.local_backends import (
+    build_doctor_report,
+    get_runtime_profile,
+)
 from vllm.entrypoints.cli.local_runtime import (
     ensure_model_available,
     find_service,
     format_service_rows,
     get_pulled_model,
+    iter_known_aliases,
     load_models_registry,
     print_kv,
     print_table,
@@ -23,11 +28,15 @@ from vllm.entrypoints.cli.local_runtime import (
     tail_file,
 )
 from vllm.entrypoints.cli.types import CLISubcommand
+from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.utils.argparse_utils import FlexibleArgumentParser
 else:
     FlexibleArgumentParser = argparse.ArgumentParser
+
+
+logger = init_logger(__name__)
 
 
 def _add_model_argument(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
@@ -64,6 +73,84 @@ def _prompt_from_args_or_stdin(args: argparse.Namespace) -> str | None:
         return None
     piped = sys.stdin.read().strip()
     return piped or None
+
+
+def _args_has_option(args: argparse.Namespace, option: str) -> bool:
+    argv = getattr(args, "_argv", [])
+    return any(arg == option or arg.startswith(f"{option}=") for arg in argv)
+
+
+def _apply_profile_defaults(args: argparse.Namespace) -> dict[str, object]:
+    profile = get_runtime_profile(args.profile)
+    applied: dict[str, object] = {}
+    if (
+        hasattr(args, "gpu_memory_utilization")
+        and profile.gpu_memory_utilization is not None
+        and not _args_has_option(args, "--gpu-memory-utilization")
+    ):
+        args.gpu_memory_utilization = profile.gpu_memory_utilization
+        applied["gpu_memory_utilization"] = profile.gpu_memory_utilization
+    if (
+        hasattr(args, "enable_prefix_caching")
+        and profile.enable_prefix_caching is not None
+        and not _args_has_option(args, "--enable-prefix-caching")
+        and not _args_has_option(args, "--no-enable-prefix-caching")
+    ):
+        args.enable_prefix_caching = profile.enable_prefix_caching
+        applied["enable_prefix_caching"] = profile.enable_prefix_caching
+    if (
+        hasattr(args, "enforce_eager")
+        and profile.enforce_eager is not None
+        and not _args_has_option(args, "--enforce-eager")
+    ):
+        args.enforce_eager = profile.enforce_eager
+        applied["enforce_eager"] = profile.enforce_eager
+    return applied
+
+
+def _format_doctor_kv(report) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "os": report.os,
+        "architecture": report.architecture,
+        "current_platform": report.current_platform,
+        "current_device_type": report.current_device_type,
+        "current_device_name": report.current_device_name,
+        "requested_backend": report.requested_backend,
+        "selected_backend": report.selected_backend,
+        "selection_reason": report.selection_reason,
+    }
+    if report.fallback_reason:
+        payload["fallback_reason"] = report.fallback_reason
+    if report.model:
+        payload["model"] = report.model
+        payload["profile"] = report.profile
+    return payload
+
+
+def _print_backend_table(report) -> None:
+    rows = []
+    for backend in report.backends:
+        rows.append(
+            {
+                "backend": backend.name,
+                "available": "yes" if backend.available else "no",
+                "selected": "yes" if backend.selected else "",
+                "tier": backend.performance_tier,
+                "source": backend.source,
+                "reason": backend.reason or "",
+            }
+        )
+    print_table(
+        rows,
+        [
+            ("backend", "BACKEND"),
+            ("available", "AVAILABLE"),
+            ("selected", "SELECTED"),
+            ("tier", "TIER"),
+            ("source", "SOURCE"),
+            ("reason", "REASON"),
+        ],
+    )
 
 
 def _run_chat(args: argparse.Namespace, llm) -> None:
@@ -136,17 +223,46 @@ class RunCommand(CLISubcommand):
     def cmd(args: argparse.Namespace) -> None:
         from vllm import LLM
 
+        report = build_doctor_report(
+            requested_backend=args.backend,
+            model=args.model,
+            dtype=args.dtype,
+            quantization=args.quantization,
+            max_model_len=args.max_model_len,
+            profile=args.profile,
+        )
+        if args.backend != "auto" and report.selected_backend != args.backend:
+            raise ValueError(
+                f"Requested backend `{args.backend}` is unavailable. "
+                f"{report.fallback_reason or report.selection_reason}"
+            )
+        profile_applied = _apply_profile_defaults(args)
         resolved = resolve_model_reference(args.model, revision=args.revision)
         record = ensure_model_available(resolved, download_dir=args.download_dir)
+
+        logger.info(
+            "Local run backend=%s profile=%s model=%s applied_defaults=%s",
+            report.selected_backend,
+            args.profile,
+            resolved.model,
+            profile_applied or "none",
+        )
+        if report.fallback_reason:
+            logger.info("Backend fallback reason: %s", report.fallback_reason)
+        if report.preflight is not None:
+            logger.info("Preflight: %s", report.preflight.summary)
 
         llm = LLM(
             model=record["local_path"],
             tensor_parallel_size=args.tensor_parallel_size,
             dtype=args.dtype,
+            quantization=args.quantization,
             gpu_memory_utilization=args.gpu_memory_utilization,
             trust_remote_code=args.trust_remote_code,
             max_model_len=args.max_model_len,
             download_dir=args.download_dir,
+            enable_prefix_caching=args.enable_prefix_caching,
+            enforce_eager=args.enforce_eager,
         )
         if args.complete:
             _run_complete(args, llm)
@@ -200,10 +316,42 @@ class RunCommand(CLISubcommand):
             help="Model dtype to use when loading the model.",
         )
         parser.add_argument(
+            "--quantization",
+            type=str,
+            default=None,
+            help="Optional quantization hint used for load and preflight diagnostics.",
+        )
+        parser.add_argument(
+            "--backend",
+            type=str,
+            default="auto",
+            choices=["auto", "cuda", "rocm", "xpu", "apple-metal", "cpu"],
+            help="Backend preference for local runtime selection.",
+        )
+        parser.add_argument(
+            "--profile",
+            type=str,
+            default="balanced",
+            choices=["balanced", "throughput", "low-memory"],
+            help="Local performance profile used to choose sensible defaults.",
+        )
+        parser.add_argument(
             "--gpu-memory-utilization",
             type=float,
             default=0.9,
             help="Fraction of GPU memory reserved by vLLM.",
+        )
+        parser.add_argument(
+            "--enable-prefix-caching",
+            action=argparse.BooleanOptionalAction,
+            default=None,
+            help="Override prefix caching behavior for local runs.",
+        )
+        parser.add_argument(
+            "--enforce-eager",
+            action="store_true",
+            default=False,
+            help="Force eager execution and disable graph-backed execution paths.",
         )
         parser.add_argument(
             "--max-model-len",
@@ -296,6 +444,48 @@ class ListAliasCommand(ListCommand):
         )
 
 
+class AliasesCommand(CLISubcommand):
+    name = "aliases"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        rows = []
+        for alias, value in sorted(iter_known_aliases().items()):
+            rows.append(
+                {
+                    "alias": alias,
+                    "resolved": value["model"],
+                    "description": value.get("description", ""),
+                }
+            )
+        if args.json:
+            print(json.dumps(rows, indent=2, sort_keys=True))
+            return
+        print_table(
+            rows,
+            [
+                ("alias", "ALIAS"),
+                ("resolved", "RESOLVED"),
+                ("description", "DESCRIPTION"),
+            ],
+        )
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(
+            self.name,
+            help="List built-in and user-defined model aliases.",
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            default=False,
+            help="Print machine-readable JSON output.",
+        )
+        return parser
+
+
 class InspectCommand(CLISubcommand):
     name = "inspect"
 
@@ -303,6 +493,14 @@ class InspectCommand(CLISubcommand):
     def cmd(args: argparse.Namespace) -> None:
         resolved = resolve_model_reference(args.model, revision=args.revision)
         record = get_pulled_model(resolved)
+        report = build_doctor_report(
+            requested_backend=args.backend,
+            model=args.model,
+            dtype=args.dtype,
+            quantization=args.quantization,
+            max_model_len=args.max_model_len,
+            profile=args.profile,
+        )
         payload = {
             "requested": resolved.requested,
             "resolved": resolved.model,
@@ -311,6 +509,12 @@ class InspectCommand(CLISubcommand):
             "revision": resolved.revision,
             "local_path": record["local_path"] if record else None,
             "pulled": record is not None,
+            "backend": report.selected_backend,
+            "selection_reason": report.selection_reason,
+            "fallback_reason": report.fallback_reason,
+            "profile": args.profile,
+            "preflight": report.preflight.to_dict() if report.preflight else None,
+            "trtllm": report.trtllm.to_dict() if report.trtllm else None,
         }
         if args.json:
             print(json.dumps(payload, indent=2, sort_keys=True))
@@ -325,6 +529,244 @@ class InspectCommand(CLISubcommand):
             help="Inspect model resolution and local cache metadata.",
         )
         _add_model_argument(parser)
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            default=False,
+            help="Print machine-readable JSON output.",
+        )
+        parser.add_argument(
+            "--backend",
+            type=str,
+            default="auto",
+            choices=["auto", "cuda", "rocm", "xpu", "apple-metal", "cpu"],
+            help="Backend preference for inspection and preflight.",
+        )
+        parser.add_argument(
+            "--profile",
+            type=str,
+            default="balanced",
+            choices=["balanced", "throughput", "low-memory"],
+            help="Local profile used when generating diagnostics.",
+        )
+        parser.add_argument(
+            "--dtype",
+            type=str,
+            default="auto",
+            help="Dtype hint used for diagnostics.",
+        )
+        parser.add_argument(
+            "--quantization",
+            type=str,
+            default=None,
+            help="Quantization hint used for diagnostics.",
+        )
+        parser.add_argument(
+            "--max-model-len",
+            type=int,
+            default=None,
+            help="Context length hint used for preflight diagnostics.",
+        )
+        return parser
+
+
+class DoctorCommand(CLISubcommand):
+    name = "doctor"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        report = build_doctor_report(
+            requested_backend=args.backend,
+            model=args.model,
+            dtype=args.dtype,
+            quantization=args.quantization,
+            max_model_len=args.max_model_len,
+            profile=args.profile,
+        )
+        if args.json:
+            print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+            return
+
+        print_kv(_format_doctor_kv(report))
+        print()
+        _print_backend_table(report)
+        if report.available_plugins:
+            print()
+            print("PLUGINS")
+            print_table(
+                report.available_plugins,
+                [("name", "NAME"), ("value", "ENTRYPOINT")],
+            )
+        if report.preflight is not None:
+            print()
+            print("PREFLIGHT")
+            print_kv(
+                {
+                    "summary": report.preflight.summary,
+                    "fit": report.preflight.fit,
+                    "estimated_weight_bytes": report.preflight.estimated_weight_bytes,
+                    "estimated_kv_cache_bytes": report.preflight.estimated_kv_cache_bytes,
+                    "estimated_runtime_overhead_bytes": (
+                        report.preflight.estimated_runtime_overhead_bytes
+                    ),
+                    "estimated_total_bytes": report.preflight.estimated_total_bytes,
+                    "available_memory_bytes": report.preflight.available_memory_bytes,
+                }
+            )
+        if report.trtllm is not None:
+            print()
+            print("TENSORRT-LLM")
+            print_kv(
+                {
+                    "eligible": report.trtllm.eligible,
+                    "environment_supported": report.trtllm.environment_supported,
+                    "model_supported": report.trtllm.model_supported,
+                    "flashinfer_available": report.trtllm.flashinfer_available,
+                    "flashinfer_trtllm_moe_available": (
+                        report.trtllm.flashinfer_trtllm_moe_available
+                    ),
+                    "sink_attention_supported": report.trtllm.sink_attention_supported,
+                    "ragged_mla_supported": report.trtllm.ragged_mla_supported,
+                    "reasons": "; ".join(report.trtllm.reasons),
+                }
+            )
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(
+            self.name,
+            help="Show backend selection, capability, and compatibility diagnostics.",
+        )
+        parser.add_argument(
+            "model",
+            nargs="?",
+            default=None,
+            help="Optional model alias, HF repo, or local path for preflight checks.",
+        )
+        parser.add_argument(
+            "--backend",
+            type=str,
+            default="auto",
+            choices=["auto", "cuda", "rocm", "xpu", "apple-metal", "cpu"],
+            help="Backend preference for diagnostics.",
+        )
+        parser.add_argument(
+            "--profile",
+            type=str,
+            default="balanced",
+            choices=["balanced", "throughput", "low-memory"],
+            help="Local profile used when generating diagnostics.",
+        )
+        parser.add_argument(
+            "--dtype",
+            type=str,
+            default="auto",
+            help="Dtype hint used for model preflight.",
+        )
+        parser.add_argument(
+            "--quantization",
+            type=str,
+            default=None,
+            help="Quantization hint used for model preflight.",
+        )
+        parser.add_argument(
+            "--max-model-len",
+            type=int,
+            default=None,
+            help="Context length hint used for model preflight.",
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            default=False,
+            help="Print machine-readable JSON output.",
+        )
+        return parser
+
+
+class StatusCommand(DoctorCommand):
+    name = "status"
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = super().subparser_init(subparsers)
+        parser.prog = parser.prog.replace("doctor", "status")
+        return parser
+
+
+class PreflightCommand(CLISubcommand):
+    name = "preflight"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        report = build_doctor_report(
+            requested_backend=args.backend,
+            model=args.model,
+            dtype=args.dtype,
+            quantization=args.quantization,
+            max_model_len=args.max_model_len,
+            profile=args.profile,
+        )
+        if report.preflight is None:
+            raise ValueError("`vllm preflight` requires a model reference.")
+        if args.json:
+            print(json.dumps(report.preflight.to_dict(), indent=2, sort_keys=True))
+            return
+        print_kv(
+            {
+                "selected_backend": report.selected_backend,
+                "selection_reason": report.selection_reason,
+                "summary": report.preflight.summary,
+                "fit": report.preflight.fit,
+                "estimated_total_bytes": report.preflight.estimated_total_bytes,
+                "available_memory_bytes": report.preflight.available_memory_bytes,
+            }
+        )
+        if report.fallback_reason:
+            print(f"\nFallback: {report.fallback_reason}")
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(
+            self.name,
+            help="Estimate whether a model is likely to fit on the selected backend.",
+        )
+        _add_model_argument(parser)
+        parser.add_argument(
+            "--backend",
+            type=str,
+            default="auto",
+            choices=["auto", "cuda", "rocm", "xpu", "apple-metal", "cpu"],
+            help="Backend preference for diagnostics.",
+        )
+        parser.add_argument(
+            "--profile",
+            type=str,
+            default="balanced",
+            choices=["balanced", "throughput", "low-memory"],
+            help="Local profile used when generating diagnostics.",
+        )
+        parser.add_argument(
+            "--dtype",
+            type=str,
+            default="auto",
+            help="Dtype hint used for preflight.",
+        )
+        parser.add_argument(
+            "--quantization",
+            type=str,
+            default=None,
+            help="Quantization hint used for preflight.",
+        )
+        parser.add_argument(
+            "--max-model-len",
+            type=int,
+            default=None,
+            help="Context length hint used for fit estimation.",
+        )
         parser.add_argument(
             "--json",
             action="store_true",
@@ -448,7 +890,11 @@ def cmd_init() -> list[CLISubcommand]:
         RunCommand(),
         ListCommand(),
         ListAliasCommand(),
+        AliasesCommand(),
         InspectCommand(),
+        DoctorCommand(),
+        StatusCommand(),
+        PreflightCommand(),
         PsCommand(),
         StopCommand(),
         LogsCommand(),

--- a/vllm/entrypoints/cli/local.py
+++ b/vllm/entrypoints/cli/local.py
@@ -1,0 +1,443 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import TYPE_CHECKING
+from pathlib import Path
+
+from vllm.entrypoints.cli.local_runtime import (
+    ensure_model_available,
+    find_service,
+    format_service_rows,
+    get_pulled_model,
+    load_models_registry,
+    print_kv,
+    print_table,
+    remove_pulled_model,
+    resolve_model_reference,
+    stop_service,
+    tail_file,
+)
+from vllm.entrypoints.cli.types import CLISubcommand
+
+if TYPE_CHECKING:
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+else:
+    FlexibleArgumentParser = argparse.ArgumentParser
+
+
+def _add_model_argument(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
+    parser.add_argument("model", type=str, help="Model alias, HF repo, or local path.")
+    parser.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help="Optional model revision when using Hugging Face repositories.",
+    )
+    parser.add_argument(
+        "--download-dir",
+        type=str,
+        default=None,
+        help="Optional Hugging Face cache override used when pulling models.",
+    )
+    return parser
+
+
+def _sampling_params_from_args(args: argparse.Namespace):
+    from vllm import SamplingParams
+
+    return SamplingParams(
+        temperature=args.temperature,
+        top_p=args.top_p,
+        max_tokens=args.max_tokens,
+    )
+
+
+def _prompt_from_args_or_stdin(args: argparse.Namespace) -> str | None:
+    if args.prompt:
+        return args.prompt
+    if sys.stdin.isatty():
+        return None
+    piped = sys.stdin.read().strip()
+    return piped or None
+
+
+def _run_chat(args: argparse.Namespace, llm) -> None:
+    conversation = []
+    if args.system_prompt:
+        conversation.append({"role": "system", "content": args.system_prompt})
+
+    prompt = _prompt_from_args_or_stdin(args)
+    if prompt:
+        conversation.append({"role": "user", "content": prompt})
+        output = llm.chat(conversation, _sampling_params_from_args(args), use_tqdm=False)
+        print(output[0].outputs[0].text)
+        return
+
+    if not args.interactive:
+        raise ValueError("No prompt provided. Use `--prompt` or `--interactive`.")
+
+    while True:
+        try:
+            user_prompt = input("> ")
+        except EOFError:
+            break
+        if not user_prompt.strip():
+            continue
+        conversation.append({"role": "user", "content": user_prompt})
+        output = llm.chat(conversation, _sampling_params_from_args(args), use_tqdm=False)
+        assistant_message = output[0].outputs[0].text
+        print(assistant_message)
+        conversation.append({"role": "assistant", "content": assistant_message})
+
+
+def _run_complete(args: argparse.Namespace, llm) -> None:
+    prompt = _prompt_from_args_or_stdin(args)
+    if prompt is None:
+        raise ValueError("`vllm run --complete` requires `--prompt` or piped stdin.")
+    outputs = llm.generate(prompt, _sampling_params_from_args(args), use_tqdm=False)
+    print(outputs[0].outputs[0].text)
+
+
+class PullCommand(CLISubcommand):
+    name = "pull"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        resolved = resolve_model_reference(args.model, revision=args.revision)
+        record = ensure_model_available(resolved, download_dir=args.download_dir)
+        print_kv(
+            {
+                "requested": resolved.requested,
+                "resolved": resolved.model,
+                "source": resolved.source,
+                "local_path": record["local_path"],
+            }
+        )
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(
+            self.name,
+            help="Resolve a model alias or HF repo and download it locally.",
+        )
+        return _add_model_argument(parser)
+
+
+class RunCommand(CLISubcommand):
+    name = "run"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        from vllm import LLM
+
+        resolved = resolve_model_reference(args.model, revision=args.revision)
+        record = ensure_model_available(resolved, download_dir=args.download_dir)
+
+        llm = LLM(
+            model=record["local_path"],
+            tensor_parallel_size=args.tensor_parallel_size,
+            dtype=args.dtype,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            trust_remote_code=args.trust_remote_code,
+            max_model_len=args.max_model_len,
+            download_dir=args.download_dir,
+        )
+        if args.complete:
+            _run_complete(args, llm)
+        else:
+            _run_chat(args, llm)
+
+    @staticmethod
+    def add_cli_args(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
+        _add_model_argument(parser)
+        parser.add_argument(
+            "-p",
+            "--prompt",
+            type=str,
+            default=None,
+            help="Single prompt to run. Without this, `vllm run` opens a shell chat.",
+        )
+        parser.add_argument(
+            "--system-prompt",
+            type=str,
+            default=None,
+            help="Optional system prompt for chat mode.",
+        )
+        parser.add_argument(
+            "--interactive",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Open an interactive shell chat when no prompt is provided.",
+        )
+        parser.add_argument(
+            "--chat",
+            action="store_true",
+            default=False,
+            help="Force chat mode explicitly.",
+        )
+        parser.add_argument(
+            "--complete",
+            action="store_true",
+            default=False,
+            help="Use text completion instead of chat mode.",
+        )
+        parser.add_argument(
+            "--tensor-parallel-size",
+            type=int,
+            default=1,
+            help="Number of devices to use for tensor parallelism.",
+        )
+        parser.add_argument(
+            "--dtype",
+            type=str,
+            default="auto",
+            help="Model dtype to use when loading the model.",
+        )
+        parser.add_argument(
+            "--gpu-memory-utilization",
+            type=float,
+            default=0.9,
+            help="Fraction of GPU memory reserved by vLLM.",
+        )
+        parser.add_argument(
+            "--max-model-len",
+            type=int,
+            default=None,
+            help="Optional maximum context length override.",
+        )
+        parser.add_argument(
+            "--trust-remote-code",
+            action="store_true",
+            default=False,
+            help="Trust model-provided custom code when loading from HF.",
+        )
+        parser.add_argument(
+            "--max-tokens",
+            type=int,
+            default=512,
+            help="Maximum number of output tokens to generate.",
+        )
+        parser.add_argument(
+            "--temperature",
+            type=float,
+            default=0.7,
+            help="Sampling temperature.",
+        )
+        parser.add_argument(
+            "--top-p",
+            type=float,
+            default=0.95,
+            help="Top-p sampling cutoff.",
+        )
+        return parser
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(
+            self.name,
+            help="Run a model directly in the terminal.",
+        )
+        return self.add_cli_args(parser)
+
+
+class ListCommand(CLISubcommand):
+    name = "ls"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        registry = load_models_registry()
+        rows = []
+        for model in sorted(registry["models"], key=lambda item: item["requested"]):
+            rows.append(
+                {
+                    "requested": model["requested"],
+                    "resolved": model["model"],
+                    "source": model["source"],
+                    "local_path": model["local_path"],
+                }
+            )
+
+        if not rows:
+            print("No pulled models found. Use `vllm pull <model>` first.")
+            return
+
+        print_table(
+            rows,
+            [
+                ("requested", "REQUESTED"),
+                ("resolved", "RESOLVED"),
+                ("source", "SOURCE"),
+                ("local_path", "LOCAL_PATH"),
+            ],
+        )
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        return subparsers.add_parser(self.name, help="List pulled local models.")
+
+
+class InspectCommand(CLISubcommand):
+    name = "inspect"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        resolved = resolve_model_reference(args.model, revision=args.revision)
+        record = get_pulled_model(resolved)
+        payload = {
+            "requested": resolved.requested,
+            "resolved": resolved.model,
+            "source": resolved.source,
+            "alias": resolved.alias,
+            "revision": resolved.revision,
+            "local_path": record["local_path"] if record else None,
+            "pulled": record is not None,
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+            return
+        print_kv(payload)
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(
+            self.name,
+            help="Inspect model resolution and local cache metadata.",
+        )
+        _add_model_argument(parser)
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            default=False,
+            help="Print machine-readable JSON output.",
+        )
+        return parser
+
+
+class PsCommand(CLISubcommand):
+    name = "ps"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        rows = format_service_rows()
+        if not rows:
+            print("No running vLLM local services.")
+            return
+        print_table(
+            rows,
+            [
+                ("name", "NAME"),
+                ("pid", "PID"),
+                ("port", "PORT"),
+                ("status", "STATUS"),
+                ("uptime_s", "UPTIME_S"),
+                ("model", "MODEL"),
+            ],
+        )
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        return subparsers.add_parser(self.name, help="List managed local services.")
+
+
+class StopCommand(CLISubcommand):
+    name = "stop"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        service = stop_service(args.service, force=args.force)
+        print(f"Stopped {service['name']} (pid {service['pid']}).")
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(self.name, help="Stop a managed local service.")
+        parser.add_argument("service", type=str, help="Service name or PID.")
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            default=False,
+            help="Send SIGKILL instead of SIGTERM.",
+        )
+        return parser
+
+
+class LogsCommand(CLISubcommand):
+    name = "logs"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        service = find_service(args.service)
+        if service is None:
+            raise ValueError(f"Unknown service: {args.service}")
+        tail_file(Path(service["log_path"]), follow=args.follow, lines=args.lines)
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(self.name, help="Show service logs.")
+        parser.add_argument("service", type=str, help="Service name or PID.")
+        parser.add_argument(
+            "--follow",
+            action="store_true",
+            default=False,
+            help="Follow the log output.",
+        )
+        parser.add_argument(
+            "--lines",
+            type=int,
+            default=40,
+            help="Number of trailing log lines to print.",
+        )
+        return parser
+
+
+class RemoveCommand(CLISubcommand):
+    name = "rm"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        resolved = resolve_model_reference(args.model, revision=args.revision)
+        removed, purged_path = remove_pulled_model(resolved, purge_cache=args.purge_cache)
+        if not removed:
+            print("Model metadata not found.")
+            return
+        if purged_path:
+            print(f"Removed metadata and deleted {purged_path}.")
+            return
+        print("Removed local metadata entry.")
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(self.name, help="Remove pulled model metadata.")
+        _add_model_argument(parser)
+        parser.add_argument(
+            "--purge-cache",
+            action="store_true",
+            default=False,
+            help="Also delete the pulled snapshot path for HF-backed models.",
+        )
+        return parser
+
+
+def cmd_init() -> list[CLISubcommand]:
+    return [
+        PullCommand(),
+        RunCommand(),
+        ListCommand(),
+        InspectCommand(),
+        PsCommand(),
+        StopCommand(),
+        LogsCommand(),
+        RemoveCommand(),
+    ]

--- a/vllm/entrypoints/cli/local.py
+++ b/vllm/entrypoints/cli/local.py
@@ -284,6 +284,18 @@ class ListCommand(CLISubcommand):
         return subparsers.add_parser(self.name, help="List pulled local models.")
 
 
+class ListAliasCommand(ListCommand):
+    name = "list"
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        return subparsers.add_parser(
+            self.name,
+            help="List pulled local models. Alias for `vllm ls`.",
+        )
+
+
 class InspectCommand(CLISubcommand):
     name = "inspect"
 
@@ -435,6 +447,7 @@ def cmd_init() -> list[CLISubcommand]:
         PullCommand(),
         RunCommand(),
         ListCommand(),
+        ListAliasCommand(),
         InspectCommand(),
         PsCommand(),
         StopCommand(),

--- a/vllm/entrypoints/cli/local_backends.py
+++ b/vllm/entrypoints/cli/local_backends.py
@@ -1,0 +1,901 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""CLI-local backend diagnostics and selection helpers.
+
+This module intentionally stays in the CLI layer. It surfaces backend and
+platform information without changing vLLM's core execution architecture.
+"""
+
+from __future__ import annotations
+
+import platform as py_platform
+import re
+from dataclasses import asdict, dataclass, field
+from importlib.metadata import entry_points
+from typing import Any
+
+from vllm.plugins import PLATFORM_PLUGINS_GROUP
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    name: str
+    description: str
+    gpu_memory_utilization: float | None = None
+    enable_prefix_caching: bool | None = None
+    enforce_eager: bool | None = None
+    notes: tuple[str, ...] = ()
+
+
+RUNTIME_PROFILES: dict[str, RuntimeProfile] = {
+    "balanced": RuntimeProfile(
+        name="balanced",
+        description="Default local profile with strong throughput and safe memory headroom.",
+        gpu_memory_utilization=0.9,
+        enable_prefix_caching=True,
+        enforce_eager=None,
+        notes=(
+            "Keeps prefix caching enabled when the backend supports it.",
+            "Leaves graph capture mode unchanged when the backend can decide safely.",
+        ),
+    ),
+    "throughput": RuntimeProfile(
+        name="throughput",
+        description="Favor higher steady-state throughput when memory headroom allows it.",
+        gpu_memory_utilization=0.95,
+        enable_prefix_caching=True,
+        enforce_eager=False,
+        notes=(
+            "Pushes cache utilization higher for better batch throughput.",
+            "Prefers graph-backed execution when the backend supports it.",
+        ),
+    ),
+    "low-memory": RuntimeProfile(
+        name="low-memory",
+        description="Reduce memory pressure for local machines with tighter budgets.",
+        gpu_memory_utilization=0.82,
+        enable_prefix_caching=False,
+        enforce_eager=True,
+        notes=(
+            "Disables prefix caching to reduce KV cache pressure.",
+            "Prefers eager mode to avoid graph-capture memory overhead.",
+        ),
+    ),
+}
+
+
+@dataclass
+class BackendCapability:
+    name: str
+    source: str
+    available: bool
+    selected: bool = False
+    device_name: str | None = None
+    device_type: str | None = None
+    performance_tier: str = "fallback"
+    reason: str | None = None
+    supported_dtypes: list[str] = field(default_factory=list)
+    supported_quantization: list[str] = field(default_factory=list)
+    supported_model_families: list[str] = field(default_factory=list)
+    attention_backends: list[str] = field(default_factory=list)
+    paged_attention: bool | None = None
+    prefix_caching: bool | None = None
+    graph_capture: bool | None = None
+    interop: list[str] = field(default_factory=list)
+    total_memory_bytes: int | None = None
+    plugin_name: str | None = None
+    plugin_target: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class BackendSelection:
+    requested_backend: str
+    selected_backend: str
+    selected_reason: str
+    fallback_reason: str | None = None
+    rejected_backends: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ModelPreflight:
+    model: str
+    dtype: str
+    quantization: str | None
+    max_model_len: int
+    parameter_count: float | None
+    estimated_weight_bytes: int | None
+    estimated_kv_cache_bytes: int | None
+    estimated_runtime_overhead_bytes: int | None
+    estimated_total_bytes: int | None
+    available_memory_bytes: int | None
+    fit: bool | None
+    summary: str
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class TrtllmDiagnostics:
+    environment_supported: bool
+    model_supported: bool | None
+    eligible: bool
+    reasons: list[str]
+    flashinfer_available: bool
+    flashinfer_trtllm_moe_available: bool
+    sink_attention_supported: bool
+    ragged_mla_supported: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class DoctorReport:
+    os: str
+    architecture: str
+    current_platform: str
+    current_device_type: str
+    current_device_name: str
+    requested_backend: str
+    selected_backend: str
+    selection_reason: str
+    fallback_reason: str | None
+    available_plugins: list[dict[str, str]]
+    backends: list[BackendCapability]
+    model: str | None = None
+    profile: str = "balanced"
+    preflight: ModelPreflight | None = None
+    trtllm: TrtllmDiagnostics | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["backends"] = [backend.to_dict() for backend in self.backends]
+        if self.preflight is not None:
+            payload["preflight"] = self.preflight.to_dict()
+        if self.trtllm is not None:
+            payload["trtllm"] = self.trtllm.to_dict()
+        return payload
+
+
+def get_runtime_profile(name: str) -> RuntimeProfile:
+    try:
+        return RUNTIME_PROFILES[name]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown profile `{name}`. Choose from: {', '.join(RUNTIME_PROFILES)}."
+        ) from exc
+
+
+def _safe_import_torch():
+    try:
+        import torch
+    except Exception:
+        return None
+    return torch
+
+
+def _safe_import_psutil():
+    try:
+        import psutil
+    except Exception:
+        return None
+    return psutil
+
+
+def _safe_import_current_platform():
+    try:
+        from vllm.platforms import current_platform
+    except Exception:
+        return None
+    return current_platform
+
+
+def _discover_platform_plugins() -> list[dict[str, str]]:
+    plugins = []
+    try:
+        discovered = entry_points(group=PLATFORM_PLUGINS_GROUP)
+    except Exception:
+        return plugins
+
+    for plugin in discovered:
+        plugins.append({"name": plugin.name, "value": plugin.value})
+    return plugins
+
+
+def _apple_plugin_record(
+    plugins: list[dict[str, str]],
+) -> dict[str, str] | None:
+    for plugin in plugins:
+        haystack = f"{plugin['name']} {plugin['value']}".lower()
+        if any(token in haystack for token in ("metal", "mlx", "apple")):
+            return plugin
+    return None
+
+
+def _dtype_names(dtypes: list[Any]) -> list[str]:
+    names = []
+    for dtype in dtypes:
+        value = getattr(dtype, "name", None)
+        if value is None:
+            value = str(dtype).replace("torch.", "")
+        names.append(value)
+    return names
+
+
+def _family_hint(model_ref: str) -> str:
+    lowered = model_ref.lower()
+    for family in (
+        "deepseek",
+        "llama",
+        "qwen",
+        "gemma",
+        "mistral",
+        "mixtral",
+        "phi",
+        "smollm",
+    ):
+        if family in lowered:
+            return family
+    return "generic"
+
+
+def _parse_parameter_count(model_ref: str) -> float | None:
+    lowered = model_ref.lower()
+    moe_match = re.search(r"(\d+)x(\d+(?:\.\d+)?)b", lowered)
+    if moe_match:
+        experts = float(moe_match.group(1))
+        per_expert = float(moe_match.group(2))
+        return experts * per_expert * 1_000_000_000
+
+    size_match = re.search(r"(\d+(?:\.\d+)?)([bm])", lowered)
+    if not size_match:
+        return None
+
+    value = float(size_match.group(1))
+    unit = size_match.group(2)
+    if unit == "b":
+        return value * 1_000_000_000
+    return value * 1_000_000
+
+
+def _bytes_per_parameter(dtype: str, quantization: str | None, backend: str) -> float:
+    quant = (quantization or "").lower()
+    dtype = dtype.lower()
+
+    if quant:
+        if any(token in quant for token in ("4", "awq", "gptq")):
+            return 0.5
+        if any(token in quant for token in ("8", "fp8", "int8")):
+            return 1.0
+
+    if dtype in {"float32", "fp32"}:
+        return 4.0
+    if dtype in {"float16", "fp16", "bfloat16", "bf16", "half"}:
+        return 2.0
+    if dtype == "auto":
+        return 4.0 if backend == "cpu" else 2.0
+    return 2.0
+
+
+def _format_bytes(num_bytes: int | None) -> str | None:
+    if num_bytes is None:
+        return None
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024.0 or unit == "TiB":
+            return f"{value:.1f}{unit}"
+        value /= 1024.0
+    return f"{value:.1f}TiB"
+
+
+def _get_available_memory_bytes(selected_backend: str, current_platform) -> int | None:
+    if current_platform is not None and selected_backend in {
+        "cuda",
+        "rocm",
+        "xpu",
+        "apple-metal",
+        "cpu",
+    }:
+        try:
+            return int(current_platform.get_device_total_memory())
+        except Exception:
+            pass
+
+    psutil = _safe_import_psutil()
+    if psutil is None:
+        return None
+    try:
+        return int(psutil.virtual_memory().available)
+    except Exception:
+        return None
+
+
+def collect_backend_capabilities() -> tuple[list[BackendCapability], dict[str, str], Any]:
+    system = py_platform.system()
+    machine = py_platform.machine().lower()
+    torch = _safe_import_torch()
+    current_platform = _safe_import_current_platform()
+    plugins = _discover_platform_plugins()
+    apple_plugin = _apple_plugin_record(plugins)
+
+    current_name = "unavailable"
+    current_device_type = "unknown"
+    current_device_name = "unknown"
+    current_dtypes: list[str] = []
+    current_quants: list[str] = []
+    current_memory: int | None = None
+    current_graph_capture: bool | None = None
+
+    if current_platform is not None:
+        current_name = current_platform.__class__.__name__
+        current_device_type = getattr(current_platform, "device_type", "unknown")
+        current_device_name = getattr(current_platform, "device_name", "unknown")
+        with_memory = getattr(current_platform, "get_device_total_memory", None)
+        if callable(with_memory):
+            try:
+                current_memory = int(with_memory())
+            except Exception:
+                current_memory = None
+        current_dtypes = _dtype_names(getattr(current_platform, "supported_dtypes", []))
+        current_quants = list(getattr(current_platform, "supported_quantization", []))
+        support_static = getattr(current_platform, "support_static_graph_mode", None)
+        if callable(support_static):
+            try:
+                current_graph_capture = bool(support_static())
+            except Exception:
+                current_graph_capture = None
+
+    cuda_available = bool(current_platform and current_platform.is_cuda())
+    rocm_available = bool(current_platform and current_platform.is_rocm())
+    xpu_available = bool(current_platform and current_platform.is_xpu())
+    cpu_available = True
+    apple_plugin_active = bool(
+        current_platform is not None
+        and current_platform.is_out_of_tree()
+        and current_device_type != "cpu"
+    )
+    apple_available = bool(
+        system == "Darwin" and machine in {"arm64", "aarch64"} and apple_plugin_active
+    )
+
+    if torch is not None and hasattr(torch, "cuda") and torch.cuda.is_available():
+        cuda_available = cuda_available or True
+
+    backends = [
+        BackendCapability(
+            name="cuda",
+            source="builtin",
+            available=cuda_available,
+            selected=bool(current_platform and current_platform.is_cuda()),
+            device_name=(
+                current_device_name if cuda_available and current_platform else None
+            ),
+            device_type="cuda",
+            performance_tier="production",
+            reason=(
+                "Detected NVIDIA CUDA runtime."
+                if cuda_available
+                else "CUDA runtime was not detected."
+            ),
+            supported_dtypes=(
+                current_dtypes
+                if cuda_available
+                else ["bfloat16", "float16", "float32"]
+            ),
+            supported_quantization=(
+                current_quants if cuda_available else ["awq", "gptq", "fp8"]
+            ),
+            supported_model_families=[
+                "generic",
+                "deepseek",
+                "llama",
+                "qwen",
+                "mixtral",
+                "phi",
+            ],
+            attention_backends=["flashinfer", "triton", "torch_sdpa"],
+            paged_attention=True if cuda_available else None,
+            prefix_caching=True,
+            graph_capture=current_graph_capture if cuda_available else True,
+            interop=["TensorRT-LLM", "FlashInfer"],
+            total_memory_bytes=current_memory if cuda_available else None,
+        ),
+        BackendCapability(
+            name="rocm",
+            source="builtin",
+            available=rocm_available,
+            selected=bool(current_platform and current_platform.is_rocm()),
+            device_name=(
+                current_device_name if rocm_available and current_platform else None
+            ),
+            device_type="cuda",
+            performance_tier="production",
+            reason=(
+                "Detected ROCm runtime."
+                if rocm_available
+                else "ROCm runtime was not detected."
+            ),
+            supported_dtypes=(
+                current_dtypes
+                if rocm_available
+                else ["bfloat16", "float16", "float32"]
+            ),
+            supported_quantization=current_quants if rocm_available else [],
+            supported_model_families=[
+                "generic",
+                "llama",
+                "qwen",
+                "mixtral",
+                "phi",
+            ],
+            attention_backends=["triton", "torch_sdpa"],
+            paged_attention=True if rocm_available else None,
+            prefix_caching=True,
+            graph_capture=current_graph_capture if rocm_available else None,
+            interop=[],
+            total_memory_bytes=current_memory if rocm_available else None,
+        ),
+        BackendCapability(
+            name="xpu",
+            source="builtin",
+            available=xpu_available,
+            selected=bool(current_platform and current_platform.is_xpu()),
+            device_name=(
+                current_device_name if xpu_available and current_platform else None
+            ),
+            device_type="xpu",
+            performance_tier="production",
+            reason=(
+                "Detected Intel XPU runtime."
+                if xpu_available
+                else "XPU runtime was not detected."
+            ),
+            supported_dtypes=(
+                current_dtypes
+                if xpu_available
+                else ["bfloat16", "float16", "float32"]
+            ),
+            supported_quantization=current_quants if xpu_available else [],
+            supported_model_families=["generic", "llama", "qwen"],
+            attention_backends=["torch_sdpa"],
+            paged_attention=True if xpu_available else None,
+            prefix_caching=True,
+            graph_capture=current_graph_capture if xpu_available else None,
+            interop=[],
+            total_memory_bytes=current_memory if xpu_available else None,
+        ),
+        BackendCapability(
+            name="apple-metal",
+            source="plugin",
+            available=apple_available,
+            selected=bool(
+                current_platform
+                and current_platform.is_out_of_tree()
+                and system == "Darwin"
+                and machine in {"arm64", "aarch64"}
+            ),
+            device_name=(
+                current_device_name
+                if apple_available and current_platform
+                else "Apple Silicon"
+            ),
+            device_type="metal",
+            performance_tier="local",
+            reason=(
+                f"Active Apple GPU plugin `{apple_plugin['name']}` is selected."
+                if apple_available and apple_plugin is not None
+                else (
+                    (
+                        "Detected Apple GPU plugin package(s), but no Apple GPU "
+                        "platform is active."
+                    )
+                    if apple_plugin is not None
+                    else (
+                        "Apple GPU backend requires an out-of-tree plugin such "
+                        "as vllm-metal."
+                    )
+                )
+            ),
+            supported_dtypes=(
+                current_dtypes
+                if apple_available
+                else ["float16", "bfloat16", "float32"]
+            ),
+            supported_quantization=current_quants if apple_available else [],
+            supported_model_families=[
+                "generic",
+                "llama",
+                "qwen",
+                "phi",
+                "gemma",
+            ],
+            attention_backends=["metal", "mlx"],
+            paged_attention=None,
+            prefix_caching=True,
+            graph_capture=current_graph_capture if apple_available else None,
+            interop=[],
+            total_memory_bytes=current_memory if apple_available else None,
+            plugin_name=apple_plugin["name"] if apple_plugin is not None else None,
+            plugin_target=(
+                apple_plugin["value"] if apple_plugin is not None else None
+            ),
+        ),
+        BackendCapability(
+            name="cpu",
+            source="builtin",
+            available=cpu_available,
+            selected=bool(current_platform and current_platform.is_cpu()),
+            device_name=(
+                current_device_name
+                if current_platform and current_platform.is_cpu()
+                else "CPU"
+            ),
+            device_type="cpu",
+            performance_tier="fallback",
+            reason="CPU fallback is always available.",
+            supported_dtypes=(
+                current_dtypes
+                if current_platform and current_platform.is_cpu()
+                else ["float32", "bfloat16"]
+            ),
+            supported_quantization=(
+                current_quants
+                if current_platform and current_platform.is_cpu()
+                else []
+            ),
+            supported_model_families=[
+                "generic",
+                "llama",
+                "qwen",
+                "phi",
+                "gemma",
+            ],
+            attention_backends=["torch_sdpa"],
+            paged_attention=None,
+            prefix_caching=False,
+            graph_capture=False,
+            interop=[],
+            total_memory_bytes=(
+                current_memory
+                if current_platform and current_platform.is_cpu()
+                else None
+            ),
+        ),
+    ]
+
+    environment = {
+        "os": system,
+        "architecture": machine,
+        "current_platform": current_name,
+        "current_device_type": current_device_type,
+        "current_device_name": current_device_name,
+    }
+    return backends, environment, current_platform
+
+
+def select_backend(
+    requested_backend: str = "auto",
+) -> tuple[BackendSelection, list[BackendCapability], dict[str, str], Any]:
+    backends, environment, current_platform = collect_backend_capabilities()
+    backend_map = {backend.name: backend for backend in backends}
+    rejected: dict[str, str] = {}
+
+    def mark_selected(name: str) -> None:
+        for backend in backends:
+            backend.selected = backend.name == name
+
+    if requested_backend != "auto":
+        chosen = backend_map.get(requested_backend)
+        if chosen is None:
+            raise ValueError(
+                f"Unknown backend `{requested_backend}`. Choose from: auto, "
+                + ", ".join(backend_map)
+            )
+        if chosen.available:
+            mark_selected(chosen.name)
+            return (
+                BackendSelection(
+                    requested_backend=requested_backend,
+                    selected_backend=chosen.name,
+                    selected_reason=f"Selected `{chosen.name}` because the user requested it.",
+                ),
+                backends,
+                environment,
+                current_platform,
+            )
+        rejected[chosen.name] = chosen.reason or "backend unavailable"
+        fallback = backend_map["cpu"]
+        mark_selected(fallback.name)
+        return (
+            BackendSelection(
+                requested_backend=requested_backend,
+                selected_backend=fallback.name,
+                selected_reason=(
+                    f"Falling back to `{fallback.name}` because the requested "
+                    f"backend `{requested_backend}` is unavailable."
+                ),
+                fallback_reason=chosen.reason or "Requested backend unavailable.",
+                rejected_backends=rejected,
+            ),
+            backends,
+            environment,
+            current_platform,
+        )
+
+    if environment["os"] == "Darwin" and environment["architecture"] in {"arm64", "aarch64"}:
+        if backend_map["apple-metal"].available:
+            mark_selected("apple-metal")
+            return (
+                BackendSelection(
+                    requested_backend="auto",
+                    selected_backend="apple-metal",
+                    selected_reason=(
+                        "Selected `apple-metal` because an Apple GPU plugin is "
+                        "available on Apple Silicon."
+                    ),
+                ),
+                backends,
+                environment,
+                current_platform,
+            )
+        rejected["apple-metal"] = backend_map["apple-metal"].reason or "plugin unavailable"
+
+    for candidate, reason in (
+        ("cuda", "Selected `cuda` because NVIDIA acceleration is available."),
+        ("rocm", "Selected `rocm` because AMD ROCm acceleration is available."),
+        ("xpu", "Selected `xpu` because Intel XPU acceleration is available."),
+    ):
+        if backend_map[candidate].available:
+            mark_selected(candidate)
+            return (
+                BackendSelection(
+                    requested_backend="auto",
+                    selected_backend=candidate,
+                    selected_reason=reason,
+                    rejected_backends=rejected,
+                ),
+                backends,
+                environment,
+                current_platform,
+            )
+        rejected[candidate] = backend_map[candidate].reason or "backend unavailable"
+
+    mark_selected("cpu")
+    fallback_reason = None
+    if rejected:
+        fallback_reason = "; ".join(
+            f"{name}: {reason}" for name, reason in rejected.items() if reason
+        )
+    return (
+        BackendSelection(
+            requested_backend="auto",
+            selected_backend="cpu",
+            selected_reason=(
+                "Selected `cpu` because no accelerator backend was available."
+            ),
+            fallback_reason=fallback_reason,
+            rejected_backends=rejected,
+        ),
+        backends,
+        environment,
+        current_platform,
+    )
+
+
+def estimate_model_preflight(
+    model: str,
+    *,
+    selected_backend: str,
+    dtype: str = "auto",
+    quantization: str | None = None,
+    max_model_len: int | None = None,
+    current_platform=None,
+) -> ModelPreflight:
+    max_model_len = max_model_len or 8192
+    params = _parse_parameter_count(model)
+    family = _family_hint(model)
+
+    if params is None:
+        return ModelPreflight(
+            model=model,
+            dtype=dtype,
+            quantization=quantization,
+            max_model_len=max_model_len,
+            parameter_count=None,
+            estimated_weight_bytes=None,
+            estimated_kv_cache_bytes=None,
+            estimated_runtime_overhead_bytes=None,
+            estimated_total_bytes=None,
+            available_memory_bytes=_get_available_memory_bytes(
+                selected_backend, current_platform
+            ),
+            fit=None,
+            summary=(
+                "Could not infer model size from the model name. Use an explicit "
+                "Hugging Face model ID that includes the parameter size or run "
+                "a real load attempt for authoritative validation."
+            ),
+            notes=["Preflight uses name-based heuristics when model metadata is unavailable."],
+        )
+
+    bytes_per_param = _bytes_per_parameter(dtype, quantization, selected_backend)
+    weight_bytes = int(params * bytes_per_param)
+    kv_ratio = 0.18 * (max_model_len / 8192.0)
+    kv_cache_bytes = int(weight_bytes * kv_ratio)
+    runtime_ratio = {
+        "cpu": 0.25,
+        "apple-metal": 0.2,
+        "cuda": 0.12,
+        "rocm": 0.14,
+        "xpu": 0.14,
+    }.get(selected_backend, 0.15)
+    runtime_overhead = int(weight_bytes * runtime_ratio)
+    total_bytes = weight_bytes + kv_cache_bytes + runtime_overhead
+    available = _get_available_memory_bytes(selected_backend, current_platform)
+    fit = None if available is None else total_bytes <= available
+
+    summary = (
+        f"Estimated {family} working set is {_format_bytes(total_bytes)} "
+        f"for backend `{selected_backend}` using dtype `{dtype}`."
+    )
+    if fit is True:
+        summary += f" Detected memory {_format_bytes(available)} appears sufficient."
+    elif fit is False:
+        summary += f" Detected memory {_format_bytes(available)} appears insufficient."
+    else:
+        summary += " Available memory could not be determined on this host."
+
+    return ModelPreflight(
+        model=model,
+        dtype=dtype,
+        quantization=quantization,
+        max_model_len=max_model_len,
+        parameter_count=params,
+        estimated_weight_bytes=weight_bytes,
+        estimated_kv_cache_bytes=kv_cache_bytes,
+        estimated_runtime_overhead_bytes=runtime_overhead,
+        estimated_total_bytes=total_bytes,
+        available_memory_bytes=available,
+        fit=fit,
+        summary=summary,
+        notes=[
+            "Preflight is heuristic and intentionally conservative.",
+            "KV cache and runtime overhead depend on sequence length, "
+            "batch size, and backend-specific planners.",
+        ],
+    )
+
+
+def inspect_trtllm(
+    *,
+    selected_backend: str,
+    model: str | None = None,
+) -> TrtllmDiagnostics:
+    reasons: list[str] = []
+
+    try:
+        from vllm.utils.flashinfer import (
+            has_flashinfer,
+            has_flashinfer_trtllm_fused_moe,
+            supports_trtllm_attention,
+        )
+    except Exception:
+        return TrtllmDiagnostics(
+            environment_supported=False,
+            model_supported=None,
+            eligible=False,
+            reasons=[
+                "FlashInfer / TensorRT-LLM helpers are unavailable in this "
+                "environment."
+            ],
+            flashinfer_available=False,
+            flashinfer_trtllm_moe_available=False,
+            sink_attention_supported=False,
+            ragged_mla_supported=False,
+        )
+
+    flashinfer_available = has_flashinfer()
+    flashinfer_trtllm_moe_available = has_flashinfer_trtllm_fused_moe()
+    environment_supported = selected_backend == "cuda" and supports_trtllm_attention()
+    if not flashinfer_available:
+        reasons.append("FlashInfer is not installed or not usable on this system.")
+    if selected_backend != "cuda":
+        reasons.append(
+            "TensorRT-LLM interoperability is only relevant on NVIDIA CUDA backends."
+        )
+    elif not environment_supported:
+        reasons.append(
+            "Current CUDA environment does not meet the TensorRT-LLM attention requirements."
+        )
+
+    ragged_mla_supported = False
+    model_supported: bool | None = None
+    if model is not None:
+        lowered = model.lower()
+        model_supported = any(
+            token in lowered for token in ("deepseek", "llama", "qwen", "mixtral")
+        )
+        if not model_supported:
+            reasons.append(
+                "Model family is not one of the common families where vLLM "
+                "already exposes TRT-LLM-related kernels."
+            )
+        ragged_mla_supported = environment_supported and "deepseek" in lowered
+        if "deepseek" in lowered and not ragged_mla_supported:
+            reasons.append(
+                "DeepSeek TRT-LLM ragged MLA prefill needs a Blackwell-class "
+                "environment with the right FlashInfer support."
+            )
+
+    eligible = environment_supported and (model_supported is not False)
+    sink_attention_supported = environment_supported
+    if eligible and not reasons:
+        reasons.append(
+            "Environment looks compatible with vLLM's existing TensorRT-LLM interoperability hooks."
+        )
+
+    return TrtllmDiagnostics(
+        environment_supported=environment_supported,
+        model_supported=model_supported,
+        eligible=eligible,
+        reasons=reasons,
+        flashinfer_available=flashinfer_available,
+        flashinfer_trtllm_moe_available=flashinfer_trtllm_moe_available,
+        sink_attention_supported=sink_attention_supported,
+        ragged_mla_supported=ragged_mla_supported,
+    )
+
+
+def build_doctor_report(
+    *,
+    requested_backend: str = "auto",
+    model: str | None = None,
+    dtype: str = "auto",
+    quantization: str | None = None,
+    max_model_len: int | None = None,
+    profile: str = "balanced",
+) -> DoctorReport:
+    selection, backends, environment, current_platform = select_backend(
+        requested_backend=requested_backend
+    )
+    report = DoctorReport(
+        os=environment["os"],
+        architecture=environment["architecture"],
+        current_platform=environment["current_platform"],
+        current_device_type=environment["current_device_type"],
+        current_device_name=environment["current_device_name"],
+        requested_backend=requested_backend,
+        selected_backend=selection.selected_backend,
+        selection_reason=selection.selected_reason,
+        fallback_reason=selection.fallback_reason,
+        available_plugins=_discover_platform_plugins(),
+        backends=backends,
+        model=model,
+        profile=profile,
+    )
+
+    if model is not None:
+        report.preflight = estimate_model_preflight(
+            model,
+            selected_backend=selection.selected_backend,
+            dtype=dtype,
+            quantization=quantization,
+            max_model_len=max_model_len,
+            current_platform=current_platform,
+        )
+        report.trtllm = inspect_trtllm(
+            selected_backend=selection.selected_backend,
+            model=model,
+        )
+    else:
+        report.trtllm = inspect_trtllm(selected_backend=selection.selected_backend)
+    return report

--- a/vllm/entrypoints/cli/local_runtime.py
+++ b/vllm/entrypoints/cli/local_runtime.py
@@ -1,0 +1,437 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Helpers for the Ollama-like local vLLM CLI experience."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+import vllm.envs as envs
+from vllm.entrypoints.cli.model_aliases import BUILTIN_MODEL_ALIASES
+from vllm.utils.network_utils import get_open_port
+
+LOCAL_RUNTIME_DIR = Path(envs.VLLM_CONFIG_ROOT) / "local"
+LOCAL_MODELS_REGISTRY = LOCAL_RUNTIME_DIR / "models.json"
+LOCAL_SERVICES_REGISTRY = LOCAL_RUNTIME_DIR / "services.json"
+LOCAL_USER_ALIASES = LOCAL_RUNTIME_DIR / "aliases.json"
+LOCAL_LOG_DIR = LOCAL_RUNTIME_DIR / "logs"
+
+
+@dataclass
+class ResolvedModel:
+    requested: str
+    model: str
+    source: str
+    alias: str | None = None
+    description: str | None = None
+    revision: str | None = None
+
+
+def ensure_runtime_dirs() -> None:
+    LOCAL_RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+    LOCAL_LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _read_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
+    if not path.exists():
+        return default
+    try:
+        with path.open() as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        return default
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    ensure_runtime_dirs()
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
+    try:
+        with os.fdopen(fd, "w") as tmp_file:
+            json.dump(payload, tmp_file, indent=2, sort_keys=True)
+            tmp_file.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp_name)
+
+
+def _default_models_registry() -> dict[str, Any]:
+    return {"version": 1, "models": []}
+
+
+def _default_services_registry() -> dict[str, Any]:
+    return {"version": 1, "services": []}
+
+
+def load_models_registry() -> dict[str, Any]:
+    return _read_json(LOCAL_MODELS_REGISTRY, _default_models_registry())
+
+
+def save_models_registry(registry: dict[str, Any]) -> None:
+    _write_json(LOCAL_MODELS_REGISTRY, registry)
+
+
+def load_user_aliases() -> dict[str, Any]:
+    return _read_json(LOCAL_USER_ALIASES, {})
+
+
+def load_services_registry() -> dict[str, Any]:
+    registry = _read_json(LOCAL_SERVICES_REGISTRY, _default_services_registry())
+    live_services = [
+        svc for svc in registry["services"] if is_process_running(svc["pid"])
+    ]
+    if len(live_services) != len(registry["services"]):
+        registry["services"] = live_services
+        save_services_registry(registry)
+    return registry
+
+
+def save_services_registry(registry: dict[str, Any]) -> None:
+    _write_json(LOCAL_SERVICES_REGISTRY, registry)
+
+
+def iter_known_aliases() -> dict[str, dict[str, str]]:
+    aliases = dict(BUILTIN_MODEL_ALIASES)
+    for alias, value in load_user_aliases().items():
+        if not isinstance(value, dict) or "model" not in value:
+            continue
+        aliases[alias] = value
+    return aliases
+
+
+def resolve_model_reference(
+    model_ref: str,
+    revision: str | None = None,
+) -> ResolvedModel:
+    if Path(model_ref).expanduser().exists():
+        return ResolvedModel(
+            requested=model_ref,
+            model=str(Path(model_ref).expanduser().resolve()),
+            source="path",
+            revision=revision,
+        )
+
+    if "/" in model_ref:
+        return ResolvedModel(
+            requested=model_ref,
+            model=model_ref,
+            source="hf",
+            revision=revision,
+        )
+
+    aliases = iter_known_aliases()
+    alias_entry = aliases.get(model_ref)
+    if alias_entry is None:
+        raise ValueError(
+            "Unknown model alias. Use an exact Hugging Face repo like "
+            "`meta-llama/Llama-3.1-8B-Instruct` or a built-in alias like "
+            "`deepseek-r1:8b`."
+        )
+
+    return ResolvedModel(
+        requested=model_ref,
+        model=alias_entry["model"],
+        source="alias",
+        alias=model_ref,
+        description=alias_entry.get("description"),
+        revision=revision,
+    )
+
+
+def record_pulled_model(resolved: ResolvedModel, local_path: str) -> dict[str, Any]:
+    registry = load_models_registry()
+    models = registry["models"]
+    record = {
+        "requested": resolved.requested,
+        "alias": resolved.alias,
+        "source": resolved.source,
+        "model": resolved.model,
+        "revision": resolved.revision,
+        "local_path": local_path,
+        "pulled_at": int(time.time()),
+        "description": resolved.description,
+    }
+
+    updated = False
+    for index, existing in enumerate(models):
+        if (
+            existing["model"] == record["model"]
+            and existing.get("revision") == record.get("revision")
+        ):
+            models[index] = record
+            updated = True
+            break
+    if not updated:
+        models.append(record)
+    save_models_registry(registry)
+    return record
+
+
+def get_pulled_model(resolved: ResolvedModel) -> dict[str, Any] | None:
+    registry = load_models_registry()
+    for record in registry["models"]:
+        if (
+            record["model"] == resolved.model
+            and record.get("revision") == resolved.revision
+        ):
+            return record
+    return None
+
+
+def ensure_model_available(
+    resolved: ResolvedModel,
+    download_dir: str | None = None,
+) -> dict[str, Any]:
+    if resolved.source == "path":
+        return record_pulled_model(resolved, resolved.model)
+
+    existing = get_pulled_model(resolved)
+    if existing is not None and Path(existing["local_path"]).exists():
+        return existing
+
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise RuntimeError(
+            "huggingface_hub is required for `vllm pull`, `vllm run`, and alias-based "
+            "serving. Install the repo environment first."
+        ) from exc
+
+    local_path = snapshot_download(
+        repo_id=resolved.model,
+        revision=resolved.revision,
+        cache_dir=download_dir,
+    )
+    return record_pulled_model(resolved, local_path)
+
+
+def remove_pulled_model(
+    resolved: ResolvedModel,
+    purge_cache: bool = False,
+) -> tuple[bool, str | None]:
+    registry = load_models_registry()
+    new_models = []
+    removed_record = None
+    for record in registry["models"]:
+        if (
+            record["model"] == resolved.model
+            and record.get("revision") == resolved.revision
+        ):
+            removed_record = record
+            continue
+        new_models.append(record)
+
+    if removed_record is None:
+        return False, None
+
+    registry["models"] = new_models
+    save_models_registry(registry)
+
+    purged_path = None
+    if purge_cache:
+        local_path = Path(removed_record["local_path"])
+        if removed_record["source"] != "path" and local_path.exists():
+            shutil.rmtree(local_path, ignore_errors=True)
+            purged_path = str(local_path)
+
+    return True, purged_path
+
+
+def slugify_model_name(model_ref: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", model_ref).strip("-").lower()
+    return slug or "model"
+
+
+def build_service_name(explicit_name: str | None, model_ref: str) -> str:
+    return explicit_name or slugify_model_name(model_ref)
+
+
+def is_process_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def find_service(name_or_id: str) -> dict[str, Any] | None:
+    registry = load_services_registry()
+    for service in registry["services"]:
+        if service["name"] == name_or_id or str(service["pid"]) == str(name_or_id):
+            return service
+    return None
+
+
+def register_service(record: dict[str, Any]) -> None:
+    registry = load_services_registry()
+    services = [svc for svc in registry["services"] if svc["name"] != record["name"]]
+    services.append(record)
+    registry["services"] = services
+    save_services_registry(registry)
+
+
+def remove_service(name_or_id: str) -> dict[str, Any] | None:
+    registry = load_services_registry()
+    removed = None
+    kept = []
+    for service in registry["services"]:
+        if service["name"] == name_or_id or str(service["pid"]) == str(name_or_id):
+            removed = service
+            continue
+        kept.append(service)
+    if removed is not None:
+        registry["services"] = kept
+        save_services_registry(registry)
+    return removed
+
+
+def allocate_service_port(preferred_port: int | None = None) -> int:
+    return preferred_port if preferred_port is not None else get_open_port()
+
+
+def spawn_service_process(command: list[str], log_path: Path) -> subprocess.Popen[str]:
+    ensure_runtime_dirs()
+    log_file = log_path.open("a")
+    return subprocess.Popen(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        text=True,
+    )
+
+
+def wait_for_service(url: str, pid: int, timeout_s: int = 60) -> None:
+    deadline = time.time() + timeout_s
+    last_error = None
+    while time.time() < deadline:
+        if not is_process_running(pid):
+            raise RuntimeError("Service process exited before becoming ready.")
+        try:
+            with request.urlopen(url, timeout=2) as response:
+                if response.status == 200:
+                    return
+        except (error.URLError, TimeoutError) as exc:
+            last_error = exc
+        time.sleep(1)
+    raise RuntimeError(f"Timed out waiting for service readiness: {last_error}")
+
+
+def stop_service(name_or_id: str, force: bool = False) -> dict[str, Any]:
+    service = find_service(name_or_id)
+    if service is None:
+        raise ValueError(f"Unknown service: {name_or_id}")
+
+    sig = signal.SIGKILL if force else signal.SIGTERM
+    os.kill(service["pid"], sig)
+    if force:
+        remove_service(name_or_id)
+        return service
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        if not is_process_running(service["pid"]):
+            remove_service(name_or_id)
+            return service
+        time.sleep(0.25)
+
+    raise RuntimeError(
+        "Timed out waiting for service to stop. Retry with `vllm stop --force`."
+    )
+
+
+def format_service_rows() -> list[dict[str, Any]]:
+    registry = load_services_registry()
+    rows = []
+    for service in sorted(registry["services"], key=lambda item: item["name"]):
+        rows.append(
+            {
+                "name": service["name"],
+                "pid": service["pid"],
+                "port": service["port"],
+                "model": service["requested_model"],
+                "resolved_model": service["resolved_model"],
+                "status": (
+                    "running" if is_process_running(service["pid"]) else "stopped"
+                ),
+                "uptime_s": max(int(time.time() - service["started_at"]), 0),
+            }
+        )
+    return rows
+
+
+def default_service_record(
+    *,
+    name: str,
+    pid: int,
+    port: int,
+    requested_model: str,
+    resolved_model: str,
+    log_path: Path,
+    command: list[str],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "pid": pid,
+        "port": port,
+        "requested_model": requested_model,
+        "resolved_model": resolved_model,
+        "log_path": str(log_path),
+        "started_at": int(time.time()),
+        "command": command,
+    }
+
+
+def print_kv(data: dict[str, Any]) -> None:
+    width = max(len(key) for key in data) if data else 0
+    for key, value in data.items():
+        print(f"{key.ljust(width)} : {value}")
+
+
+def print_table(rows: list[dict[str, Any]], columns: list[tuple[str, str]]) -> None:
+    if not rows:
+        return
+    widths = {}
+    for key, label in columns:
+        widths[key] = max(len(label), *(len(str(row.get(key, ""))) for row in rows))
+    header = "  ".join(label.ljust(widths[key]) for key, label in columns)
+    print(header)
+    print("  ".join("-" * widths[key] for key, _label in columns))
+    for row in rows:
+        print(
+            "  ".join(str(row.get(key, "")).ljust(widths[key]) for key, _label in columns)
+        )
+
+
+def tail_file(path: Path, follow: bool = False, lines: int = 40) -> None:
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    with path.open() as f:
+        content = f.readlines()
+        for line in content[-lines:]:
+            print(line, end="")
+
+        if not follow:
+            return
+
+        while True:
+            next_line = f.readline()
+            if next_line:
+                print(next_line, end="")
+            else:
+                time.sleep(0.5)

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -36,6 +36,11 @@ COMMAND_SPECS = (
         help="List locally tracked models.",
     ),
     CommandSpec(
+        name="list",
+        module="vllm.entrypoints.cli.local",
+        help="List locally tracked models. Alias for `ls`.",
+    ),
+    CommandSpec(
         name="aliases",
         module="vllm.entrypoints.cli.local",
         help="List built-in model aliases.",

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -16,6 +16,7 @@ logger = init_logger(__name__)
 def main():
     import vllm.entrypoints.cli.benchmark.main
     import vllm.entrypoints.cli.collect_env
+    import vllm.entrypoints.cli.local
     import vllm.entrypoints.cli.launch
     import vllm.entrypoints.cli.openai
     import vllm.entrypoints.cli.run_batch
@@ -24,6 +25,7 @@ def main():
     from vllm.utils.argparse_utils import FlexibleArgumentParser
 
     CMD_MODULES = [
+        vllm.entrypoints.cli.local,
         vllm.entrypoints.cli.openai,
         vllm.entrypoints.cli.serve,
         vllm.entrypoints.cli.launch,
@@ -68,6 +70,7 @@ def main():
             cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
             cmds[cmd.name] = cmd
     args = parser.parse_args()
+    setattr(args, "_argv", sys.argv[1:])
     if args.subparser in cmds:
         cmds[args.subparser].validate(args)
 

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -51,6 +51,21 @@ COMMAND_SPECS = (
         help="Show how a model reference resolves locally.",
     ),
     CommandSpec(
+        name="doctor",
+        module="vllm.entrypoints.cli.local",
+        help="Show backend diagnostics and model compatibility details.",
+    ),
+    CommandSpec(
+        name="status",
+        module="vllm.entrypoints.cli.local",
+        help="Alias for `doctor`.",
+    ),
+    CommandSpec(
+        name="preflight",
+        module="vllm.entrypoints.cli.local",
+        help="Estimate whether a model is likely to fit on the selected backend.",
+    ),
+    CommandSpec(
         name="serve",
         module="vllm.entrypoints.cli.serve",
         help="Launch a local OpenAI-compatible API server.",

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -1,43 +1,196 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""The CLI entrypoints of vLLM
+"""The CLI entrypoints of vLLM."""
 
-Note that all future modules must be lazily loaded within main
-to avoid certain eager import breakage."""
-
+import importlib
 import importlib.metadata
 import sys
+from dataclasses import dataclass
 
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
 
-def main():
-    import vllm.entrypoints.cli.benchmark.main
-    import vllm.entrypoints.cli.collect_env
-    import vllm.entrypoints.cli.local
-    import vllm.entrypoints.cli.launch
-    import vllm.entrypoints.cli.openai
-    import vllm.entrypoints.cli.run_batch
-    import vllm.entrypoints.cli.serve
-    from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG, cli_env_setup
+@dataclass(frozen=True)
+class CommandSpec:
+    name: str
+    module: str
+    help: str
+
+
+COMMAND_SPECS = (
+    CommandSpec(
+        name="pull",
+        module="vllm.entrypoints.cli.local",
+        help="Download a model by alias, Hugging Face repo, or local path.",
+    ),
+    CommandSpec(
+        name="run",
+        module="vllm.entrypoints.cli.local",
+        help="Run a model locally in the terminal.",
+    ),
+    CommandSpec(
+        name="ls",
+        module="vllm.entrypoints.cli.local",
+        help="List locally tracked models.",
+    ),
+    CommandSpec(
+        name="aliases",
+        module="vllm.entrypoints.cli.local",
+        help="List built-in model aliases.",
+    ),
+    CommandSpec(
+        name="inspect",
+        module="vllm.entrypoints.cli.local",
+        help="Show how a model reference resolves locally.",
+    ),
+    CommandSpec(
+        name="serve",
+        module="vllm.entrypoints.cli.serve",
+        help="Launch a local OpenAI-compatible API server.",
+    ),
+    CommandSpec(
+        name="ps",
+        module="vllm.entrypoints.cli.local",
+        help="List managed local services.",
+    ),
+    CommandSpec(
+        name="stop",
+        module="vllm.entrypoints.cli.local",
+        help="Stop a managed local service.",
+    ),
+    CommandSpec(
+        name="logs",
+        module="vllm.entrypoints.cli.local",
+        help="Show logs for a managed local service.",
+    ),
+    CommandSpec(
+        name="rm",
+        module="vllm.entrypoints.cli.local",
+        help="Remove local model metadata or cached files.",
+    ),
+    CommandSpec(
+        name="chat",
+        module="vllm.entrypoints.cli.openai",
+        help="Generate chat completions via the running API server.",
+    ),
+    CommandSpec(
+        name="complete",
+        module="vllm.entrypoints.cli.openai",
+        help="Generate text completions via the running API server.",
+    ),
+    CommandSpec(
+        name="bench",
+        module="vllm.entrypoints.cli.benchmark.main",
+        help="Run vLLM benchmarks.",
+    ),
+    CommandSpec(
+        name="collect-env",
+        module="vllm.entrypoints.cli.collect_env",
+        help="Collect environment information.",
+    ),
+    CommandSpec(
+        name="run-batch",
+        module="vllm.entrypoints.cli.run_batch",
+        help="Run batch prompts and write results to file.",
+    ),
+    CommandSpec(
+        name="launch",
+        module="vllm.entrypoints.cli.launch",
+        help="Launch individual vLLM components.",
+    ),
+)
+COMMAND_SPECS_BY_NAME = {spec.name: spec for spec in COMMAND_SPECS}
+
+
+def _get_root_parser():
+    from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
     from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-    CMD_MODULES = [
-        vllm.entrypoints.cli.local,
-        vllm.entrypoints.cli.openai,
-        vllm.entrypoints.cli.serve,
-        vllm.entrypoints.cli.launch,
-        vllm.entrypoints.cli.benchmark.main,
-        vllm.entrypoints.cli.collect_env,
-        vllm.entrypoints.cli.run_batch,
-    ]
+    parser = FlexibleArgumentParser(
+        description="vLLM CLI",
+        epilog=VLLM_SUBCMD_PARSER_EPILOG.format(subcmd="[subcommand]"),
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=importlib.metadata.version("vllm"),
+    )
+    subparsers = parser.add_subparsers(required=False, dest="subparser")
+    for spec in COMMAND_SPECS:
+        subparsers.add_parser(
+            spec.name,
+            help=spec.help,
+            description=spec.help,
+        )
+    return parser
+
+
+def _requested_subcommand(argv: list[str]) -> str | None:
+    for arg in argv:
+        if arg == "--":
+            break
+        if arg.startswith("-"):
+            continue
+        return arg
+    return None
+
+
+def _load_subcommand(spec: CommandSpec):
+    module = importlib.import_module(spec.module)
+    for cmd in module.cmd_init():
+        if cmd.name == spec.name:
+            return cmd
+    raise RuntimeError(
+        f"Subcommand `{spec.name}` was not found in module `{spec.module}`."
+    )
+
+
+def _build_command_parser(spec: CommandSpec):
+    from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    parser = FlexibleArgumentParser(
+        description="vLLM CLI",
+        epilog=VLLM_SUBCMD_PARSER_EPILOG.format(subcmd="[subcommand]"),
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=importlib.metadata.version("vllm"),
+    )
+    subparsers = parser.add_subparsers(required=False, dest="subparser")
+    cmd = _load_subcommand(spec)
+    cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
+    return parser, cmd
+
+
+def main():
+    from vllm.entrypoints.utils import cli_env_setup
+
+    argv = sys.argv[1:]
+    requested_subcommand = _requested_subcommand(argv)
+    if requested_subcommand is None:
+        parser = _get_root_parser()
+        args = parser.parse_args(argv)
+        if hasattr(args, "dispatch_function"):
+            args.dispatch_function(args)
+        else:
+            parser.print_help()
+        return
+
+    spec = COMMAND_SPECS_BY_NAME.get(requested_subcommand)
+    if spec is None:
+        _get_root_parser().parse_args(argv)
+        return
 
     cli_env_setup()
 
     # For 'vllm bench *': use CPU instead of UnspecifiedPlatform by default
-    if len(sys.argv) > 1 and sys.argv[1] == "bench":
+    if requested_subcommand == "bench":
         logger.debug(
             "Bench command detected, must ensure current platform is not "
             "UnspecifiedPlatform to avoid device type inference error"
@@ -52,27 +205,11 @@ def main():
                 "Unspecified platform detected, switching to CPU Platform instead."
             )
 
-    parser = FlexibleArgumentParser(
-        description="vLLM CLI",
-        epilog=VLLM_SUBCMD_PARSER_EPILOG.format(subcmd="[subcommand]"),
-    )
-    parser.add_argument(
-        "-v",
-        "--version",
-        action="version",
-        version=importlib.metadata.version("vllm"),
-    )
-    subparsers = parser.add_subparsers(required=False, dest="subparser")
-    cmds = {}
-    for cmd_module in CMD_MODULES:
-        new_cmds = cmd_module.cmd_init()
-        for cmd in new_cmds:
-            cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
-            cmds[cmd.name] = cmd
-    args = parser.parse_args()
+    parser, cmd = _build_command_parser(spec)
+    args = parser.parse_args(argv)
     setattr(args, "_argv", sys.argv[1:])
-    if args.subparser in cmds:
-        cmds[args.subparser].validate(args)
+    if args.subparser == cmd.name:
+        cmd.validate(args)
 
     if hasattr(args, "dispatch_function"):
         args.dispatch_function(args)

--- a/vllm/entrypoints/cli/model_aliases.py
+++ b/vllm/entrypoints/cli/model_aliases.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Built-in short aliases for local-runtime CLI commands."""
+
+BUILTIN_MODEL_ALIASES: dict[str, dict[str, str]] = {
+    "deepseek-r1:1.5b": {
+        "model": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+        "description": "DeepSeek R1 distilled Qwen 1.5B",
+    },
+    "deepseek-r1:7b": {
+        "model": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+        "description": "DeepSeek R1 distilled Qwen 7B",
+    },
+    "deepseek-r1:8b": {
+        "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        "description": "DeepSeek R1 distilled Llama 8B",
+    },
+    "deepseek-r1:14b": {
+        "model": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+        "description": "DeepSeek R1 distilled Qwen 14B",
+    },
+    "deepseek-r1:32b": {
+        "model": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+        "description": "DeepSeek R1 distilled Qwen 32B",
+    },
+    "llama3.1:8b-instruct": {
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "description": "Meta Llama 3.1 8B Instruct",
+    },
+    "qwen2.5:7b-instruct": {
+        "model": "Qwen/Qwen2.5-7B-Instruct",
+        "description": "Qwen 2.5 7B Instruct",
+    },
+    "qwen2.5:14b-instruct": {
+        "model": "Qwen/Qwen2.5-14B-Instruct",
+        "description": "Qwen 2.5 14B Instruct",
+    },
+}

--- a/vllm/entrypoints/cli/model_aliases.py
+++ b/vllm/entrypoints/cli/model_aliases.py
@@ -24,9 +24,97 @@ BUILTIN_MODEL_ALIASES: dict[str, dict[str, str]] = {
         "model": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
         "description": "DeepSeek R1 distilled Qwen 32B",
     },
+    "deepseek-r1:70b": {
+        "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+        "description": "DeepSeek R1 distilled Llama 70B",
+    },
+    "deepseek-v3": {
+        "model": "deepseek-ai/DeepSeek-V3",
+        "description": "DeepSeek V3",
+    },
+    "gemma2:2b-it": {
+        "model": "google/gemma-2-2b-it",
+        "description": "Gemma 2 2B Instruct",
+    },
+    "gemma2:9b-it": {
+        "model": "google/gemma-2-9b-it",
+        "description": "Gemma 2 9B Instruct",
+    },
+    "gemma2:27b-it": {
+        "model": "google/gemma-2-27b-it",
+        "description": "Gemma 2 27B Instruct",
+    },
+    "llama3.1:70b-instruct": {
+        "model": "meta-llama/Llama-3.1-70B-Instruct",
+        "description": "Meta Llama 3.1 70B Instruct",
+    },
     "llama3.1:8b-instruct": {
         "model": "meta-llama/Llama-3.1-8B-Instruct",
         "description": "Meta Llama 3.1 8B Instruct",
+    },
+    "llama3.2:1b-instruct": {
+        "model": "meta-llama/Llama-3.2-1B-Instruct",
+        "description": "Meta Llama 3.2 1B Instruct",
+    },
+    "llama3.2:3b-instruct": {
+        "model": "meta-llama/Llama-3.2-3B-Instruct",
+        "description": "Meta Llama 3.2 3B Instruct",
+    },
+    "llama3.3:70b-instruct": {
+        "model": "meta-llama/Llama-3.3-70B-Instruct",
+        "description": "Meta Llama 3.3 70B Instruct",
+    },
+    "ministral:8b-instruct": {
+        "model": "mistralai/Ministral-8B-Instruct-2410",
+        "description": "Ministral 8B Instruct",
+    },
+    "mistral:7b-instruct": {
+        "model": "mistralai/Mistral-7B-Instruct-v0.3",
+        "description": "Mistral 7B Instruct",
+    },
+    "mistral-nemo:12b-instruct": {
+        "model": "mistralai/Mistral-Nemo-Instruct-2407",
+        "description": "Mistral Nemo 12B Instruct",
+    },
+    "mixtral:8x7b-instruct": {
+        "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+        "description": "Mixtral 8x7B Instruct",
+    },
+    "phi3.5:mini-instruct": {
+        "model": "microsoft/Phi-3.5-mini-instruct",
+        "description": "Phi 3.5 Mini Instruct",
+    },
+    "phi3.5:moe-instruct": {
+        "model": "microsoft/Phi-3.5-MoE-instruct",
+        "description": "Phi 3.5 MoE Instruct",
+    },
+    "phi4": {
+        "model": "microsoft/phi-4",
+        "description": "Phi 4",
+    },
+    "qwen2.5-coder:1.5b-instruct": {
+        "model": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+        "description": "Qwen 2.5 Coder 1.5B Instruct",
+    },
+    "qwen2.5-coder:7b-instruct": {
+        "model": "Qwen/Qwen2.5-Coder-7B-Instruct",
+        "description": "Qwen 2.5 Coder 7B Instruct",
+    },
+    "qwen2.5-coder:32b-instruct": {
+        "model": "Qwen/Qwen2.5-Coder-32B-Instruct",
+        "description": "Qwen 2.5 Coder 32B Instruct",
+    },
+    "qwen2.5:0.5b-instruct": {
+        "model": "Qwen/Qwen2.5-0.5B-Instruct",
+        "description": "Qwen 2.5 0.5B Instruct",
+    },
+    "qwen2.5:1.5b-instruct": {
+        "model": "Qwen/Qwen2.5-1.5B-Instruct",
+        "description": "Qwen 2.5 1.5B Instruct",
+    },
+    "qwen2.5:3b-instruct": {
+        "model": "Qwen/Qwen2.5-3B-Instruct",
+        "description": "Qwen 2.5 3B Instruct",
     },
     "qwen2.5:7b-instruct": {
         "model": "Qwen/Qwen2.5-7B-Instruct",
@@ -35,5 +123,21 @@ BUILTIN_MODEL_ALIASES: dict[str, dict[str, str]] = {
     "qwen2.5:14b-instruct": {
         "model": "Qwen/Qwen2.5-14B-Instruct",
         "description": "Qwen 2.5 14B Instruct",
+    },
+    "qwen2.5:32b-instruct": {
+        "model": "Qwen/Qwen2.5-32B-Instruct",
+        "description": "Qwen 2.5 32B Instruct",
+    },
+    "qwen2.5:72b-instruct": {
+        "model": "Qwen/Qwen2.5-72B-Instruct",
+        "description": "Qwen 2.5 72B Instruct",
+    },
+    "smollm2:360m-instruct": {
+        "model": "HuggingFaceTB/SmolLM2-360M-Instruct",
+        "description": "SmolLM2 360M Instruct",
+    },
+    "smollm2:1.7b-instruct": {
+        "model": "HuggingFaceTB/SmolLM2-1.7B-Instruct",
+        "description": "SmolLM2 1.7B Instruct",
     },
 }

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -11,6 +11,7 @@ import uvloop
 
 import vllm
 import vllm.envs as envs
+from vllm.entrypoints.cli.local_backends import build_doctor_report, get_runtime_profile
 from vllm.entrypoints.cli.types import CLISubcommand
 from vllm.entrypoints.cli.local_runtime import (
     LOCAL_LOG_DIR,
@@ -54,6 +55,38 @@ Search by using: `--help=<ConfigGroup>` to explore options by section (e.g.,
 """
 
 
+def _argv_has_option(argv: list[str], option: str) -> bool:
+    return any(arg == option or arg.startswith(f"{option}=") for arg in argv)
+
+
+def _apply_profile_defaults(args: argparse.Namespace) -> dict[str, object]:
+    profile = get_runtime_profile(args.profile)
+    argv = list(getattr(args, "_argv", []))
+    applied: dict[str, object] = {}
+
+    if (
+        profile.gpu_memory_utilization is not None
+        and not _argv_has_option(argv, "--gpu-memory-utilization")
+    ):
+        args.gpu_memory_utilization = profile.gpu_memory_utilization
+        applied["gpu_memory_utilization"] = profile.gpu_memory_utilization
+
+    if (
+        hasattr(args, "enable_prefix_caching")
+        and profile.enable_prefix_caching is not None
+        and not _argv_has_option(argv, "--enable-prefix-caching")
+        and not _argv_has_option(argv, "--no-enable-prefix-caching")
+    ):
+        args.enable_prefix_caching = profile.enable_prefix_caching
+        applied["enable_prefix_caching"] = profile.enable_prefix_caching
+
+    if profile.enforce_eager is not None and not _argv_has_option(argv, "--enforce-eager"):
+        args.enforce_eager = profile.enforce_eager
+        applied["enforce_eager"] = profile.enforce_eager
+
+    return applied
+
+
 class ServeSubcommand(CLISubcommand):
     """The `serve` subcommand for the vLLM CLI."""
 
@@ -71,6 +104,31 @@ class ServeSubcommand(CLISubcommand):
             download_dir=args.download_dir,
         )
         args.model = pulled_model["local_path"]
+        doctor = build_doctor_report(
+            requested_backend=args.backend,
+            model=resolved_model.requested,
+            dtype=args.dtype,
+            quantization=getattr(args, "quantization", None),
+            max_model_len=args.max_model_len,
+            profile=args.profile,
+        )
+        if args.backend != "auto" and doctor.selected_backend != args.backend:
+            raise ValueError(
+                f"Requested backend `{args.backend}` is unavailable. "
+                f"{doctor.fallback_reason or doctor.selection_reason}"
+            )
+        applied_defaults = _apply_profile_defaults(args)
+        logger.info(
+            "Local serve backend=%s profile=%s model=%s applied_defaults=%s",
+            doctor.selected_backend,
+            args.profile,
+            resolved_model.model,
+            applied_defaults or "none",
+        )
+        if doctor.fallback_reason:
+            logger.info("Backend fallback reason: %s", doctor.fallback_reason)
+        if doctor.preflight is not None:
+            logger.info("Preflight: %s", doctor.preflight.summary)
 
         if not args.foreground:
             service_name = build_service_name(args.service_name, resolved_model.requested)
@@ -83,7 +141,7 @@ class ServeSubcommand(CLISubcommand):
             argv = list(getattr(args, "_argv", ["serve", resolved_model.requested]))
             if "--foreground" not in argv:
                 argv.append("--foreground")
-            if "--port" not in argv:
+            if not _argv_has_option(argv, "--port"):
                 args.port = allocate_service_port()
                 argv.extend(["--port", str(args.port)])
 
@@ -233,6 +291,20 @@ class ServeSubcommand(CLISubcommand):
             action="store_true",
             default=False,
             help="Return immediately after starting the background service.",
+        )
+        serve_parser.add_argument(
+            "--backend",
+            type=str,
+            default="auto",
+            choices=["auto", "cuda", "rocm", "xpu", "apple-metal", "cpu"],
+            help="Backend preference for local runtime selection and diagnostics.",
+        )
+        serve_parser.add_argument(
+            "--profile",
+            type=str,
+            default="balanced",
+            choices=["balanced", "throughput", "low-memory"],
+            help="Local performance profile used to choose sensible serve defaults.",
         )
         serve_parser.epilog = VLLM_SUBCMD_PARSER_EPILOG.format(subcmd=self.name)
         return serve_parser

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -3,13 +3,28 @@
 
 import argparse
 import signal
+import sys
 import time
+from pathlib import Path
 
 import uvloop
 
 import vllm
 import vllm.envs as envs
 from vllm.entrypoints.cli.types import CLISubcommand
+from vllm.entrypoints.cli.local_runtime import (
+    LOCAL_LOG_DIR,
+    allocate_service_port,
+    build_service_name,
+    default_service_record,
+    ensure_model_available,
+    find_service,
+    register_service,
+    remove_service,
+    resolve_model_reference,
+    spawn_service_process,
+    wait_for_service,
+)
 from vllm.entrypoints.openai.api_server import (
     run_server,
     run_server_worker,
@@ -49,6 +64,68 @@ class ServeSubcommand(CLISubcommand):
         # If model is specified in CLI (as positional arg), it takes precedence
         if hasattr(args, "model_tag") and args.model_tag is not None:
             args.model = args.model_tag
+
+        resolved_model = resolve_model_reference(args.model, revision=args.revision)
+        pulled_model = ensure_model_available(
+            resolved_model,
+            download_dir=args.download_dir,
+        )
+        args.model = pulled_model["local_path"]
+
+        if not args.foreground:
+            service_name = build_service_name(args.service_name, resolved_model.requested)
+            if find_service(service_name) is not None:
+                raise ValueError(
+                    f"Service `{service_name}` is already running. Use `vllm ps` "
+                    "or choose a different --service-name."
+                )
+
+            argv = list(getattr(args, "_argv", ["serve", resolved_model.requested]))
+            if "--foreground" not in argv:
+                argv.append("--foreground")
+            if "--port" not in argv:
+                args.port = allocate_service_port()
+                argv.extend(["--port", str(args.port)])
+
+            log_path = Path(LOCAL_LOG_DIR) / f"{service_name}.log"
+            command = [sys.executable, "-m", "vllm.entrypoints.cli.main", *argv]
+            process = spawn_service_process(command, log_path)
+            register_service(
+                default_service_record(
+                    name=service_name,
+                    pid=process.pid,
+                    port=args.port,
+                    requested_model=resolved_model.requested,
+                    resolved_model=resolved_model.model,
+                    log_path=log_path,
+                    command=command,
+                )
+            )
+
+            if not args.no_wait:
+                health_host = args.host or "127.0.0.1"
+                if health_host in {"0.0.0.0", "::"}:
+                    health_host = "127.0.0.1"
+                try:
+                    wait_for_service(
+                        f"http://{health_host}:{args.port}/health",
+                        process.pid,
+                    )
+                except Exception:
+                    remove_service(service_name)
+                    raise
+
+            logger.info(
+                "Started local service %s on port %s. Logs: %s",
+                service_name,
+                args.port,
+                log_path,
+            )
+            print(
+                f"Started {service_name} on http://{args.host or '127.0.0.1'}:{args.port}. "
+                f"Logs: {log_path}"
+            )
+            return
 
         if getattr(args, "grpc", False):
             from vllm.entrypoints.grpc_server import serve_grpc
@@ -138,6 +215,24 @@ class ServeSubcommand(CLISubcommand):
             default=False,
             help="Launch a gRPC server instead of the HTTP OpenAI-compatible "
             "server. Requires: pip install vllm[grpc].",
+        )
+        serve_parser.add_argument(
+            "--foreground",
+            action="store_true",
+            default=False,
+            help="Run the server in the foreground instead of as a managed local service.",
+        )
+        serve_parser.add_argument(
+            "--service-name",
+            type=str,
+            default=None,
+            help="Optional local name when running as a managed background service.",
+        )
+        serve_parser.add_argument(
+            "--no-wait",
+            action="store_true",
+            default=False,
+            help="Return immediately after starting the background service.",
         )
         serve_parser.epilog = VLLM_SUBCMD_PARSER_EPILOG.format(subcmd=self.name)
         return serve_parser


### PR DESCRIPTION
 ## Purpose

  Add a simpler local-runtime experience on top of vLLM so the repository can be used more like a CLI app instead of
  only a Python package or server entrypoint.

  This change introduces:
  - a repo-local installer via `./scripts/install.sh`
  - a lightweight `vllm` launcher for fast help and local metadata commands
  - easier local commands such as `vllm pull`, `vllm run`, `vllm serve`, `vllm aliases`, `vllm ls`, `vllm list`, `vllm
  inspect`, `vllm ps`, `vllm stop`, `vllm logs`, and `vllm rm`
  - a built-in alias catalog for common Hugging Face models
  - improved CLI startup behavior so top-level help and dispatch avoid unnecessary eager imports
  - documentation updates describing the new local-runtime workflow and model aliases
  - follow-up tracking for features that are still deferred

  This PR is intended to make this fork easier to install and use locally while preserving the underlying vLLM engine
  and existing advanced workflows.

  AI assistance was used to help draft and implement this change. I reviewed the final diff manually and validated the
  key CLI behavior with targeted tests and manual checks.

  ## Test Plan

  ```bash
  bash -n scripts/install.sh
  python3 -m py_compile scripts/vllm_launcher.py vllm/entrypoints/cli/local.py vllm/entrypoints/cli/main.py tests/
  entrypoints/test_local_cli.py tests/entrypoints/test_main_cli.py
  /Users/william/.local/share/vllm/venv/bin/python -m pytest tests/entrypoints/test_local_cli.py tests/entrypoints/
  test_main_cli.py -q
  ~/.local/bin/vllm
  ~/.local/bin/vllm list
  ~/.local/bin/vllm aliases
  python -m vllm.entrypoints.cli.main --help
  python -m vllm.entrypoints.cli.main collect-env --help

  ## Test Result

  Shell/install script validation:

  - bash -n scripts/install.sh passed

  Python syntax validation:

  - py_compile passed for:
      - scripts/vllm_launcher.py
      - vllm/entrypoints/cli/local.py
      - vllm/entrypoints/cli/main.py
      - tests/entrypoints/test_local_cli.py
      - tests/entrypoints/test_main_cli.py

  Targeted pytest result:

  9 passed, 2 warnings in 1.36s

  Manual CLI verification:

  - ~/.local/bin/vllm printed the lightweight launcher help successfully
  - ~/.local/bin/vllm list worked and stayed on the fast launcher path
  - ~/.local/bin/vllm aliases printed the alias catalog successfully
  - python -m vllm.entrypoints.cli.main --help printed top-level CLI help successfully
  - python -m vllm.entrypoints.cli.main collect-env --help printed selected subcommand help successfully

  Known limitation:

  - Full macOS source-build installation remains partially blocked by upstream native build issues in the vLLM CPU/macOS
    build flow. The CLI app and launcher changes were validated independently of that remaining native build problem.

