### PR TITLE
[ROCm][Quantization] fallback trust_remote_code=True in Quark config for some cases

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -81,6 +81,16 @@ class QuarkConfig(QuantizationConfig):
                 and "requires you to execute the configuration file" not in error_text
             ):
                 raise
+
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "The model %s requires custom code to be executed. "
+                "Falling back to `trust_remote_code=True`.",
+                model_name,
+            )
+
             self.hf_config = get_config(
                 model=model_name,
                 trust_remote_code=True,

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -64,12 +64,29 @@ class QuarkConfig(QuantizationConfig):
         self.dynamic_mxfp4_quant = False
 
     def maybe_update_config(self, model_name: str, revision: str | None = None):
-        self.hf_config = get_config(
-            model=model_name,
-            trust_remote_code=False,  # or get from model_config if available
-            revision=revision,
-            config_format="auto",
-        )
+        try:
+            self.hf_config = get_config(
+                model=model_name,
+                trust_remote_code=False,
+                revision=revision,
+                config_format="auto",
+            )
+        except (RuntimeError, ValueError) as e:
+            # Some local quantized checkpoints rely on custom HF config code.
+            # Retry only for the explicit trust-remote-code failure mode.
+            error_text = str(e)
+            if (
+                "trust_remote_code=True" not in error_text
+                and "contains custom code which must be executed" not in error_text
+                and "requires you to execute the configuration file" not in error_text
+            ):
+                raise
+            self.hf_config = get_config(
+                model=model_name,
+                trust_remote_code=True,
+                revision=revision,
+                config_format="auto",
+            )
 
         quant_config = getattr(self.hf_config, "quantization_config", None)
         if quant_config is not None:


### PR DESCRIPTION
## Purpose
Model: amd/MiniMax-M2.1-MXFP4
Transformers: 4.57.6

Error message:
```
... ...
(APIServer pid=295080)   File "/workspace/xuebwang/vllm/vllm/engine/arg_utils.py", line 1928, in create_engine_config
(APIServer pid=295080)     config = VllmConfig(
(APIServer pid=295080)              ^^^^^^^^^^^
(APIServer pid=295080)   File "/usr/local/lib/python3.12/dist-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
(APIServer pid=295080)     s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
(APIServer pid=295080) pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
(APIServer pid=295080)   Value error, The repository /workspace/amd/MiniMax-M2.1-MXFP4 contains custom code which must be executed to correctly load the model. You can inspect the repository content at /workspace/amd/MiniMax-M2.1-MXFP4 .
(APIServer pid=295080)  You can inspect the repository content at https://hf.co//workspace/amd/MiniMax-M2.1-MXFP4.
(APIServer pid=295080) Please pass the argument `trust_remote_code=True` to allow custom code to be run. [type=value_error, input_value=ArgsKwargs((), {'model_co... 'shutdown_timeout': 0}), input_type=ArgsKwargs]
```

## Test Plan & Result
After fixing:
```
vllm (pretrained=/workspace/amd/MiniMax-M2.1-MXFP4,tensor_parallel_size=2,dtype=auto,gpu_memory_utilization=0.9,enforce_eager=True,trust_remote_code=True,max_model_len=32768), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|    Tasks     |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|--------------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_platinum|      3|flexible-extract|     5|exact_match|↑  |0.9603|±  |0.0056|
|              |       |strict-match    |     5|exact_match|↑  |0.9570|±  |0.0058|
```
