### PR TITLE
[ROCm][CI] close missing quote in kernels/moe block in run-amd-test.sh

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -326,8 +326,8 @@ apply_rocm_test_overrides() {
   if [[ $cmds == *" kernels/moe"* ]]; then
     cmds="${cmds} \
     --ignore=kernels/moe/test_moe.py \
-    --ignore=kernels/moe/test_cutlass_moe.py \
-    fi
+    --ignore=kernels/moe/test_cutlass_moe.py"
+  fi
 
   # --- Entrypoint ignores ---
   if [[ $cmds == *" entrypoints/openai "* ]]; then


### PR DESCRIPTION
Addresses regression from: #32700

Fix a syntax error in `run-amd-test.sh` where the `kernels/moe` ignore block inside `apply_rocm_test_overrides` was missing the closing `"` on the `cmds` string assignment. 

cc @kenroche 