### PR TITLE
[Responses API] Fix tool_choice=required: WebSearch crash, parallel tool merge, JSON fallback

### DIFF
--- a/tests/entrypoints/openai/parser/test_responses_parser_json_fallback.py
+++ b/tests/entrypoints/openai/parser/test_responses_parser_json_fallback.py
@@ -34,11 +34,13 @@ def _make_parser(*, tool_choice="required", has_tool_parser=False):
     tool_parser_cls = None
     if has_tool_parser:
         tool_parser = MagicMock()
-        tool_parser.extract_tool_calls = MagicMock(return_value=MagicMock(
-            tools_called=False,
-            tool_calls=[],
-            content=None,
-        ))
+        tool_parser.extract_tool_calls = MagicMock(
+            return_value=MagicMock(
+                tools_called=False,
+                tool_calls=[],
+                content=None,
+            )
+        )
         tool_parser_cls = MagicMock(return_value=tool_parser)
 
     request = MagicMock()
@@ -66,13 +68,14 @@ def _make_output(text: str) -> CompletionOutput:
 
 
 class TestJsonFallbackParsing:
-
     def test_fallback_parses_json_array(self):
         """tool_choice=required + content is JSON array → parse as function_calls."""
         parser = _make_parser(tool_choice="required")
-        content = json.dumps([
-            {"name": "get_weather", "parameters": {"city": "NYC"}},
-        ])
+        content = json.dumps(
+            [
+                {"name": "get_weather", "parameters": {"city": "NYC"}},
+            ]
+        )
         output = _make_output(content)
         parser.process(output)
 
@@ -89,15 +92,20 @@ class TestJsonFallbackParsing:
     def test_fallback_parses_multiple_tools(self):
         """JSON array with multiple tool calls."""
         parser = _make_parser(tool_choice="required")
-        content = json.dumps([
-            {"name": "fn_a", "parameters": {"x": 1}},
-            {"name": "fn_b", "parameters": {"y": 2}},
-        ])
+        content = json.dumps(
+            [
+                {"name": "fn_a", "parameters": {"x": 1}},
+                {"name": "fn_b", "parameters": {"y": 2}},
+            ]
+        )
         output = _make_output(content)
         parser.process(output)
 
-        func_calls = [m for m in parser.response_messages
-                      if isinstance(m, ResponseFunctionToolCall)]
+        func_calls = [
+            m
+            for m in parser.response_messages
+            if isinstance(m, ResponseFunctionToolCall)
+        ]
         assert len(func_calls) == 2
         assert func_calls[0].name == "fn_a"
         assert func_calls[1].name == "fn_b"
@@ -110,8 +118,11 @@ class TestJsonFallbackParsing:
         parser.process(output)
 
         # Should be a text message, not a function call
-        func_calls = [m for m in parser.response_messages
-                      if isinstance(m, ResponseFunctionToolCall)]
+        func_calls = [
+            m
+            for m in parser.response_messages
+            if isinstance(m, ResponseFunctionToolCall)
+        ]
         assert len(func_calls) == 0
 
     def test_fallback_skipped_when_native_parser_succeeds(self):
@@ -120,7 +131,7 @@ class TestJsonFallbackParsing:
         # Override the mock to return a tool call
         mock_tool_call = MagicMock()
         mock_tool_call.function.name = "native_fn"
