### PR TITLE
[ROCm][CI] Fix granite_speech test for gfx90a by selecting compatible attention backend

### DIFF
--- a/tests/models/multimodal/generation/test_granite_speech.py
+++ b/tests/models/multimodal/generation/test_granite_speech.py
@@ -39,7 +39,11 @@ models = [MODEL_NAME]
 def granite_speech_attention_config():
     """Return attention config for Granite Speech tests on ROCm."""
     if current_platform.is_rocm():
-        return {"backend": "ROCM_AITER_FA"}
+        from vllm.platforms.rocm import on_mi3xx
+
+        if on_mi3xx():
+            return {"backend": "ROCM_AITER_FA"}
+        return {"backend": "TRITON_ATTN"}
     return None
 
 


### PR DESCRIPTION
Follow-up for:
- #34839 

Fixes incompatible (AITER) attention backend issue in `mi250_1: Multi-Modal Models (Extended Generation 1)`

Motivation: https://buildkite.com/vllm/amd-ci/builds/6701/steps/canvas?sid=019d07a7-1a1b-45c0-9cb9-e9f1d9f2bc33&tab=output

cc @kenroche 