### PR TITLE
Use lazy graph module during split_module to defer recompile()

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -20,6 +20,7 @@ import torch
 import torch.fx as fx
 from torch._dynamo.utils import dynamo_timed
 from torch._logging._internal import trace_structured
+from torch.fx._lazy_graph_module import _use_lazy_graph_module
 
 import vllm.envs as envs
 from vllm.config import CompilationConfig, CUDAGraphMode, VllmConfig
@@ -517,9 +518,13 @@ def split_graph(
     # otherwise pytorch might reorder the nodes and
     # the semantics of the graph will change when we
     # have mutations in the graph
-    split_gm = torch.fx.passes.split_module.split_module(
-        graph, None, lambda node: node_to_subgraph_id[node], keep_original_order=True
-    )
+    with _use_lazy_graph_module(True):
+        split_gm = torch.fx.passes.split_module.split_module(
+            graph,
+            None,
+            lambda node: node_to_subgraph_id[node],
+            keep_original_order=True,
+        )
 
     outputs = []
 


### PR DESCRIPTION
In conjunction with https://github.com/pytorch/pytorch/pull/177907

Wrap split_module call with _use_lazy_graph_module(True) to have split_module use [LazyGraphModule](https://github.com/pytorch/pytorch/blob/64d0e4bf002700cfc855bfd3c84d510f43d8a78d/torch/fx/_lazy_graph_module.py#L65) instead of normal GraphModule. This defers GraphModule.recompile() during construction. 

Since split_module creates ~57 GraphModules (29 compute + 28 splitting partitions), each triggers recompile() which is expensive. But it's not necessary to trigger recompile() until when we want to use them. This change saves ~226ms in split_graph.