### PR TITLE
[Spec Decode][Quantization] fallback quant_config to None for unquantized MTP draft model

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1222,11 +1222,35 @@ class SpecDecodeBaseProposer:
         Default method to call get_model(). Can be overridden by subclasses which
         need to customize model loading.
         """
+        import copy
+
         from vllm.compilation.backends import set_model_tag
+
+        vllm_config = self.vllm_config
+
+        # When a draft model is loaded from a different checkpoint than
+        # the target (e.g. unquantized pretrained weights paired with a
+        # quantized target), the target's quant_config must not be applied to
+        # the draft model -- its layers would be constructed expecting
+        # quantized weight formats that the pretrained checkpoint does not
+        # provide.  Clear quant_config so the draft model is built in BF16.
+        if (
+            self.method == "mtp"
+            and self.draft_model_config is not None
+            and self.vllm_config.model_config is not None
+            and self.draft_model_config.model != self.vllm_config.model_config.model
+            and vllm_config.quant_config is not None
+        ):
+            vllm_config = copy.copy(vllm_config)
+            vllm_config.quant_config = None
+            logger.warning(
+                "Draft model path differs from target model. "
+                "Loading draft model without quantization."
+            )
 
         with set_model_tag("eagle_head"):
             model = get_model(
-                vllm_config=self.vllm_config,
+                vllm_config=vllm_config,
                 model_config=self.speculative_config.draft_model_config,
                 load_config=self.speculative_config.draft_load_config,
             )


### PR DESCRIPTION
## Purpose
When a quantized model checkpoint has backbone quantized but MTP layers unquantized, the MTP model is constructed using the target model's `quant_config`. The MTP layers are built expecting quantized weight formats, but the weights are never loaded, leaving the MTP block randomly initialized. This results in 0% speculative token acceptance — MTP provides zero speedup while still consuming extra compute.

This PR allows users to specify a separate (unquantized, pretrained) checkpoint for the MTP model via `--speculative-config '{"model": "/path/to/pretrained"}'`. When the draft model path differs from the target, `_get_model()` clears `quant_config` so the MTP layers are built as BF16 modules and loaded from the pretrained checkpoint.

## Test Plan
Test model: amd/GLM-4.7-MXFP4
Script:
```bash
vllm serve amd/GLM-4.7-MXFP4 \
  --tensor-parallel-size 4 \
  --speculative-config '{"method": "mtp", "num_speculative_tokens": 1, "model": "zai-org/GLM-4.7"}' \
  --tool-call-parser glm47 \
  --reasoning-parser glm45 \
  --enable-auto-tool-choice
```

When `"model"` is not specified, MTP defaults to the target model path (existing
behavior, no change). The fix only activates when the two paths differ.

## Test Result
### Accuracy: gsm8k_platinum (lm_eval, 5-shot, greedy)

| Config | flexible-extract | strict-match |
|---|---|---|
| No MTP (baseline) | 0.9669 | 0.9611 |
| MTP=1 (fixed) | 0.9611 | 0.9586 |
| MTP=2 (fixed) | 0.9620 | 0.9595 |

All within error margin (SE ~0.005). No accuracy regression.

### Speculative Decoding Metrics (before vs after fix)

| Setting | Before: Acceptance Rate | After: Acceptance Rate |
|---|---|---|
| MTP=1, pos 1 | 0% | **~96%** |
| MTP=2, pos 1 / pos 2 | 0% / 0% | **~97% / ~63%** |

| Setting | Before: Mean Acceptance Length | After: Mean Acceptance Length |
|---|---|---|
| MTP=1 | 1.00 | **1.96** |
| MTP=2 | 1.00 | **2.60** |

Post-fix acceptance rates match the BF16 pretrained model (MTP=1 BF16: ~97%), confirming MTP weights load correctly.

### Generation Throughput (32 concurrent requests, steady state)

| Setting | Throughput (tok/s) |
|---|---|
| MTP=1 | ~237-249 |
| MTP=2 | ~280-308 |

