### PR TITLE
[Bugfix] Add size guard to `make_copy_and_call` and improve tests

### DIFF
--- a/tests/compile/test_backends.py
+++ b/tests/compile/test_backends.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.compilation.backends import make_copy_and_call
+
+
+class TestMakeCopyAndCall:
+    """Tests for make_copy_and_call.
+
+    In production, callable_fn is split_gm (a torch.fx.GraphModule) and
+    input_buffers are pre-allocated at max shape via example_inputs[x].clone().
+    sym_tensor_indices are the positions of tensors with symbolic (dynamic) dim 0.
+    """
+
+    MAX_NUM_TOKENS = 16
+    HIDDEN_SIZE = 64
+
+    @pytest.mark.parametrize(
+        "num_tokens",
+        [MAX_NUM_TOKENS - 1, MAX_NUM_TOKENS],
+        ids=["partial", "full_buffer"],
+    )
+    def test_sym_tensor_copied_as_buffer_view(self, num_tokens: int):
+        """Sym tensor is copied into buffer; callable_fn receives a view of it.
+        Covers num_tokens < buffer_size and num_tokens == buffer_size (boundary)."""
+
+        input_buffer = torch.randn(self.MAX_NUM_TOKENS, self.HIDDEN_SIZE)
+        callable_fn = MagicMock()
+        copy_and_call = make_copy_and_call(
+            sym_tensor_indices=[0],
+            input_buffers=[input_buffer],
+            callable_fn=callable_fn,
+        )
+
+        runtime_tensor = torch.randn(num_tokens, self.HIDDEN_SIZE)
+        copy_and_call(runtime_tensor)
+
+        # Check: runtime_tensor was correctly copied into the buffer
+        assert torch.allclose(input_buffer[:num_tokens], runtime_tensor)
+
+        # Check: callable_fn got a view into the buffer, not a fresh allocation
+        assert (
+            callable_fn.call_args_list[0].args[0].data_ptr() == input_buffer.data_ptr()
+        )
+
+    def test_oversize_input_raises(self):
+        """Sequence longer than max buffer size must raise AssertionError."""
+
+        input_buffer = torch.randn(self.MAX_NUM_TOKENS, self.HIDDEN_SIZE)
+        callable_fn = MagicMock()
+        copy_and_call = make_copy_and_call(
+            sym_tensor_indices=[0],
+            input_buffers=[input_buffer],
+            callable_fn=callable_fn,
+        )
+
+        # Check: input with num_tokens > MAX_NUM_TOKENS raises an error
+        with pytest.raises(AssertionError, match="exceeds static buffer size"):
+            copy_and_call(torch.randn(self.MAX_NUM_TOKENS + 1, self.HIDDEN_SIZE))
+
+        # Check: callable_fn was never reached
+        callable_fn.assert_not_called()
+
+    def test_second_call_overwrites_buffer(self):
+        """Second call overwrites the buffer with new data."""
+
+        input_buffer = torch.randn(self.MAX_NUM_TOKENS, self.HIDDEN_SIZE)
+        callable_fn = MagicMock()
+        copy_and_call = make_copy_and_call(
+            sym_tensor_indices=[0],
+            input_buffers=[input_buffer],
+            callable_fn=callable_fn,
+        )
+
+        runtime_tensor_0 = torch.randn(8, self.HIDDEN_SIZE)
+        runtime_tensor_1 = torch.randn(4, self.HIDDEN_SIZE)
+        copy_and_call(runtime_tensor_0)
+        copy_and_call(runtime_tensor_1)
+
+        # Check: second call overwrote the first 4 rows with new data
+        assert torch.allclose(input_buffer[:4], runtime_tensor_1)
+
+        # Check: rows 4:8 still contain leftover data from the first call
+        assert torch.allclose(input_buffer[4:8], runtime_tensor_0[4:8])
+
+    def test_multiple_sym_tensors_with_static_arg(self):
+        """Non-contiguous sym_tensor_indices: two sym tensors at positions 0 and 2,
+        with a static tensor at position 1 that must pass through unchanged."""
+
+        input_buffer_0 = torch.randn(self.MAX_NUM_TOKENS, self.HIDDEN_SIZE)
+        input_buffer_2 = torch.randn(self.MAX_NUM_TOKENS, self.HIDDEN_SIZE)
+        callable_fn = MagicMock()
+        copy_and_call = make_copy_and_call(
+            sym_tensor_indices=[0, 2],
+            input_buffers=[input_buffer_0, input_buffer_2],
+            callable_fn=callable_fn,
+        )
+
+        runtime_tensor_0 = torch.randn(4, self.HIDDEN_SIZE)
+        passthrough_1 = torch.ones(self.MAX_NUM_TOKENS, self.MAX_NUM_TOKENS)
+        runtime_tensor_2 = torch.randn(6, self.HIDDEN_SIZE)
+        copy_and_call(runtime_tensor_0, passthrough_1, runtime_tensor_2)
+
+        # Check: each runtime_tensor was copied into its respective buffer
+        assert torch.allclose(input_buffer_0[:4], runtime_tensor_0)
+        assert torch.allclose(input_buffer_2[:6], runtime_tensor_2)
+
+        # Check: callable_fn received buffer views, not the original runtime_tensors
+        assert (
+            callable_fn.call_args_list[0].args[0].data_ptr()
+            == input_buffer_0.data_ptr()
+        )
+        assert (
+            callable_fn.call_args_list[0].args[2].data_ptr()
+            == input_buffer_2.data_ptr()
+        )
+
+        # Check: passthrough arg at index 1 is passed through unchanged
+        assert callable_fn.call_args_list[0].args[1] is passthrough_1

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -75,9 +75,9 @@ def make_copy_and_call(
             runtime_tensor = list_args[arg_idx]
             runtime_shape = runtime_tensor.shape[0]
             assert runtime_shape <= input_buffers[buf_idx].shape[0], (
-                f"runtime shape {runtime_shape} exceeds static buffer size "
+                f"Runtime shape {runtime_shape} exceeds static buffer size "
                 f"{input_buffers[buf_idx].shape[0]}. "
-                f"The first run must use the maximum input size."
+                "Ensure input tensors do not exceed the pre-allocated buffer capacity."
             )
             static_tensor = input_buffers[buf_idx][:runtime_shape]
             static_tensor.copy_(runtime_tensor)

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -51,17 +51,18 @@ logger = init_logger(__name__)
 
 def make_copy_and_call(
     sym_tensor_indices: list[int],
-    input_buffers: list[torch.Tensor | None],
+    input_buffers: list[torch.Tensor],
     callable_fn: Callable[..., Any],
 ) -> Callable[..., Any]:
     """Create a wrapper that copies inputs to static buffers before calling.
 
     This is used for cudagraph input copying where we need to copy dynamic
     tensors to static buffers before invoking the compiled graph.
+    Assumes dim 0 is the only dynamic dimension for each symbolic tensor.
 
     Args:
         sym_tensor_indices: Indices of tensors with symbolic shapes
-        input_buffers: List of static buffers (can contain None for lazy init)
+        input_buffers: List of static buffers, one per sym_tensor_indices entry
         callable_fn: The compiled function to call
 
     Returns:
@@ -70,17 +71,17 @@ def make_copy_and_call(
 
     def copy_and_call(*args: Any) -> Any:
         list_args = list(args)
-        for i, index in enumerate(sym_tensor_indices):
-            runtime_tensor = list_args[index]
+        for buf_idx, arg_idx in enumerate(sym_tensor_indices):
+            runtime_tensor = list_args[arg_idx]
             runtime_shape = runtime_tensor.shape[0]
-
-            # lazy initialization of buffer on first call
-            if input_buffers[i] is None:
-                input_buffers[i] = runtime_tensor.clone()
-
-            static_tensor = input_buffers[i][:runtime_shape]  # type: ignore[index]
+            assert runtime_shape <= input_buffers[buf_idx].shape[0], (
+                f"runtime shape {runtime_shape} exceeds static buffer size "
+                f"{input_buffers[buf_idx].shape[0]}. "
+                f"The first run must use the maximum input size."
+            )
+            static_tensor = input_buffers[buf_idx][:runtime_shape]
             static_tensor.copy_(runtime_tensor)
-            list_args[index] = static_tensor
+            list_args[arg_idx] = static_tensor
         return callable_fn(*list_args)
 
     return copy_and_call


### PR DESCRIPTION
## Purpose

This PR refactors `make_copy_and_call` for safer buffer management and adds missing unit tests.

**Key Changes:**
* **Refactor:** Removed lazy buffer initialization (buffers are always pre-allocated in practice).
* **Guard / Fix:** Added an assertion to explicitly prevent out-of-bounds errors when runtime shape exceeds buffer size.

**New Tests (`tests/compile/test_backends.py`):**
* Sym tensor copy to pre-allocated buffer & view passing.
* Early exception for oversized inputs.
* Buffer overwriting and preservation of out-of-range rows.
* Non-contiguous indices with static passthrough args.

## Test Plan

`python -m pytest -W ignore -v tests/compile/test_backends.py
`
## Test Result

<img width="1913" height="379" alt="image" src="https://github.com/user-attachments/assets/0daf658a-2a9c-46e6-933f-28d0ec3e6725" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

