### PR TITLE
[Model Runner V2] Fix draft logits not populated during cudagraph replay

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -195,7 +195,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             num_speculative_steps=self.num_speculative_steps,
             vocab_size=self.vocab_size,
             device=self.device,
-            cache_draft_logits=not use_strict_rejection_sampling,
         )
         self.input_buffers = InputBuffers(
             max_num_reqs=self.max_num_reqs,
@@ -447,7 +446,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 next_prefill_tokens=self.req_states.next_prefill_tokens,
                 temperature=self.sampler.sampling_states.temperature.gpu,
                 seeds=self.sampler.sampling_states.seeds.gpu,
-                draft_logits_out=self.req_states.draft_logits,
                 num_tokens_across_dp=num_tokens_across_dp,
                 dummy_run=True,
                 skip_attn_for_dummy_run=skip_attn,
@@ -816,11 +814,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         else:
             # Rejection sampling for spec decoding.
             assert self.rejection_sampler is not None
+            assert self.speculator is not None
             sampler_output = self.rejection_sampler(
                 logits,
                 input_batch,
                 # Draft logits are needed for probabilistic rejection sampling.
-                self.req_states.draft_logits,
+                self.speculator.draft_logits,
             )
 
         # Get the number of sampled and rejected tokens.
@@ -1146,7 +1145,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.req_states.next_prefill_tokens,
                 self.sampler.sampling_states.temperature.gpu,
                 self.sampler.sampling_states.seeds.gpu,
-                self.req_states.draft_logits,
                 num_tokens_across_dp=num_tokens_across_dp,
             )
             self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -75,6 +75,17 @@ class EagleSpeculator:
             device=device,
         )
 
+        cache_draft_logits = self.speculative_config.rejection_sample_method != "strict"
+        self.draft_logits: torch.Tensor | None = None
+        if cache_draft_logits:
+            self.draft_logits = torch.zeros(
+                self.max_num_reqs,
+                self.num_speculative_steps,
+                self.vocab_size,
+                dtype=torch.float32,
+                device=device,
+            )
+
         # currently we don't  support PIECEWISE for Eagle.
         cudagraph_mode = vllm_config.compilation_config.cudagraph_mode
         if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
@@ -140,7 +151,6 @@ class EagleSpeculator:
         slot_mappings: dict[str, torch.Tensor] | None,
         num_tokens_across_dp: torch.Tensor | None,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
-        draft_logits_out: torch.Tensor | None = None,
     ) -> None:
         pos = self.input_buffers.positions[:num_reqs]
         query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
@@ -167,8 +177,8 @@ class EagleSpeculator:
                 self.seeds,
                 pos + 1,
                 apply_temperature=True,
-                processed_logits_out=draft_logits_out[:, step]
-                if draft_logits_out is not None
+                processed_logits_out=self.draft_logits[:, step]
+                if self.draft_logits is not None
                 else None,
             )
             self.draft_tokens[:num_reqs, step] = draft_tokens
@@ -223,8 +233,6 @@ class EagleSpeculator:
         temperature: torch.Tensor,
         # [max_num_reqs]
         seeds: torch.Tensor,
-        # [max_num_reqs, num_speculative_steps, vocab_size]
-        draft_logits_out: torch.Tensor | None,
         num_tokens_across_dp: torch.Tensor | None = None,
         dummy_run: bool = False,
         skip_attn_for_dummy_run: bool = False,
@@ -290,8 +298,8 @@ class EagleSpeculator:
             self.seeds,
             pos + 1,
             apply_temperature=True,
-            processed_logits_out=draft_logits_out[:, 0]
-            if draft_logits_out is not None
+            processed_logits_out=self.draft_logits[:, 0]
+            if self.draft_logits is not None
             else None,
         )
 
@@ -376,7 +384,6 @@ class EagleSpeculator:
             slot_mappings_updated,
             num_tokens_across_dp=num_tokens_across_dp,
             cudagraph_runtime_mode=batch_desc.cg_mode,
-            draft_logits_out=draft_logits_out,
         )
         return self.draft_tokens[:num_reqs]
 

--- a/vllm/v1/worker/gpu/states.py
+++ b/vllm/v1/worker/gpu/states.py
@@ -15,7 +15,6 @@ class RequestState:
         num_speculative_steps: int,
         vocab_size: int,
         device: torch.device,
-        cache_draft_logits: bool,
     ):
         self.max_num_reqs = max_num_reqs
         self.max_model_len = max_model_len
@@ -71,18 +70,6 @@ class RequestState:
             dtype=torch.int64,
             device=device,
         )
