### PR TITLE
Fix placeholder_block_size undefined error in initialize_kv_cache

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6504,15 +6504,17 @@ class GPUModelRunner(
         self.may_add_encoder_only_layers_to_kv_cache_config()
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)
         self.initialize_attn_backend(kv_cache_config)
-        # The kernel block size for all KV cache groups. For example, if
-        # kv_cache_manager uses block_size 256 for a given group, but the attention
-        # backends for that group only supports block_size 64, we will return
-        # kernel_block_size 64 and split the 256-token-block to 4 blocks with 64
-        # tokens each.
         kernel_block_sizes = prepare_kernel_block_sizes(
             kv_cache_config, self.attn_groups
         )
         self._kernel_block_sizes = kernel_block_sizes
+
+        block_sizes = []
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            if not isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec):
+                block_sizes.append(kv_cache_group.kv_cache_spec.block_size)
+        self._init_block_sizes = block_sizes
+        self._init_kernel_block_sizes = kernel_block_sizes
 
         # create metadata builders
         self.initialize_metadata_builders(kv_cache_config, kernel_block_sizes)


### PR DESCRIPTION
Fix for issue #37350: NameError when initializing KV cache for CUDA graph profiling.

The issue occurs when _init_minimal_kv_cache_for_profiling calls initialize_kv_cache, which references placeholder_block_size that was only defined in __init__ but never in initialize_kv_cache itself.

This fix computes block_sizes from kv_cache_config inside initialize_kv_cache to properly initialize _init_block_sizes and _init_kernel_block_sizes.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

