### PR TITLE
[Core] Enable allreduce fusion by default for SM 10.3 (B300/GB300)

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -120,7 +120,7 @@ def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
         and current_platform.is_cuda()
         and has_flashinfer()
         and (
-            current_platform.is_device_capability(100)
+            current_platform.is_device_capability_family(100)
             or current_platform.is_device_capability(90)
         )
         # tp-dp combination broken:


### PR DESCRIPTION
## Summary

Enable allreduce fusion by default for SM 10.3 (B300/GB300) by using `is_device_capability_family(100)` instead of `is_device_capability(100)` in `enable_allreduce_rms_fusion`.

## Accuracy Test

```
vllm serve nvidia/DeepSeek-V3.2-NVFP4 \
  --tensor-parallel-size 2 \
  --tokenizer-mode deepseek_v32 \
  --tool-call-parser deepseek_v32 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v3 \
  --quantization modelopt_fp4
```

```
python tests/evals/gsm8k/gsm8k_eval.py

Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:57<00:00, 23.02it/s]

Results:
Accuracy: 0.951
Invalid responses: 0.000
Total latency: 57.303 s
Questions per second: 23.018
Total output tokens: 120257
Output tokens per second: 2098.608
```