### PR TITLE
[Bugfix] Sync xgrammar termination state after failed token acceptance

### DIFF
--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -341,3 +341,33 @@ def test_trim_reasoning_for_advance():
     next_step = [post, post]
     request.append_output_token_ids(next_step)
     assert manager.trim_reasoning_for_advance(request, next_step) == next_step
+
+
+
+ 
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_accept_tokens_syncs_terminated_after_overshoot(backend):
+    """accept_tokens must keep the terminated flag in sync when a batch
+    overshoots the stop token.
+ 
+    Speculative decoding can hand accept_tokens a batch containing a token
+    *after* EOS. accept_tokens rejects that trailing token, but it must still
+    record that the grammar has terminated -- otherwise vLLM believes a
+    finished request is still running, which surfaces as a fill_next_token_
+    bitmask crash on one path and an engine livelock on another (#49210).
+    """
+    tokenizer, manager, request, prompt = _make_manager_and_request(backend)
+    grammar = request.structured_output_request.grammar
+ 
+    # Drive the grammar through a complete JSON object. Completing the
+    # structure alone does not terminate the grammar; it also needs EOS.
+    assert grammar.accept_tokens(request.request_id, prompt)
+ 
+    # Mimic a speculative-decode batch that overshoots the stop token.
+    eos = tokenizer.eos_token_id
+    stray = tokenizer.encode("\n")[0]
+    grammar.accept_tokens(request.request_id, [eos, stray])
+ 
+    # Core invariant: vLLM's view now agrees the request is finished.
+    # (Pre-fix this is False for xgrammar -> livelock / later bitmask crash.)
+    assert grammar.is_terminated()

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -159,6 +159,10 @@ class XgrammarGrammar(StructuredOutputGrammar):
             return False
         for token in tokens:
             if not self.matcher.accept_token(token):
+                # Keep vLLM-side termination state in sync with xgrammar matcher
+                # even when token acceptance fails (e.g., EOS was accepted and
+                # speculative decoding still sends extra tokens).
+                self._is_terminated = self.matcher.is_terminated()
                 logger.error(
                     "Failed to advance FSM for request %s "
                     "for tokens %s. Please file an issue.",


### PR DESCRIPTION

## Summary

Fix a termination-state desynchronization between `XgrammarGrammar` and its underlying xgrammar matcher.

With speculative decoding, an `accept_tokens()` batch can contain a stop token followed by additional speculative tokens. The matcher terminates after accepting the stop token, then rejects the following token. Because
`accept_tokens()` returned early, `XgrammarGrammar._is_terminated` was not updated and remained stale.

This change synchronizes `_is_terminated` with the matcher before returning `False`, preventing subsequent code from treating a terminated matcher as active and calling operations such as `fill_next_token_bitmask()` on it.

Without this synchronization, vLLM may continue using a matcher that has already terminated, causing later bitmask generation to fail.

Related to  #49210

## Reproduction

The original issue was reproduced with:

- xgrammar structured output
- EAGLE3 speculative decoding
- `ignore_eos=true`
- a speculative token batch continuing after EOS

Before the fix, this produces the xgrammar warning that a token is being accepted after the matcher has terminated, followed by a later bitmask failure.

The same state desynchronization was independently reproduced by @jayanth922 using xgrammar 0.2.1 and a four-token toy tokenizer without a model or GPU.
