### PR TITLE
[Bugfix] JAIS: Only apply ALiBi when position_embedding_type is alibi

### DIFF
--- a/vllm/model_executor/models/jais.py
+++ b/vllm/model_executor/models/jais.py
@@ -120,8 +120,15 @@ class JAISAttention(nn.Module):
         tp_rank = get_tensor_model_parallel_rank()
         head_start = tp_rank * self.num_heads
         head_end = (tp_rank + 1) * self.num_heads
-        alibi_slopes = _get_alibi_slopes(total_num_heads)
-        alibi_slopes = alibi_slopes[head_start:head_end]
+
+        # ALiBi is only used when position_embedding_type is "alibi"
+        # For "learned" positional embeddings, alibi_slopes should be None
+        if config.position_embedding_type == "alibi":
+            alibi_slopes = _get_alibi_slopes(total_num_heads)
+            alibi_slopes = alibi_slopes[head_start:head_end]
+        else:
+            alibi_slopes = None
+
         self.attn = Attention(
             self.num_heads,
             self.head_dim,


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where ALiBi slopes were constructed unconditionally in JAISAttention, even when the model was configured to use learned positional embeddings instead of ALiBi.

## Why is this change needed?

When `config.position_embedding_type` is `"learned"`, the model should use learned positional embeddings (via `wpe`), not ALiBi. The previous code constructed `alibi_slopes` regardless of this setting, which would result in double positional encoding (learned embeddings + ALiBi) for JAIS variants configured with learned positional embeddings.

## How was it tested?

- Verified syntax with `python -m py_compile vllm/model_executor/models/jais.py`
- The fix is a simple conditional check that aligns with the existing pattern in the codebase

## Related Issues

Fixes #37400