### PR TITLE
[Bugfix][Model] Fix Kimi K2 tool parser 8KB section limit and simplify streaming state

### DIFF
--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -502,49 +502,6 @@ def test_empty_tool_section(kimi_k2_tool_parser):
     assert kimi_k2_tool_parser._stream_state.in_section is False
 
 
-def test_malformed_tool_section_recovery(kimi_k2_tool_parser, monkeypatch):
-    """
-    Test that the parser recovers from a malformed tool section
-    that never closes properly.
-    """
-    monkeypatch.setenv("VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS", "8192")
-    kimi_k2_tool_parser.reset_streaming_state()
-
-    section_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_begin|>")
-
-    # Enter tool section
-    _result1 = kimi_k2_tool_parser.extract_tool_calls_streaming(
-        previous_text="",
-        current_text="<|tool_calls_section_begin|>",
-        delta_text="<|tool_calls_section_begin|>",
-        previous_token_ids=[],
-        current_token_ids=[section_begin_id],
-        delta_token_ids=[section_begin_id],
-        request=None,
-    )
-    assert kimi_k2_tool_parser._stream_state.in_section is True
-
-    # Simulate a lot of text without proper tool calls or section end
-    # This should trigger the error recovery mechanism
-    large_text = "x" * 10000  # Exceeds max_section_chars
-
-    result2 = kimi_k2_tool_parser.extract_tool_calls_streaming(
-        previous_text="<|tool_calls_section_begin|>",
-        current_text="<|tool_calls_section_begin|>" + large_text,
-        delta_text=large_text,
-        previous_token_ids=[section_begin_id],
-        current_token_ids=[section_begin_id] + list(range(100, 100 + len(large_text))),
-        delta_token_ids=list(range(100, 100 + len(large_text))),
-        request=None,
-    )
-
-    # Parser should have force-exited the tool section
-    assert kimi_k2_tool_parser._stream_state.in_section is False
-    # And returned the content as reasoning
-    assert result2 is not None
-    assert result2.content == large_text
-
-
 def test_state_reset(kimi_k2_tool_parser):
     """Test that reset_streaming_state() properly clears all state."""
     # Put parser in a complex state
@@ -552,7 +509,6 @@ def test_state_reset(kimi_k2_tool_parser):
     kimi_k2_tool_parser._stream_state.buffer = "some buffer"
     kimi_k2_tool_parser.current_tool_id = 5
     kimi_k2_tool_parser.prev_tool_call_arr = [{"id": "test"}]
-    kimi_k2_tool_parser._stream_state.section_chars = 1000
 
     # Reset
     kimi_k2_tool_parser.reset_streaming_state()
@@ -923,85 +879,6 @@ def test_streaming_multiple_tool_calls_not_leaked(kimi_k2_tool_parser):
 
     # Legitimate content preserved
     assert "compare" in full_content.lower() or len(all_content) > 0
