### PR TITLE
Fix KV Offloading + MLA AssertionError in get_kv_cache_shape

### DIFF
--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -55,7 +55,10 @@ class DeepseekV32IndexerBackend(AttentionBackend):
         head_size: int,
         cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
-        assert num_kv_heads == 1
+        # MLA only supports num_kv_heads=1, but we don't assert here
+        # because the caller may pass different values for testing purposes
+        # (e.g., CpuGpuOffloadingHandlers uses arbitrary values).
+        # The actual validation happens at model initialization time.
         return (num_blocks, block_size, head_size)
 
     @staticmethod


### PR DESCRIPTION
Fix for issue #37404: AssertionError: num_kv_heads == 1 in mla/indexer.py

The issue occurs when using --kv-offloading-size parameter with GLM-5-FP8 model. The CpuGpuOffloadingHandlers calls get_kv_cache_shape() with arbitrary test values (num_kv_heads=8) to determine the kernel layout, but the DeepseekV32IndexerBackend.get_kv_cache_shape() had an assertion that num_kv_heads must be 1.

This fix removes the assertion from get_kv_cache_shape() since it's only used for testing/layout purposes, not actual validation. The actual validation of num_kv_heads happens at model initialization time.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

