### PR TITLE
Backward compatible when `scaled_fp4_quant.out` symbol missing

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -92,16 +92,18 @@ if hasattr(torch.ops, "_C") and hasattr(torch.ops._C, "scaled_fp4_quant"):
         m = input.numel() // n
         return create_fp4_output_tensors(m, n, input.device, is_sf_swizzled_layout)
 
-    @register_fake("_C::scaled_fp4_quant.out")
-    def _scaled_fp4_quant_out_fake(
-        input: torch.Tensor,
-        input_scale: torch.Tensor,
-        is_sf_swizzled_layout: bool,
-        *,
-        output: torch.Tensor,
-        output_scale: torch.Tensor,
-    ) -> None:
-        return None
+    if hasattr(torch.ops._C.scaled_fp4_quant, "out"):
+
+        @register_fake("_C::scaled_fp4_quant.out")
+        def _scaled_fp4_quant_out_fake(
+            input: torch.Tensor,
+            input_scale: torch.Tensor,
+            is_sf_swizzled_layout: bool,
+            *,
+            output: torch.Tensor,
+            output_scale: torch.Tensor,
+        ) -> None:
+            return None
 
 
 # page attention ops

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -46,7 +46,9 @@ if find_spec("flashinfer"):
     except ImportError:
         pass
 
-if hasattr(torch.ops._C, "scaled_fp4_quant"):
+if hasattr(torch.ops._C, "scaled_fp4_quant") and hasattr(
+    torch.ops._C.scaled_fp4_quant, "out"
+):
     STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.out
 
 # Max size of the input tensor per world size per device capability
@@ -808,7 +810,11 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
                     self.device,
                     self.allreduce_params,
                 ).register(self.patterns)