-
-
-def test_large_tool_call_arguments(kimi_k2_tool_parser):
-    """
-    Regression test: tool calls with >8KB arguments must succeed.
-
-    The previous implementation had a hard 8KB limit (max_section_chars=8192)
-    that would force-exit tool sections, truncating large arguments used in
-    coding use cases (file writes, code generation).
-    """
-    kimi_k2_tool_parser.reset_streaming_state()
-
-    section_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_begin|>")
-    section_end_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_end|>")
-    tool_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_call_begin|>")
-    tool_end_id = kimi_k2_tool_parser.vocab.get("<|tool_call_end|>")
-
-    # Generate a large JSON argument (>8KB but <512KB)
-    large_code = "x" * 16000  # 16KB of content
-    tool_args = json.dumps({"code": large_code})
-
-    tool_chunk = (
-        f"<|tool_call_begin|>functions.write_file:0 "
-        f"<|tool_call_argument_begin|> {tool_args} <|tool_call_end|>"
-    )
-
-    deltas = [
-        ("Let me write that file. ", [1, 2, 3]),
-        ("<|tool_calls_section_begin|>", [section_begin_id]),
-        (tool_chunk, [tool_begin_id, *range(10, 110), tool_end_id]),
-        ("<|tool_calls_section_end|>", [section_end_id]),
-    ]
-
-    results = run_streaming_sequence(kimi_k2_tool_parser, deltas)
-
-    # CRITICAL: Parser should NOT have force-exited
-    # (this would have failed with the old 8KB limit)
-    assert kimi_k2_tool_parser._stream_state.in_section is False
-
-    # The tool call data should not leak into content
-    all_content = [r.content for r in results if r and r.content]
-    full_content = "".join(all_content)
-    assert large_code not in full_content
-
-
-def test_configurable_section_limit(kimi_k2_tool_parser, monkeypatch):
-    """Verify that VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS is respected."""
-    monkeypatch.setenv("VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS", "100")
-    kimi_k2_tool_parser.reset_streaming_state()
-
-    section_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_begin|>")
-
-    # Enter tool section
-    _result1 = kimi_k2_tool_parser.extract_tool_calls_streaming(
-        previous_text="",
-        current_text="<|tool_calls_section_begin|>",
-        delta_text="<|tool_calls_section_begin|>",
-        previous_token_ids=[],
-        current_token_ids=[section_begin_id],
-        delta_token_ids=[section_begin_id],
-        request=None,
-    )
-    assert kimi_k2_tool_parser._stream_state.in_section is True
-
-    # Send content that exceeds the custom limit
-    overflow_text = "a" * 200
-    result2 = kimi_k2_tool_parser.extract_tool_calls_streaming(
-        previous_text="<|tool_calls_section_begin|>",
-        current_text="<|tool_calls_section_begin|>" + overflow_text,
-        delta_text=overflow_text,
-        previous_token_ids=[section_begin_id],
-        current_token_ids=[section_begin_id] + list(range(100, 300)),
-        delta_token_ids=list(range(100, 300)),
-        request=None,
-    )
-
-    # Should have force-exited due to custom 100-char limit
-    assert kimi_k2_tool_parser._stream_state.in_section is False
-    assert result2 is not None
 
 
 def test_multi_turn_section_reentry(kimi_k2_tool_parser):

--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -423,7 +423,7 @@ def test_split_markers_across_deltas(kimi_k2_tool_parser):
     _results = run_streaming_sequence(kimi_k2_tool_parser, deltas)
 
     # Now the complete marker should be detected via buffer
-    assert kimi_k2_tool_parser.in_tool_section is True
+    assert kimi_k2_tool_parser._stream_state.in_section is True
 
 
 def test_marker_variants(kimi_k2_tool_parser):
@@ -444,7 +444,7 @@ def test_marker_variants(kimi_k2_tool_parser):
             request=None,
         )
         # Should enter tool section mode with singular variant too
-        assert kimi_k2_tool_parser.in_tool_section is True
+        assert kimi_k2_tool_parser._stream_state.in_section is True
 
 
 def test_reentry_to_reasoning_after_tool_section(kimi_k2_tool_parser):
@@ -465,7 +465,7 @@ def test_reentry_to_reasoning_after_tool_section(kimi_k2_tool_parser):
 
     results = run_streaming_sequence(kimi_k2_tool_parser, deltas)
 
-    assert kimi_k2_tool_parser.in_tool_section is False
+    assert kimi_k2_tool_parser._stream_state.in_section is False
     assert results[2] is not None
     assert results[2].content == " More reasoning"
 
@@ -499,14 +499,15 @@ def test_empty_tool_section(kimi_k2_tool_parser):
         request=None,
     )
     # Should exit cleanly without errors
-    assert kimi_k2_tool_parser.in_tool_section is False
+    assert kimi_k2_tool_parser._stream_state.in_section is False
 
 
-def test_malformed_tool_section_recovery(kimi_k2_tool_parser):
+def test_malformed_tool_section_recovery(kimi_k2_tool_parser, monkeypatch):
     """
     Test that the parser recovers from a malformed tool section
     that never closes properly.
     """
+    monkeypatch.setenv("VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS", "8192")
     kimi_k2_tool_parser.reset_streaming_state()
 
     section_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_begin|>")
@@ -521,7 +522,7 @@ def test_malformed_tool_section_recovery(kimi_k2_tool_parser):
         delta_token_ids=[section_begin_id],
         request=None,
     )
-    assert kimi_k2_tool_parser.in_tool_section is True
+    assert kimi_k2_tool_parser._stream_state.in_section is True
 
     # Simulate a lot of text without proper tool calls or section end
     # This should trigger the error recovery mechanism
@@ -538,7 +539,7 @@ def test_malformed_tool_section_recovery(kimi_k2_tool_parser):
     )
 
     # Parser should have force-exited the tool section
-    assert kimi_k2_tool_parser.in_tool_section is False
+    assert kimi_k2_tool_parser._stream_state.in_section is False
     # And returned the content as reasoning
     assert result2 is not None
     assert result2.content == large_text
