### PR TITLE
[ci] Use fresh cache directory for compile only per test case.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ from vllm.sampling_params import BeamSearchParams
 from vllm.transformers_utils.utils import maybe_model_redirect
 from vllm.utils.collection_utils import is_list_of
 from vllm.utils.torch_utils import set_default_torch_num_threads
-
+from vllm.compilation.caching import use_compile_cache_root
 from torch._inductor.utils import fresh_cache
 
 
@@ -1570,6 +1570,14 @@ def fresh_vllm_cache(monkeypatch, use_fresh_inductor_cache):
     with tempfile.TemporaryDirectory() as tmp_dir:
         monkeypatch.setenv("VLLM_CACHE_ROOT", tmp_dir)
         yield tmp_dir
+
+
+@pytest.fixture(autouse=True)
+def fresh_vllm_compile_cache(monkeypatch, use_fresh_inductor_cache):
+    """A fresh compile-only cache directory which is always applied."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with use_compile_cache_root(tmp_dir):
+            yield
 
 
 @pytest.fixture(scope="function")

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -22,6 +22,7 @@ from torch._dynamo.utils import dynamo_timed
 from torch._logging._internal import trace_structured
 
 import vllm.envs as envs
+from vllm.compilation.caching import compile_cache_prefix
 from vllm.config import CompilationConfig, CUDAGraphMode, VllmConfig
 from vllm.config.compilation import DynamicShapesType
 from vllm.config.utils import Range, hash_factors
@@ -958,9 +959,7 @@ class VllmBackend:
             # Use SHA-256 for cache key hashing to be consistent across
             # compute_hash functions. Truncate for a short cache dir name.
             hash_key = hashlib.sha256(str(factors).encode()).hexdigest()[:10]
-            cache_dir = os.path.join(
-                envs.VLLM_CACHE_ROOT, "torch_compile_cache", hash_key
-            )
+            cache_dir = os.path.join(compile_cache_prefix(), hash_key)
             self.compilation_config.cache_dir = cache_dir
 
         cache_dir = self.compilation_config.cache_dir

--- a/vllm/compilation/caching.py
+++ b/vllm/compilation/caching.py
@@ -30,6 +30,26 @@ assert isinstance(SerializableCallable, type)
 logger = init_logger(__name__)
 
 
+_COMPILE_CACHE_ROOT: str | None = None
+
+
+@contextlib.contextmanager
+def use_compile_cache_root(root: str):
+    global _COMPILE_CACHE_ROOT
+    old_root = _COMPILE_CACHE_ROOT
+    _COMPILE_CACHE_ROOT = root
+    try:
+        yield
+    finally:
+        _COMPILE_CACHE_ROOT = old_root
+
+
+def compile_cache_prefix() -> str:
+    return os.path.join(
+        _COMPILE_CACHE_ROOT or envs.VLLM_CACHE_ROOT, "torch_compile_cache"
+    )
+
+
 class StandaloneCompiledArtifacts:
     """Storage for standalone compiled artifacts with content-based deduplication.
 

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 
 import vllm.envs as envs
+from vllm.compilation.caching import compile_cache_prefix
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.config import (
@@ -473,8 +474,7 @@ def _support_torch_compile(
             factors.append(_model_hash_key(self.forward))
             hash_key = hashlib.sha256(str(factors).encode()).hexdigest()
             cache_dir = os.path.join(
-                envs.VLLM_CACHE_ROOT,
-                "torch_compile_cache",
+                compile_cache_prefix(),
                 "torch_aot_compile",
                 hash_key,
             )


### PR DESCRIPTION
Summary:

This addresses https://github.com/vllm-project/vllm/issues/29440 that currently
all test cases are sharing the same cache directory which breaks isolation.

This only limits the scope to compile cache and leave VLLM_CACHE_ROOT unchanged.
To implement this we refactor the code to always read from compile_cache_prefix()
which reads from a globally patched variable.

Test Plan:
pytest tests/compile

Reviewers:

Subscribers:

Tasks:

Tags:

Signed-off-by: zhxchen17 <zhxchen17@fb.com>




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

