### PR TITLE
 Fix NVFP4-quantized MoE checkpoint support for Step-3.5 Flash

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -2183,6 +2183,15 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
             if key.startswith(prefix_dot):
                 return info["quant_algo"].upper()
 
+        # 4. FusedMoE experts patch: prefix is e.g. "...moe.experts" but
+        #    quantized_layers keys use "...moe.gate_proj" / "...moe.up_proj".
+        #    Strip ".experts" and retry the prefix lookup.
+        if prefix.endswith(".experts"):
+            parent_dot = prefix.rsplit(".experts", 1)[0] + "."
+            for key, info in self.quantized_layers.items():
+                if key.startswith(parent_dot):
+                    return info["quant_algo"].upper()
+
         return None
 
     def get_quant_method(

--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -372,6 +372,9 @@ class FusedMoEBlock(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.share_expert",
         )
+        # NVFP4 FIX: The MoE experts should use quant_config directly
+        # The exclusion list in the checkpoint already specifies what to exclude
+        # (moe.gate, share_expert, etc.), so we don't need additional logic here
         self.experts = SharedFusedMoE(
             shared_experts=self.share_expert,
             gate=self.gate,
@@ -381,7 +384,7 @@ class FusedMoEBlock(nn.Module):
             intermediate_size=config.moe_intermediate_size,
             reduce_results=False,
             renormalize=config.norm_expert_weight,
-            quant_config=quant_config,
+            quant_config=quant_config,  # Pass quant_config correctly
             activation=activation,
             prefix=f"{prefix}.experts",
             scoring_func=getattr(config, "moe_router_activation", "sigmoid"),
@@ -647,6 +650,12 @@ class Step3p5Model(nn.Module):
             (".moe.experts.w13_weight", ".moe.gate_proj.weight", "w1"),
             (".moe.experts.w13_weight", ".moe.up_proj.weight", "w3"),
             (".moe.experts.w2_weight", ".moe.down_proj.weight", "w2"),
+            # NVFP4: per-expert input scales — must be loaded explicitly or
+            # w13_input_scale / w2_input_scale stay torch.empty (uninitialized),
+            # causing NaN logits and all-zero token generation.
+            (".moe.experts.w13_input_scale", ".moe.gate_proj.input_scale", "w1"),
+            (".moe.experts.w13_input_scale", ".moe.up_proj.input_scale", "w3"),
+            (".moe.experts.w2_input_scale", ".moe.down_proj.input_scale", "w2"),
         ]
 
         # New per-expert format: .moe.experts.E.gate_proj.weight_packed [out, in]
@@ -766,7 +775,11 @@ class Step3p5Model(nn.Module):
                     # Per-tensor global scales (e.g. weight_global_scale)
                     # have shape [1] in compressed-tensors NVFP4 checkpoints.
                     # Expand to per-expert before the iteration loop.
-                    if (
+                    if loaded_weight.ndim == 0:
+                        loaded_weight = loaded_weight.unsqueeze(0).expand(
+                            moe_expert_num
+                        )
+                    elif (
                         loaded_weight.shape[0] == 1
                         and loaded_weight.shape[0] != moe_expert_num
                     ):

--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -372,9 +372,6 @@ class FusedMoEBlock(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.share_expert",
         )
-        # NVFP4 FIX: The MoE experts should use quant_config directly
-        # The exclusion list in the checkpoint already specifies what to exclude
-        # (moe.gate, share_expert, etc.), so we don't need additional logic here
         self.experts = SharedFusedMoE(
             shared_experts=self.share_expert,
             gate=self.gate,
@@ -384,7 +381,7 @@ class FusedMoEBlock(nn.Module):
             intermediate_size=config.moe_intermediate_size,
             reduce_results=False,
             renormalize=config.norm_expert_weight,
-            quant_config=quant_config,  # Pass quant_config correctly
+            quant_config=quant_config,
             activation=activation,
             prefix=f"{prefix}.experts",
             scoring_func=getattr(config, "moe_router_activation", "sigmoid"),
@@ -650,9 +647,10 @@ class Step3p5Model(nn.Module):
             (".moe.experts.w13_weight", ".moe.gate_proj.weight", "w1"),
             (".moe.experts.w13_weight", ".moe.up_proj.weight", "w3"),
             (".moe.experts.w2_weight", ".moe.down_proj.weight", "w2"),
-            # NVFP4: per-expert input scales — must be loaded explicitly or
-            # w13_input_scale / w2_input_scale stay torch.empty (uninitialized),
-            # causing NaN logits and all-zero token generation.
+            # Required due to the Step3p5 HF model's packed expert format:
+            # input scales are stored as moe.{gate,up,down}_proj.input_scale
+            # rather than the standard per-expert format handled generically
+            # by make_expert_params_mapping.
             (".moe.experts.w13_input_scale", ".moe.gate_proj.input_scale", "w1"),
             (".moe.experts.w13_input_scale", ".moe.up_proj.input_scale", "w3"),
             (".moe.experts.w2_input_scale", ".moe.down_proj.input_scale", "w2"),


### PR DESCRIPTION

## Purpose

  Fix NVFP4-quantized MoE checkpoint support for Step-3.5 Flash. Three bugs in step3p5.py:

  1. MoE experts loaded as BF16 instead of NVFP4:   FusedMoEBlock and Step3p5MLP had extra is_layer_excluded() checks that incorrectly set quant_config=None for expert layers, bypassing quantization. The checkpoint's hf_quant_config.json exclusion list already handles this — the redundant checks caused double-exclusion. Fix: pass quant_config directly.

  2. Per-expert input_scale never loaded → NaN logits → empty output:   expert_params_mapping in load_weights only matched keys containing "weight" as a substring, so gate_proj.input_scale / up_proj.input_scale / down_proj.input_scale were silently dropped. This left w13_input_scale and w2_input_scale as uninitialized torch.empty(), producing NaN logits and all-zero token IDs on every decode step. Fix: add explicit input_scale entries to expert_params_mapping.

  3. Missing 0-dim scalar guard in weight loading loop:   Fix: add ndim == 0 check before the existing shape[0] == 1 expansion, to handle checkpoints that store scales as bare scalars.


## Test Plan

Tested with an internal NVFP4 checkpoint quantized by

## Test Result

 ✓ Memory: 56 GiB (quantized, vs ~120 GiB unquantized)
 ✓ Throughput: ~110 tok/s (TP=2, 2×RTX PRO 6000 Blackwell)

  Before: all token IDs = 0, empty output, finish_reason: length
  After:  coherent generation, finish_reason: stop

  Prompt: What is the capital of France?
  → The capital of France is Paris.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

