### PR TITLE
Don't log `exc_info` when vLLM tries to doenload a file that doesn't exist

### DIFF
--- a/vllm/transformers_utils/repo_utils.py
+++ b/vllm/transformers_utils/repo_utils.py
@@ -240,7 +240,7 @@ def _try_download_from_hf_hub(
         EntryNotFoundError,
         LocalEntryNotFoundError,
     ) as e:
-        logger.debug("File or repository not found in hf_hub_download:", exc_info=e)
+        logger.debug("File or repository not found in hf_hub_download: %s", e)
         return None
     except HfHubHTTPError as e:
         logger.warning(


### PR DESCRIPTION
Stops the error from logging the whole trace and instead just log the outcome, which looks like:

```console
$vllm serve Qwen/Qwen3-0.6B
...
(APIServer pid=512211) DEBUG 03-18 17:33:04 [transformers_utils/repo_utils.py:243] File or repository not found in hf_hub_download: 404 Client Error. (Request ID: Root=1-69bad3c0-7e2614cb419ee11c31e7220d;b239b780-98d7-469d-89ee-55afe6f6ecdf)
(APIServer pid=512211) DEBUG 03-18 17:33:04 [transformers_utils/repo_utils.py:243] 
(APIServer pid=512211) DEBUG 03-18 17:33:04 [transformers_utils/repo_utils.py:243] Entry Not Found for url: https://huggingface.co/Qwen/Qwen3-0.6B/resolve/main/processor_config.json.
```