### PR TITLE
[Feature] Add LoRA support for Qwen3ASRForConditionalGeneration

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -808,7 +808,7 @@ Speech2Text models trained specifically for Automatic Speech Recognition.
 | `Gemma3nForConditionalGeneration` | Gemma3n | `google/gemma-3n-E2B-it`, `google/gemma-3n-E4B-it`, etc. | | |
 | `GlmAsrForConditionalGeneration` | GLM-ASR | `zai-org/GLM-ASR-Nano-2512` | ✅︎ | ✅︎ |
 | `GraniteSpeechForConditionalGeneration` | Granite Speech | `ibm-granite/granite-speech-3.3-2b`, `ibm-granite/granite-speech-3.3-8b`, etc. | ✅︎ | ✅︎ |
-| `Qwen3ASRForConditionalGeneration` | Qwen3-ASR | `Qwen/Qwen3-ASR-1.7B`, etc. | | ✅︎ |
+| `Qwen3ASRForConditionalGeneration` | Qwen3-ASR | `Qwen/Qwen3-ASR-1.7B`, etc. | ✅︎ | ✅︎ |
 | `Qwen3OmniMoeThinkerForConditionalGeneration` | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct`, etc. | | ✅︎ |
 | `VoxtralForConditionalGeneration` | Voxtral (Mistral format) | `mistralai/Voxtral-Mini-3B-2507`, `mistralai/Voxtral-Small-24B-2507`, etc. | ✅︎ | ✅︎ |
 | `WhisperForConditionalGeneration` | Whisper | `openai/whisper-small`, `openai/whisper-large-v3-turbo`, etc. | | |

--- a/vllm/model_executor/models/qwen3_asr.py
+++ b/vllm/model_executor/models/qwen3_asr.py
@@ -37,6 +37,7 @@ from vllm.inputs.data import PromptType, TokensPrompt
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import (
     MultiModalEmbeddings,
+    SupportsLoRA,
     SupportsMRoPE,
     SupportsMultiModal,
     SupportsPP,
@@ -265,11 +266,29 @@ class Qwen3ASRMultiModalProcessor(
 class Qwen3ASRForConditionalGeneration(
     nn.Module,
     SupportsMultiModal,
+    SupportsLoRA,
     SupportsPP,
     SupportsMRoPE,
     SupportsTranscription,
 ):
     supported_languages = ISO639_1_SUPPORTED_LANGS
+
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    }
+
+    embedding_modules = {
+        "embed_tokens": "input_embeddings",
+        "lm_head": "output_embeddings",
+    }
 
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={


### PR DESCRIPTION
## Summary

- Adds `SupportsLoRA` mixin to `Qwen3ASRForConditionalGeneration`, enabling `--enable-lora` for `Qwen/Qwen3-ASR-0.6B` and similar models
- Adds `packed_modules_mapping` and `embedding_modules` class attributes, following the same pattern as `Qwen3ForCausalLM`, `Qwen2_5OmniThinkerForConditionalGeneration`, and `Qwen3VLForConditionalGeneration`
- The model already has `get_mm_mapping()` which correctly identifies language model and tower model prefixes for LoRA weight routing
- Marks LoRA support for Qwen3-ASR in the speech-to-text section of the supported models docs (the multimodal section already had the checkmark)

Closes #37223

## Test plan

- [ ] Serve `Qwen/Qwen3-ASR-0.6B` with `--enable-lora` and verify the model loads without the `ValueError: Qwen3ASRForConditionalGeneration does not support LoRA yet.` error
- [ ] Verify inference works correctly with and without a LoRA adapter applied