-        mock_tool_call.function.arguments = '{}'
+        mock_tool_call.function.arguments = "{}"
         parser.tool_parser_instance.extract_tool_calls.return_value = MagicMock(
             tools_called=True,
             tool_calls=[mock_tool_call],
@@ -132,8 +143,11 @@ class TestJsonFallbackParsing:
         parser.process(output)
 
         # Should have the native call, not the fallback
-        func_calls = [m for m in parser.response_messages
-                      if isinstance(m, ResponseFunctionToolCall)]
+        func_calls = [
+            m
+            for m in parser.response_messages
+            if isinstance(m, ResponseFunctionToolCall)
+        ]
         assert len(func_calls) == 1
         assert func_calls[0].name == "native_fn"
 
@@ -144,8 +158,11 @@ class TestJsonFallbackParsing:
         output = _make_output(content)
         parser.process(output)
 
-        func_calls = [m for m in parser.response_messages
-                      if isinstance(m, ResponseFunctionToolCall)]
+        func_calls = [
+            m
+            for m in parser.response_messages
+            if isinstance(m, ResponseFunctionToolCall)
+        ]
         assert len(func_calls) == 0
         # Content preserved as text message
         assert len(parser.response_messages) == 1
@@ -157,8 +174,11 @@ class TestJsonFallbackParsing:
         output = _make_output(content)
         parser.process(output)
 
-        func_calls = [m for m in parser.response_messages
-                      if isinstance(m, ResponseFunctionToolCall)]
+        func_calls = [
+            m
+            for m in parser.response_messages
+            if isinstance(m, ResponseFunctionToolCall)
+        ]
         assert len(func_calls) == 0
 
     def test_fallback_skipped_when_content_is_none(self):
@@ -172,3 +192,40 @@ class TestJsonFallbackParsing:
         parser.process(output)
 
         assert len(parser.response_messages) == 0
+
+    def test_fallback_atomic_rejects_partial_invalid(self):
+        """If any item in the JSON array is invalid, all are rejected."""
+        parser = _make_parser(tool_choice="required")
+        content = json.dumps(
+            [
+                {"name": "fn_a", "parameters": {"x": 1}},
+                {"name": "", "parameters": {}},  # invalid: empty name
+            ]
+        )
+        output = _make_output(content)
+        parser.process(output)
+
+        # No function calls — atomic rejection
+        func_calls = [
+            m
+            for m in parser.response_messages
+            if isinstance(m, ResponseFunctionToolCall)
+        ]
+        assert len(func_calls) == 0
+        # Content preserved as text message
+        assert len(parser.response_messages) == 1
+
+    def test_fallback_rejects_non_dict_items(self):
+        """JSON array with non-dict items → rejected, becomes text."""
+        parser = _make_parser(tool_choice="required")
+        content = json.dumps(["not_a_dict", {"name": "fn", "parameters": {}}])
+        output = _make_output(content)
+        parser.process(output)
+
+        func_calls = [
+            m
+            for m in parser.response_messages
+            if isinstance(m, ResponseFunctionToolCall)
+        ]
+        assert len(func_calls) == 0
+        assert len(parser.response_messages) == 1

--- a/tests/entrypoints/openai/parser/test_responses_parser_json_fallback.py
+++ b/tests/entrypoints/openai/parser/test_responses_parser_json_fallback.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the JSON fallback parsing in ResponsesParser.process().
+
+When tool_choice="required" and guided generation forces the model to output
+a JSON array of {name, parameters} objects (instead of native tool-call
+tokens), the native tool parser won't recognise them.  The fallback path
+parses the JSON directly.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from openai.types.responses import ResponseFunctionToolCall
+
+from vllm.entrypoints.openai.parser.responses_parser import ResponsesParser
+from vllm.outputs import CompletionOutput
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _make_parser(*, tool_choice="required", has_tool_parser=False):
+    """Create a ResponsesParser with mocked dependencies."""
+    tokenizer = MagicMock()
+
+    # Mock reasoning parser that returns (None, content) — no reasoning
+    reasoning_parser = MagicMock()
+    reasoning_parser.extract_reasoning = lambda text, request=None: (None, text)
+    reasoning_parser_cls = MagicMock(return_value=reasoning_parser)
+
+    # Mock tool parser that never finds tool calls (simulating native parser failure)
+    tool_parser = None
+    tool_parser_cls = None
+    if has_tool_parser:
+        tool_parser = MagicMock()
+        tool_parser.extract_tool_calls = MagicMock(return_value=MagicMock(
+            tools_called=False,
+            tool_calls=[],
+            content=None,
+        ))
+        tool_parser_cls = MagicMock(return_value=tool_parser)
+
+    request = MagicMock()
+    request.tool_choice = tool_choice
+
+    parser = ResponsesParser(
+        tokenizer=tokenizer,
+        reasoning_parser_cls=reasoning_parser_cls,
+        response_messages=[],
+        request=request,
+        tool_parser_cls=tool_parser_cls,
+    )
+    return parser
+
+
+def _make_output(text: str) -> CompletionOutput:
+    return CompletionOutput(
+        index=0,
+        text=text,
+        token_ids=(),
+        cumulative_logprob=None,
+        logprobs=None,
+        finish_reason="stop",
+    )
+
+
+class TestJsonFallbackParsing:
+
+    def test_fallback_parses_json_array(self):
+        """tool_choice=required + content is JSON array → parse as function_calls."""
+        parser = _make_parser(tool_choice="required")
+        content = json.dumps([
+            {"name": "get_weather", "parameters": {"city": "NYC"}},
+        ])
+        output = _make_output(content)
+        parser.process(output)
+
+        # Should have 1 function call, no text message
+        msgs = parser.response_messages
+        func_calls = [m for m in msgs if isinstance(m, ResponseFunctionToolCall)]
+        assert len(func_calls) == 1
+        assert func_calls[0].name == "get_weather"
+        assert json.loads(func_calls[0].arguments) == {"city": "NYC"}
+        # No text message since content was consumed
+        text_msgs = [m for m in msgs if not isinstance(m, ResponseFunctionToolCall)]
+        assert len(text_msgs) == 0
+
+    def test_fallback_parses_multiple_tools(self):
+        """JSON array with multiple tool calls."""
+        parser = _make_parser(tool_choice="required")
+        content = json.dumps([
+            {"name": "fn_a", "parameters": {"x": 1}},
+            {"name": "fn_b", "parameters": {"y": 2}},
+        ])
+        output = _make_output(content)
+        parser.process(output)
+
+        func_calls = [m for m in parser.response_messages
+                      if isinstance(m, ResponseFunctionToolCall)]
+        assert len(func_calls) == 2
+        assert func_calls[0].name == "fn_a"
+        assert func_calls[1].name == "fn_b"
+
+    def test_fallback_skipped_when_tool_choice_auto(self):
+        """tool_choice=auto → no fallback even if content is JSON."""
+        parser = _make_parser(tool_choice="auto")
+        content = json.dumps([{"name": "fn", "parameters": {}}])
+        output = _make_output(content)
+        parser.process(output)
+
+        # Should be a text message, not a function call
+        func_calls = [m for m in parser.response_messages
+                      if isinstance(m, ResponseFunctionToolCall)]
+        assert len(func_calls) == 0
+
+    def test_fallback_skipped_when_native_parser_succeeds(self):
+        """Native parser found tool calls → fallback not triggered."""
+        parser = _make_parser(tool_choice="required", has_tool_parser=True)
+        # Override the mock to return a tool call
+        mock_tool_call = MagicMock()
+        mock_tool_call.function.name = "native_fn"
+        mock_tool_call.function.arguments = '{}'
+        parser.tool_parser_instance.extract_tool_calls.return_value = MagicMock(
+            tools_called=True,
+            tool_calls=[mock_tool_call],
+            content=None,
+        )
+
+        content = json.dumps([{"name": "fallback_fn", "parameters": {}}])
+        output = _make_output(content)
+        parser.process(output)
+
+        # Should have the native call, not the fallback
+        func_calls = [m for m in parser.response_messages
+                      if isinstance(m, ResponseFunctionToolCall)]
+        assert len(func_calls) == 1
+        assert func_calls[0].name == "native_fn"
+
+    def test_fallback_handles_invalid_json(self):
+        """Malformed JSON content → gracefully ignored, becomes text message."""
+        parser = _make_parser(tool_choice="required")
+        content = "not valid json {"
+        output = _make_output(content)
+        parser.process(output)
+
+        func_calls = [m for m in parser.response_messages
+                      if isinstance(m, ResponseFunctionToolCall)]
+        assert len(func_calls) == 0
+        # Content preserved as text message
+        assert len(parser.response_messages) == 1
+
+    def test_fallback_handles_json_object_not_array(self):
+        """JSON object (not array) → ignored, becomes text message."""
+        parser = _make_parser(tool_choice="required")
+        content = json.dumps({"name": "fn", "parameters": {}})
+        output = _make_output(content)
+        parser.process(output)
+
+        func_calls = [m for m in parser.response_messages
+                      if isinstance(m, ResponseFunctionToolCall)]
+        assert len(func_calls) == 0
+
+    def test_fallback_skipped_when_content_is_none(self):
+        """No content → fallback not triggered."""
+        parser = _make_parser(tool_choice="required")
+        # Mock reasoning parser to return no content
+        parser.reasoning_parser_instance.extract_reasoning = (
+            lambda text, request=None: (None, None)
+        )
+        output = _make_output("")
+        parser.process(output)
+
+        assert len(parser.response_messages) == 0

--- a/tests/entrypoints/openai/responses/test_consecutive_function_call_merge.py
+++ b/tests/entrypoints/openai/responses/test_consecutive_function_call_merge.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for consecutive function_call merging in
+construct_chat_messages_with_tool_call.
+
+Regression test: when Responses API input contains consecutive
+ResponseFunctionToolCall items (parallel tool calls), they should be merged
+into a single assistant message with multiple tool_calls entries, matching
+the Chat Completions format that models were trained on.
+"""
+
+import pytest
+from openai.types.responses.response_function_tool_call import (
+    ResponseFunctionToolCall,
+)
+from openai.types.responses.response_function_tool_call_output_item import (
+    ResponseFunctionToolCallOutputItem,
+)
+from openai.types.responses.response_output_message import ResponseOutputMessage
+from openai.types.responses.response_output_text import ResponseOutputText
+
+from vllm.entrypoints.openai.responses.utils import (
+    construct_chat_messages_with_tool_call,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _make_function_call(name: str, args: str, call_id: str) -> ResponseFunctionToolCall:
+    return ResponseFunctionToolCall(
+        id=f"fc_{call_id}",
+        call_id=f"call_{call_id}",
+        type="function_call",
+        status="completed",
+        name=name,
+        arguments=args,
+    )
+
+
+def _make_tool_output(call_id: str, output: str) -> ResponseFunctionToolCallOutputItem:
+    return ResponseFunctionToolCallOutputItem(
+        id=f"fco_{call_id}",
+        type="function_call_output",
+        call_id=f"call_{call_id}",
+        output=output,
+        status="completed",
+    )
+
+
+def _make_message(text: str) -> ResponseOutputMessage:
+    return ResponseOutputMessage(
+        id="msg_1",
+        content=[
+            ResponseOutputText(
+                annotations=[],
+                text=text,
+                type="output_text",
+                logprobs=None,
+            )
+        ],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+
+
+class TestConsecutiveFunctionCallMerge:
+
+    def test_two_consecutive_calls_merged(self):
+        """Two consecutive function_call items → 1 assistant message with 2 tool_calls."""
+        items = [
+            _make_function_call("get_weather", '{"city": "NYC"}', "1"),
+            _make_function_call("get_weather", '{"city": "LA"}', "2"),
+        ]
+        messages = construct_chat_messages_with_tool_call(items)
+
+        assert len(messages) == 1
+        msg = messages[0]
+        assert msg["role"] == "assistant"
+        assert len(msg["tool_calls"]) == 2
+        assert msg["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert msg["tool_calls"][0]["function"]["arguments"] == '{"city": "NYC"}'
+        assert msg["tool_calls"][0]["id"] == "call_1"
+        assert msg["tool_calls"][1]["function"]["name"] == "get_weather"
+        assert msg["tool_calls"][1]["function"]["arguments"] == '{"city": "LA"}'
+        assert msg["tool_calls"][1]["id"] == "call_2"
+
+    def test_three_consecutive_calls_merged(self):
+        """Three consecutive function_call items → 1 assistant message with 3 tool_calls."""
+        items = [
+            _make_function_call("fn_a", '{"x": 1}', "a"),
+            _make_function_call("fn_b", '{"y": 2}', "b"),
+            _make_function_call("fn_c", '{"z": 3}', "c"),
+        ]
+        messages = construct_chat_messages_with_tool_call(items)
+
+        assert len(messages) == 1
+        assert len(messages[0]["tool_calls"]) == 3
+
+    def test_message_then_call_not_merged(self):
+        """ResponseOutputMessage followed by function_call → 2 separate messages."""
+        items = [
+            _make_message("Hello"),
+            _make_function_call("fn", '{}', "1"),
+        ]
+        messages = construct_chat_messages_with_tool_call(items)
+
+        assert len(messages) == 2
+        assert messages[0]["role"] == "assistant"
+        assert messages[0]["content"] == "Hello"
+        assert messages[1]["role"] == "assistant"
+        assert len(messages[1]["tool_calls"]) == 1
+
+    def test_tool_output_between_calls_breaks_merge(self):
+        """function_call, function_call_output, function_call → 3 messages (not merged)."""
+        items = [
+            _make_function_call("fn_a", '{}', "a"),
+            _make_tool_output("a", "result_a"),
+            _make_function_call("fn_b", '{}', "b"),
+        ]
+        messages = construct_chat_messages_with_tool_call(items)
+
+        assert len(messages) == 3
+        # First: assistant with tool_calls
+        assert messages[0]["role"] == "assistant"
+        assert len(messages[0]["tool_calls"]) == 1
+        # Second: tool output
+        assert messages[1]["role"] == "tool"
+        assert messages[1]["content"] == "result_a"
+        # Third: new assistant with tool_calls
+        assert messages[2]["role"] == "assistant"
+        assert len(messages[2]["tool_calls"]) == 1
+
+    def test_single_call_unchanged(self):
+        """A single function_call still produces 1 assistant message with 1 tool_call."""
+        items = [_make_function_call("fn", '{"k": "v"}', "1")]
+        messages = construct_chat_messages_with_tool_call(items)
+
+        assert len(messages) == 1
+        assert messages[0]["role"] == "assistant"
+        assert len(messages[0]["tool_calls"]) == 1
+
+    def test_parallel_calls_then_outputs(self):
+        """Two parallel calls followed by two outputs → assistant(2 tools) + 2 tool msgs."""
+        items = [
+            _make_function_call("fn_a", '{}', "a"),
+            _make_function_call("fn_b", '{}', "b"),
+            _make_tool_output("a", "res_a"),
+            _make_tool_output("b", "res_b"),
+        ]
+        messages = construct_chat_messages_with_tool_call(items)
+
+        assert len(messages) == 3
+        # Merged assistant message
+        assert messages[0]["role"] == "assistant"
+        assert len(messages[0]["tool_calls"]) == 2
+        # Tool outputs
+        assert messages[1]["role"] == "tool"
+        assert messages[2]["role"] == "tool"

--- a/tests/entrypoints/openai/responses/test_consecutive_function_call_merge.py
+++ b/tests/entrypoints/openai/responses/test_consecutive_function_call_merge.py
@@ -65,9 +65,8 @@ def _make_message(text: str) -> ResponseOutputMessage:
 
 
 class TestConsecutiveFunctionCallMerge:
-
     def test_two_consecutive_calls_merged(self):
-        """Two consecutive function_call items → 1 assistant message with 2 tool_calls."""
+        """Two consecutive function_call items merge into one message."""
         items = [
             _make_function_call("get_weather", '{"city": "NYC"}', "1"),
             _make_function_call("get_weather", '{"city": "LA"}', "2"),
@@ -86,7 +85,7 @@ class TestConsecutiveFunctionCallMerge:
         assert msg["tool_calls"][1]["id"] == "call_2"
 
     def test_three_consecutive_calls_merged(self):
-        """Three consecutive function_call items → 1 assistant message with 3 tool_calls."""
+        """Three consecutive function_call items merge into one."""
         items = [
             _make_function_call("fn_a", '{"x": 1}', "a"),
             _make_function_call("fn_b", '{"y": 2}', "b"),
@@ -101,7 +100,7 @@ class TestConsecutiveFunctionCallMerge:
         """ResponseOutputMessage followed by function_call → 2 separate messages."""
         items = [
             _make_message("Hello"),
-            _make_function_call("fn", '{}', "1"),
+            _make_function_call("fn", "{}", "1"),
         ]
         messages = construct_chat_messages_with_tool_call(items)
 
@@ -112,11 +111,11 @@ class TestConsecutiveFunctionCallMerge:
         assert len(messages[1]["tool_calls"]) == 1
 
     def test_tool_output_between_calls_breaks_merge(self):
-        """function_call, function_call_output, function_call → 3 messages (not merged)."""
+        """Tool output between calls breaks the merge."""
         items = [
-            _make_function_call("fn_a", '{}', "a"),
+            _make_function_call("fn_a", "{}", "a"),
             _make_tool_output("a", "result_a"),
-            _make_function_call("fn_b", '{}', "b"),
+            _make_function_call("fn_b", "{}", "b"),
         ]
         messages = construct_chat_messages_with_tool_call(items)
 
@@ -132,7 +131,7 @@ class TestConsecutiveFunctionCallMerge:
         assert len(messages[2]["tool_calls"]) == 1
 
     def test_single_call_unchanged(self):
-        """A single function_call still produces 1 assistant message with 1 tool_call."""
+        """Single function_call produces one assistant message."""
         items = [_make_function_call("fn", '{"k": "v"}', "1")]
         messages = construct_chat_messages_with_tool_call(items)
 
@@ -141,10 +140,10 @@ class TestConsecutiveFunctionCallMerge:
         assert len(messages[0]["tool_calls"]) == 1
 
     def test_parallel_calls_then_outputs(self):
-        """Two parallel calls followed by two outputs → assistant(2 tools) + 2 tool msgs."""
+        """Parallel calls then outputs → merged assistant + tool msgs."""
         items = [
-            _make_function_call("fn_a", '{}', "a"),
-            _make_function_call("fn_b", '{}', "b"),
+            _make_function_call("fn_a", "{}", "a"),
+            _make_function_call("fn_b", "{}", "b"),
             _make_tool_output("a", "res_a"),
             _make_tool_output("b", "res_b"),
         ]

--- a/tests/tool_use/test_tool_choice_required_web_search.py
+++ b/tests/tool_use/test_tool_choice_required_web_search.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests that tool_choice=required works correctly when the tools list
+contains non-function tools (e.g. WebSearchTool) that lack a JSON schema.
+
+Regression test: previously, passing a WebSearchTool alongside FunctionTools
+with tool_choice="required" would crash _get_json_schema_from_tools because
+WebSearchTool has no .name / .parameters attributes.
+"""
+
+import pytest
+from openai.types.responses import FunctionTool
+
+from vllm.tool_parsers.utils import get_json_schema_from_tools
+
+pytestmark = pytest.mark.cpu_test
+
+WEATHER_TOOL = FunctionTool(
+    type="function",
+    name="get_weather",
+    description="Get the weather",
+    parameters={
+        "type": "object",
+        "properties": {
+            "city": {"type": "string"},
+        },
+        "required": ["city"],
+    },
+    strict=False,
+)
+
+
+class _FakeWebSearchTool:
+    """Minimal stand-in for openai.types.responses.WebSearchTool.
+
+    We avoid importing the real class because it may not exist in all
+    openai SDK versions.  The key property is that it is NOT a FunctionTool
+    and NOT a ChatCompletionToolsParam.
+    """
+
+    type = "web_search_preview"
+
+
+def test_required_with_mixed_function_and_non_function_tools():
+    """tool_choice=required with FunctionTool + non-function tool should
+    return a valid schema containing only the FunctionTool."""
+    tools = [WEATHER_TOOL, _FakeWebSearchTool()]
+    schema = get_json_schema_from_tools(tools=tools, tool_choice="required")
+
+    assert isinstance(schema, dict)
+    # Schema should reference get_weather only
+    any_of = schema["items"]["anyOf"]
+    assert len(any_of) == 1
+    assert any_of[0]["properties"]["name"]["enum"] == ["get_weather"]
+
+
+def test_required_with_only_non_function_tools():
+    """tool_choice=required with only non-function tools should return None
+    rather than crashing."""
+    tools = [_FakeWebSearchTool()]
+    schema = get_json_schema_from_tools(tools=tools, tool_choice="required")
+    assert schema is None
+
+
+def test_required_with_only_function_tools_unchanged():
+    """tool_choice=required with only FunctionTools should work as before."""
+    tools = [WEATHER_TOOL]
+    schema = get_json_schema_from_tools(tools=tools, tool_choice="required")
+
+    assert isinstance(schema, dict)
+    any_of = schema["items"]["anyOf"]
+    assert len(any_of) == 1
+    assert any_of[0]["properties"]["name"]["enum"] == ["get_weather"]
+
+
+def test_auto_ignores_non_function_tools():
+    """tool_choice=auto should return None regardless of tool types."""
+    tools = [WEATHER_TOOL, _FakeWebSearchTool()]
+    schema = get_json_schema_from_tools(tools=tools, tool_choice="auto")
+    assert schema is None
+
+
+def test_none_returns_none():
+    """tool_choice=none should return None."""
+    tools = [WEATHER_TOOL]
+    schema = get_json_schema_from_tools(tools=tools, tool_choice="none")
+    assert schema is None

--- a/vllm/entrypoints/openai/parser/responses_parser.py
+++ b/vllm/entrypoints/openai/parser/responses_parser.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
+import json
 import logging
 from collections.abc import Callable
 
@@ -101,6 +103,33 @@ class ResponsesParser:
                 content = tool_call_info.content
                 if content and content.strip() == "":
                     content = None
+
+        # Fallback: when tool_choice="required", guided generation forces the
+        # model to output a JSON array of {name, parameters} objects instead of
+        # the native tool-call token format.  The native tool parser won't
+        # recognise this, so we parse the JSON directly — mirroring the Chat
+        # Completions handling (engine/serving.py line 905-919).
+        tool_choice = getattr(self.request, "tool_choice", None)
+        if not function_calls and tool_choice == "required" and content:
+            with contextlib.suppress(Exception):
+                parsed = json.loads(content)
+                if isinstance(parsed, list):
+                    for item in parsed:
+                        name = item.get("name", "")
+                        params = item.get("parameters", {})
+                        function_calls.append(
+                            ResponseFunctionToolCall(
+                                id=f"fc_{random_uuid()}",
+                                call_id=f"call_{random_uuid()}",
+                                type="function_call",
+                                status="completed",
+                                name=name,
+                                arguments=json.dumps(
+                                    params, ensure_ascii=False),
+                            )
+                        )
+                    if function_calls:
+                        content = None
 
         if content:
             self.response_messages.append(

--- a/vllm/entrypoints/openai/parser/responses_parser.py
+++ b/vllm/entrypoints/openai/parser/responses_parser.py
@@ -124,8 +124,7 @@ class ResponsesParser:
                                 type="function_call",
                                 status="completed",
                                 name=name,
-                                arguments=json.dumps(
-                                    params, ensure_ascii=False),
+                                arguments=json.dumps(params, ensure_ascii=False),
                             )
                         )
                     if function_calls:

