### PR TITLE
[Bugfix] Fix MLA KV cache blocks not zeroed on reuse, causing CUDA crashes under concurrent load

### DIFF
--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -209,7 +209,7 @@ class SingleTypeKVCacheManager(ABC):
                 cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
             )
             req_blocks.extend(allocated_blocks)
-            if type(self.kv_cache_spec) is FullAttentionSpec:
+            if isinstance(self.kv_cache_spec, FullAttentionSpec):
                 self.new_block_ids.extend(b.block_id for b in allocated_blocks)
 
     def allocate_new_blocks(
@@ -237,7 +237,7 @@ class SingleTypeKVCacheManager(ABC):
         else:
             new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
             req_blocks.extend(new_blocks)
-            if type(self.kv_cache_spec) is FullAttentionSpec:
+            if isinstance(self.kv_cache_spec, FullAttentionSpec):
                 self.new_block_ids.extend(b.block_id for b in new_blocks)
             return new_blocks
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -495,5 +495,11 @@ class KVCacheConfig:
         return any(isinstance(g.kv_cache_spec, MambaSpec) for g in self.kv_cache_groups)
 
     @property
+    def has_mla_layers(self) -> bool:
+        return any(
+            isinstance(g.kv_cache_spec, MLAAttentionSpec) for g in self.kv_cache_groups
+        )
+
+    @property
     def needs_kv_cache_zeroing(self) -> bool:
-        return self.has_mamba_layers
+        return self.has_mamba_layers or self.has_mla_layers

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -120,7 +120,7 @@ class KVBlockZeroer:
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
-            if type(spec) is not FullAttentionSpec:
+            if not isinstance(spec, FullAttentionSpec):
                 continue
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix a CUDA illegal memory access crash in MLA (Multi-head Latent Attention) models under sustained concurrent load.

Reproduced with [kakaocorp/kanana-2-30b-a3b-instruct-2601](https://huggingface.co/kakaocorp/kanana-2-30b-a3b-instruct-2601) (DeepSeek V3 architecture) with FP8 dynamic quantization on NVIDIA H200.

When KV cache blocks are freed by completed requests and reallocated to new ones, they retain stale data from the previous request. For standard attention (`FullAttentionSpec`), these blocks are zeroed before reuse via the `KVBlockZeroer` pipeline. However, MLA attention (`MLAAttentionSpec`) is completely excluded from this zeroing pipeline, so reused blocks contain stale KV data that corrupts FP8 computation and crashes CUTLASS kernels.

The crash occurs under **continuous concurrent load** because sustained traffic causes frequent block alloc/free cycles, leading to stale data accumulation in reused blocks. It is reproducible both with and without prefix caching, though disabling prefix caching (`--no-enable-prefix-caching`) makes it deterministic since blocks are directly reused without hash-based validation.

**Root cause:** `MLAAttentionSpec` is a subclass of `FullAttentionSpec`, but three places use exact type matching (`type(x) is FullAttentionSpec`) instead of `isinstance()`, excluding MLA from the entire block zeroing pipeline:

1. **`vllm/v1/kv_cache_interface.py`** — `needs_kv_cache_zeroing` only checks `has_mamba_layers`. Since this property gates the entire zeroing pipeline (kernel initialization, block ID collection, and GPU zeroing execution), MLA models never have any blocks zeroed.

2. **`vllm/v1/core/single_type_kv_cache_manager.py`** (2 occurrences) — `type(self.kv_cache_spec) is FullAttentionSpec` in `allocate_new_blocks()` and the external-computed-tokens path excludes MLA blocks from the `new_block_ids` collection. Even if the pipeline is enabled, no MLA block IDs are ever collected for zeroing.

3. **`vllm/v1/worker/utils.py`** — `type(spec) is not FullAttentionSpec` in `KVBlockZeroer.init_meta()` skips MLA layers when building the GPU memory address table for the Triton zeroing kernel. Without MLA segment addresses, the zeroing kernel cannot zero MLA KV cache memory.

All three must be fixed together — the pipeline has a gate (1), data collection (2), and execution (3) stage, and MLA was excluded from all of them.

**Fix:**
- Add `has_mla_layers` property and include it in `needs_kv_cache_zeroing`
- Change `type(x) is FullAttentionSpec` → `isinstance(x, FullAttentionSpec)` (2 files, 3 occurrences)

## Test Plan

- **Serving benchmark** — Verify the model serves correctly under concurrent load with variable-length inputs:

```bash
# Start server
vllm serve <MLA_FP8_MODEL> --port 8000

# Run benchmark (128 concurrent, variable-length inputs)
vllm bench serve \
  --model <MLA_FP8_MODEL> \
  --base-url http://localhost:8000 \
  --endpoint /v1/completions \
  --dataset-name random \
  --num-prompts 2048 \
  --request-rate inf \
  --max-concurrency 128 \
  --random-input-len 2048 \
  --random-output-len 512 \
  --random-range-ratio 0.3 \
  --ignore-eos \
  --seed 42
```

> **Note:** `--random-range-ratio 0.3` creates variable input/output lengths that diversify block alloc/free patterns, triggering stale-data reuse.

## Test Result

- **Environment:** NVIDIA H200 (141GB) x 1, vLLM v0.17.1
- **Model:** (DeepSeek V3 architecture, MLA + FP8)

Before fix — Server crashes after ~775 requests with `CUDA error: an illegal memory access`:
```
(EngineCore_DP0) ERROR [core.py:1102] EngineCore encountered a fatal error.
(EngineCore_DP0) ERROR [core.py:1102] Traceback (most recent call last):
(EngineCore_DP0) ERROR [core.py:1102]   File "vllm/v1/engine/core.py", line 497, in step_with_batch_queue
(EngineCore_DP0) ERROR [core.py:1102]     model_output = future.result()
(EngineCore_DP0) ERROR [core.py:1102]   File "vllm/v1/worker/gpu_model_runner.py", line 251, in get_output
(EngineCore_DP0) ERROR [core.py:1102]     self.async_copy_ready_event.synchronize()
(EngineCore_DP0) ERROR [core.py:1102] torch.AcceleratorError: CUDA error: an illegal memory access was encountered

(APIServer) ERROR [async_llm.py:708] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue.

============ Serving Benchmark Result ============
Successful requests:                     775
Failed requests:                         1273
Maximum request concurrency:             128
Benchmark duration (s):                  120.67
Total input tokens:                      1594182
Total generated tokens:                  362632
Request throughput (req/s):              6.42
Output token throughput (tok/s):         3005.03
Peak output token throughput (tok/s):    6889.00
Peak concurrent requests:                142.00
Total token throughput (tok/s):          16215.59
---------------Time to First Token----------------
Mean TTFT (ms):                          802.84
Median TTFT (ms):                        308.69
P99 TTFT (ms):                           5555.58
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          41.23
Median TPOT (ms):                        41.78
P99 TPOT (ms):                           53.93
---------------Inter-token Latency----------------
Mean ITL (ms):                           40.27
Median ITL (ms):                         19.55
P99 ITL (ms):                            149.26
==================================================
```

After fix — All 2048 requests succeed with no errors:
```
============ Serving Benchmark Result ============
Successful requests:                     2048
Failed requests:                         0
Maximum request concurrency:             128
Benchmark duration (s):                  351.99
Total input tokens:                      4193816
Total generated tokens:                  1048660
Request throughput (req/s):              5.82
Output token throughput (tok/s):         2979.21
Peak output token throughput (tok/s):    6875.00
Peak concurrent requests:                139.00
Total token throughput (tok/s):          14893.70
---------------Time to First Token----------------
Mean TTFT (ms):                          471.01
Median TTFT (ms):                        304.73
P99 TTFT (ms):                           5093.49
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          41.56
Median TPOT (ms):                        42.67
P99 TPOT (ms):                           45.77
---------------Inter-token Latency----------------
Mean ITL (ms):                           41.55
Median ITL (ms):                         19.53
P99 ITL (ms):                            150.89
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>