-                if current_platform.has_device_capability(100):
+                if (
+                    current_platform.has_device_capability(100)
+                    and hasattr(torch.ops._C, "scaled_fp4_quant")
+                    and hasattr(torch.ops._C.scaled_fp4_quant, "out")
+                ):
                     AllReduceFusedRMSNormStaticQuantNVFP4Pattern(
                         epsilon,
                         self.model_dtype,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -46,9 +46,12 @@ if find_spec("flashinfer"):
     except ImportError:
         pass
 
-if hasattr(torch.ops._C, "scaled_fp4_quant") and hasattr(
-    torch.ops._C.scaled_fp4_quant, "out"
-):
+_SCALED_FP4_QUANT_OUT_AVAILABLE = (
+    hasattr(torch.ops._C, "scaled_fp4_quant")
+    and hasattr(torch.ops._C.scaled_fp4_quant, "out")
+)
+
+if _SCALED_FP4_QUANT_OUT_AVAILABLE:
     STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.out
 
 # Max size of the input tensor per world size per device capability

--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -37,7 +37,11 @@ QUANT_OPS: dict[QuantKey, OpOverload] = {
     kFp8DynamicTokenSym: torch.ops._C.dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
 }
 
-if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
+if (
+    current_platform.is_cuda()
+    and hasattr(torch.ops._C, "scaled_fp4_quant")
+    and hasattr(torch.ops._C.scaled_fp4_quant, "out")
+):
     QUANT_OPS[kNvfp4Dynamic] = torch.ops._C.scaled_fp4_quant.out  # noqa: E501
 
 if current_platform.is_cuda():

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -62,7 +62,11 @@ QUANT_OPS: dict[QuantKey, OpOverload] = {
     kFp8DynamicTensorSym: torch.ops._C.dynamic_scaled_fp8_quant.default,  # noqa: E501
     kFp8DynamicTokenSym: torch.ops._C.dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
 }
-if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
+if (
+    current_platform.is_cuda()
+    and hasattr(torch.ops._C, "scaled_fp4_quant")
+    and hasattr(torch.ops._C.scaled_fp4_quant, "out")
+):
     QUANT_OPS[kNvfp4Dynamic] = torch.ops._C.scaled_fp4_quant.out
 if current_platform.is_cuda():
     QUANT_OPS[kFp8Dynamic128Sym] = torch.ops._C.per_token_group_fp8_quant.default  # noqa: E501


### PR DESCRIPTION

## Purpose
To Fix issue #NA( when creating a new issue, it seems a lot of AI claw 🦞 will "eat" it....)

The .out overload was added recently in commit eeabf740b, 
but the code **always assume  scaled_fp4_quant.out exists** (whenever scaled_fp4_quant is avail)

### Issue 

  When Python source code is too new(main branch) than the runtime env (with v0.16 image or `pip install -e` with old code), 
  
  when importing vLLM , it would failed:
```
  AttributeError: The underlying op of '_C.scaled_fp4_quant' has no overload name 'out'
```

since it's missing in the old env's  compiled C .so. 



## Test Plan

1. in old env (like v0.16 docker image or old env which `pip install -e` with old code)
1. then `git rebase` latest code.
1. just `vllm -v` will reveal the bug.


## Test Result


Before fix:

```
vllm -v
```
or 

```

(/root/peter/conda) root@peter-dev-6486786b56-nxqm2:~/peter/vllm# vllm serve /mnt/nfs-hdd-csi/models/Qwen3-0.6B  --load-format=dummy

Traceback (most recent call last):
  File "/root/peter/conda/bin/vllm", line 3, in <module>
    from vllm.entrypoints.cli.main import main
  File "/root/peter/vllm/vllm/entrypoints/cli/__init__.py", line 4, in <module>
    from vllm.entrypoints.cli.benchmark.mm_processor import (
  File "/root/peter/vllm/vllm/entrypoints/cli/benchmark/mm_processor.py", line 5, in <module>
    from vllm.benchmarks.mm_processor import add_cli_args, main
  File "/root/peter/vllm/vllm/benchmarks/mm_processor.py", line 26, in <module>
    from vllm.benchmarks.datasets import (
  File "/root/peter/vllm/vllm/benchmarks/datasets.py", line 39, in <module>
    from vllm.lora.utils import get_adapter_absolute_path
  File "/root/peter/vllm/vllm/lora/utils.py", line 18, in <module>
    from vllm.lora.layers import (
  File "/root/peter/vllm/vllm/lora/layers/__init__.py", line 4, in <module>
    from vllm.lora.layers.column_parallel_linear import (
  File "/root/peter/vllm/vllm/lora/layers/column_parallel_linear.py", line 13, in <module>
    from vllm.model_executor.layers.linear import (
  File "/root/peter/vllm/vllm/model_executor/layers/linear.py", line 28, in <module>
    from vllm.model_executor.layers.utils import (
  File "/root/peter/vllm/vllm/model_executor/layers/utils.py", line 9, in <module>
    from vllm import _custom_ops as ops
  File "/root/peter/vllm/vllm/_custom_ops.py", line 95, in <module>
    @register_fake("_C::scaled_fp4_quant.out")
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/peter/conda/lib/python3.12/site-packages/torch/library.py", line 1073, in register
    use_lib._register_fake(
  File "/root/peter/conda/lib/python3.12/site-packages/torch/library.py", line 203, in _register_fake
    handle = entry.fake_impl.register(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/peter/conda/lib/python3.12/site-packages/torch/_library/fake_impl.py", line 50, in register
    if torch._C._dispatch_has_kernel_for_dispatch_key(self.qualname, "Meta"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: operator _C::scaled_fp4_quant.out does not exist

```

After Fix:
```
(/root/peter/conda) root@peter-dev-6486786b56-nxqm2:~/peter/vllm# vllm -v
0.17.2rc1.dev58+geaf7c9b97.precompiled

...

(/root/peter/conda) root@peter-dev-6486786b56-nxqm2:~/peter/vllm# vllm serve /mnt/nfs-hdd-csi/models/Qwen3-0.6B  --load-format=dummy
(APIServer pid=4622) INFO 03-19 06:07:27 [utils.py:297]
(APIServer pid=4622) INFO 03-19 06:07:27 [utils.py:297]        █     █     █▄   ▄█
(APIServer pid=4622) INFO 03-19 06:07:27 [utils.py:297]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.17.2rc1.dev60+g17c47fb86
(APIServer pid=4622) INFO 03-19 06:07:27 [utils.py:297]   █▄█▀ █     █     █     █  model   /mnt/nfs-hdd-csi/models/Qwen3-0.6B
(APIServer pid=4622) INFO 03-19 06:07:27 [utils.py:297]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=4622) INFO 03-19 06:07:27 [utils.py:297]
(APIServer pid=4622) INFO 03-19 06:07:27 [utils.py:233] non-default args: {'model_tag': '/mnt/nfs-hdd-csi/models/Qwen3-0.6B', 'model': '/mnt/nfs-hdd-csi/models/Qwen3-0.6B', 'load_format': 'dummy'}
(APIServer pid=4622) INFO 03-19 06:07:27 [model.py:533] Resolved architecture: Qwen3ForCausalLM
(APIServer pid=4622) INFO 03-19 06:07:27 [model.py:1582] Using max model len 40960
(APIServer pid=4622) INFO 03-19 06:07:27 [vllm.py:750] Asynchronous scheduling is enabled.
(EngineCore pid=4763) INFO 03-19 06:07:34 [core.py:103] Initializing a V1 LLM engine (v0.17.2rc1.dev60+g17c47fb86) with config: model='/mnt/nfs-hdd-csi/models/Qwen3-0.6B', speculative_config=None, tokenizer='/mnt/nfs-hdd-csi/models/Qwen3-0.6B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=40960, download_dir=None, load_format=dummy, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=/mnt/nfs-hdd-csi/models/Qwen3-0.6B, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore pid=4763) INFO 03-19 06:07:35 [parallel_state.py:1400] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://10.233.99.55:32769 backend=nccl
(EngineCore pid=4763) INFO 03-19 06:07:35 [parallel_state.py:1716] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(EngineCore pid=4763) INFO 03-19 06:07:36 [gpu_model_runner.py:4509] Starting to load model /mnt/nfs-hdd-csi/models/Qwen3-0.6B...
(EngineCore pid=4763) INFO 03-19 06:07:37 [cuda.py:333] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(EngineCore pid=4763) INFO 03-19 06:07:37 [flash_attn.py:598] Using FlashAttention version 2
(EngineCore pid=4763) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(EngineCore pid=4763) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(EngineCore pid=4763) INFO 03-19 06:07:37 [gpu_model_runner.py:4594] Model loading took 1.12 GiB memory and 0.655299 seconds
(EngineCore pid=4763) INFO 03-19 06:07:44 [backends.py:990] Using cache directory: /root/.cache/vllm/torch_compile_cache/4246623061/rank_0_0/backbone for vLLM's torch.compile
(EngineCore pid=4763) INFO 03-19 06:07:44 [backends.py:1050] Dynamo bytecode transform time: 6.83 s
(EngineCore pid=4763) INFO 03-19 06:07:48 [backends.py:371] Cache the graph of compile range (1, 2048) for later use
(EngineCore pid=4763) INFO 03-19 06:07:52 [backends.py:389] Compiling a graph for compile range (1, 2048) takes 7.27 s
(EngineCore pid=4763) INFO 03-19 06:07:53 [decorators.py:627] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/7d50e4e6c03efe8b5b2b3249baf48555f6e25df4769685fc3075f1a90c4923f4/rank_0_0/model
(EngineCore pid=4763) INFO 03-19 06:07:53 [monitor.py:48] torch.compile took 15.95 s in total
(EngineCore pid=4763) INFO 03-19 06:07:54 [monitor.py:76] Initial profiling/warmup run took 0.33 s
(EngineCore pid=4763) INFO 03-19 06:07:54 [kv_cache_utils.py:826] Overriding num_gpu_blocks=0 with num_gpu_blocks_override=512
(EngineCore pid=4763) INFO 03-19 06:07:54 [gpu_model_runner.py:5636] Profiling CUDA graph memory: PIECEWISE=51 (largest=512), FULL=35 (largest=256)
(EngineCore pid=4763) INFO 03-19 06:07:55 [gpu_model_runner.py:5715] Estimated CUDA graph memory: 0.13 GiB total
(EngineCore pid=4763) INFO 03-19 06:07:56 [gpu_worker.py:456] Available KV cache memory: 15.87 GiB
(EngineCore pid=4763) INFO 03-19 06:07:56 [gpu_worker.py:490] In v0.19, CUDA graph memory profiling will be enabled by default (VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1), which more accurately accounts for CUDA graph memory during KV cache allocation. To try it now, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1 and increase --gpu-memory-utilization from 0.9000 to 0.9066 to maintain the same effective KV cache size.
(EngineCore pid=4763) INFO 03-19 06:07:56 [kv_cache_utils.py:1316] GPU KV cache size: 148,560 tokens
(EngineCore pid=4763) INFO 03-19 06:07:56 [kv_cache_utils.py:1321] Maximum concurrency for 40,960 tokens per request: 3.63x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 51/51 [00:02<00:00, 21.07it/s]
Capturing CUDA graphs (decode, FULL): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 35/35 [00:01<00:00, 23.37it/s]
(EngineCore pid=4763) INFO 03-19 06:08:00 [gpu_model_runner.py:5775] Graph capturing finished in 5 secs, took 0.05 GiB
(EngineCore pid=4763) INFO 03-19 06:08:00 [gpu_worker.py:617] CUDA graph pool memory: 0.05 GiB (actual), 0.13 GiB (estimated), difference: 0.08 GiB (175.0%).
(EngineCore pid=4763) INFO 03-19 06:08:01 [core.py:281] init engine (profile, create kv cache, warmup model) took 23.33 seconds
(EngineCore pid=4763) INFO 03-19 06:08:01 [vllm.py:750] Asynchronous scheduling is enabled.
(APIServer pid=4622) INFO 03-19 06:08:02 [api_server.py:595] Supported tasks: ['generate']
(APIServer pid=4622) WARNING 03-19 06:08:02 [model.py:1376] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=4622) INFO 03-19 06:08:02 [hf.py:320] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=4622) INFO 03-19 06:08:02 [api_server.py:599] Starting vLLM server on http://0.0.0.0:8000
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:37] Available routes are:
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=4622) INFO 03-19 06:08:02 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=4622) INFO:     Started server process [4622]
(APIServer pid=4622) INFO:     Waiting for application startup.
(APIServer pid=4622) INFO:     Application startup complete.
```


















**FAQ: will other ops needs this kind of fix?**

**Answer:  No. **

Because:  `scaled_fp4_quant` is the only operator with a .out variant registered via @register_fake,  but  all other ops only register their base variant. (as below)
This mismatch between the existence check (base) and registration  target (.out) causes the crash when the C++ .so ext has the base op but not the .out overload.


```
 grep register_fake vllm/_custom_ops.py

     @register_fake("_C::scaled_fp4_quant.out") <--------- only it registery_fake(*.out)
    @register_fake("_C::awq_dequantize")
    @register_fake("_C::awq_gemm")
    @register_fake("_C::gptq_gemm")
    @register_fake("_C::allspark_w8a16_gemm")
    @register_fake("_C::ggml_dequantize")
    @register_fake("_C::ggml_mul_mat_vec_a8")
    @register_fake("_C::ggml_mul_mat_a8")
    @register_fake("_C::ggml_moe_a8")
    @register_fake("_C::ggml_moe_a8_vec")
    @register_fake("_C::mxfp8_experts_quant")
    @register_fake("_C::cutlass_mxfp8_grouped_mm")
    @register_fake("_C::gptq_marlin_repack")
    @register_fake("_C::awq_marlin_repack")
    @register_fake("_C::marlin_gemm")
    @register_fake("_C::machete_mm")
    @register_fake("_C::machete_prepack_B")
    @register_fake("_C::cutlass_w4a8_mm")
    @register_fake("_C::cutlass_pack_scale_fp8")
    @register_fake("_C::cutlass_encode_and_reorder_int4b")
    @register_fake("_C::cutlass_encode_and_reorder_int4b_grouped")
    @register_fake("_C::permute_cols")
    @register_fake("_moe_C::router_gemm_bf16_fp32")
    @register_fake("_moe_C::marlin_gemm_moe")
    @register_fake("_moe_C::moe_wna16_marlin_gemm")
    @register_fake("_C::weight_packed_linear")
    @register_fake("_C::fused_experts_cpu")
    @register_fake("_C::int8_scaled_mm_with_quant")
    @register_fake("_qutlass_C::matmul_mxf4_bf16_tn")
    @register_fake("_qutlass_C::matmul_ada_mxf4_bf16_tn")
    @register_fake("_qutlass_C::fusedQuantizeMxQuest")
    @register_fake("_qutlass_C::fusedQuantizeMxAbsMax")
    @register_fake("_qutlass_C::fusedQuantizeNv")
    @register_fake("_C::hadacore_transform")
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

