### PR TITLE
[Bugfix] fix AWQ layer to dispatch the correct kernel with torch.compile()

### DIFF
--- a/tests/models/quantization/test_awq.py
+++ b/tests/models/quantization/test_awq.py
@@ -141,13 +141,16 @@ def test_awq_models(
     )
 
 
-@pytest.mark.parametrize("num_tokens,expect_gemm", [
-    (1, True),
-    (128, True),
-    (255, True),
-    (256, False),
-    (512, False),
-])
+@pytest.mark.parametrize(
+    "num_tokens,expect_gemm",
+    [
+        (1, True),
+        (128, True),
+        (255, True),
+        (256, False),
+        (512, False),
+    ],
+)
 @torch.inference_mode()
 def test_awq_linear_kernel_dispatch(num_tokens, expect_gemm):
     """Verify awq_linear dispatches to awq_gemm for small batch sizes
@@ -159,25 +162,33 @@ def test_awq_linear_kernel_dispatch(num_tokens, expect_gemm):
     group_size = 32
     pack_factor = 8
 
-    input = torch.randn(num_tokens, in_features, dtype=torch.float16,
-                         device="cuda")
-    qweight = torch.randint(0, 100, (in_features, out_features // pack_factor),
-                            dtype=torch.int32, device="cuda")
-    scales = torch.randn(in_features // group_size, out_features,
-                         dtype=torch.float16, device="cuda")
-    qzeros = torch.randint(0, 100,
-                           (in_features // group_size,
-                            out_features // pack_factor),
-                           dtype=torch.int32, device="cuda")
+    input = torch.randn(num_tokens, in_features, dtype=torch.float16, device="cuda")
+    qweight = torch.randint(
+        0,
+        100,
+        (in_features, out_features // pack_factor),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    scales = torch.randn(
+        in_features // group_size, out_features, dtype=torch.float16, device="cuda"
+    )
+    qzeros = torch.randint(
+        0,
+        100,
+        (in_features // group_size, out_features // pack_factor),
+        dtype=torch.int32,
+        device="cuda",
+    )
 
     # Mock both paths and return tensors of the correct shape
-    gemm_ret = torch.empty(num_tokens, out_features, dtype=torch.float16,
-                           device="cuda")
-    deq_ret = torch.empty(in_features, out_features, dtype=torch.float16,
-                          device="cuda")
+    gemm_ret = torch.empty(num_tokens, out_features, dtype=torch.float16, device="cuda")
+    deq_ret = torch.empty(in_features, out_features, dtype=torch.float16, device="cuda")
 
-    with patch("vllm._custom_ops.awq_gemm", return_value=gemm_ret) as mock_gemm, \
-         patch("vllm._custom_ops.awq_dequantize", return_value=deq_ret) as mock_deq:
+    with (
+        patch("vllm._custom_ops.awq_gemm", return_value=gemm_ret) as mock_gemm,
+        patch("vllm._custom_ops.awq_dequantize", return_value=deq_ret) as mock_deq,
+    ):
         awq_linear(input, qweight, scales, qzeros, pack_factor)
 
         if expect_gemm:

--- a/tests/models/quantization/test_awq.py
+++ b/tests/models/quantization/test_awq.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from unittest.mock import patch
+
 import pytest
 import torch
 
@@ -30,6 +32,7 @@ def run_awq_test(
     num_logprobs: int,
     tensor_parallel_size: int,
     distributed_executor_backend: str | None = None,
+    enforce_eager: bool = True,
 ):
     images = [asset.pil_image for asset in image_assets]
 
@@ -53,7 +56,7 @@ def run_awq_test(
         dtype=dtype,
         tensor_parallel_size=tensor_parallel_size,
         distributed_executor_backend=distributed_executor_backend,
-        enforce_eager=True,
+        enforce_eager=enforce_eager,
         default_torch_num_threads=1,
     ) as vllm_model:
         source_outputs_per_image = [
@@ -70,7 +73,7 @@ def run_awq_test(
         dtype=dtype,
         tensor_parallel_size=tensor_parallel_size,
         distributed_executor_backend=distributed_executor_backend,
-        enforce_eager=True,
+        enforce_eager=enforce_eager,
         default_torch_num_threads=1,
     ) as vllm_model:
         quant_outputs_per_image = [
@@ -111,6 +114,7 @@ def run_awq_test(
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("max_tokens", [128])
 @pytest.mark.parametrize("num_logprobs", [5])
+@pytest.mark.parametrize("enforce_eager", [True, False])
 @torch.inference_mode()
 def test_awq_models(
     vllm_runner,
@@ -121,6 +125,7 @@ def test_awq_models(
     dtype,
     max_tokens,
     num_logprobs,
+    enforce_eager,
 ) -> None:
     run_awq_test(
         vllm_runner,
@@ -132,4 +137,52 @@ def test_awq_models(
         max_tokens=max_tokens,
         num_logprobs=num_logprobs,
         tensor_parallel_size=1,
+        enforce_eager=enforce_eager,
     )
+
+
+@pytest.mark.parametrize("num_tokens,expect_gemm", [
+    (1, True),
+    (128, True),
+    (255, True),
+    (256, False),
+    (512, False),
+])
+@torch.inference_mode()
+def test_awq_linear_kernel_dispatch(num_tokens, expect_gemm):
+    """Verify awq_linear dispatches to awq_gemm for small batch sizes
+    and to awq_dequantize + matmul for large batch sizes."""
+    from vllm._custom_ops import awq_linear
+
+    in_features = 64
+    out_features = 128
+    group_size = 32
+    pack_factor = 8
+
+    input = torch.randn(num_tokens, in_features, dtype=torch.float16,
+                         device="cuda")
+    qweight = torch.randint(0, 100, (in_features, out_features // pack_factor),
+                            dtype=torch.int32, device="cuda")
+    scales = torch.randn(in_features // group_size, out_features,
+                         dtype=torch.float16, device="cuda")
+    qzeros = torch.randint(0, 100,
+                           (in_features // group_size,
+                            out_features // pack_factor),
+                           dtype=torch.int32, device="cuda")
+
+    # Mock both paths and return tensors of the correct shape
+    gemm_ret = torch.empty(num_tokens, out_features, dtype=torch.float16,
+                           device="cuda")
+    deq_ret = torch.empty(in_features, out_features, dtype=torch.float16,
+                          device="cuda")
+
+    with patch("vllm._custom_ops.awq_gemm", return_value=gemm_ret) as mock_gemm, \
+         patch("vllm._custom_ops.awq_dequantize", return_value=deq_ret) as mock_deq:
+        awq_linear(input, qweight, scales, qzeros, pack_factor)
+
+        if expect_gemm:
+            mock_gemm.assert_called_once()
+            mock_deq.assert_not_called()
+        else:
+            mock_deq.assert_called_once()
+            mock_gemm.assert_not_called()

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -13,6 +13,7 @@ from vllm.utils.flashinfer import (
     flashinfer_quant_nvfp4_8x4_sf_layout,
 )
 from vllm.utils.math_utils import cdiv
+from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
 
@@ -678,8 +679,6 @@ def _awq_linear_fake(
         device=input.device,
     )
 
-
-from vllm.utils.torch_utils import direct_register_custom_op
 
 direct_register_custom_op(
     op_name="awq_linear",

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -640,6 +640,55 @@ if hasattr(torch.ops._C, "awq_gemm"):
         ).sum(0)
 
 
+def awq_linear(
+    input: torch.Tensor,
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    qzeros: torch.Tensor,
+    pack_factor: int,
+) -> torch.Tensor:
+    """AWQ linear with runtime kernel dispatch.
+
+    Dispatches to fused awq_gemm for small batch sizes (num_tokens < 256)
+    and to awq_dequantize + matmul for large batch sizes. Registered as a
+    custom op so that the branch is evaluated at runtime (including during
+    CUDAGraph capture) rather than being baked in at torch.compile trace
+    time.
+    """
+    num_tokens = input.shape[0]
+    if num_tokens >= 256:
+        weight = awq_dequantize(qweight, scales, qzeros, 0, 0, 0)
+        return torch.matmul(input, weight)
+    else:
+        return awq_gemm(input, qweight, scales, qzeros, pack_factor)
+
+
+def _awq_linear_fake(
+    input: torch.Tensor,
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    qzeros: torch.Tensor,
+    pack_factor: int,
+) -> torch.Tensor:
+    num_in_feats = input.size(0)
+    out_features = qweight.size(1) * 8
+    return torch.empty(
+        (num_in_feats, out_features),
+        dtype=input.dtype,
+        device=input.device,
+    )
+
+
+from vllm.utils.torch_utils import direct_register_custom_op
+
+direct_register_custom_op(
+    op_name="awq_linear",
+    op_func=awq_linear,
+    mutates_args=[],
+    fake_impl=_awq_linear_fake,
+)
+
+
 # gptq
 def gptq_gemm(
     a: torch.Tensor,

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -265,14 +265,8 @@ class AWQLinearMethod(LinearMethodBase):
         out_shape = x.shape[:-1] + (qweight.shape[-1] * pack_factor,)
         reshaped_x = x.reshape(-1, x.shape[-1])
 
-        # num_tokens >= threshold
-        FP16_MATMUL_HEURISTIC_CONDITION = x.shape[:-1].numel() >= 256
-
-        if FP16_MATMUL_HEURISTIC_CONDITION:
-            out = ops.awq_dequantize(qweight, scales, qzeros, 0, 0, 0)
-            out = torch.matmul(reshaped_x, out)
-        else:
-            out = ops.awq_gemm(reshaped_x, qweight, scales, qzeros, pack_factor)
+        out = torch.ops.vllm.awq_linear(
+            reshaped_x, qweight, scales, qzeros, pack_factor)
         if bias is not None:
             out.add_(bias)
         return out.reshape(out_shape)

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Union
 import torch
 from safetensors.torch import _TYPES as _SAFETENSORS_TO_TORCH_DTYPE
 
-from vllm import _custom_ops as ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.linear import (
@@ -266,7 +265,8 @@ class AWQLinearMethod(LinearMethodBase):
         reshaped_x = x.reshape(-1, x.shape[-1])
 
         out = torch.ops.vllm.awq_linear(
-            reshaped_x, qweight, scales, qzeros, pack_factor)
+            reshaped_x, qweight, scales, qzeros, pack_factor
+        )
         if bias is not None:
             out.add_(bias)
         return out.reshape(out_shape)


### PR DESCRIPTION

## Purpose
There is branching inside the apply() function, which doesn't behave properly when torch.compile() is enabled(no --enforce-eager):
https://github.com/vllm-project/vllm/blob/0091017188ab26d4e4d146e0ec748d6ee34968d8/vllm/model_executor/layers/quantization/awq.py#L255

The idea is that fused kernel is preferred for small batch_size/number of tokens combine (<256), but larger number means it is more compute bound and BLAS library is better.
Since guards are turned off by default, Dynamo will trace this **_FP16_MATMUL_HEURISTIC_CONDITION_** and evaluate this statically _FP16_MATMUL_HEURISTIC_CONDITION_ as True _(warmup run in VLLM uses large # of tokens)_. All following launches use cached Dynamo graph, and use separate Dequantize + GEMM, leading to perf drop.
#### Thoughts: 
this bug wasn't captured probably due to using large batch_size, so _FP16_MATMUL_HEURISTIC_CONDITION_ is never False.
## what I changed
Created a custom_op, awq_linear and moved the branching logic inside. Dynamo doesn't trace into custom_ops, ensuring correct behaviour.
## Test Result
#### Hardware used: gfx1201
It shows with GPU profiler and vllm bench throughput that the optimal kernel is selected.

```bash
vllm bench throughput  --model Meta-Llama-3.1-8B-Instruct-AWQ-INT4/   --trust-remote-code   --dataset ShareGPT_V3_unfiltered_cleaned_split.json   --num-prompts 200   --max-model-len 49152

vllm bench throughput  --model Meta-Llama-3.1-8B-Instruct-AWQ-INT4/   --trust-remote-code   --dataset ShareGPT_V3_unfiltered_cleaned_split.json   --num-prompts 10   --max-model-len 49152 --max-num-seqs 1

```

<img width="761" height="416" alt="image" src="https://github.com/user-attachments/assets/80a1ad47-0e7f-4bc9-99ab-0dcc6fe7c39a" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

