### PR TITLE
fix: preserve logprobs for control tokens in streaming tool calls

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1027,12 +1027,10 @@ class OpenAIServingChat(OpenAIServing):
                     # wasn't ready to send a token, then
                     #   get the next token without streaming a chunk
                     if delta_message is None:
-                        # NOTE: If return_token_ids is enabled, we still need to
-                        # send a chunk with token_ids even if delta_message is None
-                        # to ensure all tokens are included in the response
                         if (
                             output.finish_reason is None
                             and not request.return_token_ids
+                            and not request.logprobs
                         ):
                             continue
                         delta_message = DeltaMessage()


### PR DESCRIPTION
When streaming tool_calls chunks with control tokens (e.g. <tool_call/>), the delta_message may be None but logprobs should still be preserved. Previously, chunks with None delta_message were skipped entirely when return_token_ids was False, causing logprobs to be lost.

Now we also check if logprobs is requested before skipping the chunk, ensuring control token logprobs are included in the streaming response.

Fixes #37737




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

