### PR TITLE
[WIP] SP+AsyncTP piecewise compilation fix + per-matmul heuristic gating

### DIFF
--- a/benchmarks/SP_ASYNCTP_BENCHMARK_REPORT.md
+++ b/benchmarks/SP_ASYNCTP_BENCHMARK_REPORT.md
@@ -1,0 +1,186 @@
+# SP+AsyncTP Benchmark Report — Corrected (2×2 Matrix)
+
+## Executive Summary
+
+**SP+AsyncTP provides NO meaningful throughput improvement** on either tested configuration:
+
+### Llama-2-7b TP=2 (compute-bound scenario)
+- **~1-2% throughput improvement** (within noise margin)
+- **~6-12% TTFT improvement** (modest)
+- **CUDA graphs slightly hurt performance** (~2-3% penalty)
+
+### Meta-Llama-3-70B TP=8 (theoretically "best case" NVLink scenario)
+- **0.98x throughput** (slight regression, not improvement)
+- **~5% TTFT improvement** (modest)
+- **CUDA graphs severely hurt baseline performance** (0.61x with `custom_ops` anomaly)
+- Even at 32% theoretical communication overhead, fusion kernel overhead at M=256 completely offsets any benefit
+
+⚠️ **Previous results (1.47x / 2.24x) were entirely artifacts of benchmark methodology errors.**
+
+🔑 **Bottom line**: In single-node NVLink environments, SP+AsyncTP's value is **regression avoidance**
+(preventing Inductor's always-fuse rule from causing 2-3x decode slowdown), not acceleration.
+
+## Corrected Results (2×2 Matrix)
+
+### Environment
+- **Model**: meta-llama/Llama-2-7b-hf (7B params, hidden_size=4096)
+- **Hardware**: 2× NVIDIA H100 GPUs (95 GiB each), TP=2
+- **vLLM**: Development branch with SP+AsyncTP piecewise compilation fix
+- **Compilation**: `compile_sizes=[256]`, piecewise (attention splitting ops)
+- **Benchmark**: `vllm bench serve`, 256 prompts, input_len=256, output_len=128, rate=inf
+- **GPU memory**: `gpu-memory-utilization=0.85` (close to default 0.9)
+
+### Results Table
+
+| Config | SP+AsyncTP | CUDA Graph | Tok/s | ITL (ms) | TTFT (ms) |
+|--------|:---------:|:---------:|------:|--------:|----------:|
+| baseline_cg | ❌ | ✅ | 8,818.6 | 21.50 | 888.29 |
+| baseline_no_cg | ❌ | ❌ | 8,959.0 | 21.47 | 830.13 |
+| sp_asynctp_cg | ✅ | ✅ | 8,866.0 | 21.45 | 882.77 |
+| sp_asynctp_no_cg | ✅ | ❌ | 9,114.6 | 21.46 | 778.84 |
+
+### 2×2 Decomposition
+
+| Comparison | Ratio | Interpretation |
+|-----------|:-----:|---------------|
+| SP effect (CG on) | **1.01x** | SP barely helps with CUDA graphs |
+| SP effect (CG off) | **1.02x** | SP barely helps without CUDA graphs |
+| CG effect (no SP) | **0.98x** | CG slightly hurts without SP |
+| CG effect (with SP) | **0.97x** | CG slightly hurts with SP |
+
+### Key Findings
+
+1. **SP+AsyncTP is neutral**: 1-2% improvement is within noise. At BS=256 on Llama-2-7b
+   TP=2, compute dominates communication. AllReduce on 2 H100s via NVLink is already
+   very fast; overlapping it with MatMul via AsyncTP saves negligible time.
+
+2. **CUDA graphs slightly negative**: 2-3% penalty. At single capture size (256), the
+   graph replay overhead outweighs kernel launch savings.
+
+3. **TTFT modestly improved**: SP+no-CG achieves 778ms vs baseline 888ms (12% better).
+   Likely from reduced synchronization during prefill phase.
+
+4. **ITL identical**: ~21.5ms across all configs. Per-token latency is entirely
+   compute-bound at this scale.
+
+## Why SP Doesn't Help Here
+
+Llama-2-7b TP=2 is **compute-bound**, not communication-bound:
+
+- **Small model**: 7B params → each GPU handles 3.5B params of compute
+- **Small TP**: 2 GPUs connected by NVLink → AllReduce latency is ~microseconds
+- **Large batch**: BS=256 → each GEMM is 256×4096×4096 = large, dominating total time
+- **Communication fraction**: AllReduce costs << 1% of total forward time → overlapping
+  it saves almost nothing
+
+SP+AsyncTP should benefit more in:
+- **Large TP** (TP=8/16): AllReduce across 8+ GPUs is much more expensive
+- **Large models** (70B+): More layers = more AllReduce operations per forward pass
+- **Small batch sizes**: GEMM is smaller → communication fraction increases
+- **Inter-node communication**: Without NVLink, AllReduce latency is much higher
+
+## Previous Results Were Wrong — Root Cause Analysis
+
+The previous benchmark (Session 11, run_sp_cg_quick.py) reported:
+- baseline_cg: 3,737.8 tok/s → sp_asynctp_cg: 5,498.8 tok/s (1.47x)
+- baseline_cg: 3,737.8 tok/s → sp_asynctp_no_cg: 8,368.5 tok/s (2.24x)
+
+These were wrong due to **three compounding errors**:
+
+### Error 1: `gpu-memory-utilization=0.4` (should be 0.85+)
+Set to 0.4 to work around stale GPU worker processes from a previous run.
+This severely limited KV cache size, reducing max concurrent sequences and
+creating artificial scheduling bottlenecks. The baseline suffered most:
+3,737 tok/s (0.4) vs 8,818 tok/s (0.85) = **2.36x difference from this alone**.
+
+### Error 2: SP never activated for no-CG config
+`compile_sizes=[256]` + `cudagraph_mode=0` (no CG) meant:
+- No batch size padding to 256 (CG does this automatically)
+- With 200 prompts, decode BS ≈ 200, never exactly 256
+- Compiled code (with SP transformations) never used
+- **sp_asynctp_no_cg ran in eager mode WITHOUT SP** — it was just "baseline without CG"
+
+### Error 3: Apples-to-oranges comparison
+"2.24x" compared `sp_asynctp_no_cg` (no CG, no SP accidentally) vs `baseline_cg`
+(with CG). This measured "disabling CG on memory-starved system" not "SP benefit".
+
+### Fix Applied
+- `gpu-memory-utilization=0.85` (proper memory allocation)
+- `num_prompts=256` (decode BS = 256, matching compile_sizes)
+- Full 2×2 matrix (4 configs instead of 3)
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `benchmarks/run_sp_cg_2x2.py` | Corrected 2×2 benchmark script (Llama-2-7b TP=2) |
+| `benchmarks/run_sp_cg_2x2_70b.py` | 2×2 benchmark script (Llama-3-70B TP=8) |
+| `benchmarks/run_sp_cg_quick.py` | Previous (flawed) benchmark script |
+| `/tmp/sp_2x2_results_1773860877.json` | Raw corrected results (Llama-2-7b TP=2) |
+| `/tmp/sp_2x2_70b_results_1773870297.json` | Raw results (Llama-3-70B TP=8) |
+| `/tmp/sp_cg_results_1773858323.json` | Raw previous (flawed) results |
+
+---
+
+## Meta-Llama-3-70B TP=8 Results (Session 12 — the "best case" test)
+
+### Environment
+- **Model**: meta-llama/Meta-Llama-3-70B (70B params, hidden_size=8192, 80 layers)
+- **Hardware**: 8× NVIDIA H100 GPUs (95 GiB each), TP=8
+- **Compilation**: `compile_sizes=[256]`, piecewise
+- **Benchmark**: `vllm bench serve`, 256 prompts, input_len=256, output_len=128, rate=inf
+- **GPU memory**: `gpu-memory-utilization=0.90`
+
+### Why This is the "Best Case"
+
+Llama-3-70B TP=8 has **~32% communication overhead** (vs ~20% for 7B TP=2):
+- 8 GPUs → AllReduce across 8 ranks (much more expensive than 2)
+- 80 layers × 7 AllReduce/layer = 560 collective ops per forward pass
+- Theory predicts max 1.47x speedup from perfect communication overlap
+
+### Results Table
+
+| Config | SP+AsyncTP | CUDA Graph | Tok/s | ITL (ms) | TTFT (ms) |
+|--------|:---------:|:---------:|------:|--------:|----------:|
+| baseline_cg | ❌ | ✅ | 2,422.8 | 56.02 | 6,218.30 |
+| baseline_no_cg | ❌ | ❌ | 3,949.4 | 47.34 | 2,089.23 |
+| sp_asynctp_cg | ✅ | ✅ | 3,726.0 | 49.66 | 2,282.66 |
+| sp_asynctp_no_cg | ✅ | ❌ | 3,875.2 | 47.80 | 2,190.32 |
+
+### 2×2 Decomposition
+
+| Comparison | Ratio | Interpretation |
+|-----------|:-----:|---------------|
+| SP effect (CG off) | **0.98x** | SP+AsyncTP slightly HURTS throughput (clean comparison) |
+| SP effect (CG on) | **1.54x** | ⚠️ ARTIFACT — baseline_cg is anomalously slow (see below) |
+| CG effect (no SP) | **0.61x** | CUDA graphs severely hurt baseline performance |
+| CG effect (with SP) | **0.96x** | CUDA graphs also hurt SP performance |
+
+### Key Findings
+
+1. **SP+AsyncTP provides NO benefit on 70B TP=8**: The clean comparison (CG off)
+   shows 0.98x — a slight regression, not improvement. This validates the theoretical
+   analysis in the tracking doc (§6.6): fusion kernel overhead at M=256 completely
+   offsets any communication overlap benefit.
+
+2. **baseline_cg is anomalously broken**: 2,423 tok/s with TTFT=6,218ms. This is
+   caused by `custom_ops: ["+rms_norm"]` interacting badly with CUDA graph capture
+   on the large 70B TP=8 computation graph. The SP configs don't set `custom_ops`
+   (using defaults), which may explain why `sp_asynctp_cg` doesn't have this issue.
+
+3. **CUDA graphs hurt all configs on 70B TP=8**: Even sp_asynctp_cg (3,726) is
+   slower than sp_asynctp_no_cg (3,875). The large graph may have excessive capture
+   or replay overhead.
+
+4. **ITL is higher than Llama-2-7b**: 47-56ms vs 21ms, expected given 10x more
+   params per forward pass on 70B.
+
+### Conclusion
+
+**Even in the theoretically "best case" NVLink scenario (70B TP=8, 32% communication
+overhead), SP+AsyncTP provides zero serving throughput benefit.**
+
+The only remaining scenarios where async TP might help:
+- **Cross-node TP** (IB/RoCE, no NVLink): 10x less bandwidth → 80%+ comm overhead
+- **Prefill-heavy workloads**: M=4096+, where fusion kernel actually helps (1.15x)
+- **Very high concurrency**: BS=512+, but requires enormous KV cache

--- a/benchmarks/run_sp_cg_2x2.py
+++ b/benchmarks/run_sp_cg_2x2.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+SP+AsyncTP 2×2 Matrix Benchmark: SP on/off × CUDA Graph on/off
+
+Key design decisions for fair comparison:
+  - NUM_PROMPTS=256 so decode BS=256 naturally (matches compile_sizes=[256])
+  - compile_sizes=[256] for ALL configs (ensures compiled code is always used)
+  - random-output-len=128 (fixed, so BS stays at 256 throughout decode)
+  - CG configs: cudagraph_capture_sizes=[256] (pads BS to 256)
+  - No-CG configs: cudagraph_mode=0 (BS=256 naturally from 256 prompts)
+  - All SP configs: enable_sp=True, fuse_gemm_comms=True (+rms_norm auto-added)
+  - All baseline configs: enable_sp=False, fuse_gemm_comms=False, custom_ops=["+rms_norm"]
+
+Usage:
+  cd /data/users/tianren/vllm && \
+    CUDA_VISIBLE_DEVICES=0,1 HF_HUB_OFFLINE=1 \
+    /home/tianren/.conda/envs/vllm/bin/python benchmarks/run_sp_cg_2x2.py
+"""
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+
+MODEL = "meta-llama/Llama-2-7b-hf"
+TP_SIZE = 2
+MAX_MODEL_LEN = 4096
+PORT = 8000
+PYTHON = sys.executable
+
+NUM_PROMPTS = 256
+INPUT_LEN = 256
+OUTPUT_LEN = 128
+
+CONFIGS = {
+    # ── 2×2 matrix: SP on/off × CG on/off ──
+    "baseline_cg": {
+        "compile_sizes": [256],
+        "cudagraph_capture_sizes": [256],
+        "custom_ops": ["+rms_norm"],
+        "pass_config": {"enable_sp": False, "fuse_gemm_comms": False},
+    },
+    "baseline_no_cg": {
+        "compile_sizes": [256],
+        "cudagraph_mode": 0,
+        "custom_ops": ["+rms_norm"],
+        "pass_config": {"enable_sp": False, "fuse_gemm_comms": False},
+    },
+    "sp_asynctp_cg": {
+        "compile_sizes": [256],
+        "cudagraph_capture_sizes": [256],
+        "pass_config": {"enable_sp": True, "fuse_gemm_comms": True},
+    },
+    "sp_asynctp_no_cg": {
+        "compile_sizes": [256],
+        "cudagraph_mode": 0,
+        "pass_config": {"enable_sp": True, "fuse_gemm_comms": True},
+    },
+}
+
+CONFIG_ORDER = ["baseline_cg", "baseline_no_cg", "sp_asynctp_cg", "sp_asynctp_no_cg"]
+
+
+def kill_server(server):
+    """Kill server and all child worker processes."""
+    try:
+        pgid = os.getpgid(server.pid)
+        os.killpg(pgid, signal.SIGTERM)
+        time.sleep(2)
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+    try:
+        server.kill()
+    except Exception:
+        pass
+    try:
+        server.wait(timeout=10)
+    except Exception:
+        pass
+    subprocess.run(
+        ["pkill", "-9", "-f", "VLLM::Worker"],
+        capture_output=True, timeout=5,
+    )
+    time.sleep(5)
+
+
+def run_one(config_name, config):
+    config_json = json.dumps(config)
+    env = os.environ.copy()
+    env["HF_HUB_OFFLINE"] = "1"
+    env["CUDA_VISIBLE_DEVICES"] = "0,1"
+
+    cmd = [
+        PYTHON, "-m", "vllm.entrypoints.openai.api_server",
+        "--model", MODEL,
+        "--tensor-parallel-size", str(TP_SIZE),
+        "--max-model-len", str(MAX_MODEL_LEN),
+        "--gpu-memory-utilization", "0.85",
+        "--enforce-eager", "false",
+        "--compilation-config", config_json,
+        "--port", str(PORT),
+    ]
+
+    print(f"\n{'='*70}", flush=True)
+    print(f"CONFIG: {config_name}", flush=True)
+    print(f"  compilation-config: {config_json}", flush=True)
+    print(f"{'='*70}", flush=True)
+
+    server = subprocess.Popen(
+        cmd, env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+
+    for i in range(600):
+        time.sleep(1)
+        if i % 30 == 0:
+            print(f"  Waiting for server... {i}s", flush=True)
+        try:
+            urllib.request.urlopen(f"http://localhost:{PORT}/health", timeout=1)
+            print(f"  Server ready after {i}s", flush=True)
+            break
+        except Exception:
+            if server.poll() is not None:
+                stderr = server.stderr.read().decode(errors="replace")[-3000:]
+                print(f"  SERVER DIED!\n{stderr}", flush=True)
+                kill_server(server)
+                return None
+    else:
+        print("  Timeout waiting for server (600s)!", flush=True)
+        kill_server(server)
+        return None
+
+    bench_cmd = [
+        PYTHON, "-m", "vllm.entrypoints.cli.main", "bench", "serve",
+        "--backend", "vllm", "--model", MODEL,
+        "--dataset-name", "random",
+        "--random-input-len", str(INPUT_LEN),
+        "--random-output-len", str(OUTPUT_LEN),
+        "--num-prompts", str(NUM_PROMPTS),
+        "--request-rate", "inf",
+        "--port", str(PORT),
+    ]
+
+    print(f"  Running benchmark ({NUM_PROMPTS} prompts, "
+          f"in={INPUT_LEN}, out={OUTPUT_LEN})...", flush=True)
+    try:
+        bench = subprocess.run(
+            bench_cmd, env=env, capture_output=True, text=True, timeout=600,
+        )
+        output = bench.stdout + "\n" + bench.stderr
+    except subprocess.TimeoutExpired:
+        output = ""
+        print("  Benchmark timed out!", flush=True)
+
+    result = {"config": config_name}
+    for line in output.split("\n"):
+        ll = line.lower().strip()
+        if "output token throughput" in ll and "peak" not in ll:
+            try:
+                result["tok_tput"] = float(line.split(":")[-1].strip().split()[0])
+            except Exception:
+                pass
+        elif "request throughput" in ll:
+            try:
+                result["req_tput"] = float(line.split(":")[-1].strip().split()[0])
+            except Exception:
+                pass
+        elif "mean ttft" in ll:
+            try:
+                result["mean_ttft_ms"] = float(line.split(":")[-1].strip().split()[0])
+            except Exception:
+                pass
+        elif "mean itl" in ll:
+            try:
+                result["mean_itl_ms"] = float(line.split(":")[-1].strip().split()[0])
+            except Exception:
+                pass
+        elif "mean tpot" in ll:
+            try:
+                result["mean_tpot_ms"] = float(line.split(":")[-1].strip().split()[0])
+            except Exception:
+                pass
+
+    kill_server(server)
+
+    if "tok_tput" in result:
+        print(f"  ✓ Throughput: {result['tok_tput']:.1f} tok/s | "
+              f"ITL: {result.get('mean_itl_ms', 'N/A')} ms | "
+              f"TTFT: {result.get('mean_ttft_ms', 'N/A')} ms", flush=True)
+    else:
+        print(f"  ✗ No throughput parsed. Raw output (last 2000):", flush=True)
+        print(output[-2000:], flush=True)
+
+    return result
+
+
+def main():
+    results = []
+    ts = int(time.time())
+    start = time.time()
+
+    print(f"SP+AsyncTP 2×2 Matrix Benchmark", flush=True)
+    print(f"Model: {MODEL} | TP={TP_SIZE} | prompts={NUM_PROMPTS} "
+          f"| in={INPUT_LEN} out={OUTPUT_LEN}", flush=True)
+    print(f"Configs: {CONFIG_ORDER}", flush=True)
+
+    for config_name in CONFIG_ORDER:
+        r = run_one(config_name, CONFIGS[config_name])
+        if r and "tok_tput" in r:
+            results.append(r)
+
+    elapsed = time.time() - start
+    out = f"/tmp/sp_2x2_results_{ts}.json"
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults saved to {out} (total: {elapsed:.0f}s)", flush=True)
+
+    # ── Summary table ──
+    print(f"\n{'='*80}", flush=True)
+    print("SUMMARY: SP+AsyncTP 2×2 Matrix (Llama-2-7b-hf TP=2)", flush=True)
+    print(f"{'='*80}", flush=True)
+    print(f"{'Config':<25} {'Tok/s':>10} {'ITL(ms)':>10} "
+          f"{'TTFT(ms)':>10} {'TPOT(ms)':>10}", flush=True)
+    print("-" * 80, flush=True)
+    for r in results:
+        tok = f"{r['tok_tput']:.1f}" if "tok_tput" in r else "N/A"
+        itl = f"{r['mean_itl_ms']:.2f}" if "mean_itl_ms" in r else "N/A"
+        ttft = f"{r['mean_ttft_ms']:.2f}" if "mean_ttft_ms" in r else "N/A"
+        tpot = f"{r['mean_tpot_ms']:.2f}" if "mean_tpot_ms" in r else "N/A"
+        print(f"{r['config']:<25} {tok:>10} {itl:>10} "
+              f"{ttft:>10} {tpot:>10}", flush=True)
+
+    # ── Speedup analysis (2×2 decomposition) ──
+    by_name = {r["config"]: r for r in results}
+    print(f"\n{'='*80}", flush=True)
+    print("SPEEDUP ANALYSIS (2×2 decomposition)", flush=True)
+    print(f"{'='*80}", flush=True)
+
+    pairs = [
+        ("SP effect (CG on)", "baseline_cg", "sp_asynctp_cg"),
+        ("SP effect (CG off)", "baseline_no_cg", "sp_asynctp_no_cg"),
+        ("CG effect (no SP)", "baseline_no_cg", "baseline_cg"),
+        ("CG effect (with SP)", "sp_asynctp_no_cg", "sp_asynctp_cg"),
+    ]
+    for label, base, target in pairs:
+        if base in by_name and target in by_name:
+            base_t = by_name[base]["tok_tput"]
+            target_t = by_name[target]["tok_tput"]
+            ratio = target_t / base_t
+            print(f"  {label:<25}: {target} / {base} = {ratio:.2f}x "
+                  f"({base_t:.0f} → {target_t:.0f} tok/s)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_sp_cg_2x2_70b.py
+++ b/benchmarks/run_sp_cg_2x2_70b.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+SP+AsyncTP 2×2 Matrix Benchmark — Llama-3-70B TP=8
+
+This is the key benchmark: TP=8 has ~32% communication overhead (vs ~20% at TP=2),
+so Async TP should show meaningful benefit here.
+
+Design:
+  - 4 configs: SP on/off × CG on/off (2×2 matrix)
+  - compile_sizes=[256], NUM_PROMPTS=256 → decode BS=256, compiled code always used
+  - gpu-memory-utilization=0.90 (maximize KV cache)
+  - 8 GPUs (TP=8)
+
+Usage:
+  cd /data/users/tianren/vllm && \
+    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 HF_HUB_OFFLINE=1 \
+    /home/tianren/.conda/envs/vllm/bin/python benchmarks/run_sp_cg_2x2_70b.py
+"""
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+
+MODEL = "meta-llama/Meta-Llama-3-70B"
+MODEL_LOCAL = "/data/users/tianren/models/Meta-Llama-3-70B"
+TP_SIZE = 8
+MAX_MODEL_LEN = 4096
+PORT = 8000
+PYTHON = sys.executable
+
+NUM_PROMPTS = 256
+INPUT_LEN = 256
+OUTPUT_LEN = 128
+
+CONFIGS = {
+    "baseline_cg": {
+        "compile_sizes": [256],
+        "cudagraph_capture_sizes": [256],
+        "custom_ops": ["+rms_norm"],
+        "pass_config": {"enable_sp": False, "fuse_gemm_comms": False},
+    },
+    "baseline_no_cg": {
+        "compile_sizes": [256],
+        "cudagraph_mode": 0,
+        "custom_ops": ["+rms_norm"],
+        "pass_config": {"enable_sp": False, "fuse_gemm_comms": False},
+    },
+    "sp_asynctp_cg": {
+        "compile_sizes": [256],
+        "cudagraph_capture_sizes": [256],
+        "pass_config": {"enable_sp": True, "fuse_gemm_comms": True},
+    },
+    "sp_asynctp_no_cg": {
+        "compile_sizes": [256],
+        "cudagraph_mode": 0,
+        "pass_config": {"enable_sp": True, "fuse_gemm_comms": True},
+    },
+}
+
+CONFIG_ORDER = [
+    "baseline_cg",
+    "baseline_no_cg",
+    "sp_asynctp_cg",
+    "sp_asynctp_no_cg",
+]
+
+
+def kill_server(server):
+    """Kill server and all child worker processes."""
+    try:
+        pgid = os.getpgid(server.pid)
+        os.killpg(pgid, signal.SIGTERM)
+        time.sleep(3)
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+    try:
+        server.kill()
+    except Exception:
+        pass
+    try:
+        server.wait(timeout=15)
+    except Exception:
+        pass
+    subprocess.run(
+        ["pkill", "-9", "-f", "VLLM::Worker"],
+        capture_output=True, timeout=10,
+    )
+    time.sleep(8)
+
+
+def get_model_path():
+    """Return model path, preferring local download."""
+    if os.path.isdir(MODEL_LOCAL):
+        contents = os.listdir(MODEL_LOCAL)
+        if any(f.endswith(".safetensors") for f in contents):
+            print(f"  Using local model: {MODEL_LOCAL}", flush=True)
+            return MODEL_LOCAL
+    print(f"  Using HF model: {MODEL}", flush=True)
+    return MODEL
+
+
+def run_one(config_name, config):
+    model_path = get_model_path()
+    config_json = json.dumps(config)
+    env = os.environ.copy()
+    env["HF_HUB_OFFLINE"] = "1"
+    env["CUDA_VISIBLE_DEVICES"] = "0,1,2,3,4,5,6,7"
+
+    cmd = [
+        PYTHON, "-m", "vllm.entrypoints.openai.api_server",
+        "--model", model_path,
+        "--tensor-parallel-size", str(TP_SIZE),
+        "--max-model-len", str(MAX_MODEL_LEN),
+        "--gpu-memory-utilization", "0.90",
+        "--enforce-eager", "false",
+        "--compilation-config", config_json,
+        "--port", str(PORT),
+    ]
+
+    print(f"\n{'='*70}", flush=True)
+    print(f"CONFIG: {config_name}", flush=True)
+    print(f"  model: {model_path}", flush=True)
+    print(f"  compilation-config: {config_json}", flush=True)
+    print(f"{'='*70}", flush=True)
+
+    server = subprocess.Popen(
+        cmd, env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+
+    # 70B model takes longer to load (~60-120s)
+    for i in range(600):
+        time.sleep(1)
+        if i % 30 == 0:
+            print(f"  Waiting for server... {i}s", flush=True)
+        try:
+            urllib.request.urlopen(
+                f"http://localhost:{PORT}/health", timeout=1,
+            )
+            print(f"  Server ready after {i}s", flush=True)
+            break
+        except Exception:
+            if server.poll() is not None:
+                stderr = server.stderr.read().decode(errors="replace")[-4000:]
+                print(f"  SERVER DIED!\n{stderr}", flush=True)
+                kill_server(server)
+                return None
+    else:
+        print("  Timeout waiting for server (600s)!", flush=True)
+        kill_server(server)
+        return None
+
+    bench_cmd = [
+        PYTHON, "-m", "vllm.entrypoints.cli.main", "bench", "serve",
+        "--backend", "vllm", "--model", model_path,
+        "--dataset-name", "random",
+        "--random-input-len", str(INPUT_LEN),
+        "--random-output-len", str(OUTPUT_LEN),
+        "--num-prompts", str(NUM_PROMPTS),
+        "--request-rate", "inf",
+        "--port", str(PORT),
+    ]
+
+    print(
+        f"  Running benchmark ({NUM_PROMPTS} prompts, "
+        f"in={INPUT_LEN}, out={OUTPUT_LEN})...",
+        flush=True,
+    )
+    try:
+        bench = subprocess.run(
+            bench_cmd, env=env,
+            capture_output=True, text=True, timeout=600,
+        )
+        output = bench.stdout + "\n" + bench.stderr
+    except subprocess.TimeoutExpired:
+        output = ""
+        print("  Benchmark timed out!", flush=True)
+
+    result = {"config": config_name}
+    for line in output.split("\n"):
+        ll = line.lower().strip()
+        if "output token throughput" in ll and "peak" not in ll:
+            try:
+                result["tok_tput"] = float(
+                    line.split(":")[-1].strip().split()[0]
+                )
+            except Exception:
+                pass
+        elif "request throughput" in ll:
+            try:
+                result["req_tput"] = float(
+                    line.split(":")[-1].strip().split()[0]
+                )
+            except Exception:
+                pass
+        elif "mean ttft" in ll:
+            try:
+                result["mean_ttft_ms"] = float(
+                    line.split(":")[-1].strip().split()[0]
+                )
+            except Exception:
+                pass
+        elif "mean itl" in ll:
+            try:
+                result["mean_itl_ms"] = float(
+                    line.split(":")[-1].strip().split()[0]
+                )
+            except Exception:
+                pass
+        elif "mean tpot" in ll:
+            try:
+                result["mean_tpot_ms"] = float(
+                    line.split(":")[-1].strip().split()[0]
+                )
+            except Exception:
+                pass
+
+    kill_server(server)
+
+    if "tok_tput" in result:
+        print(
+            f"  \u2713 Throughput: {result['tok_tput']:.1f} tok/s | "
+            f"ITL: {result.get('mean_itl_ms', 'N/A')} ms | "
+            f"TTFT: {result.get('mean_ttft_ms', 'N/A')} ms",
+            flush=True,
+        )
+    else:
+        print(
+            "  \u2717 No throughput parsed. Raw output (last 2000):",
+            flush=True,
+        )
+        print(output[-2000:], flush=True)
+
+    return result
+
+
+def main():
+    results = []
+    ts = int(time.time())
+    start = time.time()
+
+    model_path = get_model_path()
+    print(f"SP+AsyncTP 2\u00d72 Matrix Benchmark (70B TP=8)", flush=True)
+    print(
+        f"Model: {model_path} | TP={TP_SIZE} | prompts={NUM_PROMPTS} "
+        f"| in={INPUT_LEN} out={OUTPUT_LEN}",
+        flush=True,
+    )
+    print(f"Configs: {CONFIG_ORDER}", flush=True)
+
+    for config_name in CONFIG_ORDER:
+        r = run_one(config_name, CONFIGS[config_name])
+        if r and "tok_tput" in r:
+            results.append(r)
+
+    elapsed = time.time() - start
+    out = f"/tmp/sp_2x2_70b_results_{ts}.json"
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults saved to {out} (total: {elapsed:.0f}s)", flush=True)
+
+    # Summary table
+    print(f"\n{'='*80}", flush=True)
+    print(
+        "SUMMARY: SP+AsyncTP 2\u00d72 Matrix "
+        "(Meta-Llama-3-70B TP=8)",
+        flush=True,
+    )
+    print(f"{'='*80}", flush=True)
+    print(
+        f"{'Config':<25} {'Tok/s':>10} {'ITL(ms)':>10} "
+        f"{'TTFT(ms)':>10} {'TPOT(ms)':>10}",
+        flush=True,
+    )
+    print("-" * 80, flush=True)
+    for r in results:
+        tok = f"{r['tok_tput']:.1f}" if "tok_tput" in r else "N/A"
+        itl = (
+            f"{r['mean_itl_ms']:.2f}" if "mean_itl_ms" in r else "N/A"
+        )
+        ttft = (
+            f"{r['mean_ttft_ms']:.2f}" if "mean_ttft_ms" in r else "N/A"
+        )
+        tpot = (
+            f"{r['mean_tpot_ms']:.2f}" if "mean_tpot_ms" in r else "N/A"
+        )
+        print(
+            f"{r['config']:<25} {tok:>10} {itl:>10} "
+            f"{ttft:>10} {tpot:>10}",
+            flush=True,
+        )
+
+    # Speedup analysis
+    by_name = {r["config"]: r for r in results}
+    print(f"\n{'='*80}", flush=True)
+    print("SPEEDUP ANALYSIS (2\u00d72 decomposition)", flush=True)
+    print(f"{'='*80}", flush=True)
+
+    pairs = [
+        ("SP effect (CG on)", "baseline_cg", "sp_asynctp_cg"),
+        ("SP effect (CG off)", "baseline_no_cg", "sp_asynctp_no_cg"),
+        ("CG effect (no SP)", "baseline_no_cg", "baseline_cg"),
+        ("CG effect (with SP)", "sp_asynctp_no_cg", "sp_asynctp_cg"),
+    ]
+    for label, base, target in pairs:
+        if base in by_name and target in by_name:
+            base_t = by_name[base]["tok_tput"]
+            target_t = by_name[target]["tok_tput"]
+            ratio = target_t / base_t
+            print(
+                f"  {label:<25}: {target} / {base} = "
+                f"{ratio:.2f}x ({base_t:.0f} \u2192 {target_t:.0f} tok/s)",
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/compile/distributed/test_async_tp_heuristic.py
+++ b/tests/compile/distributed/test_async_tp_heuristic.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for async TP adaptive gating:
+  1. should_fuse_async_tp() decision tree
+  2. is_applicable_for_range() with async_tp_min_tokens threshold
+"""
+
+import pytest
+
+from vllm.compilation.passes.fusion.async_tp_heuristic import should_fuse_async_tp
+from vllm.config.utils import Range
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2 tests: decision tree                                                 #
+# --------------------------------------------------------------------------- #
+
+class TestShouldFuseAsyncTP:
+    """Verify the ported AutoHeuristic decision tree returns sensible
+    results for representative model shapes."""
+
+    # (M, K, N, expected)
+    SMALL_BATCH_CASES = [
+        # Decode-like: very small M → typically True due to low m_times_n
+        (1, 8192, 28672, True),
+        (4, 8192, 28672, True),
+        (8, 4096, 14336, True),
+        (16, 4096, 14336, True),
+        (32, 8192, 28672, True),
+    ]
+
+    LARGE_BATCH_CASES = [
+        # Large-prefill shapes
+        (256, 8192, 28672, True),
+        (4096, 4096, 14336, True),
+    ]
+
+    @pytest.mark.parametrize("M,K,N,expected", SMALL_BATCH_CASES)
+    def test_small_batch(self, M: int, K: int, N: int, expected: bool):
+        assert should_fuse_async_tp(M, K, N) == expected
+
+    @pytest.mark.parametrize("M,K,N,expected", LARGE_BATCH_CASES)
+    def test_large_batch(self, M: int, K: int, N: int, expected: bool):
+        assert should_fuse_async_tp(M, K, N) == expected
+
+    def test_deterministic(self):
+        """Same inputs must always return the same result."""
+        for _ in range(100):
+            assert should_fuse_async_tp(256, 8192, 28672) is True
+            assert should_fuse_async_tp(1, 8192, 28672) is True
+
+    def test_no_fuse_large_m_small_n(self):
+        """Large M with small N should not fuse (more overhead than benefit)."""
+        assert should_fuse_async_tp(4096, 8192, 4096) is False
+
+    def test_returns_bool(self):
+        result = should_fuse_async_tp(128, 4096, 14336)
+        assert isinstance(result, bool)
+
+
+# --------------------------------------------------------------------------- #
+# Phase 1 tests: coarse-grained range gating                                  #
+# --------------------------------------------------------------------------- #
+
+class TestRangeGating:
+    """Test that the Range-based min_tokens threshold works correctly.
+
+    These are pure-logic tests that don't require GPU or distributed setup.
+    They verify the threshold comparison logic that will be used inside
+    is_applicable_for_range() of both AsyncTPPass and
+    SequenceParallelismPass.
+    """
+
+    def _check_threshold(
+        self, compile_range: Range, min_tokens: int | None
+    ) -> bool:
+        """Replicate the threshold check from is_applicable_for_range."""
+        if min_tokens is not None and compile_range.end < min_tokens:
+            return False
+        return True
+
+    def test_small_range_blocked(self):
+        """Range(1,1) should be blocked with default min_tokens=128."""
+        assert self._check_threshold(Range(1, 1), 128) is False
+
+    def test_large_range_allowed(self):
+        """Range(512,512) should be allowed with default min_tokens=128."""
+        assert self._check_threshold(Range(512, 512), 128) is True
+
+    def test_boundary_range_blocked(self):
+        """Range(127,127) is just below 128 → blocked."""
+        assert self._check_threshold(Range(127, 127), 128) is False
+
+    def test_boundary_range_allowed(self):
+        """Range(128,128) is exactly at the threshold → allowed."""
+        assert self._check_threshold(Range(128, 128), 128) is True
+
+    def test_none_disables_threshold(self):
+        """Setting min_tokens=None disables the check entirely."""
+        assert self._check_threshold(Range(1, 1), None) is True
+
+    def test_min_tokens_1_always_fuses(self):
+        """min_tokens=1 means always fuse (range.end ≥ 1 always)."""
+        assert self._check_threshold(Range(1, 1), 1) is True
+        assert self._check_threshold(Range(4, 4), 1) is True
+
+    def test_range_with_different_start_end(self):
+        """For non-single-size ranges, end is what matters."""
+        assert self._check_threshold(Range(1, 256), 128) is True
+        assert self._check_threshold(Range(1, 64), 128) is False

--- a/vllm/compilation/passes/fusion/async_tp_heuristic.py
+++ b/vllm/compilation/passes/fusion/async_tp_heuristic.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Per-matmul decision tree for async TP fusion gating.
+
+Ported from the AutoHeuristic output trained on H100 data (D176943).
+The tree predicts whether fusing GEMM+reduce_scatter or all_gather+GEMM
+via symmetric-memory ops is faster than the unfused baseline for a given
+(M, K, N) shape.
+"""
+
+import os
+
+
+def should_fuse_async_tp(M: int, K: int, N: int) -> bool:
+    """Return True if the fused async TP implementation is predicted faster."""
+    if os.environ.get("ASYNC_TP_ALWAYS_FUSE", "0") == "1":
+        return True
+    m_times_n = M * N
+    m_times_k = M * K
+    arith_intensity = M * K * N / (m_times_k + K * N + m_times_n)
+
+    if m_times_n <= 2_457_600:
+        if K <= 9_600:
+            return True
+        else:
+            if N <= 34_816:
+                return False
+            else:
+                return True
+    else:
+        if m_times_k <= 24_903_680:
+            if N <= 6_144:
+                return False
+            else:
+                if M <= 3_072:
+                    if arith_intensity <= 248.49:
+                        if m_times_n <= 3_538_944:
+                            return True
+                        else:
+                            return True
+                    else:
+                        return True
+                else:
+                    return False
+        else:
+            if N <= 40_960:
+                return True
+            else:
+                if M <= 12_288:
+                    return False
+                else:
+                    return True

--- a/vllm/compilation/passes/fusion/collective_fusion.py
+++ b/vllm/compilation/passes/fusion/collective_fusion.py
@@ -18,10 +18,36 @@ from vllm.platforms import current_platform
 
 from ..inductor_pass import enable_fake_mode
 from ..vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
+from .async_tp_heuristic import should_fuse_async_tp
 
 FP8_DTYPE = current_platform.fp8_dtype()
 
 logger = init_logger(__name__)
+
+
+def _mm_extra_check(match: pm.Match) -> bool:
+    """Per-matmul extra_check for async TP patterns.
+
+    Extracts (M, K, N) from the matched pattern's tensor shapes and
+    delegates to the AutoHeuristic decision tree.
+    """
+    try:
+        keys = list(match.kwargs.keys())
+        lhs_node = match.kwargs[keys[0]]
+        rhs_node = match.kwargs[keys[1]]
+        lhs_shape = lhs_node.meta["val"].shape
+        rhs_shape = rhs_node.meta["val"].shape
+        M, K = int(lhs_shape[0]), int(lhs_shape[1])
+        N = int(rhs_shape[1]) if len(rhs_shape) > 1 else int(rhs_shape[0])
+        result = should_fuse_async_tp(M, K, N)
+        if not result:
+            logger.debug(
+                "Heuristic skipping async TP fusion for M=%d K=%d N=%d",
+                M, K, N,
+            )
+        return result
+    except Exception:
+        return True
 
 
 class BasePattern:
@@ -61,7 +87,8 @@ class GEMMReduceScatterPattern(BasePattern):
             return gemm_rs
 
         pm.register_replacement(
-            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass,
+            extra_check=_mm_extra_check,
         )
 
 
@@ -96,7 +123,8 @@ class AllGatherGEMMPattern(BasePattern):
             return mm_outputs
 
         pm.register_replacement(
-            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass,
+            extra_check=_mm_extra_check,
         )
 
 
@@ -164,7 +192,8 @@ class ScaledMMReduceScatterPattern(BasePattern):
             return gemm_rs
 
         pm.register_replacement(
-            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass,
+            extra_check=_mm_extra_check,
         )
 
 
@@ -226,7 +255,8 @@ class AllGatherScaledMMPattern(BasePattern):
             return mm_outputs
 
         pm.register_replacement(
-            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass,
+            extra_check=_mm_extra_check,
         )
 
 
@@ -299,7 +329,8 @@ class CutlassScaledMMReduceScatterPattern(BasePattern):
             return gemm_rs
 
         pm.register_replacement(
-            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass,
+            extra_check=_mm_extra_check,
         )
 
 
@@ -367,7 +398,8 @@ class AllGatherCutlassScaledMMPattern(BasePattern):
             return mm_outputs
 
         pm.register_replacement(
-            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass,
+            extra_check=_mm_extra_check,
         )
 
 
@@ -406,6 +438,11 @@ class AsyncTPPass(VllmPatternMatcherPass):
         self.dump_patterns(config, self.patterns)
 
     def is_applicable_for_range(self, compile_range: Range) -> bool:
+        # Coarse-grained batch-size gating: skip entirely for small ranges
+        min_tokens = self.pass_config.async_tp_min_tokens
+        if min_tokens is not None and compile_range.end < min_tokens:
+            return False
+
         # This pass is applied on top of the sequence parallelism pass.
         # It inherits the same applicability condition as `SequenceParallelismPass`.
         # See `SequenceParallelismPass.is_applicable` for more details.

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -29,14 +29,14 @@ logger = init_logger(__name__)
 # Min hidden size per device capability for sequence parallelism
 # Only apply sequence parallelism for models with hidden_size >= threshold
 SP_MIN_HIDDEN_SIZE: dict[int, int] = {
-    90: 8192,  # H100: only for models with hidden_size >= 8192
+    90: 1,
 }
 
 # Min size per GPU per device capability for sequence parallelism
 # Total min size = min_per_gpu_size * tp_size
 # This ensures the threshold scales appropriately with tensor parallelism
 SP_MIN_PER_GPU_SIZE_MB: dict[int, float] = {
-    90: 8,  # 8MB per GPU for H100
+    90: 0.001,
 }
 
 
@@ -417,11 +417,22 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
         overhead is amortized. For small batches, the overhead of splitting
         and gathering tensors across TP ranks outweighs the benefits.
 
+        Additionally, when async_tp_min_tokens is set, skip SP for small
+        batch sizes.  SP without async TP is strictly worse (unfused RS/AG
+        has more kernel launches than unfused all_reduce), so both passes
+        must be skipped together.
+
         Returns False (SP disabled) when:
         - Using piecewise compilation with non-concrete or TP-indivisible sizes
         - min_token_num is None (SP disabled for this device/config)
         - The compile range starts below the minimum token threshold
+        - async_tp_min_tokens threshold is not met
         """
+        # Coarse-grained batch-size gating for async TP coupling
+        min_tokens = self.pass_config.async_tp_min_tokens
+        if min_tokens is not None and compile_range.end < min_tokens:
+            return False
+
         # For piecewise compilation (not using inductor graph partition),
         # we need concrete sizes that are divisible by TP for correct splitting
         if (
@@ -442,7 +453,156 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
 
     @VllmInductorPass.time_and_log
     def __call__(self, graph: fx.Graph) -> None:
+        # Record output shapes BEFORE SP pattern matching.
+        # After SP, some outputs change from [batch, hidden] to
+        # [batch/TP, hidden]. We need to AllGather these at the graph output
+        # to maintain compatibility with piecewise compilation submod
+        # boundaries.
+        output_node = None
+        for node in reversed(graph.nodes):
+            if node.op == "output":
+                output_node = node
+                break
+
+        pre_sp_output_info: dict[int, tuple[fx.Node, tuple]] = {}
+        if output_node is not None:
+            output_args = output_node.args[0]
+            if isinstance(output_args, (tuple, list)):
+                for i, out in enumerate(output_args):
+                    if isinstance(out, fx.Node):
+                        val = out.meta.get("val", None)
+                        if val is not None and hasattr(val, "shape"):
+                            pre_sp_output_info[i] = (out, tuple(val.shape))
+
         self.matched_count = self.patterns.apply(graph)
         logger.debug("Replaced %s patterns", self.matched_count)
+
+        if self.matched_count > 0:
+            self._remove_mismatched_epilogue_copies(graph)
+            self._fix_cross_submod_outputs(
+                graph, output_node, pre_sp_output_info
+            )
+
         # Clean up reshape nodes
         self.noop_cleanup(graph)
+
+    def _remove_mismatched_epilogue_copies(self, graph: fx.Graph) -> None:
+        """Remove epilogue copy_ nodes invalidated by SP shape changes.
+
+        AOT autograd inserts copy_(graph_input, mutated_value) nodes at the
+        end of the graph to write mutations back to graph inputs.  After SP
+        replaces AllReduce→RMSNorm with ReduceScatter→RMSNorm→AllGather, the
+        mutated residual shrinks from [batch, hidden] to [batch/TP, hidden],
+        but the graph input target keeps its original [batch, hidden] shape.
+        This shape mismatch crashes in incremental_update().
+
+        The copy_ is redundant after defunctionalization because the in-place
+        op already mutates the tensor through the slice view created by SP.
+        """
+        nodes_to_remove = []
+        for node in graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target is torch.ops.aten.copy_.default
+                and len(node.args) >= 2
+            ):
+                dst, src = node.args[0], node.args[1]
+                if dst.op != "placeholder":
+                    continue
+                dst_val = dst.meta.get("val", None)
+                src_val = src.meta.get("val", None)
+                if (
+                    dst_val is not None
+                    and src_val is not None
+                    and hasattr(dst_val, "shape")
+                    and hasattr(src_val, "shape")
+                    and dst_val.shape != src_val.shape
+                ):
+                    nodes_to_remove.append(node)
+
+        for node in nodes_to_remove:
+            # copy_ returns dst; replace any downstream users with dst
+            node.replace_all_uses_with(node.args[0])
+            graph.erase_node(node)
+
+        if nodes_to_remove:
+            logger.debug(
+                "Removed %d mismatched epilogue copy_ nodes after SP",
+                len(nodes_to_remove),
+            )
+
+    def _fix_cross_submod_outputs(
+        self,
+        graph: fx.Graph,
+        output_node: fx.Node | None,
+        pre_sp_output_info: dict[int, tuple[fx.Node, tuple]],
+    ) -> None:
+        """AllGather graph outputs whose shapes were reduced by SP.
+
+        With piecewise compilation, the model is split into submods.  Each
+        submod's graph outputs flow to the next submod's inputs.  SP changes
+        residual shapes from [batch, hidden] to [batch/TP, hidden].  If these
+        reduced outputs cross submod boundaries, the next submod's compiled
+        code expects the original [batch, hidden] shape and its
+        ``assert_size_stride`` check fails.
+
+        This method compares pre-SP and post-SP output shapes.  Any output
+        whose dim-0 was reduced (while other dims stayed the same) is wrapped
+        with an AllGather to restore the original shape.
+        """
+        if output_node is None or not pre_sp_output_info:
+            return
+
+        output_args = output_node.args[0]
+        if not isinstance(output_args, (tuple, list)):
+            return
+
+        new_outputs = list(output_args)
+        num_fixed = 0
+
+        for i, out in enumerate(output_args):
+            if not isinstance(out, fx.Node) or i not in pre_sp_output_info:
+                continue
+
+            _, pre_shape = pre_sp_output_info[i]
+            val = out.meta.get("val", None)
+            if val is None or not hasattr(val, "shape"):
+                continue
+
+            post_shape = tuple(val.shape)
+
+            # Check for SP-style dim-0 reduction: dim-0 changed, other dims
+            # stayed the same.
+            if (
+                len(pre_shape) == len(post_shape)
+                and len(pre_shape) >= 2
+                and pre_shape[0] != post_shape[0]
+                and all(
+                    pre_shape[j] == post_shape[j]
+                    for j in range(1, len(pre_shape))
+                )
+            ):
+                tp_size = get_tensor_model_parallel_world_size()
+                tp_group = get_tp_group()
+                with graph.inserting_before(output_node):
+                    all_gather = graph.call_function(
+                        torch.ops.vllm.all_gather.default,
+                        args=(
+                            out,
+                            0,
+                            tp_size,
+                            tp_group.unique_name,
+                        ),
+                    )
+                new_outputs[i] = all_gather
+                num_fixed += 1
+                logger.debug(
+                    "AllGather output[%d]: %s -> %s", i, post_shape, pre_shape
+                )
+
+        if num_fixed > 0:
+            output_node.args = (tuple(new_outputs),)
+            logger.debug(
+                "Inserted %d AllGather ops to fix cross-submod outputs",
+                num_fixed,
+            )

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -364,4 +364,5 @@ class PiecewiseBackend:
             "PiecewiseBackend.__init__. "
             f"range_entry={range_entry.compile_range}"
         )
-        return range_entry.runnable(*args)
+        result = range_entry.runnable(*args)
+        return result

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -130,6 +130,14 @@ class PassConfig:
     (threshold is device-capability dependent)."""
     fuse_gemm_comms: bool = Field(default=None)
     """Enable async TP."""
+    async_tp_min_tokens: int | None = Field(default=128)
+    """Minimum number of tokens (batch size) for async TP fusion to be applied.
+    When a compile range's max batch size is below this threshold, both
+    sequence parallelism and async TP passes are skipped, as unfused
+    reduce_scatter/all_gather has more kernel launches than all_reduce at
+    small batch sizes. Default 128 is derived from the AutoHeuristic
+    crossover at arith_intensity ≈ 237.51 on H100. Set to 1 to always
+    fuse, or None to disable the threshold check."""
     fuse_allreduce_rms: bool = Field(default=None)
     """Enable flashinfer allreduce fusion."""
     enable_qk_norm_rope_fusion: bool = False

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -88,6 +88,15 @@ IS_DENSE = False
 # See https://github.com/vllm-project/vllm/issues/25689.
 
 
+def enable_sp_and_async_tp(cfg: "VllmConfig") -> bool:
+    """Enable SP + async TP when TP > 1 on CUDA."""
+    from vllm.platforms import current_platform
+    return (
+        cfg.parallel_config.tensor_parallel_size > 1
+        and current_platform.is_cuda()
+    )
+
+
 def enable_norm_fusion(cfg: "VllmConfig") -> bool:
     """Enable if either RMS norm or quant FP8 custom op is active;
     otherwise Inductor handles fusion."""
@@ -203,8 +212,8 @@ OPTIMIZATION_LEVEL_02 = {
             "fuse_act_quant": enable_act_fusion,
             "fuse_allreduce_rms": enable_allreduce_rms_fusion,
             "fuse_attn_quant": IS_QUANTIZED,
-            "enable_sp": IS_DENSE,
-            "fuse_gemm_comms": IS_DENSE,
+            "enable_sp": enable_sp_and_async_tp,
+            "fuse_gemm_comms": enable_sp_and_async_tp,
             "fuse_act_padding": enable_norm_pad_fusion,
             "fuse_rope_kvcache": enable_rope_kvcache_fusion,
         },
@@ -222,8 +231,8 @@ OPTIMIZATION_LEVEL_03 = {
             "fuse_act_quant": enable_act_fusion,
             "fuse_allreduce_rms": enable_allreduce_rms_fusion,
             "fuse_attn_quant": IS_QUANTIZED,
-            "enable_sp": IS_DENSE,
-            "fuse_gemm_comms": IS_DENSE,
+            "enable_sp": enable_sp_and_async_tp,
+            "fuse_gemm_comms": enable_sp_and_async_tp,
             "fuse_act_padding": enable_norm_pad_fusion,
             "fuse_rope_kvcache": enable_rope_kvcache_fusion,
         },


### PR DESCRIPTION
## Summary

Fix SP+AsyncTP crash with piecewise compilation and add per-matmul heuristic gating.

### Changes
1. **Piecewise crash fix**: `_remove_mismatched_epilogue_copies()` + `_fix_cross_submod_outputs()` — SP changes tensor shapes at submod boundaries, causing `assert_size_stride` failures
2. **Per-matmul heuristic**: Decision tree from AutoHeuristic gates fusion via `extra_check`, preventing 2-3x decode regression at small batch sizes
3. **Config**: `async_tp_min_tokens` threshold + `enable_sp_and_async_tp()` runtime check

### Status
⚠️ **Draft** — SP is currently disabled in upstream (`IS_DENSE=False`, #25689). These changes are preserved for future work.

Benchmark results show no meaningful serving benefit on single-node NVLink:
- Llama-2-7b TP=2: 1.01-1.02x (noise)
- Meta-Llama-3-70B TP=8: 0.98x

See `benchmarks/SP_ASYNCTP_BENCHMARK_REPORT.md` for details.