### PR TITLE
[Bugfix] Zero-init ROCm MLA attention output buffers for graph padding

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -278,6 +278,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         from aiter import flash_attn_varlen_func
 
         self.flash_attn_varlen_func = flash_attn_varlen_func
+        self._decode_out = None
 
     def _flash_attn_varlen_diff_headdims(
         self, q, k, v, return_softmax_lse=False, softmax_scale=None, **kwargs
@@ -316,13 +317,20 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         else:
             kernel_num_heads = self.num_heads
 
-        o = torch.zeros(
-            B,
-            kernel_num_heads,
-            self.kv_lora_rank,
-            dtype=attn_metadata.decode.attn_out_dtype,
-            device=q.device,
-        )
+        dtype = attn_metadata.decode.attn_out_dtype
+        if (
+            self._decode_out is None
+            or self._decode_out.shape[0] < B
+            or self._decode_out.dtype != dtype
+        ):
+            self._decode_out = torch.zeros(
+                B,
+                kernel_num_heads,
+                self.kv_lora_rank,
+                dtype=dtype,
+                device=q.device,
+            )
+        o = self._decode_out[:B]
 
         kv_buffer = kv_c_and_k_pe_cache.unsqueeze(2)
 

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -300,6 +300,7 @@ class ROCMAiterMLASparseImpl(SparseMLAAttentionImpl[ROCMAiterMLASparseMetadata])
         indexer: "Indexer | None" = None,
         **mla_args,
     ) -> None:
+        self._decode_out = None
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)
@@ -318,11 +319,18 @@ class ROCMAiterMLASparseImpl(SparseMLAAttentionImpl[ROCMAiterMLASparseMetadata])
         attn_metadata: ROCMAiterMLASparseMetadata,
     ) -> torch.Tensor:
         num_tokens = q.shape[0]
-        output = torch.empty(
-            [num_tokens, self.num_heads, self.kv_lora_rank],
-            dtype=q.dtype,
-            device=q.device,
-        )
+        dtype = q.dtype
+        if (
+            self._decode_out is None
+            or self._decode_out.shape[0] < num_tokens
+            or self._decode_out.dtype != dtype
+        ):
+            self._decode_out = torch.zeros(
+                [num_tokens, self.num_heads, self.kv_lora_rank],
+                dtype=dtype,
+                device=q.device,
+            )
+        output = self._decode_out[:num_tokens]
         seq_len = (topk_indices != -1).sum(dim=-1)
         torch.cumsum(seq_len, dim=0, out=attn_metadata.paged_kv_indptr[1:])
         attn_metadata.paged_kv_indptr_rest.fill_(attn_metadata.paged_kv_indptr[-1])


### PR DESCRIPTION
## Summary
This ports the zero-init MLA output-buffer fix to the ROCm MLA backends.

Specifically:
- `vllm/v1/attention/backends/mla/rocm_aiter_mla.py`
- `vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py`

The change replaces per-call uninitialized / freshly allocated decode outputs with reusable zero-initialized output buffers, matching the intent of the existing CUDA-side `#37442` fix.

## Root cause
Under graph capture / padded decode paths, unused MLA output rows can retain stale values if the backend does not guarantee they are written. On ROCm:
- dense AITER MLA was allocating a new `torch.zeros(...)` output every call, which was safe but suboptimal for graph replay
- sparse AITER MLA used `torch.empty(...)`, which could expose stale / garbage data in unwritten padded slots

## Fix
- add persistent `self._decode_out` buffers
- allocate them with `torch.zeros(...)`
- reuse via slicing (`self._decode_out[:B]` / `[:num_tokens]`)

## Validation
Validated on MI300X ROCm with forced `attention_backend='ROCM_AITER_MLA'` using `deepseek-ai/DeepSeek-V2-Lite`:
- confirmed log: `Using AITER MLA backend.`
- passed model load
- passed torch.compile
- passed KV cache init
- passed graph capture
- end-to-end run completed successfully

This is the ROCm counterpart to `#37442`.
