### PR TITLE
[Bugfix] Add early detection for CUDA < 13.0 on sm_103+ GPUs (GB300)

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -196,8 +196,9 @@ class CudaPlatformBase(Platform):
                     f"GPU {gpu_name} (compute capability "
                     f"{device_cap.major}.{device_cap.minor}, sm_{sm_version})"
                     f" requires CUDA >= 13.0, but found CUDA {cuda_version}."
-                    f" Please use a container image with CUDA 13.0 or newer"
-                    f" (e.g. a 'cu130' tagged image)."
+                    f" Please upgrade to PyTorch 2.11+ (which defaults to"
+                    f" CUDA 13.0) or use a container image with CUDA 13.0"
+                    f" or newer (e.g. a 'cu130' tagged image)."
                 )
 
         parallel_config = vllm_config.parallel_config

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -182,6 +182,24 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+        # Check CUDA version compatibility for sm_103+ (GB300)
+        # CUDA <= 12.9 does not support sm_103a architecture
+        # See: https://github.com/vllm-project/vllm/issues/30245
+        device_cap = cls.get_device_capability()
+        if device_cap is not None and torch.version.cuda is not None:
+            cuda_version = torch.version.cuda
+            cuda_major = int(cuda_version.split(".")[0])
+            sm_version = device_cap.major * 10 + device_cap.minor
+            if sm_version >= 103 and cuda_major < 13:
+                gpu_name = cls.get_device_name()
+                raise RuntimeError(
+                    f"GPU {gpu_name} (compute capability "
+                    f"{device_cap.major}.{device_cap.minor}, sm_{sm_version})"
+                    f" requires CUDA >= 13.0, but found CUDA {cuda_version}."
+                    f" Please use a container image with CUDA 13.0 or newer"
+                    f" (e.g. a 'cu130' tagged image)."
+                )
+
         parallel_config = vllm_config.parallel_config
         model_config = vllm_config.model_config
 


### PR DESCRIPTION
When running vLLM with CUDA < `13.0` on GB300 GPUs (sm_103), users get a cryptic Triton ptxas error. This adds an early check that gives a clear error message directing users to use a cu130 container.

Fixes #30245




## Purpose

When running vLLM with CUDA < 13.0 on GB300 GPUs (sm_103), users get a cryptic error, this PR adds an early check in `CudaPlatformBase.check_and_update_config` to detect this incompatible combination and raise a clear error message:
**Note:** The underlying Triton ptxas issue has been resolved for cu130 containers by:
- PR #30525 (torch 2.10 upgrade → triton 3.6.0, which includes triton-lang/triton#8941)

This PR addresses the remaining UX gap: users who accidentally run cu129 on GB300 should get a helpful error instead of a cryptic Triton crash.

Fixes #30245

## Test Plan

Tested on GB300 (sm_103) with `vllm/vllm-openai:nightly` (cu129):

```bash
python3 -m vllm.entrypoints.openai.api_server --model facebook/opt-125m --max-model-len 256
```

## Test Result

**Before (without patch):**
ptxas fatal : Value 'sm_103a' is not defined for option 'gpu-name'


**After (with patch):**
RuntimeError: GPU NVIDIA GB300 (compute capability 10.3, sm_103) requires CUDA >= 13.0, but found CUDA 12.9. Please use a cu130 container image (e.g. vllm/vllm-openai:-cu130).