### PR TITLE
[Bugfix] Avoid OpenMP thread reallocation in CPU torch compile

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -246,6 +246,7 @@ class CpuPlatform(Platform):
                     "size_asserts": False,
                     "nan_asserts": False,
                     "epilogue_fusion": True,
+                    "cpp.dynamic_threads": True,
                 }
             )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

CPU torch compile will generate code with ```num_threads()``` by default, which causes OpenMP thread reallocation and breaks thread binding. This PR disabled it.

## Test Plan

CI tests

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

