### PR TITLE
Fix Quark OCP-MX W4A6 support: dequant dtype + apply_weights

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -304,7 +304,11 @@ def rocm_aiter_fused_experts(
         quant_method = QuantMethod.NO.value
         # mxfp4 i.e. w4a4, w4a16 uses BLOCK_1X32
         # mxfp6 and mxfp8 are unsupported in AITER currently and use emulation instead
-        if quant_config.use_mxfp4_w4a4 or quant_config.use_mxfp4_w4a16:
+        if (
+            quant_config.use_mxfp4_w4a4
+            or quant_config.use_mxfp4_w4a16
+            or quant_config.weight_quant_dtype == "mxfp4"
+        ):
             quant_method = QuantMethod.BLOCK_1X32.value
         # w8a8 block-scaled
         if quant_config.block_shape is not None and quant_config.use_fp8_w8a8:

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
@@ -364,7 +364,10 @@ class QuarkOCP_MX(QuarkScheme):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if self.emulate:
-            dq_w = self.dequant_func(layer.weight, layer.weight_scale, x.dtype)
+            float_dtype = x.dtype if x.dtype.is_floating_point else torch.bfloat16
+            if not x.dtype.is_floating_point:
+                x = x.to(float_dtype)
+            dq_w = self.dequant_func(layer.weight, layer.weight_scale, float_dtype)
             qdq_x = self.quant_dequant_func(x)
             return F.linear(qdq_x, dq_w, bias)
         y = torch.ops.vllm.gemm_with_dynamic_quant(


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes two issues preventing Quark W4A6 models (MXFP4 weights / MXFP6 activations, e.g. `ziliangpeng/DeepSeek-V3-Quark-MXFP4-v4-w4a6`) from running on ROCm:

1. **MoE QuantType crash** (`rocm_aiter_moe.py`): W4A6 models set `weight_quant_dtype="mxfp4"` but not the `use_mxfp4_w4a4/w4a16` flags, causing AITER MoE to receive `QuantType.NO` and crash with "Unsupported kernel config for moe heuristic dispatch". Fixed by adding a fallback check on `weight_quant_dtype`. This is the caller-side fix suggested by @valarLip in ROCm/aiter#2457.

2. **Emulate path byte tensor crash** (`quark_ocp_mx.py`): In the emulation path (used when native MXFP6 kernels are not available), input `x` can arrive as `uint8` from upstream quantized tensor flow. This causes `F.linear(uint8, uint8)` to crash and the Quark dequant kernel to reject the dtype. Fixed with defensive dtype handling: non-floating-point inputs are cast to `bfloat16` before dequantization. The activation QDQ path (`quant_dequant_func`) is preserved for accuracy.

### Test Plan

**Hardware:** AMD Instinct MI350X / MI355X (gfx950), 8xGPU  
**Model:** `ziliangpeng/DeepSeek-V3-Quark-MXFP4-v4-w4a6`

**1. Build and install vLLM with this PR:**
```bash
# Start ROCm container
docker run -it --network=host --device=/dev/kfd --device=/dev/dri \
  --ipc=host --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
  -v /path/to/models:/workspace/models \
  vllm/vllm-openai-rocm:latest bash

# Inside container: clone and install the PR branch
git clone https://github.com/vecheruk-amd/vllm.git -b fix/quark-w4a6-mxfp4-compat
cd vllm && pip install -e .
```

**2. Set environment variables:**
```bash
export VLLM_ROCM_USE_AITER=1
```

**3. Serve the model (TP=8, eager mode):**
```bash
vllm serve /workspace/models/DeepSeek-V3-Quark-MXFP4-v4-w4a6 \
  --tensor-parallel-size 8 \
  --block-size 1 \
  --kv-cache-dtype fp8 \
  --gpu-memory-utilization 0.90 \
  --max-model-len 32000 \
  --enforce-eager \
  --port 8000
```

**4. Test inference:**
```bash
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "/workspace/models/DeepSeek-V3-Quark-MXFP4-v4-w4a6",
       "messages": [{"role":"user","content":"Explain quantum computing"}],
       "max_tokens": 256}'
```

**Without this PR:** Step 3 crashes with "Unsupported kernel config for moe heuristic dispatch" (QuantType issue).  
**With this PR:** Both short and long generation produce correct, coherent output.

### Test Result
Both short and long generation produce correct, coherent output with `--enforce-eager`.

### Known Issue
CUDA graph mode segfaults during decode with the W4A6 emulation path on PyTorch 2.10+ / ROCm 7.2+ (works on v0.18.0 / PyTorch 2.9 / ROCm 7.0). `--enforce-eager` is the workaround. A separate issue will be filed.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

