### PR TITLE
[Bugfix] Fix elastic EP scale-up after scale-down

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1585,7 +1585,7 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             self.vllm_config,
             new_data_parallel_size,
         )
-        wait_future = self._eep_wait_for_setup_switch_complete()
+        wait_future = asyncio.ensure_future(self._eep_wait_for_setup_switch_complete())
 
         # Phase 3: Wait for new engines to be created
         # and reconfig messages to be received
@@ -1678,7 +1678,7 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         # NOTE(yongji): Immediately stop sending requests to the removing engines.
         self.core_engines = self.core_engines[:new_data_parallel_size]
         self.lb_engines = self.lb_engines[:new_data_parallel_size]
-        wait_future = self._eep_wait_for_setup_switch_complete()
+        wait_future = asyncio.ensure_future(self._eep_wait_for_setup_switch_complete())
 
         await asyncio.gather(*reconfig_futures)
 

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -784,9 +784,10 @@ class CoreEngineActorManager:
             pg = self.created_placement_groups.pop()
             is_local = self.placement_group_is_local.pop()
             if is_local:
-                self.local_engine_actors.pop()
+                actor = self.local_engine_actors.pop()
             else:
-                self.remote_engine_actors.pop()
+                actor = self.remote_engine_actors.pop()
+            ray.kill(actor)
             ray.util.remove_placement_group(pg)
 
     def get_run_refs(self):


### PR DESCRIPTION
#### Overview:

Without this fix, elastic EP scale-up after a prior scale-down always fails — either timing out after 600s or hanging indefinitely. Scale-up from a cold start works, but once any scale-down has occurred, subsequent scale-up is broken.

Two bugs combine to cause this:

**Bug 1 (`utils.py`):** `CoreEngineActorManager.scale_down_elastic_ep()` removed actor handles from tracking lists and deleted placement groups but never called `ray.kill(actor)`. Removed actors blocked forever on `input_queue.get(block=True)`, keeping their ZMQ DEALER sockets alive with stale identities. On the next scale-up, new engines with reused identities triggered `ROUTER_HANDOVER` ping-pong with the zombies — the client's `poll()` never received the ready `b""` and timed out after 600s.

**Bug 2 (`core_client.py`):** `_eep_wait_for_setup_switch_complete()` was called as a bare coroutine (`wait_future = self._eep_wait_for_setup_switch_complete()`). The coroutine was not scheduled onto the event loop until explicitly awaited, so it missed events that fired between creation and the first `await`. Wrapping it in `asyncio.ensure_future()` schedules it immediately, so no events are dropped during the intervening `asyncio.gather(*reconfig_futures)`.

#### Details:

**`vllm/v1/engine/utils.py` — add `ray.kill(actor)` before placement group removal:**
- `scale_down_elastic_ep()` now captures the popped actor handle and calls `ray.kill(actor)` before `ray.util.remove_placement_group(pg)`, matching what `shutdown()` already does
- Without this, removed actors held ZMQ DEALER sockets indefinitely, causing the 600s timeout on subsequent scale-up

**`vllm/v1/engine/core_client.py` — wrap wait coroutine in `asyncio.ensure_future()`:**
- Both scale-up (`_scale_up_elastic_ep`) and scale-down (`_scale_down_elastic_ep`) paths changed from `wait_future = self._eep_wait_for_setup_switch_complete()` to `wait_future = asyncio.ensure_future(...)`
- Ensures the poller is scheduled immediately and does not miss ready signals that arrive before the first explicit `await`

#### Where should the reviewer start?

- `vllm/v1/engine/utils.py:784-793` — the `ray.kill(actor)` fix; compare against `shutdown()` which already does this correctly
- `vllm/v1/engine/core_client.py:1585` and `L1678` — the `asyncio.ensure_future()` wrapping in both scale paths

**Test plan:**
- Deployed on AKS (4×A100-SXM4-80GB) with `data_parallel_size=2`, then issued the following sequence of `POST /engine/scale_elastic_ep` calls:
  - `dp=2 → 3 → 4 → 3 → 2 → 4 → 2`
- After each step: verified GPU memory via `nvidia-smi`, confirmed Ray actor process count via `ps aux`, and validated inference with a live request
- All 6 transitions returned `{"status":"ok"}` with correct GPU activation/release at each step
- After each scale-down, confirmed no zombie Ray actor processes remained via `ray list actors`