### PR TITLE
[ROCm][Bugfix] fix cache block size mismatch for aiter unified attention

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -665,7 +665,6 @@ class RocmPlatform(Platform):
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         from vllm.config.compilation import CUDAGraphMode
 
-        cache_config = vllm_config.cache_config
         compilation_config = vllm_config.compilation_config
         parallel_config = vllm_config.parallel_config
 
@@ -687,31 +686,8 @@ class RocmPlatform(Platform):
                 )
                 compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
-        if cache_config and not cache_config.user_specified_block_size:
-            if (
-                envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION and envs.VLLM_ROCM_USE_AITER
-                # NOTE: This block has been deprecated
-                # or get_env_variable_attn_backend()
-                # == AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN
-                # TODO: monitor https://github.com/vllm-project/vllm/pull/30396
-                # to see how we can transition to the new way of selecting
-                # attention backends
-            ):
-                cache_config.block_size = 64
-                logger.warning(
-                    "[ROCM_AITER_UNIFIED_ATTN]: Setting kv cache block size to 64."
-                )
-            else:
-                cache_config.block_size = 16
-
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.gpu_worker.Worker"
-
-    @classmethod
-    def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> None:
-        # TODO: ROCm still sets block_size in check_and_update_config.
-        # Move that logic here so block_size is chosen by the backend.
-        pass
 
     @classmethod
     def verify_model_arch(cls, model_arch: str) -> None:

--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -30,6 +30,13 @@ class RocmAiterUnifiedAttentionBackend(RocmAttentionBackend):
         return [MultipleOf(16)]
 
     @classmethod
+    def get_preferred_block_size(cls, default_block_size: int) -> int:
+        logger.warning_once(
+            "[ROCM_AITER_UNIFIED_ATTN]: Setting kv cache block size to 64."
+        )
+        return 64
+
+    @classmethod
     def supports_block_size(cls, block_size: int | None) -> bool:
         if block_size is None:
             return True


### PR DESCRIPTION
This PR fixes the following issue (Resolves https://github.com/vllm-project/vllm/issues/37548):

- We want to use cache block size of `64` for AITER_UNIFIED_ATTENTION. The current logic works as intended when we use the env variable `VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1`
- However, cache block size still resolves to 16 when  `--attention-config '{"backend": "ROCM_AITER_UNIFIED_ATTN"}'` is used.

This PR resolves this mismatch irrespective of how the AITER_UNIFIED_ATTN is set (via ENV var or as an arg) in accordance with the recent refactoring of `check_and_update_config` (https://github.com/vllm-project/vllm/pull/35122) 


The remaining backends (`ROCM_AITER_FA`, `ROCM_ATTN`, `TRITON_ATTN`) will continue to default to cache block size = 16
