### PR TITLE
[Core] Preallocate sampler logits workspace during memory profiling

### DIFF
--- a/tests/v1/sample/test_sampler.py
+++ b/tests/v1/sample/test_sampler.py
@@ -30,6 +30,70 @@ def _create_fake_logits(batch_size: int, vocab_size: int) -> torch.Tensor:
     return fake_logits
 
 
+def test_sampler_workspace_reused_for_float32_cast():
+    sampler = Sampler()
+    logits = torch.arange(8, dtype=torch.float16).reshape(2, 4)
+    workspace = torch.empty((3, 4), dtype=torch.float32)
+    sampler.sampler_workspace = workspace
+
+    logits_fp32 = sampler._convert_logits_to_float32(logits)
+
+    assert logits_fp32.data_ptr() == workspace.data_ptr()
+    torch.testing.assert_close(logits_fp32, logits.to(torch.float32))
+
+
+def test_sampler_workspace_falls_back_when_too_small():
+    sampler = Sampler()
+    logits = torch.arange(8, dtype=torch.float16).reshape(2, 4)
+    sampler.sampler_workspace = torch.empty((1, 4), dtype=torch.float32)
+
+    logits_fp32 = sampler._convert_logits_to_float32(logits)
+
+    assert logits_fp32.shape == logits.shape
+    assert logits_fp32.dtype == torch.float32
+    assert logits_fp32.data_ptr() != sampler.sampler_workspace.data_ptr()
+    torch.testing.assert_close(logits_fp32, logits.to(torch.float32))
+
+
+def test_sampler_workspace_leaves_float32_logits_in_place():
+    sampler = Sampler()
+    logits = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    sampler.sampler_workspace = torch.empty((2, 4), dtype=torch.float32)
+
+    logits_fp32 = sampler._convert_logits_to_float32(logits)
+
+    assert logits_fp32 is logits
+
+
+def test_sampler_full_processed_logits_do_not_alias_reusable_workspace():
+    batch_size = 2
+    vocab_size = 4
+    sampler = Sampler(logprobs_mode="processed_logits")
+    sampler.sampler_workspace = torch.empty(
+        (batch_size, vocab_size), dtype=torch.float32
+    )
+    logits = torch.arange(batch_size * vocab_size, dtype=torch.float16).reshape(
+        batch_size, vocab_size
+    )
+    metadata = _create_default_sampling_metadata(
+        num_output_tokens=0,
+        batch_size=batch_size,
+        vocab_size=vocab_size,
+        device=torch.device("cpu"),
+    )
+    metadata.max_num_logprobs = -1
+
+    output = sampler(logits, metadata)
+
+    assert output.logprobs_tensors is not None
+    returned_logits = output.logprobs_tensors.logprobs
+    assert (
+        returned_logits.untyped_storage().data_ptr()
+        != sampler.sampler_workspace.untyped_storage().data_ptr()
+    )
+    torch.testing.assert_close(returned_logits, logits.to(torch.float32))
+
+
 def _create_penalty_tensor(
     batch_size: int, penalty_value: float, device: torch.device
 ) -> torch.Tensor:

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -857,6 +857,51 @@ def test_reload_weights_before_load_model(model_runner):
         model_runner.reload_weights()
 
 
+@pytest.mark.parametrize(
+    ("runner_type", "is_last_rank", "should_allocate"),
+    [
+        ("generate", True, True),
+        ("generate", False, False),
+        ("pooling", True, False),
+        ("draft", True, False),
+    ],
+)
+def test_sampler_workspace_allocation_is_limited_to_last_generation_rank(
+    monkeypatch: pytest.MonkeyPatch,
+    runner_type: str,
+    is_last_rank: bool,
+    should_allocate: bool,
+):
+    runner = object.__new__(GPUModelRunner)
+    runner.sampler = SimpleNamespace(sampler_workspace="stale")
+    runner.model_config = SimpleNamespace(
+        runner_type=runner_type,
+        get_vocab_size=lambda: 11,
+    )
+    runner.max_num_reqs = 7
+    runner.device = torch.device("cpu")
+
+    allocated = torch.empty((7, 11), dtype=torch.float32)
+    empty = Mock(return_value=allocated)
+    monkeypatch.setattr(gpu_model_runner_module.torch, "empty", empty)
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=is_last_rank),
+    )
+
+    GPUModelRunner._allocate_sampler_workspace(runner)
+
+    if should_allocate:
+        empty.assert_called_once_with(
+            (7, 11), dtype=torch.float32, device=torch.device("cpu")
+        )
+        assert runner.sampler.sampler_workspace is allocated
+    else:
+        empty.assert_not_called()
+        assert runner.sampler.sampler_workspace is None
+
+
 def test_sample_passes_reordered_draft_probs_to_rejection_sampler():
     runner = object.__new__(GPUModelRunner)
     runner.use_async_scheduling = False

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -68,6 +68,39 @@ class Sampler(nn.Module):
         self.pin_memory = PIN_MEMORY
         self.logprobs_mode = logprobs_mode
         self.use_fp64_gumbel = use_fp64_gumbel
