### PR TITLE
[Bugfix] JAIS: Only apply ALiBi when position_embedding_type is alibi

### DIFF
--- a/vllm/model_executor/models/jais.py
+++ b/vllm/model_executor/models/jais.py
@@ -120,8 +120,15 @@ class JAISAttention(nn.Module):
         tp_rank = get_tensor_model_parallel_rank()
         head_start = tp_rank * self.num_heads
         head_end = (tp_rank + 1) * self.num_heads
-        alibi_slopes = _get_alibi_slopes(total_num_heads)
-        alibi_slopes = alibi_slopes[head_start:head_end]
+
+        # ALiBi is only used when position_embedding_type is "alibi"
+        # For "learned" positional embeddings, alibi_slopes should be None
+        if config.position_embedding_type == "alibi":
+            alibi_slopes = _get_alibi_slopes(total_num_heads)
+            alibi_slopes = alibi_slopes[head_start:head_end]
+        else:
+            alibi_slopes = None
+
         self.attn = Attention(
             self.num_heads,
             self.head_dim,


### PR DESCRIPTION
## What does this PR do?

Fixes a correctness bug in JAIS model where ALiBi slopes were constructed and passed to Attention unconditionally, even when `config.position_embedding_type` was set to `"learned"`.

This resulted in double positional encoding (learned embeddings via `wpe` + ALiBi bias in attention) for JAIS variants configured with learned positional embeddings.

The fix adds a conditional check to only construct and pass `alibi_slopes` when `position_embedding_type == "alibi"`, making ALiBi and learned positional embeddings mutually exclusive as intended.

## Why is this change needed?

From my review of `vllm/model_executor/models/jais.py`, the code was applying ALiBi regardless of the `position_embedding_type` config:

```python
# Before (bug)
alibi_slopes = _get_alibi_slopes(total_num_heads)
alibi_slopes = alibi_slopes[head_start:head_end]
```

This means any JAIS checkpoint using `position_embedding_type="learned"` would get incorrect attention behavior with both learned embeddings AND ALiBi applied simultaneously.

While most public JAIS checkpoints use `position_embedding_type="alibi"`, this is still a correctness issue for the model implementation.

## How was it tested?

- Syntax validation: `python -m py_compile vllm/model_executor/models/jais.py` ✓
- Import validation: Verified module imports without errors
- Logic review: Confirmed conditional matches the pattern used in other models (e.g., Falcon, GPT-2) that support both ALiBi and learned positional embeddings

## Related Issues

Fixes #37400