### PR TITLE
[cpu][ci] remove soft-fail for Arm CI and add quant model tests

### DIFF
--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -101,6 +101,7 @@ steps:
 
 - label: "Arm CPU Test"
   depends_on: []
+  soft_fail: false
   device: arm_cpu
   no_plugin: true
   commands: 

--- a/.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh
+++ b/.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh
@@ -5,8 +5,8 @@
 set -ex
 
 # allow to bind to different cores
-CORE_RANGE=${CORE_RANGE:-0-16}
-OMP_CORE_RANGE=${OMP_CORE_RANGE:-0-16}
+CORE_RANGE=${CORE_RANGE:-0-31}
+OMP_CORE_RANGE=${OMP_CORE_RANGE:-0-31}
 
 export CMAKE_BUILD_PARALLEL_LEVEL=16
 
@@ -40,6 +40,11 @@ function cpu_tests() {
   docker exec cpu-test bash -c "
     set -e
     pytest -x -v -s tests/models/multimodal/generation/test_whisper.py -m cpu_model"
+
+  # Run quantized model tests
+  docker exec cpu-test bash -c "
+    set -e
+    pytest -x -v -s tests/quantization/test_compressed_tensors.py::test_compressed_tensors_w8a8_logprobs"
 
   # Run kernel tests
   docker exec cpu-test bash -c "


### PR DESCRIPTION

## Purpose

- Remove soft-fail from Arm pipelines: these pipelines have been running for a few months (in under 30 minutes) with no glitches, they only failed for genuine bugs in vLLM.....so it's time to remove the soft-fail.
- Adds w8a8 quantized model tests

## Test Plan

CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [Y] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [Y] The test plan, such as providing test command.
- [Y] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

