### PR TITLE
Fix tensor size mismatch in per-channel weight scale loading for MoE …

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -926,13 +926,25 @@ class FusedMoE(CustomOp):
         if shard_id == "w2":
             expert_data.copy_(loaded_weight)
         elif shard_id in ("w1", "w3"):
-            self._load_w13(
-                shard_id=shard_id,
-                shard_dim=shard_dim,
-                loaded_weight=loaded_weight,
-                expert_data=expert_data,
-                tp_rank=tp_rank,
-            )
+            # Index the loaded weight for tp sharding.
+            # gate_up_proj: "MergedColumnParallel", so tp sharding on output_dim
+            if self.moe_config.is_act_and_mul:
+                shard_size = expert_data.shape[shard_dim] // 2
+            else:
+                shard_size = expert_data.shape[shard_dim]
+            # Only narrow if the loaded_weight is not a scalar (0-dim tensor)
+            if loaded_weight.ndim > 0:
+                loaded_weight = loaded_weight.narrow(
+                    shard_dim, shard_size * tp_rank, shard_size
+                )
+            # Narrow parameter and load.
+            # w1, gate_proj: Load into first logical weight of w13.
+            if shard_id == "w1":
+                expert_data = expert_data.narrow(shard_dim, 0, shard_size)
+            # w3, up_proj: Load into second logical weight of w13.
+            else:
+                expert_data = expert_data.narrow(shard_dim, shard_size, shard_size)
+            expert_data.copy_(loaded_weight)
 
     def _load_w13(
         self,


### PR DESCRIPTION
…layers

Fix for MiniMax-M2 model loading with tensor parallel.

The issue was that _load_per_channel_weight_scale was calling _load_w13 without properly handling the tp_rank sharding. The error was: RuntimeError: The size of tensor a (3072) must match the size of tensor b (1536) at non-singleton dimension 1

This fix adds proper tp_rank sharding logic directly in _load_per_channel_weight_scale for w1/w3 weight scales, similar to how it's done in _load_w13 and _load_model_weight_or_group_weight_scale.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

