### PR TITLE
Fix attribute error in `isaac_patch_hf_runner`

### DIFF
--- a/tests/models/multimodal/generation/vlm_utils/model_utils.py
+++ b/tests/models/multimodal/generation/vlm_utils/model_utils.py
@@ -24,6 +24,7 @@ from transformers import (
     GenerationConfig,
     GenerationMixin,
 )
+from transformers.masking_utils import create_causal_mask
 from transformers.video_utils import VideoMetadata
 
 from vllm.logprobs import SampleLogprobs
@@ -680,10 +681,14 @@ def isaac_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
         sin = sin.to(inputs_embeds.dtype)
 
         # Prepare attention mask
-        if attention_mask is not None:
-            attention_mask = self._update_causal_mask(
-                attention_mask, inputs_embeds, cache_position, past_key_values, False
-            )
+        attention_mask = create_causal_mask(
+            config=self.config,
+            input_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+            cache_position=cache_position,
+        )
 
         # Initialize and collect hidden states
         hidden_states = inputs_embeds


### PR DESCRIPTION
After https://huggingface.co/PerceptronAI/Isaac-0.1/commit/a8885ab12d5241ff8719eabf4d131f5cbe8b095b, `_update_causal_mask` no longer exists.

This PR makes the same update that was applied in that commit.

Fixes

```console
AttributeError: 'IsaacModel' object has no attribute '_update_causal_mask'`
```

However, there will still be

```console
RuntimeError: Cannot find any model weights with `PerceptronAI/Isaac-0.1`
```

because of other changes made since the linked commit.