### PR TITLE
[Perf] Eliminate redundant SparseMatrix creation in gpt_oss_triton_kernels

### DIFF
--- a/tests/kernels/moe/test_gpt_oss_triton_kernels.py
+++ b/tests/kernels/moe/test_gpt_oss_triton_kernels.py
@@ -21,12 +21,16 @@ from triton_kernels.numerics_details.mxfp import downcast_to_mxfp, upcast_from_m
 from triton_kernels.tensor import FP4, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 from triton_kernels.testing import assert_close
+from triton_kernels.topk import topk as topk_fn
 
 from vllm.model_executor.layers.fused_moe.config import mxfp4_w4a16_moe_quant_config
 from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
+    legacy_routing,
+    make_routing_data,
     triton_kernel_moe_forward,
 )
 from vllm.utils.math_utils import round_up
+from vllm.utils.torch_utils import set_random_seed
 
 from .utils import shuffle_weight
 
@@ -355,3 +359,43 @@ def test_unit_shuffle():
     )
 
     assert_close(ref=out_ref, tri=out)
+
+
+@pytest.mark.parametrize("num_tokens", [2, 8, 64])
+@pytest.mark.parametrize("num_experts", [32, 128])
+@pytest.mark.parametrize("topk", [1, 4])
+@pytest.mark.parametrize("renormalize", [True, False])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_legacy_routing(
+    num_tokens: int, num_experts: int, topk: int, renormalize: bool, dtype: torch.dtype
+):
+    set_random_seed(0)
+    gating_output = torch.randn(num_tokens, num_experts, device="cuda", dtype=dtype)
+
+    sm_first = not renormalize
+    logits = gating_output
+    if sm_first:
+        logits = torch.softmax(logits, dim=-1)
+    sparse_logits = topk_fn(logits, topk, apply_softmax=not sm_first)
+    topk_ids = sparse_logits.indx.to(torch.long)
+    topk_weights = sparse_logits.vals
+    routing_data_ref, gather_indx_ref, scatter_indx_ref = make_routing_data(
+        topk_ids, topk_weights, num_experts
+    )
+
+    routing_data, gather_indx, scatter_indx = legacy_routing(
+        gating_output, topk, sm_first=sm_first
+    )
+
+    assert_close(
+        ref=gather_indx_ref.src_indx, tri=gather_indx.src_indx, maxtol=0, rmstol=0
+    )
+    assert_close(
+        ref=gather_indx_ref.dst_indx, tri=gather_indx.dst_indx, maxtol=0, rmstol=0
+    )
+    assert_close(
+        ref=scatter_indx_ref.src_indx, tri=scatter_indx.src_indx, maxtol=0, rmstol=0
+    )
+    assert_close(
+        ref=scatter_indx_ref.dst_indx, tri=scatter_indx.dst_indx, maxtol=0, rmstol=0
+    )

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -142,6 +142,33 @@ def legacy_routing_from_bitmatrix(
     return routing_data, gather_idx, scatter_idx
 
 
+def legacy_routing_from_sparsematrix(
+    sparse_logits: "SparseMatrix",
+    n_expts_tot: int,
+    n_expts_act: int,
+) -> tuple["RoutingData", "GatherIndx", "ScatterIndx"]:
+    """
+    Creates routing data from a SparseMatrix representation.
+    """
+    dispatch_indx = sparse_logits.mask_metadata.row_sorted_indx
+    combine_indx = sparse_logits.mask_metadata.col_sorted_indx
+    ragged_batch_metadata = make_ragged_tensor_metadata(
+        sparse_logits.mask_metadata.col_sum,
+        dispatch_indx.shape[0],
+    )
+    gate_scal = sparse_logits.vals.flatten()[combine_indx]
+    routing_data = RoutingData(
+        gate_scal,
+        ragged_batch_metadata.block_sizes,
+        n_expts_tot,
+        n_expts_act,
+        ragged_batch_metadata,
+    )
+    gather_idx = GatherIndx(combine_indx, dispatch_indx)
+    scatter_idx = ScatterIndx(dispatch_indx, combine_indx)
+    return routing_data, gather_idx, scatter_idx
+
+
 def legacy_routing(
     logits: torch.Tensor,
     n_expts_act: int,
@@ -158,10 +185,8 @@ def legacy_routing(
     if sm_first:
         logits = torch.softmax(logits, dim=-1)
     sparse_logits = topk(logits, n_expts_act, apply_softmax=not sm_first)
-    return legacy_routing_from_bitmatrix(
-        sparse_logits.mask,
-        sparse_logits.vals,
-        sparse_logits.indx,
+    return legacy_routing_from_sparsematrix(
+        sparse_logits,
         logits.shape[-1],
         n_expts_act,
     )


### PR DESCRIPTION



## Purpose

During profiling I noticed `_sum_bitmatrix_rows` + `_bitmatrix_metadata_compute_stage1` +`_bitmatrix_metadata_compute_stage2` kernels were launched twice.

* Creating `SparseMatrix` object will launch these 3 kernels, see in triton_kernels [SparseMatrix](https://github.com/triton-lang/triton/blob/v3.6.0/python/triton_kernels/triton_kernels/tensor.py#L233) and then [make_bitmatrix_metadata](https://github.com/triton-lang/triton/blob/v3.6.0/python/triton_kernels/triton_kernels/tensor_details/bitmatrix.py#L110)
* In `legacy_routing` function, [topk](https://github.com/vllm-project/vllm/blob/v0.18.0/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py#L160) will create `SparseMatrix`, see [here](https://github.com/triton-lang/triton/blob/v3.6.0/python/triton_kernels/triton_kernels/topk.py#L134). Then inside [legacy_routing_from_bitmatrix](https://github.com/vllm-project/vllm/blob/v0.18.0/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py#L108), `SparseMatrix` object is created again [here](https://github.com/vllm-project/vllm/blob/v0.18.0/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py#L125), this makes these 3 kernels launched again. Therefore avoid creating `SparseMatrix` twice will eliminate redundant kernel launching and improve performance.
* e2e output token throughput improves 4% at batch_size=1 on H200.

Implementation details:
* Directly pass the `sparse_logits` returned by triton_kernels `topk`, to avoid reconstruct `SparseMatrix` object again.
* Add a separate `legacy_routing_from_sparsematrix` function to avoid touching `legacy_routing_from_bitmatrix`, which is also used somewhere else.
* Add test cases in test_gpt_oss_triton_kernels.py

## Test Plan

```
pytest -s -v tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_legacy_routing
```
## Test Result

Unit test passed.

## Profiling

Main:
<img width="1908" height="491" alt="Screenshot 2026-03-19 at 10 33 53 PM copy" src="https://github.com/user-attachments/assets/123537b1-0f71-4499-88ac-82273f6918f1" />

PR:
<img width="1905" height="490" alt="Screenshot 2026-03-19 at 10 33 32 PM" src="https://github.com/user-attachments/assets/0c9cff2e-175d-4a28-b28c-08c521d293fc" />

Main: `_sum_bitmatrix_rows`, `_bitmatrix_metadata_compute_stage1`, `_bitmatrix_metadata_compute_stage2` kernels were launched twice.

PR: `_sum_bitmatrix_rows`, `_bitmatrix_metadata_compute_stage1`, `_bitmatrix_metadata_compute_stage2` kernels launched once.

## Benchmarking

```
vllm serve /opt/dlami/nvme/models/gpt-oss-20b \
  --tensor-parallel-size 1 \
  --max-num-seqs 16 \
  --no-enable-prefix-caching
```

```
vllm bench serve \
        --model /opt/dlami/nvme/models/gpt-oss-20b \
        --dataset-name sharegpt \
        --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
        --sharegpt-output-len 300 \
        --num-prompts ${num_prompts} \
        --max-concurrency ${concurrency} \
        --num-warmups 50 \
        --ignore-eos \
        --temperature 0
```

Main:

concurrency=1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  67.91     
Total input tokens:                      15599     
Total generated tokens:                  18000     
Request throughput (req/s):              0.88      
Output token throughput (tok/s):         265.06    
Peak output token throughput (tok/s):    269.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          494.76    
---------------Time to First Token----------------
Mean TTFT (ms):                          18.03     
Median TTFT (ms):                        17.42     
P99 TTFT (ms):                           29.93     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.72      
Median TPOT (ms):                        3.72      
P99 TPOT (ms):                           3.73      
---------------Inter-token Latency----------------
Mean ITL (ms):                           3.73      
Median ITL (ms):                         3.73      
P99 ITL (ms):                            4.06      
==================================================
```

concurrency=16
```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  124.87    
Total input tokens:                      217301    
Total generated tokens:                  288000    
Request throughput (req/s):              7.69      
Output token throughput (tok/s):         2306.46   
Peak output token throughput (tok/s):    2592.00   
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          4046.73   
---------------Time to First Token----------------
Mean TTFT (ms):                          63.83     
Median TTFT (ms):                        51.60     
P99 TTFT (ms):                           146.81    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.74      
Median TPOT (ms):                        6.74      
P99 TPOT (ms):                           7.13      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.74      
Median ITL (ms):                         6.57      
P99 ITL (ms):                            10.85     
==================================================
```

PR:

concurrency=1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  65.24     
Total input tokens:                      15599     
Total generated tokens:                  18000     
Request throughput (req/s):              0.92      
Output token throughput (tok/s):         275.91    
Peak output token throughput (tok/s):    279.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          515.03    
---------------Time to First Token----------------
Mean TTFT (ms):                          17.70     
Median TTFT (ms):                        16.89     
P99 TTFT (ms):                           28.35     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.58      
Median TPOT (ms):                        3.58      
P99 TPOT (ms):                           3.58      
---------------Inter-token Latency----------------
Mean ITL (ms):                           3.58      
Median ITL (ms):                         3.58      
P99 ITL (ms):                            3.96      
==================================================
```

concurrency=16

```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  122.33    
Total input tokens:                      217301    
Total generated tokens:                  288000    
Request throughput (req/s):              7.85      
Output token throughput (tok/s):         2354.31   
Peak output token throughput (tok/s):    2643.00   
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          4130.68   
---------------Time to First Token----------------
Mean TTFT (ms):                          72.87     
Median TTFT (ms):                        42.57     
P99 TTFT (ms):                           1150.95   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.57      
Median TPOT (ms):                        6.53      
P99 TPOT (ms):                           8.40      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.57      
Median ITL (ms):                         6.38      
P99 ITL (ms):                            11.49     
==================================================
```

## Accuracy Testing

```
OPENAI_API_KEY=EMPTY python3 -m gpt_oss.evals --model /opt/dlami/nvme/models/gpt-oss-20b --eval gpqa --n-threads 200 --reasoning-effort low
```

Main:
```
Writing report to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260320_061535.html
{'chars': np.float64(65.20265151515152), 'chars:std': np.float64(238.24060490668424), 'score': np.float64(0.5574494949494949), 'score:std': np.float64(0.4966885900944856)}
Writing results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260320_061535.json
Writing all results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260320_061535_allresults.json
[{'eval_name': 'gpqa', 'model_name': '__opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260320_061535', 'metric': 0.5574494949494949}]
```

PR:

```
Writing report to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260320_053502.html
{'chars': np.float64(72.3074494949495), 'chars:std': np.float64(253.2575635195493), 'score': np.float64(0.5675505050505051), 'score:std': np.float64(0.495415915436133)}
Writing results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260320_053502.json
Writing all results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260320_053502_allresults.json
[{'eval_name': 'gpqa', 'model_name': '__opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260320_053502', 'metric': 0.5675505050505051}]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

