### PR TITLE
[Bugfix][Core] Preserve target hf_overrides in MTP draft config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ from vllm.config.vllm import (
     OPTIMIZATION_LEVEL_TO_CONFIG,
     OptimizationLevel,
 )
+from vllm.model_executor.models.config import NomicBertModelConfig
 from vllm.platforms import current_platform
 
 
@@ -1452,3 +1453,41 @@ def test_mtp_draft_model_config_allows_non_dict_nested_override_values():
     draft_model_config = speculative_config.draft_model_config
     assert draft_model_config.hf_config.text_config is None
     assert draft_model_config.hf_config.model_type == "qwen3_5_mtp"
+
+
+def test_nomic_config_honors_mapping_like_max_model_len_override():
+    """Mapping-like draft overrides should still affect Nomic max_model_len."""
+
+    class NomicBertConfig(_FakeHFConfig):
+        pass
+
+    hf_config = NomicBertConfig(
+        activation_function="swiglu",
+        mlp_fc1_bias=False,
+        mlp_fc2_bias=False,
+        qkv_proj_bias=False,
+        rotary_emb_scale_base=None,
+        rotary_emb_interleaved=False,
+        layer_norm_epsilon=1e-5,
+        n_inner=64,
+        n_embd=32,
+        n_layer=4,
+        num_attention_heads=4,
+        max_trained_positions=2048,
+        rope_parameters={"rope_type": "yarn"},
+    )
+    model_config = SimpleNamespace(
+        hf_config=hf_config,
+        hf_text_config=hf_config,
+        hf_overrides=SpeculativeConfig._get_draft_hf_overrides({"max_model_len": 1024}),
+        original_max_model_len=None,
+        max_model_len=4096,
+        encoder_config={"max_seq_length": 512},
+        model_arch_config=SimpleNamespace(),
+        get_and_verify_max_len=lambda value: value,
+    )
+
+    NomicBertModelConfig.verify_and_update_model_config(model_config)
+
+    assert model_config.max_model_len == 1024
+    assert model_config.encoder_config == {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1172,11 +1172,17 @@ def test_mtp_draft_model_config_preserves_target_hf_overrides():
 
     def apply_nested_overrides(target, overrides):
         for key, value in overrides.items():
-            nested_target = getattr(target, key, None)
+            if isinstance(target, dict):
+                nested_target = target.get(key)
+            else:
+                nested_target = getattr(target, key, None)
             if isinstance(value, dict) and nested_target is not None:
                 apply_nested_overrides(nested_target, value)
             else:
-                setattr(target, key, value)
+                if isinstance(target, dict):
+                    target[key] = value
+                else:
+                    setattr(target, key, value)
 
     class FakeHFConfig(SimpleNamespace):
 
@@ -1198,10 +1204,10 @@ def test_mtp_draft_model_config_preserves_target_hf_overrides():
                 ),
             )
 
-            if isinstance(self.hf_overrides, dict):
-                apply_nested_overrides(self.hf_config, self.hf_overrides)
-            elif callable(self.hf_overrides):
+            if callable(self.hf_overrides):
                 self.hf_config = self.hf_overrides(self.hf_config)
+            elif isinstance(self.hf_overrides, dict):
+                apply_nested_overrides(self.hf_config, self.hf_overrides)
 
             self.hf_text_config = self.hf_config.text_config
 
@@ -1236,6 +1242,8 @@ def test_mtp_draft_model_config_preserves_target_hf_overrides():
         )
 
     draft_model_config = speculative_config.draft_model_config
+    assert isinstance(draft_model_config.hf_overrides, dict)
+    assert draft_model_config.hf_overrides == target_hf_overrides
     assert (
         draft_model_config.hf_config.text_config.rope_parameters
         == target_rope_parameters

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import pickle
 from collections import UserDict
 from dataclasses import MISSING, Field, asdict, dataclass, field
 from types import SimpleNamespace
@@ -1154,19 +1155,34 @@ def test_eagle_draft_model_config():
     assert draft_model_config.architecture == "EagleLlamaForCausalLM"
 
 
-def _apply_nested_overrides(target, overrides):
+def _update_fake_nested_overrides(target, overrides):
     for key, value in overrides.items():
-        if isinstance(target, dict):
-            nested_target = target.get(key)
-        else:
-            nested_target = getattr(target, key, None)
-        if isinstance(value, dict) and nested_target is not None:
-            _apply_nested_overrides(nested_target, value)
-        else:
+        if isinstance(value, dict):
             if isinstance(target, dict):
-                target[key] = value
+                nested_target = target.get(key)
             else:
-                setattr(target, key, value)
+                nested_target = getattr(target, key, None)
+
+            if nested_target is not None and (
+                isinstance(nested_target, dict)
+                or isinstance(nested_target, PretrainedConfig)
+            ):
+                _update_fake_nested_overrides(nested_target, value)
+                continue
+
+        if isinstance(target, dict):
+            target[key] = value
+        else:
+            setattr(target, key, value)
+
+
+def _apply_fake_dict_overrides(config, overrides):
+    for key, value in overrides.items():
+        attr = getattr(config, key, None)
+        if attr is not None and isinstance(attr, PretrainedConfig):
+            _update_fake_nested_overrides(attr, value)
+        else:
+            setattr(config, key, value)
 
 
 class _FakeHFConfig(PretrainedConfig):
@@ -1176,6 +1192,18 @@ class _FakeHFConfig(PretrainedConfig):
         super().__init__()
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+
+_CALLABLE_TARGET_ROPE_PARAMETERS = {
+    "rope_type": "yarn",
+    "factor": 2.0,
+    "original_max_position_embeddings": 262_144,
+}
+
+
+def _callable_target_hf_overrides(hf_config):
+    hf_config.text_config.rope_parameters = _CALLABLE_TARGET_ROPE_PARAMETERS
+    return hf_config
 
 
 class _FakeDraftModelConfig:
@@ -1196,7 +1224,7 @@ class _FakeDraftModelConfig:
         if callable(self.hf_overrides):
             self.hf_config = self.hf_overrides(self.hf_config)
         elif isinstance(self.hf_overrides, dict):
-            _apply_nested_overrides(self.hf_config, self.hf_overrides)
+            _apply_fake_dict_overrides(self.hf_config, self.hf_overrides)
 
         self.hf_text_config = self.hf_config.text_config
 
@@ -1253,8 +1281,7 @@ def test_mtp_draft_model_config_preserves_target_hf_overrides():
         )
 
     draft_model_config = speculative_config.draft_model_config
