### PR TITLE
[Bugfix] Remove assertion for NVFP4 scale dynamic range

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -37,9 +37,6 @@ def _nvfp4_compute_scale_factor(marlin_scales: torch.Tensor) -> float:
         min_val = ws_float[nonzero_mask].min()
         if min_val < 2:
             sf = (2 / min_val).log2().ceil().exp2()
-            assert (ws_float[nonzero_mask] * sf <= 448 * (2**7)).all(), (
-                "NVFP4 scale dynamic range too large for rescaling"
-            )
             return sf.item()
     return 1.0
 


### PR DESCRIPTION
Removed assertion to check if NVFP4 scale dynamic range is too large for rescaling.


## Purpose

Remove this assert as it breaks Nemotron 3 Super https://github.com/vllm-project/vllm/pull/34577#issuecomment-4083666493

Jinzhen's opinion justifying:
> For now, I suggest commenting out this assertion rather than reverting the PR entirely. The end result should be the same, and even with a revert, we would still face subtle numerical precision issues. Moving forward, I recommend clamping extremely small scale values to zero, this should have a negligible impact on numerical consistency.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

