### PR TITLE
[Bugfix][Structured Output] Fix structural_tag bitmask not applied on reasoning models

### DIFF
--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -317,7 +317,13 @@ class StructuredOutputManager:
         if self.enable_in_reasoning:
             return True
 
+        # structural_tag grammars handle reasoning/content boundaries
+        # internally via triggers — always advance so the grammar can
+        # track tokens and fire triggers at the right time.
         structured_req = request.structured_output_request
+        if structured_req.params.structural_tag is not None:
+            return True
+
         if structured_req.reasoning_ended:
             return True
 


### PR DESCRIPTION
## Purpose

Fix `structural_tag` constraints being silently ignored on reasoning models (e.g., gpt-oss with `openai_gptoss` reasoning parser).

When a reasoning model uses a `structural_tag` constraint (e.g., `triggered_tags` format), `should_fill_bitmask()` and `should_advance()` in `StructuredOutputManager` return `False` during the reasoning phase. This happens because `reasoning_ended` is computed once from prompt tokens (which do not contain the reasoning end sequence) and never updated during generation. As a result, the grammar bitmask is never applied, the grammar state is never advanced, triggers never fire, and the constraint is completely ignored.

`structural_tag` grammars handle reasoning/content boundaries internally via triggers — the grammar itself knows when to allow free text (reasoning) and when to constrain output. The external `reasoning_ended` gate prevents this from working.

**Fix**: Add an early return in both `should_fill_bitmask()` and `should_advance()` when the request uses a `structural_tag` constraint, bypassing the `reasoning_ended` gate. Other constraint types (`json_schema`, `regex`, etc.) are unaffected and keep the existing behavior.

## Test Plan

Tested with gpt-oss-120b (tp=4) via `vllm serve` HTTP Chat Completions with a `structural_tag` response_format:

```bash
curl -s -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/raid/models/openai/gpt-oss-120b",
    "messages": [{"role": "user", "content": "List exactly 2 fruits."}],
    "response_format": {
      "type": "structural_tag",
      "format": {
        "type": "triggered_tags",
        "triggers": ["<|channel|>analysis", "<|channel|>final"],
        "tags": [
          {"begin": "<|channel|>analysis<|message|>", "content": {"type": "any_text"}, "end": "<|end|>"},
          {"begin": "<|channel|>final<|constrain|>json<|message|>", "content": {"type": "json_schema", "json_schema": {"type": "object", "properties": {"items": {"type": "array", "items": {"type": "string"}, "minItems": 2, "maxItems": 2}}, "required": ["items"], "additionalProperties": false}}, "end": ""}
        ],
        "at_least_one": true,
        "stop_after_first": false
      }
    },
    "temperature": 0
  }'
```

## Test Result

**Before** — structural_tag trigger never fires, Harmony markers leak into content:
```json
{
    "message": {
        "content": "<|channel|>final<|constrain|>json<|message|>{\"items\":[\"Apple\",\"Banana\"]}",
        "reasoning": "The user asks: \"List exactly 2 fruits.\" So we need to output exactly two fruit names..."
    },
    "finish_reason": "stop",
    "usage": {"completion_tokens": 98}
}
```

**After** — grammar bitmask applied, trigger fires, clean constrained JSON:
```json
{
    "message": {
        "content": "{\"items\":[\"Apple\",\"Banana\"]}",
        "reasoning": "The user asks: \"List exactly 2 fruits.\" So we need to output exactly two fruit names..."
    },
    "finish_reason": "stop",
    "usage": {"completion_tokens": 78}
}
```

Note the 20 fewer completion tokens — the text-encoded `<|channel|>final<|constrain|>json<|message|>` markers are no longer generated.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR: Fix structural_tag constraint silently ignored on reasoning models
- [x] The test plan: Tested with gpt-oss-120b via HTTP Chat Completions with structural_tag response_format
- [x] The test results: Before/after comparison with token count difference
- [ ] (Optional) Documentation update: N/A
- [ ] (Optional) Release notes: N/A
</details>
