### PR TITLE
[Bugfix] Handle None compilation times in v1 Executor initialize_from_config

### DIFF
--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -115,15 +115,19 @@ class Executor(ABC):
         underlying workers.
         """
         self.collective_rpc("initialize_from_config", args=(kv_cache_configs,))
-        compilation_times: list[float] = self.collective_rpc("compile_or_warm_up_model")
+        compilation_times: list[float | None] = self.collective_rpc(
+            "compile_or_warm_up_model"
+        )
         # Propagate compilation time from workers back to the main process.
         # With TP>1, compilation happens in worker processes, so the main
         # process config is never updated. Use max across workers since they
         # compile in parallel.
+        # Filter out None values from workers that didn't compile
+        # (e.g., PP follower nodes).
         if compilation_times:
-            self.vllm_config.compilation_config.compilation_time = max(
-                compilation_times
-            )
+            valid_times = [t for t in compilation_times if t is not None]
+            if valid_times:
+                self.vllm_config.compilation_config.compilation_time = max(valid_times)
 
     def register_failure_callback(self, callback: FailureCallback):  # noqa: B027
         """


### PR DESCRIPTION
## Summary
Fixes a startup crash in v1 distributed executor initialization when `compile_or_warm_up_model` returns `None` for one or more workers.

Current code in `vllm/v1/executor/abstract.py` assumes every worker returns a `float` and executes `max(compilation_times)`. In multi-process / PP scenarios, some workers can return `None`, causing:

```text
TypeError: '>' not supported between instances of 'NoneType' and 'float'
```

## Root Cause
In `Executor.initialize_from_config`, we currently do:

- `compilation_times: list[float] = self.collective_rpc("compile_or_warm_up_model")`
- `self.vllm_config.compilation_config.compilation_time = max(compilation_times)`

This fails when any element is `None`.

## Fix
- Widen local type to `list[float | None]`
- Filter out `None` values before computing max
- Only assign `compilation_time` when at least one valid float exists

## Why this is safe
- Preserves existing behavior when all workers return floats
- Prevents hard crash when some workers legitimately return `None`
- Keeps `compilation_time` untouched if no worker reports a valid timing

## Scope
This PR intentionally contains only one file change:
- `vllm/v1/executor/abstract.py`

## Validation
- Pre-commit hooks executed and passed (ruff/format/mypy and repo hook set).