### PR TITLE
[Bugfix] Decode prompt text from token IDs upstream in renderer

### DIFF
--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -648,6 +648,8 @@ class BaseRenderer(ABC, Generic[_T]):
 
         if prompt_text := prompt.get("prompt"):
             inputs["prompt"] = prompt_text
+        elif self.tokenizer is not None:
+            inputs["prompt"] = self.tokenizer.decode(prompt_token_ids)
         if cache_salt := prompt.get("cache_salt"):
             inputs["cache_salt"] = cache_salt
 


### PR DESCRIPTION
## Summary
- When using models like gpt-oss-20b via the Chat Completions API, the prompt is rendered directly to token IDs (via Harmony encoding), so the engine prompt only contains `prompt_token_ids` without a text `prompt` field. This caused `prompt: None` in debug logs and left the prompt text unavailable for any downstream consumer (logging, responses API, etc.).
- **Fix (per @qandrew's review suggestion):** move the decode upstream into `BaseRenderer._process_tokens` so that `inputs["prompt"]` is always populated when token IDs are available. When the tokenizer is not initialized (`skip_tokenizer_init=True`), `self.tokenizer` is `None` and the decode is safely skipped.
- This replaces the previous approach of decoding in `OpenAIServing._log_inputs`, which only fixed the logging symptom. The upstream fix ensures prompt text is available for all consumers.
- Also fixes the same issue for Mistral tokenizer models whose chat templates return token IDs directly.

Fixes #37253

## Test plan
- [ ] Verify with a model that uses Harmony rendering (e.g., gpt-oss-20b) that the debug log now shows the decoded prompt text instead of `None`
- [ ] Verify with a standard HF model (e.g., Gemma-3) that behavior is unchanged (prompt text was already available, so the `elif` is not reached)
- [ ] Verify with Mistral tokenizer models that the decoded prompt now appears in logs
- [ ] Confirm no performance regression — `tokenizer.decode()` is only called when `prompt` text is not already present in the `TokensPrompt`
- [ ] Verify that when `skip_tokenizer_init=True`, the decode is safely skipped (`self.tokenizer is None`)