### PR TITLE
[XPU] Automatically detect target platform as XPU in build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ elif sys.platform.startswith("linux") and os.getenv("VLLM_TARGET_DEVICE") is Non
     if torch.version.hip is not None:
         VLLM_TARGET_DEVICE = "rocm"
         logger.info("Auto-detected ROCm")
+    elif torch.version.xpu is not None:
+        VLLM_TARGET_DEVICE = "xpu"
+        logger.info("Auto-detected XPU")
     elif torch.version.cuda is not None:
         VLLM_TARGET_DEVICE = "cuda"
         logger.info("Auto-detected CUDA")


### PR DESCRIPTION
## Purpose
Before VLLM_TARGET_DEVICE=xpu is required to build vLLM for XPU, this patch will automatically detect XPU as target platform. 
## Test Plan
pip install -r requirements/xpu.txt && \
pip install --no-build-isolation .
## Test Result

