### PR TITLE
Fix: Add EAGLE/MTP slots calculation in max_num_new_slots_for_drafting

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -839,6 +839,11 @@ class SpeculativeConfig:
             # For draft model-based speculation, we need one new slot per request
             # Since we do not slice the draft tokens
             slots_per_req += 1
+        elif self.use_eagle():
+            # For EAGLE/MTP methods, we need one new slot per request for draft
+            # tokens when not parallel drafting
+            if not self.parallel_drafting:
+                slots_per_req += 1
         return slots_per_req
 
     def use_eagle(self) -> bool:


### PR DESCRIPTION
When using MTP speculative decoding (e.g., GLM-4.7-FP8) with a small --max-num-batched-tokens value, the system crashes with CUDA illegal memory access because the max_num_new_slots_for_drafting property does not account for EAGLE/MTP methods.

The fix adds the proper slot calculation for EAGLE/MTP methods when parallel_drafting is disabled (the default case). This ensures that max_num_scheduled_tokens is correctly reduced to leave room for draft tokens in the batch.

Fixes #37599




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

