### PR TITLE
[Bugfix] Cache tokenizer calls in tool parsers to prevent concurrent RuntimeError

### DIFF
--- a/vllm/tool_parsers/functiongemma_tool_parser.py
+++ b/vllm/tool_parsers/functiongemma_tool_parser.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import threading
 from collections.abc import Sequence
 
 import regex as re
@@ -33,6 +34,27 @@ class FunctionGemmaToolParser(ToolParser):
     <start_function_call>call:func_name{param:<escape>value<escape>}<end_function_call>
     """
 
+    _encode_cache: dict[tuple[int, str], list[int]] = {}
+    _encode_cache_lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def _get_cached_token_ids(
+        cls,
+        tokenizer: TokenizerLike,
+        token: str,
+    ) -> list[int]:
+        cache_key = (id(tokenizer), token)
+        cached = cls._encode_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        with cls._encode_cache_lock:
+            cached = cls._encode_cache.get(cache_key)
+            if cached is not None:
+                return cached
+            token_ids: list[int] = tokenizer.encode(token, add_special_tokens=False)
+            cls._encode_cache[cache_key] = token_ids
+            return token_ids
+
     def __init__(self, tokenizer: TokenizerLike):
         super().__init__(tokenizer)
 
@@ -58,11 +80,11 @@ class FunctionGemmaToolParser(ToolParser):
         )
 
         if self.model_tokenizer:
-            self.tool_call_start_token_ids = self.model_tokenizer.encode(
-                self.tool_call_start_token, add_special_tokens=False
+            self.tool_call_start_token_ids = self._get_cached_token_ids(
+                self.model_tokenizer, self.tool_call_start_token
             )
-            self.tool_call_end_token_ids = self.model_tokenizer.encode(
-                self.tool_call_end_token, add_special_tokens=False
+            self.tool_call_end_token_ids = self._get_cached_token_ids(
+                self.model_tokenizer, self.tool_call_end_token
             )
         else:
             self.tool_call_start_token_ids = []

--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import threading
 from collections.abc import Sequence
 
 import partial_json_parser
@@ -31,6 +32,29 @@ logger = init_logger(__name__)
 
 
 class Hermes2ProToolParser(ToolParser):
+    _token_cache: dict[tuple[int, str], tuple[list[int], list[str]]] = {}
+    _token_cache_lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def _get_cached_token_data(
+        cls,
+        tokenizer: TokenizerLike,
+        token: str,
+    ) -> tuple[list[int], list[str]]:
+        cache_key = (id(tokenizer), token)
+        cached = cls._token_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        with cls._token_cache_lock:
+            cached = cls._token_cache.get(cache_key)
+            if cached is not None:
+                return cached
+            token_ids: list[int] = tokenizer.encode(token, add_special_tokens=False)
+            token_str_array: list[str] = [tokenizer.decode([tid]) for tid in token_ids]
+            result = (token_ids, token_str_array)
+            cls._token_cache[cache_key] = result
+            return result
+
     def __init__(self, tokenizer: TokenizerLike):
         super().__init__(tokenizer)
 
@@ -60,22 +84,16 @@ class Hermes2ProToolParser(ToolParser):
                 "The model tokenizer must be passed to the ToolParser "
                 "constructor during construction."
             )
-        self.tool_call_start_token_ids = self.model_tokenizer.encode(
-            self.tool_call_start_token, add_special_tokens=False
+        start_ids, start_arr = self._get_cached_token_data(
+            self.model_tokenizer, self.tool_call_start_token
         )
-        self.tool_call_end_token_ids = self.model_tokenizer.encode(
-            self.tool_call_end_token, add_special_tokens=False
+        end_ids, end_arr = self._get_cached_token_data(
+            self.model_tokenizer, self.tool_call_end_token
         )
-
-        self.tool_call_start_token_array = [
-            self.model_tokenizer.decode([token_id])
-            for token_id in self.tool_call_start_token_ids
-        ]
-
-        self.tool_call_end_token_array = [
-            self.model_tokenizer.decode([token_id])
-            for token_id in self.tool_call_end_token_ids
-        ]
+        self.tool_call_start_token_ids = start_ids
+        self.tool_call_end_token_ids = end_ids
+        self.tool_call_start_token_array = start_arr
+        self.tool_call_end_token_array = end_arr
 
         self.buffered_delta_text = ""
 

--- a/vllm/tool_parsers/llama_tool_parser.py
+++ b/vllm/tool_parsers/llama_tool_parser.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import threading
 from collections.abc import Sequence
 
 import partial_json_parser
@@ -44,6 +45,27 @@ class Llama3JsonToolParser(ToolParser):
     llama4_json are set.
     """
 
