### PR TITLE
[PERF] Extend NCCL symmetric memory to AllGather and ReduceScatter

### DIFF
--- a/tests/distributed/test_nccl_symm_mem_allreduce.py
+++ b/tests/distributed/test_nccl_symm_mem_allreduce.py
@@ -94,3 +94,132 @@ def test_nccl_symm_mem_allreduce(monkeypatch: pytest.MonkeyPatch, world_size):
 
     mp.spawn(nccl_symm_mem_allreduce_worker, args=(world_size,), nprocs=world_size)
     cleanup_dist_env_and_memory()
+
+
+def nccl_symm_mem_allgather_worker(local_rank: int, world_size: int):
+    monkeypatch = pytest.MonkeyPatch()
+    with monkeypatch.context() as m:
+        m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        dtype = torch.bfloat16
+        device = torch.device(f"cuda:{local_rank}")
+        torch.cuda.set_device(device)
+        torch.set_default_device(device)
+        torch.set_default_dtype(dtype)
+        update_environment_variables(
+            {
+                "RANK": str(local_rank),
+                "LOCAL_RANK": str(local_rank),
+                "WORLD_SIZE": str(world_size),
+                "MASTER_ADDR": "localhost",
+                "MASTER_PORT": "12346",
+            }
+        )
+
+        init_distributed_environment()
+        initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+        cuda_communicator = typing.cast(
+            CudaCommunicator, get_tp_group().device_communicator
+        )
+        if get_nccl_mem_pool() is None:
+            pytest.skip(
+                "NCCL allocator compilation failed (probably missing NCCL headers)."
+            )
+        if not is_symmetric_memory_enabled():
+            pytest.skip("NCCL symmetric memory is disabled.")
+
+        per_rank_size = test_size_elements // world_size
+        input_tensor = torch.randint(
+            1, 23, (per_rank_size,), dtype=dtype, device=device
+        )
+        output = cuda_communicator.all_gatherv(input_tensor, dim=0)
+
+        group = get_tp_group().device_group
+        expected = torch.empty(
+            test_size_elements, dtype=dtype, device=device
+        )
+        dist.all_gather_into_tensor(expected, input_tensor, group=group)
+        torch.testing.assert_close(output, expected, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="NCCL symmetric memory is only available for CUDA platforms.",
+)
+@pytest.mark.parametrize("world_size", [2])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
+def test_nccl_symm_mem_allgather(monkeypatch: pytest.MonkeyPatch, world_size):
+    if world_size > torch.cuda.device_count():
+        pytest.skip("Not enough GPUs to run the test.")
+
+    monkeypatch.setenv("VLLM_USE_NCCL_SYMM_MEM", "1")
+    monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
+    monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
+
+    mp.spawn(nccl_symm_mem_allgather_worker, args=(world_size,), nprocs=world_size)
+    cleanup_dist_env_and_memory()
+
+
+def nccl_symm_mem_reduce_scatter_worker(local_rank: int, world_size: int):
+    monkeypatch = pytest.MonkeyPatch()
+    with monkeypatch.context() as m:
+        m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        dtype = torch.bfloat16
+        device = torch.device(f"cuda:{local_rank}")
+        torch.cuda.set_device(device)
+        torch.set_default_device(device)
+        torch.set_default_dtype(dtype)
+        update_environment_variables(
+            {
+                "RANK": str(local_rank),
+                "LOCAL_RANK": str(local_rank),
+                "WORLD_SIZE": str(world_size),
+                "MASTER_ADDR": "localhost",
+                "MASTER_PORT": "12347",
+            }
+        )
+
+        init_distributed_environment()
+        initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+        cuda_communicator = typing.cast(
+            CudaCommunicator, get_tp_group().device_communicator
+        )
+        if get_nccl_mem_pool() is None:
+            pytest.skip(
+                "NCCL allocator compilation failed (probably missing NCCL headers)."
+            )
+        if not is_symmetric_memory_enabled():
+            pytest.skip("NCCL symmetric memory is disabled.")
+
+        per_rank_size = test_size_elements // world_size
+        input_tensor = torch.randint(
+            1, 23, (test_size_elements,), dtype=dtype, device=device
+        )
+        input_clone = input_tensor.clone()
+        output = cuda_communicator.reduce_scatter(input_tensor, dim=0)
+
+        group = get_tp_group().device_group
+        expected = torch.empty(per_rank_size, dtype=dtype, device=device)
+        dist.reduce_scatter_tensor(expected, input_clone, group=group)
+        torch.testing.assert_close(output, expected, atol=2.5, rtol=0.1)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="NCCL symmetric memory is only available for CUDA platforms.",
+)
+@pytest.mark.parametrize("world_size", [2])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
+def test_nccl_symm_mem_reduce_scatter(monkeypatch: pytest.MonkeyPatch, world_size):
+    if world_size > torch.cuda.device_count():
+        pytest.skip("Not enough GPUs to run the test.")
+
+    monkeypatch.setenv("VLLM_USE_NCCL_SYMM_MEM", "1")
+    monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
+    monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
+
+    mp.spawn(
+        nccl_symm_mem_reduce_scatter_worker, args=(world_size,), nprocs=world_size
+    )
+    cleanup_dist_env_and_memory()

