### PR TITLE
[Misc] Improve DCP error messages with actionable guidance

### DIFF
--- a/tests/v1/worker/test_cp_utils.py
+++ b/tests/v1/worker/test_cp_utils.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.worker import cp_utils
+
+
+class _DummyImplNoDCP:
+    """Simulates an attention impl that does NOT support DCP."""
+
+    need_to_return_lse_for_decode = False
+    supports_pcp = True
+    supports_mtp_with_cp_non_trivial_interleave_size = True
+
+
+class _DummyImplNoPCP:
+    """Simulates an attention impl that does NOT support PCP."""
+
+    need_to_return_lse_for_decode = True
+    supports_pcp = False
+    supports_mtp_with_cp_non_trivial_interleave_size = True
+
+
+class _DummyImplNoMTPInterleave:
+    """Simulates an attention impl that does NOT support MTP with
+    cp_kv_cache_interleave_size > 1."""
+
+    need_to_return_lse_for_decode = True
+    supports_pcp = True
+    supports_mtp_with_cp_non_trivial_interleave_size = False
+
+
+class _DummyImplFullSupport:
+    """Simulates an attention impl that supports all CP features."""
+
+    need_to_return_lse_for_decode = True
+    supports_pcp = True
+    supports_mtp_with_cp_non_trivial_interleave_size = True
+
+
+class _DummyLayer:
+    def __init__(self, impl):
+        self.impl = impl
+
+
+def _make_vllm_config(
+    dcp_size=1,
+    pcp_size=1,
+    interleave_size=1,
+    speculative_config=None,
+):
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=pcp_size,
+            decode_context_parallel_size=dcp_size,
+            cp_kv_cache_interleave_size=interleave_size,
+        ),
+        speculative_config=speculative_config,
+    )
+
+
+def test_dcp_error_includes_backend_guidance(monkeypatch: pytest.MonkeyPatch):
+    """DCP error should mention --attention-backend and list compatible
+    backends."""
+    vllm_config = _make_vllm_config(dcp_size=2)
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_: {"layer.0": _DummyLayer(_DummyImplNoDCP())},
+    )
+
+    with pytest.raises(AssertionError, match="--attention-backend") as exc:
+        cp_utils.check_attention_cp_compatibility(vllm_config)
+
+    msg = str(exc.value)
+    # Should mention the failing impl name
+    assert "_DummyImplNoDCP" in msg
+    # Should mention the CLI flag
+    assert "--attention-backend" in msg
+    # Should list at least one compatible backend
+    assert "FLASH_ATTN" in msg
+    assert "FLASHINFER" in msg
+
+
+def test_pcp_error_includes_backend_guidance(monkeypatch: pytest.MonkeyPatch):
+    """PCP error should mention --attention-backend and the impl name."""
+    vllm_config = _make_vllm_config(pcp_size=2)
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_: {"layer.0": _DummyLayer(_DummyImplNoPCP())},
+    )
+
+    with pytest.raises(AssertionError, match="--attention-backend") as exc:
+        cp_utils.check_attention_cp_compatibility(vllm_config)
+
+    msg = str(exc.value)
+    assert "_DummyImplNoPCP" in msg
+    assert "--attention-backend" in msg
+
+
+def test_mtp_interleave_error_includes_backend_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """MTP interleave error should mention --attention-backend and the
+    impl name."""
+    vllm_config = _make_vllm_config(
+        dcp_size=2,
+        interleave_size=2,
+        speculative_config=SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_: {"layer.0": _DummyLayer(_DummyImplNoMTPInterleave())},
+    )
+
+    with pytest.raises(AssertionError, match="--attention-backend") as exc:
+        cp_utils.check_attention_cp_compatibility(vllm_config)
+
+    msg = str(exc.value)
+    assert "_DummyImplNoMTPInterleave" in msg
+    assert "--attention-backend" in msg
+
+
+def test_no_error_when_backend_supports_all_cp(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """No error should be raised when the backend supports all CP
+    features."""
+    vllm_config = _make_vllm_config(
+        dcp_size=2,
+        pcp_size=2,
+        interleave_size=2,
+        speculative_config=SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_: {"layer.0": _DummyLayer(_DummyImplFullSupport())},
+    )
+
+    # Should not raise any exception
+    cp_utils.check_attention_cp_compatibility(vllm_config)

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -10,6 +10,17 @@ if TYPE_CHECKING:
 else:
     AttentionLayerBase = object
 
+# Backends known to support DCP (decode context parallelism).
+# Non-MLA backends:
+_DCP_COMPATIBLE_BACKENDS = ["FLASH_ATTN", "FLASHINFER"]
+# MLA backends:
+_DCP_COMPATIBLE_MLA_BACKENDS = [
+    "FLASHMLA",
+    "TRITON_MLA",
+    "CUTLASS_MLA",
+    "FLASH_ATTN_MLA",
+]
+
 
 def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
     pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
@@ -25,21 +36,32 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
             if vllm_config.speculative_config is not None and interleave_size > 1:
                 assert layer_impl.supports_mtp_with_cp_non_trivial_interleave_size, (
                     "MTP with cp_kv_cache_interleave_size > 1 is not "
-                    f"supported in {layer_impl.__class__.__name__}."
+                    f"supported by the current attention backend "
+                    f"({layer_impl.__class__.__name__}). "
+                    f"Try switching to a compatible backend via "
+                    f"the --attention-backend CLI flag."
                 )
             if dcp_size > 1:
                 assert layer_impl.need_to_return_lse_for_decode, (
-                    "DCP requires attention impls to return"
-                    " the softmax lse for decode, but the impl "
-                    f"{layer_impl.__class__.__name__} "
-                    "does not return the softmax lse for decode."
+                    f"Decode context parallelism (DCP) requires the "
+                    f"attention backend to return softmax LSE for "
+                    f"decode, but the current backend "
+                    f"({layer_impl.__class__.__name__}) does not "
+                    f"support this. To fix, switch to a compatible "
+                    f"backend via the --attention-backend CLI flag. "
+                    f"Compatible backends: "
+                    f"{', '.join(_DCP_COMPATIBLE_BACKENDS)} "
+                    f"(or for MLA models: "
+                    f"{', '.join(_DCP_COMPATIBLE_MLA_BACKENDS)})."
                 )
 
             if pcp_size > 1:
                 assert layer_impl.supports_pcp, (
-                    "PCP requires attention impls' support, "
-                    f"but the impl {layer_impl.__class__.__name__} "
-                    "does not support PCP."
+                    f"Prefill context parallelism (PCP) is not "
+                    f"supported by the current attention backend "
+                    f"({layer_impl.__class__.__name__}). "
+                    f"Try switching to a compatible backend via "
+                    f"the --attention-backend CLI flag."
                 )
 
 


### PR DESCRIPTION
## Summary
- Improved all three context parallelism (CP) error messages in `check_attention_cp_compatibility` to provide actionable guidance:
  - **DCP error**: Now explains the issue clearly and lists all compatible backends (`FLASH_ATTN`, `FLASHINFER`, and MLA variants `FLASHMLA`, `TRITON_MLA`, `CUTLASS_MLA`, `FLASH_ATTN_MLA`)
  - **PCP error**: Now suggests using `--attention-backend` to switch backends
  - **MTP interleave error**: Same actionable guidance added
- Added unit tests covering all three error paths plus a happy-path test
- References only the `--attention-backend` CLI flag (the deprecated `VLLM_ATTENTION_BACKEND` env var was removed in #30564)

Closes #28407

## Test plan
- [x] `pytest tests/v1/worker/test_cp_utils.py -v` passes (4 tests: DCP, PCP, MTP interleave error messages, and happy-path)
- [x] Pre-commit hooks pass (ruff check, ruff format, mypy, typos, SPDX headers all green)