### PR TITLE
Add API docs link if the CLI arg is a config class

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -108,6 +108,7 @@ from vllm.utils.network_utils import get_ip
 from vllm.utils.torch_utils import resolve_kv_cache_dtype_string
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.sample.logits_processor import LogitsProcessor
+from vllm.version import __version__ as VLLM_VERSION
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization import QuantizationMethods
@@ -247,10 +248,7 @@ def _maybe_add_docs_url(cls: Any) -> str:
     """Generate API docs URL for a vllm config class."""
     if not cls.__module__.startswith("vllm.config"):
         return ""
-
-    from vllm.version import __version__
-
-    version = f"v{__version__}" if "dev" not in __version__ else "latest"
+    version = f"v{VLLM_VERSION}" if "dev" not in VLLM_VERSION else "latest"
     return f"\n\nAPI docs: https://docs.vllm.ai/en/{version}/api/vllm/config/#vllm.config.{cls.__name__}"
 
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -243,6 +243,17 @@ NEEDS_HELP = (
 )
 
 
+def _maybe_add_docs_url(cls: Any) -> str:
+    """Generate API docs URL for a vllm config class."""
+    if not cls.__module__.startswith("vllm.config"):
+        return ""
+
+    from vllm.version import __version__
+
+    version = f"v{__version__}" if "dev" not in __version__ else "latest"
+    return f"\n\nAPI docs: https://docs.vllm.ai/en/{version}/api/vllm/config/#vllm.config.{cls.__name__}"
+
+
 @functools.lru_cache(maxsize=30)
 def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
     # Save time only getting attr docs if we're generating help text
@@ -293,6 +304,7 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
                     raise argparse.ArgumentTypeError(repr(e)) from e
 
             kwargs[name]["type"] = parse_dataclass
+            kwargs[name]["help"] += _maybe_add_docs_url(dataclass_cls)
             kwargs[name]["help"] += f"\n\n{json_tip}"
         elif contains_type(type_hints, bool):
             # Creates --no-<name> and --<name> flags


### PR DESCRIPTION
A QoL improvement for configs that are directly exposed to the CLI so that their API documentation is linked to.

```console
$ vllm serve --help=VllmConfig
...
  --attention-config ATTENTION_CONFIG, -ac ATTENTION_CONFIG
                        Attention configuration.
                        API docs: https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.AttentionConfig
                        Should either be a valid JSON string or JSON keys passed individually. (default: ...
```