--- a/vllm/distributed/device_communicators/all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/all_reduce_utils.py
@@ -125,6 +125,44 @@ def should_nccl_symm_mem_allreduce(world_size: int, input_tensor: torch.Tensor) 
     return world_size > NCCL_SYMM_MEM_ALL_REDUCE_CONFIG["always_use_above_world_size"]
 
 
+NCCL_SYMM_MEM_AG_RS_CONFIG: dict[str, Any] = {
+    "min_world_size": 2,
+    "always_use_above_world_size": 8,
+}
+
+
+def should_nccl_symm_mem_allgather(
+    world_size: int, input_tensor: torch.Tensor
+) -> bool:
+    from vllm.distributed.device_communicators.pynccl_allocator import (
+        is_symmetric_memory_enabled,
+    )
+
+    if vllm_is_batch_invariant():
+        return False
+    if not is_symmetric_memory_enabled():
+        return False
+    if world_size < NCCL_SYMM_MEM_AG_RS_CONFIG["min_world_size"]:
+        return False
+    return True
+
+
+def should_nccl_symm_mem_reduce_scatter(
+    world_size: int, input_tensor: torch.Tensor
+) -> bool:
+    from vllm.distributed.device_communicators.pynccl_allocator import (
+        is_symmetric_memory_enabled,
+    )
+
+    if vllm_is_batch_invariant():
+        return False
+    if not is_symmetric_memory_enabled():
+        return False
+    if world_size < NCCL_SYMM_MEM_AG_RS_CONFIG["min_world_size"]:
+        return False
+    return True
+
+
 def producer(
     batch_src: Sequence[int],
     producer_queue,

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -7,7 +7,9 @@ from torch.distributed import ProcessGroup
 
 import vllm.envs as envs
 from vllm.distributed.device_communicators.all_reduce_utils import (
+    should_nccl_symm_mem_allgather,
     should_nccl_symm_mem_allreduce,
+    should_nccl_symm_mem_reduce_scatter,
 )
 from vllm.distributed.device_communicators.pynccl import register_nccl_symmetric_ops
 from vllm.distributed.device_communicators.pynccl_allocator import (
@@ -252,11 +254,15 @@ class CudaCommunicator(DeviceCommunicatorBase):
         chunk_size = input_tensor.shape[0] // world_size
         output_shape = (chunk_size,) + input_tensor.shape[1:]
 
-        output = torch.empty(
-            output_shape, dtype=input_tensor.dtype, device=input_tensor.device
-        )
-
-        pynccl_comm.reduce_scatter(output, input_tensor)
+        if should_nccl_symm_mem_reduce_scatter(world_size, input_tensor):
+            output = self._reduce_scatter_symm_mem(
+                input_tensor, output_shape, sizes=None
+            )
+        else:
+            output = torch.empty(
+                output_shape, dtype=input_tensor.dtype, device=input_tensor.device
+            )
+            pynccl_comm.reduce_scatter(output, input_tensor)
 
         # Reshape before returning
         return output.movedim(0, dim).contiguous()
@@ -284,17 +290,49 @@ class CudaCommunicator(DeviceCommunicatorBase):
             chunk_size = input_tensor.shape[0] // world_size
         output_shape = (chunk_size,) + input_tensor.shape[1:]
 
-        output = torch.empty(
-            output_shape, dtype=input_tensor.dtype, device=input_tensor.device
-        )
-
-        if sizes is not None and sizes.count(sizes[0]) != len(sizes):
-            pynccl_comm.reduce_scatterv(output, input_tensor, sizes=sizes)
+        if should_nccl_symm_mem_reduce_scatter(world_size, input_tensor):
+            output = self._reduce_scatter_symm_mem(
+                input_tensor, output_shape, sizes=sizes
+            )
         else:
-            pynccl_comm.reduce_scatter(output, input_tensor)
+            output = torch.empty(
+                output_shape, dtype=input_tensor.dtype, device=input_tensor.device
+            )
+            if sizes is not None and sizes.count(sizes[0]) != len(sizes):
+                pynccl_comm.reduce_scatterv(output, input_tensor, sizes=sizes)
+            else:
+                pynccl_comm.reduce_scatter(output, input_tensor)
 
         # Reshape before returning
         return output.movedim(0, dim).contiguous()
+
+    def _reduce_scatter_symm_mem(
+        self,
+        input_tensor: torch.Tensor,
+        output_shape: tuple,
+        sizes: list[int] | None,
+    ) -> torch.Tensor:
+        from vllm.distributed.device_communicators.pynccl_allocator import (
+            nccl_symm_mem_context,
+        )
+
+        pynccl_comm = self.pynccl_comm
+        assert pynccl_comm is not None
+
+        with nccl_symm_mem_context(pynccl_comm):
+            symm_input = torch.empty_like(input_tensor)
+            symm_output = torch.empty(
+                output_shape, dtype=input_tensor.dtype, device=input_tensor.device
+            )
+
+        symm_input.copy_(input_tensor)
+
+        if sizes is not None and sizes.count(sizes[0]) != len(sizes):
+            pynccl_comm.reduce_scatterv(symm_output, symm_input, sizes=sizes)
+        else:
+            pynccl_comm.reduce_scatter(symm_output, symm_input)
+
+        return symm_output
 
     def send(self, tensor: torch.Tensor, dst: int | None = None) -> None:
         """Sends a tensor to the destination rank in a blocking way"""
@@ -365,6 +403,19 @@ class CudaCommunicator(DeviceCommunicatorBase):
         if sizes is not None and all(s == sizes[0] for s in sizes):
             sizes = None
 
+        use_symm_mem = False
+        if isinstance(input_, torch.Tensor):
+            use_symm_mem = should_nccl_symm_mem_allgather(
+                world_size, input_
+            )
+        elif len(input_) > 0:
+            use_symm_mem = should_nccl_symm_mem_allgather(
+                world_size, input_[0]
+            )
+
+        if use_symm_mem:
+            return self._all_gatherv_symm_mem(input_, sizes, world_size)
+
         def _all_gather_single(input_: torch.Tensor, sizes: list[int] | None = None):
             input_size = input_.size()
             if sizes is not None:
@@ -395,6 +446,57 @@ class CudaCommunicator(DeviceCommunicatorBase):
         pynccl_comm.group_end()
 
         return output_list
+
+    def _all_gatherv_symm_mem(
+        self,
+        input_: torch.Tensor | list[torch.Tensor],
+        sizes: list[int] | None,
+        world_size: int,
+    ):
+        from vllm.distributed.device_communicators.pynccl_allocator import (
+            nccl_symm_mem_context,
+        )
+
+        pynccl_comm = self.pynccl_comm
+        assert pynccl_comm is not None
+
+        inputs = [input_] if isinstance(input_, torch.Tensor) else input_
+
+        symm_inputs = []
+        symm_outputs = []
+        with nccl_symm_mem_context(pynccl_comm):
+            for inp in inputs:
+                symm_inputs.append(torch.empty_like(inp))
+                if sizes is not None:
+                    out_size = (sum(sizes),) + inp.size()[1:]
+                else:
+                    out_size = (inp.size(0) * world_size,) + inp.size()[1:]
+                symm_outputs.append(
+                    torch.empty(out_size, dtype=inp.dtype, device=inp.device)
+                )
+
+        for symm_in, inp in zip(symm_inputs, inputs):
+            symm_in.copy_(inp)
+
+        if len(inputs) == 1:
+            if sizes is not None:
+                pynccl_comm.all_gatherv(
+                    symm_outputs[0], symm_inputs[0], sizes=sizes
+                )
+            else:
+                pynccl_comm.all_gather(symm_outputs[0], symm_inputs[0])
+        else:
+            pynccl_comm.group_start()
+            for symm_out, symm_in in zip(symm_outputs, symm_inputs):
+                if sizes is not None:
+                    pynccl_comm.all_gatherv(symm_out, symm_in, sizes=sizes)
+                else:
+                    pynccl_comm.all_gather(symm_out, symm_in)
+            pynccl_comm.group_end()
+
+        if isinstance(input_, torch.Tensor):
+            return symm_outputs[0]
+        return symm_outputs
 
     def dispatch_router_logits(
         self,

--- a/vllm/distributed/device_communicators/pynccl_allocator.py
+++ b/vllm/distributed/device_communicators/pynccl_allocator.py
@@ -39,7 +39,7 @@ void nccl_free_plug(void* ptr, size_t size, int device, void* stream) {
 _allocator = None
 _allocator_wrapper = None
 _mem_pool = None
-_registered_base_addrs = set()
+_registered_base_addrs: dict[int, set] = {}
 _graph_pool_id = None
 _nccl_allocator_failed_to_compile = False
 _cached_pool_snapshot = None
@@ -181,11 +181,14 @@ class nccl_symm_mem_context:
         assert _pool is not None
         _cached_pool_snapshot = _pool.snapshot()
         assert self.pynccl_comm is not None
+        comm_id = id(self.pynccl_comm)
+        if comm_id not in _registered_base_addrs:
+            _registered_base_addrs[comm_id] = set()
         for segment in _cached_pool_snapshot:
-            if segment["address"] not in _registered_base_addrs:
+            if segment["address"] not in _registered_base_addrs[comm_id]:
                 self.pynccl_comm.register_comm_window_raw(
                     segment["address"], segment["total_size"]
                 )
-                _registered_base_addrs.add(segment["address"])
+                _registered_base_addrs[comm_id].add(segment["address"])
         if self.is_graph_capture:
             torch._C._cuda_beginAllocateCurrentThreadToPool(self.device, _graph_pool_id)


### PR DESCRIPTION
Enable NVLS for AG/RS collectives used by MoE dispatch/combine in

Expert Parallel deployments. Fix per-communicator window registration so multiple NCCL communicators can share the symmetric memory pool.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