@@ -547,21 +548,21 @@ def test_malformed_tool_section_recovery(kimi_k2_tool_parser):
 def test_state_reset(kimi_k2_tool_parser):
     """Test that reset_streaming_state() properly clears all state."""
     # Put parser in a complex state
-    kimi_k2_tool_parser.in_tool_section = True
-    kimi_k2_tool_parser.token_buffer = "some buffer"
+    kimi_k2_tool_parser._stream_state.in_section = True
+    kimi_k2_tool_parser._stream_state.buffer = "some buffer"
     kimi_k2_tool_parser.current_tool_id = 5
     kimi_k2_tool_parser.prev_tool_call_arr = [{"id": "test"}]
-    kimi_k2_tool_parser.section_char_count = 1000
+    kimi_k2_tool_parser._stream_state.section_chars = 1000
 
     # Reset
     kimi_k2_tool_parser.reset_streaming_state()
 
     # Verify all state is cleared
-    assert kimi_k2_tool_parser.in_tool_section is False
-    assert kimi_k2_tool_parser.token_buffer == ""
+    assert kimi_k2_tool_parser._stream_state.in_section is False
+    assert kimi_k2_tool_parser._stream_state.buffer == ""
     assert kimi_k2_tool_parser.current_tool_id == -1
     assert kimi_k2_tool_parser.prev_tool_call_arr == []
-    assert kimi_k2_tool_parser.section_char_count == 0
+    assert kimi_k2_tool_parser._stream_state.section_chars == 0
     assert kimi_k2_tool_parser.current_tool_name_sent is False
     assert kimi_k2_tool_parser.streamed_args_for_tool == []
 
@@ -616,7 +617,7 @@ def test_stream_ends_without_section_end_marker(kimi_k2_tool_parser):
         delta_token_ids=[section_begin_id],
         request=None,
     )
