### PR TITLE
[bug fix] not override "partial_rotary_factor" if it is in model config

### DIFF
--- a/vllm/model_executor/models/bailing_moe.py
+++ b/vllm/model_executor/models/bailing_moe.py
@@ -127,8 +127,9 @@ class BailingAttention(nn.Module):
             prefix=f"{prefix}.dense",
         )
 
-        rotary_dim = getattr(config, "rotary_dim", self.head_dim)
-        config.rope_parameters["partial_rotary_factor"] = rotary_dim / self.head_dim
+        if "partial_rotary_factor" not in config.rope_parameters:
+            rotary_dim = getattr(config, "rotary_dim", self.head_dim)
+            config.rope_parameters["partial_rotary_factor"] = rotary_dim / self.head_dim
 
         self.rotary_emb = get_rope(
             self.head_dim,


### PR DESCRIPTION



## Purpose
i am trying https://huggingface.co/inclusionAI/Ling-flash-2.0
it shows garbage output. turns out bailing_moe.py override partial_rotary_factor even when it is in the model config

## Test Plan
run
```bash
vllm serve /path/Ling-flash-2.0 --trust-remote-code --enforce-eager -tp 2 --disable-custom-all-reduce
```
and request same prompts

## Test Result
Before fix:
```text
 message=ChatCompletionMessage(content='**❄❄❄❄❄❄😂🤂😂🤣🤂😂🤣🤣🤣🤣🤣🤣🤖😄😄😄😂😊🤔🤔🤔🤔😂🤂🤖🤖
```
After fix:
```text
 message=ChatCompletionMessage(content='好呀，来个轻松的小笑话：\n\n有一天，一只鸭子走进一家药店
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

