### PR TITLE
[Perf] Add SM 10.3 (B300/GB300) all-reduce communicator tuning

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -62,6 +62,11 @@ FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
         4: 32,  # 32MB
         8: 1,  # 1MB
     },
+    103: {
+        2: 64,  # 64MB
+        4: 64,  # 64MB
+        8: 2,  # 2MB
+    },
 }
 
 # Max size of the input tensor per world size per device capability
@@ -77,6 +82,11 @@ _FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB: dict[int, dict[int, float]] = {
         2: 32,  # 32MB
         4: 4,  # 4MB
         8: 1,  # 1MB
+    },
+    103: {
+        2: 32,  # 32MB
+        4: 4,  # 4MB
+        8: 2,  # 2MB
     },
 }
 

--- a/vllm/distributed/device_communicators/all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/all_reduce_utils.py
@@ -44,6 +44,12 @@ CUSTOM_ALL_REDUCE_MAX_SIZES = {
         6: 1 * MiB,  # 1 MB
         8: 1 * MiB,  # 1 MB
     },
+    "10.3": {
+        2: 4 * MiB,  # 4 MB
+        4: 4 * MiB,  # 4 MB
+        6: 8 * MiB,  # 8 MB
+        8: 4 * MiB,  # 4 MB
+    },
 }
 
 SYMM_MEM_ALL_REDUCE_MAX_SIZES = {
@@ -58,6 +64,12 @@ SYMM_MEM_ALL_REDUCE_MAX_SIZES = {
         4: 32 * MiB,  # 32 MB
         6: 128 * MiB,  # 128 MB
         8: 128 * MiB,  # 128 MB
+    },
+    "10.3": {
+        2: 4 * MiB,  # 4 MB
+        4: 32 * MiB,  # 32 MB
+        6: 32 * MiB,  # 32 MB
+        8: 64 * MiB,  # 64 MB
     },
 }
 

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -28,6 +28,7 @@ class SymmMemCommunicator:
     _WORLD_SIZES_MULTIMEM = {
         "9.0": [4, 6, 8],
         "10.0": [6, 8],
+        "10.3": [6, 8],
     }
 
     def __init__(


### PR DESCRIPTION
## Summary

Add benchmarked optimal all-reduce communicator config values for SM 10.3 (B300/GB300).

Depends on #37755 for allreduce fusion to be auto-enabled on SM 10.3.

## Config Values

| Config | ws=2 | ws=4 | ws=6 | ws=8 |
|--------|------|------|------|------|
| `CUSTOM_ALL_REDUCE_MAX_SIZES` | 4 MiB | 4 MiB | 8 MiB | 4 MiB |
| `SYMM_MEM_ALL_REDUCE_MAX_SIZES` | 4 MiB | 32 MiB | 32 MiB | 64 MiB |
| `_WORLD_SIZES_MULTIMEM` | -- | -- | yes | yes |
| `FI_ALLREDUCE_FUSION_MAX_SIZE_MB` | 64 | 64 | -- | 2 |
| `_FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB` | 32 | 4 | -- | 2 |

### Notes

- **`CUSTOM_ALL_REDUCE_MAX_SIZES`**: Crossover where custom all-reduce loses to `pynccl`. Custom AR wins at small tensors, `pynccl` takes over at 4-8 MiB depending on world size.

- **`SYMM_MEM_ALL_REDUCE_MAX_SIZES`**: Crossover where symmetric memory loses to `pynccl`. Symm mem stays competitive longer at higher world sizes (up to 64 MiB at `ws=8`).

- **`_WORLD_SIZES_MULTIMEM = [6, 8]`**: All-or-nothing `multimem` vs `two_shot` selection per world size. At `ws=6` (12/12) and `ws=8` (13/13), `multimem` wins all sizes. At `ws=2` and `ws=4`, `multimem` wins more sizes by count but `two_shot` wins at larger sizes with much bigger absolute savings (e.g. `ws=4`: 0.001 ms at 16 KiB vs 0.058 ms at 32 MiB).

- **`FI_ALLREDUCE_FUSION_MAX_SIZE_MB`**: Crossover where FlashInfer fused allreduce+rmsnorm (default `trtllm` backend) loses to standard. `trtllm` wins at all sizes for `ws=2` and `ws=4`. At `ws=8`, wins up to 2 MiB only.

- **`_FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB`**: `oneshot` vs `twoshot` crossover within FlashInfer `allreduce_fusion`. Only affects `trtllm` (`mnnvl` ignores the flag). `ws=2`: capped at 32 MiB. `ws=4`: 4 MiB. `ws=8`: 2 MiB.

## Full Benchmark Results

### Standalone All-Reduce (`benchmark_device_communicators.py`)

<details>
<summary>World Size = 2</summary>

| Tensor Size | ca_1stage | ca_2stage | flashinfer_mnnvl | flashinfer_trtllm | pynccl | pynccl-symm | symm_mem_multimem | symm_mem_two_shot | Winner |
|-------------|-----------|-----------|------------------|-------------------|--------|-------------|-------------------|-------------------|--------|
| 16 KiB | 0.007 | 0.011 | **0.004** | 0.004 | 0.021 | 0.012 | 0.013 | 0.014 | flashinfer_mnnvl |
| 32 KiB | 0.007 | 0.013 | **0.004** | 0.005 | 0.012 | 0.013 | 0.013 | 0.015 | flashinfer_mnnvl |
| 64 KiB | 0.007 | 0.013 | **0.004** | 0.005 | 0.011 | 0.014 | 0.015 | 0.016 | flashinfer_mnnvl |
| 128 KiB | 0.007 | 0.012 | **0.004** | 0.005 | 0.011 | 0.015 | 0.016 | 0.018 | flashinfer_mnnvl |
| 256 KiB | 0.007 | 0.015 | **0.005** | 0.005 | 0.014 | 0.016 | 0.016 | 0.018 | flashinfer_mnnvl |
| 512 KiB | 0.009 | 0.014 | 0.005 | **0.005** | 0.015 | 0.017 | 0.019 | 0.018 | flashinfer_trtllm |
| 1 MiB | 0.013 | 0.018 | 0.007 | **0.006** | 0.017 | 0.019 | 0.023 | 0.021 | flashinfer_trtllm |
| 2 MiB | 0.020 | 0.026 | 0.009 | **0.008** | 0.021 | 0.024 | 0.032 | 0.025 | flashinfer_trtllm |
| 4 MiB | 0.033 | 0.041 | 0.015 | **0.011** | 0.035 | 0.042 | 0.049 | 0.034 | flashinfer_trtllm |
| 8 MiB | 0.060 | 0.068 | 0.025 | **0.020** | 0.046 | 0.048 | 0.085 | 0.049 | flashinfer_trtllm |
| 16 MiB | 0.112 | 0.122 | 0.047 | **0.038** | 0.057 | 0.062 | 0.157 | 0.081 | flashinfer_trtllm |
| 32 MiB | 0.217 | 0.231 | 0.089 | **0.078** | 0.086 | 0.098 | 0.305 | 0.154 | flashinfer_trtllm |
| 64 MiB | 0.428 | 0.498 | 0.174 | 0.154 | **0.150** | 0.176 | 0.638 | 0.333 | pynccl |
| 128 MiB | 0.848 | 0.999 | 0.351 | 0.300 | **0.281** | 0.324 | 1.298 | 0.669 | pynccl |

</details>

<details>
<summary>World Size = 4</summary>

| Tensor Size | ca_1stage | ca_2stage | flashinfer_mnnvl | flashinfer_trtllm | pynccl | pynccl-symm | symm_mem_multimem | symm_mem_two_shot | Winner |
|-------------|-----------|-----------|------------------|-------------------|--------|-------------|-------------------|-------------------|--------|
| 16 KiB | 0.007 | 0.015 | **0.004** | 0.005 | 0.025 | 0.017 | 0.013 | 0.014 | flashinfer_mnnvl |
| 32 KiB | 0.007 | 0.016 | **0.004** | 0.005 | 0.017 | 0.018 | 0.013 | 0.014 | flashinfer_mnnvl |
| 64 KiB | 0.007 | 0.017 | **0.004** | 0.005 | 0.018 | 0.019 | 0.013 | 0.016 | flashinfer_mnnvl |
| 128 KiB | 0.007 | 0.018 | **0.005** | 0.005 | 0.019 | 0.021 | 0.015 | 0.017 | flashinfer_mnnvl |
| 256 KiB | 0.008 | 0.019 | **0.005** | 0.006 | 0.019 | 0.021 | 0.017 | 0.019 | flashinfer_mnnvl |
| 512 KiB | 0.010 | 0.019 | **0.006** | 0.007 | 0.020 | 0.022 | 0.017 | 0.019 | flashinfer_mnnvl |
| 1 MiB | 0.014 | 0.019 | **0.008** | 0.010 | 0.022 | 0.024 | 0.019 | 0.020 | flashinfer_mnnvl |
| 2 MiB | 0.023 | 0.028 | **0.010** | 0.015 | 0.027 | 0.029 | 0.024 | 0.024 | flashinfer_mnnvl |
| 4 MiB | 0.038 | 0.043 | **0.017** | 0.026 | 0.039 | 0.042 | 0.033 | 0.029 | flashinfer_mnnvl |
| 8 MiB | 0.068 | 0.074 | **0.029** | 0.050 | 0.049 | 0.052 | 0.054 | 0.042 | flashinfer_mnnvl |
| 16 MiB | 0.126 | 0.130 | **0.053** | 0.066 | 0.076 | 0.080 | 0.093 | 0.064 | flashinfer_mnnvl |
| 32 MiB | 0.245 | 0.242 | **0.101** | 0.115 | 0.123 | 0.136 | 0.175 | 0.118 | flashinfer_mnnvl |
| 64 MiB | 0.482 | 0.479 | 0.199 | 0.215 | **0.189** | 0.214 | 0.367 | 0.234 | pynccl |
| 128 MiB | 0.956 | 0.970 | 0.400 | 0.409 | **0.366** | 0.410 | 0.731 | 0.456 | pynccl |

</details>

<details>
<summary>World Size = 6</summary>

| Tensor Size | ca_1stage | ca_2stage | pynccl | pynccl-symm | symm_mem_multimem | symm_mem_two_shot | Winner |
|-------------|-----------|-----------|--------|-------------|-------------------|-------------------|--------|
| 16 KiB | **0.007** | 0.019 | 0.029 | 0.024 | 0.013 | 0.019 | ca_1stage |
| 32 KiB | **0.008** | 0.020 | 0.024 | 0.025 | 0.013 | 0.019 | ca_1stage |
| 64 KiB | **0.008** | 0.021 | 0.025 | 0.026 | 0.013 | 0.020 | ca_1stage |
| 128 KiB | **0.008** | 0.022 | 0.026 | 0.028 | 0.015 | 0.022 | ca_1stage |
| 256 KiB | **0.009** | 0.022 | 0.027 | 0.028 | 0.015 | 0.022 | ca_1stage |
| 512 KiB | **0.011** | 0.023 | 0.027 | 0.029 | 0.017 | 0.024 | ca_1stage |
| 1 MiB | **0.017** | 0.023 | 0.027 | 0.029 | 0.018 | 0.024 | ca_1stage |
| 2 MiB | 0.026 | 0.036 | 0.032 | 0.035 | **0.022** | 0.027 | symm_mem_multimem |
| 4 MiB | 0.045 | 0.049 | 0.046 | 0.050 | **0.029** | 0.038 | symm_mem_multimem |
| 8 MiB | 0.080 | 0.074 | 0.080 | 0.083 | **0.043** | 0.059 | symm_mem_multimem |
| 16 MiB | 0.150 | 0.136 | 0.083 | 0.090 | **0.072** | 0.099 | symm_mem_multimem |
| 32 MiB | 0.291 | 0.250 | 0.141 | 0.153 | **0.132** | 0.177 | symm_mem_multimem |
| 64 MiB | 0.575 | 0.488 | **0.219** | 0.241 | 0.271 | 0.331 | pynccl |
| 128 MiB | 1.142 | 0.975 | **0.393** | 0.440 | 0.541 | 0.680 | pynccl |

</details>

<details>
<summary>World Size = 8</summary>

| Tensor Size | ca_1stage | ca_2stage | flashinfer_mnnvl | flashinfer_trtllm | pynccl | pynccl-symm | symm_mem_multimem | symm_mem_two_shot | Winner |
|-------------|-----------|-----------|------------------|-------------------|--------|-------------|-------------------|-------------------|--------|
| 16 KiB | 0.007 | 0.022 | **0.004** | 0.005 | 0.044 | 0.028 | 0.013 | 0.018 | flashinfer_mnnvl |
| 32 KiB | 0.008 | 0.024 | **0.005** | 0.005 | 0.027 | 0.029 | 0.013 | 0.018 | flashinfer_mnnvl |
| 64 KiB | 0.008 | 0.025 | **0.005** | 0.006 | 0.028 | 0.030 | 0.013 | 0.019 | flashinfer_mnnvl |
| 128 KiB | 0.009 | 0.025 | **0.006** | 0.007 | 0.029 | 0.030 | 0.014 | 0.020 | flashinfer_mnnvl |
| 256 KiB | 0.010 | 0.027 | **0.006** | 0.009 | 0.031 | 0.032 | 0.015 | 0.022 | flashinfer_mnnvl |
| 512 KiB | 0.013 | 0.026 | **0.007** | 0.014 | 0.031 | 0.033 | 0.017 | 0.024 | flashinfer_mnnvl |
| 1 MiB | 0.020 | 0.027 | **0.008** | 0.023 | 0.031 | 0.033 | 0.017 | 0.024 | flashinfer_mnnvl |
| 2 MiB | 0.032 | 0.029 | **0.011** | 0.043 | 0.035 | 0.037 | 0.020 | 0.026 | flashinfer_mnnvl |
| 4 MiB | 0.056 | 0.046 | **0.017** | 0.039 | 0.056 | 0.058 | 0.026 | 0.035 | flashinfer_mnnvl |
| 8 MiB | 0.103 | 0.079 | **0.030** | 0.054 | 0.073 | 0.077 | 0.038 | 0.046 | flashinfer_mnnvl |
| 16 MiB | 0.195 | 0.144 | **0.056** | 0.083 | 0.102 | 0.108 | 0.060 | 0.078 | flashinfer_mnnvl |
| 32 MiB | 0.378 | 0.262 | **0.107** | 0.136 | 0.170 | 0.176 | 0.109 | 0.138 | flashinfer_mnnvl |
| 64 MiB | 0.751 | 0.503 | **0.207** | 0.247 | 0.277 | 0.289 | 0.223 | 0.265 | flashinfer_mnnvl |
| 128 MiB | 1.486 | 0.981 | 0.411 | 0.470 | **0.396** | 0.421 | 0.439 | 0.525 | pynccl |

</details>

### Fused AllReduce+RMSNorm (`benchmark_fused_collective.py`)

<details>
<summary>World Size = 2</summary>

#### Input Size: 2.00 MiB (num_tokens=128)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.047 | 0.49x |
| Standard Allreduce  Custom Rms Norm | 0.024 | 0.97x |
| Standard Allreduce Rmsnorm Native Compiled | 0.023 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | **0.009** | 2.45x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.029 | 0.80x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.010 | 2.37x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.010 | 2.36x |

#### Input Size: 4.00 MiB (num_tokens=256)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.071 | 0.52x |
| Standard Allreduce  Custom Rms Norm | 0.039 | 0.97x |
| Standard Allreduce Rmsnorm Native Compiled | 0.037 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | **0.014** | 2.74x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.031 | 1.19x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.017 | 2.16x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.017 | 2.15x |

#### Input Size: 8.00 MiB (num_tokens=512)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.151 | 0.61x |
| Standard Allreduce  Custom Rms Norm | 0.093 | 0.98x |
| Standard Allreduce Rmsnorm Native Compiled | 0.092 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | **0.025** | 3.72x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.040 | 2.30x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.032 | 2.83x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.032 | 2.84x |

#### Input Size: 16.00 MiB (num_tokens=1024)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.271 | 0.63x |
| Standard Allreduce  Custom Rms Norm | 0.169 | 1.01x |
| Standard Allreduce Rmsnorm Native Compiled | 0.171 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | **0.047** | 3.62x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.059 | 2.92x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.062 | 2.78x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.061 | 2.79x |

#### Input Size: 32.00 MiB (num_tokens=2048)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.533 | 0.62x |
| Standard Allreduce  Custom Rms Norm | 0.331 | 0.99x |
| Standard Allreduce Rmsnorm Native Compiled | 0.329 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | **0.097** | 3.38x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.104 | 3.15x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.123 | 2.68x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.123 | 2.68x |

#### Input Size: 64.00 MiB (num_tokens=4096)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 1.134 | 0.61x |
| Standard Allreduce  Custom Rms Norm | 0.690 | 1.00x |
| Standard Allreduce Rmsnorm Native Compiled | 0.693 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | **0.197** | 3.52x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.200 | 3.47x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.247 | 2.81x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.247 | 2.81x |

</details>

<details>
<summary>World Size = 4</summary>

#### Input Size: 2.00 MiB (num_tokens=128)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.055 | 0.57x |
| Standard Allreduce  Custom Rms Norm | 0.031 | 0.99x |
| Standard Allreduce Rmsnorm Native Compiled | 0.031 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | **0.016** | 1.97x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.035 | 0.90x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.010 | 2.96x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.010 | 2.99x |

#### Input Size: 4.00 MiB (num_tokens=256)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.082 | 0.58x |
| Standard Allreduce  Custom Rms Norm | 0.049 | 0.97x |
| Standard Allreduce Rmsnorm Native Compiled | 0.048 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | **0.028** | 1.68x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.040 | 1.18x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.019 | 2.52x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.019 | 2.51x |

#### Input Size: 8.00 MiB (num_tokens=512)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.118 | 0.49x |
| Standard Allreduce  Custom Rms Norm | 0.060 | 0.97x |
| Standard Allreduce Rmsnorm Native Compiled | 0.058 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.054 | 1.07x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | **0.049** | 1.18x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.035 | 1.66x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.035 | 1.66x |

#### Input Size: 16.00 MiB (num_tokens=1024)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.202 | 0.52x |
| Standard Allreduce  Custom Rms Norm | 0.102 | 1.03x |
| Standard Allreduce Rmsnorm Native Compiled | 0.104 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.105 | 0.99x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | **0.072** | 1.45x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.067 | 1.57x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.066 | 1.57x |

#### Input Size: 32.00 MiB (num_tokens=2048)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.400 | 0.49x |
| Standard Allreduce  Custom Rms Norm | 0.198 | 0.99x |
| Standard Allreduce Rmsnorm Native Compiled | 0.196 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.208 | 0.94x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | **0.135** | 1.45x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.133 | 1.48x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.133 | 1.47x |

#### Input Size: 64.00 MiB (num_tokens=4096)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.854 | 0.48x |
| Standard Allreduce  Custom Rms Norm | 0.412 | 0.99x |
| Standard Allreduce Rmsnorm Native Compiled | 0.409 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.411 | 1.00x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | **0.250** | 1.63x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.264 | 1.55x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.264 | 1.55x |

</details>

<details>
<summary>World Size = 8</summary>

#### Input Size: 2.00 MiB (num_tokens=128)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.056 | 0.57x |
| Standard Allreduce  Custom Rms Norm | 0.033 | 0.98x |
| Standard Allreduce Rmsnorm Native Compiled | 0.032 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.031 | 1.03x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.054 | 0.59x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | **0.012** | 2.78x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.012 | 2.75x |

#### Input Size: 4.00 MiB (num_tokens=256)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.085 | 0.59x |
| Standard Allreduce  Custom Rms Norm | 0.052 | 0.97x |
| Standard Allreduce Rmsnorm Native Compiled | 0.050 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.058 | 0.86x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.051 | 0.99x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | **0.019** | 2.59x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.019 | 2.59x |

#### Input Size: 8.00 MiB (num_tokens=512)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.103 | 0.42x |
| Standard Allreduce  Custom Rms Norm | 0.044 | 0.96x |
| Standard Allreduce Rmsnorm Native Compiled | 0.043 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.115 | 0.37x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.070 | 0.61x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.039 | 1.08x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | **0.036** | 1.18x |

#### Input Size: 16.00 MiB (num_tokens=1024)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.170 | 0.43x |
| Standard Allreduce  Custom Rms Norm | 0.071 | 1.03x |
| Standard Allreduce Rmsnorm Native Compiled | 0.073 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.224 | 0.32x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.107 | 0.68x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | **0.069** | 1.05x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | 0.069 | 1.05x |

#### Input Size: 32.00 MiB (num_tokens=2048)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.335 | 0.39x |
| Standard Allreduce  Custom Rms Norm | 0.138 | 0.95x |
| Standard Allreduce Rmsnorm Native Compiled | 0.131 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.447 | 0.29x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.202 | 0.65x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.139 | 0.95x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | **0.139** | 0.95x |

#### Input Size: 64.00 MiB (num_tokens=4096)

| Operation | Time (ms) | Speedup |
|-----------|-----------|---------|
| Standard Allreduce  Native Rms Norm | 0.713 | 0.37x |
| Standard Allreduce  Custom Rms Norm | 0.271 | 0.98x |
| Standard Allreduce Rmsnorm Native Compiled | 0.266 | baseline |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Oneshot | 0.895 | 0.30x |
| Flashinfer Trtllm Fused Allreduce Rmsnorm Twoshot | 0.376 | 0.71x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Oneshot | 0.283 | 0.94x |
| Flashinfer Mnnvl Fused Allreduce Rmsnorm Twoshot | **0.283** | 0.94x |

</details>

## Test Plan

- `torchrun benchmarks/kernels/benchmark_device_communicators.py` across world sizes 2, 4, 6, 8 with and without NCCL symmetric memory, 100 trials each
- `torchrun benchmarks/kernels/benchmark_fused_collective.py` across world sizes 2, 4, 8 for oneshot vs twoshot comparison, 100 trials each
