### PR TITLE
[Bugfix] Fix SamplingParams bad_words tokenizer conversion for space-prefixed tokens

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -553,11 +553,12 @@ class SamplingParams(
                 )
 
                 # If no space at the beginning
-                # or if prefix space produces a new word token
+                # or if prefix space produces a different first token
+                # (handles tokenizers where space prefix changes tokenization,
+                # e.g., Qwen3 where " exaggerated" -> [61158] but "exaggerated" -> [327, 10114, 657])
                 if (not add_prefix_space) or (
                     add_prefix_space
                     and prompt_token_ids[0] != self._bad_words_token_ids[-1][0]
-                    and len(prompt_token_ids) == len(self._bad_words_token_ids[-1])
                 ):
                     self._bad_words_token_ids.append(prompt_token_ids)
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in `SamplingParams.update_from_tokenizer()` where the `bad_words` parameter was not correctly converted to token IDs for tokenizers that produce different tokenization lengths with/without a leading space.

## Root Cause

The previous implementation had an overly restrictive check when adding space-prefixed bad word token IDs:

```python
if (not add_prefix_space) or (
    add_prefix_space
    and prompt_token_ids[0] != self._bad_words_token_ids[-1][0]
    and len(prompt_token_ids) == len(self._bad_words_token_ids[-1])  # BUG: too restrictive
):
```

The `len(prompt_token_ids) == len(self._bad_words_token_ids[-1])` check prevented space-prefixed versions from being added when the tokenizer produces different token counts.

### Example (Qwen3 tokenizer)
- `" exaggerated"` → `[61158]` (1 token)
- `"exaggerated"` → `[327, 10114, 657]` (3 tokens)

The length mismatch (1 ≠ 3) caused the space-prefixed version to be skipped, meaning tokens with a leading space (like `Ġexaggerated`) were never added to `_bad_words_token_ids`.

## Fix

Remove the length equality check. We only need to verify that the first token differs:

```python
if (not add_prefix_space) or (
    add_prefix_space
    and prompt_token_ids[0] != self._bad_words_token_ids[-1][0]
):
```

This correctly handles all tokenizer behaviors:
- Tokenizers where space prefix doesn't change tokenization (original behavior preserved)
- Tokenizers where space prefix creates a single merged token (now fixed)
- Tokenizers where space prefix changes token count but not first token (correctly skipped)

## Testing

The fix was validated against the reproduction case from issue #32557:
- **Before**: `bad_words=['exaggerated']` with Qwen3 tokenizer failed to add space-prefixed token IDs
- **After**: Both space-prefixed and non-prefixed token IDs are correctly added

No additional testing required as this is a bug fix that restores intended behavior. The change is minimal (removing one condition) and doesn't affect other functionality.

## Related Issues

Fixes: #32557

Also mentioned in: #23886