### PR TITLE
[Bug] Fix fp8 deepgemm batch invariant

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -305,6 +305,11 @@ def _flashinfer_fp8_blockscale_gemm_impl(
         )
         return output
 
+    from vllm.model_executor.layers.batch_invariant import vllm_is_batch_invariant
+
+    if vllm_is_batch_invariant():
+        return run_deepgemm(input, weight, weight_scale)
+
     condition = input.shape[0] < 32
 
     # PyTorch's torch.compile cannot handle input-dependent control flow in standard


### PR DESCRIPTION
## Purpose

Selecting kernels between `run_flashinfer_deepgemm_swapAB` and `run_deepgemm` will break batch invaraince, this PR fixes the issue.

## Test

`VLLM_TEST_MODEL="Qwen/Qwen3-30B-A3B-Thinking-2507-FP8" pytest tests/v1/determinism/test_batch_invariance.py -svx`

```bash
# now
============== 10 passed, 28 warnings in 458.02s (0:07:38) ===============
# original
======================= short test summary info ========================
FAILED tests/v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[FLASH_ATTN] - Failed: Nondeterministic outputs detected: 1 failed out of 1 trials...
!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!
============== 1 failed, 19 warnings in 79.75s (0:01:19) ===============
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```