### PR TITLE
fix(anthropic): remove non-standard 'data: [DONE]' from Anthropic streaming

### DIFF
--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -576,7 +576,6 @@ class AnthropicServingMessages(OpenAIServingChat):
                             exclude_unset=True, exclude_none=True
                         )
                         yield wrap_data_with_event(data, "message_stop")
-                        yield "data: [DONE]\n\n"
                     else:
                         origin_chunk = ChatCompletionStreamResponse.model_validate_json(
                             data_str
@@ -773,7 +772,6 @@ class AnthropicServingMessages(OpenAIServingChat):
                     )
                     data = error_response.model_dump_json(exclude_unset=True)
                     yield wrap_data_with_event(data, "error")
-                    yield "data: [DONE]\n\n"
 
         except Exception as e:
             logger.exception("Error in message stream converter.")
@@ -783,7 +781,6 @@ class AnthropicServingMessages(OpenAIServingChat):
             )
             data = error_response.model_dump_json(exclude_unset=True)
             yield wrap_data_with_event(data, "error")
-            yield "data: [DONE]\n\n"
 
     async def count_tokens(
         self,


### PR DESCRIPTION
## Purpose

Fix protocol leakage in the Anthropic streaming endpoint: remove the non-standard `data: [DONE]\n\n` marker from all stream termination paths.

The `data: [DONE]` sentinel is specific to the [OpenAI streaming protocol](https://github.com/openai/openai-python/blob/main/src/openai/_streaming.py#L63). According to the [Anthropic API specification](https://platform.claude.com/docs/en/build-with-claude/streaming#event-types), a stream terminates with an `event: message_stop` block where the data payload is valid JSON (e.g., `{"type": "message_stop"}`).

Appending the OpenAI-style `[DONE]` marker to the Anthropic protocol breaks strict API gateways/middleware (such as LiteLLM) that expect all `data:` payloads to be JSON objects — `json.loads(" [DONE]")` evaluates to `['DONE']`, causing an `AttributeError` when calling `.get("type")`.


## Test Plan

```bash
curl -s http://localhost:8000/v1/messages \
    -H "x-api-key: dummy" \
    -H "Content-Type: application/json" \
    -H "anthropic-version: 2023-06-01" \
    -d '{
      "model": "<model>",
      "messages": [{"role": "user", "content": "Say hi"}],
      "max_tokens": 20,
      "stream": true
    }'
```

Verify the stream ends with `event: message_stop` and no trailing `data: [DONE]`.

## Test Result

Before: stream ends with `event: message_stop` followed by `data: [DONE]`
After: stream ends cleanly with `event: message_stop` only

Standard Anthropic clients (Claude Code, official SDKs) continue to function correctly, as their state machines close upon receiving `message_stop`.
