### PR TITLE
[Responses API] Add ToolChoiceRequiredLogitsProcessor for thinking models

### DIFF
--- a/tests/tool_parsers/test_adjust_request_responses.py
+++ b/tests/tool_parsers/test_adjust_request_responses.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ToolParser.adjust_request() with ResponsesRequest.
+
+Verifies that thinking models use the logits processor path while
+non-thinking models use guided generation (ResponseFormatTextJSONSchemaConfig).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from openai.types.responses import FunctionTool
+
+from vllm.tool_parsers.abstract_tool_parser import ToolParser
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _make_tokenizer(vocab: dict[str, int]):
+    """Create a mock tokenizer with given vocab."""
+    tok = MagicMock()
+    tok.get_vocab.return_value = vocab
+    return tok
+
+
+def _make_responses_request(*, tools=None, tool_choice="required", reasoning=None,
+                            vllm_xargs=None):
+    """Create a mock ResponsesRequest."""
+    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+    request = MagicMock(spec=ResponsesRequest)
+    request.tools = tools or [
+        FunctionTool(
+            type="function",
+            name="get_weather",
+            description="Get weather",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}},
+            strict=False,
+        )
+    ]
+    request.tool_choice = tool_choice
+    request.reasoning = reasoning
+    request.vllm_xargs = vllm_xargs
+    request.text = None
+    return request
+
+
+class TestAdjustRequestResponses:
+
+    def test_thinking_model_uses_logits_processor(self):
+        """Model with </think> + <|im_end|> + reasoning enabled → sets vllm_xargs."""
+        vocab = {
+            "</think>": 100,
+            "<|im_end|>": 101,
+            "<|tool_call_end|>": 103,
+        }
+        parser = ToolParser(_make_tokenizer(vocab))
+        request = _make_responses_request(
+            reasoning=MagicMock(),  # reasoning is not None
+            vllm_xargs=None,
+        )
+
+        result = parser.adjust_request(request)
+
+        assert result.vllm_xargs is not None
+        assert result.vllm_xargs["tool_choice_required_think_end"] == 100
+        assert result.vllm_xargs["tool_choice_required_stop"] == 101
+        assert result.vllm_xargs["tool_choice_required_section_end"] == 103
+        # Should NOT have set guided generation
+        assert result.text is None
+
+    def test_non_thinking_model_uses_guided_generation(self):
+        """Model without </think> → uses ResponseFormatTextJSONSchemaConfig."""
+        vocab = {
+            "<|im_end|>": 101,
+            # No </think> → not a thinking model
+        }
+        parser = ToolParser(_make_tokenizer(vocab))
+        request = _make_responses_request(
+            reasoning=MagicMock(),
+        )
+
+        result = parser.adjust_request(request)
+
+        # Should have set guided generation
+        assert result.text is not None
+        assert result.text.format is not None
+        assert result.text.format.type == "json_schema"
+        # Should NOT have set vllm_xargs
+        assert result.vllm_xargs is None
+
+    def test_reasoning_off_uses_guided_generation(self):
+        """Even thinking model, reasoning=None → guided generation."""
+        vocab = {
+            "</think>": 100,
+            "<|im_end|>": 101,
+            "<|tool_call_end|>": 103,
+        }
+        parser = ToolParser(_make_tokenizer(vocab))
+        request = _make_responses_request(
+            reasoning=None,  # reasoning is off
+        )
+
+        result = parser.adjust_request(request)
+
+        assert result.text is not None
+        assert result.text.format is not None
+
+    def test_tool_call_end_token_optional(self):
+        """Model with </think> but no <|tool_call_end|> → section_end not set."""
+        vocab = {
+            "</think>": 100,
+            "<|im_end|>": 101,
+            # No <|tool_call_end|>
+        }
+        parser = ToolParser(_make_tokenizer(vocab))
+        request = _make_responses_request(
+            reasoning=MagicMock(),
+            vllm_xargs=None,
+        )
+
+        result = parser.adjust_request(request)
+
+        assert result.vllm_xargs is not None
+        assert result.vllm_xargs["tool_choice_required_think_end"] == 100
+        assert result.vllm_xargs["tool_choice_required_stop"] == 101
+        assert "tool_choice_required_section_end" not in result.vllm_xargs
+
+    def test_tool_choice_none_skips_adjustment(self):
+        """tool_choice=none → no schema, no xargs."""
+        vocab = {"</think>": 100, "<|im_end|>": 101}
+        parser = ToolParser(_make_tokenizer(vocab))
+        request = _make_responses_request(
+            tool_choice="none",
+            reasoning=MagicMock(),
+        )
+
+        result = parser.adjust_request(request)
+
+        assert result.text is None
+        assert result.vllm_xargs is None
+
+    def test_tool_choice_auto_skips_adjustment(self):
+        """tool_choice=auto → no schema, no xargs."""
+        vocab = {"</think>": 100, "<|im_end|>": 101}
+        parser = ToolParser(_make_tokenizer(vocab))
+        request = _make_responses_request(
+            tool_choice="auto",
+            reasoning=MagicMock(),
+        )
+
+        result = parser.adjust_request(request)
+
+        assert result.text is None
+        assert result.vllm_xargs is None
+
+    def test_preserves_existing_vllm_xargs(self):
+        """Existing vllm_xargs should be preserved, not overwritten."""
+        vocab = {
+            "</think>": 100,
+            "<|im_end|>": 101,
+        }
+        parser = ToolParser(_make_tokenizer(vocab))
+        request = _make_responses_request(
+            reasoning=MagicMock(),
+            vllm_xargs={"existing_key": "existing_value"},
+        )
+
+        result = parser.adjust_request(request)
+
+        assert result.vllm_xargs["existing_key"] == "existing_value"
+        assert result.vllm_xargs["tool_choice_required_think_end"] == 100
+
+    def test_no_tools_skips_adjustment(self):
+        """No tools → early return, no changes."""
+        vocab = {"</think>": 100, "<|im_end|>": 101}
+        parser = ToolParser(_make_tokenizer(vocab))
+        request = _make_responses_request(reasoning=MagicMock())
+        request.tools = None
+
+        result = parser.adjust_request(request)
+
+        assert result.text is None
+        assert result.vllm_xargs is None