+        self.sampler_workspace: torch.Tensor | None = None
+
+    def _convert_logits_to_float32(self, logits: torch.Tensor) -> torch.Tensor:
+        """Convert logits to float32, reusing a profiled workspace if possible."""
+        if logits.dtype == torch.float32:
+            return logits
+
+        workspace = self.sampler_workspace
+        if (
+            workspace is not None
+            and workspace.ndim == 2
+            and workspace.dtype == torch.float32
+            and workspace.device == logits.device
+            and workspace.shape[0] >= logits.shape[0]
+            and workspace.shape[1] == logits.shape[1]
+        ):
+            logits_fp32 = workspace[: logits.shape[0]]
+            logits_fp32.copy_(logits)
+            return logits_fp32
+
+        return logits.to(torch.float32)
+
+    def _clone_if_workspace_alias(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Keep reusable workspace storage out of asynchronous outputs."""
+        workspace = self.sampler_workspace
+        if (
+            workspace is not None
+            and workspace.device == tensor.device
+            and workspace.untyped_storage().data_ptr()
+            == tensor.untyped_storage().data_ptr()
+        ):
+            return tensor.clone()
+        return tensor
 
     def forward(
         self,
@@ -92,8 +125,10 @@ class Sampler(nn.Module):
                 else:
                     raw_logprobs = logits.to(torch.float32)
 
-        # Use float32 for the logits.
-        logits = logits.to(torch.float32)
+        # Use float32 for the logits. The model runner preallocates this
+        # workspace during memory profiling so the common sampler cast is
+        # accounted for in KV-cache sizing.
+        logits = self._convert_logits_to_float32(logits)
 
         logits = self.apply_logits_processors(
             logits, sampling_metadata, predict_bonus_token
@@ -120,6 +155,12 @@ class Sampler(nn.Module):
         if num_logprobs is None:
             logprobs_tensors = logprob_token_ids_tensors
         elif num_logprobs == -1:
+            assert raw_logprobs is not None
+            # processed_logits may be a view of sampler_workspace. The model
+            # runner can start reusing that workspace while an asynchronous
+            # D2H copy still reads this output, so detach it from reusable
+            # storage before returning it.
+            raw_logprobs = self._clone_if_workspace_alias(raw_logprobs)
             # Return the full unsorted and unranked logprobs.
             logprobs_tensors = LogprobsTensors(
                 torch.empty(0), raw_logprobs, torch.empty(0)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5227,6 +5227,24 @@ class GPUModelRunner(
             new_config = update_config(config, config_overrides)
             setattr(self, config_name, new_config)
 
+    def _allocate_sampler_workspace(self) -> None:
+        # Clear a workspace left by a previous load before applying the current
+        # rank/runner policy.
+        self.sampler.sampler_workspace = None
+        if (
+            self.model_config.runner_type != "generate"
+            or not get_pp_group().is_last_rank
+        ):
+            return
+
+        # Sampler receives one bonus/next-token logits row per live request;
+        # speculative target rows are handled separately by RejectionSampler.
+        self.sampler.sampler_workspace = torch.empty(
+            (self.max_num_reqs, self.model_config.get_vocab_size()),
+            dtype=torch.float32,
+            device=self.device,
+        )
+
     @instrument(span_name="Loading (GPU)")
     def load_model(self, load_dummy_weights: bool = False) -> None:
         """
@@ -5316,6 +5334,10 @@ class GPUModelRunner(
                         self.model_config,
                     )
                     eplb_models += 1
+
+                # Keep this persistent allocation in model memory accounting so
+                # it is deducted before KV-cache sizing.
+                self._allocate_sampler_workspace()
 
                 time_after_load = time.perf_counter()
             self.model_memory_usage = m.consumed_memory


### PR DESCRIPTION
## Summary

Classification: `PARTIAL_MITIGATION / TARGETED sampler workspace accounting improvement`.

This PR preallocates a float32 sampler logits workspace during GPU memory profiling and reuses that workspace in `Sampler.forward()` when it is compatible with the current logits tensor. If the workspace is absent, too small, on the wrong device, or the logits are already float32, the sampler uses the normal safe path instead of blindly slicing the workspace.

The intended benefit is narrow: account for the sampler fp16-to-fp32 logits workspace when vLLM sizes the KV cache, reducing an unprofiled allocation spike during sampler warmup/serving.

## Change

- Allocate `sampler_workspace` as a static float32 tensor sized to maximum live requests and vocabulary size, only on the last pipeline rank of generation runners, during model memory accounting.
- In `Sampler.forward()`, reuse that workspace only when dtype, device, row capacity, and vocab dimension match the current logits.
- Leave float32 logits in place and fall back to `logits.to(torch.float32)` when the preallocated workspace cannot safely satisfy the current call.
- Keep the claim limited to this workspace allocation path.

## Validation Scope

Independent GCP validation was run on 2026-05-05 against the original PR head before the final workspace-hardening follow-up:

- base: `be12afd284f3f09991a7fcf506553375dc58be36`
- validated PR head: `4d580373668c3441c16dde174c1af603d0bb3c40`
- historical hardening head: `ab70bb5249ef4f93f6958b23aba9641591ca43a6`
- model: `Qwen/Qwen2.5-0.5B`
- L4 24 GB: GCP `g2-standard-32`, NVIDIA L4, driver 580.126.20, CUDA 13.0
- A100: GCP `a2-highgpu-1g`, CUDA 13.0
- Python 3.10.12, torch 2.11.0+cu130, transformers 4.57.6

Results on L4 24 GB:

- Base at `gpu_memory_utilization=0.99`: failed during CUDA graph capture with CUDA OOM.
- PR head at `gpu_memory_utilization=0.99`: still failed before serving with CUDA OOM while trying to allocate 2 MiB.
- PR head at `gpu_memory_utilization=0.95`: booted and completed repeated greedy generation probes.
- PR head at `0.95` with prompt logprobs plus chunked prefill: booted and probe passed.
- PR head at `0.95` with `max_num_seqs=2` and `max_num_batched_tokens=128`: booted and boundary probe passed.
- PR head at `0.95` with ngram speculative decoding: booted and probe passed.

Results on A100:

- Base/head at `gpu_memory_utilization=0.99` both failed early because free startup memory was below the requested 0.99 reservation.
- PR head at `0.95` passed generation, prompt-logprobs/chunked-prefill, max-seqs/batched-token boundary, and ngram speculative probes.

## Current rebase and validation (2026-07-12)

Rebased onto upstream `main` at `27c3e579f0e5f345a86e512e26e1231d3689931f`.

The current head corrects the prior over-reservation and reuse race:

- `Sampler.forward()` receives one next/bonus logits row per live request; speculative target rows are handled separately by `RejectionSampler`, so the persistent workspace is `max_num_reqs × vocab_size`, not `max_num_reqs × (1 + num_spec_tokens) × vocab_size`.
- The workspace is allocated only on the last pipeline rank for generation runners. Other ranks and pooling/draft runners do not reserve it.
- Full processed-logit outputs are cloned if they alias the reusable workspace, preventing the next default-stream sample from racing an asynchronous D2H output copy.
- Incompatible dtype, device, rank, capacity, or vocabulary width still falls back to the normal float32 conversion.

Current focused validation:

- `pytest -q tests/v1/sample/test_sampler.py -k "workspace or full_processed" --confcutdir=tests/v1/sample` on CPU -> `4 passed, 36 deselected`
- `pytest -q tests/v1/worker/test_gpu_model_runner.py -k "sampler_workspace_allocation" --confcutdir=tests/v1/worker` on CPU -> `4 passed, 34 deselected`
- `ruff format --check`, `ruff check`, `python -m py_compile`, and `git diff --check` on all four changed files -> passed

The earlier L4/A100 runtime results remain historical validation of the targeted accounting approach. This follow-up was not rerun on GPU and does not strengthen the original OOM claim.

## What This Does Not Prove

This PR should not claim to make `gpu_memory_utilization=0.99` safe on 24 GB GPUs. The L4 head run still OOMed at `0.99`.

This PR also does not prove a fix for the closest sampler OOM issue I found, #33920. That issue uses GLM-4.7-Flash, tensor parallel size 2, 2x RTX 4090, `max_model_len=90000`, and an OOM in the top-k/top-p sort path. That original issue was not reproduced by this validation.

## Safe Claim

Preallocates/account-profiles the sampler fp32 logits workspace to avoid one unprofiled allocation spike; full 24 GB/`0.99` OOM behavior remains unresolved. The current head safely falls back when the workspace is not compatible. On L4, this validated boot/generation at `0.95` and prompt-logprobs, chunked-prefill, max-seqs/batched-token, and ngram speculative probes. It does not make `0.99` utilization safe on 24 GB GPUs and does not prove the GLM-4.7-Flash/top-k-sort issue is fixed.

## Review Recommendation

Review this as a targeted sampler workspace accounting improvement. If the goal is to fix a 24 GB `0.99` boot OOM or #33920 specifically, that needs a separate original-condition reproduction and broader memory-sizing fix.