### PR TITLE
[Responses API] Fix ParsableContext: defer parsing to end of generation

### DIFF
--- a/tests/entrypoints/openai/responses/test_parsable_context_deferred.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context_deferred.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ParsableContext deferred parsing.
+
+The ParsableContext accumulates output text across multiple append_output
+calls and runs a single full parse when _ensure_final_parse() is called.
+This avoids feeding partial deltas to ResponsesParser.process() which
+expects complete output text.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.entrypoints.openai.responses.context import ParsableContext
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _make_request():
+    request = MagicMock()
+    request.tools = []
+    request.tool_choice = "auto"
+    request.enable_response_messages = False
+    return request
+
+
+def _make_output(text: str, token_ids: tuple = (), finish_reason=None):
+    """Create a mock RequestOutput."""
+    inner = MagicMock()
+    inner.text = text
+    inner.token_ids = token_ids
+    inner.finish_reason = finish_reason
+    inner.logprobs = None
+
+    output = MagicMock()
+    output.outputs = [inner]
+    output.prompt_token_ids = [1, 2, 3]
+    output.num_cached_tokens = 0
+    output.prompt = "test"
+    output.kv_transfer_params = None
+    return output
+
+
+def _make_context():
+    """Create a ParsableContext and replace its parser with a mock."""
+    request = _make_request()
+    reasoning_parser = MagicMock()
+    reasoning_parser_cls = MagicMock(return_value=reasoning_parser)
+
+    ctx = ParsableContext(
+        response_messages=[],
+        tokenizer=MagicMock(),
+        reasoning_parser_cls=reasoning_parser_cls,
+        request=request,
+        available_tools=None,
+        tool_parser_cls=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+    )
+    # Replace the real ResponsesParser with a mock so we can track calls
+    ctx.parser = MagicMock()
+    ctx.parser.response_messages = []
+    return ctx
+
+
+class TestDeferredParsing:
+
+    def test_append_output_accumulates_text(self):
+        """Multiple append_output calls accumulate text without parsing."""
+        ctx = _make_context()
+
+        ctx.append_output(_make_output("Hello "))
+        ctx.append_output(_make_output("world!"))
+
+        assert ctx._accumulated_text == "Hello world!"
+        assert not ctx._final_parsed
+        # Parser.process should NOT have been called yet
+        ctx.parser.process.assert_not_called()
+
+    def test_ensure_final_parse_runs_once(self):
+        """_ensure_final_parse triggers parse exactly once."""
+        ctx = _make_context()
+
+        ctx.append_output(_make_output(
+            "<think>reasoning</think>tool call", finish_reason="stop"))
+
+        ctx._ensure_final_parse()
+        assert ctx._final_parsed
+        ctx.parser.process.assert_called_once()
+
+        # Second call is a no-op
+        ctx._ensure_final_parse()
+        ctx.parser.process.assert_called_once()
+
+    def test_ensure_final_parse_creates_synthetic_output(self):
+        """The synthetic CompletionOutput has accumulated text and token_ids."""
+        ctx = _make_context()
+
+        ctx.append_output(_make_output("part1", (10, 11)))
+        ctx.append_output(_make_output("part2", (12, 13), finish_reason="stop"))
+
+        ctx._ensure_final_parse()
+
+        call_args = ctx.parser.process.call_args[0][0]
+        assert call_args.text == "part1part2"
+        assert call_args.token_ids == (10, 11, 12, 13)
+        assert call_args.finish_reason == "stop"
+
+    def test_append_tool_output_resets_accumulation(self):
+        """append_tool_output triggers parse, then resets for next turn."""
+        ctx = _make_context()
+
+        ctx.append_output(_make_output("first turn", finish_reason="stop"))
+        ctx.append_tool_output([MagicMock()])
+
+        # Should have parsed
+        assert ctx.parser.process.call_count == 1
+        # Accumulation reset
+        assert ctx._accumulated_text == ""
+        assert ctx._accumulated_token_ids == []
+        assert not ctx._final_parsed
+
+        # New turn accumulation works
+        ctx.append_output(_make_output("second turn", finish_reason="stop"))
+        assert ctx._accumulated_text == "second turn"
+
+    def test_need_builtin_tool_call_triggers_parse(self):
+        """need_builtin_tool_call calls _ensure_final_parse before checking."""
+        ctx = _make_context()
+        # Set up parser to return a non-tool message
+        mock_msg = MagicMock()
+        mock_msg.type = "message"
+        ctx.parser.response_messages = [mock_msg]
+
+        ctx.append_output(_make_output("some text", finish_reason="stop"))
+        result = ctx.need_builtin_tool_call()
+
+        assert ctx._final_parsed
+        assert result is False
+
+    def test_no_parse_when_no_text(self):
+        """If no text accumulated, _ensure_final_parse does nothing."""
+        ctx = _make_context()
+        ctx._ensure_final_parse()
+
+        assert ctx._final_parsed
+        ctx.parser.process.assert_not_called()
+
+    def test_last_output_stored(self):
+        """append_output stores last_output for finish_reason access."""
+        ctx = _make_context()
+        out = _make_output("text", finish_reason="length")
+        ctx.append_output(out)
+
+        assert ctx.last_output is out
+
+    def test_multi_turn_accumulation(self):
+        """Two generation turns each accumulate and parse independently."""
+        ctx = _make_context()
+
+        # Turn 1
+        ctx.append_output(_make_output("turn1_a", (1,)))
+        ctx.append_output(_make_output("turn1_b", (2,), finish_reason="stop"))
+        ctx.append_tool_output([MagicMock()])
+
+        assert ctx.parser.process.call_count == 1
+        first_call = ctx.parser.process.call_args_list[0][0][0]
+        assert first_call.text == "turn1_aturn1_b"
+
+        # Turn 2
+        ctx.append_output(_make_output("turn2", (3,), finish_reason="stop"))
+        ctx._ensure_final_parse()
+
+        assert ctx.parser.process.call_count == 2
+        second_call = ctx.parser.process.call_args_list[1][0][0]
+        assert second_call.text == "turn2"