-    assert isinstance(draft_model_config.hf_overrides, dict)
-    assert draft_model_config.hf_overrides == target_hf_overrides
+    assert callable(draft_model_config.hf_overrides)
     assert (
         draft_model_config.hf_config.text_config.rope_parameters
         == target_rope_parameters
@@ -1265,17 +1292,9 @@ def test_mtp_draft_model_config_preserves_target_hf_overrides():
 @pytest.mark.skip_global_cleanup
 def test_mtp_draft_model_config_preserves_callable_target_hf_overrides():
     """Test that callable target HF overrides are composed for MTP drafts."""
-    target_rope_parameters = {
-        "rope_type": "yarn",
-        "factor": 2.0,
-        "original_max_position_embeddings": 262_144,
-    }
-
-    def target_hf_overrides(hf_config):
-        hf_config.text_config.rope_parameters = target_rope_parameters
-        return hf_config
-
-    target_model_config = _make_fake_target_model_config(target_hf_overrides)
+    target_model_config = _make_fake_target_model_config(
+        _callable_target_hf_overrides
+    )
 
     with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
         speculative_config = SpeculativeConfig(
@@ -1289,7 +1308,7 @@ def test_mtp_draft_model_config_preserves_callable_target_hf_overrides():
     assert callable(draft_model_config.hf_overrides)
     assert (
         draft_model_config.hf_config.text_config.rope_parameters
-        == target_rope_parameters
+        == _CALLABLE_TARGET_ROPE_PARAMETERS
     )
     assert draft_model_config.hf_config.model_type == "qwen3_5_mtp"
 
@@ -1345,10 +1364,62 @@ def test_mtp_draft_model_config_preserves_mapping_target_hf_overrides():
         )
 
     draft_model_config = speculative_config.draft_model_config
-    assert isinstance(draft_model_config.hf_overrides, dict)
-    assert draft_model_config.hf_overrides == dict(target_hf_overrides)
+    assert callable(draft_model_config.hf_overrides)
     assert draft_model_config.hf_config.text_config.rope_parameters == {
         "rope_type": "yarn",
         "factor": 2.0,
         "original_max_position_embeddings": 262_144,
     }
+
+
+@pytest.mark.skip_global_cleanup
+def test_mtp_draft_model_config_keeps_default_hf_config_override():
+    """Empty target overrides should still preserve the draft config rewrite."""
+    target_model_config = _make_fake_target_model_config({})
+
+    with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
+        speculative_config = SpeculativeConfig(
+            target_model_config=target_model_config,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            num_speculative_tokens=1,
+        )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert callable(draft_model_config.hf_overrides)
+    assert draft_model_config.hf_config.model_type == "qwen3_5_mtp"
+    assert draft_model_config.hf_config.architectures == ["Qwen3_5MTP"]
+
+
+@pytest.mark.skip_global_cleanup
+def test_mtp_draft_model_config_callable_hf_overrides_is_picklable():
+    """Composed callable overrides should remain picklable."""
+    target_model_config = _make_fake_target_model_config(
+        _callable_target_hf_overrides
+    )
+
+    with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
+        speculative_config = SpeculativeConfig(
+            target_model_config=target_model_config,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            num_speculative_tokens=1,
+        )
+
+    serialized_overrides = pickle.dumps(
+        speculative_config.draft_model_config.hf_overrides
+    )
+    restored_overrides = pickle.loads(serialized_overrides)
+    restored_config = restored_overrides(
+        _FakeHFConfig(
+            model_type="qwen3_5",
+            architectures=["Qwen3ForCausalLM"],
+            text_config=_FakeHFConfig(rope_parameters={"rope_type": "default"}),
+        )
+    )
+
+    assert restored_config.model_type == "qwen3_5_mtp"
+    assert (
+        restored_config.text_config.rope_parameters
+        == _CALLABLE_TARGET_ROPE_PARAMETERS
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,9 +3,9 @@
 
 import logging
 import os
-import pickle
 from collections import UserDict
 from dataclasses import MISSING, Field, asdict, dataclass, field
+from multiprocessing.reduction import ForkingPickler
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -1164,8 +1164,7 @@ def _update_fake_nested_overrides(target, overrides):
                 nested_target = getattr(target, key, None)
 
             if nested_target is not None and (
-                isinstance(nested_target, dict)
-                or isinstance(nested_target, PretrainedConfig)
+                isinstance(nested_target, (dict, PretrainedConfig))
                 or hasattr(nested_target, "__dict__")
             ):
                 _update_fake_nested_overrides(nested_target, value)
@@ -1208,7 +1207,6 @@ def _callable_target_hf_overrides(hf_config):
 
 
 class _FakeDraftModelConfig:
-
     def __init__(self, **kwargs):
         self.model = kwargs["model"]
         self.hf_overrides = kwargs["hf_overrides"]
@@ -1293,9 +1291,7 @@ def test_mtp_draft_model_config_preserves_target_hf_overrides():
 @pytest.mark.skip_global_cleanup
 def test_mtp_draft_model_config_preserves_callable_target_hf_overrides():
     """Test that callable target HF overrides are composed for MTP drafts."""
-    target_model_config = _make_fake_target_model_config(
-        _callable_target_hf_overrides
-    )
+    target_model_config = _make_fake_target_model_config(_callable_target_hf_overrides)
 
     with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
         speculative_config = SpeculativeConfig(
@@ -1366,9 +1362,10 @@ def test_mtp_draft_model_config_preserves_mapping_target_hf_overrides():
 
     draft_model_config = speculative_config.draft_model_config
     assert callable(draft_model_config.hf_overrides)
-    assert draft_model_config.hf_overrides.get("text_config") == dict(
-        target_hf_overrides
-    )["text_config"]
+    assert (
+        draft_model_config.hf_overrides.get("text_config")
+        == dict(target_hf_overrides)["text_config"]
+    )
     assert draft_model_config.hf_config.text_config.rope_parameters == {
         "rope_type": "yarn",
         "factor": 2.0,
@@ -1398,9 +1395,7 @@ def test_mtp_draft_model_config_keeps_default_hf_config_override():
 @pytest.mark.skip_global_cleanup
 def test_mtp_draft_model_config_callable_hf_overrides_is_picklable():
     """Composed callable overrides should remain picklable."""
-    target_model_config = _make_fake_target_model_config(
-        _callable_target_hf_overrides
-    )
+    target_model_config = _make_fake_target_model_config(_callable_target_hf_overrides)
 
     with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
         speculative_config = SpeculativeConfig(
@@ -1410,10 +1405,10 @@ def test_mtp_draft_model_config_callable_hf_overrides_is_picklable():
             num_speculative_tokens=1,
         )
 
-    serialized_overrides = pickle.dumps(
+    serialized_overrides = ForkingPickler.dumps(
         speculative_config.draft_model_config.hf_overrides
     )
-    restored_overrides = pickle.loads(serialized_overrides)
+    restored_overrides = ForkingPickler.loads(serialized_overrides)
     restored_config = restored_overrides(
         _FakeHFConfig(
             model_type="qwen3_5",
@@ -1424,8 +1419,7 @@ def test_mtp_draft_model_config_callable_hf_overrides_is_picklable():
 
     assert restored_config.model_type == "qwen3_5_mtp"
     assert (
-        restored_config.text_config.rope_parameters
-        == _CALLABLE_TARGET_ROPE_PARAMETERS
+        restored_config.text_config.rope_parameters == _CALLABLE_TARGET_ROPE_PARAMETERS
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,12 +3,14 @@
 
 import logging
 import os
+from collections import UserDict
 from dataclasses import MISSING, Field, asdict, dataclass, field
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
+from transformers import PretrainedConfig
 
 from vllm.compilation.backends import VllmBackend
 from vllm.config import (
@@ -1167,10 +1169,12 @@ def _apply_nested_overrides(target, overrides):
                 setattr(target, key, value)
 
 
-class _FakeHFConfig(SimpleNamespace):
+class _FakeHFConfig(PretrainedConfig):
+    model_type = "fake"
 
-    def update(self, values):
-        for key, value in values.items():
+    def __init__(self, **kwargs):
+        super().__init__()
+        for key, value in kwargs.items():
             setattr(self, key, value)
 
 
@@ -1183,6 +1187,7 @@ class _FakeDraftModelConfig:
         self.hf_config = _FakeHFConfig(
             model_type="qwen3_5",
             architectures=["Qwen3ForCausalLM"],
+            rope_parameters={"rope_type": "default", "rope_theta": 1_000_000},
             text_config=_FakeHFConfig(
                 rope_parameters={"rope_type": "default"},
             ),
@@ -1287,3 +1292,63 @@ def test_mtp_draft_model_config_preserves_callable_target_hf_overrides():
         == target_rope_parameters
     )
     assert draft_model_config.hf_config.model_type == "qwen3_5_mtp"
+
+
+@pytest.mark.skip_global_cleanup
+def test_mtp_draft_model_config_matches_top_level_dict_override_semantics():
+    """Top-level dict-valued attrs should be replaced, not merged."""
+    target_hf_overrides = {
+        "rope_parameters": {
+            "rope_type": "yarn",
+            "factor": 2.0,
+        },
+    }
+    target_model_config = _make_fake_target_model_config(target_hf_overrides)
+
+    with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
+        speculative_config = SpeculativeConfig(
+            target_model_config=target_model_config,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            num_speculative_tokens=1,
+        )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert draft_model_config.hf_config.rope_parameters == {
+        "rope_type": "yarn",
+        "factor": 2.0,
+    }
+
+
+@pytest.mark.skip_global_cleanup
+def test_mtp_draft_model_config_preserves_mapping_target_hf_overrides():
+    """Mapping-like target overrides should not be silently dropped."""
+    target_hf_overrides = UserDict(
+        {
+            "text_config": {
+                "rope_parameters": {
+                    "rope_type": "yarn",
+                    "factor": 2.0,
+                    "original_max_position_embeddings": 262_144,
+                },
+            },
+        }
+    )
+    target_model_config = _make_fake_target_model_config(target_hf_overrides)
+
+    with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
+        speculative_config = SpeculativeConfig(
+            target_model_config=target_model_config,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            num_speculative_tokens=1,
+        )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert isinstance(draft_model_config.hf_overrides, dict)
+    assert draft_model_config.hf_overrides == dict(target_hf_overrides)
+    assert draft_model_config.hf_config.text_config.rope_parameters == {
+        "rope_type": "yarn",
+        "factor": 2.0,
+        "original_max_position_embeddings": 262_144,
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1166,6 +1166,7 @@ def _update_fake_nested_overrides(target, overrides):
             if nested_target is not None and (
                 isinstance(nested_target, dict)
                 or isinstance(nested_target, PretrainedConfig)
+                or hasattr(nested_target, "__dict__")
             ):
                 _update_fake_nested_overrides(nested_target, value)
                 continue
@@ -1365,6 +1366,9 @@ def test_mtp_draft_model_config_preserves_mapping_target_hf_overrides():
 
     draft_model_config = speculative_config.draft_model_config
     assert callable(draft_model_config.hf_overrides)
+    assert draft_model_config.hf_overrides.get("text_config") == dict(
+        target_hf_overrides
+    )["text_config"]
     assert draft_model_config.hf_config.text_config.rope_parameters == {
         "rope_type": "yarn",
         "factor": 2.0,
@@ -1423,3 +1427,24 @@ def test_mtp_draft_model_config_callable_hf_overrides_is_picklable():
         restored_config.text_config.rope_parameters
         == _CALLABLE_TARGET_ROPE_PARAMETERS
     )
+
+
+@pytest.mark.skip_global_cleanup
+def test_mtp_draft_model_config_allows_non_dict_nested_override_values():
+    """Nested config attributes should allow scalar replacement values."""
+    target_hf_overrides = {
+        "text_config": None,
+    }
+    target_model_config = _make_fake_target_model_config(target_hf_overrides)
+
+    with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
+        speculative_config = SpeculativeConfig(
+            target_model_config=target_model_config,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            num_speculative_tokens=1,
+        )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert draft_model_config.hf_config.text_config is None
+    assert draft_model_config.hf_config.model_type == "qwen3_5_mtp"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1152,6 +1152,74 @@ def test_eagle_draft_model_config():
     assert draft_model_config.architecture == "EagleLlamaForCausalLM"
 
 
+def _apply_nested_overrides(target, overrides):
+    for key, value in overrides.items():
+        if isinstance(target, dict):
+            nested_target = target.get(key)
+        else:
+            nested_target = getattr(target, key, None)
+        if isinstance(value, dict) and nested_target is not None:
+            _apply_nested_overrides(nested_target, value)
+        else:
+            if isinstance(target, dict):
+                target[key] = value
+            else:
+                setattr(target, key, value)
+
+
+class _FakeHFConfig(SimpleNamespace):
+
+    def update(self, values):
+        for key, value in values.items():
+            setattr(self, key, value)
+
+
+class _FakeDraftModelConfig:
+
+    def __init__(self, **kwargs):
+        self.model = kwargs["model"]
+        self.hf_overrides = kwargs["hf_overrides"]
+        self.max_model_len = kwargs["spec_target_max_model_len"]
+        self.hf_config = _FakeHFConfig(
+            model_type="qwen3_5",
+            architectures=["Qwen3ForCausalLM"],
+            text_config=_FakeHFConfig(
+                rope_parameters={"rope_type": "default"},
+            ),
+        )
+
+        if callable(self.hf_overrides):
+            self.hf_config = self.hf_overrides(self.hf_config)
+        elif isinstance(self.hf_overrides, dict):
+            _apply_nested_overrides(self.hf_config, self.hf_overrides)
+
+        self.hf_text_config = self.hf_config.text_config
+
+    def verify_with_parallel_config(self, parallel_config):
+        return None
+
+
+def _make_fake_target_model_config(hf_overrides):
+    return SimpleNamespace(
+        model="lukealonso/Qwen3.5-397B-A17B-NVFP4",
+        tokenizer="lukealonso/Qwen3.5-397B-A17B-NVFP4",
+        tokenizer_mode="auto",
+        trust_remote_code=True,
+        allowed_local_media_path="",
+        allowed_media_domains=None,
+        dtype="bfloat16",
+        seed=0,
+        hf_overrides=hf_overrides,
+        hf_text_config=SimpleNamespace(model_type="qwen3_5"),
+        quantization=None,
+        tokenizer_revision=None,
+        max_model_len=524_288,
+        enforce_eager=False,
+        max_logprobs=20,
+        config_format="auto",
+    )
+
+
 @pytest.mark.skip_global_cleanup
 def test_mtp_draft_model_config_preserves_target_hf_overrides():
     """Test that MTP draft config keeps target HF overrides."""
@@ -1169,71 +1237,9 @@ def test_mtp_draft_model_config_preserves_target_hf_overrides():
             "rope_parameters": target_rope_parameters,
         },
     }
+    target_model_config = _make_fake_target_model_config(target_hf_overrides)
 
-    def apply_nested_overrides(target, overrides):
-        for key, value in overrides.items():
-            if isinstance(target, dict):
-                nested_target = target.get(key)
-            else:
-                nested_target = getattr(target, key, None)
-            if isinstance(value, dict) and nested_target is not None:
-                apply_nested_overrides(nested_target, value)
-            else:
-                if isinstance(target, dict):
-                    target[key] = value
-                else:
-                    setattr(target, key, value)
-
-    class FakeHFConfig(SimpleNamespace):
-
-        def update(self, values):
-            for key, value in values.items():
-                setattr(self, key, value)
-
-    class FakeDraftModelConfig:
-
-        def __init__(self, **kwargs):
-            self.model = kwargs["model"]
-            self.hf_overrides = kwargs["hf_overrides"]
-            self.max_model_len = kwargs["spec_target_max_model_len"]
-            self.hf_config = FakeHFConfig(
-                model_type="qwen3_5",
-                architectures=["Qwen3ForCausalLM"],
-                text_config=FakeHFConfig(
-                    rope_parameters={"rope_type": "default"},
-                ),
-            )
-
-            if callable(self.hf_overrides):
-                self.hf_config = self.hf_overrides(self.hf_config)
-            elif isinstance(self.hf_overrides, dict):
-                apply_nested_overrides(self.hf_config, self.hf_overrides)
-
-            self.hf_text_config = self.hf_config.text_config
-
-        def verify_with_parallel_config(self, parallel_config):
-            return None
-
-    target_model_config = SimpleNamespace(
-        model="lukealonso/Qwen3.5-397B-A17B-NVFP4",
-        tokenizer="lukealonso/Qwen3.5-397B-A17B-NVFP4",
-        tokenizer_mode="auto",
-        trust_remote_code=True,
-        allowed_local_media_path="",
-        allowed_media_domains=None,
-        dtype="bfloat16",
-        seed=0,
-        hf_overrides=target_hf_overrides,
-        hf_text_config=SimpleNamespace(model_type="qwen3_5"),
-        quantization=None,
-        tokenizer_revision=None,
-        max_model_len=524_288,
-        enforce_eager=False,
-        max_logprobs=20,
-        config_format="auto",
-    )
-
-    with patch("vllm.config.speculative.ModelConfig", FakeDraftModelConfig):
+    with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
         speculative_config = SpeculativeConfig(
             target_model_config=target_model_config,
             target_parallel_config=ParallelConfig(),
@@ -1244,6 +1250,38 @@ def test_mtp_draft_model_config_preserves_target_hf_overrides():
     draft_model_config = speculative_config.draft_model_config
     assert isinstance(draft_model_config.hf_overrides, dict)
     assert draft_model_config.hf_overrides == target_hf_overrides
+    assert (
+        draft_model_config.hf_config.text_config.rope_parameters
+        == target_rope_parameters
+    )
+    assert draft_model_config.hf_config.model_type == "qwen3_5_mtp"
+
+
+@pytest.mark.skip_global_cleanup
+def test_mtp_draft_model_config_preserves_callable_target_hf_overrides():
+    """Test that callable target HF overrides are composed for MTP drafts."""
+    target_rope_parameters = {
+        "rope_type": "yarn",
+        "factor": 2.0,
+        "original_max_position_embeddings": 262_144,
+    }
+
+    def target_hf_overrides(hf_config):
+        hf_config.text_config.rope_parameters = target_rope_parameters
+        return hf_config
+
+    target_model_config = _make_fake_target_model_config(target_hf_overrides)
+
+    with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
+        speculative_config = SpeculativeConfig(
+            target_model_config=target_model_config,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            num_speculative_tokens=1,
+        )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert callable(draft_model_config.hf_overrides)
     assert (
         draft_model_config.hf_config.text_config.rope_parameters
         == target_rope_parameters

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@
 import logging
 import os
 from dataclasses import MISSING, Field, asdict, dataclass, field
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -1149,3 +1150,94 @@ def test_eagle_draft_model_config():
     assert draft_model_config.hf_text_config.model_type == "eagle"
     assert draft_model_config.architectures == ["EagleLlamaForCausalLM"]
     assert draft_model_config.architecture == "EagleLlamaForCausalLM"
+
+
+@pytest.mark.skip_global_cleanup
+def test_mtp_draft_model_config_preserves_target_hf_overrides():
+    """Test that MTP draft config keeps target HF overrides."""
+    target_rope_parameters = {
+        "mrope_interleaved": True,
+        "mrope_section": [11, 11, 10],
+        "rope_type": "yarn",
+        "rope_theta": 10_000_000,
+        "partial_rotary_factor": 0.25,
+        "factor": 2.0,
+        "original_max_position_embeddings": 262_144,
+    }
+    target_hf_overrides = {
+        "text_config": {
+            "rope_parameters": target_rope_parameters,
+        },
+    }
+
+    def apply_nested_overrides(target, overrides):
+        for key, value in overrides.items():
+            nested_target = getattr(target, key, None)
+            if isinstance(value, dict) and nested_target is not None:
+                apply_nested_overrides(nested_target, value)
+            else:
+                setattr(target, key, value)
+
+    class FakeHFConfig(SimpleNamespace):
+
+        def update(self, values):
+            for key, value in values.items():
+                setattr(self, key, value)
+
+    class FakeDraftModelConfig:
+
+        def __init__(self, **kwargs):
+            self.model = kwargs["model"]
+            self.hf_overrides = kwargs["hf_overrides"]
+            self.max_model_len = kwargs["spec_target_max_model_len"]
+            self.hf_config = FakeHFConfig(
+                model_type="qwen3_5",
+                architectures=["Qwen3ForCausalLM"],
+                text_config=FakeHFConfig(
+                    rope_parameters={"rope_type": "default"},
+                ),
+            )
+
+            if isinstance(self.hf_overrides, dict):
+                apply_nested_overrides(self.hf_config, self.hf_overrides)
+            elif callable(self.hf_overrides):
+                self.hf_config = self.hf_overrides(self.hf_config)
+
+            self.hf_text_config = self.hf_config.text_config
+
+        def verify_with_parallel_config(self, parallel_config):
+            return None
+
+    target_model_config = SimpleNamespace(
+        model="lukealonso/Qwen3.5-397B-A17B-NVFP4",
+        tokenizer="lukealonso/Qwen3.5-397B-A17B-NVFP4",
+        tokenizer_mode="auto",
+        trust_remote_code=True,
+        allowed_local_media_path="",
+        allowed_media_domains=None,
+        dtype="bfloat16",
+        seed=0,
+        hf_overrides=target_hf_overrides,
+        hf_text_config=SimpleNamespace(model_type="qwen3_5"),
+        quantization=None,
+        tokenizer_revision=None,
+        max_model_len=524_288,
+        enforce_eager=False,
+        max_logprobs=20,
+        config_format="auto",
+    )
+
+    with patch("vllm.config.speculative.ModelConfig", FakeDraftModelConfig):
+        speculative_config = SpeculativeConfig(
+            target_model_config=target_model_config,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            num_speculative_tokens=1,
+        )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert (
+        draft_model_config.hf_config.text_config.rope_parameters
+        == target_rope_parameters
+    )
+    assert draft_model_config.hf_config.model_type == "qwen3_5_mtp"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1289,8 +1289,8 @@ def test_mtp_draft_model_config_preserves_target_hf_overrides():
 
 
 @pytest.mark.skip_global_cleanup
-def test_mtp_draft_model_config_preserves_callable_target_hf_overrides():
-    """Test that callable target HF overrides are composed for MTP drafts."""
+def test_mtp_draft_model_config_does_not_propagate_callable_target_hf_overrides():
+    """Callable target overrides should not leak target-only mutations."""
     target_model_config = _make_fake_target_model_config(_callable_target_hf_overrides)
 
     with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
@@ -1303,10 +1303,9 @@ def test_mtp_draft_model_config_preserves_callable_target_hf_overrides():
 
     draft_model_config = speculative_config.draft_model_config
     assert callable(draft_model_config.hf_overrides)
-    assert (
-        draft_model_config.hf_config.text_config.rope_parameters
-        == _CALLABLE_TARGET_ROPE_PARAMETERS
-    )
+    assert draft_model_config.hf_config.text_config.rope_parameters == {
+        "rope_type": "default"
+    }
     assert draft_model_config.hf_config.model_type == "qwen3_5_mtp"
 
 
@@ -1393,9 +1392,19 @@ def test_mtp_draft_model_config_keeps_default_hf_config_override():
 
 
 @pytest.mark.skip_global_cleanup
-def test_mtp_draft_model_config_callable_hf_overrides_is_picklable():
-    """Composed callable overrides should remain picklable."""
-    target_model_config = _make_fake_target_model_config(_callable_target_hf_overrides)
+def test_mtp_draft_model_config_mapping_hf_overrides_is_picklable():
+    """Mapping-derived draft overrides should remain picklable."""
+    target_hf_overrides = UserDict(
+        {
+            "text_config": {
+                "rope_parameters": {
+                    "rope_type": "yarn",
+                    "factor": 2.0,
+                },
+            },
+        }
+    )
+    target_model_config = _make_fake_target_model_config(target_hf_overrides)
 
     with patch("vllm.config.speculative.ModelConfig", _FakeDraftModelConfig):
         speculative_config = SpeculativeConfig(
@@ -1418,9 +1427,10 @@ def test_mtp_draft_model_config_callable_hf_overrides_is_picklable():
     )
 
     assert restored_config.model_type == "qwen3_5_mtp"
-    assert (
-        restored_config.text_config.rope_parameters == _CALLABLE_TARGET_ROPE_PARAMETERS
-    )
+    assert restored_config.text_config.rope_parameters == {
+        "rope_type": "yarn",
+        "factor": 2.0,
+    }
 
 
 @pytest.mark.skip_global_cleanup

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -3,7 +3,7 @@
 
 import ast
 import copy
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from pydantic import Field, SkipValidation, model_validator
@@ -64,20 +64,13 @@ RejectionSampleMethod = Literal["strict", "probabilistic"]
 class _DraftHfOverrides:
     """Compose target-model HF overrides with draft-model overrides."""
 
-    def __init__(
-        self,
-        target_hf_overrides: Mapping[str, Any]
-        | Callable[[PretrainedConfig], PretrainedConfig],
-    ) -> None:
+    def __init__(self, target_hf_overrides: Mapping[str, Any]) -> None:
         self.target_hf_overrides = target_hf_overrides
 
     def __call__(self, hf_config: PretrainedConfig) -> PretrainedConfig:
-        if isinstance(self.target_hf_overrides, Mapping):
-            SpeculativeConfig._apply_hf_overrides_dict(
-                hf_config, dict(self.target_hf_overrides)
-            )
-        else:
-            hf_config = self.target_hf_overrides(hf_config)
+        SpeculativeConfig._apply_hf_overrides_dict(
+            hf_config, dict(self.target_hf_overrides)
+        )
         return SpeculativeConfig.hf_config_override(hf_config)
 
     def get(self, key: str, default: Any = None) -> Any:
@@ -410,9 +403,9 @@ class SpeculativeConfig:
                 return SpeculativeConfig.hf_config_override
             return _DraftHfOverrides(copy.deepcopy(dict(target_hf_overrides)))
 
-        if callable(target_hf_overrides):
-            return _DraftHfOverrides(target_hf_overrides)
-
+        # Arbitrary callable hf_overrides can encode target-only config mutations
+        # (e.g. layer-count or architecture changes) that should not leak into
+        # the derived draft model. Preserve only the draft-specific rewrite here.
         return SpeculativeConfig.hf_config_override
 
     def __post_init__(self):

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -3,6 +3,7 @@
 
 import ast
 import copy
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from pydantic import Field, SkipValidation, model_validator
@@ -374,19 +375,21 @@ class SpeculativeConfig:
         config: PretrainedConfig,
         overrides: dict[str, Any],
     ) -> None:
+        from transformers import PretrainedConfig
+
         for key, value in overrides.items():
             attr = getattr(config, key, None)
-            if isinstance(value, dict) and attr is not None and (
-                isinstance(attr, dict) or hasattr(attr, "__dict__")
-            ):
+            if attr is not None and isinstance(attr, PretrainedConfig):
                 SpeculativeConfig._update_nested_hf_config(attr, value)
             else:
                 setattr(config, key, value)
 
     @staticmethod
     def _get_draft_hf_overrides(target_hf_overrides: Any) -> Any:
-        if isinstance(target_hf_overrides, dict):
-            merged_overrides = _DraftHfOverrides(copy.deepcopy(target_hf_overrides))
+        if isinstance(target_hf_overrides, Mapping):
+            merged_overrides = _DraftHfOverrides(
+                copy.deepcopy(dict(target_hf_overrides))
+            )
             return merged_overrides
 
         if callable(target_hf_overrides):

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -377,9 +377,7 @@ class SpeculativeConfig:
                     isinstance(nested_target, dict)
                     or hasattr(nested_target, "__dict__")
                 ):
-                    SpeculativeConfig._update_nested_hf_config(
-                        nested_target, value
-                    )
+                    SpeculativeConfig._update_nested_hf_config(nested_target, value)
                     continue
 
             if isinstance(target, dict):

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -3,7 +3,7 @@
 
 import ast
 import copy
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from pydantic import Field, SkipValidation, model_validator
@@ -61,11 +61,23 @@ SpeculativeMethod = Literal[
 RejectionSampleMethod = Literal["strict", "probabilistic"]
 
 
-class _DraftHfOverrides(dict[str, Any]):
-    """Draft-model HF overrides that remain dict-like after config loading."""
+class _DraftHfOverrides:
+    """Compose target-model HF overrides with draft-model overrides."""
+
+    def __init__(
+        self,
+        target_hf_overrides: Mapping[str, Any]
+        | Callable[[PretrainedConfig], PretrainedConfig],
+    ) -> None:
+        self.target_hf_overrides = target_hf_overrides
 
     def __call__(self, hf_config: PretrainedConfig) -> PretrainedConfig:
-        SpeculativeConfig._apply_hf_overrides_dict(hf_config, self)
+        if isinstance(self.target_hf_overrides, Mapping):
+            SpeculativeConfig._apply_hf_overrides_dict(
+                hf_config, dict(self.target_hf_overrides)
+            )
+        else:
+            hf_config = self.target_hf_overrides(hf_config)
         return SpeculativeConfig.hf_config_override(hf_config)
 
 
@@ -387,20 +399,12 @@ class SpeculativeConfig:
     @staticmethod
     def _get_draft_hf_overrides(target_hf_overrides: Any) -> Any:
         if isinstance(target_hf_overrides, Mapping):
-            merged_overrides = _DraftHfOverrides(
-                copy.deepcopy(dict(target_hf_overrides))
-            )
-            return merged_overrides
+            if not target_hf_overrides:
+                return SpeculativeConfig.hf_config_override
+            return _DraftHfOverrides(copy.deepcopy(dict(target_hf_overrides)))
 
         if callable(target_hf_overrides):
-
-            def composed_hf_overrides(
-                hf_config: PretrainedConfig,
-            ) -> PretrainedConfig:
-                hf_config = target_hf_overrides(hf_config)
-                return SpeculativeConfig.hf_config_override(hf_config)
-
-            return composed_hf_overrides
+            return _DraftHfOverrides(target_hf_overrides)
 
         return SpeculativeConfig.hf_config_override
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -60,6 +60,14 @@ SpeculativeMethod = Literal[
 RejectionSampleMethod = Literal["strict", "probabilistic"]
 
 
+class _DraftHfOverrides(dict[str, Any]):
+    """Draft-model HF overrides that remain dict-like after config loading."""
+
+    def __call__(self, hf_config: PretrainedConfig) -> PretrainedConfig:
+        SpeculativeConfig._apply_hf_overrides_dict(hf_config, self)
+        return SpeculativeConfig.hf_config_override(hf_config)
+
+
 @config
 class SpeculativeConfig:
     """Configuration for speculative decoding."""
@@ -335,6 +343,64 @@ class SpeculativeConfig:
 
         return hf_config
 
+    @staticmethod
+    def _update_nested_hf_config(
+        target: PretrainedConfig | dict[str, Any],
+        updates: dict[str, Any],
+    ) -> None:
+        for key, value in updates.items():
+            if isinstance(value, dict):
+                if isinstance(target, dict):
+                    nested_target = target.get(key)
+                else:
+                    nested_target = getattr(target, key, None)
+
+                if nested_target is not None and (
+                    isinstance(nested_target, dict)
+                    or hasattr(nested_target, "__dict__")
+                ):
+                    SpeculativeConfig._update_nested_hf_config(
+                        nested_target, value
+                    )
+                    continue
+
+            if isinstance(target, dict):
+                target[key] = value
+            else:
+                setattr(target, key, value)
+
+    @staticmethod
+    def _apply_hf_overrides_dict(
+        config: PretrainedConfig,
+        overrides: dict[str, Any],
+    ) -> None:
+        for key, value in overrides.items():
+            attr = getattr(config, key, None)
+            if isinstance(value, dict) and attr is not None and (
+                isinstance(attr, dict) or hasattr(attr, "__dict__")
+            ):
+                SpeculativeConfig._update_nested_hf_config(attr, value)
+            else:
+                setattr(config, key, value)
+
+    @staticmethod
+    def _get_draft_hf_overrides(target_hf_overrides: Any) -> Any:
+        if isinstance(target_hf_overrides, dict):
+            merged_overrides = _DraftHfOverrides(copy.deepcopy(target_hf_overrides))
+            return merged_overrides
+
+        if callable(target_hf_overrides):
+
+            def composed_hf_overrides(
+                hf_config: PretrainedConfig,
+            ) -> PretrainedConfig:
+                hf_config = target_hf_overrides(hf_config)
+                return SpeculativeConfig.hf_config_override(hf_config)
+
+            return composed_hf_overrides
+
+        return SpeculativeConfig.hf_config_override
+
     def __post_init__(self):
         # Note: "method" is a new parameter that helps to extend the
         # configuration of non-model-based proposers, and the "model" parameter
@@ -472,7 +538,9 @@ class SpeculativeConfig:
                     quantization=self.quantization,
                     enforce_eager=self.target_model_config.enforce_eager,
                     max_logprobs=self.target_model_config.max_logprobs,
-                    hf_overrides=SpeculativeConfig.hf_config_override,
+                    hf_overrides=SpeculativeConfig._get_draft_hf_overrides(
+                        self.target_model_config.hf_overrides
+                    ),
                     config_format=self.target_model_config.config_format,
                 )
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -80,6 +80,11 @@ class _DraftHfOverrides:
             hf_config = self.target_hf_overrides(hf_config)
         return SpeculativeConfig.hf_config_override(hf_config)
 
+    def get(self, key: str, default: Any = None) -> Any:
+        if isinstance(self.target_hf_overrides, Mapping):
+            return self.target_hf_overrides.get(key, default)
+        return default
+
 
 @config
 class SpeculativeConfig:
@@ -391,7 +396,11 @@ class SpeculativeConfig:
 
         for key, value in overrides.items():
             attr = getattr(config, key, None)
-            if attr is not None and isinstance(attr, PretrainedConfig):
+            if (
+                attr is not None
+                and isinstance(attr, PretrainedConfig)
+                and isinstance(value, dict)
+            ):
                 SpeculativeConfig._update_nested_hf_config(attr, value)
             else:
                 setattr(config, key, value)

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -514,8 +514,8 @@ class NomicBertModelConfig(VerifyAndUpdateConfig):
             # greater than position_embedding.
             hf_text_config = model_config.hf_text_config
 
-            if isinstance(model_config.hf_overrides, dict):
-                # hf_overrides_kw
+            if hasattr(model_config.hf_overrides, "get"):
+                # Mapping-style hf_overrides_kw (including draft wrappers).
                 max_model_len = model_config.hf_overrides.get(
                     "max_model_len", model_config.max_model_len
                 )


### PR DESCRIPTION
## Summary
This PR fixes #37435 by preserving mapping-style target-model `hf_overrides` when vLLM rebuilds the speculative/MTP draft `ModelConfig`.

The updated implementation keeps the draft model derived from its own base config, then reapplies only mapping-style target `hf_overrides` before the internal speculative `hf_config_override` runs.

That preserves long-context / YaRN / RoPE overrides for the real user path while avoiding broader target-only config mutations from arbitrary callable overrides leaking into the derived draft model.

## Test coverage
The focused regression coverage now includes:
- nested dict YaRN/RoPE-style overrides
- top-level dict-valued override replacement semantics, aligned with `ModelConfig`
- mapping-like `hf_overrides` inputs, so they are not silently dropped
- empty/default target `hf_overrides`, to ensure the draft `hf_config_override` still runs
- pickling of mapping-derived draft overrides
- scalar replacement for nested config attributes
- callable target `hf_overrides` are intentionally not propagated into the draft model

## Validation
- `python3 -m py_compile vllm/config/speculative.py tests/test_config.py`
- `VLLM_TARGET_DEVICE=cpu PYTHONPATH=. .venv/bin/python -m pytest -q tests/test_config.py -k 'test_mtp_draft_model_config_preserves_target_hf_overrides or test_mtp_draft_model_config_does_not_propagate_callable_target_hf_overrides or test_mtp_draft_model_config_matches_top_level_dict_override_semantics or test_mtp_draft_model_config_preserves_mapping_target_hf_overrides or test_mtp_draft_model_config_keeps_default_hf_config_override or test_mtp_draft_model_config_mapping_hf_overrides_is_picklable or test_mtp_draft_model_config_allows_non_dict_nested_override_values'`

## Why this is not duplicating an existing PR
I checked for existing open PRs linked to #37435 and for likely duplicates in this area when opening the branch:
- `gh pr list --repo vllm-project/vllm --state open --search "37435 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "speculative hf_overrides mtp"`

## AI assistance
AI assistance was used to prepare this PR.

