### PR TITLE
[Bugfix] Fix AttributeError when serving MXFP8 models with DeepGEMM installed

### DIFF
--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -138,8 +138,8 @@ def _fp8_linear_may_use_deep_gemm(module: torch.nn.Module) -> bool:
         isinstance(module, LinearBase)
         and isinstance(module.quant_method, Fp8LinearMethod)
         and not isinstance(module.quant_method, Mxfp8OnlineLinearMethod)
-        and module.quant_method.block_quant
-        and not module.quant_method.use_marlin
+        and getattr(module.quant_method, "block_quant", False)
+        and not getattr(module.quant_method, "use_marlin", True)
     ):
         return False
 

--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.fused_moe.triton_deep_gemm_moe import (
 )
 from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
+from vllm.model_executor.layers.quantization.mxfp8 import Mxfp8OnlineLinearMethod
 from vllm.tracing import instrument
 from vllm.utils.deep_gemm import (
     fp8_gemm_nt,
@@ -136,6 +137,7 @@ def _fp8_linear_may_use_deep_gemm(module: torch.nn.Module) -> bool:
     if not (
         isinstance(module, LinearBase)
         and isinstance(module.quant_method, Fp8LinearMethod)
+        and not isinstance(module.quant_method, Mxfp8OnlineLinearMethod)
         and module.quant_method.block_quant
         and not module.quant_method.use_marlin
     ):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Mxfp8OnlineLinearMethod is incompatible with DeepGEMM. However, because it inherits from Fp8LinearMethod, it gets picked up by the `isinstance` check in `_fp8_linear_may_use_deep_gemm` and crashes with AttributeError on machines with deep_gemm installed.

This PR explicitly skips DeepGEMM for `Mxfp8OnlineLinearMethod` in `_fp8_linear_may_use_deep_gemm`.

## Test Plan
First, install DeepGeMM by `bash tools/install_deepgemm.sh`. Next, evaluate  MXFP8 quantized `Qwen/Qwen3-30B-A3B
` by
```
vllm serve  Qwen/Qwen3-30B-A3B --quantization mxfp8
  
lm_eval \
  --model local-completions \
  --tasks gsm8k,mmlu_pro \
  --model_args \
base_url=http://0.0.0.0:8000/v1/completions,\
model=Qwen/Qwen3-30B-A3B,\
tokenized_requests=False,tokenizer_backend=None,\
num_concurrent=128,timeout=120,max_retries=5
```

## Test Result
| Task | MXFP8 |
|----------|--------|
| GSM8K  (flexible-extract)     |   89.8    |
| GSM8K  (strict-match)   |   89.3    |
| MMLU-Pro   |    68.8   |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