-        # Draft token logits.
-        # NOTE: This tensor maintains the "processed" logits after applying temperature,
-        # top-p, etc.
-        self.draft_logits: torch.Tensor | None = None
-        if cache_draft_logits:
-            self.draft_logits = torch.zeros(
-                self.max_num_reqs,
-                self.num_speculative_steps,
-                self.vocab_size,
-                dtype=torch.float32,
-                device=device,
-            )
 
         self.next_prefill_tokens = torch.zeros(
             self.max_num_reqs, dtype=torch.int32, device=device


### PR DESCRIPTION
# TLDR
When using probabilistic rejection sampling with Eagle speculative decoding and CUDA graphs enabled, the draft logits for speculative steps 1+ were not being written, causing incorrect rejection sampling behavior.

# Root Cause
The draft logits (`draft_logits_out`) passed into `EagleSpeculator` was not being passed into `EagleCudaGraphManager`, and thus not included in the CUDA graph capture. 

# Fix
Move `draft_logits` from `RequestState` to `EagleSpeculator`, matching the existing pattern used by draft_tokens. This approach also makes it easier for my upcoming PR to add FULL cudagraph for Eagle prefill: https://github.com/vllm-project/vllm/pull/37588

# Benchmark

Comprehensive accuracy & performance benchmark results across multiple models (llama3, mimo, qwen, glm), spec decode methods (eagle-1, eagle-3, MTP), parallelisms (TP, EP), output lengths (1, 1024), and concurrencies (1, 8, 64): https://gistpreview.github.io/?1dc71a0fa70ae78b1aa2a70e635a5a01.

We see clear improvements in acceptance rates, and increases in output token throughput for some models. However for some models, we see that the bump in acceptance rates doesn't offset the per-step overhead of probabilistic rejection sampling.

**Server**
```
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve openai/gpt-oss-20b --no-enable-prefix-caching --tensor-parallel-size=1 --data-parallel-size=1 --speculative-config '{"method": "eagle3", "model": "RedHatAI/gpt-oss-20b-speculator.eagle3", "num_speculative_tokens": 3}'
```

**Client**
```
vllm bench serve --model openai/gpt-oss-20b --tokenizer openai/gpt-oss-20b --host 0.0.0.0 --dataset-name hf --dataset-path philschmid/mt-bench --ignore-eos --request-rate inf --max-concurrency 16 --temperature 1.0
```

MRV2 + probabilistic rejection sampling yield better acceptances for all draft steps compared to MRV2 + strict and MRV1. The improvement is not as dramatic as before, due to the incorrect draft logits for steps 1+. In retrospect, the draft acceptances for positions 1 and 2 in my previous PR (https://github.com/vllm-project/vllm/pull/37364) were sus... I should probably add some accuracy tests soon.

| Metric | MRV1 | MRV2 (strict) | MRV2 (probabilistic) |
|---|---|---|---|
| **Benchmark duration (s)** | 141.13 | 108.38 | 107.00 |
| **Successful requests** | 1000 | 1000 | 1000 |
| **Failed requests** | 0 | 0 | 0 |
| **Max request concurrency** | 16 | 16 | 16 |
| **Peak concurrent requests** | 29 | 31 | 31 |
| **Total input tokens** | 136,120 | 136,120 | 136,120 |
| **Total generated tokens** | 256,000 | 256,000 | 256,000 |
| **Request throughput (req/s)** | 7.09 | 9.23 | 9.35 |
| **Output token throughput (tok/s)** | 1,813.92 | 2,362.12 | 2,392.50 |
| **Peak output token throughput (tok/s)** | 966.00 | 1,131.00 | 1,100.00 |
| **Total token throughput (tok/s)** | 2,778.41 | 3,618.10 | 3,664.64 |
| **Mean TTFT (ms)** | 66.28 | 56.23 | 58.23 |
| **Median TTFT (ms)** | 59.19 | 50.36 | 51.28 |
| **P99 TTFT (ms)** | 386.53 | 327.76 | 384.18 |
| **Mean TPOT (ms)** | 8.53 | 6.53 | 6.44 |
| **Median TPOT (ms)** | 8.60 | 6.52 | 6.43 |
| **P99 TPOT (ms)** | 11.17 | 8.37 | 8.29 |
| **Mean ITL (ms)** | 17.52 | 14.79 | 15.24 |
| **Median ITL (ms)** | 16.53 | 13.73 | 14.15 |
| **P99 ITL (ms)** | 28.09 | 24.69 | 24.91 |
| **Acceptance rate (%)** | 35.33 | 42.44 | 45.79 |
| **Acceptance length** | 2.06 | 2.27 | 2.37 |
| **Drafts** | 124,189 | 112,584 | 107,821 |
| **Draft tokens** | 372,567 | 337,752 | 323,463 |
| **Accepted tokens** | 131,632 | 143,358 | 148,111 |
| **Acceptance pos 0 (%)** | 54.56 | 63.10 | 66.39 |
| **Acceptance pos 1 (%)** | 32.44 | 40.92 | 44.73 |
| **Acceptance pos 2 (%)** | 18.99 | 23.31 | 26.24 |
