### PR TITLE
[Bugfix] Zero-init NVFP4 padding scales to prevent NaN contamination

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -56,6 +56,11 @@ def create_fp4_scale_tensor(
         rounded_m = round_up(m, 128)
         scale_n = n // block_size
         rounded_n = round_up(scale_n, 4)
+        # Use torch.zeros (not torch.empty) so padding scales are 0.
+        # The TRT-LLM mm_fp4 kernel with use_8x4_sf_layout reads padding
+        # rows' scales and mixes them into real rows' output. Zero scales
+        # neutralize this: 0 * data = 0.
+        # See: https://github.com/flashinfer-ai/flashinfer/issues/2861
         return torch.zeros(
             (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
         )
@@ -1763,6 +1768,7 @@ def scaled_fp4_experts_quant(
     output = torch.empty(
         m_numtopk, k // 2, device=input_tensor.device, dtype=torch.uint8
     )
+    # See create_fp4_scale_tensor for why we use torch.zeros here.
     output_scales = torch.zeros(
         MAX_TOKENS_PER_EXPERT * topk,
         padded_k,
@@ -1828,6 +1834,7 @@ def silu_and_mul_scaled_fp4_experts_quant(
     output = torch.empty(
         m_numtopk, k // 2, device=input_tensor.device, dtype=torch.uint8
     )
+    # See create_fp4_scale_tensor for why we use torch.zeros here.
     output_scales = torch.zeros(
         MAX_TOKENS_PER_EXPERT * topk,
         padded_k,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1763,7 +1763,7 @@ def scaled_fp4_experts_quant(
     output = torch.empty(
         m_numtopk, k // 2, device=input_tensor.device, dtype=torch.uint8
     )
-    output_scales = torch.empty(
+    output_scales = torch.zeros(
         MAX_TOKENS_PER_EXPERT * topk,
         padded_k,
         dtype=torch.int32,
@@ -1828,7 +1828,7 @@ def silu_and_mul_scaled_fp4_experts_quant(
     output = torch.empty(
         m_numtopk, k // 2, device=input_tensor.device, dtype=torch.uint8
     )
-    output_scales = torch.empty(
+    output_scales = torch.zeros(
         MAX_TOKENS_PER_EXPERT * topk,
         padded_k,
         dtype=torch.int32,


### PR DESCRIPTION
## Summary

- Zero-initialize NVFP4 scale tensors (`torch.zeros` instead of `torch.empty`) at three allocation sites to prevent NaN/garbage from stale memory leaking into real rows' output

## Problem

When NVFP4 scale tensors are allocated with `torch.empty`, padding rows (beyond actual token count but within the tile-aligned allocation) contain uninitialized memory. Under CUDA graphs, this stale memory can contain NaN bytes.

The `mm_fp4` TRT-LLM backend with `use_8x4_sf_layout=True` ([`_custom_ops.py:1732`](https://github.com/vllm-project/vllm/blob/17c47fb8691f2efd7948659952c44ef167462534/vllm/_custom_ops.py#L1732)) reads padding scales and applies them to real rows, causing:
1. **NaN contamination** when padding scales contain NaN
2. **Silent numerical errors** (max_diff ~500-700 in bf16) even with finite padding scale values

See #37563 for detailed reproduction and test results.

## Fix

Replace `torch.empty` → `torch.zeros` for all NVFP4 scale allocations:
- `create_fp4_scale_tensor` — attention linear layers
- `scaled_fp4_experts_quant` — MoE Gemm1 input quantization
- `silu_and_mul_scaled_fp4_experts_quant` — MoE Gemm2 input quantization

Zero scales ensure that even if a kernel incorrectly reads padding rows, the contribution is `0 * data = 0`, which is harmless.

## Test plan

- [x] Verify NaN contamination test passes (padding NaN no longer leaks into real rows)
- [x] Verify finite contamination test shows SAME for all backends
- [ ] Run existing `test_flashinfer_nvfp4_scaled_mm` tests
- [ ] Benchmark to confirm no perf regression from `torch.zeros` vs `torch.empty`

Closes #37563

🤖 Generated with [Claude Code](https://claude.com/claude-code)