--- a/vllm/entrypoints/openai/parser/responses_parser.py
+++ b/vllm/entrypoints/openai/parser/responses_parser.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import contextlib
 import json
 import logging
 from collections.abc import Callable
@@ -111,13 +110,24 @@ class ResponsesParser:
         # Completions handling (engine/serving.py line 905-919).
         tool_choice = getattr(self.request, "tool_choice", None)
         if not function_calls and tool_choice == "required" and content:
-            with contextlib.suppress(Exception):
+            try:
                 parsed = json.loads(content)
                 if isinstance(parsed, list):
+                    temp_calls = []
                     for item in parsed:
-                        name = item.get("name", "")
+                        if not isinstance(item, dict):
+                            raise TypeError("Tool call item must be a dictionary.")
+                        name = item.get("name")
+                        if not isinstance(name, str) or not name:
+                            raise TypeError(
+                                "Tool call 'name' must be a non-empty string."
+                            )
                         params = item.get("parameters", {})
-                        function_calls.append(
+                        if not isinstance(params, dict):
+                            raise TypeError(
+                                "Tool call 'parameters' must be a dictionary."
+                            )
+                        temp_calls.append(
                             ResponseFunctionToolCall(
                                 id=f"fc_{random_uuid()}",
                                 call_id=f"call_{random_uuid()}",
@@ -127,8 +137,10 @@ class ResponsesParser:
                                 arguments=json.dumps(params, ensure_ascii=False),
                             )
                         )
-                    if function_calls:
-                        content = None
+                    function_calls.extend(temp_calls)
+                    content = None
+            except (json.JSONDecodeError, TypeError):
+                pass
 
         if content:
             self.response_messages.append(

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -159,13 +159,42 @@ def construct_chat_messages_with_tool_call(
     """This function wraps _construct_single_message_from_response_item
     Because some chatMessages come from multiple response items
     for example a reasoning item and a MCP tool call are two response items
-    but are one chat message
+    but are one chat message.
+
+    Consecutive function_call items are merged into a single assistant
+    message with multiple tool_calls so that models that support parallel
+    tool calling see them as one assistant turn (matching the format they
+    were trained on).
     """
     messages: list[ChatCompletionMessageParam] = []
     for item in input_messages:
         maybe_combined_message = _maybe_combine_reasoning_and_tool_call(item, messages)
         if maybe_combined_message is not None:
             messages[-1] = maybe_combined_message
+        elif isinstance(item, ResponseFunctionToolCall):
+            # Merge consecutive function_call items into one assistant
+            # message so parallel tool calls stay in a single turn.
+            tool_call_param = ChatCompletionMessageToolCallParam(
+                id=item.call_id,
+                function=FunctionCallTool(
+                    name=item.name,
+                    arguments=item.arguments,
+                ),
+                type="function",
+            )
+            if (
+                messages
+                and messages[-1].get("role") == "assistant"
+                and "tool_calls" in messages[-1]
+            ):
+                messages[-1]["tool_calls"].append(tool_call_param)
+            else:
+                messages.append(
+                    ChatCompletionAssistantMessageParam(
+                        role="assistant",
+                        tool_calls=[tool_call_param],
+                    )
+                )
         else:
             messages.append(_construct_single_message_from_response_item(item))
 

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -187,7 +187,7 @@ def construct_chat_messages_with_tool_call(
                 and messages[-1].get("role") == "assistant"
                 and "tool_calls" in messages[-1]
             ):
-                messages[-1]["tool_calls"].append(tool_call_param)
+                messages[-1]["tool_calls"].append(tool_call_param)  # type: ignore[union-attr]
             else:
                 messages.append(
                     ChatCompletionAssistantMessageParam(

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -224,8 +224,7 @@ def get_json_schema_from_tools(
         # such as WebSearchTool do not have a JSON schema and would crash
         # _get_json_schema_from_tools.
         func_tools = [
-            t for t in tools
-            if isinstance(t, (FunctionTool, ChatCompletionToolsParam))
+            t for t in tools if isinstance(t, (FunctionTool, ChatCompletionToolsParam))
         ]
         if not func_tools:
             return None

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -219,7 +219,17 @@ def get_json_schema_from_tools(
         return tool_map[tool_name].function.parameters
     # tool_choice: "required"
     if tool_choice == "required":
-        return _get_json_schema_from_tools(tools)
+        # Filter to only function-style tools (FunctionTool for Responses API,
+        # ChatCompletionToolsParam for Chat Completions).  Built-in tool types
+        # such as WebSearchTool do not have a JSON schema and would crash
+        # _get_json_schema_from_tools.
+        func_tools = [
+            t for t in tools
+            if isinstance(t, (FunctionTool, ChatCompletionToolsParam))
+        ]
+        if not func_tools:
+            return None
+        return _get_json_schema_from_tools(func_tools)
     # tool_choice: "auto"
     return None
 


### PR DESCRIPTION
## Summary

Three independent bug fixes for `tool_choice=required` in the Responses API:

- **WebSearchTool crash** (`tool_parsers/utils.py`): `_get_json_schema_from_tools` crashes when tools list includes non-function types (e.g. `WebSearchTool`) because they lack `.name`/`.parameters`. Now filters to only `FunctionTool`/`ChatCompletionToolsParam` before schema generation.
- **Consecutive function_call merge** (`responses/utils.py`): Consecutive `ResponseFunctionToolCall` items in the input (parallel tool calling) were each emitted as separate assistant messages. Models expect them in a single message with multiple `tool_calls[]`. Now merges consecutive function_call items.
- **JSON fallback parsing** (`responses_parser.py`): With guided generation, model outputs JSON `[{name, parameters}]` instead of native tool-call tokens. The native tool parser doesn't recognise this. Added fallback JSON parsing, mirroring Chat Completions handling (`engine/serving.py`).

## Test plan

- [x] `tests/tool_use/test_tool_choice_required_web_search.py` — 5 tests for WebSearchTool + FunctionTool mixed scenarios
- [x] `tests/entrypoints/openai/responses/test_consecutive_function_call_merge.py` — 6 tests for parallel tool call merging
- [x] `tests/entrypoints/openai/parser/test_responses_parser_json_fallback.py` — 7 tests for JSON fallback parsing
- [x] All 18 new unit tests pass (CPU only, no model required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)