### PR TITLE
[Bugfix] AsyncLLM: Add the ability to specify the pooling_task

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -20,7 +20,7 @@ from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.inputs import PromptType
-from vllm.outputs import PoolingRequestOutput, RequestOutput
+from vllm.outputs import PoolingOutput, PoolingRequestOutput, RequestOutput
 from vllm.platforms import current_platform
 from vllm.sampling_params import RequestOutputKind
 from vllm.utils.torch_utils import set_default_torch_num_threads

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -7,6 +7,7 @@ from contextlib import ExitStack
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from vllm import PoolingParams, SamplingParams
 from vllm.assets.image import ImageAsset
@@ -105,15 +106,17 @@ async def test_encode_accepts_pooling_task():
     class FakeCollector:
         def __init__(self):
             self.request_id = "request-1"
-            self._output = PoolingRequestOutput(
-                request_id="request-1",
-                outputs=PoolingOutput(data=torch.empty(0)),
-                prompt_token_ids=[],
-                num_cached_tokens=0,
-                finished=True,
+            self._output: PoolingRequestOutput[PoolingOutput] | None = (
+                PoolingRequestOutput(
+                    request_id="request-1",
+                    outputs=PoolingOutput(data=torch.empty(0)),
+                    prompt_token_ids=[],
+                    num_cached_tokens=0,
+                    finished=True,
+                )
             )
 
-        def get_nowait(self):
+        def get_nowait(self) -> PoolingRequestOutput[PoolingOutput] | None:
             output, self._output = self._output, None
             return output
 

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -107,7 +107,7 @@ async def test_encode_accepts_pooling_task():
             self.request_id = "request-1"
             self._output = PoolingRequestOutput(
                 request_id="request-1",
-                outputs=[],
+                outputs=PoolingOutput(data=torch.empty(0)),
                 prompt_token_ids=[],
                 num_cached_tokens=0,
                 finished=True,

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vllm import SamplingParams
+from vllm import PoolingParams, SamplingParams
 from vllm.assets.image import ImageAsset
 from vllm.config import VllmConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -20,7 +20,7 @@ from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.inputs import PromptType
-from vllm.outputs import RequestOutput
+from vllm.outputs import PoolingRequestOutput, RequestOutput
 from vllm.platforms import current_platform
 from vllm.sampling_params import RequestOutputKind
 from vllm.utils.torch_utils import set_default_torch_num_threads
@@ -96,6 +96,73 @@ async def generate(
         await asyncio.sleep(0.0)
 
     return count, request_id
+
+
+@pytest.mark.asyncio
+async def test_encode_accepts_pooling_task():
+    engine = object.__new__(AsyncLLM)
+
+    class FakeCollector:
+        def __init__(self):
+            self.request_id = "request-1"
+            self._output = PoolingRequestOutput(
+                request_id="request-1",
+                outputs=[],
+                prompt_token_ids=[],
+                num_cached_tokens=0,
+                finished=True,
+            )
+
+        def get_nowait(self):
+            output, self._output = self._output, None
+            return output
+
+        async def get(self):
+            raise AssertionError("encode should not await when output is ready")
+
+        def close(self):
+            return None
+
+    async def fake_add_request(
+        request_id: str,
+        prompt: PromptType,
+        params: PoolingParams,
+        **_: object,
+    ):
+        assert request_id == "request-1"
+        assert prompt == TEXT_PROMPT
+        assert params.task == "embed"
+        return FakeCollector()
+
+    engine.add_request = fake_add_request  # type: ignore[method-assign]
+    engine.log_requests = False
+
+    outputs = []
+    async for output in engine.encode(
+        TEXT_PROMPT,
+        PoolingParams(),
+        request_id="request-1",
+        pooling_task="embed",
+    ):
+        outputs.append(output)
+
+    assert len(outputs) == 1
+    assert outputs[0].finished
+
+
+@pytest.mark.asyncio
+async def test_encode_rejects_conflicting_pooling_task():
+    engine = object.__new__(AsyncLLM)
+    engine.log_requests = False
+
+    with pytest.raises(ValueError, match="cannot overwrite"):
+        async for _ in engine.encode(
+            TEXT_PROMPT,
+            PoolingParams(task="token_embed"),
+            request_id="request-1",
+            pooling_task="embed",
+        ):
+            pass
 
 
 @pytest.mark.parametrize(

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -18,7 +18,7 @@ from vllm.plugins.io_processors import IOProcessor
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import BaseRenderer
 from vllm.sampling_params import SamplingParams
-from vllm.tasks import SupportedTask
+from vllm.tasks import PoolingTask, SupportedTask
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.input_processor import InputProcessor
 
@@ -95,6 +95,7 @@ class EngineClient(ABC):
         priority: int = 0,
         tokenization_kwargs: dict[str, Any] | None = None,
         reasoning_ended: bool | None = None,
+        pooling_task: PoolingTask | None = None,
     ) -> AsyncGenerator[PoolingRequestOutput, None]:
         """Generate outputs for a request from a pooling model."""
         ...

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -31,7 +31,7 @@ from vllm.pooling_params import PoolingParams
 from vllm.renderers import renderer_from_config
 from vllm.renderers.inputs.preprocess import extract_prompt_components
 from vllm.sampling_params import RequestOutputKind, SamplingParams
-from vllm.tasks import SupportedTask
+from vllm.tasks import PoolingTask, SupportedTask
 from vllm.tokenizers import TokenizerLike
 from vllm.tracing import init_tracer
 from vllm.transformers_utils.config import maybe_register_config_serialize_by_value
@@ -784,6 +784,7 @@ class AsyncLLM(EngineClient):
         priority: int = 0,
         tokenization_kwargs: dict[str, Any] | None = None,
         reasoning_ended: bool | None = None,
+        pooling_task: PoolingTask | None = None,
     ) -> AsyncGenerator[PoolingRequestOutput, None]:
         """
         Main function called by the API server to kick off a request
@@ -801,6 +802,17 @@ class AsyncLLM(EngineClient):
 
         q: RequestOutputCollector | None = None
         try:
+            if pooling_task is not None:
+                if pooling_params.task is None:
+                    pooling_params = pooling_params.clone()
+                    pooling_params.task = pooling_task
+                elif pooling_params.task != pooling_task:
+                    msg = (
+                        f"You cannot overwrite {pooling_params.task=!r} "
+                        f"with {pooling_task=!r}!"
+                    )
+                    raise ValueError(msg)
+
             q = await self.add_request(
                 request_id,
                 prompt,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix the issue that AsyncLLM Engine has no way of specifying a pooling model task, unlike the LLM Engine. This in turn causes the default task to be `token_embed` which in turn turns off the prefix cache.

## Test Plan
I added a unit test to make sure that the adding of the task field to the Pooling params to mirror its behavior in the LLM Engine.  I haven't been able to run the tests, as I don't have easy access to a linux machine where I can build VLLM from source. 
I have checked in a separate repo that adding the private field task="embed" to the PoolingParams does in fact get the normal expected embedding outputs and it uses the prefix cache. 

## Test Result
The `task="embed"` in PoolingParams does in fact give the same results as `pooling_task="embed"` on the LLM Engine (with the caveat that the sync engine takes in multiple inputs).  

I will update the release notes if this PR is accepted

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

