### PR TITLE
[Misc] Use logger.info_once for auto tool choice log message

### DIFF
--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -199,7 +199,7 @@ class ParserManager:
         parser: type[ToolParser] | None = None
         if not enable_auto_tools or tool_parser_name is None:
             return parser
-        logger.info('"auto" tool choice has been enabled.')
+        logger.info_once('"auto" tool choice has been enabled.')
 
         try:
             if (


### PR DESCRIPTION


## Purpose
beforce

<img width="2600" height="578" alt="image" src="https://github.com/user-attachments/assets/5fa3a144-fa50-484f-bdce-5fb161cd6ccf" />

this pr

<img width="2738" height="466" alt="image" src="https://github.com/user-attachments/assets/60c512b1-015d-454d-a98b-7005cae42fd6" />



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

