### PR TITLE
[Model Runner V2] Add full cuda graph support for eagle prefill

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -464,7 +464,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         slot_mappings_by_layer = self.execute_model_state.slot_mappings_by_layer
         hidden_states = self.execute_model_state.hidden_states
         aux_hidden_states = self.execute_model_state.aux_hidden_states
-        num_tokens_across_dp = self.execute_model_state.num_tokens_across_dp
         self.execute_model_state = None
 
         # dummy run the eagle speculator's propose to ensure DP/EP sync.
@@ -496,7 +495,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 next_prefill_tokens=self.req_states.next_prefill_tokens,
                 temperature=self.sampler.sampling_states.temperature.gpu,
                 seeds=self.sampler.sampling_states.seeds.gpu,
-                num_tokens_across_dp=num_tokens_across_dp,
                 dummy_run=True,
                 skip_attn_for_dummy_run=skip_attn,
                 mm_inputs=mm_inputs,
@@ -1110,7 +1108,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             hidden_states=hidden_states,
             aux_hidden_states=aux_hidden_states,
             kv_connector_output=kv_connector_output,
-            num_tokens_across_dp=num_tokens_across_dp,
         )
 
         if not self.is_last_pp_rank:
@@ -1135,7 +1132,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         hidden_states = self.execute_model_state.hidden_states
         aux_hidden_states = self.execute_model_state.aux_hidden_states
         kv_connector_output = self.execute_model_state.kv_connector_output
-        num_tokens_across_dp = self.execute_model_state.num_tokens_across_dp
         self.execute_model_state = None
 
         if not self.is_last_pp_rank:
@@ -1228,7 +1224,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.req_states.next_prefill_tokens,
                 self.sampler.sampling_states.temperature.gpu,
                 self.sampler.sampling_states.seeds.gpu,
-                num_tokens_across_dp=num_tokens_across_dp,
                 mm_inputs=mm_inputs,
             )
             self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
@@ -1336,4 +1331,3 @@ class ExecuteModelState(NamedTuple):
     hidden_states: torch.Tensor | None
     aux_hidden_states: list[torch.Tensor] | None
     kv_connector_output: KVConnectorOutput | None
-    num_tokens_across_dp: torch.Tensor | None

--- a/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
@@ -19,21 +19,16 @@ from vllm.v1.worker.utils import AttentionGroup
 
 
 class EagleCudaGraphManager(CudaGraphManager):
-    """CudaGraphManager for Eagle speculative decoding (FULL mode only)."""
+    """CudaGraphManager for Eagle speculative decoding."""
 
     def __init__(
         self,
         vllm_config: VllmConfig,
         device: torch.device,
         cudagraph_mode: CUDAGraphMode,
-        draft_tokens: torch.Tensor,
+        decode_query_len: int,
     ):
-        assert not cudagraph_mode.has_mode(CUDAGraphMode.PIECEWISE), (
-            "EagleCudaGraphManager does not support PIECEWISE mode yet"
-        )
-        # Eagle always uses uniform decode with query_len=1
-        super().__init__(vllm_config, device, cudagraph_mode, decode_query_len=1)
-        self.draft_tokens = draft_tokens
+        super().__init__(vllm_config, device, cudagraph_mode, decode_query_len)
 
         # Use a dedicated pool for Eagle to avoid memory overlap with the main
         # model's cudagraph. The base class uses a shared global pool, but Eagle's
@@ -44,7 +39,7 @@ class EagleCudaGraphManager(CudaGraphManager):
 
     def capture(
         self,
-        generate_fn: Callable,
+        forward_fn: Callable,
         model_state: ModelState,
         input_buffers: InputBuffers,
         block_tables: BlockTables,
@@ -52,7 +47,7 @@ class EagleCudaGraphManager(CudaGraphManager):
         kv_cache_config: KVCacheConfig,
         progress_bar_desc: str = "Capturing CUDA graphs",
     ) -> None:
-        """Capture CUDA graphs for Eagle speculative decoding (FULL mode only)."""
+        """Capture CUDA graphs for Eagle."""
 
         def create_forward_fn(
             desc: BatchExecutionDescriptor,
@@ -74,7 +69,7 @@ class EagleCudaGraphManager(CudaGraphManager):
                 kv_cache_config,
             )
 
-            return lambda cg_mode: generate_fn(
+            return lambda cg_mode: forward_fn(
                 num_reqs,
                 num_tokens,
                 attn_metadata,
@@ -84,8 +79,3 @@ class EagleCudaGraphManager(CudaGraphManager):
             )
 
         super().capture(create_forward_fn, progress_bar_desc)
-
-    def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor:
-        """Replay a captured FULL cudagraph and return draft tokens."""
-        super().run_fullgraph(desc)
-        return self.draft_tokens

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -19,11 +19,16 @@ from vllm.v1.worker.gpu.attn_utils import (
     init_attn_backend,
 )
 from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.cudagraph_utils import (
+    get_uniform_token_count,
+)
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
-from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import EagleCudaGraphManager
+from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import (
+    EagleCudaGraphManager,
+)
 from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
 
 logger = init_logger(__name__)
@@ -76,6 +81,9 @@ class EagleSpeculator:
             dtype=torch.int64,
             device=device,
         )
+        self.last_token_indices = torch.zeros(
+            self.max_num_reqs, dtype=torch.int64, device=device
+        )
 
         self.supports_mm_inputs = MULTIMODAL_REGISTRY.supports_multimodal_inputs(
             self.draft_model_config
@@ -95,20 +103,26 @@ class EagleSpeculator:
                 device=device,
             )
 
