### PR TITLE
Fix: preserve streaming logprobs

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -753,6 +753,8 @@ class OpenAIServingChat(OpenAIServing):
                         else:
                             current_token_ids = as_list(output.token_ids)
 
+                    suppressed_auto_tool_delta = False
+
                     if self.use_harmony:
                         delta_message, tools_streamed_flag = (
                             extract_harmony_streaming_delta(
@@ -968,6 +970,7 @@ class OpenAIServingChat(OpenAIServing):
                                 delta_token_ids=delta_token_ids,
                                 request=request,
                             )
+                            suppressed_auto_tool_delta = delta_message is None
                             if delta_message and delta_message.tool_calls:
                                 tools_streamed[i] = True
                     # when only tool calls
@@ -982,6 +985,7 @@ class OpenAIServingChat(OpenAIServing):
                             delta_token_ids=output.token_ids,
                             request=request,
                         )
+                        suppressed_auto_tool_delta = delta_message is None
                         if delta_message and delta_message.tool_calls:
                             tools_streamed[i] = True
 
@@ -1027,16 +1031,17 @@ class OpenAIServingChat(OpenAIServing):
                     # wasn't ready to send a token, then
                     #   get the next token without streaming a chunk
                     if delta_message is None:
-                        # Some tool parsers intentionally suppress control
-                        # tokens by returning None. When the client asked for
-                        # token_ids or logprobs, still emit an empty delta so
-                        # those per-token details are not dropped from the
-                        # stream.
-                        if not self._should_emit_empty_delta_chunk(
-                            output=output,
-                            request=request,
-                            logprobs=logprobs,
-                        ):
+                        # Keep metadata-only chunks only for finish events,
+                        # token_ids, or auto tool parser control tokens.
+                        should_emit_empty_delta_chunk = (
+                            output.finish_reason is not None
+                            or request.return_token_ids
+                            or (
+                                suppressed_auto_tool_delta
+                                and logprobs is not None
+                            )
+                        )
+                        if not should_emit_empty_delta_chunk:
                             continue
                         delta_message = DeltaMessage()
 
@@ -1781,18 +1786,6 @@ class OpenAIServingChat(OpenAIServing):
             and delta_message.tool_calls[0]
             and delta_message.tool_calls[0].function
             and delta_message.tool_calls[0].function.arguments is not None
-        )
-
-    @staticmethod
-    def _should_emit_empty_delta_chunk(
-        output: CompletionOutput,
-        request: ChatCompletionRequest,
-        logprobs: ChatCompletionLogProbs | None,
-    ) -> bool:
-        return bool(
-            output.finish_reason is not None
-            or request.return_token_ids
-            or logprobs is not None
         )
 
     @staticmethod

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1027,12 +1027,15 @@ class OpenAIServingChat(OpenAIServing):
                     # wasn't ready to send a token, then
                     #   get the next token without streaming a chunk
                     if delta_message is None:
-                        # NOTE: If return_token_ids is enabled, we still need to
-                        # send a chunk with token_ids even if delta_message is None
-                        # to ensure all tokens are included in the response
-                        if (
-                            output.finish_reason is None
-                            and not request.return_token_ids
+                        # Some tool parsers intentionally suppress control
+                        # tokens by returning None. When the client asked for
+                        # token_ids or logprobs, still emit an empty delta so
+                        # those per-token details are not dropped from the
+                        # stream.
+                        if not self._should_emit_empty_delta_chunk(
+                            output=output,
+                            request=request,
+                            logprobs=logprobs,
                         ):
                             continue
                         delta_message = DeltaMessage()
@@ -1778,6 +1781,18 @@ class OpenAIServingChat(OpenAIServing):
             and delta_message.tool_calls[0]
             and delta_message.tool_calls[0].function
             and delta_message.tool_calls[0].function.arguments is not None
+        )
+
+    @staticmethod
+    def _should_emit_empty_delta_chunk(
+        output: CompletionOutput,
+        request: ChatCompletionRequest,
+        logprobs: ChatCompletionLogProbs | None,
+    ) -> bool:
+        return bool(
+            output.finish_reason is not None
+            or request.return_token_ids
+            or logprobs is not None
         )
 
     @staticmethod


### PR DESCRIPTION



## Purpose

Fixes #37737.

When a streaming tool parser suppresses a control-token chunk by returning `None`, the chat streaming path can skip the whole chunk even if it still carries logprobs. This change keeps emitting an empty delta chunk when per-token metadata must be preserved.

## Test Plan

Run the streaming chat completion flow with `logprobs=true` and reproduce the tool-call path with `Qwen/Qwen3-VL-8B-Thinking`. Confirm that `<tool_call>` logprobs are preserved even when the parser suppresses the visible delta.

## Test Result

After the fix, repeated requests all returned logprobs for the `<tool_call>` token.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

