### PR TITLE
[Perf] Disable inductor size_asserts by default for serving performance

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -833,6 +833,16 @@ class CompilationConfig:
         if KEY not in self.inductor_compile_config:
             self.inductor_compile_config[KEY] = False
 
+        # Disable inductor size/stride assertions at runtime for performance.
+        # These assertions add ~2ms overhead per forward pass on large models
+        # (e.g., DeepSeek-R1 671B: ~340 assert_size_stride calls per forward).
+        # PyTorch is working on an assert-once solution; until then, we
+        # disable by default for serving. Users can re-enable via:
+        #   --compilation-config '{"inductor_compile_config": {"size_asserts": true}}'
+        # See: https://github.com/pytorch/pytorch/issues/177719
+        if "size_asserts" not in self.inductor_compile_config:
+            self.inductor_compile_config["size_asserts"] = False
+
         for k, v in self.inductor_passes.items():
             if not isinstance(v, str):
                 assert callable(v), f"pass {k} should be callable or a qualified name"


### PR DESCRIPTION
Inductor generates assert_size_stride() calls in compiled output code to validate tensor shapes and strides at runtime. For large models like DeepSeek-R1 671B with piecewise compilation, this results in ~340 C++ assert calls per forward pass, adding ~2ms overhead (~2.6% of TPOT at request rate 15).

These assertions are useful during development but unnecessary during production serving where tensor shapes are validated during the first compilation. This change disables size_asserts by default in vLLM's inductor compile config.

Users can re-enable assertions for debugging via:
  --compilation-config '{"inductor_compile_config": {"size_asserts": true}}'

PyTorch is also working on an assert-once solution upstream:
  https://github.com/pytorch/pytorch/issues/177719

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