--- a/tests/tool_parsers/test_adjust_request_responses.py
+++ b/tests/tool_parsers/test_adjust_request_responses.py
@@ -23,8 +23,9 @@ def _make_tokenizer(vocab: dict[str, int]):
     return tok
 
 
-def _make_responses_request(*, tools=None, tool_choice="required", reasoning=None,
-                            vllm_xargs=None):
+def _make_responses_request(
+    *, tools=None, tool_choice="required", reasoning=None, vllm_xargs=None
+):
     """Create a mock ResponsesRequest."""
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
@@ -46,7 +47,6 @@ def _make_responses_request(*, tools=None, tool_choice="required", reasoning=Non
 
 
 class TestAdjustRequestResponses:
-
     def test_thinking_model_uses_logits_processor(self):
         """Model with </think> + <|im_end|> + reasoning enabled → sets vllm_xargs."""
         vocab = {

--- a/tests/v1/logits_processors/test_tool_choice_required.py
+++ b/tests/v1/logits_processors/test_tool_choice_required.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ToolChoiceRequiredLogitsProcessor.
+
+This processor suppresses stop/EOS tokens from the start of generation until
+the model produces a release token (e.g. <|tool_call_end|>), forcing thinking
+models to generate tool calls when tool_choice=required.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor.builtin import (
+    ToolChoiceRequiredLogitsProcessor,
+)
+from vllm.v1.sample.logits_processor.interface import (
+    BatchUpdate,
+    MoveDirectionality,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+DEVICE = torch.device("cpu")
+VOCAB_SIZE = 256
+
+# Token IDs for testing
+THINK_END = 100    # </think>
+IM_END = 101       # <|im_end|>
+EOS_TOKEN = 102    # [EOS]
+TOOL_CALL_END = 103  # <|tool_call_end|>
+
+
+def _make_vllm_config():
+    config = MagicMock()
+    config.scheduler_config.max_num_seqs = 32
+    return config
+
+
+def _make_params(*, extra_args=None, eos_token_id=None, stop_token_ids=None):
+    kwargs = {}
+    if extra_args is not None:
+        kwargs["extra_args"] = extra_args
+    if stop_token_ids is not None:
+        kwargs["stop_token_ids"] = stop_token_ids
+    params = SamplingParams(**kwargs)
+    if eos_token_id is not None:
+        params._eos_token_id = eos_token_id
+    return params
+
+
+def _make_batch_update(added=None, removed=None, moved=None, batch_size=4):
+    update = BatchUpdate(
+        batch_size=batch_size,
+        removed=removed or [],
+        added=added or [],
+        moved=moved or [],
+    )
+    return update
+
+
+class TestAddRequest:
+
+    def test_returns_none_without_extra_args(self):
+        """Normal requests without extra_args → processor not activated."""
+        params = _make_params()
+        result = ToolChoiceRequiredLogitsProcessor.add_request(params, None, [])
+        assert result is None
+
+    def test_returns_none_with_partial_extra_args(self):
+        """Only think_end without stop → not activated."""
+        params = _make_params(extra_args={
+            "tool_choice_required_think_end": THINK_END,
+        })
+        result = ToolChoiceRequiredLogitsProcessor.add_request(params, None, [])
+        assert result is None
+
+    def test_collects_stop_token(self):
+        """Basic activation with stop token."""
+        params = _make_params(extra_args={
+            "tool_choice_required_think_end": THINK_END,
+            "tool_choice_required_stop": IM_END,
+        })
+        stop_toks, release, out_ids = ToolChoiceRequiredLogitsProcessor.add_request(
+            params, None, []
+        )
+        assert IM_END in stop_toks
+        assert release == -1  # No section_end → never releases
+
+    def test_collects_eos_and_stop_token_ids(self):
+        """Collects eos_token_id + stop_token_ids in addition to the main stop."""
+        params = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": IM_END,
+            },
+            eos_token_id=EOS_TOKEN,
+            stop_token_ids=[200, 201],
+        )
+        stop_toks, release, out_ids = ToolChoiceRequiredLogitsProcessor.add_request(
+            params, None, []
+        )
+        assert IM_END in stop_toks
+        assert EOS_TOKEN in stop_toks
+        assert 200 in stop_toks
+        assert 201 in stop_toks
+        assert len(stop_toks) == 4
+
+    def test_no_duplicate_when_eos_equals_stop(self):
+        """When eos_token_id == stop, it should not be duplicated."""
+        params = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": IM_END,
+            },
+            eos_token_id=IM_END,  # Same as stop
+        )
+        stop_toks, _, _ = ToolChoiceRequiredLogitsProcessor.add_request(
+            params, None, []
+        )
+        assert stop_toks.count(IM_END) == 1
+
+    def test_section_end_sets_release_token(self):
+        """section_end sets the release token."""
+        params = _make_params(extra_args={
+            "tool_choice_required_think_end": THINK_END,
+            "tool_choice_required_stop": IM_END,
+            "tool_choice_required_section_end": TOOL_CALL_END,
+        })
+        _, release, _ = ToolChoiceRequiredLogitsProcessor.add_request(
+            params, None, []
+        )
+        assert release == TOOL_CALL_END
+
+
+class TestUpdateStateAndApply:
+
+    def _make_processor(self):
+        return ToolChoiceRequiredLogitsProcessor(
+            _make_vllm_config(), DEVICE, False
+        )
+
+    def test_no_op_when_inactive(self):
+        """When no requests have extra_args, apply is a no-op."""
+        proc = self._make_processor()
+        logits = torch.randn(4, VOCAB_SIZE)
+        original = logits.clone()
+
+        params = _make_params()  # No extra_args
+        update = _make_batch_update(
+            added=[(0, params, None, [])],
+        )
+        proc.update_state(update)
+        result = proc.apply(logits)
+
+        assert torch.equal(result, original)
+
+    def test_suppresses_stop_tokens(self):
+        """Active request → stop tokens set to -inf."""
+        proc = self._make_processor()
+        logits = torch.zeros(4, VOCAB_SIZE)
+
+        out_ids = []  # Empty — no tokens generated yet
+        params = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": IM_END,
+                "tool_choice_required_section_end": TOOL_CALL_END,
+            },
+            eos_token_id=EOS_TOKEN,
+        )
+        update = _make_batch_update(
+            added=[(0, params, None, out_ids)],
+        )
+        proc.update_state(update)
+        result = proc.apply(logits)
+
+        # Stop tokens should be -inf for request 0
+        assert result[0, IM_END].item() == float("-inf")
+        assert result[0, EOS_TOKEN].item() == float("-inf")
+        # Other tokens unaffected
+        assert result[0, 50].item() == 0.0
+        # Other requests unaffected
+        assert result[1, IM_END].item() == 0.0
+
+    def test_release_after_tool_call_end(self):
+        """After release token appears in output_tok_ids, suppression lifts."""
+        proc = self._make_processor()
+
+        out_ids = []
+        params = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": IM_END,
+                "tool_choice_required_section_end": TOOL_CALL_END,
+            },
+        )
+        update = _make_batch_update(added=[(0, params, None, out_ids)])
+        proc.update_state(update)
+
+        # Initially suppressing
+        logits = torch.zeros(4, VOCAB_SIZE)
+        proc.apply(logits)
+        assert logits[0, IM_END].item() == float("-inf")
+
+        # Simulate model generating the release token
+        out_ids.append(TOOL_CALL_END)
+
+        # Update state — should detect release
+        proc.update_state(_make_batch_update())
+        logits = torch.zeros(4, VOCAB_SIZE)
+        proc.apply(logits)
+
+        # Suppression lifted — stop tokens no longer -inf
+        assert logits[0, IM_END].item() == 0.0
+
+    def test_no_release_without_section_end(self):
+        """When section_end not set (release=-1), suppression never lifts."""
+        proc = self._make_processor()
+
+        out_ids = [50, 60, 70]  # Some tokens but not the release token
+        params = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": IM_END,
+                # No section_end
+            },
+        )
+        update = _make_batch_update(added=[(0, params, None, out_ids)])
+        proc.update_state(update)
+
+        logits = torch.zeros(4, VOCAB_SIZE)
+        proc.apply(logits)
+        assert logits[0, IM_END].item() == float("-inf")
+
+    def test_multiple_requests(self):
+        """Multiple active requests each get their stop tokens suppressed."""
+        proc = self._make_processor()
+
+        out_ids_0 = []
+        params_0 = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": IM_END,
+            },
+        )
+        out_ids_1 = []
+        params_1 = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": 150,  # Different stop token
+            },
+        )
+        update = _make_batch_update(added=[
+            (0, params_0, None, out_ids_0),
+            (2, params_1, None, out_ids_1),
+        ])
+        proc.update_state(update)
+
+        logits = torch.zeros(4, VOCAB_SIZE)
+        proc.apply(logits)
+
+        assert logits[0, IM_END].item() == float("-inf")
+        assert logits[2, 150].item() == float("-inf")
+        # Request 1 unaffected
+        assert logits[1, IM_END].item() == 0.0
+
+    def test_removed_request(self):
+        """Removed request no longer suppressed."""
+        proc = self._make_processor()
+
+        out_ids = []
+        params = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": IM_END,
+            },
+        )
+        proc.update_state(_make_batch_update(added=[(0, params, None, out_ids)]))
+
+        # Verify active
+        logits = torch.zeros(4, VOCAB_SIZE)
+        proc.apply(logits)
+        assert logits[0, IM_END].item() == float("-inf")
+
+        # Remove
+        proc.update_state(_make_batch_update(removed=[0]))
+
+        logits = torch.zeros(4, VOCAB_SIZE)
+        proc.apply(logits)
+        assert logits[0, IM_END].item() == 0.0

