### PR TITLE
fix(bench): compute peak output throughput from token-volume decode windows

### DIFF
--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.benchmarks.datasets import SampleRequest
+from vllm.benchmarks.lib.endpoint_request_func import RequestFuncOutput
+from vllm.benchmarks.serve import calculate_metrics
+
+
+def test_peak_output_throughput_not_less_than_average_with_chunked_streaming():
+    # Simulate two successful requests where streaming events are chunked
+    # (few ITL events) but each request still generates many output tokens.
+    input_requests = [
+        SampleRequest(prompt='a', prompt_len=16, expected_output_len=0),
+        SampleRequest(prompt='b', prompt_len=16, expected_output_len=0),
+    ]
+    outputs = [
+        RequestFuncOutput(
+            success=True,
+            start_time=0.0,
+            latency=4.0,
+            ttft=1.0,
+            itl=[1.5],  # chunk-level events, not per-token events
+            output_tokens=600,
+            generated_text='x' * 600,
+        ),
+        RequestFuncOutput(
+            success=True,
+            start_time=0.5,
+            latency=4.0,
+            ttft=1.0,
+            itl=[1.0],
+            output_tokens=600,
+            generated_text='y' * 600,
+        ),
+    ]
+
+    metrics, _ = calculate_metrics(
+        input_requests=input_requests,
+        outputs=outputs,
+        dur_s=4.5,
+        tokenizer=None,  # output_tokens already present
+        selected_percentiles=[50],
+        goodput_config_dict={},
+    )
+
+    assert metrics.output_throughput > 0
+    assert metrics.max_output_tokens_per_s >= metrics.output_throughput

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -506,34 +506,62 @@ def calculate_metrics(
             output.start_time + output.latency for output in successful_outputs
         )
 
-        # Create second buckets (ceiling to ensure we capture all time)
-        duration_seconds = int(np.ceil(max_end_time - min_start_time)) + 1
+        # Create second buckets covering the full active time window.
+        duration_seconds = max(1, int(np.ceil(max_end_time - min_start_time)))
         tokens_per_second = np.zeros(duration_seconds)
         concurrent_requests_per_second = np.zeros(duration_seconds)
 
-        for i, output in enumerate(successful_outputs):
-            # Calculate token generation timestamp using
-            # start_time, ttft, and itl
-            token_times = [output.start_time + output.ttft]
-            current_time = token_times[0]
-            for itl_value in output.itl:
-                current_time += itl_value
-                token_times.append(current_time)
+        for i, output in enumerate(outputs):
+            if not output.success:
+                continue
 
-            # Add tokens to second buckets
-            for token_time in token_times:
-                second_bucket = int(token_time - min_start_time)
+            output_len = actual_output_lens[i]
+            request_start = output.start_time
+            request_end = output.start_time + output.latency
+
+            # Track concurrent requests by overlap with each 1-second bucket.
+            request_start_second = max(
+                0, int(np.floor(request_start - min_start_time))
+            )
+            request_end_second = min(
+                duration_seconds - 1,
+                int(np.ceil(request_end - min_start_time)) - 1,
+            )
+            for second in range(request_start_second, request_end_second + 1):
+                bucket_start = min_start_time + second
+                bucket_end = bucket_start + 1.0
+                if min(request_end, bucket_end) > max(request_start, bucket_start):
+                    concurrent_requests_per_second[second] += 1
+
+            if output_len <= 0:
+                continue
+
+            # Estimate per-second output-token rate from observed decode window.
+            # `itl` can be chunk-level rather than token-level, so counting
+            # events underestimates token throughput when chunks contain
+            # multiple tokens.
+            decode_start = output.start_time + output.ttft
+            decode_end = request_end
+
+            if decode_end <= decode_start:
+                second_bucket = int(np.floor(decode_start - min_start_time))
                 if 0 <= second_bucket < duration_seconds:
-                    tokens_per_second[second_bucket] += 1
+                    tokens_per_second[second_bucket] += output_len
+                continue
 
-            # Track concurrent requests for each second this request was active
-            request_start_second = int(output.start_time - min_start_time)
-            request_end_second = int(
-                (output.start_time + output.latency) - min_start_time
+            token_rate = output_len / (decode_end - decode_start)
+            decode_start_second = max(0, int(np.floor(decode_start - min_start_time)))
+            decode_end_second = min(
+                duration_seconds - 1,
+                int(np.ceil(decode_end - min_start_time)) - 1,
             )
 
-            for second in range(request_start_second, request_end_second + 1):
-                concurrent_requests_per_second[second] += 1
+            for second in range(decode_start_second, decode_end_second + 1):
+                bucket_start = min_start_time + second
+                bucket_end = bucket_start + 1.0
+                overlap = min(decode_end, bucket_end) - max(decode_start, bucket_start)
+                if overlap > 0:
+                    tokens_per_second[second] += token_rate * overlap
 
         # Find the maximum tokens per second and corresponding
         # concurrent requests


### PR DESCRIPTION
## Summary
Fix `vllm bench serve` peak output throughput calculation so it is based on generated token volume over decode windows, not stream chunk-event count.

## Root Cause
`max_output_tokens_per_s` was computed from `ttft/itl` event timestamps. In chunked streaming, one event can contain multiple tokens, so event-count bucketing can undercount output token throughput and report peak lower than average throughput.

## Changes
- Reworked peak output throughput calculation in `vllm/benchmarks/serve.py`:
  - Use `actual_output_lens` token counts with decode windows (`start_time + ttft` to `start_time + latency`)
  - Accumulate per-second token volume by overlap with 1-second buckets
  - Keep concurrent request peak tracking with overlap-based bucket counting
- Added regression test `tests/benchmarks/test_serve_metrics.py` to cover chunked-streaming behavior.

## Why this is not duplicating an existing open PR
- Open PR #35471 also touches this metric area, but this patch is materially different:
  - this patch removes dependency on chunk-event count (`itl`) entirely for peak token throughput,
  - uses decode-window overlap integration with actual token volume,
  - and includes explicit degenerate-window handling.
- Coordination/differentiation notes were added on issue #37666:
  - https://github.com/vllm-project/vllm/issues/37666#issuecomment-4098247969
  - https://github.com/vllm-project/vllm/issues/37666#issuecomment-4098250795

## Tests
- `python3 -m py_compile vllm/benchmarks/serve.py tests/benchmarks/test_serve_metrics.py` ✅
- `python3 -m pytest -q tests/benchmarks/test_serve_metrics.py` ❌ (not runnable in this local environment: missing `pytest`/`torch` dependencies)

## AI Assistance
This change was developed with AI-assisted tooling and reviewed by a human contributor.

Closes #37666
