### PR TITLE
[ROCm][CI] Update GSM8K eval config to use fp8-and-mixed models list (MI355)

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -3571,7 +3571,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx-fp8.txt
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-mi3xx-fp8-and-mixed.txt
 
 
 - label: LM Eval Large Models (4 GPUs)(FP8) # TBD


### PR DESCRIPTION
Follow-up for:
- #34839 

Updated the GSM8K correctness eval in the AMD CI pipeline to use the `models-mi3xx-fp8-and-mixed.txt` config list instead of `models-mi3xx-fp8.txt`. Addresses failure in `mi355_2: LM Eval Small Models (B200-MI325)`

Motivation: https://buildkite.com/vllm/amd-ci/builds/6721/steps/canvas?sid=019d09d4-713e-4e07-bcb9-9b38689611a0&tab=output

cc @kenroche 