### PR TITLE
[Bugfix] Fix GLM-4 tool parser double serialization in streaming

### DIFF
--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -165,4 +165,7 @@ class TestGlm47Streaming:
                 delta_token_ids=[],
                 request=mock_request,
             )
-        assert glm47_tool_parser.prev_tool_call_arr[0]["arguments"]["city"] == "Beijing"
+        assert (
+            json.loads(glm47_tool_parser.prev_tool_call_arr[0]["arguments"])["city"]
+            == "Beijing"
+        )

--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -561,12 +561,12 @@ def test_streaming_empty_tool_call(glm4_moe_tool_parser, mock_request):
 
 
 def test_streaming_prev_tool_call_arr_updates(glm4_moe_tool_parser, mock_request):
-    """Test that prev_tool_call_arr contains parsed dict after tool call."""
+    """Test that prev_tool_call_arr stores arguments as JSON string."""
     _reset_streaming_state(glm4_moe_tool_parser)
 
     # Stream a complete tool call
-    name_only = {"name": "get_weather", "arguments": {}}
-    name_and_args = {"name": "get_weather", "arguments": {"city": "Beijing"}}
+    name_only = {"name": "get_weather", "arguments": "{}"}
+    name_and_args = {"name": "get_weather", "arguments": '{"city": "Beijing"}'}
     chunks = [
         # Delta, expected streamed_args_for_tool, expected prev_tool_call_arr
         ("<tool_call>get_weather\n", "", name_only),
@@ -589,20 +589,20 @@ def test_streaming_prev_tool_call_arr_updates(glm4_moe_tool_parser, mock_request
         assert glm4_moe_tool_parser.streamed_args_for_tool[0] == exp_streamed
         assert glm4_moe_tool_parser.prev_tool_call_arr[0] == exp_prev_tc
 
-    # After the tool call completes, prev_tool_call_arr should have parsed dict
+    # After the tool call completes, prev_tool_call_arr should have JSON string
     assert len(glm4_moe_tool_parser.prev_tool_call_arr) == 1
     tool_entry = glm4_moe_tool_parser.prev_tool_call_arr[0]
     assert tool_entry.get("name") == "get_weather"
-    # arguments should be a dict, not a string
+    # arguments should be a JSON string to avoid double serialization
     args = tool_entry.get("arguments")
-    assert isinstance(args, dict), f"Expected dict, got {type(args)}"
-    assert args.get("city") == "Beijing"
+    assert isinstance(args, str), f"Expected str, got {type(args)}"
+    assert json.loads(args)["city"] == "Beijing"
 
     # Test equivalence of prev_tool_call_arr and streamed_args_for_tool
     # Simulates logic in chat_completion/serving.py:chat_completion_stream_generator
-    tool_call_json = json.dumps(tool_entry.get("arguments", {}))
+    # Since arguments is now stored as a string, it should match directly
     streamed_content = glm4_moe_tool_parser.streamed_args_for_tool[0]
-    assert tool_call_json.startswith(streamed_content)
+    assert args == streamed_content
 
 
 def test_streaming_multiple_tool_calls_sequential(glm4_moe_tool_parser, mock_request):
@@ -634,8 +634,14 @@ def test_streaming_multiple_tool_calls_sequential(glm4_moe_tool_parser, mock_req
 
     # Should have two tool calls in prev_tool_call_arr
     assert len(glm4_moe_tool_parser.prev_tool_call_arr) == 2
-    assert glm4_moe_tool_parser.prev_tool_call_arr[0]["arguments"]["city"] == "Beijing"
-    assert glm4_moe_tool_parser.prev_tool_call_arr[1]["arguments"]["city"] == "Shanghai"
+    assert (
+        json.loads(glm4_moe_tool_parser.prev_tool_call_arr[0]["arguments"])["city"]
+        == "Beijing"
+    )
+    assert (
+        json.loads(glm4_moe_tool_parser.prev_tool_call_arr[1]["arguments"])["city"]
+        == "Shanghai"
+    )
 
 
 def test_streaming_json_escape_in_string(glm4_moe_tool_parser, mock_request):

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -377,10 +377,10 @@ class Glm4MoeModelToolParser(ToolParser):
                         full_args_str = self.streamed_args_for_tool[
                             self.current_tool_id
                         ]
-                        args_dict = json.loads(full_args_str)
+                        json.loads(full_args_str)  # validate JSON
                         self.prev_tool_call_arr[self.current_tool_id] = {
                             "name": self._current_tool_name,
-                            "arguments": args_dict,
+                            "arguments": full_args_str,
                         }
                     except (json.JSONDecodeError, IndexError) as e:
                         logger.warning(
@@ -454,7 +454,7 @@ class Glm4MoeModelToolParser(ToolParser):
     def _emit_tool_name_delta(self, tool_name: str) -> DeltaMessage:
         self.prev_tool_call_arr[self.current_tool_id] = {
             "name": self._current_tool_name,
-            "arguments": {},
+            "arguments": "{}",
         }
         return DeltaMessage(
             tool_calls=[


### PR DESCRIPTION
## Summary

Fix double serialization bug in GLM-4 tool parser streaming where `prev_tool_call_arr` stored arguments as a parsed dict instead of a JSON string, causing malformed final delta chunks in streaming tool call responses.

## Root Cause

In `glm4_moe_tool_parser.py`, the streaming finalization code stored `arguments` as a dict:
```python
args_dict = json.loads(full_args_str)
self.prev_tool_call_arr[self.current_tool_id] = {
    "arguments": args_dict,  # stored as dict -- BUG
}
```

The serving layer (`chat_completion/serving.py`) then called `json.dumps(args)` on this dict, which could produce different JSON formatting than `streamed_args_for_tool`, causing the `replace()` logic to fail and emit a spurious cumulative final delta.

## Fix

Store arguments as the raw JSON string (matching other tool parsers like Qwen3Coder, DeepSeek-V3.2, Seed-OSS):
```python
json.loads(full_args_str)  # validate only
self.prev_tool_call_arr[self.current_tool_id] = {
    "arguments": full_args_str,  # stored as string
}
```

The serving layer already handles both `str` and `dict` types at lines 1143-1146:
```python
if isinstance(args, str):
    expected_call = args  # use directly, no double serialization
else:
    expected_call = json.dumps(args, ensure_ascii=False)
```

## Test Plan

```bash
pytest tests/tool_parsers/test_glm4_moe_tool_parser.py -v
pytest tests/tool_parsers/test_glm47_moe_tool_parser.py -v
```

Fixes #36833