--- a/tests/v1/logits_processors/test_tool_choice_required.py
+++ b/tests/v1/logits_processors/test_tool_choice_required.py
@@ -18,7 +18,6 @@ from vllm.v1.sample.logits_processor.builtin import (
 )
 from vllm.v1.sample.logits_processor.interface import (
     BatchUpdate,
-    MoveDirectionality,
 )
 
 pytestmark = pytest.mark.cpu_test
@@ -27,9 +26,9 @@ DEVICE = torch.device("cpu")
 VOCAB_SIZE = 256
 
 # Token IDs for testing
-THINK_END = 100    # </think>
-IM_END = 101       # <|im_end|>
-EOS_TOKEN = 102    # [EOS]
+THINK_END = 100  # </think>
+IM_END = 101  # <|im_end|>
+EOS_TOKEN = 102  # [EOS]
 TOOL_CALL_END = 103  # <|tool_call_end|>
 
 
@@ -62,7 +61,6 @@ def _make_batch_update(added=None, removed=None, moved=None, batch_size=4):
 
 
 class TestAddRequest:
-
     def test_returns_none_without_extra_args(self):
         """Normal requests without extra_args → processor not activated."""
         params = _make_params()
@@ -71,18 +69,22 @@ class TestAddRequest:
 
     def test_returns_none_with_partial_extra_args(self):
         """Only think_end without stop → not activated."""
