### PR TITLE
[Bugfix] Mask padded rows for FlashInfer CUTLASS MoE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
@@ -5,6 +5,10 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.config import get_current_vllm_config
+from vllm.forward_context import (
+    get_forward_context,
+    is_forward_context_available,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
@@ -31,6 +35,51 @@ from vllm.utils.flashinfer import (
 )
 
 logger = init_logger(__name__)
+
+
+def _iter_slot_mapping_tensors(slot_mapping):
+    if slot_mapping is None:
+        return
+    if isinstance(slot_mapping, list):
+        for mapping_group in slot_mapping:
+            if not mapping_group:
+                continue
+            for tensor in mapping_group.values():
+                if isinstance(tensor, torch.Tensor):
+                    yield tensor
+        return
+    for tensor in slot_mapping.values():
+        if isinstance(tensor, torch.Tensor):
+            yield tensor
+
+
+def _mask_padded_rows_for_flashinfer_moe(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> None:
+    if not is_forward_context_available():
+        return
+
+    ctx = get_forward_context()
+    num_rows = hidden_states.shape[0]
+    pad_rows = None
+    for slot_mapping in _iter_slot_mapping_tensors(ctx.slot_mapping):
+        if (
+            slot_mapping.ndim == 1
+            and slot_mapping.shape[0] == num_rows
+            and slot_mapping.device == topk_ids.device
+        ):
+            pad_rows = slot_mapping.eq(-1)
+            break
+
+    if pad_rows is None:
+        return
+
+    # Padded rows should not participate in MoE routing.
+    pad_rows = pad_rows.unsqueeze(-1)
+    topk_ids.masked_fill_(pad_rows, -1)
+    topk_weights.masked_fill_(pad_rows, 0)
 
 
 def is_valid_flashinfer_cutlass_fused_moe(
@@ -365,6 +414,12 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             a1q_scale = None
             fc1_expert_weights = w1
             fc2_expert_weights = w2
+
+        _mask_padded_rows_for_flashinfer_moe(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+        )
 
         _ = flashinfer_cutlass_fused_moe(
             input=hidden_states,

--- a/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
@@ -54,7 +54,6 @@ def _iter_slot_mapping_tensors(slot_mapping):
 
 
 def _mask_padded_rows_for_flashinfer_moe(
-    hidden_states: torch.Tensor,
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
 ) -> None:
@@ -62,7 +61,7 @@ def _mask_padded_rows_for_flashinfer_moe(
         return
 
     ctx = get_forward_context()
-    num_rows = hidden_states.shape[0]
+    num_rows = topk_ids.shape[0]
     pad_rows = None
     for slot_mapping in _iter_slot_mapping_tensors(ctx.slot_mapping):
         if (
@@ -110,6 +109,14 @@ def is_valid_flashinfer_cutlass_fused_moe(
 
 
 class FlashInferExperts(mk.FusedMoEExpertsModular):
+    def preprocess_inputs_before_prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> None:
+        _mask_padded_rows_for_flashinfer_moe(topk_ids, topk_weights)
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if self.quant_config.use_nvfp4_w4a4:
             layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
@@ -414,12 +421,6 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             a1q_scale = None
             fc1_expert_weights = w1
             fc2_expert_weights = w2
-
-        _mask_padded_rows_for_flashinfer_moe(
-            hidden_states=hidden_states,
-            topk_ids=topk_ids,
-            topk_weights=topk_weights,
-        )
 
         _ = flashinfer_cutlass_fused_moe(
             input=hidden_states,

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -858,6 +858,20 @@ class FusedMoEExpertsModular(FusedMoEExperts):
     ) -> None:
         apply_moe_activation(activation, output, input)
 
+    def preprocess_inputs_before_prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> None:
+        """
+        Backend-specific hook to mutate routing inputs before prepare/finalize.
+
+        This runs before any prepare-time quantization or token redistribution,
+        so implementations that need the original row layout can use it.
+        """
+        return
+
     @abstractmethod
     def finalize_weight_and_reduce_impl(self) -> TopKWeightAndReduce:
         raise NotImplementedError
@@ -1352,6 +1366,12 @@ class FusedMoEKernelModularImpl:
         local_num_experts = w1.size(0)
         if global_num_experts == -1:
             global_num_experts = local_num_experts
+
+        self.fused_experts.preprocess_inputs_before_prepare(
+            hidden_states,
+            topk_ids,
+            topk_weights,
+        )
 
         a1q, a1q_scale, expert_tokens_meta, topk_ids, topk_weights = self._prepare(
             hidden_states,


### PR DESCRIPTION



## Purpose

This PR masks padded rows before the FlashInfer CUTLASS MoE call. It uses ForwardContext.slot_mapping to identify rows that are padding (slot_mapping == -1), then sets those rows topk_ids to -1 and topk_weights to 0. In FlashInfer finalize, invalid expert ids are skipped before the permutation-table lookup, so padded rows no longer reach the failing map read under CUDAGraph replay. 


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

