### PR TITLE
[Bugfix] Allow tensorizer load format for S3/GCS/Azure object storage

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1570,11 +1570,12 @@ class VllmConfig:
             elif self.load_config.load_format not in (
                 "runai_streamer",
                 "runai_streamer_sharded",
+                "tensorizer",  # Tensorizer also supports S3/GCS/Azure object storage
             ):
                 raise ValueError(
                     f"To load a model from object storage (S3/GCS/Azure), "
-                    f"'load_format' must be 'runai_streamer' or "
-                    f"'runai_streamer_sharded', "
+                    f"'load_format' must be 'runai_streamer', "
+                    f"'runai_streamer_sharded', or 'tensorizer', "
                     f"but got '{self.load_config.load_format}'. "
                     f"Model: {self.model_config.model}"
                 )


### PR DESCRIPTION
## Summary

This PR fixes a validation error that prevented users from using `--load-format tensorizer` with S3/GCS/Azure object storage paths.

## Root Cause

The validation logic in `VllmConfig._verify_and_update_model_config()` was too restrictive. When an object storage URI (s3://, gs://, az://) was detected, it only allowed `runai_streamer` and `runai_streamer_sharded` load formats, blocking `tensorizer` even though the TensorizerLoader fully supports object storage.

## Fix

Added `"tensorizer"` to the list of allowed load formats for object storage URIs:

```python
elif self.load_config.load_format not in (
    "runai_streamer",
    "runai_streamer_sharded",
    "tensorizer",  # Tensorizer also supports S3/GCS/Azure object storage
):
```

## Impact

Users can now correctly use tensorizer with object storage:

```bash
# This now works correctly
vllm serve s3://my-bucket/vllm/facebook/opt-125m/v1 \
    --load-format tensorizer
```

## Related

Fixes: #32807

The TensorizerLoader already has full S3/GCS/Azure support (see `vllm/model_executor/model_loader/tensorizer.py` lines 373-383, 723-725), this fix just removes the incorrect validation barrier.