### PR TITLE
[Bugfix] Fix bogus "Loading weights took" time in DefaultModelLoader

### DIFF
--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -68,9 +68,6 @@ class DefaultModelLoader(BaseModelLoader):
         allow_patterns_overrides: list[str] | None = None
         """If defined, weights will load exclusively using these patterns."""
 
-    counter_before_loading_weights: float = 0.0
-    counter_after_loading_weights: float = 0.0
-
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
         self.local_expert_ids: set[int] | None = None
@@ -280,8 +277,6 @@ class DefaultModelLoader(BaseModelLoader):
                     self.load_config.pt_load_map_location,
                 )
 
-        if self.counter_before_loading_weights == 0.0:
-            self.counter_before_loading_weights = time.perf_counter()
         # Apply the prefix.
         return ((source.prefix + name, tensor) for (name, tensor) in weights_iterator)
 
@@ -391,12 +386,12 @@ class DefaultModelLoader(BaseModelLoader):
 
         self._init_ep_weight_filter(model_config)
 
+        counter_before_loading_weights = time.perf_counter()
         loaded_weights = model.load_weights(self.get_all_weights(model_config, model))
-
-        self.counter_after_loading_weights = time.perf_counter()
+        counter_after_loading_weights = time.perf_counter()
         logger.info_once(
             "Loading weights took %.2f seconds",
-            self.counter_after_loading_weights - self.counter_before_loading_weights,
+            counter_after_loading_weights - counter_before_loading_weights,
         )
         # We only enable strict check for non-quantized models
         # that have loaded weights tracking by default.

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -68,9 +68,6 @@ class DefaultModelLoader(BaseModelLoader):
         allow_patterns_overrides: list[str] | None = None
         """If defined, weights will load exclusively using these patterns."""
 
-    counter_before_loading_weights: float = 0.0
-    counter_after_loading_weights: float = 0.0
-
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
         self.local_expert_ids: set[int] | None = None
@@ -313,8 +310,6 @@ class DefaultModelLoader(BaseModelLoader):
                     self.load_config.pt_load_map_location,
                 )
 
-        if self.counter_before_loading_weights == 0.0:
-            self.counter_before_loading_weights = time.perf_counter()
         # Apply the prefix.
         return ((source.prefix + name, tensor) for (name, tensor) in weights_iterator)
 
@@ -424,12 +419,12 @@ class DefaultModelLoader(BaseModelLoader):
 
         self._init_ep_weight_filter(model_config)
 
+        counter_before_loading_weights = time.perf_counter()
         loaded_weights = model.load_weights(self.get_all_weights(model_config, model))
-
-        self.counter_after_loading_weights = time.perf_counter()
+        counter_after_loading_weights = time.perf_counter()
         logger.info_once(
             "Loading weights took %.2f seconds",
-            self.counter_after_loading_weights - self.counter_before_loading_weights,
+            counter_after_loading_weights - counter_before_loading_weights,
         )
         # We only enable strict check for non-quantized models
         # that have loaded weights tracking by default.


### PR DESCRIPTION
## Purpose

Disclaimer: this PR contains AI-generated code

The "Loading weights took %.2f seconds" log message reports absurdly large values (thousands of seconds) for models whose load_weights() method does not iterate the weights generator.

Root cause: PR #14063 moved counter_before_loading_weights into _get_weights_iterator() to exclude HF download time from the measurement. Since _get_weights_iterator() is called from get_all_weights(), which is a generator function (uses yield from), the counter is only set when model.load_weights() actually iterates the generator. Models that return immediately without iterating (e.g. those that load weights lazily from a separate directory) leave counter_before_loading_weights at its class-level default of 0.0. The logged delta then becomes time.perf_counter() - 0.0, which equals the process uptime.

Fix: replace the class-level counter attributes with local variables in load_weights(), bracketing the model.load_weights() call. This matches the pattern already used by ShardedStateLoader and ensures the timer is always set regardless of whether the generator is consumed.

## Test Plan

Run this test script before and after the commit:
```python
#!/usr/bin/env python3
import logging
import re
from unittest.mock import MagicMock, patch

from vllm.config.load import LoadConfig
from vllm.model_executor.model_loader.default_loader import DefaultModelLoader


class NoOpModel:
    """Model whose load_weights() skips the weights generator entirely."""

    def named_parameters(self):
        return []

    def load_weights(self, weights):
        return set()


def empty_generator(self, model_config, model):
    return
    yield


def main():
    log = logging.getLogger("vllm.model_executor.model_loader.default_loader")
    log.setLevel(logging.INFO)
    records = []
    handler = logging.Handler()
    handler.emit = lambda record: records.append(record)
    log.addHandler(handler)

    loader = DefaultModelLoader(LoadConfig(load_format="dummy"))
    model_config = MagicMock()
    model_config.quantization = None

    with patch.object(DefaultModelLoader, "get_all_weights", empty_generator), \
         patch.object(DefaultModelLoader, "_init_ep_weight_filter", lambda s, m: None):
        loader.load_weights(NoOpModel(), model_config)

    for r in records:
        msg = r.getMessage()
        m = re.search(r"Loading weights took ([\d.]+) seconds", msg)
        if m:
            reported = float(m.group(1))
            ok = reported < 1.0
            print(f"Loader reported: {reported:.2f}s — {'PASS' if ok else 'FAIL'}")
            return 0 if ok else 1

    print("FAIL: no 'Loading weights took' message found in logs")
    return 1


if __name__ == "__main__":
    raise SystemExit(main())
```

## Test Result

before:
```
INFO 03-20 14:00:45 [default_loader.py:384] Loading weights took 6446.59 seconds
Loader reported: 6446.59s — FAIL
```
after
```
INFO 03-20 14:00:59 [default_loader.py:379] Loading weights took 0.00 seconds
Loader reported: 0.00s — PASS
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