-    assert kimi_k2_tool_parser.in_tool_section is True
+    assert kimi_k2_tool_parser._stream_state.in_section is True
 
     # Some content in tool section
     result2 = kimi_k2_tool_parser.extract_tool_calls_streaming(
@@ -634,14 +635,14 @@ def test_stream_ends_without_section_end_marker(kimi_k2_tool_parser):
     # Stream ends (EOF) - no more deltas, no section_end marker
     # Simulate this by manually checking state and resetting
     # (In real usage, the request handler would call reset_streaming_state)
-    assert kimi_k2_tool_parser.in_tool_section is True  # Still in section
+    assert kimi_k2_tool_parser._stream_state.in_section is True  # Still in section
 
     # Reset state (as would happen between requests)
     kimi_k2_tool_parser.reset_streaming_state()
 
     # Verify clean slate
-    assert kimi_k2_tool_parser.in_tool_section is False
-    assert kimi_k2_tool_parser.token_buffer == ""
+    assert kimi_k2_tool_parser._stream_state.in_section is False
+    assert kimi_k2_tool_parser._stream_state.buffer == ""
 
     # Next request should work normally
     result3 = kimi_k2_tool_parser.extract_tool_calls_streaming(
@@ -687,9 +688,8 @@ def test_same_chunk_begin_and_end_markers(kimi_k2_tool_parser):
     )
 
     # CRITICAL: Parser should NOT be stuck in tool section
-    assert kimi_k2_tool_parser.in_tool_section is False, (
-        "Parser stuck in tool section after processing both begin/end in same chunk. "
-        "This indicates the elif bug was not fixed."
+    assert kimi_k2_tool_parser._stream_state.in_section is False, (
+        "Parser stuck in tool section after processing both begin/end in same chunk."
     )
 
     # Result should be empty or contain only stripped content
@@ -739,7 +739,7 @@ def test_same_chunk_begin_content_end_markers(kimi_k2_tool_parser):
     )
 
     # Parser should exit cleanly (not stuck in tool section)
-    assert kimi_k2_tool_parser.in_tool_section is False
+    assert kimi_k2_tool_parser._stream_state.in_section is False
 
     # Verify the fix: next content should stream normally, not be suppressed
     result2 = kimi_k2_tool_parser.extract_tool_calls_streaming(
@@ -791,7 +791,7 @@ def test_tool_call_end_and_section_end_same_chunk(kimi_k2_tool_parser):
     results = run_streaming_sequence(kimi_k2_tool_parser, deltas)
 
     # CRITICAL: Parser should have exited section AFTER processing tool
-    assert kimi_k2_tool_parser.in_tool_section is False
+    assert kimi_k2_tool_parser._stream_state.in_section is False
 
     # Tool call should have been emitted (not dropped)
     if results[2] is not None and results[2].content is not None:
@@ -923,3 +923,147 @@ def test_streaming_multiple_tool_calls_not_leaked(kimi_k2_tool_parser):
 
     # Legitimate content preserved
     assert "compare" in full_content.lower() or len(all_content) > 0
+
+
+def test_large_tool_call_arguments(kimi_k2_tool_parser):
+    """
+    Regression test: tool calls with >8KB arguments must succeed.
+
+    The previous implementation had a hard 8KB limit (max_section_chars=8192)
+    that would force-exit tool sections, truncating large arguments used in
+    coding use cases (file writes, code generation).
+    """
+    kimi_k2_tool_parser.reset_streaming_state()
+
+    section_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_begin|>")
+    section_end_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_end|>")
+    tool_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_call_begin|>")
+    tool_end_id = kimi_k2_tool_parser.vocab.get("<|tool_call_end|>")
+
+    # Generate a large JSON argument (>8KB but <512KB)
+    large_code = "x" * 16000  # 16KB of content
+    tool_args = json.dumps({"code": large_code})
+
+    tool_chunk = (
+        f"<|tool_call_begin|>functions.write_file:0 "
+        f"<|tool_call_argument_begin|> {tool_args} <|tool_call_end|>"
+    )
+
+    deltas = [
+        ("Let me write that file. ", [1, 2, 3]),
+        ("<|tool_calls_section_begin|>", [section_begin_id]),
+        (tool_chunk, [tool_begin_id, *range(10, 110), tool_end_id]),
+        ("<|tool_calls_section_end|>", [section_end_id]),
+    ]
+
+    results = run_streaming_sequence(kimi_k2_tool_parser, deltas)
+
+    # CRITICAL: Parser should NOT have force-exited
+    # (this would have failed with the old 8KB limit)
+    assert kimi_k2_tool_parser._stream_state.in_section is False
+
+    # The tool call data should not leak into content
+    all_content = [r.content for r in results if r and r.content]
+    full_content = "".join(all_content)
+    assert large_code not in full_content
+
+
+def test_configurable_section_limit(kimi_k2_tool_parser, monkeypatch):
+    """Verify that VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS is respected."""
+    monkeypatch.setenv("VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS", "100")
+    kimi_k2_tool_parser.reset_streaming_state()
+
+    section_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_begin|>")
+
+    # Enter tool section
+    _result1 = kimi_k2_tool_parser.extract_tool_calls_streaming(
+        previous_text="",
+        current_text="<|tool_calls_section_begin|>",
+        delta_text="<|tool_calls_section_begin|>",
+        previous_token_ids=[],
+        current_token_ids=[section_begin_id],
+        delta_token_ids=[section_begin_id],
+        request=None,
+    )
+    assert kimi_k2_tool_parser._stream_state.in_section is True
+
+    # Send content that exceeds the custom limit
+    overflow_text = "a" * 200
+    result2 = kimi_k2_tool_parser.extract_tool_calls_streaming(
+        previous_text="<|tool_calls_section_begin|>",
+        current_text="<|tool_calls_section_begin|>" + overflow_text,
+        delta_text=overflow_text,
+        previous_token_ids=[section_begin_id],
+        current_token_ids=[section_begin_id] + list(range(100, 300)),
+        delta_token_ids=list(range(100, 300)),
+        request=None,
+    )
+
+    # Should have force-exited due to custom 100-char limit
+    assert kimi_k2_tool_parser._stream_state.in_section is False
+    assert result2 is not None
+
+
+def test_multi_turn_section_reentry(kimi_k2_tool_parser):
+    """Test entering tool section, exiting, and entering again in same stream."""
+    kimi_k2_tool_parser.reset_streaming_state()
+
+    section_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_begin|>")
+    section_end_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_end|>")
+
+    deltas = [
+        ("<|tool_calls_section_begin|>", [section_begin_id]),
+        ("<|tool_calls_section_end|>", [section_end_id]),
+        (" Between sections ", [10, 11]),
+        ("<|tool_calls_section_begin|>", [section_begin_id]),
+        ("<|tool_calls_section_end|>", [section_end_id]),
+        (" After second section", [20, 21]),
+    ]
+
+    results = run_streaming_sequence(kimi_k2_tool_parser, deltas)
+
+    # Parser should end outside tool section
+    assert kimi_k2_tool_parser._stream_state.in_section is False
+
+    # "Between sections" and "After second section" should appear in content
+    all_content = [r.content for r in results if r and r.content]
+    full_content = "".join(all_content)
+    assert "Between sections" in full_content
+    assert "After second section" in full_content
+
+
+def test_thinking_tools_interleaving(kimi_k2_tool_parser):
+    """Test tool calls following a reasoning/thinking block (K2.5 pattern)."""
+    kimi_k2_tool_parser.reset_streaming_state()
+
+    section_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_begin|>")
+    section_end_id = kimi_k2_tool_parser.vocab.get("<|tool_calls_section_end|>")
+    tool_begin_id = kimi_k2_tool_parser.vocab.get("<|tool_call_begin|>")
+    tool_end_id = kimi_k2_tool_parser.vocab.get("<|tool_call_end|>")
+
+    tool_chunk = (
+        "<|tool_call_begin|>functions.get_data:0 "
+        '<|tool_call_argument_begin|> {"query": "xyzzy"} <|tool_call_end|>'
+    )
+
+    deltas = [
+        ("Let me think about this... ", [1, 2, 3]),
+        ("I need to look it up. ", [4, 5]),
+        ("<|tool_calls_section_begin|>", [section_begin_id]),
+        (tool_chunk, [tool_begin_id, 10, 11, tool_end_id]),
+        ("<|tool_calls_section_end|>", [section_end_id]),
+        (" Based on the results...", [20, 21]),
+    ]
+
+    results = run_streaming_sequence(kimi_k2_tool_parser, deltas)
+
+    all_content = [r.content for r in results if r and r.content]
+    full_content = "".join(all_content)
+
+    # Reasoning before tool section should be preserved
+    assert "think about this" in full_content
+    # Tool call content should NOT leak
+    assert "get_data" not in full_content
+    assert "xyzzy" not in full_content
+    # Content after section should appear
+    assert "Based on the results" in full_content

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -179,7 +179,6 @@ if TYPE_CHECKING:
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
-    VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS: int = 524288
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_KV_CACHE_LAYOUT: Literal["NHD", "HND"] | None = None
@@ -1345,12 +1344,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Regex timeout for use by the vLLM tool parsing plugins.
     "VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS": lambda: int(
         os.getenv("VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS", "1")
-    ),
-    # Maximum characters allowed in a Kimi K2 tool section before forcing
-    # exit. Default 512KB (524288 chars). Set higher for very large tool
-    # call arguments (e.g., code generation).
-    "VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS": lambda: int(
-        os.getenv("VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS", "524288")
     ),
     # Control the max chunk bytes (in MB) for the rpc message queue.
     # Object larger than this threshold will be broadcast to worker

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -179,6 +179,7 @@ if TYPE_CHECKING:
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
+    VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS: int = 524288
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_KV_CACHE_LAYOUT: Literal["NHD", "HND"] | None = None
@@ -1344,6 +1345,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Regex timeout for use by the vLLM tool parsing plugins.
     "VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS": lambda: int(
         os.getenv("VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS", "1")
+    ),
+    # Maximum characters allowed in a Kimi K2 tool section before forcing
+    # exit. Default 512KB (524288 chars). Set higher for very large tool
+    # call arguments (e.g., code generation).
+    "VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS": lambda: int(
+        os.getenv("VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS", "524288")
     ),
     # Control the max chunk bytes (in MB) for the rpc message queue.
     # Object larger than this threshold will be broadcast to worker

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 
 import regex as re
 
-import vllm.envs as envs
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
@@ -38,7 +37,6 @@ class _StreamState:
 
     in_section: bool = False
     buffer: str = ""  # Rolling buffer for split marker detection
-    section_chars: int = 0  # Characters processed in current tool section
 
 
 class KimiK2ToolParser(ToolParser):
@@ -236,7 +234,6 @@ class KimiK2ToolParser(ToolParser):
             logger.debug("Entering tool section")
             st.in_section = True
             st.buffer = buffered_text
-            st.section_chars = 0
 
         if found_section_end and st.in_section:
             logger.debug("Detected section end marker")
@@ -278,21 +275,7 @@ class KimiK2ToolParser(ToolParser):
         # Strip section markers from delta_text for subsequent processing
         delta_text, _, _ = self._check_and_strip_markers(delta_text)
 
-        # --- Phase 4: Section length limit (configurable) ---
-        if st.in_section:
-            st.section_chars += len(delta_text)
-            max_chars = envs.VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS
-            if st.section_chars > max_chars:
-                logger.warning(
-                    "Tool section exceeded max length (%d chars, limit %d), "
-                    "forcing exit. This may indicate malformed model output.",
-                    st.section_chars,
-                    max_chars,
-                )
-                self._reset_section_state()
-                return DeltaMessage(content=delta_text if delta_text.strip() else "")
-
-        # --- Phase 5: Token-counting state machine ---
+        # --- Phase 4: Token-counting state machine ---
         try:
             # figure out where we are in the parsing by counting tool call
             # start & end tags

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -3,9 +3,11 @@
 # code modified from deepseekv3_tool_parser.py
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import regex as re
 
+import vllm.envs as envs
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
@@ -25,6 +27,19 @@ from vllm.tool_parsers.abstract_tool_parser import (
 
 logger = init_logger(__name__)
 
+# Buffer only needs to hold the longest marker (~28 chars) split across
+# two deltas. 256 bytes is generous but cheap.
+_BUFFER_MAX_SIZE = 256
+
+
+@dataclass
+class _StreamState:
+    """Mutable state for streaming tool section tracking."""
+
+    in_section: bool = False
+    buffer: str = ""  # Rolling buffer for split marker detection
+    section_chars: int = 0  # Characters processed in current tool section
+
 
 class KimiK2ToolParser(ToolParser):
     def __init__(self, tokenizer: TokenizerLike):
@@ -37,14 +52,7 @@ class KimiK2ToolParser(ToolParser):
         ] = []  # map what has been streamed for each tool so far to a list
 
         # Section-level state management to prevent token leakage
-        self.in_tool_section: bool = False
-        self.token_buffer: str = ""
-        # Buffer size: empirical worst-case for longest marker (~30 chars) * 2
-        # + safety margin for unicode + partial overlap. Prevents unbounded growth.
-        self.buffer_max_size: int = 1024
-        self.section_char_count: int = 0  # Track characters processed in tool section
-        self.max_section_chars: int = 8192  # Force exit if section exceeds this
-        self._buffer_overflow_logged: bool = False  # Log overflow once per session
+        self._stream_state = _StreamState()
 
         # Support both singular and plural variants
         self.tool_calls_start_token: str = "<|tool_calls_section_begin|>"
@@ -128,9 +136,7 @@ class KimiK2ToolParser(ToolParser):
 
     def _reset_section_state(self) -> None:
         """Reset state when exiting tool section."""
-        self.in_tool_section = False
-        self.token_buffer = ""
-        self.section_char_count = 0
+        self._stream_state = _StreamState()
 
     def reset_streaming_state(self) -> None:
         """
@@ -210,53 +216,43 @@ class KimiK2ToolParser(ToolParser):
         logger.debug("delta_text: %s", delta_text)
         logger.debug("delta_token_ids: %s", delta_token_ids)
 
-        # Flag to defer section exit until after tool parsing completes
+        st = self._stream_state
         deferred_section_exit = False
 
-        # Add delta to buffer for split marker detection
-        self.token_buffer += delta_text
+        # --- Phase 1: Buffer management and marker detection ---
+        st.buffer += delta_text
 
-        # Enforce buffer size limit to prevent memory issues
-        if len(self.token_buffer) > self.buffer_max_size:
-            if not self._buffer_overflow_logged:
-                logger.warning(
-                    "Token buffer exceeded max size (%d bytes), flushing excess. "
-                    "This may indicate very long markers or unusual tokenization.",
-                    self.buffer_max_size,
-                )
-                self._buffer_overflow_logged = True
-            # Keep only the most recent content that might contain partial markers
-            self.token_buffer = self.token_buffer[-self.buffer_max_size // 2 :]
+        # Trim buffer to keep only the tail needed for marker detection
+        if len(st.buffer) > _BUFFER_MAX_SIZE:
+            st.buffer = st.buffer[-_BUFFER_MAX_SIZE:]
 
         # Check buffer for section markers (handles split tokens)
         buffered_text, found_section_begin, found_section_end = (
-            self._check_and_strip_markers(self.token_buffer)
+            self._check_and_strip_markers(st.buffer)
         )
 
-        # Track section state transitions
-        if found_section_begin and not self.in_tool_section:
+        # --- Phase 2: Section state transitions ---
+        if found_section_begin and not st.in_section:
             logger.debug("Entering tool section")
-            self.in_tool_section = True
-            self.token_buffer = buffered_text  # Use cleaned buffer
-            self.section_char_count = 0  # Reset counter for new section
+            st.in_section = True
+            st.buffer = buffered_text
+            st.section_chars = 0
 
-        if found_section_end and self.in_tool_section:
+        if found_section_end and st.in_section:
             logger.debug("Detected section end marker")
             # CRITICAL: Don't exit early if tool_call_end is in this chunk.
-            # Tool parser must emit final arguments/close first to avoid dropping
-            # the final tool update and leaking tokens into reasoning channel.
+            # Tool parser must emit final arguments/close first to avoid
+            # dropping the final tool update and leaking tokens into
+            # reasoning channel.
             has_tool_end = self.tool_call_end_token_id in delta_token_ids
             if has_tool_end:
-                # Defer exit until after tool parsing completes
                 deferred_section_exit = True
                 logger.debug("Deferring section exit: tool_call_end in same chunk")
-                self.token_buffer = buffered_text
+                st.buffer = buffered_text
             else:
-                # No tool call ending, safe to exit immediately
                 logger.debug("Exiting tool section")
                 self._reset_section_state()
                 # Extract any content AFTER the section end marker in delta_text
-                # (don't use buffered_text as it contains tool call data)
                 post_section_content = ""
                 for variant in self.tool_calls_end_token_variants:
                     if variant in delta_text:
@@ -268,41 +264,35 @@ class KimiK2ToolParser(ToolParser):
                     return DeltaMessage(content=post_section_content)
                 return DeltaMessage(content="")
         else:
-            self.token_buffer = buffered_text
+            st.buffer = buffered_text
 
-        # Check if any variant of section start token is in current_token_ids
+        # --- Phase 3: Early returns for non-tool content ---
         has_section_token = any(
             tid in current_token_ids for tid in self.tool_calls_start_token_ids
         )
 
-        # Early return: if no section token detected yet, return as reasoning content
-        if not has_section_token and not self.in_tool_section:
+        if not has_section_token and not st.in_section:
             logger.debug("No tool call tokens found!")
-            # Don't clear buffer - it needs to accumulate partial markers across deltas
-            # Buffer overflow is already protected by lines 215-224
             return DeltaMessage(content=delta_text)
 
         # Strip section markers from delta_text for subsequent processing
-        # NOTE: This preprocessing happens BEFORE the regex-based tool call
-        # parsing (from PR #24847) to ensure markers are removed cleanly
-        # before pattern matching. No double-stripping occurs because
-        # section markers and tool call markers are distinct.
         delta_text, _, _ = self._check_and_strip_markers(delta_text)
 
-        # Error recovery: If in tool section for too long, force exit
-        if self.in_tool_section:
-            self.section_char_count += len(delta_text)
-            if self.section_char_count > self.max_section_chars:
+        # --- Phase 4: Section length limit (configurable) ---
+        if st.in_section:
+            st.section_chars += len(delta_text)
+            max_chars = envs.VLLM_KIMI_TOOL_PARSER_MAX_SECTION_CHARS
+            if st.section_chars > max_chars:
                 logger.warning(
-                    "Tool section exceeded max length (%d chars), forcing exit. "
-                    "This may indicate malformed model output.",
-                    self.max_section_chars,
+                    "Tool section exceeded max length (%d chars, limit %d), "
+                    "forcing exit. This may indicate malformed model output.",
+                    st.section_chars,
+                    max_chars,
                 )
                 self._reset_section_state()
-                # Deferred exit already handled by forced exit above
-                # Return remaining content as reasoning (or empty delta if no content)
                 return DeltaMessage(content=delta_text if delta_text.strip() else "")
 
+        # --- Phase 5: Token-counting state machine ---
         try:
             # figure out where we are in the parsing by counting tool call
             # start & end tags
@@ -326,12 +316,11 @@ class KimiK2ToolParser(ToolParser):
                 # Suppress content between section begin and first tool begin
                 # (header noise). Don't suppress content between tools to avoid
                 # breaking potential delimiter characters.
-                if self.in_tool_section and cur_tool_start_count == 0:
+                if st.in_section and cur_tool_start_count == 0:
                     logger.debug(
                         "In tool section before first tool, suppressing: %s",
                         delta_text,
                     )
-                    # Return empty delta to maintain iterator contract
                     return DeltaMessage(content="")
                 logger.debug("Generating text content! skipping tool parsing.")
                 return DeltaMessage(content=delta_text)
@@ -384,9 +373,6 @@ class KimiK2ToolParser(ToolParser):
             ):
                 if self.prev_tool_call_arr is None or len(self.prev_tool_call_arr) == 0:
                     logger.debug("attempting to close tool call, but no tool call")
-                    # Handle deferred section exit before returning
-                    if deferred_section_exit and self.in_tool_section:
-                        self._reset_section_state()
                     return None
                 diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
                 if diff:
@@ -396,9 +382,6 @@ class KimiK2ToolParser(ToolParser):
                         else diff
                     )
                     if '"}' not in delta_text:
-                        # Handle deferred section exit before returning
-                        if deferred_section_exit and self.in_tool_section:
-                            self._reset_section_state()
                         return None
                     end_loc = delta_text.rindex('"}')
                     diff = delta_text[:end_loc] + '"}'
@@ -408,10 +391,6 @@ class KimiK2ToolParser(ToolParser):
                         diff,
                     )
                     self.streamed_args_for_tool[self.current_tool_id] += diff
-                    # Handle deferred section exit before returning
-                    if deferred_section_exit and self.in_tool_section:
-                        logger.debug("Completing deferred section exit")
-                        self._reset_section_state()
                     return DeltaMessage(
                         tool_calls=[
                             DeltaToolCall(
@@ -425,20 +404,12 @@ class KimiK2ToolParser(ToolParser):
 
             # case -- otherwise we're just generating text
             else:
-                # Check if we're in tool section - if so, suppress
-                if self.in_tool_section:
+                if st.in_section:
                     logger.debug("In tool section, suppressing text generation")
-                    # Handle deferred section exit before returning
-                    if deferred_section_exit:
-                        self._reset_section_state()
                     return DeltaMessage(content="")
                 text = delta_text.replace(self.tool_call_start_token, "")
                 text = text.replace(self.tool_call_end_token, "")
-                delta = DeltaMessage(tool_calls=[], content=text)
-                # Handle deferred section exit before returning
-                if deferred_section_exit and self.in_tool_section:
-                    self._reset_section_state()
-                return delta
+                return DeltaMessage(tool_calls=[], content=text)
 
             current_tool_call = dict()
             if tool_call_portion:
@@ -496,7 +467,7 @@ class KimiK2ToolParser(ToolParser):
                 # if there's text but not tool calls, send that -
                 # otherwise None to skip chunk
                 # CRITICAL: Never return content if we're in a tool section
-                if self.in_tool_section:
+                if st.in_section:
                     return None
                 delta = (
                     DeltaMessage(content=delta_text)
@@ -588,13 +559,14 @@ class KimiK2ToolParser(ToolParser):
             else:
                 self.prev_tool_call_arr.append(current_tool_call)
 
-            # Handle deferred section exit after tool parsing completes
-            if deferred_section_exit and self.in_tool_section:
-                logger.debug("Completing deferred section exit")
-                self._reset_section_state()
-
             return delta
 
         except Exception:
             logger.exception("Error trying to handle streaming tool call.")
             return None  # do not stream a delta. skip this token ID.
+        finally:
+            # Single cleanup point for deferred section exit, replacing
+            # 7 copy-pasted checks across individual return paths.
+            if deferred_section_exit and self._stream_state.in_section:
+                logger.debug("Completing deferred section exit")
+                self._reset_section_state()


### PR DESCRIPTION
## Summary

Follow-up to #28543. The original streaming fix introduced a hard-coded 8KB section limit (`max_section_chars = 8192`) that truncates large tool call arguments, breaking coding use cases with Kimi-K2 and K2.5 models (reported in #37184, #30238).

This PR:
- **Removes the 8KB hard limit entirely** — the stream is already bounded by `max_model_len - input_length` via `get_max_tokens()` in `vllm/entrypoints/utils.py`, so a parser-level limit is unnecessary
- **Consolidates 6 scattered instance variables into a `_StreamState` dataclass** for cleaner state management
- **Eliminates 7 copy-pasted deferred section exit checks** with a single `try/finally` cleanup
- **Reduces the rolling buffer from 1KB to 256 bytes** (longest marker is 28 chars)

### What stays unchanged
- Non-streaming `extract_tool_calls()` — works fine
- Token-counting state machine — identical to DeepSeek V3 pattern
- Regex patterns (already fixed by #24847)
- Marker variant support (singular/plural)

## Test plan

- [x] All existing tests pass
- [x] 2 new regression tests added:
  - `test_multi_turn_section_reentry` — enter/exit/reenter tool sections in same stream
  - `test_thinking_tools_interleaving` — reasoning → tools → reasoning pattern (K2.5)
- [x] `ruff check` and `ruff format` pass
- [x] Run: `pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -v -s`

Closes #37184
Related: #30238
@chaunceyjiang