### PR TITLE
Run MacOS smoke test on daily `cron` job instead of every commit

### DIFF
--- a/.github/workflows/macos-smoke-test.yml
+++ b/.github/workflows/macos-smoke-test.yml
@@ -1,9 +1,9 @@
 name: macOS Apple Silicon Smoke Test
 
 on:
-  # push:
-  #   branches:
-  #     - main
+  schedule:
+    # Daily at 2:30 AM UTC
+    - cron: '30 2 * * *'
   workflow_dispatch:  # Manual trigger
 
 permissions:

--- a/.github/workflows/macos-smoke-test.yml
+++ b/.github/workflows/macos-smoke-test.yml
@@ -1,9 +1,9 @@
 name: macOS Apple Silicon Smoke Test
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:  # Manual trigger
 
 permissions:


### PR DESCRIPTION
This check is of low importance and is consuming significant GitHub actions resources, causing long queues in more important checks.

This PR changes it to run once a day instead of on every commit on main.