### PR TITLE
reshape instead of view in FP8ScaledMMLinearKernel

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
@@ -132,7 +132,7 @@ class FP8ScaledMMLinearKernel(
         #   If dynamic, layer.input_scale is None and x_s computed from x.
         #   If static, layer.input_scale is scalar and x_s is input_scale.
         # View input as 2D matrix for fp8 methods
-        x_2d = x.view(-1, x.shape[-1])
+        x_2d = x.reshape(-1, x.shape[-1])
         output_shape = [*x.shape[:-1], w.shape[1]]
         out_dtype = x.dtype if maybe_out_dtype is None else maybe_out_dtype
 


### PR DESCRIPTION
## Purpose
Fix FP8ScaledMMLinearKernel failing to run when invoked with a batched input which creates non-contiguous input to the kernel especially in in the case of image generation models like Flux.2 or Qwen-Image.

Although reshape has additional inefficiency compared to view, it will not crash when running these kinds of inputs. Probably batched matmul is more appropriate in this case, but IDK if there's a kernel for fp8 bmm.

## Test Plan
```bash
vllm serve Qwen/Qwen-Image-2512 --omni --port 8000 --log-stats --cache-backend cache_dit --quantization-config '{"method": "fp8"}' --enforce-eager
```

```bash
curl -X POST "http://localhost:8000/v1/images/generations"   -H "Content-Type: application/json"   -d '{
    "prompt": "A panda playing guitar in a bamboo forest, cinematic lighting",
    "size": "1024x1024",
    "seed": 719,
    "n": 2
  }'
```

## Test Result

```log
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/cache_dit/caching/cache_adapters/cache_adapter.py", line 436, in new_forward                                                             
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     outputs = original_forward(*args, **kwargs)                                                                                                                                          
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                          
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/tmp/vllm-omni/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py", line 1051, in forward                                                                           
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     encoder_hidden_states, hidden_states = block(                                                                                                                                        
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]                                            ^^^^^^                                                                                                                                        
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl                                                                            
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     return self._call_impl(*args, **kwargs)                                                                                                                                              
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                              
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl                                                                                    
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     return forward_call(*args, **kwargs)                                                                                                                                                 
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                 
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/cache_dit/caching/cache_blocks/pattern_base.py", line 250, in forward                                                                    
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     hidden_states, encoder_hidden_states = self.call_Fn_blocks(                                                                                                                          
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]                                            ^^^^^^^^^^^^^^^^^^^^                                                                                                                          
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/cache_dit/caching/cache_blocks/pattern_base.py", line 426, in call_Fn_blocks                                                             
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     hidden_states = block(                                                                                                                                                               
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]                     ^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     return self._call_impl(*args, **kwargs)
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     return forward_call(*args, **kwargs)
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/tmp/vllm-omni/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py", line 781, in forward
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     attn_output = self.attn(
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]                   ^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     return self._call_impl(*args, **kwargs)
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     return forward_call(*args, **kwargs)
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/tmp/vllm-omni/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py", line 658, in forward
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     img_attn_output = self.to_out(img_attn_output)
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     return self._call_impl(*args, **kwargs)
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     return forward_call(*args, **kwargs)
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/linear.py", line 1473, in forward
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     output_parallel = self.quant_method.apply(self, input_parallel, bias_)
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/fp8.py", line 523, in apply
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     return self.fp8_linear.apply_weights(layer, x, bias)
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/kernels/scaled_mm/ScaledMMLinearKernel.py", line 135, in apply_weights
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]     x_2d = x.view(-1, x.shape[-1])
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430]            ^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 03-20 01:02:19 [diffusion_worker.py:430] RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```

