### PR TITLE
jais: only enable ALiBi when position_embedding_type == "alibi"

### DIFF
--- a/vllm/model_executor/models/jais.py
+++ b/vllm/model_executor/models/jais.py
@@ -120,8 +120,16 @@ class JAISAttention(nn.Module):
         tp_rank = get_tensor_model_parallel_rank()
         head_start = tp_rank * self.num_heads
         head_end = (tp_rank + 1) * self.num_heads
-        alibi_slopes = _get_alibi_slopes(total_num_heads)
-        alibi_slopes = alibi_slopes[head_start:head_end]
+        # Only enable ALiBi when the config explicitly requests it. If the
+        # positional embedding type is "alibi", compute and pass alibi_slopes;
+        # otherwise, pass None so no ALiBi bias is applied (avoids double
+        # positional encodings when learned embeddings are used).
+        use_alibi = getattr(config, "position_embedding_type", "") == "alibi"
+        alibi_slopes = None
+        if use_alibi:
+            _slopes = _get_alibi_slopes(total_num_heads)
+            alibi_slopes = _slopes[head_start:head_end]
+
         self.attn = Attention(
             self.num_heads,
             self.head_dim,


### PR DESCRIPTION
Summary
This change fixes a correctness issue in the JAIS model implementation where the ALiBi positional bias was unconditionally constructed and applied even when the model configuration used learned positional embeddings. Applying both learned positional embeddings and an ALiBi bias results in double positional encoding, which can lead to incorrect attention behavior for JAIS variants configured with learned positional embeddings.

What I changed
File: vllm/model_executor/models/jais.py
Change: ALiBi slopes are now only computed and passed to the Attention layer when the HF config explicitly sets position_embedding_type == "alibi". When position_embedding_type is other values (e.g., "learned"), alibi_slopes is set to None so no ALiBi bias is applied.

  Code excerpt (conceptual)
  
Before:
  alibi_slopes = _get_alibi_slopes(total_num_heads)
  alibi_slopes = alibi_slopes[head_start:head_end]
self.attn = Attention(..., alibi_slopes=alibi_slopes, ...)
  
After:
  use_alibi = getattr(config, "position_embedding_type", "") == "alibi"
  alibi_slopes = _get_alibi_slopes(...) if use_alibi else None
  self.attn = Attention(..., alibi_slopes=alibi_slopes, ...)

Why this fixes the issue
The JAISModel already conditionally creates the learned positional embedding (wpe) when position_embedding_type != "alibi", but the attention code was still enabling ALiBi unconditionally. This patch makes the attention implementation consistent with the model’s positional embedding config and prevents applying two forms of positional encoding simultaneously.

Testing & validation
I created a working branch (agent/37400-fix) with the change and pushed it to a fork (ahmedabbas104/vllm).
Recommended tests to run upstream or CI:
Unit tests covering attention behavior (existing attention tests exercise alibi paths; ensure none fail).
Model initialization checks for JAIS configs with position_embedding_type == "learned" and "alibi".
Minimal forward pass smoke test for a JAIS config using learned embeddings to confirm outputs run without ALiBi.

Backward compatibility
No behavior change for models configured with position_embedding_type == "alibi".
Models that rely on learned embeddings will no longer see redundant ALiBi bias.

Related issue
Fixes / addresses: vllm-project/vllm#37400
