### PR TITLE
[Bugfix] Fix EAGLE3+async crash: clear stale spec_token_ids for unscheduled requests

### DIFF
--- a/tests/v1/core/test_scheduler_spec_stale_placeholders.py
+++ b/tests/v1/core/test_scheduler_spec_stale_placeholders.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Regression test for issue #36906: stale spec_token_ids = [-1, ...] placeholders
+leak into scheduled_spec_decode_tokens when a running decode request is not
+scheduled due to token budget exhaustion, then re-scheduled in a later step.
+
+This bug is NOT multimodal-specific. It affects any model using async scheduling
++ speculative decoding under high enough concurrency to exhaust the token budget.
+"""
+
+import pytest
+
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+
+from .utils import create_requests, create_scheduler
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _get_async_scheduler(
+    num_spec_tokens: int = 3,
+    max_num_batched_tokens: int = 30,
+    num_requests: int = 10,
+    prompt_len: int = 10,
+) -> tuple[AsyncScheduler, list]:
+    """Create an async scheduler with spec decode config and add requests."""
+    scheduler = create_scheduler(
+        max_num_seqs=num_requests,
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_model_len=4096,
+        async_scheduling=True,
+        enable_chunked_prefill=True,
+    )
+    assert isinstance(scheduler, AsyncScheduler)
+    scheduler.num_spec_tokens = num_spec_tokens
+    scheduler.num_lookahead_tokens = num_spec_tokens
+    scheduler._spec_token_placeholders = [-1] * num_spec_tokens
+
+    requests = create_requests(
+        num_requests=num_requests,
+        num_tokens=prompt_len,
+        max_tokens=256,
+    )
+    for req in requests:
+        scheduler.add_request(req)
+    return scheduler, requests
+
+
+def test_stale_spec_token_ids_cleared_for_unscheduled_requests():
+    """Directly verify: after schedule(), any running request NOT in
+    num_scheduled_tokens must have spec_token_ids = [].
+
+    Simulates the production scenario:
+    1. Requests start in running queue with spec_token_ids = [-1,-1,-1]
+       (set by _update_after_schedule from a previous step)
+    2. schedule() exhausts token budget before visiting all requests
+    3. Unvisited requests must have spec_token_ids cleared
+
+    Uses text-only requests to prove the bug is not multimodal-specific.
+    """
+    num_spec_tokens = 3
+    # Budget=30 can fit 7 decode requests (7*4=28 < 30) but not 10 (10*4=40).
+    scheduler, requests = _get_async_scheduler(
+        num_spec_tokens=num_spec_tokens,
+        max_num_batched_tokens=25,
+        num_requests=10,
+        prompt_len=10,
+    )
+
+    # Manually move all requests to running + decode state,
+    # simulating the state after prefill completes.
+    for req in requests:
+        scheduler.waiting.pop_request()
+        scheduler.running.append(req)
+        req.num_computed_tokens = len(req.prompt_token_ids)
+        req.status = req.status  # keep WAITING->RUNNING handled by scheduler
+        # Simulate _update_after_schedule: set stale spec placeholders.
+        req.spec_token_ids = list(scheduler._spec_token_placeholders)
+
+    # Now schedule(). With budget=30, only ~7 of 10 decode requests fit.
+    output = scheduler.schedule()
+    scheduled_ids = set(output.num_scheduled_tokens.keys())
+
+    # Verify budget caused some requests to be unscheduled.
+    unscheduled = [r for r in scheduler.running if r.request_id not in scheduled_ids]
+    assert len(unscheduled) > 0, (
+        f"Expected some unscheduled requests, but all were scheduled. "
+        f"Tokens: {dict(output.num_scheduled_tokens)}"
+    )
+
+    # THE FIX: stale spec_token_ids must be cleared for unscheduled requests.
+    for req in unscheduled:
+        assert req.spec_token_ids == [], (
+            f"Unscheduled request {req.request_id} has stale "
+            f"spec_token_ids={req.spec_token_ids}. "
+            f"Without the fix, these -1 values would leak into "
+            f"scheduled_spec_decode_tokens when re-scheduled."
+        )
+
+
+def test_no_negative_one_in_scheduled_spec_decode_tokens():
+    """Verify: scheduled_spec_decode_tokens never contains -1.
+
+    After the fix, unscheduled requests have spec_token_ids cleared.
+    When re-scheduled in a later step, they won't contribute -1 to
+    scheduled_spec_decode_tokens.
+    """
+    num_spec_tokens = 3
+    scheduler, requests = _get_async_scheduler(
+        num_spec_tokens=num_spec_tokens,
+        max_num_batched_tokens=25,
+        num_requests=10,
+        prompt_len=10,
+    )
+
+    # Move all requests to decode state with stale spec placeholders.
+    for req in requests:
+        scheduler.waiting.pop_request()
+        scheduler.running.append(req)
+        req.num_computed_tokens = len(req.prompt_token_ids)
+        req.spec_token_ids = list(scheduler._spec_token_placeholders)
+
+    # Step 0: initial schedule — some scheduled with [-1,-1,-1]
+    # (expected: these are fresh placeholders for the first decode step).
+    output0 = scheduler.schedule()
+    first_unscheduled = {
+        r.request_id
+        for r in scheduler.running
+        if r.request_id not in output0.num_scheduled_tokens
+    }
+    assert len(first_unscheduled) > 0, "Need budget pressure for this test"
+
+    # Step 1+: the previously unscheduled requests should NOT have -1
+    # when they get scheduled, because the fix cleared their spec_token_ids.
+    for step in range(1, 4):
+        output = scheduler.schedule()
+
+        for req_id, spec_tokens in output.scheduled_spec_decode_tokens.items():
+            if req_id in first_unscheduled:
+                assert all(t != -1 for t in spec_tokens), (
+                    f"Step {step}: previously unscheduled request {req_id} "
+                    f"has -1 in scheduled_spec_decode_tokens={spec_tokens}. "
+                    f"Stale placeholders leaked into scheduler output."
+                )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -543,6 +543,19 @@ class Scheduler(SchedulerInterface):
                     if self.ec_connector is not None:
                         self.ec_connector.update_state_after_alloc(request, i)
 
+        # Clear stale spec token placeholders for unscheduled running
+        # requests. In async scheduling, _update_after_schedule sets
+        # spec_token_ids = [-1, ...] which persists if the request is
+        # not scheduled (e.g. budget exhausted). If re-scheduled later,
+        # the stale -1 values leak into token_ids_cpu and reach
+        # F.embedding(), causing CUDA device-side assert. (See #36906)
+        for request in self.running:
+            if (
+                request.request_id not in num_scheduled_tokens
+                and request.spec_token_ids
+            ):
+                request.spec_token_ids = []
+
         # Record the LoRAs in scheduled_running_reqs
         scheduled_loras: set[int] = set()
         if self.lora_config:


### PR DESCRIPTION
## Purpose

Fixes #36906.

EAGLE3 speculative decoding with async scheduling crashes under high concurrency:
`CUDA error: device-side assert triggered` in `F.embedding()`.

**Root cause**: In async scheduling, `_update_after_schedule` sets
`spec_token_ids = [-1, -1, -1]` as placeholders for every decode request.
These are cleared when the request is successfully scheduled. However, under
high concurrency (e.g., 256 multimodal requests), the scheduler's token budget
can be exhausted before visiting all running requests. Unvisited requests retain
stale `spec_token_ids = [-1, -1, -1]`, creating a thrashing cycle:

1. Scheduler skips the request (budget exhausted before reaching it)
2. Worker removes it from the persistent batch (unscheduled)
3. Next step: scheduler re-schedules it with stale `spec_token_ids = [-1, -1, -1]`
4. Worker re-adds it — writes `-1` to `token_ids_cpu` via `update_req_spec_token_ids()`
5. Scatter in `_prepare_input_ids` skips it (not in `prev_req_id_to_index`)
6. `-1` reaches `F.embedding()` → CUDA device-side assert
7. Back to step 1

Debug log showing the thrashing — request generates 1 token per cycle but is
removed/re-added every step:

```
[sched]: req=8e65: not_visited budget=0 loop_exited_at=65/255  ← not reached by scheduler
[remove]: req=8e65 output_len=6                                ← removed from batch
[add+spec]: req=8e65 spec=[-1,-1,-1] num_output=6              ← re-added with stale -1
[sched]: req=8e65: not_visited budget=0 loop_exited_at=66/256  ← not reached again
[remove]: req=8e65 output_len=7                                ← removed again
```

Multimodal models trigger this because large image prompts (~1500-2400 tokens) consume
disproportionate token budget per prefill chunk, leaving fewer slots for decode requests.

**Fix**: Clear `spec_token_ids` for running requests not scheduled in the current step,
preventing stale `-1` placeholders from persisting across scheduling steps.

## Test Plan

- Serve `lightonai/LightOnOCR-2-1B` with EAGLE3 speculator
  (`staghado/LightOnOCR-2-1B-speculator-eagle3-bug-report`)
- Send all 1403 images from `staghado/olmo-ocr` dataset at concurrency 256
- Verify no CUDA errors and all requests succeed

## Test Result

- **Without fix**: crashes at ~959/1403 requests (CUDA device-side assert)
- **With fix**: **1403/1403 succeed**, 0 errors