### PR TITLE
Fix SM121 GB10 FP4 quantization sticky CUDA error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -647,9 +647,9 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   # The nvfp4_scaled_mm_sm120 kernels for Geforce Blackwell SM120 require
   # CUDA 12.8 or later
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
-    cuda_archs_loose_intersection(FP4_ARCHS "12.0f" "${CUDA_ARCHS}")
+    cuda_archs_loose_intersection(FP4_ARCHS "12.0f;12.1f" "${CUDA_ARCHS}")
   else()
-    cuda_archs_loose_intersection(FP4_ARCHS "12.0a" "${CUDA_ARCHS}")
+    cuda_archs_loose_intersection(FP4_ARCHS "12.0a;12.1a" "${CUDA_ARCHS}")
   endif()
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8 AND FP4_ARCHS)
     set(SRCS

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1729,7 +1729,37 @@ def scaled_fp4_quant(
         f"input.dtype needs to be fp16 or bf16 but got {input.dtype}."
     )
 
+    # Check if we're on SM121 (Blackwell GB10) which has a bug in
+    # torch.ops._C.scaled_fp4_quant that causes sticky CUDA errors.
+    # In that case, fall back to FlashInfer's nvfp4_quantize.
+    use_flashinfer_fallback = False
+    if "flashinfer" in backend.lower():
+        try:
+            compute_capability = torch.cuda.get_device_capability(input.device)
+            if compute_capability == (12, 1):
+                use_flashinfer_fallback = True
+        except Exception:
+            pass
+
     use_8x4_sf_layout = True if "trtllm" in backend and m <= 32 else False  # noqa: SIM210
+
+    if use_flashinfer_fallback:
+        # On SM121, use FlashInfer's nvfp4_quantize which works correctly
+        from flashinfer import nvfp4_quantize, SfLayout
+
+        _fp4, _sf = nvfp4_quantize(
+            input,
+            input_global_scale,
+            sfLayout=SfLayout.layout_128x4,
+            do_shuffle=False,
+        )
+        if is_sf_swizzled_layout:
+            from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+                swizzle_blockscale,
+            )
+
+            _sf = swizzle_blockscale(_sf.to(torch.float8_e4m3fn))
+        return _fp4, _sf.view(torch.float8_e4m3fn).reshape(m, -1)
 
     if use_8x4_sf_layout:
         output, output_scale = flashinfer_quant_nvfp4_8x4_sf_layout(


### PR DESCRIPTION
Fix for issue #37402: scaled_fp4_quant produces sticky CUDA error on SM121 (DGX Spark GB10).

Root cause: _C.abi3.so contains sm_120 cubins but lacks sm_121a compatible kernels. The scaled_fp4_quant kernel triggers a code path that launches a sub-kernel incompatible with SM121, producing an asynchronous CUDA error that persists as a sticky error.

This fix adds a fallback to FlashInfer's nvfp4_quantize when:
1. Using FlashInfer backend (detected from backend parameter)
2. Running on SM121 GPU (compute capability 12.1)

FlashInfer's nvfp4_quantize is JIT-compiled for sm_121a and works correctly.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