+    _encode_cache: dict[tuple[int, str], list[int]] = {}
+    _encode_cache_lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def _get_cached_token_ids(
+        cls,
+        tokenizer: PreTrainedTokenizerBase,
+        token: str,
+    ) -> list[int]:
+        cache_key = (id(tokenizer), token)
+        cached = cls._encode_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        with cls._encode_cache_lock:
+            cached = cls._encode_cache.get(cache_key)
+            if cached is not None:
+                return cached
+            token_ids: list[int] = tokenizer.encode(token, add_special_tokens=False)
+            cls._encode_cache[cache_key] = token_ids
+            return token_ids
+
     def __init__(self, tokenizer: PreTrainedTokenizerBase):
         super().__init__(tokenizer)
 
@@ -56,9 +78,7 @@ class Llama3JsonToolParser(ToolParser):
             str
         ] = []  # map what has been streamed for each tool so far to a list
         self.bot_token = "<|python_tag|>"
-        self.bot_token_id = tokenizer.encode(self.bot_token, add_special_tokens=False)[
-            0
-        ]
+        self.bot_token_id = self._get_cached_token_ids(tokenizer, self.bot_token)[0]
         # Simple regex to find opening braces - we'll use JSON decoder for parsing
         # This handles arbitrary nesting depth correctly
         self.tool_call_start_regex = re.compile(r"\{")

--- a/vllm/tool_parsers/longcat_tool_parser.py
+++ b/vllm/tool_parsers/longcat_tool_parser.py
@@ -19,19 +19,13 @@ class LongcatFlashToolParser(Hermes2ProToolParser):
             re.DOTALL,
         )
 
-        self.tool_call_start_token_ids = self.model_tokenizer.encode(
-            self.tool_call_start_token, add_special_tokens=False
+        start_ids, start_arr = self._get_cached_token_data(
+            self.model_tokenizer, self.tool_call_start_token
         )
-        self.tool_call_end_token_ids = self.model_tokenizer.encode(
-            self.tool_call_end_token, add_special_tokens=False
+        end_ids, end_arr = self._get_cached_token_data(
+            self.model_tokenizer, self.tool_call_end_token
         )
-
-        self.tool_call_start_token_array = [
-            self.model_tokenizer.decode([token_id])
-            for token_id in self.tool_call_start_token_ids
-        ]
-
-        self.tool_call_end_token_array = [
-            self.model_tokenizer.decode([token_id])
-            for token_id in self.tool_call_end_token_ids
-        ]
+        self.tool_call_start_token_ids = start_ids
+        self.tool_call_end_token_ids = end_ids
+        self.tool_call_start_token_array = start_arr
+        self.tool_call_end_token_array = end_arr


### PR DESCRIPTION
## Summary

- **Root cause**: `Hermes2ProToolParser.__init__`, `LongcatFlashToolParser.__init__`, `FunctionGemmaToolParser.__init__`, and `Llama3JsonToolParser.__init__` call `tokenizer.encode()` and/or `tokenizer.decode()` on a shared HuggingFace tokenizer instance during every instantiation. Under concurrent load, the tokenizer's Rust backend (PyO3 `RefCell`) panics with `RuntimeError: Already borrowed`.
- **Fix**: Add a class-level cache (`dict`) with a `threading.Lock` using double-checked locking. Token IDs and decoded strings for tool call start/end tokens are deterministic per tokenizer instance, so they only need to be computed once. All subsequent instantiations read from the cache without touching the tokenizer.
- **Scope**: Fixed in all 4 parsers in the codebase that call `encode()`/`decode()` in `__init__`: `hermes_tool_parser.py`, `longcat_tool_parser.py`, `functiongemma_tool_parser.py`, and `llama_tool_parser.py`. All other tool parsers were audited and confirmed to not have this issue.

## Test plan

- [x] All pre-commit checks pass (ruff check, ruff format, mypy, etc.)
- [ ] Verify existing Hermes tool parser unit tests still pass (`tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py`)
- [ ] Verify FunctionGemma tool parser tests still pass (`tests/tool_parsers/test_functiongemma_tool_parser.py`)
- [ ] Verify Llama tool parser tests still pass (`tests/entrypoints/openai/tool_parsers/test_llama3_json_tool_parser.py`)
- [ ] Stress test: start vLLM with `--enable-auto-tool-choice --tool-call-parser hermes` and send concurrent requests to confirm no `RuntimeError: Already borrowed`

Fixes #34932