-        params = _make_params(extra_args={
-            "tool_choice_required_think_end": THINK_END,
-        })
+        params = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+            }
+        )
         result = ToolChoiceRequiredLogitsProcessor.add_request(params, None, [])
         assert result is None
 
     def test_collects_stop_token(self):
         """Basic activation with stop token."""
-        params = _make_params(extra_args={
-            "tool_choice_required_think_end": THINK_END,
-            "tool_choice_required_stop": IM_END,
-        })
+        params = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": IM_END,
+            }
+        )
         stop_toks, release, out_ids = ToolChoiceRequiredLogitsProcessor.add_request(
             params, None, []
         )
@@ -124,23 +126,20 @@ class TestAddRequest:
 
     def test_section_end_sets_release_token(self):
         """section_end sets the release token."""
-        params = _make_params(extra_args={
-            "tool_choice_required_think_end": THINK_END,
-            "tool_choice_required_stop": IM_END,
-            "tool_choice_required_section_end": TOOL_CALL_END,
-        })
-        _, release, _ = ToolChoiceRequiredLogitsProcessor.add_request(
-            params, None, []
+        params = _make_params(
+            extra_args={
+                "tool_choice_required_think_end": THINK_END,
+                "tool_choice_required_stop": IM_END,
+                "tool_choice_required_section_end": TOOL_CALL_END,
+            }
         )
+        _, release, _ = ToolChoiceRequiredLogitsProcessor.add_request(params, None, [])
         assert release == TOOL_CALL_END
 
 
 class TestUpdateStateAndApply:
-
     def _make_processor(self):
-        return ToolChoiceRequiredLogitsProcessor(
-            _make_vllm_config(), DEVICE, False
-        )
+        return ToolChoiceRequiredLogitsProcessor(_make_vllm_config(), DEVICE, False)
 
     def test_no_op_when_inactive(self):
         """When no requests have extra_args, apply is a no-op."""
@@ -162,7 +161,7 @@ class TestUpdateStateAndApply:
         proc = self._make_processor()
         logits = torch.zeros(4, VOCAB_SIZE)
 
-        out_ids = []  # Empty — no tokens generated yet
+        out_ids: list[int] = []  # Empty — no tokens generated yet
         params = _make_params(
             extra_args={
                 "tool_choice_required_think_end": THINK_END,
@@ -189,7 +188,7 @@ class TestUpdateStateAndApply:
         """After release token appears in output_tok_ids, suppression lifts."""
         proc = self._make_processor()
 
-        out_ids = []
+        out_ids: list[int] = []
         params = _make_params(
             extra_args={
                 "tool_choice_required_think_end": THINK_END,
@@ -239,24 +238,26 @@ class TestUpdateStateAndApply:
         """Multiple active requests each get their stop tokens suppressed."""
         proc = self._make_processor()
 
-        out_ids_0 = []
+        out_ids_0: list[int] = []
         params_0 = _make_params(
             extra_args={
                 "tool_choice_required_think_end": THINK_END,
                 "tool_choice_required_stop": IM_END,
             },
         )
-        out_ids_1 = []
+        out_ids_1: list[int] = []
         params_1 = _make_params(
             extra_args={
                 "tool_choice_required_think_end": THINK_END,
                 "tool_choice_required_stop": 150,  # Different stop token
             },
         )
-        update = _make_batch_update(added=[
-            (0, params_0, None, out_ids_0),
-            (2, params_1, None, out_ids_1),
-        ])
+        update = _make_batch_update(
+            added=[
+                (0, params_0, None, out_ids_0),
+                (2, params_1, None, out_ids_1),
+            ]
+        )
         proc.update_state(update)
 
         logits = torch.zeros(4, VOCAB_SIZE)
@@ -271,7 +272,7 @@ class TestUpdateStateAndApply:
         """Removed request no longer suppressed."""
         proc = self._make_processor()
 
-        out_ids = []
+        out_ids: list[int] = []
         params = _make_params(
             extra_args={
                 "tool_choice_required_think_end": THINK_END,

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -72,14 +72,41 @@ class ToolParser:
                 )
                 request.response_format = None
             if isinstance(request, ResponsesRequest):
-                request.text = ResponseTextConfig()
-                request.text.format = ResponseFormatTextJSONSchemaConfig(
-                    name="tool_calling_response",
-                    schema=json_schema_from_tool,
-                    type="json_schema",
-                    description="Response format for tool calling",
-                    strict=True,
+                # For thinking models, guided generation corrupts <think>
+                # tokens.  Instead, use a conditional logits processor that
+                # suppresses <|im_end|> for one token after </think>, which
+                # forces the model into the native tool-call token sequence.
+                think_end = self.vocab.get("</think>")
+                im_end = self.vocab.get("<|im_end|>")
+                reasoning_on = (
+                    getattr(request, "reasoning", None) is not None
                 )
+                tool_call_end = self.vocab.get(
+                    "<|tool_call_end|>"
+                )
+                if think_end is not None and im_end is not None and reasoning_on:
+                    # Thinking model: use logits processor instead of
+                    # guided generation (which would corrupt reasoning).
+                    if request.vllm_xargs is None:
+                        request.vllm_xargs = {}
+                    request.vllm_xargs["tool_choice_required_think_end"] = (
+                        think_end
+                    )
+                    request.vllm_xargs["tool_choice_required_stop"] = im_end
+                    if tool_call_end is not None:
+                        request.vllm_xargs[
+                            "tool_choice_required_section_end"
+                        ] = tool_call_end
+                else:
+                    # Non-thinking model: guided generation works fine.
+                    request.text = ResponseTextConfig()
+                    request.text.format = ResponseFormatTextJSONSchemaConfig(
+                        name="tool_calling_response",
+                        schema=json_schema_from_tool,
+                        type="json_schema",
+                        description="Response format for tool calling",
+                        strict=True,
+                    )
 
         return request
 

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -78,25 +78,19 @@ class ToolParser:
                 # forces the model into the native tool-call token sequence.
                 think_end = self.vocab.get("</think>")
                 im_end = self.vocab.get("<|im_end|>")
-                reasoning_on = (
-                    getattr(request, "reasoning", None) is not None
-                )
-                tool_call_end = self.vocab.get(
-                    "<|tool_call_end|>"
-                )
+                reasoning_on = getattr(request, "reasoning", None) is not None
+                tool_call_end = self.vocab.get("<|tool_call_end|>")
                 if think_end is not None and im_end is not None and reasoning_on:
                     # Thinking model: use logits processor instead of
                     # guided generation (which would corrupt reasoning).
                     if request.vllm_xargs is None:
                         request.vllm_xargs = {}
-                    request.vllm_xargs["tool_choice_required_think_end"] = (
-                        think_end
-                    )
+                    request.vllm_xargs["tool_choice_required_think_end"] = think_end
                     request.vllm_xargs["tool_choice_required_stop"] = im_end
                     if tool_call_end is not None:
-                        request.vllm_xargs[
-                            "tool_choice_required_section_end"
-                        ] = tool_call_end
+                        request.vllm_xargs["tool_choice_required_section_end"] = (
+                            tool_call_end
+                        )
                 else:
                     # Non-thinking model: guided generation works fine.
                     request.text = ResponseTextConfig()

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -18,6 +18,7 @@ from vllm.v1.sample.logits_processor.builtin import (
     LogitBiasLogitsProcessor,
     MinPLogitsProcessor,
     MinTokensLogitsProcessor,
+    ToolChoiceRequiredLogitsProcessor,
     process_dict_updates,
 )
 from vllm.v1.sample.logits_processor.interface import (
@@ -50,6 +51,7 @@ BUILTIN_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
     MinTokensLogitsProcessor,
     LogitBiasLogitsProcessor,
     MinPLogitsProcessor,
+    ToolChoiceRequiredLogitsProcessor,
 ]
 
 

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -363,9 +363,7 @@ class ToolChoiceRequiredLogitsProcessor(LogitsProcessor):
         ).to(device=self.device, non_blocking=True)
 
     def update_state(self, batch_update: BatchUpdate | None):
-        needs_update = process_dict_updates(
-            self.reqs, batch_update, self.add_request
-        )
+        process_dict_updates(self.reqs, batch_update, self.add_request)
 
         reqs_to_suppress: list[int] = []
         toks_to_suppress: list[int] = []

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -291,6 +291,116 @@ class MinTokensLogitsProcessor(LogitsProcessor):
         return logits
 
 
+class ToolChoiceRequiredLogitsProcessor(LogitsProcessor):
+    """Suppress all stop/EOS tokens from the start of generation until
+    the model completes at least one tool call (<|tool_call_end|>).
+
+    This forces thinking models to produce tool calls when
+    tool_choice=required. Stop tokens are suppressed continuously —
+    during reasoning and after </think> — preventing premature
+    termination. Once the first tool call is complete, suppression
+    lifts and the model can finish naturally.
+
+    Suppresses the explicit stop token (e.g. <|im_end|>), the primary
+    eos_token_id (e.g. [EOS]), and any additional stop_token_ids.
+
+    Activated via extra_args:
+        tool_choice_required_think_end: int      (</think> token id)
+        tool_choice_required_stop: int            (<|im_end|> token id)
+        tool_choice_required_section_end: int     (<|tool_call_end|> token id)
+    """
+
+    # Per-request state:
+    #   (stop_toks, release_tok, output_tok_ids)
+
+    def __init__(
+        self, vllm_config: "VllmConfig", device: torch.device, is_pin_memory: bool
+    ):
+        self.device = device
+        self.pin_memory = is_pin_memory
+        self.reqs: dict[int, tuple[list[int], int, Sequence[int]]] = {}
+
+        self.logits_slice: tuple[torch.Tensor, torch.Tensor] = (
+            self._device_tensor([], torch.int32),
+            self._device_tensor([], torch.int32),
+        )
+        self.neg_inf_tensor = torch.tensor(
+            -float("inf"), dtype=torch.float32, device=device
+        )
+
+    def is_argmax_invariant(self) -> bool:
+        return False
+
+    @staticmethod
+    def add_request(
+        params: SamplingParams, _: list[int] | None, output_tok_ids: list[int]
+    ) -> tuple[list[int], int, Sequence[int]] | None:
+        extra = params.extra_args or {}
+        think_end = extra.get("tool_choice_required_think_end")
+        stop = extra.get("tool_choice_required_stop")
+        section_end = extra.get("tool_choice_required_section_end")
+        if think_end is None or stop is None:
+            return None
+        # Collect all tokens that can terminate generation
+        stop_toks: list[int] = [int(stop)]
+        # Also suppress the primary eos_token_id if different from stop
+        eos = params.eos_token_id
+        if eos is not None and eos != int(stop):
+            stop_toks.append(eos)
+        # Also suppress any additional stop_token_ids from generation_config
+        if params.stop_token_ids:
+            for st in params.stop_token_ids:
+                if st not in stop_toks:
+                    stop_toks.append(st)
+        # Release token: <|tool_call_end|> — suppression lifts after
+        # the first complete tool call
+        release = int(section_end) if section_end is not None else -1
+        return (stop_toks, release, output_tok_ids)
+
+    def _device_tensor(self, data: list, dtype: torch.dtype) -> torch.Tensor:
+        return torch.tensor(
+            data, device="cpu", dtype=dtype, pin_memory=self.pin_memory
+        ).to(device=self.device, non_blocking=True)
+
+    def update_state(self, batch_update: BatchUpdate | None):
+        needs_update = process_dict_updates(
+            self.reqs, batch_update, self.add_request
+        )
+
+        reqs_to_suppress: list[int] = []
+        toks_to_suppress: list[int] = []
+        done: list[int] = []
+
+        for index, (stop_toks, release, out_ids) in self.reqs.items():
+            # Check if model completed a tool call
+            if out_ids and out_ids[-1] == release:
+                done.append(index)
+                continue
+
+            # Suppress all stop tokens for this request
+            for tok in stop_toks:
+                reqs_to_suppress.append(index)
+                toks_to_suppress.append(tok)
+
+        # Remove completed requests
+        for index in done:
+            del self.reqs[index]
+
+        # Rebuild tensors
+        prev_numel = self.logits_slice[0].numel()
+        new_numel = len(reqs_to_suppress)
+        if new_numel != prev_numel or new_numel > 0:
+            self.logits_slice = (
+                self._device_tensor(reqs_to_suppress, torch.int32),
+                self._device_tensor(toks_to_suppress, torch.int32),
+            )
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        if self.logits_slice[0].numel() > 0:
+            logits.index_put_(self.logits_slice, self.neg_inf_tensor)
+        return logits
+
+
 def process_dict_updates(
     req_entries: dict[int, T],
     batch_update: BatchUpdate | None,


### PR DESCRIPTION
## Summary

- **Problem**: `tool_choice=required` with thinking models (QwQ, Kimi K2, DeepSeek R1, etc.) fails because guided generation corrupts `<think>` reasoning tokens. The model either produces garbled reasoning or terminates before generating any tool calls.
- **Solution**: Add `ToolChoiceRequiredLogitsProcessor` that suppresses all stop/EOS tokens from the start of generation, forcing the model to produce tool calls. Activated automatically when `ToolParser.adjust_request()` detects a thinking model (vocab contains `</think>` + `<|im_end|>`) with reasoning enabled.
- **Key behaviors**:
  - Suppresses all stop tokens (`eos_token_id`, `stop_token_ids`) — handles models with dual EOS (e.g. Kimi K2 has both `[EOS]` and `<|im_end|>`)
  - Optional release token (`<|tool_call_end|>`) lifts suppression after the first complete tool call
  - When release token is unavailable, suppression continues until `max_tokens` — clients should set `max_output_tokens` accordingly
  - Zero overhead for non-tool-choice requests (early return in `add_request`)
  - Non-thinking models continue to use guided generation (unchanged)

## Test plan

- [x] `tests/v1/logits_processors/test_tool_choice_required.py` — 12 tests:
  - `add_request` returns None for normal requests
  - Collects all stop/EOS tokens, deduplicates
  - Suppresses correct logit positions to `-inf`
  - Releases suppression after tool_call_end token
  - No release when section_end unset
  - Multiple concurrent requests
  - Removed request cleanup
- [x] `tests/tool_parsers/test_adjust_request_responses.py` — 8 tests:
  - Thinking model → logits processor path (vllm_xargs)
  - Non-thinking model → guided generation path
  - reasoning=None → guided generation
  - Optional `<|tool_call_end|>` token
  - tool_choice=none/auto → no adjustment
  - Preserves existing vllm_xargs
- [x] All 20 tests pass (CPU only, no model required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)