### PR TITLE
Fix `SpeculatorsConfig` now that `PreTrainedConfig` is a `dataclass` in Transformers

### DIFF
--- a/vllm/transformers_utils/configs/speculators/base.py
+++ b/vllm/transformers_utils/configs/speculators/base.py
@@ -18,8 +18,10 @@ class SpeculatorsConfig(PretrainedConfig):
     model_type = "speculators"
 
     def __init__(self, **kwargs):
-        """PretrainedConfig is a dataclass in Transformers v5.
-        This pass through is needed to avoid unexpected keyword arguments."""
+        """In Transformers v5, `PretrainedConfig` is decorated with `dataclass` and
+        `huggingface_hub.dataclasses.strict(accept_kwargs=True)`.
+        Inheriting classes do not inherit the `accept_kwargs=True` behaviour so we must
+        explicitly pass any kwargs to `PretrainedConfig.__init__`."""
         super().__init__(**kwargs)
 
     @classmethod

--- a/vllm/transformers_utils/configs/speculators/base.py
+++ b/vllm/transformers_utils/configs/speculators/base.py
@@ -17,6 +17,11 @@ from vllm.transformers_utils.utils import without_trust_remote_code
 class SpeculatorsConfig(PretrainedConfig):
     model_type = "speculators"
 
+    def __init__(self, **kwargs):
+        """PretrainedConfig is a dataclass in Transformers v5.
+        This pass through is needed to avoid unexpected keyword arguments."""
+        super().__init__(**kwargs)
+
     @classmethod
     def from_pretrained(
         cls,


### PR DESCRIPTION
Since Transformers converted `PretrainedConfig` to a `dataclass`, users will see unexpected keyword argument errors on `SpeculatorsConfig.__init__`.

This PR adds a passthrough so that `SpeculatorsConfig.__init__` can accept `kwargs` and passes them directly to `PretrainedConfig.__init__` which also accepts `kwargs`