### PR TITLE
[Feature] Add OCI Image Annotations to container images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -493,6 +493,14 @@ ARG DEADSNAKES_MIRROR_URL
 ARG DEADSNAKES_GPGKEY_URL
 ARG GET_PIP_URL
 
+# OCI Image Annotations (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+LABEL org.opencontainers.image.title="vLLM" \
+      org.opencontainers.image.description="A high-throughput and memory-efficient inference and serving engine for LLMs" \
+      org.opencontainers.image.url="https://vllm.ai" \
+      org.opencontainers.image.source="https://github.com/vllm-project/vllm" \
+      org.opencontainers.image.vendor="vLLM Project" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /vllm-workspace
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -205,11 +205,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,from=vllm-build,src=/vllm-workspace/dist,target=dist \
     uv pip install dist/*.whl
 
-# Add labels to document build configuration
-LABEL org.opencontainers.image.title="vLLM CPU"
-LABEL org.opencontainers.image.description="vLLM inference engine for CPU platforms"
-LABEL org.opencontainers.image.vendor="vLLM Project"
-LABEL org.opencontainers.image.source="https://github.com/vllm-project/vllm"
+# OCI Image Annotations (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+LABEL org.opencontainers.image.title="vLLM CPU" \
+      org.opencontainers.image.description="vLLM inference engine for CPU platforms (x86_64 and aarch64)" \
+      org.opencontainers.image.url="https://vllm.ai" \
+      org.opencontainers.image.source="https://github.com/vllm-project/vllm" \
+      org.opencontainers.image.vendor="vLLM Project" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 # Build configuration labels
 ARG TARGETARCH

--- a/docker/Dockerfile.ppc64le
+++ b/docker/Dockerfile.ppc64le
@@ -277,6 +277,14 @@ RUN git clone --recursive https://github.com/Reference-LAPACK/lapack.git -b v${L
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:${BASE_UBI_IMAGE_TAG} AS vllm-openai
 
+# OCI Image Annotations (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+LABEL org.opencontainers.image.title="vLLM PowerPC" \
+      org.opencontainers.image.description="vLLM inference engine for PowerPC (ppc64le) platforms" \
+      org.opencontainers.image.url="https://vllm.ai" \
+      org.opencontainers.image.source="https://github.com/vllm-project/vllm" \
+      org.opencontainers.image.vendor="vLLM Project" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 ARG PYTHON_VERSION=3.12
 ARG OPENBLAS_VERSION=0.3.30
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -443,4 +443,13 @@ CMD ["/bin/bash"]
 
 #Set entrypoint for vllm-openai official images
 FROM final AS vllm-openai
+
+# OCI Image Annotations (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+LABEL org.opencontainers.image.title="vLLM ROCm" \
+      org.opencontainers.image.description="vLLM inference engine for AMD ROCm platforms" \
+      org.opencontainers.image.url="https://vllm.ai" \
+      org.opencontainers.image.source="https://github.com/vllm-project/vllm" \
+      org.opencontainers.image.vendor="vLLM Project" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 ENTRYPOINT ["vllm", "serve"]

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -111,6 +111,14 @@ CMD ["/bin/bash"]
 
 FROM vllm-base AS vllm-openai
 
+# OCI Image Annotations (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+LABEL org.opencontainers.image.title="vLLM XPU" \
+      org.opencontainers.image.description="vLLM inference engine for Intel XPU platforms" \
+      org.opencontainers.image.url="https://vllm.ai" \
+      org.opencontainers.image.source="https://github.com/vllm-project/vllm" \
+      org.opencontainers.image.vendor="vLLM Project" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 # install additional dependencies for openai api server
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install accelerate hf_transfer pytest pytest_asyncio lm_eval[api] modelscope


### PR DESCRIPTION
## Summary

This PR adds standard [OCI Image Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md) to all vLLM Dockerfiles, improving container image metadata for registries and tooling.

## Changes

Added OCI-compliant `LABEL` instructions to the following Dockerfiles:

- **Dockerfile** (CUDA) - `org.opencontainers.image.*` annotations
- **Dockerfile.cpu** - Enhanced existing annotations with complete OCI spec
- **Dockerfile.rocm** - Added full OCI annotations
- **Dockerfile.xpu** - Added full OCI annotations
- **Dockerfile.ppc64le** - Added full OCI annotations

## Annotations Added

Each image now includes:

| Annotation | Value |
|------------|-------|
| `org.opencontainers.image.title` | vLLM [variant] |
| `org.opencontainers.image.description` | Platform-specific description |
| `org.opencontainers.image.url` | https://vllm.ai |
| `org.opencontainers.image.source` | https://github.com/vllm-project/vllm |
| `org.opencontainers.image.vendor` | vLLM Project |
| `org.opencontainers.image.licenses` | Apache-2.0 |

## Benefits

1. **Registry Integration**: Container registries (GHCR, Docker Hub, ECR, etc.) can display rich metadata
2. **Security & Compliance**: Automated tools can verify source and license information
3. **SBOM Generation**: Software Bill of Materials tools use OCI annotations for provenance
4. **Discoverability**: Better search and categorization in container registries
5. **Standards Compliance**: Follows OCI Image Format Specification v1.0

## Example

After building, the image metadata will show:

```bash
$ docker inspect vllm/vllm-openai:latest | jq '.[0].Config.Labels'
{
  "org.opencontainers.image.title": "vLLM",
  "org.opencontainers.image.description": "A high-throughput and memory-efficient inference and serving engine for LLMs",
  "org.opencontainers.image.url": "https://vllm.ai",
  "org.opencontainers.image.source": "https://github.com/vllm-project/vllm",
  "org.opencontainers.image.vendor": "vLLM Project",
  "org.opencontainers.image.licenses": "Apache-2.0"
}
```

## Related

Fixes: #32674