### PR TITLE
[ROCm][CI] Fix MEGA_AOT_ARTIFACT fallback when PyTorch < 2.10.0 lacks AOT support

### DIFF
--- a/tests/compile/test_startup.py
+++ b/tests/compile/test_startup.py
@@ -15,6 +15,7 @@ from torch._dynamo.utils import counters
 import vllm.envs as envs
 from vllm.compilation.counter import compilation_counter
 from vllm.config import CompilationConfig, CompilationMode, CUDAGraphMode
+from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from ..utils import fork_new_process_for_each_test
 
@@ -71,7 +72,10 @@ def test_moe_startup(monkeypatch, vllm_runner, fresh_vllm_cache, mega_aot_artifa
         num_compiled_artifacts_saved=0,
     ):
         _run_vllm(vllm_runner)
-    if envs.VLLM_USE_MEGA_AOT_ARTIFACT:
+    mega_aot_active = envs.VLLM_USE_MEGA_AOT_ARTIFACT and is_torch_equal_or_newer(
+        "2.10.0"
+    )
+    if mega_aot_active:
         # MEGA_AOT_ARTIFACT is enabled, so we expect no aot_autograd running on
         # subgraphs.
         assert counters["aot_autograd"]["total"] == 0


### PR DESCRIPTION
When `VLLM_USE_MEGA_AOT_ARTIFACT=1` is set on PyTorch < 2.10.0 (e.g. ROCm), `standalone_compile` correctly falls back to non-AOT mode, but `set_functorch_config()` still leaves `bundled_autograd_cache` enabled because it only checks the env var, not the PyTorch version.

This causes `test_moe_startup[1]` to fail: 
```
assert counters["aot_autograd"]["total"] == 0
E   assert 30 == 0
```

In this PR, we gate on both `VLLM_USE_MEGA_AOT_ARTIFACT` and `is_torch_equal_or_newer("2.10.0")` before keeping `bundled_autograd_cache` enabled, matching the existing fallback logic in `StandaloneInductorAdaptor.compile()`. Alos, apply the same version check in the warm-start assertion so the test expects `total == 30` when AOT isn't actually active.

cc @kenroche 