### PR TITLE
[CI] Fix wrong path test file, missing `rlhf_async_new_apis.py`

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -194,7 +194,7 @@ steps:
   num_devices: 2
   commands:
     - pytest -v -s tests/distributed/test_context_parallel.py
-    - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 examples/offline_inference/new_weight_syncing/rlhf_async_new_apis.py
+    - VLLM_ALLOW_INSECURE_SERIALIZATION=1 python3 examples/rl/rlhf_async_new_apis.py
     - VLLM_USE_DEEP_GEMM=1 VLLM_LOGGING_LEVEL=DEBUG python3 examples/offline_inference/data_parallel.py --model=Qwen/Qwen1.5-MoE-A2.7B -tp=1 -dp=2 --max-model-len=2048 --all2all-backend=deepep_high_throughput
     - pytest -v -s tests/v1/distributed/test_dbo.py
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix https://buildkite.com/vllm/ci/builds/56931/steps/canvas?sid=019d03bb-7ad8-4f4e-bef3-7599fb7aae29&tab=output
caused by this PR https://github.com/vllm-project/vllm/pull/36188

`python3: can't open file '/vllm-workspace/examples/offline_inference/new_weight_syncing/rlhf_async_new_apis.py': [Errno 2] No such file or directory`



## Test Plan

## Test Result

The Test Group passed now
https://buildkite.com/vllm/ci/builds/56972/steps/canvas?sid=019d0516-a1e8-46dc-8380-dc5a92eb7a4e&tab=output

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

