### PR TITLE
[VLLMZ-905] fix(xpu): Clamp compile warmup sizes to model runner token capacity

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -594,7 +594,24 @@ class Worker(WorkerBase):
                     warmup_sizes.append(compile_range.end)
 
         # We skip EPLB here since we don't want to record dummy metrics
-        for size in sorted(warmup_sizes, reverse=True):
+        max_num_tokens = self.model_runner.max_num_tokens
+        invalid_warmup_sizes = sorted(
+            {size for size in warmup_sizes if size > max_num_tokens},
+            reverse=True,
+        )
+        if invalid_warmup_sizes:
+            logger.warning(
+                "Skipping invalid compile warmup sizes %s because they exceed "
+                "max_num_tokens=%d.",
+                invalid_warmup_sizes,
+                max_num_tokens,
+            )
+
+        valid_warmup_sizes = sorted(
+            {size for size in warmup_sizes if size <= max_num_tokens},
+            reverse=True,
+        )
+        for size in valid_warmup_sizes:
             logger.info("Compile and warming up model for size %d", size)
             self.model_runner._dummy_run(size, skip_eplb=True, remove_lora=False)
         self.model_runner.maybe_remove_all_loras(self.model_runner.lora_config)


### PR DESCRIPTION
When using torch.compile mode with XPU backend (particularly MLA models), the compile_ranges_endpoints may exceed the actual max_num_tokens available for warmup. This causes an AssertionError in _dummy_run when the warmup size is checked against max_num_tokens.

This commit filters out invalid warmup sizes that exceed max_num_tokens, logs a warning for skipped sizes, and only executes dummy runs for valid sizes.

Fixes the issue where compile mode initialization fails with:
  assert num_tokens <= self.max_num_tokens
  AssertionError

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

