### PR TITLE
[Bugfix][Tool Parser] Remove hardcoded 8K section char limit in Kimi-K2 tool parser

### DIFF
--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -502,10 +502,12 @@ def test_empty_tool_section(kimi_k2_tool_parser):
     assert kimi_k2_tool_parser.in_tool_section is False
 
 
-def test_malformed_tool_section_recovery(kimi_k2_tool_parser):
+def test_malformed_tool_section_no_forced_exit(kimi_k2_tool_parser):
     """
-    Test that the parser recovers from a malformed tool section
-    that never closes properly.
+    Test that the parser does NOT force-exit a tool section based on
+    character count. The parser should remain in the tool section until
+    a proper end marker is received, allowing arbitrarily large tool call
+    arguments (e.g., file content > 8K chars).
     """
     kimi_k2_tool_parser.reset_streaming_state()
 
@@ -523,11 +525,11 @@ def test_malformed_tool_section_recovery(kimi_k2_tool_parser):
     )
     assert kimi_k2_tool_parser.in_tool_section is True
 
-    # Simulate a lot of text without proper tool calls or section end
-    # This should trigger the error recovery mechanism
-    large_text = "x" * 10000  # Exceeds max_section_chars
+    # Simulate a lot of text without proper tool calls or section end.
+    # The parser should NOT force-exit; it stays in tool section.
+    large_text = "x" * 10000
 
-    result2 = kimi_k2_tool_parser.extract_tool_calls_streaming(
+    _result2 = kimi_k2_tool_parser.extract_tool_calls_streaming(
         previous_text="<|tool_calls_section_begin|>",
         current_text="<|tool_calls_section_begin|>" + large_text,
         delta_text=large_text,
@@ -537,11 +539,8 @@ def test_malformed_tool_section_recovery(kimi_k2_tool_parser):
         request=None,
     )
 
-    # Parser should have force-exited the tool section
-    assert kimi_k2_tool_parser.in_tool_section is False
-    # And returned the content as reasoning
-    assert result2 is not None
-    assert result2.content == large_text
+    # Parser should still be in tool section (no forced exit)
+    assert kimi_k2_tool_parser.in_tool_section is True
 
 
 def test_state_reset(kimi_k2_tool_parser):
@@ -551,8 +550,6 @@ def test_state_reset(kimi_k2_tool_parser):
     kimi_k2_tool_parser.token_buffer = "some buffer"
     kimi_k2_tool_parser.current_tool_id = 5
     kimi_k2_tool_parser.prev_tool_call_arr = [{"id": "test"}]
-    kimi_k2_tool_parser.section_char_count = 1000
-
     # Reset
     kimi_k2_tool_parser.reset_streaming_state()
 
@@ -561,7 +558,6 @@ def test_state_reset(kimi_k2_tool_parser):
     assert kimi_k2_tool_parser.token_buffer == ""
     assert kimi_k2_tool_parser.current_tool_id == -1
     assert kimi_k2_tool_parser.prev_tool_call_arr == []
-    assert kimi_k2_tool_parser.section_char_count == 0
     assert kimi_k2_tool_parser.current_tool_name_sent is False
     assert kimi_k2_tool_parser.streamed_args_for_tool == []
 

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -39,11 +39,10 @@ class KimiK2ToolParser(ToolParser):
         # Section-level state management to prevent token leakage
         self.in_tool_section: bool = False
         self.token_buffer: str = ""
-        # Buffer size: empirical worst-case for longest marker (~30 chars) * 2
-        # + safety margin for unicode + partial overlap. Prevents unbounded growth.
+        # Buffer size for detecting split markers across token boundaries.
+        # Only needs to hold the longest marker (~30 chars) with safety margin.
+        # Prevents unbounded growth of the marker-detection buffer.
         self.buffer_max_size: int = 1024
-        self.section_char_count: int = 0  # Track characters processed in tool section
-        self.max_section_chars: int = 8192  # Force exit if section exceeds this
         self._buffer_overflow_logged: bool = False  # Log overflow once per session
 
         # Support both singular and plural variants
@@ -130,7 +129,6 @@ class KimiK2ToolParser(ToolParser):
         """Reset state when exiting tool section."""
         self.in_tool_section = False
         self.token_buffer = ""
-        self.section_char_count = 0
 
     def reset_streaming_state(self) -> None:
         """
@@ -216,7 +214,9 @@ class KimiK2ToolParser(ToolParser):
         # Add delta to buffer for split marker detection
         self.token_buffer += delta_text
 
-        # Enforce buffer size limit to prevent memory issues
+        # Enforce buffer size limit to prevent memory issues.
+        # This buffer is only used to detect section markers that may be split
+        # across token boundaries; it does NOT limit tool call argument size.
         if len(self.token_buffer) > self.buffer_max_size:
             if not self._buffer_overflow_logged:
                 logger.warning(
@@ -238,7 +238,6 @@ class KimiK2ToolParser(ToolParser):
             logger.debug("Entering tool section")
             self.in_tool_section = True
             self.token_buffer = buffered_text  # Use cleaned buffer
-            self.section_char_count = 0  # Reset counter for new section
 
         if found_section_end and self.in_tool_section:
             logger.debug("Detected section end marker")
@@ -279,7 +278,7 @@ class KimiK2ToolParser(ToolParser):
         if not has_section_token and not self.in_tool_section:
             logger.debug("No tool call tokens found!")
             # Don't clear buffer - it needs to accumulate partial markers across deltas
-            # Buffer overflow is already protected by lines 215-224
+            # Buffer overflow is already handled above
             return DeltaMessage(content=delta_text)
 
         # Strip section markers from delta_text for subsequent processing
@@ -288,20 +287,6 @@ class KimiK2ToolParser(ToolParser):
         # before pattern matching. No double-stripping occurs because
         # section markers and tool call markers are distinct.
         delta_text, _, _ = self._check_and_strip_markers(delta_text)
-
-        # Error recovery: If in tool section for too long, force exit
-        if self.in_tool_section:
-            self.section_char_count += len(delta_text)
-            if self.section_char_count > self.max_section_chars:
-                logger.warning(
-                    "Tool section exceeded max length (%d chars), forcing exit. "
-                    "This may indicate malformed model output.",
-                    self.max_section_chars,
-                )
-                self._reset_section_state()
-                # Deferred exit already handled by forced exit above
-                # Return remaining content as reasoning (or empty delta if no content)
-                return DeltaMessage(content=delta_text if delta_text.strip() else "")
 
         try:
             # figure out where we are in the parsing by counting tool call


### PR DESCRIPTION
## Summary
- Removes the hardcoded `max_section_chars=8192` limit in the Kimi-K2 tool parser that force-exited the tool section when arguments exceeded 8K characters, breaking agentic workflows with large tool call arguments (e.g., writing files > 8K chars).
- Removes the associated `section_char_count` tracking state. The parser now relies solely on proper section end markers (`<|tool_calls_section_end|>`) for termination, which is the engine's responsibility.
- Keeps `buffer_max_size=1024` unchanged as it only limits the marker-detection buffer (for detecting split markers across token boundaries), not tool call argument size.
- Updates tests to verify the parser no longer force-exits on large content.

Fixes #34442

## Test plan
- [x] Updated `test_malformed_tool_section_no_forced_exit` to verify the parser stays in the tool section with 10K+ chars of content (no forced exit).
- [x] Updated `test_state_reset` to remove references to the deleted `section_char_count` attribute.
- [x] All other existing Kimi-K2 parser tests remain unchanged and should pass (streaming, markers, multi-tool calls, etc.).
- [x] Pre-commit checks pass (ruff check, ruff format, typos, SPDX headers).