### PR TITLE
[BugFix] Allow qk_nope_head_dim=192 in FlashInfer MLA backend checks

### DIFF
--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -86,9 +86,8 @@ class FlashInferMLABackend(MLACommonBackend):
             qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 1)
             if qk_nope_head_dim not in [64, 128, 192]:
                 return (
-                    "FlashInfer MLA kernel requires qk_nope_head_dim in [64, 128, "
-                    f"192], "
-                    f"but got {qk_nope_head_dim}"
+                    "FlashInfer MLA kernel requires qk_nope_head_dim "
+                    f"in [64, 128, 192], but got {qk_nope_head_dim}"
                 )
         return None
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -77,16 +77,17 @@ class FlashInferMLABackend(MLACommonBackend):
         use_sparse: bool,
         device_capability: DeviceCapability,
     ) -> str | None:
-        # FlashInfer MLA kernel requires qk_nope_head_dim in [64, 128]
+        # FlashInfer MLA kernel requires qk_nope_head_dim in [64, 128, 192]
         from vllm.config import get_current_vllm_config
 
         vllm_config = get_current_vllm_config()
         if vllm_config.model_config is not None:
             hf_text_config = vllm_config.model_config.hf_text_config
             qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 1)
-            if qk_nope_head_dim not in [64, 128]:
+            if qk_nope_head_dim not in [64, 128, 192]:
                 return (
-                    f"FlashInfer MLA kernel requires qk_nope_head_dim in [64, 128], "
+                    "FlashInfer MLA kernel requires qk_nope_head_dim in [64, 128, "
+                    f"192], "
                     f"but got {qk_nope_head_dim}"
                 )
         return None

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -113,16 +113,17 @@ class FlashInferMLASparseBackend(AttentionBackend):
         use_sparse: bool,
         device_capability: DeviceCapability,
     ) -> str | None:
-        # FlashInfer MLA sparse kernel requires qk_nope_head_dim == 128
+        # FlashInfer MLA sparse kernel requires qk_nope_head_dim in [128, 192]
         from vllm.config import get_current_vllm_config
 
         vllm_config = get_current_vllm_config()
         if vllm_config.model_config is not None:
             hf_text_config = vllm_config.model_config.hf_text_config
             qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 1)
-            if qk_nope_head_dim != 128:
+            if qk_nope_head_dim not in [128, 192]:
                 return (
-                    f"FlashInfer MLA Sparse kernel requires qk_nope_head_dim == 128, "
+                    "FlashInfer MLA Sparse kernel requires qk_nope_head_dim in "
+                    f"[128, 192], "
                     f"but got {qk_nope_head_dim}"
                 )
             # Check for index_topk which indicates sparse model

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -122,9 +122,8 @@ class FlashInferMLASparseBackend(AttentionBackend):
             qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 1)
             if qk_nope_head_dim not in [128, 192]:
                 return (
-                    "FlashInfer MLA Sparse kernel requires qk_nope_head_dim in "
-                    f"[128, 192], "
-                    f"but got {qk_nope_head_dim}"
+                    "FlashInfer MLA Sparse kernel requires qk_nope_head_dim "
+                    f"in [128, 192], but got {qk_nope_head_dim}"
                 )
             # Check for index_topk which indicates sparse model
             if not hasattr(hf_text_config, "index_topk"):


### PR DESCRIPTION


## Purpose

Align vLLM's FlashInfer MLA backend gating with [FlashInfer](https://github.com/flashinfer-ai/flashinfer/pull/2607) support for `qk_nope_head_dim=192' for glm-5 model.

## Test Plan

Run and check its accuracy
`vllm serve models/GLM-5-NVFP4   -tp 8   --trust-remote-code   --enable-auto-tool-choice   --tool-call-parser glm47   --reasoning-parser glm45   --enable-chunked-prefill   --max-num-batched-tokens 131072 --gpu-memory-utilization 0.80`

## Test Result

The model is now supported with normal output on gsm8k dataset. 