### PR TITLE
Add get_device_uuid for rocm

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -28,6 +28,7 @@ try:
     from amdsmi import (
         AmdSmiException,
         amdsmi_get_gpu_asic_info,
+        amdsmi_get_gpu_device_uuid,
         amdsmi_get_processor_handles,
         amdsmi_init,
         amdsmi_shut_down,
@@ -607,6 +608,12 @@ class RocmPlatform(Platform):
         if device_name in _ROCM_DEVICE_ID_NAME_MAP:
             return _ROCM_DEVICE_ID_NAME_MAP[device_name]
         return asic_info["market_name"]
+
+    @classmethod
+    @with_amdsmi_context
+    def get_device_uuid(cls, device_id: int = 0) -> str:
+        device = amdsmi_get_processor_handles()[device_id]
+        return amdsmi_get_gpu_device_uuid(device)
 
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -612,8 +612,16 @@ class RocmPlatform(Platform):
     @classmethod
     @with_amdsmi_context
     def get_device_uuid(cls, device_id: int = 0) -> str:
-        device = amdsmi_get_processor_handles()[device_id]
-        return amdsmi_get_gpu_device_uuid(device)
+        try:
+            device = amdsmi_get_processor_handles()[device_id]
+        except AmdSmiException as error:
+            logger.error("amdsmi device query failed ", exc_info=error)
+            return ""
+        try:
+            device_uuid = amdsmi_get_gpu_device_uuid(device)
+        except AmdSmiException as error:
+            logger.error("amdsmi device uuid query failed ", exc_info=error)
+        return device_uuid
 
     @classmethod
     def get_device_total_memory(cls, device_id: int = 0) -> int:


### PR DESCRIPTION
Adding an implementation of `get_device_uuid` for the rocm platform. This implementation is need for the Verl application PPO and Fully Async uses cases which executes the code below when the vllm backend is being used:

```python
def get_device_uuid(device_id: int) -> str:
    from vllm.platforms import current_platform
 
    # Convert torch.npu.current_device to its corresponding ASCEND_RT_VISIBLE_DEVICES.
    if is_npu_available:
        if os.getenv("ASCEND_RT_VISIBLE_DEVICES") is not None:
            npu_visible_devices = os.environ["ASCEND_RT_VISIBLE_DEVICES"].split(",")
            assert device_id < len(npu_visible_devices), f"device_id {device_id} must less than {npu_visible_devices}"
            return "NPU-" + npu_visible_devices[device_id]
        else:
            return f"NPU-{device_id}"
    else:
        return current_platform.get_device_uuid(device_id)
```
This code is found in the Verl source code file `verl/workers/rollout/vllm_rollout/utils.py`

An implementation of  `get_device_uuid` already exists for the CUDA platform in vLLM.