### PR TITLE
fix(jais): only apply ALiBi when position_embedding_type is 'alibi'

### DIFF
--- a/vllm/model_executor/models/jais.py
+++ b/vllm/model_executor/models/jais.py
@@ -120,8 +120,11 @@ class JAISAttention(nn.Module):
         tp_rank = get_tensor_model_parallel_rank()
         head_start = tp_rank * self.num_heads
         head_end = (tp_rank + 1) * self.num_heads
-        alibi_slopes = _get_alibi_slopes(total_num_heads)
-        alibi_slopes = alibi_slopes[head_start:head_end]
+        if config.position_embedding_type == "alibi":
+            alibi_slopes: list[float] | None = _get_alibi_slopes(total_num_heads)
+            alibi_slopes = alibi_slopes[head_start:head_end]
+        else:
+            alibi_slopes = None
         self.attn = Attention(
             self.num_heads,
             self.head_dim,


### PR DESCRIPTION
## Summary

Fixes #37400

In `JAISAttention.__init__`, ALiBi slopes were computed and passed to `Attention` unconditionally, regardless of `position_embedding_type`. This caused models with `position_embedding_type="learned"` to apply **both** learned positional embeddings (wpe) and ALiBi simultaneously.

## Changes

Added a conditional check in `JAISAttention.__init__`:

```python
if config.position_embedding_type == "alibi":
    alibi_slopes = _get_alibi_slopes(total_num_heads)
    alibi_slopes = alibi_slopes[head_start:head_end]
else:
    alibi_slopes = None
```

This is consistent with how `JAISModel` already handles `wpe` — only creating learned position embeddings when `position_embedding_type != "alibi"`.

## Testing

- [ ] Verified the fix is consistent with the existing `wpe` guard in `JAISModel`
- No functional tests added as this requires a JAIS model checkpoint to test