-        self.cudagraph_manager: EagleCudaGraphManager | None = None
+        self.prefill_cudagraph_manager: EagleCudaGraphManager | None = None
+        self.decode_cudagraph_manager: EagleCudaGraphManager | None = None
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
-        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
-            cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
-        else:
-            cudagraph_mode = CUDAGraphMode.NONE
-
-        self.cudagraph_manager = EagleCudaGraphManager(
+        cudagraph_mode = self.vllm_config.compilation_config.cudagraph_mode
+        self.prefill_cudagraph_manager = EagleCudaGraphManager(
             self.vllm_config,
             self.device,
             cudagraph_mode,
-            self.draft_tokens,
+            self.num_speculative_steps + 1,
         )
+        self.decode_cudagraph_manager = EagleCudaGraphManager(
+            self.vllm_config,
+            self.device,
+            cudagraph_mode,
+            decode_query_len=1,
+        )
+        # Share a single pool between prefill and decode since they never
+        # execute concurrently.
+        self.decode_cudagraph_manager.pool = self.prefill_cudagraph_manager.pool
 
     def load_model(self, target_model: nn.Module) -> None:
         target_attn_layer_names = get_layers_from_vllm_config(
@@ -188,6 +202,47 @@ class EagleSpeculator:
         else:
             last_hidden_states, hidden_states = ret_hidden_states
         return last_hidden_states, hidden_states
+
+    def prefill(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings: dict[str, torch.Tensor] | None,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+    ) -> None:
+        last_token_indices = self.last_token_indices[:num_reqs]
+        pos = self.input_buffers.positions[last_token_indices]
+        idx_mapping = self.idx_mapping[:num_reqs]
+
+        last_hidden_states, hidden_states = self.run_model(
+            num_tokens,
+            attn_metadata,
+            slot_mappings,
+            num_tokens_across_dp=num_tokens_across_dp,
+            cudagraph_runtime_mode=cudagraph_runtime_mode,
+            mm_inputs=mm_inputs,
+        )
+        sample_hidden_states = last_hidden_states[last_token_indices]
+        logits = self.model.compute_logits(sample_hidden_states)
+
+        # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
+        # used for draft and target sampling.
+        self.draft_tokens[:num_reqs, 0] = gumbel_sample(
+            logits,
+            idx_mapping,
+            self.temperature,
+            self.seeds,
+            pos + 1,
+            apply_temperature=True,
+            processed_logits_out=self.draft_logits[:, 0]
+            if self.draft_logits is not None
+            else None,
+        )
+        self.hidden_states[:num_reqs] = hidden_states[last_token_indices]
+        self.input_buffers.positions[:num_reqs] = pos
 
     def generate_draft(
         self,
@@ -281,19 +336,33 @@ class EagleSpeculator:
         return attn_metadata
 
     def capture_model(self) -> None:
-        assert self.cudagraph_manager is not None
+        logger.info("Capturing model for Eagle speculator...")
+        # Reset indices to zeros to prevent stale values from prior
+        # dummy runs to cause out-of-bounds indexing during capture.
+        self.last_token_indices.zero_()
+
+        assert self.prefill_cudagraph_manager is not None
+        self.prefill_cudagraph_manager.capture(
+            self.prefill,
+            self.model_state,
+            self.input_buffers,
+            self.block_tables,
+            self.attn_groups,
+            self.kv_cache_config,
+            progress_bar_desc="Capturing eagle prefill CUDA graphs",
+        )
+
         if self.num_speculative_steps == 1:
             return
-
-        logger.info("Capturing model for Eagle speculator...")
-        self.cudagraph_manager.capture(
+        assert self.decode_cudagraph_manager is not None
+        self.decode_cudagraph_manager.capture(
             self.generate_draft,
             self.model_state,
             self.input_buffers,
             self.block_tables,
             self.attn_groups,
             self.kv_cache_config,
-            progress_bar_desc="Capturing eagle CUDA graphs",
+            progress_bar_desc="Capturing eagle decode CUDA graphs",
         )
 
     @torch.inference_mode()
@@ -324,6 +393,10 @@ class EagleSpeculator:
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
     ) -> torch.Tensor:
+        num_tokens = input_batch.num_tokens_after_padding
+        num_reqs = input_batch.num_reqs
+        max_query_len = input_batch.num_scheduled_tokens.max()
+
         # NOTE(woosuk): To avoid CPU-GPU synchronization without CPU knowing the
         # number of rejected tokens, we maintain the size of eagle's input_ids and
         # hidden_states the same as the target model's. This means, we pad each
@@ -337,74 +410,76 @@ class EagleSpeculator:
             )
         else:
             hidden_states = last_hidden_states
-        num_tokens = input_batch.num_tokens_after_padding
-        self.hidden_states[:num_tokens] = hidden_states
+        self.hidden_states[:num_tokens].copy_(hidden_states)
 
-        # Get the input ids and last token indices for the speculator.
-        last_token_indices = prepare_eagle_inputs(
-            self.input_buffers,
-            input_batch,
-            num_sampled,
-            num_rejected,
-            last_sampled,
-            next_prefill_tokens,
-        )
-
-        # Prefill: Run the eagle speculator with eager mode.
-        # TODO(woosuk): Support CUDA graph for prefill.
-        last_hidden_states, hidden_states = self.run_model(
-            num_tokens,
-            attn_metadata,
-            slot_mappings,
-            num_tokens_across_dp=num_tokens_across_dp,
-            mm_inputs=mm_inputs,
-        )
-        sample_hidden_states = last_hidden_states[last_token_indices]
-        logits = self.model.compute_logits(sample_hidden_states)
-
-        num_reqs = input_batch.num_reqs
+        # Copy temperature, seeds, and idx mapping to the pre-allocated buffers.
         # NOTE(woosuk): For draft sampling, we only consider the temperature
         # and ignore the other sampling parameters such as top_k and top_p,
         # for simplicity and performance.
         # While this may slightly degrade the acceptance rate, it does not
         # affect the output distribution after rejection sampling.
-        idx_mapping = self.idx_mapping[:num_reqs]
-        idx_mapping.copy_(input_batch.idx_mapping)
         self.temperature.copy_(temperature)
         self.seeds.copy_(seeds)
+        self.idx_mapping[:num_reqs].copy_(input_batch.idx_mapping)
 
-        # Gather the values and copy them to the pre-allocated buffers.
-        pos = self.input_buffers.positions[:num_reqs]
-        torch.gather(input_batch.positions, 0, last_token_indices, out=pos)
-        # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
-        # used for draft and target sampling.
-        draft_tokens = gumbel_sample(
-            logits,
-            idx_mapping,
-            self.temperature,
-            self.seeds,
-            pos + 1,
-            apply_temperature=True,
-            processed_logits_out=self.draft_logits[:, 0]
-            if self.draft_logits is not None
-            else None,
+        # Get the input ids and last token indices for the speculator.
+        prepare_eagle_inputs(
+            self.input_buffers,
+            input_batch,
+            self.last_token_indices,
+            num_sampled,
+            num_rejected,
+            last_sampled,
+            next_prefill_tokens,
+            self.max_num_reqs,
         )
+
+        # When all requests are decoding (no true prefills), each has
+        # num_speculative_steps + 1 tokens, enabling FULL cudagraph.
+        # Mixed or prefill-only batches fall back to PIECEWISE.
+        prefill_batch_desc, num_tokens_across_dp = self._dispatch_and_sync_dp(
+            self.prefill_cudagraph_manager,
+            num_reqs,
+            num_tokens,
+            get_uniform_token_count(num_reqs, num_tokens, max_query_len),
+        )
+
+        if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
+            # It is necessary to rebuild the attention metadata when
+            # replaying the FULL cudagraph so that any attention
+            # metadata builder state is updated.
+            self._build_draft_attn_metadata(
+                num_reqs=num_reqs,
+                num_reqs_padded=prefill_batch_desc.num_reqs or num_reqs,
+                num_tokens_padded=prefill_batch_desc.num_tokens,
+                max_query_len=self.num_speculative_steps + 1,
+            )
+            assert self.prefill_cudagraph_manager is not None
+            self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
+        else:
+            # The target model's attention metadata and slot mappings
+            # can directly be used for draft prefill, because of the
+            # identical batch shape and KV cache layout.
+            self.prefill(
+                num_reqs,
+                prefill_batch_desc.num_tokens,
+                attn_metadata,
+                slot_mappings,
+                num_tokens_across_dp=num_tokens_across_dp,
+                cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
+                mm_inputs=mm_inputs,
+            )
 
         if self.num_speculative_steps == 1:
             # Early exit.
-            return draft_tokens.view(-1, 1)
+            return self.draft_tokens[:num_reqs, :1]
 
-        # Save the draft tokens for the first step.
-        self.draft_tokens[:num_reqs, 0] = draft_tokens
         # Prepare the inputs for the decode steps.
         prepare_eagle_decode(
-            draft_tokens,
-            hidden_states,
-            last_token_indices,
+            self.draft_tokens[:num_reqs, 0],
             input_batch.seq_lens,
             num_rejected,
             self.input_buffers,
-            self.hidden_states,
             self.max_model_len,
             self.max_num_reqs,
         )
@@ -412,7 +487,7 @@ class EagleSpeculator:
         # Each request produces exactly 1 token per draft decode step,
         # enabling FULL cudagraph.
         decode_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
-            self.cudagraph_manager,
+            self.decode_cudagraph_manager,
             num_reqs,
             num_reqs,
             uniform_token_count=1,
@@ -429,9 +504,9 @@ class EagleSpeculator:
             # metadata even when replaying the FULL cudagraph so that
             # any attention metadata builder state is updated.
             slot_mappings = self.block_tables.compute_slot_mappings(
-                idx_mapping,
+                self.idx_mapping[:num_reqs],
                 self.input_buffers.query_start_loc[: num_reqs + 1],
-                pos,
+                self.input_buffers.positions[:num_reqs],
                 decode_batch_desc.num_tokens,
             )
             slot_mappings_updated = build_slot_mappings_by_layer(
@@ -445,8 +520,8 @@ class EagleSpeculator:
             )
 
         if decode_batch_desc.cg_mode == CUDAGraphMode.FULL:
-            assert self.cudagraph_manager is not None
-            self.cudagraph_manager.run_fullgraph(decode_batch_desc)
+            assert self.decode_cudagraph_manager is not None
+            self.decode_cudagraph_manager.run_fullgraph(decode_batch_desc)
         else:
             self.generate_draft(
                 num_reqs,
@@ -464,6 +539,8 @@ def _prepare_eagle_inputs_kernel(
     last_token_indices_ptr,
     eagle_input_ids_ptr,
     eagle_positions_ptr,
+    eagle_query_start_loc_ptr,
+    eagle_seq_lens_ptr,
     target_input_ids_ptr,
     target_positions_ptr,
     idx_mapping_ptr,
@@ -472,20 +549,24 @@ def _prepare_eagle_inputs_kernel(
     num_sampled_ptr,
     num_rejected_ptr,
     query_start_loc_ptr,
+    seq_lens_ptr,
+    max_num_reqs,
     BLOCK_SIZE: tl.constexpr,
 ):
-    batch_idx = tl.program_id(0)
-    req_state_idx = tl.load(idx_mapping_ptr + batch_idx)
+    req_idx = tl.program_id(0)
+    num_reqs = tl.num_programs(0)
+    req_state_idx = tl.load(idx_mapping_ptr + req_idx)
 
-    query_start = tl.load(query_start_loc_ptr + batch_idx)
-    query_end = tl.load(query_start_loc_ptr + batch_idx + 1)
+    query_start = tl.load(query_start_loc_ptr + req_idx)
+    query_end = tl.load(query_start_loc_ptr + req_idx + 1)
     query_len = query_end - query_start
+    seq_len = tl.load(seq_lens_ptr + req_idx)
 
     # Get the true query length and next token after accounting for rejected tokens.
-    num_rejected = tl.load(num_rejected_ptr + batch_idx)
+    num_rejected = tl.load(num_rejected_ptr + req_idx)
     query_len -= num_rejected
 
-    num_sampled = tl.load(num_sampled_ptr + batch_idx)
+    num_sampled = tl.load(num_sampled_ptr + req_idx)
     if num_sampled > 0:
         next_token = tl.load(last_sampled_ptr + req_state_idx).to(tl.int32)
     else:
@@ -501,7 +582,7 @@ def _prepare_eagle_inputs_kernel(
         tl.store(eagle_input_ids_ptr + query_start + block - 1, input_ids, mask=mask)
 
     last_token_index = query_start + query_len - 1
-    tl.store(last_token_indices_ptr + batch_idx, last_token_index)
+    tl.store(last_token_indices_ptr + req_idx, last_token_index)
     tl.store(eagle_input_ids_ptr + last_token_index, next_token)
 
     # Copy positions.
@@ -511,10 +592,28 @@ def _prepare_eagle_inputs_kernel(
         target_pos = tl.load(target_positions_ptr + query_start + block, mask=mask)
         tl.store(eagle_positions_ptr + query_start + block, target_pos, mask=mask)
 
+    # Copy query start locations.
+    tl.store(eagle_query_start_loc_ptr + req_idx, query_start)
+    # Copy sequence lengths.
+    tl.store(eagle_seq_lens_ptr + req_idx, seq_len)
+    if req_idx == (num_reqs - 1):
+        # Pad query_start_loc for CUDA graphs.
+        for i in range(num_reqs, max_num_reqs + 1, BLOCK_SIZE):
+            block = i + tl.arange(0, BLOCK_SIZE)
+            mask = block < max_num_reqs + 1
+            tl.store(eagle_query_start_loc_ptr + block, query_end, mask=mask)
+        # Pad seq_lens for CUDA graphs.
+        for i in range(num_reqs, max_num_reqs, BLOCK_SIZE):
+            block = i + tl.arange(0, BLOCK_SIZE)
+            mask = block < max_num_reqs
+            tl.store(eagle_seq_lens_ptr + block, 0, mask=mask)
+
 
 def prepare_eagle_inputs(
     input_buffers: InputBuffers,
     input_batch: InputBatch,
+    # [num_reqs]
+    last_token_indices: torch.Tensor,
     # [num_reqs]
     num_sampled: torch.Tensor,
     # [num_reqs]
@@ -523,17 +622,15 @@ def prepare_eagle_inputs(
     last_sampled: torch.Tensor,
     # [max_num_reqs]
     next_prefill_tokens: torch.Tensor,
+    max_num_reqs,
 ) -> torch.Tensor:
     num_reqs = input_batch.num_reqs
-    last_token_indices = torch.empty(
-        num_reqs,
-        dtype=torch.int64,
-        device=num_sampled.device,
-    )
     _prepare_eagle_inputs_kernel[(num_reqs,)](
         last_token_indices,
         input_buffers.input_ids,
         input_buffers.positions,
+        input_buffers.query_start_loc,
+        input_buffers.seq_lens,
         input_batch.input_ids,
         input_batch.positions,
         input_batch.idx_mapping,
@@ -542,6 +639,8 @@ def prepare_eagle_inputs(
         num_sampled,
         num_rejected,
         input_batch.query_start_loc,
+        input_batch.seq_lens,
+        max_num_reqs,
         BLOCK_SIZE=1024,
     )
     return last_token_indices
@@ -550,18 +649,13 @@ def prepare_eagle_inputs(
 @triton.jit
 def _prepare_eagle_docode_kernel(
     draft_tokens_ptr,
-    output_hidden_states_ptr,
-    output_hidden_states_stride,
-    last_token_indices_ptr,
+    draft_tokens_stride,
     target_seq_lens_ptr,
     num_rejected_ptr,
     input_ids_ptr,
     positions_ptr,
-    input_hidden_states_ptr,
-    input_hidden_states_stride,
     query_start_loc_ptr,
     seq_lens_ptr,
-    hidden_size,
     max_model_len,
     max_num_reqs,
     BLOCK_SIZE: tl.constexpr,
@@ -584,23 +678,8 @@ def _prepare_eagle_docode_kernel(
         return
 
     # draft token -> input id.
-    draft_token = tl.load(draft_tokens_ptr + req_idx)
+    draft_token = tl.load(draft_tokens_ptr + req_idx * draft_tokens_stride)
     tl.store(input_ids_ptr + req_idx, draft_token)
-
-    # output hidden states -> input hidden states.
-    src_idx = tl.load(last_token_indices_ptr + req_idx)
-    for i in range(0, hidden_size, BLOCK_SIZE):
-        block = i + tl.arange(0, BLOCK_SIZE)
-        mask = block < hidden_size
-        output_hidden_states = tl.load(
-            output_hidden_states_ptr + src_idx * output_hidden_states_stride + block,
-            mask=mask,
-        )
-        tl.store(
-            input_hidden_states_ptr + req_idx * input_hidden_states_stride + block,
-            output_hidden_states,
-            mask=mask,
-        )
 
     # Compute position and seq_lens.
     # NOTE(woosuk): To prevent out-of-range access, we clamp these values
@@ -618,31 +697,22 @@ def _prepare_eagle_docode_kernel(
 
 def prepare_eagle_decode(
     draft_tokens: torch.Tensor,
-    output_hidden_states: torch.Tensor,
-    last_token_indices: torch.Tensor,
     target_seq_lens: torch.Tensor,
     num_rejected: torch.Tensor,
     input_buffers: InputBuffers,
-    input_hidden_states: torch.Tensor,
     max_model_len: int,
     max_num_reqs: int,
 ):
     num_reqs = draft_tokens.shape[0]
-    hidden_size = output_hidden_states.shape[-1]
     _prepare_eagle_docode_kernel[(num_reqs + 1,)](
         draft_tokens,
-        output_hidden_states,
-        output_hidden_states.stride(0),
-        last_token_indices,
+        draft_tokens.stride(0),
         target_seq_lens,
         num_rejected,
         input_buffers.input_ids,
         input_buffers.positions,
-        input_hidden_states,
-        input_hidden_states.stride(0),
         input_buffers.query_start_loc,
         input_buffers.seq_lens,
-        hidden_size,
         max_model_len,
         max_num_reqs,
         BLOCK_SIZE=1024,

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -108,16 +108,20 @@ class EagleSpeculator:
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         cudagraph_mode = self.vllm_config.compilation_config.cudagraph_mode
+        # Initialize cudagraph manager for draft prefill (draft position 0).
         self.prefill_cudagraph_manager = EagleCudaGraphManager(
             self.vllm_config,
             self.device,
             cudagraph_mode,
             self.num_speculative_steps + 1,
         )
+        # Initialize cudagraph manager for draft generation (draft positions > 0).
         self.decode_cudagraph_manager = EagleCudaGraphManager(
             self.vllm_config,
             self.device,
-            cudagraph_mode,
+            # Only use FULL graph mode, if available, because draft decodes
+            # only consist of a single token.
+            cudagraph_mode.decode_mode(),
             decode_query_len=1,
         )
         # Share a single pool between prefill and decode since they never
@@ -341,6 +345,11 @@ class EagleSpeculator:
         # dummy runs to cause out-of-bounds indexing during capture.
         self.last_token_indices.zero_()
 
+        # Capture the prefill routine (model forward + compute_logits +
+        # gumbel_sample).
+        # For FULL graphs, the entire routine is recorded as one graph.
+        # For PIECEWISE, only the model's compiled regions are captured
+        # and the rest (compute_logits, gumbel_sample) runs eagerly.
         assert self.prefill_cudagraph_manager is not None
         self.prefill_cudagraph_manager.capture(
             self.prefill,
@@ -354,6 +363,14 @@ class EagleSpeculator:
 
         if self.num_speculative_steps == 1:
             return
+
+        # Capture the decode draft generation loop (model forward +
+        # compute_logits + gumbel_sample + update_eagle_inputs, for
+        # each step).
+        # For FULL graphs, the entire multi-step loop is recorded as
+        # one graph. For PIECEWISE, only the model's compiled regions
+        # are captured, and the rest (compute_logits, gumbel_sample,
+        # update_eagle_inputs) runs eagerly.
         assert self.decode_cudagraph_manager is not None
         self.decode_cudagraph_manager.capture(
             self.generate_draft,
@@ -435,25 +452,29 @@ class EagleSpeculator:
         )
 
         # When all requests are decoding (no true prefills), each has
-        # num_speculative_steps + 1 tokens, enabling FULL cudagraph.
+        # num_speculative_steps + 1 tokens, enabling FULL graph replay.
         # Mixed or prefill-only batches fall back to PIECEWISE.
-        prefill_batch_desc, num_tokens_across_dp = self._dispatch_and_sync_dp(
+        prefill_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.prefill_cudagraph_manager,
             num_reqs,
             num_tokens,
             get_uniform_token_count(num_reqs, num_tokens, max_query_len),
+            dp_size=self.dp_size,
+            dp_rank=self.dp_rank,
+            need_eager=is_profile,
         )
 
         if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
             # It is necessary to rebuild the attention metadata when
-            # replaying the FULL cudagraph so that any attention
-            # metadata builder state is updated.
+            # replaying the FULL graph so that any attention metadata
+            # builder state is updated.
             self._build_draft_attn_metadata(
                 num_reqs=num_reqs,
                 num_reqs_padded=prefill_batch_desc.num_reqs or num_reqs,
                 num_tokens_padded=prefill_batch_desc.num_tokens,
                 max_query_len=self.num_speculative_steps + 1,
             )
+            # Replay the full graph for draft prefill.
             assert self.prefill_cudagraph_manager is not None
             self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
         else:
@@ -484,8 +505,8 @@ class EagleSpeculator:
             self.max_num_reqs,
         )
 
-        # Each request produces exactly 1 token per draft decode step,
-        # enabling FULL cudagraph.
+        # Each request produces exactly 1 token per draft generation step,
+        # enabling FULL graph replay.
         decode_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.decode_cudagraph_manager,
             num_reqs,
@@ -501,8 +522,8 @@ class EagleSpeculator:
         if not (dummy_run and skip_attn_for_dummy_run):
             # Build attention metadata and slot mappings for the draft
             # decode steps. It is necessary to rebuild the attention
-            # metadata even when replaying the FULL cudagraph so that
-            # any attention metadata builder state is updated.
+            # metadata even when replaying the FULL graph so that any
+            # attention metadata builder state is updated.
             slot_mappings = self.block_tables.compute_slot_mappings(
                 self.idx_mapping[:num_reqs],
                 self.input_buffers.query_start_loc[: num_reqs + 1],
@@ -520,6 +541,7 @@ class EagleSpeculator:
             )
 
         if decode_batch_desc.cg_mode == CUDAGraphMode.FULL:
+            # Replay the full graph for draft generation.
             assert self.decode_cudagraph_manager is not None
             self.decode_cudagraph_manager.run_fullgraph(decode_batch_desc)
         else:


### PR DESCRIPTION
# Purpose
FULL cudagraphs are currently only used for the position 1+ drafting phase. In this PR, I apply FULL cudagraphs to the Eagle prefill path as well to reduce the CPU dispatch overhead in `EagleSpeculator.propose`.

# Benchmarks

## H200
I ran an exhaustive set of accuracy and performance benchmarks across several models (Llama3, Qwen3, Mimo, GLM 4.7 Flash), parallelizations (TP, EP, DP), and spec decode types (Eagle-1, Eagle-3, MTP), and compared main (baseline) with this PR. Here are the full results for both commits: https://docs.google.com/spreadsheets/d/1EY4OO9TrPOg4qQPTr6lKmeMpQL1EqCpi633hqU6SboA/edit?usp=sharing.

That spreadsheet is difficult to read due to the size, so I vibe-coded an HTML visualization here: https://gistpreview.github.io/?4a6fc01a426c25560fbbb03a389906ec

NOTE: "ol" means output length, and "c" stands for concurrency in the HTML visualization

In summary, we see significantly more improvements than regressions, particularly with TPOT.

## GB300
Using vigil I benchmarked with the following MiniMax M2.5 config:
```
model: lukealonso/MiniMax-M2.5-NVFP4
mode: local
precheck: true
collect_env: true

pre_serve:
  - cmd: nvidia-smi

serving:
  roles:
    - role: worker
      vllm_engine:
        repo_path: /home/gdelfin/vllm
        env:
          HF_HOME: /home/hf-models/
          VLLM_FLASHINFER_MOE_BACKEND: latency
          VLLM_SERVER_DEV_MODE: "1"
          VLLM_USE_V2_MODEL_RUNNER: "1"
        cmd: >-
          vllm serve {model}
          -tp 4
          --performance-mode interactivity
          --trust-remote-code
          --max-num-seq 64
          --kv-cache-dtype fp8
          --compilation-config '{"mode":3,"pass_config":{"fuse_norm_quant":true,"fuse_act_quant":true,"fuse_gemm_comms":true}}'
          --speculative-config '{"method": "eagle3", "model": "novita/Eagle3-Spec-Minimax-M2.5-Exp15", "num_speculative_tokens": 3, "rejection_sample_method": "synthetic", "synthetic_acceptance_rate": 0.5}'
        health_check:
          url: http://localhost:8000/health
          timeout_s: 1200
          poll_interval_s: 5

post_serve:
  - cmd: >-
      vllm-bench
      --backend openai-chat
      --base-url http://127.0.0.1:8000
      --model {model}
      --dataset-name speed-bench
      --speed-bench-config throughput_16k
      --speed-bench-max-input-len 10240
      --speed-bench-category low_entropy
      --num-prompts 50
      --output-len 256
  - cmd: >-
      vllm-bench
      --backend openai-chat
      --base-url http://127.0.0.1:8000
      --model {model}
      --dataset-name speed-bench
      --speed-bench-config throughput_16k
      --speed-bench-max-input-len 10240
      --speed-bench-category low_entropy
      --num-warmups 50
      --num-prompts 1000
      --output-len 1536
      --sweep-max-concurrency 1,2,4,8,16,32,64
      --sweep-num-prompts-factor 10
      --reset-prefix-cache
      --save-result
```

And here is the comparison of results for eager vs cudagraph draft prefill:
Concurrency | Req/s (Eager) | Req/s (Cuda) | Tok/s (Eager) | Tok/s (Cuda) | Total tok/s (Eager) | Total tok/s (Cuda) | TTFT ms (Eager) | TTFT ms (Cuda) | TPOT ms (Eager) | TPOT ms (Cuda)
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 0.13 | 0.17 | 205.95 | 254.79 | 1,578.96 | 1,953.37 | 303.82 | 341.87 | 4.66 | 3.70
2 | 0.26 | 0.31 | 401.75 | 483.79 | 3,080.10 | 3,709.09 | 377.62 | 358.72 | 4.71 | 3.89
4 | 0.48 | 0.56 | 732.15 | 859.16 | 5,613.12 | 6,586.87 | 384.88 | 403.47 | 5.19 | 4.37
8 | 0.78 | 0.87 | 1,196.03 | 1,338.52 | 9,169.57 | 10,262.00 | 417.58 | 407.14 | 6.40 | 5.70
16 | 1.26 | 1.33 | 1,941.84 | 2,041.97 | 14,887.43 | 15,655.13 | 455.93 | 474.35 | 7.89 | 7.48
32 | 1.95 | 2.00 | 2,992.65 | 3,074.22 | 22,943.65 | 23,569.02 | 593.04 | 616.02 | 10.23 | 9.94
64 | 2.79 | 2.79 | 4,280.37 | 4,281.85 | 32,816.14 | 32,827.58 | 762.89 | 755.76 | 14.36 | 14.37

For smaller concurrencies, this PR yields better TPOT at the cost of TTFT. But the tradeoff seems worth it given the improvement in output tok/s.

NOTE: I used `synthetic_acceptance_rate = 0.5` to isolate the performance improvement of Eagle prefill cudagraph.

## DP + EP Edge Case
I also verified that there are no regressions for DP + EP by testing the case from https://github.com/vllm-project/vllm/pull/35294 and not observing any hangs:
**Server**
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve zai-org/GLM-4.7-Flash --trust-remote-code --no-enable-prefix-caching --tensor-parallel-size 1 --data-parallel-size 2 --enable-expert-parallel --seed 42 --gpu-memory-utilization 0.8 --speculative-config '{"method": "mtp", "num_speculative_tokens": 2, "model": "zai-org/GLM-4.7-Flash"}'
```
**Client**
```
vllm bench serve --model zai-org/GLM-4.7-Flash --host 0.0.0.0 --dataset-name hf --dataset-path philschmid/mt-bench --ignore-eos --request-rate inf --max-concurrency 16 --temperature 0
```
**Results**
Metric | main | #37588
-- | -- | --
Successful requests | 1,000 | 1,000
Failed requests | 0 | 0
Max request concurrency | 16 | 16
Benchmark duration (s) | 117.81 | 116.21
Total input tokens | 75,028 | 75,028
Total generated tokens | 256,000 | 256,000
Request throughput (req/s) | 8.49 | 8.61
Output token throughput (tok/s) | 2,172.98 | 2,202.99
Peak output token throughput (tok/s) | 1,117.00 | 1,136.00
Peak concurrent requests | 32.00 | 32.00
Total token throughput (tok/s) | 2,809.83 | 2,848.64
Time to First Token |   |  
Mean TTFT (ms) | 50.20 | 50.86
Median TTFT (ms) | 46.23 | 46.32
P99 TTFT (ms) | 256.56 | 293.25
Time per Output Token (excl. 1st) |   |  
Mean TPOT (ms) | 7.15 | 7.05
Median TPOT (ms) | 7.19 | 7.08
P99 TPOT (ms) | 8.05 | 7.89
Inter-token Latency |   |  
Mean ITL (ms) | 14.83 | 14.68
Median ITL (ms) | 14.55 | 14.34
P99 ITL (ms) | 20.20 | 20.57
Speculative Decoding |   |  
Acceptance rate (%) | 53.91 | 54.36
Acceptance length | 2.08 | 2.09
Drafts | 122,972 | 122,454
Draft tokens | 245,944 | 244,908
Accepted tokens | 132,593 | 133,129
Position 0 acceptance (%) | 86.79 | 86.70
Position 1 acceptance (%) | 21.03 | 22.01

# Profiling
**Server**
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve meta-llama/Meta-Llama-3-8B-Instruct --no-enable-prefix-caching --tensor-parallel-size 1 --data-parallel-size 1 --speculative-config '{"method": "eagle", "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B", "num_speculative_tokens": 3}' --profiler-config '{"profiler": "torch", "torch_profiler_dir": "~/traces/"}'
```

**Client**
```
vllm bench serve --model meta-llama/Meta-Llama-3-8B-Instruct --tokenizer meta-llama/Meta-Llama-3-8B-Instruct --dataset-name random --random-input-len 16 --random-output-len 1024 --num-prompts 8 --max-concurrency 8 --request-rate inf --ignore-eos --temperature 0
```

Profiling revealed a 70% decrease in the `propose` CPU dispatch overhead:
**Before**
<img width="1512" height="836" alt="image" src="https://github.com/user-attachments/assets/aa3ad848-1e47-41c9-ad8c-be4c475bd49e" />
**After**
<img width="1371" height="389" alt="image" src="https://github.com/user-attachments/assets/84f21283-cedf-4df8-bd40-ba06830510ef" />

# Testing
Manually verified that the outputs for the following prompts remained unchanged, using meta-llama/Meta-Llama-3-8B-Instruct with Eagle-1:

**Before**
<details>
<summary><strong>[0] "Explain the theory of relativity in simple terms."</strong></summary>

> **Response:** The theory of relativity! It's a mind-bending concept, but I

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `The` | -0.1073 | `The`: -0.107, `A`: -2.482, `Albert`: -4.357 |
| ` theory` | -0.0027 | ` theory`: -0.003, ` Theory`: -6.003, ` famous`: -9.128 |
| ` of` | 0.0000 | ` of`: 0.000 |
| ` rel` | -0.0000 | ` rel`: -0.000, ` special`: -13.375, ` relative`: -14.625 |
| `ativity` | -0.0000 | `ativity`: -0.000 |
| `!` | -0.2347 | `!`: -0.235, `,`: -1.985, ` is`: -2.860 |
| ` It` | -0.4301 | ` It`: -0.430, ` One`: -1.555, ` Albert`: -2.930 |
| `'s` | -0.0043 | `'s`: -0.004, ` can`: -6.129, ` may`: -6.629 |
| ` a` | -0.0226 | ` a`: -0.023, ` actually`: -4.023, ` one`: -6.148 |
| ` mind` | -0.4806 | ` mind`: -0.481, ` complex`: -1.981, ` big`: -1.981 |
| `-b` | -0.0010 | `-b`: -0.001, `-st`: -7.501, `-bl`: -8.501 |
| `ending` | -0.2530 | `ending`: -0.253, `low`: -1.503, `ender`: -7.003 |
| ` concept` | -0.0258 | ` concept`: -0.026, ` idea`: -3.776, ` topic`: -6.151 |
| `,` | -0.5774 | `,`: -0.577, ` that`: -0.827, ` developed`: -6.702 |
| ` but` | -0.0000 | ` but`: -0.000 |
| ` I` | -0.0801 | ` I`: -0.080, ` don`: -2.580, ` fear`: -7.205 |

</details>

<details>
<summary><strong>[1] "What is the capital of France?"</strong></summary>

> **Response:** The capital of France is Paris.

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `The` | -0.0586 | `The`: -0.059, `That`: -2.934, `Easy`: -6.309 |
| ` capital` | -0.0000 | ` capital`: -0.000, ` answer`: -11.125, `capital`: -14.125 |
| ` of` | -0.0000 | ` of`: -0.000, ` city`: -14.750, ` and`: -18.750 |
| ` France` | -0.0000 | ` France`: -0.000, `France`: -14.375, ` Franc`: -18.250 |
| ` is` | 0.0000 | ` is`: 0.000, ` was`: -18.375, ` adalah`: -18.625 |
| ` Paris` | -0.0001 | ` Paris`: -0.000, `Paris`: -9.625, ` PAR`: -12.125 |
| `.` | -0.2090 | `.`: -0.209, `!`: -1.709, ` (`: -5.084 |
| `<\|eot_id\|>` | -0.0001 | `<\|eot_id\|>`: -0.000, ` It`: -11.125, ` Paris`: -11.750 |

</details>

<details>
<summary><strong>[2] "Write a haiku about coding."</strong></summary>

> **Response:** Here is a haiku about coding:
>
> Lines of code unfold
> Logic flows like

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `Here` | -0.1743 | `Here`: -0.174, `Lines`: -2.674, `Code`: -3.174 |
| ` is` | -0.0381 | ` is`: -0.038, `'s`: -3.288, `'s`: -12.163 |
| ` a` | -0.0000 | ` a`: -0.000 |
| ` ha` | -0.0001 | ` ha`: -0.000, ` short`: -9.750 |
| `iku` | 0.0000 | `iku`: 0.000 |
| ` about` | -0.0000 | ` about`: -0.000 |
| ` coding` | -0.0000 | ` coding`: -0.000 |
| `:\n\n` | -0.0000 | `:\n\n`: -0.000 |
| `Lines` | -0.4447 | `Lines`: -0.445, `Code`: -1.320, ` Lines`: -3.695 |
| ` of` | -0.0013 | ` of`: -0.001, ` dance`: -8.001, ` and`: -8.251 |
| ` code` | -0.0006 | ` code`: -0.001, ` logic`: -8.501, ` ones`: -9.251 |
| ` unfold` | -0.5843 | ` unfold`: -0.584, ` flow`: -1.334, ` dance`: -2.459 |
| `\n` | -0.0000 | `\n`: -0.000 |
| `Logic` | -1.4517 | `Logic`: -1.452, `Bug`: -2.077, `Mean`: -2.202 |
| ` flows` | -1.2300 | ` flows`: -1.230, `'s`: -1.355, ` and`: -1.480 |
| ` like` | -0.4286 | ` like`: -0.429, `,`: -1.179, ` from`: -3.429 |

</details>

<details>
<summary><strong>[3] "List three benefits of regular exercise."</strong></summary>

> **Response:** Here are three benefits of regular exercise:
>
> 1. **Improves Physical Health**:

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `Here` | -0.0001 | `Here`: -0.000, `Regular`: -9.750, `A`: -10.500 |
| ` are` | -0.0000 | ` are`: -0.000 |
| ` three` | -0.0000 | ` three`: -0.000 |
| ` benefits` | -0.0000 | ` benefits`: -0.000 |
| ` of` | 0.0000 | ` of`: 0.000 |
| ` regular` | -0.0000 | ` regular`: -0.000 |
| ` exercise` | -0.0000 | ` exercise`: -0.000, ` Exercise`: -14.375, ` exercises`: -14.750 |
| `:\n\n` | -0.0000 | `:\n\n`: -0.000 |
| `1` | -0.0000 | `1`: -0.000 |
| `.` | 0.0000 | `.`: 0.000 |
| ` **` | -0.0000 | ` **`: -0.000 |
| `Impro` | -0.4097 | `Impro`: -0.410, `Improved`: -1.410, `Weight`: -2.410 |
| `ves` | -0.0005 | `ves`: -0.000, `vements`: -8.750, `ving`: -9.125 |
| ` Physical` | -0.4622 | ` Physical`: -0.462, ` Cardio`: -1.337, ` Mental`: -2.837 |
| ` Health` | -0.0001 | ` Health`: -0.000 |
| `**:` | -0.0000 | `**:`: -0.000 |

</details>

<details>
<summary><strong>[4] "How does a refrigerator keep food cold?"</strong></summary>

> **Response:** A refrigerator keeps food cold by using a combination of several technologies and principles to remove

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `A` | -0.2289 | `A`: -0.229, `Re`: -1.604, `The`: -5.854 |
| ` refrigerator` | -0.0010 | ` refrigerator`: -0.001 |
| ` keeps` | -0.0742 | ` keeps`: -0.074, ` is`: -3.449, `,`: -3.699 |
| ` food` | -0.0000 | ` food`: -0.000 |
| ` cold` | -0.0000 | ` cold`: -0.000 |
| ` by` | -0.4406 | ` by`: -0.441, ` through`: -1.066, ` using`: -4.441 |
| ` using` | -0.0041 | ` using`: -0.004, ` utilizing`: -5.879 |
| ` a` | -0.0047 | ` a`: -0.005, ` refriger`: -5.755 |
| ` combination` | -0.0713 | ` combination`: -0.071, ` refriger`: -3.321, ` process`: -3.821 |
| ` of` | 0.0000 | ` of`: 0.000 |
| ` several` | -1.3681 | ` several`: -1.368, ` technologies`: -1.368, ` principles`: -2.118 |
| ` technologies` | -0.6389 | ` technologies`: -0.639, ` components`: -1.389 |
| ` and` | -0.5262 | ` and`: -0.526, ` to`: -0.901 |
| ` principles` | -0.4496 | ` principles`: -0.450, ` mechanisms`: -1.575 |
| ` to` | -0.2880 | ` to`: -0.288, `.`: -1.413 |
| ` remove` | -0.7531 | ` remove`: -0.753, ` transfer`: -1.378, ` maintain`: -1.878 |

</details>

<details>
<summary><strong>[5] "What is the difference between HTTP and HTTPS?"</strong></summary>

> **Response:** HTTP (Hypertext Transfer Protocol) and HTTPS (Hypertext Transfer Protocol

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `HTTP` | -0.0221 | `HTTP`: -0.022, `The`: -3.897, `HTTPS`: -6.897 |
| ` (` | -0.0013 | ` (`: -0.001, ` and`: -6.626 |
| `H` | -0.0142 | `H`: -0.014, `Hyper`: -4.264 |
| `yp` | -0.0002 | `yp`: -0.000 |
| `ertext` | -0.0000 | `ertext`: -0.000 |
| ` Transfer` | -0.0001 | ` Transfer`: -0.000, ` Transport`: -10.125 |
| ` Protocol` | -0.0000 | ` Protocol`: -0.000 |
| `)` | -0.0000 | `)`: -0.000 |
| ` and` | -0.0549 | ` and`: -0.055, ` is`: -2.930 |
| ` HTTPS` | -0.0000 | ` HTTPS`: -0.000 |
| ` (` | -0.0000 | ` (`: -0.000 |
| `H` | -0.0000 | `H`: -0.000, `Hyper`: -11.000, `Secure`: -12.000 |
| `yp` | -0.0000 | `yp`: -0.000 |
| `ertext` | -0.0000 | `ertext`: -0.000 |
| ` Transfer` | -0.0001 | ` Transfer`: -0.000, ` Transport`: -9.125 |
| ` Protocol` | -0.0000 | ` Protocol`: -0.000 |

</details>

<details>
<summary><strong>[6] "Suggest a short book to read on a rainy day."</strong></summary>

> **Response:** A rainy day is the perfect excuse to curl up with a good book! Here

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `A` | -0.1214 | `A`: -0.121, `What`: -2.371, `Perfect`: -4.746 |
| ` rainy` | -0.4776 | ` rainy`: -0.478, ` perfect`: -1.103, ` cozy`: -3.603 |
| ` day` | -0.0000 | ` day`: -0.000 |
| ` is` | -0.0017 | ` is`: -0.002, `!`: -7.502 |
| ` the` | -0.0008 | ` the`: -0.001, ` a`: -7.376 |
| ` perfect` | -0.0006 | ` perfect`: -0.001, ` pur`: -7.626 |
| ` excuse` | -0.0001 | ` excuse`: -0.000, ` opportunity`: -10.375 |
| ` to` | -0.0000 | ` to`: -0.000 |
| ` curl` | -0.4008 | ` curl`: -0.401, ` cozy`: -1.401, ` sn`: -3.151 |
| ` up` | -0.0000 | ` up`: -0.000 |
| ` with` | -0.0000 | ` with`: -0.000 |
| ` a` | 0.0000 | ` a`: 0.000 |
| ` good` | -0.0087 | ` good`: -0.009, ` great`: -4.759 |
| ` book` | -0.0000 | ` book`: -0.000 |
| `!` | -0.1882 | `!`: -0.188, `!\n\n`: -1.813 |
| ` Here` | -0.0143 | ` Here`: -0.014, ` I`: -4.389 |

</details>

<details>
<summary><strong>[7] "2+2=?"</strong></summary>

> **Response:** The answer is 4!

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `The` | -0.3403 | `The`: -0.340, `2`: -1.965, `4`: -2.090 |
| ` answer` | -0.0022 | ` answer`: -0.002, ` correct`: -6.127 |
| ` is` | -0.2519 | ` is`: -0.252, ` to`: -1.502 |
| ` ` | -0.4650 | ` `: -0.465, `...`: -1.215, `:`: -2.715 |
| `4` | -0.0000 | `4`: -0.000 |
| `!` | -0.0919 | `!`: -0.092, `.`: -2.467 |
| `<\|eot_id\|>` | -0.0003 | `<\|eot_id\|>`: -0.000 |

</details>

**After**
<details>
<summary><strong>[0] "Explain the theory of relativity in simple terms."</strong></summary>

> **Response:** The theory of relativity! It's a mind-bending concept, but I

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `The` | -0.1074 | `The`: -0.107, `A`: -2.482, `Albert`: -4.357 |
| ` theory` | -0.0027 | ` theory`: -0.003, ` Theory`: -6.003, ` famous`: -9.128 |
| ` of` | 0.0000 | ` of`: 0.000 |
| ` rel` | -0.0000 | ` rel`: -0.000, ` special`: -13.375, ` relative`: -14.625 |
| `ativity` | -0.0000 | `ativity`: -0.000 |
| `!` | -0.2348 | `!`: -0.235, `,`: -1.985, ` is`: -2.860 |
| ` It` | -0.4299 | ` It`: -0.430, ` One`: -1.555, ` Albert`: -2.930 |
| `'s` | -0.0040 | `'s`: -0.004, ` can`: -6.254, ` may`: -6.629 |
| ` a` | -0.0226 | ` a`: -0.023, ` actually`: -4.023, ` one`: -6.148 |
| ` mind` | -0.4989 | ` mind`: -0.499, ` complex`: -1.874, ` big`: -1.999 |
| `-b` | -0.0009 | `-b`: -0.001, `-st`: -7.501, `-bl`: -8.626 |
| `ending` | -0.2266 | `ending`: -0.227, `low`: -1.602, `ender`: -6.852 |
| ` concept` | -0.0258 | ` concept`: -0.026, ` idea`: -3.776, ` topic`: -6.151 |
| `,` | -0.5774 | `,`: -0.577, ` that`: -0.827, ` developed`: -6.702 |
| ` but` | -0.0000 | ` but`: -0.000 |
| ` I` | -0.0800 | ` I`: -0.080, ` don`: -2.580, ` fear`: -7.330 |

</details>

<details>
<summary><strong>[1] "What is the capital of France?"</strong></summary>

> **Response:** The capital of France is Paris.

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `The` | -0.0586 | `The`: -0.059, `That`: -2.934, `Easy`: -6.309 |
| ` capital` | -0.0000 | ` capital`: -0.000, ` answer`: -11.125 |
| ` of` | -0.0000 | ` of`: -0.000 |
| ` France` | -0.0000 | ` France`: -0.000 |
| ` is` | 0.0000 | ` is`: 0.000 |
| ` Paris` | -0.0001 | ` Paris`: -0.000, `Paris`: -9.500 |
| `.` | -0.2083 | `.`: -0.208, `!`: -1.708, ` (`: -5.208 |
| `<\|eot_id\|>` | -0.0000 | `<\|eot_id\|>`: -0.000 |

</details>

<details>
<summary><strong>[2] "Write a haiku about coding."</strong></summary>

> **Response:** Here is a haiku about coding:
>
> Lines of code unfold
> Logic flows like

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `Here` | -0.1551 | `Here`: -0.155, `Lines`: -2.780, `Code`: -3.280 |
| ` is` | -0.0337 | ` is`: -0.034, `'s`: -3.409 |
| ` a` | -0.0000 | ` a`: -0.000 |
| ` ha` | -0.0001 | ` ha`: -0.000, ` short`: -9.750 |
| `iku` | 0.0000 | `iku`: 0.000 |
| ` about` | -0.0000 | ` about`: -0.000 |
| ` coding` | -0.0000 | ` coding`: -0.000 |
| `:\n\n` | -0.0000 | `:\n\n`: -0.000 |
| `Lines` | -0.4432 | `Lines`: -0.443, `Code`: -1.318 |
| ` of` | -0.0013 | ` of`: -0.001, ` dance`: -7.876 |
| ` code` | -0.0006 | ` code`: -0.001, ` logic`: -8.626 |
| ` unfold` | -0.5850 | ` unfold`: -0.585, ` flow`: -1.335, ` dance`: -2.460 |
| `\n` | -0.0000 | `\n`: -0.000 |
| `Logic` | -1.3611 | `Logic`: -1.361, `Bug`: -2.174, `Mean`: -2.174 |
| ` flows` | -1.2459 | ` flows`: -1.246, `'s`: -1.371, ` and`: -1.496 |
| ` like` | -0.3868 | ` like`: -0.387, `,`: -1.262, ` from`: -3.512 |

</details>

<details>
<summary><strong>[3] "List three benefits of regular exercise."</strong></summary>

> **Response:** Here are three benefits of regular exercise:
>
> 1. **Improves Physical Health**:

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `Here` | -0.0001 | `Here`: -0.000, `Regular`: -9.875, `A`: -10.500 |
| ` are` | -0.0000 | ` are`: -0.000 |
| ` three` | -0.0000 | ` three`: -0.000 |
| ` benefits` | -0.0000 | ` benefits`: -0.000 |
| ` of` | 0.0000 | ` of`: 0.000 |
| ` regular` | -0.0000 | ` regular`: -0.000 |
| ` exercise` | -0.0000 | ` exercise`: -0.000 |
| `:\n\n` | -0.0000 | `:\n\n`: -0.000 |
| `1` | -0.0000 | `1`: -0.000 |
| `.` | 0.0000 | `.`: 0.000 |
| ` **` | -0.0000 | ` **`: -0.000 |
| `Impro` | -0.4096 | `Impro`: -0.410, `Improved`: -1.410, `Weight`: -2.410 |
| `ves` | -0.0006 | `ves`: -0.001, `vements`: -8.501 |
| ` Physical` | -0.4182 | ` Physical`: -0.418, ` Cardio`: -1.418, ` Mental`: -2.918 |
| ` Health` | -0.0001 | ` Health`: -0.000 |
| `**:` | -0.0000 | `**:`: -0.000 |

</details>

<details>
<summary><strong>[4] "How does a refrigerator keep food cold?"</strong></summary>

> **Response:** A refrigerator keeps food cold by using a combination of several technologies and principles to remove

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `A` | -0.2293 | `A`: -0.229, `Re`: -1.604, `The`: -5.729 |
| ` refrigerator` | -0.0010 | ` refrigerator`: -0.001 |
| ` keeps` | -0.0784 | ` keeps`: -0.078, ` is`: -3.328, `,`: -3.703 |
| ` food` | -0.0000 | ` food`: -0.000 |
| ` cold` | -0.0000 | ` cold`: -0.000 |
| ` by` | -0.3993 | ` by`: -0.399, ` through`: -1.149, ` using`: -4.399 |
| ` using` | -0.0041 | ` using`: -0.004, ` utilizing`: -5.879 |
| ` a` | -0.0047 | ` a`: -0.005, ` refriger`: -5.755 |
| ` combination` | -0.0806 | ` combination`: -0.081, ` refriger`: -3.206, ` process`: -3.706 |
| ` of` | 0.0000 | ` of`: 0.000 |
| ` several` | -1.3180 | ` several`: -1.318, ` technologies`: -1.318, ` principles`: -2.193 |
| ` technologies` | -0.6518 | ` technologies`: -0.652, ` components`: -1.402 |
| ` and` | -0.5261 | ` and`: -0.526, ` to`: -0.901 |
| ` principles` | -0.4470 | ` principles`: -0.447, ` mechanisms`: -1.572 |
| ` to` | -0.2880 | ` to`: -0.288, `.`: -1.413 |
| ` remove` | -0.7062 | ` remove`: -0.706, ` transfer`: -1.456, ` maintain`: -1.831 |

</details>

<details>
<summary><strong>[5] "What is the difference between HTTP and HTTPS?"</strong></summary>

> **Response:** HTTP (Hypertext Transfer Protocol) and HTTPS (Hypertext Transfer Protocol

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `HTTP` | -0.0196 | `HTTP`: -0.020, `The`: -4.020, `HTTPS`: -7.020 |
| ` (` | -0.0013 | ` (`: -0.001, ` and`: -6.626 |
| `H` | -0.0161 | `H`: -0.016, `Hyper`: -4.141 |
| `yp` | -0.0002 | `yp`: -0.000 |
| `ertext` | -0.0000 | `ertext`: -0.000 |
| ` Transfer` | -0.0001 | ` Transfer`: -0.000, ` Transport`: -10.125 |
| ` Protocol` | -0.0000 | ` Protocol`: -0.000 |
| `)` | -0.0000 | `)`: -0.000 |
| ` and` | -0.0620 | ` and`: -0.062, ` is`: -2.812 |
| ` HTTPS` | -0.0000 | ` HTTPS`: -0.000 |
| ` (` | -0.0000 | ` (`: -0.000 |
| `H` | -0.0000 | `H`: -0.000, `Hyper`: -11.000, `Secure`: -12.000 |
| `yp` | -0.0000 | `yp`: -0.000 |
| `ertext` | -0.0000 | `ertext`: -0.000 |
| ` Transfer` | -0.0001 | ` Transfer`: -0.000, ` Transport`: -9.250 |
| ` Protocol` | -0.0000 | ` Protocol`: -0.000 |

</details>

<details>
<summary><strong>[6] "Suggest a short book to read on a rainy day."</strong></summary>

> **Response:** A rainy day is the perfect excuse to curl up with a good book! Here

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `A` | -0.1221 | `A`: -0.122, `What`: -2.372, `Perfect`: -4.747 |
| ` rainy` | -0.4375 | ` rainy`: -0.438, ` perfect`: -1.188, ` cozy`: -3.563 |
| ` day` | -0.0000 | ` day`: -0.000 |
| ` is` | -0.0017 | ` is`: -0.002, `!`: -7.502 |
| ` the` | -0.0008 | ` the`: -0.001, ` a`: -7.376 |
| ` perfect` | -0.0006 | ` perfect`: -0.001, ` pur`: -7.626 |
| ` excuse` | -0.0001 | ` excuse`: -0.000, ` opportunity`: -10.375 |
| ` to` | -0.0000 | ` to`: -0.000 |
| ` curl` | -0.4305 | ` curl`: -0.431, ` cozy`: -1.306, ` sn`: -3.306 |
| ` up` | -0.0000 | ` up`: -0.000 |
| ` with` | -0.0000 | ` with`: -0.000 |
| ` a` | 0.0000 | ` a`: 0.000 |
| ` good` | -0.0087 | ` good`: -0.009, ` great`: -4.759 |
| ` book` | -0.0000 | ` book`: -0.000 |
| `!` | -0.1882 | `!`: -0.188, `!\n\n`: -1.813 |
| ` Here` | -0.0129 | ` Here`: -0.013, ` I`: -4.513 |

</details>

<details>
<summary><strong>[7] "2+2=?"</strong></summary>

> **Response:** The answer is 4!

| Token | Logprob | Top Alternatives |
|-------|---------|-----------------|
| `The` | -0.3413 | `The`: -0.341, `2`: -1.966, `4`: -2.091 |
| ` answer` | -0.0022 | ` answer`: -0.002, ` correct`: -6.127 |
| ` is` | -0.2519 | ` is`: -0.252, ` to`: -1.502 |
| ` ` | -0.4214 | ` `: -0.421, `...`: -1.296, `:`: -2.796 |
| `4` | -0.0000 | `4`: -0.000 |
| `!` | -0.0923 | `!`: -0.092, `.`: -2.467 |
| `<\|eot_id\|>` | -0.0003 | `<\|eot_id\|>`: -0.000 |

</details>

**Cudagraph Capture**
```
Capturing CUDA graphs (PIECEWISE): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 49/49 [00:01<00:00, 27.87it/s]
Capturing CUDA graphs (FULL): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 49/49 [00:00<00:00, 50.23it/s]
(EngineCore pid=2249478) INFO 04-10 19:11:15 [speculator.py:343] Capturing model for Eagle speculator...
Capturing eagle prefill CUDA graphs (PIECEWISE): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 49/49 [00:00<00:00, 119.90it/s]
Capturing eagle prefill CUDA graphs (FULL): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 49/49 [00:00<00:00, 274.72it/s]
Capturing eagle decode CUDA graphs (FULL): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 49/49 [00:00<00:00, 172.80it/s]
```