--- a/tests/entrypoints/openai/responses/test_parsable_context_deferred.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context_deferred.py
@@ -8,7 +8,7 @@ This avoids feeding partial deltas to ResponsesParser.process() which
 expects complete output text.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -65,7 +65,6 @@ def _make_context():
 
 
 class TestDeferredParsing:
-
     def test_append_output_accumulates_text(self):
         """Multiple append_output calls accumulate text without parsing."""
         ctx = _make_context()
@@ -82,8 +81,9 @@ class TestDeferredParsing:
         """_ensure_final_parse triggers parse exactly once."""
         ctx = _make_context()
 
-        ctx.append_output(_make_output(
-            "<think>reasoning</think>tool call", finish_reason="stop"))
+        ctx.append_output(
+            _make_output("<think>reasoning</think>tool call", finish_reason="stop")
+        )
 
         ctx._ensure_final_parse()
         assert ctx._final_parsed
@@ -175,3 +175,15 @@ class TestDeferredParsing:
         assert ctx.parser.process.call_count == 2
         second_call = ctx.parser.process.call_args_list[1][0][0]
         assert second_call.text == "turn2"
+
+    def test_need_builtin_tool_call_empty_messages(self):
+        """need_builtin_tool_call returns False when no messages parsed."""
+        ctx = _make_context()
+        ctx.append_output(_make_output("some text", finish_reason="stop"))
+        # parser.response_messages is empty (mock default)
+        ctx.parser.response_messages = []
+
+        result = ctx.need_builtin_tool_call()
+
+        assert ctx._final_parsed
+        assert result is False

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -280,7 +280,7 @@ class ParsableContext(ConversationContext):
         chat_template: str | None,
         chat_template_content_format: ChatTemplateContentFormatOption,
     ):
-        self.last_output = None
+        self.last_output: RequestOutput | None = None
         self.num_prompt_tokens = 0
         self.num_output_tokens = 0
         self.num_cached_tokens = 0

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -388,6 +388,8 @@ class ParsableContext(ConversationContext):
         """Return true if the last message is a builtin tool call
         that the request has enabled."""
         self._ensure_final_parse()
+        if not self.parser.response_messages:
+            return False
         last_message = self.parser.response_messages[-1]
         if last_message.type != "function_call":
             return False

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -280,6 +280,7 @@ class ParsableContext(ConversationContext):
         chat_template: str | None,
         chat_template_content_format: ChatTemplateContentFormatOption,
     ):
+        self.last_output = None
         self.num_prompt_tokens = 0
         self.num_output_tokens = 0
         self.num_cached_tokens = 0
@@ -312,14 +313,21 @@ class ParsableContext(ConversationContext):
         self.output_messages: list[ResponseRawMessageAndToken] = []
         self._accumulated_token_ids: list[int] = []
         self.kv_transfer_params: dict[str, Any] | None = None
+        self._accumulated_text: str = ""
+        self._final_parsed: bool = False
 
     def append_output(self, output: RequestOutput) -> None:
+        self.last_output = output
         self.num_prompt_tokens = len(output.prompt_token_ids or [])
         self.num_cached_tokens = output.num_cached_tokens or 0
         self.num_output_tokens += len(output.outputs[0].token_ids or [])
         if output.kv_transfer_params is not None:
             self.kv_transfer_params = output.kv_transfer_params
-        self.parser.process(output.outputs[0])
+
+        # Accumulate text for deferred parsing — process() expects the
+        # complete output, not per-token deltas.  We run a single full
+        # parse when the generation finishes (see _ensure_final_parse).
+        self._accumulated_text += output.outputs[0].text
         output_token_ids = output.outputs[0].token_ids or []
         self._accumulated_token_ids.extend(output_token_ids)
 
@@ -348,12 +356,38 @@ class ParsableContext(ConversationContext):
                 )
             )
 
+    def _ensure_final_parse(self) -> None:
+        """Run the full parse exactly once over accumulated text."""
+        if self._final_parsed:
+            return
+        self._final_parsed = True
+        if self._accumulated_text:
+            from vllm.outputs import CompletionOutput
+
+            synthetic = CompletionOutput(
+                index=0,
+                text=self._accumulated_text,
+                token_ids=tuple(self._accumulated_token_ids),
+                cumulative_logprob=None,
+                logprobs=None,
+                finish_reason=self.last_output.outputs[0].finish_reason
+                if self.last_output
+                else None,
+            )
+            self.parser.process(synthetic)
+
     def append_tool_output(self, output: list[ResponseInputOutputItem]) -> None:
+        self._ensure_final_parse()
         self.parser.response_messages.extend(output)
+        # Reset accumulation for the next generation turn.
+        self._accumulated_text = ""
+        self._accumulated_token_ids = []
+        self._final_parsed = False
 
     def need_builtin_tool_call(self) -> bool:
         """Return true if the last message is a builtin tool call
         that the request has enabled."""
+        self._ensure_final_parse()
         last_message = self.parser.response_messages[-1]
         if last_message.type != "function_call":
             return False

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1360,9 +1360,11 @@ class OpenAIServingResponses(OpenAIServing):
             if ctx.last_output is None:
                 continue
             if reasoning_parser and prompt_is_reasoning_end is None:
-                prompt_is_reasoning_end = reasoning_parser.is_reasoning_end(
-                    ctx.last_output.prompt_token_ids
-                )
+                prompt_ids = ctx.last_output.prompt_token_ids
+                if prompt_ids is not None:
+                    prompt_is_reasoning_end = reasoning_parser.is_reasoning_end(
+                        prompt_ids
+                    )
             if ctx.last_output.outputs:
                 output = ctx.last_output.outputs[0]
                 # finish_reason='error' indicates a retryable error

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -782,6 +782,7 @@ class OpenAIServingResponses(OpenAIServing):
             else:
                 status = "incomplete"
         elif isinstance(context, ParsableContext):
+            context._ensure_final_parse()
             output = context.parser.make_response_output_items_from_parsable_context()
 
             if request.enable_response_messages:
@@ -1355,7 +1356,7 @@ class OpenAIServingResponses(OpenAIServing):
         first_delta_sent = False
         previous_delta_messages: list[DeltaMessage] = []
         async for ctx in result_generator:
-            assert isinstance(ctx, SimpleContext)
+            assert isinstance(ctx, (SimpleContext, ParsableContext))
             if ctx.last_output is None:
                 continue
             if reasoning_parser and prompt_is_reasoning_end is None:


### PR DESCRIPTION
## Summary

- **Bug**: `ParsableContext.append_output()` called `parser.process()` on every streaming delta, but `ResponsesParser.process()` internally calls `extract_reasoning()` and `extract_tool_calls()` which expect **complete** output text. This caused incorrect parsing when reasoning content (`<think>...</think>`) was split across multiple deltas.
- **Fix**: Accumulate text across `append_output()` calls, run a single full parse via `_ensure_final_parse()` when results are first accessed. After a tool output round-trip, accumulation resets for the next generation turn.
- **Also**: Fix streaming assert in `serving.py` to allow `ParsableContext` (not just `SimpleContext`) when streaming with tool parsers.

## Test plan

- [x] `tests/entrypoints/openai/responses/test_parsable_context_deferred.py` — 8 unit tests:
  - Text accumulation across multiple `append_output` calls
  - `_ensure_final_parse` idempotency (runs exactly once)
  - Synthetic `CompletionOutput` contains accumulated text + token_ids
  - `append_tool_output` resets accumulation for next turn
  - `need_builtin_tool_call` triggers deferred parse
  - No-op when no text accumulated
  - Multi-turn accumulation and independent parsing
- [x] All 8 tests pass (CPU only, no model required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)