### PR TITLE
[bugfix] Outputting full results for long audio files in stream_api_response() mode

### DIFF
--- a/examples/online_serving/openai_transcription_client.py
+++ b/examples/online_serving/openai_transcription_client.py
@@ -104,6 +104,9 @@ def stream_api_response(audio_path: str, model: str, openai_api_base: str):
         ):
             if chunk:
                 data = chunk[len("data: ") :]
+                # For long audio files, we should only check for b"[DONE]",
+                # because they are split into multiple chunks, and each chunk
+                # has its own finish_reason.
                 if data == b"[DONE]":
                     break
                 data = json.loads(data.decode("utf-8"))

--- a/examples/online_serving/openai_transcription_client.py
+++ b/examples/online_serving/openai_transcription_client.py
@@ -104,15 +104,12 @@ def stream_api_response(audio_path: str, model: str, openai_api_base: str):
         ):
             if chunk:
                 data = chunk[len("data: ") :]
+                if data == b"[DONE]":
+                    break
                 data = json.loads(data.decode("utf-8"))
                 data = data["choices"][0]
                 delta = data["delta"]["content"]
                 print(delta, end="", flush=True)
-
-                finish_reason = data.get("finish_reason")
-                if finish_reason is not None:
-                    print(f"\n[Stream finished reason: {finish_reason}]")
-                    break
 
 
 def main(args):


### PR DESCRIPTION
@DarkLight1337 @Isotr0py Please take a look this small bugfix.

If we use a long audio file (e.g., 70s), it will be split into three chunks (30s/30s/10s), and the ASR model will be called three times. Each result contains a finish reason. The bug is that `def stream_api_response()` only prints the result of chunks[0] because of `if finish_reason is not None: break`, as shown below.

`transcription result [stream]: 试错的过程很简单啊今特别是今天报名昌学海的同学你们可以听到后面的有专门的活动课它会大大降低你的试错成本其实你也可以不要来听课为什么你自己写嘛我先今天写五个点我就试试试验一下发现这五个点不行我再写五个点这是再不行那再写五个点嘛你总会所谓的活动大神和所谓的高手`

In fact, there are still two chunk results waiting to be consumed. Therefore, we should only check for `b"[DONE]"` instead of finish_reason, so that the full result can be displayed.
`transcription result [stream]: 试错的过程很简单啊今特别是今天报名昌学海的同学你们可以听到后面的有专门的活动课它会大大降低你的试错成本其实你也可以不要来听课为什么你自己写嘛我先今天写五个点我就试试试验一下发现这五个点不行我再写五个点这是再不行那再写五个点嘛你总会所谓的活动大神和所谓的高手都是只有一个把所有的错所有的坑全部趟一遍留下正确的你就是所谓的大神明白吗所以说关于活动通过这一块儿我只送给你们四个字啊换位思考如果说你要想降低你的试错成本今天来这里你们就是对的因为有畅享畅享卡这个机会所以说关于活动过于不过这个问题或者活动很难通过这个话题呃如果真的要坐下来聊的话要聊一天但是我觉得我刚才说的四个字足够好谢谢好非常感谢那个三毛老师的回答啊三毛老师说我们在整个店铺的这个活动当中我们要学会换位思考其实`

server
`vllm serve allendou/FireRedASR2-LLM-vllm --dtype=float32`

client
`python3 openai_transcription_client.py --repetition_penalty=1.0 --audio_path=/root/vad_example.wav`

test audio: https://isv-data.oss-cn-hangzhou.aliyuncs.com/ics/MaaS/ASR/test_audio/vad_example.wav

