### PR TITLE
Fix: Handle $ref in json-schema in qwen3_coder tool parser

### DIFF
--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -158,11 +158,15 @@ class Qwen3CoderToolParser(ToolParser):
         ):
             param_type = str(param_config[param_name]["type"]).strip().lower()
         elif isinstance(param_config[param_name], dict) and (
-            "anyOf" in param_config[param_name] or "$ref" in param_config[param_name]
+            "anyOf" in param_config[param_name]
         ):
-            # anyOf and $ref have no top-level "type"; treat as object to trigger
-            # json.loads.
+            # anyOf has no top-level "type"; treat as object to trigger json.loads.
             param_type = "object"
+        elif isinstance(param_config[param_name], dict) and (
+            "$ref" in param_config[param_name]
+        ):
+            # $ref has no type information at this level; treat it separately.
+            param_type = "$ref"
         else:
             param_type = "string"
         if param_type in ["string", "str", "text", "varchar", "char", "enum"]:
@@ -214,6 +218,24 @@ class Qwen3CoderToolParser(ToolParser):
                     func_name,
                 )
             return param_value == "true"
+        elif param_type == "$ref":
+            # For $ref types, we don't have direct type information here.
+            # Attempt JSON parsing first, then fallback to string.
+            # We avoid ast.literal_eval for $ref types due to potential complexity and
+            # security concerns.
+            try:
+                param_value = json.loads(param_value)
+                return param_value
+            except (json.JSONDecodeError, TypeError, ValueError):
+                logger.debug(
+                    "Parsed value '%s' of parameter '%s' cannot be "
+                    "parsed with json.loads for $ref type in tool '%s', "
+                    "degenerating to string.",
+                    param_value,
+                    param_name,
+                    func_name,
+                )
+                return param_value
         else:
             if (
                 param_type in ["object", "array", "arr"]

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -157,11 +157,11 @@ class Qwen3CoderToolParser(ToolParser):
             and "type" in param_config[param_name]
         ):
             param_type = str(param_config[param_name]["type"]).strip().lower()
-        elif (
-            isinstance(param_config[param_name], dict)
-            and "anyOf" in param_config[param_name]
+        elif isinstance(param_config[param_name], dict) and (
+            "anyOf" in param_config[param_name] or "$ref" in param_config[param_name]
         ):
-            # anyOf has no top-level "type"; treat as object to trigger json.loads.
+            # anyOf and $ref have no top-level "type"; treat as object to trigger
+            # json.loads.
             param_type = "object"
         else:
             param_type = "string"


### PR DESCRIPTION


## Purpose
This PR improves the qwen3_coder tool parser by allowing it to handle modern json-schema annotations including references. 

Json schemas for tool definitions might have complex types using the references annotation (e.g. when the tools are python functions using pydantic models as input). This type of tool definitions is for example now sent by pydantic-ai after a recent update (see for example https://github.com/pydantic/pydantic-ai/issues/3617 for a related bug).

However, in that case the parameter definition has no "type"-field; it might for example look like this:
```json
"tool_input": {
  "$ref": "#/$defs/ToolInput"
}
```
The qwen3_coder tool call parser so far did not handle this case and consequently treated these parameters as strings leading to downstream errors.

This PR handles this case by treating parameters with a "$ref" as objects in order to trigger a `json.loads`. In principle it would be possible to fully resolve the reference. However, a reference will almost always be of object type anyhow and in case of any parsing error the tool parser falls back to treating it as a string which is the current behaviour.





