### PR TITLE
[Model Runner V2] fix draft attention metadata generation

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -30,7 +30,10 @@ def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
 
 
 def init_attn_backend(
-    kv_cache_config: KVCacheConfig, vllm_config: VllmConfig, device: torch.device
+    kv_cache_config: KVCacheConfig,
+    vllm_config: VllmConfig,
+    device: torch.device,
+    active_layer_names: set[str] | None = None,
 ):
     attn_backends: dict[str, type[AttentionBackend]] = {}
     attn_groups: list[list[AttentionGroup]] = []
@@ -39,6 +42,8 @@ def init_attn_backend(
         kv_cache_config.kv_cache_groups
     ):
         layer_names = kv_cache_group_spec.layer_names
+        if active_layer_names is not None:
+            layer_names = list(active_layer_names.intersection(layer_names))
 
         layer_type = cast(type[Any], AttentionLayerBase)
         attn_layers = get_layers_from_vllm_config(vllm_config, layer_type, layer_names)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -351,7 +351,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.speculator.set_attn(
                 self.model_state,
                 self.kv_cache_config,
-                self.attn_groups,
                 self.block_tables,
             )
 

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -5,15 +5,17 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.triton_utils import tl, triton
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import (
     build_attn_metadata,
     build_slot_mappings_by_layer,
+    init_attn_backend,
 )
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.dp_utils import sync_cudagraph_and_dp_padding
@@ -22,7 +24,6 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import EagleCudaGraphManager
 from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
-from vllm.v1.worker.utils import AttentionGroup
 
 logger = init_logger(__name__)
 
@@ -87,18 +88,35 @@ class EagleSpeculator:
         )
 
     def load_model(self, target_model: nn.Module) -> None:
+        target_attn_layer_names = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        ).keys()
+
         self.model = load_eagle_model(target_model, self.vllm_config)
+
+        all_attn_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        ).keys()
+        self.draft_attn_layer_names = set(all_attn_layers) - set(
+            target_attn_layer_names
+        )
 
     def set_attn(
         self,
         model_state: ModelState,
         kv_cache_config: KVCacheConfig,
-        attn_groups: list[list[AttentionGroup]],
         block_tables: BlockTables,
     ) -> None:
         self.model_state = model_state
         self.kv_cache_config = kv_cache_config
-        self.attn_groups = attn_groups
+        _, self.attn_groups = init_attn_backend(
+            kv_cache_config,
+            self.vllm_config,
+            self.device,
+            active_layer_names=self.draft_attn_layer_names,
+        )
         self.block_tables = block_tables
 
     @torch.inference_mode()


### PR DESCRIPTION
# Purpose
Hybrid models + spec decoding currently builds metadata for the draft model decode-drafting phase for all KV cache groups, even though the draft model typically only belongs to one of them. This is wasteful.

This PR fixes this by simply skipping building attention groups that the draft model does not belong to, and using those to generate the attention metadata for decode-drafting. This is similar to what Model Runner V1 does.

# Benchmarks
I used the following commands to benchmark and verify that there is no drop in acceptance rate. I benchmarked using openai/gpt-oss-20b, which is a hybrid model (alternates between sliding window and full attention). MRV2 main, MRV2 with my changes, and MRV1 results are very similar.

**Server**
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve openai/gpt-oss-20b --no-enable-prefix-caching --tensor-parallel-size=1 --data-parallel-size=1 --speculative-config '{"method": "eagle3", "model": "RedHatAI/gpt-oss-20b-speculator.eagle3", "num_speculative_tokens": 3}'
```

**Client**
```
vllm bench serve --model openai/gpt-oss-20b --tokenizer openai/gpt-oss-20b --host 0.0.0.0 --dataset-name hf --dataset-path philschmid/mt-bench --ignore-eos --request-rate inf --max-concurrency 16 --temperature 0.0
```

| Metric | MRV1 | MRV2 (main) | MRV2 (#37364) |
|--------|-----:|------------:|--------------:|
| **Throughput** | | | |
| Duration (s) | 59.19 | 57.50 | 57.26 |
| Request throughput (req/s) | 16.89 | 17.39 | 17.46 |
| Output token throughput (tok/s) | 4324.70 | 4452.34 | 4470.87 |
| Peak output throughput (tok/s) | 1776.00 | 1824.00 | 1826.00 |
| Total token throughput (tok/s) | 6624.22 | 6819.73 | 6848.12 |
| **Time to First Token** | | | |
| Mean TTFT (ms) | 36.94 | 36.36 | 34.56 |
| Median TTFT (ms) | 29.29 | 28.06 | 28.28 |
| P99 TTFT (ms) | 464.28 | 493.51 | 380.98 |
| **Time per Output Token** | | | |
| Mean TPOT (ms) | 3.54 | 3.44 | 3.44 |
| Median TPOT (ms) | 3.56 | 3.44 | 3.45 |
| P99 TPOT (ms) | 4.47 | 4.31 | 4.30 |
| **Inter-token Latency** | | | |
| Mean ITL (ms) | 9.00 | 8.77 | 8.76 |
| Median ITL (ms) | 8.63 | 8.42 | 8.41 |
| P99 ITL (ms) | 13.00 | 14.49 | 13.50 |
| **Speculative Decoding** | | | |
| Acceptance rate (%) | 51.67 | 51.92 | 52.03 |
| Acceptance length | 2.55 | 2.56 | 2.56 |
| Drafts | 100,405 | 100,131 | 100,020 |
| Draft tokens | 301,215 | 300,393 | 300,060 |
| Accepted tokens | 155,645 | 155,954 | 156,112 |
| Position 0 acceptance (%) | 71.34 | 71.60 | 71.67 |
| Position 1 acceptance (%) | 50.68 | 50.91 | 51.14 |
| Position 2 acceptance (%) | 32.99 | 33.24 | 33.27 |