### PR TITLE
[MoE] Unify MoE oracles with class structure

### DIFF
--- a/tests/kernels/moe/test_oracle_class_structure.py
+++ b/tests/kernels/moe/test_oracle_class_structure.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Minimal structural tests for the MoE oracle class hierarchy.
+
+Verifies that all oracle classes correctly inherit from MoEKernelOracle
+and that module-level wrapper functions delegate to oracle instances.
+No GPU or model weights required.
+"""
+
+import pytest
+
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+    Fp8MoeBackend,
+    Fp8MoEKernelOracle,
+)
+from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+    Mxfp4MoeBackend,
+    Mxfp4MoEKernelOracle,
+)
+from vllm.model_executor.layers.fused_moe.oracle.mxfp8 import (
+    Mxfp8MoEKernelOracle,
+)
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
+    NvFp4MoEKernelOracle,
+)
+from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+    UnquantizedMoeBackend,
+    UnquantizedMoEKernelOracle,
+)
+
+ALL_ORACLE_CLASSES = [
+    Fp8MoEKernelOracle,
+    NvFp4MoEKernelOracle,
+    Mxfp8MoEKernelOracle,
+    Mxfp4MoEKernelOracle,
+    UnquantizedMoEKernelOracle,
+]
+
+
+@pytest.mark.parametrize("oracle_cls", ALL_ORACLE_CLASSES)
+def test_oracle_inherits_from_base(oracle_cls):
+    """Each oracle class must inherit from MoEKernelOracle."""
+    assert issubclass(oracle_cls, MoEKernelOracle)
+
+
+@pytest.mark.parametrize("oracle_cls", ALL_ORACLE_CLASSES)
+def test_oracle_is_instantiable(oracle_cls):
+    """Each oracle class must be instantiable (all abstract methods implemented)."""
+    oracle = oracle_cls()
+    assert isinstance(oracle, MoEKernelOracle)
+
+
+@pytest.mark.parametrize("oracle_cls", ALL_ORACLE_CLASSES)
+def test_oracle_has_required_methods(oracle_cls):
+    """Each oracle must implement the 4 standard methods + 2 helpers."""
+    oracle = oracle_cls()
+    # 4 standard methods from the issue
+    assert callable(getattr(oracle, "select_backend", None))
+    assert callable(getattr(oracle, "convert_to_kernel_format", None))
+    assert callable(getattr(oracle, "make_quant_config", None))
+    assert callable(getattr(oracle, "make_kernel", None))
+    # 2 helper methods
+    assert callable(getattr(oracle, "backend_to_kernel_cls", None))
+    assert callable(getattr(oracle, "map_backend", None))
+
+
+def test_fp8_module_wrapper_delegates_to_oracle():
+    """Module-level wrapper must delegate to the oracle singleton."""
+    from vllm.model_executor.layers.fused_moe.oracle import fp8 as fp8_mod
+
+    assert isinstance(fp8_mod._oracle, Fp8MoEKernelOracle)
+    # map_fp8_backend should delegate to _oracle.map_backend
+    backend = fp8_mod.map_fp8_backend("triton")
+    assert backend == Fp8MoeBackend.TRITON
+
+
+def test_nvfp4_module_wrapper_delegates_to_oracle():
+    """Module-level wrapper must delegate to the oracle singleton."""
+    from vllm.model_executor.layers.fused_moe.oracle import nvfp4 as nvfp4_mod
+
+    assert isinstance(nvfp4_mod._oracle, NvFp4MoEKernelOracle)
+    backend = nvfp4_mod.map_nvfp4_backend("marlin")
+    assert backend == NvFp4MoeBackend.MARLIN
+
+
+def test_mxfp4_module_wrapper_delegates_to_oracle():
+    """Module-level wrapper must delegate to the oracle singleton."""
+    from vllm.model_executor.layers.fused_moe.oracle import mxfp4 as mxfp4_mod
+
+    assert isinstance(mxfp4_mod._oracle, Mxfp4MoEKernelOracle)
+    backend = mxfp4_mod.map_mxfp4_backend("triton")
+    assert backend == Mxfp4MoeBackend.TRITON
+
+
+def test_unquantized_module_wrapper_delegates_to_oracle():
+    """Module-level wrapper must delegate to the oracle singleton."""
+    from vllm.model_executor.layers.fused_moe.oracle import (
+        unquantized as unquant_mod,
+    )
+
+    assert isinstance(unquant_mod._oracle, UnquantizedMoEKernelOracle)
+    backend = unquant_mod.map_unquantized_backend("triton")
+    assert backend == UnquantizedMoeBackend.TRITON
+
+
+def test_map_backend_invalid_raises():
+    """map_backend should raise ValueError for unsupported backend strings."""
+    oracle = Fp8MoEKernelOracle()
+    with pytest.raises(ValueError, match="not supported"):
+        oracle.map_backend("nonexistent_backend")

--- a/vllm/model_executor/layers/fused_moe/oracle/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/__init__.py
@@ -1,2 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
+
+__all__ = ["MoEKernelOracle"]

--- a/vllm/model_executor/layers/fused_moe/oracle/base.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/base.py
@@ -24,13 +24,15 @@ class MoEKernelOracle(ABC, Generic[BackendT]):
         - ``convert_to_kernel_format`` – shuffle weights for a backend
         - ``make_quant_config`` – build a ``FusedMoEQuantConfig``
         - ``make_kernel`` – construct the ``FusedMoEKernel``
-    """
 
-    @property
-    @abstractmethod
-    def quant_type_name(self) -> str:
-        """Human-readable quantization type name (e.g. 'Fp8', 'NvFp4')."""
-        ...
+    Note: Method signatures intentionally vary across subclasses because
+    each quantization type requires different weight/scale parameters.
+    This ABC provides structural guarantees (every oracle implements the
+    same set of operations) rather than call-site polymorphism.
+    Optional methods (convert_to_kernel_format, make_quant_config,
+    make_kernel) raise NotImplementedError by default for oracles that
+    delegate these operations (e.g. MXFP8 reuses FP8's kernel logic).
+    """
 
     @abstractmethod
     def backend_to_kernel_cls(
@@ -60,8 +62,7 @@ class MoEKernelOracle(ABC, Generic[BackendT]):
         NotImplementedError.
         """
         raise NotImplementedError(
-            f"{self.quant_type_name} oracle does not implement "
-            "convert_to_kernel_format."
+            f"{type(self).__name__} does not implement convert_to_kernel_format."
         )
 
     def make_quant_config(self, *args, **kwargs):
@@ -71,7 +72,7 @@ class MoEKernelOracle(ABC, Generic[BackendT]):
         raises NotImplementedError.
         """
         raise NotImplementedError(
-            f"{self.quant_type_name} oracle does not implement make_quant_config."
+            f"{type(self).__name__} does not implement make_quant_config."
         )
 
     def make_kernel(self, *args, **kwargs):
@@ -81,5 +82,5 @@ class MoEKernelOracle(ABC, Generic[BackendT]):
         NotImplementedError.
         """
         raise NotImplementedError(
-            f"{self.quant_type_name} oracle does not implement make_kernel."
+            f"{type(self).__name__} does not implement make_kernel."
         )

--- a/vllm/model_executor/layers/fused_moe/oracle/base.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/base.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Generic, TypeVar
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.config.kernel import MoEBackend
+
+BackendT = TypeVar("BackendT", bound=Enum)
+
+
+class MoEKernelOracle(ABC, Generic[BackendT]):
+    """Abstract base class for MoE kernel selection oracles.
+
+    Each oracle selects the right MoE kernel for a given quantization
+    type (e.g. FP8, NvFP4, MXFP4, MXFP8, unquantized). Subclasses
+    implement backend-specific selection, weight conversion, quant
+    config creation, and kernel construction.
+
+    Standard oracle operations (subclasses override as needed):
+        - ``select_backend``  – choose the best kernel backend
+        - ``convert_to_kernel_format`` – shuffle weights for a backend
+        - ``make_quant_config`` – build a ``FusedMoEQuantConfig``
+        - ``make_kernel`` – construct the ``FusedMoEKernel``
+    """
+
+    @property
+    @abstractmethod
+    def quant_type_name(self) -> str:
+        """Human-readable quantization type name (e.g. 'Fp8', 'NvFp4')."""
+        ...
+
+    @abstractmethod
+    def backend_to_kernel_cls(
+        self,
+        backend: BackendT,
+    ) -> list[type[mk.FusedMoEExperts]]:
+        """Map a backend enum value to its expert class(es)."""
+        ...
+
+    @abstractmethod
+    def map_backend(self, runner_backend: MoEBackend) -> BackendT:
+        """Map a user-specified MoEBackend string to the typed backend enum."""
+        ...
+
+    @abstractmethod
+    def select_backend(self, *args, **kwargs):
+        """Select the best backend for the given configuration.
+
+        Signature varies per oracle – see concrete subclass for details.
+        """
+        ...
+
+    def convert_to_kernel_format(self, *args, **kwargs):
+        """Convert loaded weights into backend-specific kernel format.
+
+        Not all oracles need this (e.g. MXFP8). Default raises
+        NotImplementedError.
+        """
+        raise NotImplementedError(
+            f"{self.quant_type_name} oracle does not implement "
+            "convert_to_kernel_format."
+        )
+
+    def make_quant_config(self, *args, **kwargs):
+        """Create FusedMoEQuantConfig for the selected backend.
+
+        Not all oracles need this (e.g. MXFP8, unquantized). Default
+        raises NotImplementedError.
+        """
+        raise NotImplementedError(
+            f"{self.quant_type_name} oracle does not implement make_quant_config."
+        )
+
+    def make_kernel(self, *args, **kwargs):
+        """Construct the FusedMoEKernel for the selected backend.
+
+        Not all oracles need this (e.g. MXFP8). Default raises
+        NotImplementedError.
+        """
+        raise NotImplementedError(
+            f"{self.quant_type_name} oracle does not implement make_kernel."
+        )

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     fp8_w8a8_moe_quant_config,
     fp8_w8a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     FlashinferMoeBackend,
     get_flashinfer_moe_backend,
@@ -102,108 +103,524 @@ def _get_priority_backends(
     return _AVAILABLE_BACKENDS
 
 
+class Fp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
+    """Oracle for FP8 MoE kernel selection."""
+
+    @property
+    def quant_type_name(self) -> str:
+        return "Fp8"
+
+    def backend_to_kernel_cls(
+        self,
+        backend: Fp8MoeBackend,
+    ) -> list[type[mk.FusedMoEExperts]]:
+        if backend == Fp8MoeBackend.FLASHINFER_TRTLLM:
+            from vllm.model_executor.layers.fused_moe.experts.trtllm_fp8_moe import (  # noqa: E501
+                TrtLlmFp8ExpertsModular,
+                TrtLlmFp8ExpertsMonolithic,
+            )
+
+            return [TrtLlmFp8ExpertsMonolithic, TrtLlmFp8ExpertsModular]
+
+        elif backend == Fp8MoeBackend.FLASHINFER_CUTLASS:
+            from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
+                FlashInferExperts,
+            )
+
+            return [FlashInferExperts]
+
+        elif backend == Fp8MoeBackend.DEEPGEMM:
+            from vllm.model_executor.layers.fused_moe.triton_deep_gemm_moe import (
+                TritonOrDeepGemmExperts,
+            )
+
+            return [TritonOrDeepGemmExperts]
+
+        elif backend == Fp8MoeBackend.BATCHED_DEEPGEMM:
+            from vllm.model_executor.layers.fused_moe.batched_deep_gemm_moe import (
+                BatchedDeepGemmExperts,
+            )
+
+            return [BatchedDeepGemmExperts]
+
+        elif backend == Fp8MoeBackend.MARLIN:
+            from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
+                MarlinExperts,
+            )
+
+            return [MarlinExperts]
+
+        elif backend == Fp8MoeBackend.TRITON:
+            from vllm.model_executor.layers.fused_moe.fused_moe import (
+                TritonExperts,
+            )
+
+            return [TritonExperts]
+
+        elif backend == Fp8MoeBackend.BATCHED_TRITON:
+            from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
+                BatchedTritonExperts,
+            )
+
+            return [BatchedTritonExperts]
+
+        elif backend == Fp8MoeBackend.AITER:
+            from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+                AiterExperts,
+            )
+
+            return [AiterExperts]
+
+        elif backend == Fp8MoeBackend.VLLM_CUTLASS:
+            from vllm.model_executor.layers.fused_moe.triton_cutlass_moe import (
+                TritonOrCutlassExperts,
+            )
+
+            return [TritonOrCutlassExperts]
+
+        elif backend == Fp8MoeBackend.BATCHED_VLLM_CUTLASS:
+            from vllm.model_executor.layers.fused_moe.cutlass_moe import (
+                CutlassBatchedExpertsFp8,
+            )
+
+            return [CutlassBatchedExpertsFp8]
+
+        elif backend == Fp8MoeBackend.XPU:
+            from vllm.model_executor.layers.fused_moe.xpu_fused_moe import (
+                XPUExpertsFp8,
+            )
+
+            return [XPUExpertsFp8]
+
+        else:
+            raise ValueError(f"Unknown FP8 MoE backend: {backend.value}")
+
+    def map_backend(self, runner_backend: MoEBackend) -> Fp8MoeBackend:
+        """Map user's MoEBackend to Fp8MoeBackend."""
+        mapping = {
+            "triton": Fp8MoeBackend.TRITON,
+            "deep_gemm": Fp8MoeBackend.DEEPGEMM,
+            "cutlass": Fp8MoeBackend.VLLM_CUTLASS,
+            "flashinfer_trtllm": Fp8MoeBackend.FLASHINFER_TRTLLM,
+            "flashinfer_cutlass": Fp8MoeBackend.FLASHINFER_CUTLASS,
+            "marlin": Fp8MoeBackend.MARLIN,
+            "aiter": Fp8MoeBackend.AITER,
+        }
+        if backend := mapping.get(runner_backend):
+            return backend
+        raise ValueError(
+            f"moe_backend='{runner_backend}' is not supported for FP8 MoE. "
+            f"Expected one of {list(mapping.keys())}."
+        )
+
+    def select_backend(
+        self,
+        config: FusedMoEConfig,
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+        allow_vllm_cutlass: bool = False,
+    ) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts] | None]:
+        """
+        Select the primary FP8 MoE backend
+        Note: Shape-specific fallbacks may still occur at runtime.
+        """
+
+        if config.is_lora_enabled:
+            return Fp8MoeBackend.TRITON, backend_to_kernel_cls(Fp8MoeBackend.TRITON)[0]
+
+        # NOTE: the kernels are selected in the following order.
+        AVAILABLE_BACKENDS = _get_priority_backends(config, weight_key, activation_key)
+
+        # NOTE(rob): We need to peak into the P/F selection to determine
+        # if we are using the batched or standard expert format, which
+        # if not ideal. Once we unify TP + DP/EP, we can select P/F first.
+        activation_format = (
+            mk.FusedMoEActivationFormat.BatchedExperts
+            if config.moe_parallel_config.use_batched_activation_format
+            else mk.FusedMoEActivationFormat.Standard
+        )
+
+        def _make_log_backend(backend: Fp8MoeBackend):
+            available_backend_strs = [b.value for b in AVAILABLE_BACKENDS]
+            return (
+                f"Using {backend.value} Fp8 MoE backend out "
+                f"of potential backends: {available_backend_strs}."
+            )
+
+        def _make_log_unsupported(backend: Fp8MoeBackend, reason: str | None) -> str:
+            if reason:
+                return (
+                    f"FP8 MoE backend {backend.value} does not support the "
+                    f"deployment configuration since {reason}."
+                )
+            else:
+                return (
+                    f"FP8 MoE backend '{backend.value}' does not support the "
+                    "deployment configuration."
+                )
+
+        def _return_or_raise(
+            backend: Fp8MoeBackend,
+            config: FusedMoEConfig,
+            weight_key: QuantKey | None,
+            activation_key: QuantKey | None,
+            activation_format: mk.FusedMoEActivationFormat,
+        ) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts]]:
+            for k_cls in backend_to_kernel_cls(backend):
+                supported, reason = k_cls.is_supported_config(
+                    k_cls, config, weight_key, activation_key, activation_format
+                )
+                if supported:
+                    logger.info_once(_make_log_backend(backend), scope="local")
+                    return backend, k_cls
+            raise ValueError(_make_log_unsupported(backend, reason))
+
+        # Handle explicit moe_backend from user.
+        runner_backend = config.moe_backend
+        if runner_backend != "auto":
+            requested_backend = map_fp8_backend(runner_backend)
+            # For batched activation format, use batched variants if available.
+            if activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
+                if requested_backend == Fp8MoeBackend.DEEPGEMM:
+                    requested_backend = Fp8MoeBackend.BATCHED_DEEPGEMM
+                elif requested_backend == Fp8MoeBackend.TRITON:
+                    requested_backend = Fp8MoeBackend.BATCHED_TRITON
+                elif requested_backend == Fp8MoeBackend.VLLM_CUTLASS:
+                    requested_backend = Fp8MoeBackend.BATCHED_VLLM_CUTLASS
+
+            if (
+                requested_backend
+                in [
+                    Fp8MoeBackend.VLLM_CUTLASS,
+                    Fp8MoeBackend.BATCHED_VLLM_CUTLASS,
+                ]
+                and not allow_vllm_cutlass
+            ):
+                raise ValueError(
+                    "vLLM CUTLASS FP8 MoE backend is disabled for this configuration."
+                )
+
+            return _return_or_raise(
+                requested_backend, config, weight_key, activation_key, activation_format
+            )
+
+        # Handle explicit FlashInfer FP8 configuration.
+        if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP8"):
+            if not envs.VLLM_USE_FLASHINFER_MOE_FP8:
+                # If the user rejects FlashInfer remove those backends.
+                AVAILABLE_BACKENDS.remove(Fp8MoeBackend.FLASHINFER_TRTLLM)
+                AVAILABLE_BACKENDS.remove(Fp8MoeBackend.FLASHINFER_CUTLASS)
+
+            elif envs.is_set("VLLM_FLASHINFER_MOE_BACKEND"):
+                # If user is explicit about backend, validate it.
+                fi_backend = get_flashinfer_moe_backend()
+                if fi_backend == FlashinferMoeBackend.CUTLASS:
+                    backend = Fp8MoeBackend.FLASHINFER_CUTLASS
+                elif fi_backend == FlashinferMoeBackend.TENSORRT_LLM:
+                    backend = Fp8MoeBackend.FLASHINFER_TRTLLM
+                else:
+                    raise ValueError(
+                        f"FlashInfer MOE backend {fi_backend} does not support FP8 MoE."
+                    )
+                k_cls = backend_to_kernel_cls(backend)[0]
+                return _return_or_raise(
+                    backend, config, weight_key, activation_key, activation_format
+                )
+            else:
+                # If the user is not explicit about the backend, try both.
+                for backend in [
+                    Fp8MoeBackend.FLASHINFER_TRTLLM,
+                    Fp8MoeBackend.FLASHINFER_CUTLASS,
+                ]:
+                    for k_cls in backend_to_kernel_cls(backend):
+                        supported, reason = k_cls.is_supported_config(
+                            k_cls,
+                            config,
+                            weight_key,
+                            activation_key,
+                            activation_format,
+                        )
+
+                        if supported:
+                            logger.info_once(_make_log_backend(backend), scope="local")
+                            return backend, k_cls
+                        else:
+                            logger.debug_once(
+                                _make_log_unsupported(backend, reason), scope="local"
+                            )
+
+                raise NotImplementedError(
+                    "Found VLLM_USE_FLASHINFER_MOE_FP8=1, but no "
+                    "FlashInfer FP8 MoE backend supports the configuration."
+                )
+
+        # Handle explicit DeepGEMM FP8 configuration.
+        if envs.is_set("VLLM_USE_DEEP_GEMM") or envs.is_set("VLLM_MOE_USE_DEEP_GEMM"):
+            if not envs.VLLM_USE_DEEP_GEMM or not envs.VLLM_MOE_USE_DEEP_GEMM:
+                AVAILABLE_BACKENDS.remove(Fp8MoeBackend.DEEPGEMM)
+                AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_DEEPGEMM)
+            else:
+                backend = (
+                    Fp8MoeBackend.DEEPGEMM
+                    if activation_format == mk.FusedMoEActivationFormat.Standard
+                    else Fp8MoeBackend.BATCHED_DEEPGEMM
+                )
+                return _return_or_raise(
+                    backend, config, weight_key, activation_key, activation_format
+                )
+
+        # Handle explicit MARLIN FP8 configuration.
+        if envs.VLLM_TEST_FORCE_FP8_MARLIN:
+            backend = Fp8MoeBackend.MARLIN
+            return _return_or_raise(
+                backend, config, weight_key, activation_key, activation_format
+            )
+
+        # Handle explicit AITER FP8 configuration.
+        if envs.is_set("VLLM_ROCM_USE_AITER") or envs.is_set("VLLM_ROCM_USE_AITER_MOE"):
+            if not envs.VLLM_ROCM_USE_AITER or not envs.VLLM_ROCM_USE_AITER_MOE:
+                AVAILABLE_BACKENDS.remove(Fp8MoeBackend.AITER)
+            else:
+                backend = Fp8MoeBackend.AITER
+                return _return_or_raise(
+                    backend, config, weight_key, activation_key, activation_format
+                )
+
+        if not allow_vllm_cutlass:
+            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.VLLM_CUTLASS)
+            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_VLLM_CUTLASS)
+
+        # Select kernels in order of backend.
+        for backend in AVAILABLE_BACKENDS:
+            for k_cls in backend_to_kernel_cls(backend):
+                supported, reason = k_cls.is_supported_config(
+                    k_cls,
+                    config,
+                    weight_key,
+                    activation_key,
+                    activation_format,
+                )
+                if supported:
+                    logger.info_once(_make_log_backend(backend), scope="local")
+                    return backend, k_cls
+                else:
+                    logger.debug_once(
+                        _make_log_unsupported(backend, reason), scope="local"
+                    )
+
+        # TODO(rob): per discussion with TPU team, we need a way to register
+        # MoE backends by OOT plugins, rather than having an explicit list
+        # of AVAILABLE_BACKENDS. Enabling returning `Fp8MoeBackend.NONE` is
+        # a temporary measure until these register APIs are complete.
+        if current_platform.is_cuda() or current_platform.is_rocm():
+            raise NotImplementedError(
+                "No FP8 MoE backend supports the deployment configuration."
+            )
+
+        return Fp8MoeBackend.NONE, None
+
+    def convert_to_kernel_format(
+        self,
+        fp8_backend: Fp8MoeBackend,
+        layer: torch.nn.Module,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        w13_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        w13_input_scale: torch.Tensor | None,
+        w2_input_scale: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        block_quant = hasattr(layer, "weight_block_size")
+        if fp8_backend in [Fp8MoeBackend.DEEPGEMM, Fp8MoeBackend.BATCHED_DEEPGEMM]:
+            assert block_quant
+            w13, w2, w13_scale, w2_scale = prepare_fp8_moe_layer_for_deepgemm(
+                w13,
+                w2,
+                w13_scale,
+                w2_scale,
+                tuple(layer.weight_block_size),
+            )
+        elif fp8_backend == Fp8MoeBackend.AITER:
+            w13, w2 = rocm_aiter_ops.shuffle_weights(w13, w2)
+        elif fp8_backend == Fp8MoeBackend.MARLIN:
+            w13, w2, w13_scale, w2_scale = prepare_fp8_moe_layer_for_marlin(
+                layer,
+                w13,
+                w2,
+                w13_scale,
+                w2_scale,
+            )
+        elif fp8_backend in [
+            Fp8MoeBackend.FLASHINFER_CUTLASS,
+            Fp8MoeBackend.FLASHINFER_TRTLLM,
+        ]:
+            w13, w2, w13_scale, w2_scale = prepare_fp8_moe_layer_for_fi(
+                layer=layer,
+                w13=w13,
+                w2=w2,
+                w13_scale=w13_scale,
+                w13_input_scale=w13_input_scale,
+                w2_scale=w2_scale,
+                w2_input_scale=w2_input_scale,
+                is_trtllm=(fp8_backend == Fp8MoeBackend.FLASHINFER_TRTLLM),
+            )
+        else:
+            if fp8_backend not in [
+                Fp8MoeBackend.TRITON,
+                Fp8MoeBackend.BATCHED_TRITON,
+                Fp8MoeBackend.VLLM_CUTLASS,
+                Fp8MoeBackend.BATCHED_VLLM_CUTLASS,
+                Fp8MoeBackend.XPU,
+            ]:
+                raise ValueError(f"Unsupported FP8 MoE backend: {fp8_backend.value}")
+
+        return w13, w2, w13_scale, w2_scale
+
+    def make_quant_config(
+        self,
+        fp8_backend: Fp8MoeBackend,
+        w1_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        a1_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        block_shape: list[int] | None = None,
+        per_act_token_quant: bool = False,
+        per_out_ch_quant: bool = False,
+    ) -> FusedMoEQuantConfig:
+        """
+        Create FusedMoEQuantConfig for the specified FP8 Backend.
+        The FusedMoEQuantConfig holds the scales that are used
+        at runtime by the Modular Kernel abstraction.
+
+        Note that certain kernels (e.g. Flashinfer CUTLASS) need
+        special Quant configs to handle non-standard inputs to
+        their kernel interfaces.
+
+        In a future PR, we will have this function should be
+        a method of the modular kernel itself.
+        """
+
+        # MARLIN is mixed precision W8A16 config.
+        if fp8_backend == Fp8MoeBackend.MARLIN:
+            return fp8_w8a16_moe_quant_config(
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                block_shape=block_shape,
+            )
+
+        # Flashinfer CUTLASS per-tensor uses single dq scale
+        # (alpha = w_scale * a_scale) and inverse a2 scale.
+        if fp8_backend == Fp8MoeBackend.FLASHINFER_CUTLASS and block_shape is None:
+            assert a1_scale is not None and a2_scale is not None
+            return fp8_w8a8_moe_quant_config(
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                a1_scale=a1_scale,
+                a2_scale=a2_scale,
+                a1_gscale=(1.0 / a1_scale),
+                a2_gscale=(1.0 / a2_scale),
+                g1_alphas=(w1_scale * a1_scale).squeeze(),
+                g2_alphas=(w2_scale * a2_scale).squeeze(),
+            )
+        # MXFP8 uses "mxfp8" quant_dtype so the prepare step dispatches to
+        # _mxfp8_e4m3_quantize rather than standard FP8 block quantization.
+        # Non-swizzled layout is required since the TRTLLM kernel expects
+        # scales in (num_tokens, hidden_dim // 32) format.
+        if block_shape == [1, 32]:
+            return FusedMoEQuantConfig.make(
+                "mxfp8",
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                a1_scale=a1_scale,
+                a2_scale=a2_scale,
+                block_shape=block_shape,
+                is_nvfp4_scale_swizzled=False,
+            )
+
+        # All other backends use normal config.
+        return fp8_w8a8_moe_quant_config(
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            block_shape=block_shape,
+            per_act_token_quant=per_act_token_quant,
+            per_out_ch_quant=per_out_ch_quant,
+        )
+
+    def make_kernel(
+        self,
+        moe_quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        experts_cls: type[mk.FusedMoEExperts],
+        fp8_backend: Fp8MoeBackend,
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+        shared_experts: torch.nn.Module | None = None,
+    ) -> mk.FusedMoEKernel:
+        # Create Prepare/Finalize.
+        prepare_finalize = maybe_make_prepare_finalize(
+            moe=moe_config,
+            quant_config=moe_quant_config,
+            routing_tables=routing_tables,
+            allow_new_interface=True,
+            use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),
+        )
+        assert prepare_finalize is not None
+
+        logger.info_once("Using %s", prepare_finalize.__class__.__name__, scope="local")
+
+        # Create Experts.
+        if (
+            prepare_finalize.activation_format
+            == mk.FusedMoEActivationFormat.BatchedExperts
+        ):
+            max_num_tokens = prepare_finalize.max_num_tokens_per_rank()
+            assert max_num_tokens is not None
+            experts = experts_cls(
+                moe_config=moe_config,
+                quant_config=moe_quant_config,
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=prepare_finalize.num_dispatchers(),
+            )
+        else:
+            experts = experts_cls(
+                moe_config=moe_config,
+                quant_config=moe_quant_config,
+            )
+
+        # NOTE(rob): we only want the mk to control the shared_expert
+        # if using all2all (for SBO). bnell is making this explicit in
+        # the new MoE runner class.
+        kernel = mk.FusedMoEKernel(
+            prepare_finalize,
+            experts,
+            shared_experts=(
+                shared_experts
+                if moe_config.moe_parallel_config.use_deepep_ll_kernels
+                else None
+            ),
+            moe_parallel_config=moe_config.moe_parallel_config,
+            inplace=(
+                not moe_config.disable_inplace
+                and fp8_backend != Fp8MoeBackend.FLASHINFER_CUTLASS
+            ),
+        )
+
+        return kernel
+
+
+_oracle = Fp8MoEKernelOracle()
+
+
 def backend_to_kernel_cls(
     backend: Fp8MoeBackend,
 ) -> list[type[mk.FusedMoEExperts]]:
-    if backend == Fp8MoeBackend.FLASHINFER_TRTLLM:
-        from vllm.model_executor.layers.fused_moe.experts.trtllm_fp8_moe import (  # noqa: E501
-            TrtLlmFp8ExpertsModular,
-            TrtLlmFp8ExpertsMonolithic,
-        )
-
-        return [TrtLlmFp8ExpertsMonolithic, TrtLlmFp8ExpertsModular]
-
-    elif backend == Fp8MoeBackend.FLASHINFER_CUTLASS:
-        from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
-            FlashInferExperts,
-        )
-
-        return [FlashInferExperts]
-
-    elif backend == Fp8MoeBackend.DEEPGEMM:
-        from vllm.model_executor.layers.fused_moe.triton_deep_gemm_moe import (
-            TritonOrDeepGemmExperts,
-        )
-
-        return [TritonOrDeepGemmExperts]
-
-    elif backend == Fp8MoeBackend.BATCHED_DEEPGEMM:
-        from vllm.model_executor.layers.fused_moe.batched_deep_gemm_moe import (
-            BatchedDeepGemmExperts,
-        )
-
-        return [BatchedDeepGemmExperts]
-
-    elif backend == Fp8MoeBackend.MARLIN:
-        from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
-            MarlinExperts,
-        )
-
-        return [MarlinExperts]
-
-    elif backend == Fp8MoeBackend.TRITON:
-        from vllm.model_executor.layers.fused_moe.fused_moe import (
-            TritonExperts,
-        )
-
-        return [TritonExperts]
-
-    elif backend == Fp8MoeBackend.BATCHED_TRITON:
-        from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
-            BatchedTritonExperts,
-        )
-
-        return [BatchedTritonExperts]
-
-    elif backend == Fp8MoeBackend.AITER:
-        from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
-            AiterExperts,
-        )
-
-        return [AiterExperts]
-
-    elif backend == Fp8MoeBackend.VLLM_CUTLASS:
-        from vllm.model_executor.layers.fused_moe.triton_cutlass_moe import (
-            TritonOrCutlassExperts,
-        )
-
-        return [TritonOrCutlassExperts]
-
-    elif backend == Fp8MoeBackend.BATCHED_VLLM_CUTLASS:
-        from vllm.model_executor.layers.fused_moe.cutlass_moe import (
-            CutlassBatchedExpertsFp8,
-        )
-
-        return [CutlassBatchedExpertsFp8]
-
-    elif backend == Fp8MoeBackend.XPU:
-        from vllm.model_executor.layers.fused_moe.xpu_fused_moe import (
-            XPUExpertsFp8,
-        )
-
-        return [XPUExpertsFp8]
-
-    else:
-        raise ValueError(f"Unknown FP8 MoE backend: {backend.value}")
+    return _oracle.backend_to_kernel_cls(backend)
 
 
 def map_fp8_backend(runner_backend: MoEBackend) -> Fp8MoeBackend:
     """Map user's MoEBackend to Fp8MoeBackend."""
-    mapping = {
-        "triton": Fp8MoeBackend.TRITON,
-        "deep_gemm": Fp8MoeBackend.DEEPGEMM,
-        "cutlass": Fp8MoeBackend.VLLM_CUTLASS,
-        "flashinfer_trtllm": Fp8MoeBackend.FLASHINFER_TRTLLM,
-        "flashinfer_cutlass": Fp8MoeBackend.FLASHINFER_CUTLASS,
-        "marlin": Fp8MoeBackend.MARLIN,
-        "aiter": Fp8MoeBackend.AITER,
-    }
-    if backend := mapping.get(runner_backend):
-        return backend
-    raise ValueError(
-        f"moe_backend='{runner_backend}' is not supported for FP8 MoE. "
-        f"Expected one of {list(mapping.keys())}."
-    )
+    return _oracle.map_backend(runner_backend)
 
 
 def select_fp8_moe_backend(
@@ -216,198 +633,9 @@ def select_fp8_moe_backend(
     Select the primary FP8 MoE backend
     Note: Shape-specific fallbacks may still occur at runtime.
     """
-
-    if config.is_lora_enabled:
-        return Fp8MoeBackend.TRITON, backend_to_kernel_cls(Fp8MoeBackend.TRITON)[0]
-
-    # NOTE: the kernels are selected in the following order.
-    AVAILABLE_BACKENDS = _get_priority_backends(config, weight_key, activation_key)
-
-    # NOTE(rob): We need to peak into the P/F selection to determine
-    # if we are using the batched or standard expert format, which
-    # if not ideal. Once we unify TP + DP/EP, we can select P/F first.
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
+    return _oracle.select_backend(
+        config, weight_key, activation_key, allow_vllm_cutlass
     )
-
-    def _make_log_backend(backend: Fp8MoeBackend):
-        available_backend_strs = [b.value for b in AVAILABLE_BACKENDS]
-        return (
-            f"Using {backend.value} Fp8 MoE backend out "
-            f"of potential backends: {available_backend_strs}."
-        )
-
-    def _make_log_unsupported(backend: Fp8MoeBackend, reason: str | None) -> str:
-        if reason:
-            return (
-                f"FP8 MoE backend {backend.value} does not support the "
-                f"deployment configuration since {reason}."
-            )
-        else:
-            return (
-                f"FP8 MoE backend '{backend.value}' does not support the "
-                "deployment configuration."
-            )
-
-    def _return_or_raise(
-        backend: Fp8MoeBackend,
-        config: FusedMoEConfig,
-        weight_key: QuantKey | None,
-        activation_key: QuantKey | None,
-        activation_format: mk.FusedMoEActivationFormat,
-    ) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts]]:
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, weight_key, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
-                return backend, k_cls
-        raise ValueError(_make_log_unsupported(backend, reason))
-
-    # Handle explicit moe_backend from user.
-    runner_backend = config.moe_backend
-    if runner_backend != "auto":
-        requested_backend = map_fp8_backend(runner_backend)
-        # For batched activation format, use batched variants if available.
-        if activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
-            if requested_backend == Fp8MoeBackend.DEEPGEMM:
-                requested_backend = Fp8MoeBackend.BATCHED_DEEPGEMM
-            elif requested_backend == Fp8MoeBackend.TRITON:
-                requested_backend = Fp8MoeBackend.BATCHED_TRITON
-            elif requested_backend == Fp8MoeBackend.VLLM_CUTLASS:
-                requested_backend = Fp8MoeBackend.BATCHED_VLLM_CUTLASS
-
-        if (
-            requested_backend
-            in [
-                Fp8MoeBackend.VLLM_CUTLASS,
-                Fp8MoeBackend.BATCHED_VLLM_CUTLASS,
-            ]
-            and not allow_vllm_cutlass
-        ):
-            raise ValueError(
-                "vLLM CUTLASS FP8 MoE backend is disabled for this configuration."
-            )
-
-        return _return_or_raise(
-            requested_backend, config, weight_key, activation_key, activation_format
-        )
-
-    # Handle explicit FlashInfer FP8 configuration.
-    if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP8"):
-        if not envs.VLLM_USE_FLASHINFER_MOE_FP8:
-            # If the user rejects FlashInfer remove those backends.
-            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.FLASHINFER_TRTLLM)
-            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.FLASHINFER_CUTLASS)
-
-        elif envs.is_set("VLLM_FLASHINFER_MOE_BACKEND"):
-            # If user is explicit about backend, validate it.
-            fi_backend = get_flashinfer_moe_backend()
-            if fi_backend == FlashinferMoeBackend.CUTLASS:
-                backend = Fp8MoeBackend.FLASHINFER_CUTLASS
-            elif fi_backend == FlashinferMoeBackend.TENSORRT_LLM:
-                backend = Fp8MoeBackend.FLASHINFER_TRTLLM
-            else:
-                raise ValueError(
-                    f"FlashInfer MOE backend {fi_backend} does not support FP8 MoE."
-                )
-            k_cls = backend_to_kernel_cls(backend)[0]
-            return _return_or_raise(
-                backend, config, weight_key, activation_key, activation_format
-            )
-        else:
-            # If the user is not explicit about the backend, try both.
-            for backend in [
-                Fp8MoeBackend.FLASHINFER_TRTLLM,
-                Fp8MoeBackend.FLASHINFER_CUTLASS,
-            ]:
-                for k_cls in backend_to_kernel_cls(backend):
-                    supported, reason = k_cls.is_supported_config(
-                        k_cls,
-                        config,
-                        weight_key,
-                        activation_key,
-                        activation_format,
-                    )
-
-                    if supported:
-                        logger.info_once(_make_log_backend(backend), scope="local")
-                        return backend, k_cls
-                    else:
-                        logger.debug_once(
-                            _make_log_unsupported(backend, reason), scope="local"
-                        )
-
-            raise NotImplementedError(
-                "Found VLLM_USE_FLASHINFER_MOE_FP8=1, but no "
-                "FlashInfer FP8 MoE backend supports the configuration."
-            )
-
-    # Handle explicit DeepGEMM FP8 configuration.
-    if envs.is_set("VLLM_USE_DEEP_GEMM") or envs.is_set("VLLM_MOE_USE_DEEP_GEMM"):
-        if not envs.VLLM_USE_DEEP_GEMM or not envs.VLLM_MOE_USE_DEEP_GEMM:
-            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.DEEPGEMM)
-            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_DEEPGEMM)
-        else:
-            backend = (
-                Fp8MoeBackend.DEEPGEMM
-                if activation_format == mk.FusedMoEActivationFormat.Standard
-                else Fp8MoeBackend.BATCHED_DEEPGEMM
-            )
-            return _return_or_raise(
-                backend, config, weight_key, activation_key, activation_format
-            )
-
-    # Handle explicit MARLIN FP8 configuration.
-    if envs.VLLM_TEST_FORCE_FP8_MARLIN:
-        backend = Fp8MoeBackend.MARLIN
-        return _return_or_raise(
-            backend, config, weight_key, activation_key, activation_format
-        )
-
-    # Handle explicit AITER FP8 configuration.
-    if envs.is_set("VLLM_ROCM_USE_AITER") or envs.is_set("VLLM_ROCM_USE_AITER_MOE"):
-        if not envs.VLLM_ROCM_USE_AITER or not envs.VLLM_ROCM_USE_AITER_MOE:
-            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.AITER)
-        else:
-            backend = Fp8MoeBackend.AITER
-            return _return_or_raise(
-                backend, config, weight_key, activation_key, activation_format
-            )
-
-    if not allow_vllm_cutlass:
-        AVAILABLE_BACKENDS.remove(Fp8MoeBackend.VLLM_CUTLASS)
-        AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_VLLM_CUTLASS)
-
-    # Select kernels in order of backend.
-    for backend in AVAILABLE_BACKENDS:
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls,
-                config,
-                weight_key,
-                activation_key,
-                activation_format,
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
-                return backend, k_cls
-            else:
-                logger.debug_once(_make_log_unsupported(backend, reason), scope="local")
-
-    # TODO(rob): per discussion with TPU team, we need a way to register
-    # MoE backends by OOT plugins, rather than having an explicit list
-    # of AVAILABLE_BACKENDS. Enabling returning `Fp8MoeBackend.NONE` is
-    # a temporary measure until these register APIs are complete.
-    if current_platform.is_cuda() or current_platform.is_rocm():
-        raise NotImplementedError(
-            "No FP8 MoE backend supports the deployment configuration."
-        )
-
-    return Fp8MoeBackend.NONE, None
 
 
 def convert_to_fp8_moe_kernel_format(
@@ -420,51 +648,16 @@ def convert_to_fp8_moe_kernel_format(
     w13_input_scale: torch.Tensor | None,
     w2_input_scale: torch.Tensor | None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    block_quant = hasattr(layer, "weight_block_size")
-    if fp8_backend in [Fp8MoeBackend.DEEPGEMM, Fp8MoeBackend.BATCHED_DEEPGEMM]:
-        assert block_quant
-        w13, w2, w13_scale, w2_scale = prepare_fp8_moe_layer_for_deepgemm(
-            w13,
-            w2,
-            w13_scale,
-            w2_scale,
-            tuple(layer.weight_block_size),
-        )
-    elif fp8_backend == Fp8MoeBackend.AITER:
-        w13, w2 = rocm_aiter_ops.shuffle_weights(w13, w2)
-    elif fp8_backend == Fp8MoeBackend.MARLIN:
-        w13, w2, w13_scale, w2_scale = prepare_fp8_moe_layer_for_marlin(
-            layer,
-            w13,
-            w2,
-            w13_scale,
-            w2_scale,
-        )
-    elif fp8_backend in [
-        Fp8MoeBackend.FLASHINFER_CUTLASS,
-        Fp8MoeBackend.FLASHINFER_TRTLLM,
-    ]:
-        w13, w2, w13_scale, w2_scale = prepare_fp8_moe_layer_for_fi(
-            layer=layer,
-            w13=w13,
-            w2=w2,
-            w13_scale=w13_scale,
-            w13_input_scale=w13_input_scale,
-            w2_scale=w2_scale,
-            w2_input_scale=w2_input_scale,
-            is_trtllm=(fp8_backend == Fp8MoeBackend.FLASHINFER_TRTLLM),
-        )
-    else:
-        if fp8_backend not in [
-            Fp8MoeBackend.TRITON,
-            Fp8MoeBackend.BATCHED_TRITON,
-            Fp8MoeBackend.VLLM_CUTLASS,
-            Fp8MoeBackend.BATCHED_VLLM_CUTLASS,
-            Fp8MoeBackend.XPU,
-        ]:
-            raise ValueError(f"Unsupported FP8 MoE backend: {fp8_backend.value}")
-
-    return w13, w2, w13_scale, w2_scale
+    return _oracle.convert_to_kernel_format(
+        fp8_backend,
+        layer,
+        w13,
+        w2,
+        w13_scale,
+        w2_scale,
+        w13_input_scale,
+        w2_input_scale,
+    )
 
 
 def make_fp8_moe_quant_config(
@@ -489,53 +682,15 @@ def make_fp8_moe_quant_config(
     In a future PR, we will have this function should be
     a method of the modular kernel itself.
     """
-
-    # MARLIN is mixed precision W8A16 config.
-    if fp8_backend == Fp8MoeBackend.MARLIN:
-        return fp8_w8a16_moe_quant_config(
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-            block_shape=block_shape,
-        )
-
-    # Flashinfer CUTLASS per-tensor uses single dq scale
-    # (alpha = w_scale * a_scale) and inverse a2 scale.
-    if fp8_backend == Fp8MoeBackend.FLASHINFER_CUTLASS and block_shape is None:
-        assert a1_scale is not None and a2_scale is not None
-        return fp8_w8a8_moe_quant_config(
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-            a1_scale=a1_scale,
-            a2_scale=a2_scale,
-            a1_gscale=(1.0 / a1_scale),
-            a2_gscale=(1.0 / a2_scale),
-            g1_alphas=(w1_scale * a1_scale).squeeze(),
-            g2_alphas=(w2_scale * a2_scale).squeeze(),
-        )
-    # MXFP8 uses "mxfp8" quant_dtype so the prepare step dispatches to
-    # _mxfp8_e4m3_quantize rather than standard FP8 block quantization.
-    # Non-swizzled layout is required since the TRTLLM kernel expects
-    # scales in (num_tokens, hidden_dim // 32) format.
-    if block_shape == [1, 32]:
-        return FusedMoEQuantConfig.make(
-            "mxfp8",
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-            a1_scale=a1_scale,
-            a2_scale=a2_scale,
-            block_shape=block_shape,
-            is_nvfp4_scale_swizzled=False,
-        )
-
-    # All other backends use normal config.
-    return fp8_w8a8_moe_quant_config(
-        w1_scale=w1_scale,
-        w2_scale=w2_scale,
-        a1_scale=a1_scale,
-        a2_scale=a2_scale,
-        block_shape=block_shape,
-        per_act_token_quant=per_act_token_quant,
-        per_out_ch_quant=per_out_ch_quant,
+    return _oracle.make_quant_config(
+        fp8_backend,
+        w1_scale,
+        w2_scale,
+        a1_scale,
+        a2_scale,
+        block_shape,
+        per_act_token_quant,
+        per_out_ch_quant,
     )
 
 
@@ -547,50 +702,11 @@ def make_fp8_moe_kernel(
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     shared_experts: torch.nn.Module | None = None,
 ) -> mk.FusedMoEKernel:
-    # Create Prepare/Finalize.
-    prepare_finalize = maybe_make_prepare_finalize(
-        moe=moe_config,
-        quant_config=moe_quant_config,
-        routing_tables=routing_tables,
-        allow_new_interface=True,
-        use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),
+    return _oracle.make_kernel(
+        moe_quant_config,
+        moe_config,
+        experts_cls,
+        fp8_backend,
+        routing_tables,
+        shared_experts,
     )
-    assert prepare_finalize is not None
-
-    logger.info_once("Using %s", prepare_finalize.__class__.__name__, scope="local")
-
-    # Create Experts.
-    if prepare_finalize.activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
-        max_num_tokens = prepare_finalize.max_num_tokens_per_rank()
-        assert max_num_tokens is not None
-        experts = experts_cls(
-            moe_config=moe_config,
-            quant_config=moe_quant_config,
-            max_num_tokens=max_num_tokens,
-            num_dispatchers=prepare_finalize.num_dispatchers(),
-        )
-    else:
-        experts = experts_cls(
-            moe_config=moe_config,
-            quant_config=moe_quant_config,
-        )
-
-    # NOTE(rob): we only want the mk to control the shared_expert
-    # if using all2all (for SBO). bnell is making this explicit in
-    # the new MoE runner class.
-    kernel = mk.FusedMoEKernel(
-        prepare_finalize,
-        experts,
-        shared_experts=(
-            shared_experts
-            if moe_config.moe_parallel_config.use_deepep_ll_kernels
-            else None
-        ),
-        moe_parallel_config=moe_config.moe_parallel_config,
-        inplace=(
-            not moe_config.disable_inplace
-            and fp8_backend != Fp8MoeBackend.FLASHINFER_CUTLASS
-        ),
-    )
-
-    return kernel

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -106,10 +106,6 @@ def _get_priority_backends(
 class Fp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
     """Oracle for FP8 MoE kernel selection."""
 
-    @property
-    def quant_type_name(self) -> str:
-        return "Fp8"
-
     def backend_to_kernel_cls(
         self,
         backend: Fp8MoeBackend,
@@ -226,7 +222,8 @@ class Fp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
         """
 
         if config.is_lora_enabled:
-            return Fp8MoeBackend.TRITON, backend_to_kernel_cls(Fp8MoeBackend.TRITON)[0]
+            triton_cls = self.backend_to_kernel_cls(Fp8MoeBackend.TRITON)
+            return Fp8MoeBackend.TRITON, triton_cls[0]
 
         # NOTE: the kernels are selected in the following order.
         AVAILABLE_BACKENDS = _get_priority_backends(config, weight_key, activation_key)
@@ -266,7 +263,7 @@ class Fp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
             activation_key: QuantKey | None,
             activation_format: mk.FusedMoEActivationFormat,
         ) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts]]:
-            for k_cls in backend_to_kernel_cls(backend):
+            for k_cls in self.backend_to_kernel_cls(backend):
                 supported, reason = k_cls.is_supported_config(
                     k_cls, config, weight_key, activation_key, activation_format
                 )
@@ -278,7 +275,7 @@ class Fp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
         # Handle explicit moe_backend from user.
         runner_backend = config.moe_backend
         if runner_backend != "auto":
-            requested_backend = map_fp8_backend(runner_backend)
+            requested_backend = self.map_backend(runner_backend)
             # For batched activation format, use batched variants if available.
             if activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
                 if requested_backend == Fp8MoeBackend.DEEPGEMM:
@@ -322,7 +319,7 @@ class Fp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
                     raise ValueError(
                         f"FlashInfer MOE backend {fi_backend} does not support FP8 MoE."
                     )
-                k_cls = backend_to_kernel_cls(backend)[0]
+                k_cls = self.backend_to_kernel_cls(backend)[0]
                 return _return_or_raise(
                     backend, config, weight_key, activation_key, activation_format
                 )
@@ -332,7 +329,7 @@ class Fp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
                     Fp8MoeBackend.FLASHINFER_TRTLLM,
                     Fp8MoeBackend.FLASHINFER_CUTLASS,
                 ]:
-                    for k_cls in backend_to_kernel_cls(backend):
+                    for k_cls in self.backend_to_kernel_cls(backend):
                         supported, reason = k_cls.is_supported_config(
                             k_cls,
                             config,
@@ -392,7 +389,7 @@ class Fp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
 
         # Select kernels in order of backend.
         for backend in AVAILABLE_BACKENDS:
-            for k_cls in backend_to_kernel_cls(backend):
+            for k_cls in self.backend_to_kernel_cls(backend):
                 supported, reason = k_cls.is_supported_config(
                     k_cls,
                     config,

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -7,6 +7,7 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm import envs
+from vllm.config.kernel import MoEBackend
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
@@ -109,10 +110,6 @@ def _backend_activation_key(backend: Mxfp4MoeBackend) -> QuantKey | None:
 class Mxfp4MoEKernelOracle(MoEKernelOracle[Mxfp4MoeBackend]):
     """Oracle for MXFP4 MoE kernel selection."""
 
-    @property
-    def quant_type_name(self) -> str:
-        return "Mxfp4"
-
     def backend_to_kernel_cls(
         self,
         backend: Mxfp4MoeBackend,
@@ -181,7 +178,7 @@ class Mxfp4MoEKernelOracle(MoEKernelOracle[Mxfp4MoeBackend]):
         else:
             raise ValueError(f"Unknown MXFP4 MoE backend: {backend.value}")
 
-    def map_backend(self, runner_backend: str) -> Mxfp4MoeBackend:
+    def map_backend(self, runner_backend: MoEBackend) -> Mxfp4MoeBackend:
         """Map user's moe_backend string to Mxfp4MoeBackend."""
         mapping: dict[str, Mxfp4MoeBackend] = {
             "flashinfer_trtllm": Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
@@ -218,11 +215,11 @@ class Mxfp4MoEKernelOracle(MoEKernelOracle[Mxfp4MoeBackend]):
                 raise NotImplementedError("Mxfp4 LoRA only supported on CUDA Platform.")
             if envs.VLLM_MXFP4_USE_MARLIN is False and triton_kernels_supported:
                 logger.info_once("Using Triton backend for mxfp4 lora")
-                return Mxfp4MoeBackend.TRITON_UNFUSED, backend_to_kernel_cls(
+                return Mxfp4MoeBackend.TRITON_UNFUSED, self.backend_to_kernel_cls(
                     Mxfp4MoeBackend.TRITON_UNFUSED
                 )[0]
             logger.info_once("Using Marlin backend for mxfp4 lora")
-            return Mxfp4MoeBackend.MARLIN, backend_to_kernel_cls(
+            return Mxfp4MoeBackend.MARLIN, self.backend_to_kernel_cls(
                 Mxfp4MoeBackend.MARLIN
             )[0]
 
@@ -254,7 +251,7 @@ class Mxfp4MoEKernelOracle(MoEKernelOracle[Mxfp4MoeBackend]):
             activation_format: mk.FusedMoEActivationFormat,
         ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
             reason: str | None = None
-            for k_cls in backend_to_kernel_cls(backend):
+            for k_cls in self.backend_to_kernel_cls(backend):
                 supported, reason = k_cls.is_supported_config(
                     k_cls, config, weight_key, activation_key, activation_format
                 )
@@ -265,7 +262,7 @@ class Mxfp4MoEKernelOracle(MoEKernelOracle[Mxfp4MoeBackend]):
 
         runner_backend = config.moe_backend
         if runner_backend != "auto":
-            requested_backend = map_mxfp4_backend(runner_backend)
+            requested_backend = self.map_backend(runner_backend)
             if (
                 activation_format == mk.FusedMoEActivationFormat.BatchedExperts
                 and requested_backend == Mxfp4MoeBackend.MARLIN
@@ -348,7 +345,7 @@ class Mxfp4MoEKernelOracle(MoEKernelOracle[Mxfp4MoeBackend]):
 
         for backend in AVAILABLE_BACKENDS:
             activation_key = _backend_activation_key(backend)
-            for k_cls in backend_to_kernel_cls(backend):
+            for k_cls in self.backend_to_kernel_cls(backend):
                 supported, reason = k_cls.is_supported_config(
                     k_cls, config, kMxfp4Static, activation_key, activation_format
                 )

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     mxfp4_w4a16_moe_quant_config,
     ocp_mx_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
     _swizzle_mxfp4,
     get_padding_alignment,
@@ -78,93 +79,6 @@ TRITON_BACKENDS = (
 )
 
 
-def backend_to_kernel_cls(
-    backend: Mxfp4MoeBackend,
-) -> list[type[mk.FusedMoEExperts]]:
-    if backend in (
-        Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
-        Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
-    ):
-        from vllm.model_executor.layers.fused_moe.experts.trtllm_mxfp4_moe import (
-            TrtLlmMxfp4ExpertsModular,
-            TrtLlmMxfp4ExpertsMonolithic,
-        )
-
-        # NOTE: prefer Monolithic > Modular, so return Monolithic first.
-        return [TrtLlmMxfp4ExpertsMonolithic, TrtLlmMxfp4ExpertsModular]
-
-    elif backend in (
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
-    ):
-        from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
-            FlashInferExperts,
-        )
-
-        return [FlashInferExperts]
-
-    elif backend == Mxfp4MoeBackend.TRITON:
-        from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
-            OAITritonExperts,
-            OAITritonMxfp4ExpertsMonolithic,
-        )
-
-        # NOTE: prefer Monolithic > Modular, so return Monolithic first.
-        return [OAITritonMxfp4ExpertsMonolithic, OAITritonExperts]
-
-    elif backend == Mxfp4MoeBackend.TRITON_UNFUSED:
-        from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
-            UnfusedOAITritonExperts,
-        )
-
-        return [UnfusedOAITritonExperts]
-
-    elif backend == Mxfp4MoeBackend.MARLIN:
-        from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
-            MarlinExperts,
-        )
-
-        return [MarlinExperts]
-
-    elif backend == Mxfp4MoeBackend.BATCHED_MARLIN:
-        from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
-            BatchedMarlinExperts,
-        )
-
-        return [BatchedMarlinExperts]
-
-    elif backend == Mxfp4MoeBackend.CK:
-        from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
-            AiterExperts,
-        )
-
-        return [AiterExperts]
-
-    elif backend == Mxfp4MoeBackend.XPU:
-        raise NotImplementedError("XPU backend uses XpuMxfp4MoEMethod directly.")
-    else:
-        raise ValueError(f"Unknown MXFP4 MoE backend: {backend.value}")
-
-
-def map_mxfp4_backend(runner_backend: str) -> Mxfp4MoeBackend:
-    """Map user's moe_backend string to Mxfp4MoeBackend."""
-    mapping: dict[str, Mxfp4MoeBackend] = {
-        "flashinfer_trtllm": Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
-        "flashinfer_trtllm_afp8": Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
-        "flashinfer_cutlass": Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
-        "flashinfer_cutlass_afp8": Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
-        "triton": Mxfp4MoeBackend.TRITON,
-        "marlin": Mxfp4MoeBackend.MARLIN,
-        "ck": Mxfp4MoeBackend.CK,
-    }
-    if backend := mapping.get(runner_backend):
-        return backend
-    raise ValueError(
-        f"moe_backend='{runner_backend}' is not supported for MXFP4 MoE. "
-        f"Expected one of {list(mapping.keys())}."
-    )
-
-
 def _get_priority_backends() -> list[Mxfp4MoeBackend]:
     """
     Get available backends in priority order based on platform and config.
@@ -192,6 +106,783 @@ def _backend_activation_key(backend: Mxfp4MoeBackend) -> QuantKey | None:
     return None
 
 
+class Mxfp4MoEKernelOracle(MoEKernelOracle[Mxfp4MoeBackend]):
+    """Oracle for MXFP4 MoE kernel selection."""
+
+    @property
+    def quant_type_name(self) -> str:
+        return "Mxfp4"
+
+    def backend_to_kernel_cls(
+        self,
+        backend: Mxfp4MoeBackend,
+    ) -> list[type[mk.FusedMoEExperts]]:
+        if backend in (
+            Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
+            Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
+        ):
+            from vllm.model_executor.layers.fused_moe.experts.trtllm_mxfp4_moe import (
+                TrtLlmMxfp4ExpertsModular,
+                TrtLlmMxfp4ExpertsMonolithic,
+            )
+
+            # NOTE: prefer Monolithic > Modular, so return Monolithic first.
+            return [TrtLlmMxfp4ExpertsMonolithic, TrtLlmMxfp4ExpertsModular]
+
+        elif backend in (
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+        ):
+            from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
+                FlashInferExperts,
+            )
+
+            return [FlashInferExperts]
+
+        elif backend == Mxfp4MoeBackend.TRITON:
+            from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (  # noqa: E501
+                OAITritonExperts,
+                OAITritonMxfp4ExpertsMonolithic,
+            )
+
+            # NOTE: prefer Monolithic > Modular, so return Monolithic first.
+            return [OAITritonMxfp4ExpertsMonolithic, OAITritonExperts]
+
+        elif backend == Mxfp4MoeBackend.TRITON_UNFUSED:
+            from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (  # noqa: E501
+                UnfusedOAITritonExperts,
+            )
+
+            return [UnfusedOAITritonExperts]
+
+        elif backend == Mxfp4MoeBackend.MARLIN:
+            from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
+                MarlinExperts,
+            )
+
+            return [MarlinExperts]
+
+        elif backend == Mxfp4MoeBackend.BATCHED_MARLIN:
+            from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
+                BatchedMarlinExperts,
+            )
+
+            return [BatchedMarlinExperts]
+
+        elif backend == Mxfp4MoeBackend.CK:
+            from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+                AiterExperts,
+            )
+
+            return [AiterExperts]
+
+        elif backend == Mxfp4MoeBackend.XPU:
+            raise NotImplementedError("XPU backend uses XpuMxfp4MoEMethod directly.")
+        else:
+            raise ValueError(f"Unknown MXFP4 MoE backend: {backend.value}")
+
+    def map_backend(self, runner_backend: str) -> Mxfp4MoeBackend:
+        """Map user's moe_backend string to Mxfp4MoeBackend."""
+        mapping: dict[str, Mxfp4MoeBackend] = {
+            "flashinfer_trtllm": Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
+            "flashinfer_trtllm_afp8": Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
+            "flashinfer_cutlass": Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+            "flashinfer_cutlass_afp8": Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+            "triton": Mxfp4MoeBackend.TRITON,
+            "marlin": Mxfp4MoeBackend.MARLIN,
+            "ck": Mxfp4MoeBackend.CK,
+        }
+        if backend := mapping.get(runner_backend):
+            return backend
+        raise ValueError(
+            f"moe_backend='{runner_backend}' is not supported for MXFP4 MoE. "
+            f"Expected one of {list(mapping.keys())}."
+        )
+
+    def select_backend(
+        self,
+        config: FusedMoEConfig,
+    ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts] | None]:
+        """
+        Select the primary MXFP4 MoE backend.
+        Note: Shape-specific fallbacks may still occur at runtime.
+        """
+        triton_kernels_supported = has_triton_kernels() and (
+            9,
+            0,
+        ) <= current_platform.get_device_capability() < (11, 0)
+
+        # LoRA: separate experts backend path
+        if config.is_lora_enabled:
+            if not current_platform.is_cuda():
+                raise NotImplementedError("Mxfp4 LoRA only supported on CUDA Platform.")
+            if envs.VLLM_MXFP4_USE_MARLIN is False and triton_kernels_supported:
+                logger.info_once("Using Triton backend for mxfp4 lora")
+                return Mxfp4MoeBackend.TRITON_UNFUSED, backend_to_kernel_cls(
+                    Mxfp4MoeBackend.TRITON_UNFUSED
+                )[0]
+            logger.info_once("Using Marlin backend for mxfp4 lora")
+            return Mxfp4MoeBackend.MARLIN, backend_to_kernel_cls(
+                Mxfp4MoeBackend.MARLIN
+            )[0]
+
+        activation_format = (
+            mk.FusedMoEActivationFormat.BatchedExperts
+            if config.moe_parallel_config.use_batched_activation_format
+            else mk.FusedMoEActivationFormat.Standard
+        )
+
+        def _make_log_backend(backend: Mxfp4MoeBackend):
+            return f"Using '{backend.value}' Mxfp4 MoE backend."
+
+        def _make_log_unsupported(backend: Mxfp4MoeBackend, reason: str | None) -> str:
+            if reason:
+                return (
+                    f"Mxfp4 MoE backend '{backend.value}' does not support the "
+                    f"deployment configuration since {reason}."
+                )
+            return (
+                f"Mxfp4 MoE backend '{backend.value}' does not support the "
+                "deployment configuration."
+            )
+
+        def _return_or_raise(
+            backend: Mxfp4MoeBackend,
+            config: FusedMoEConfig,
+            weight_key: QuantKey | None,
+            activation_key: QuantKey | None,
+            activation_format: mk.FusedMoEActivationFormat,
+        ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
+            reason: str | None = None
+            for k_cls in backend_to_kernel_cls(backend):
+                supported, reason = k_cls.is_supported_config(
+                    k_cls, config, weight_key, activation_key, activation_format
+                )
+                if supported:
+                    logger.info_once(_make_log_backend(backend), scope="local")
+                    return backend, k_cls
+            raise ValueError(_make_log_unsupported(backend, reason))
+
+        runner_backend = config.moe_backend
+        if runner_backend != "auto":
+            requested_backend = map_mxfp4_backend(runner_backend)
+            if (
+                activation_format == mk.FusedMoEActivationFormat.BatchedExperts
+                and requested_backend == Mxfp4MoeBackend.MARLIN
+            ):
+                requested_backend = Mxfp4MoeBackend.BATCHED_MARLIN
+            return _return_or_raise(
+                requested_backend,
+                config,
+                kMxfp4Static,
+                _backend_activation_key(requested_backend),
+                activation_format,
+            )
+
+        # Select kernels in order of backend.
+        AVAILABLE_BACKENDS = _get_priority_backends()
+
+        # Handle explicit FlashInfer MXFP4 BF16 configuration.
+        if envs.is_set("VLLM_USE_FLASHINFER_MOE_MXFP4_BF16"):
+            if not envs.VLLM_USE_FLASHINFER_MOE_MXFP4_BF16:
+                AVAILABLE_BACKENDS.remove(Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16)
+                AVAILABLE_BACKENDS.remove(Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16)
+            else:
+                if current_platform.is_device_capability(90):
+                    return _return_or_raise(
+                        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+                        config,
+                        kMxfp4Static,
+                        None,
+                        activation_format,
+                    )
+                if current_platform.is_device_capability_family(100):
+                    return _return_or_raise(
+                        Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
+                        config,
+                        kMxfp4Static,
+                        None,
+                        activation_format,
+                    )
+                raise ValueError(
+                    "VLLM_USE_FLASHINFER_MOE_MXFP4_BF16=1 is set but the "
+                    "current device capability is not supported. "
+                    "Only SM90 (CUTLASS) and SM100+ (TRTLLM) are supported."
+                )
+
+        # Handle explicit FlashInfer MXFP4 MXFP8 TRTLLM configuration.
+        if (
+            envs.is_set("VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8")
+            and envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8
+        ):
+            return _return_or_raise(
+                Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
+                config,
+                kMxfp4Static,
+                kMxfp8Dynamic,
+                activation_format,
+            )
+
+        # Handle explicit FlashInfer MXFP4 MXFP8 CUTLASS configuration.
+        if (
+            envs.is_set("VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS")
+            and envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS
+        ):
+            return _return_or_raise(
+                Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+                config,
+                kMxfp4Static,
+                kMxfp8Dynamic,
+                activation_format,
+            )
+
+        # Handle explicit Marlin MXFP4 configuration.
+        if envs.is_set("VLLM_MXFP4_USE_MARLIN") and envs.VLLM_MXFP4_USE_MARLIN:
+            return _return_or_raise(
+                Mxfp4MoeBackend.MARLIN,
+                config,
+                kMxfp4Static,
+                None,
+                activation_format,
+            )
+
+        for backend in AVAILABLE_BACKENDS:
+            activation_key = _backend_activation_key(backend)
+            for k_cls in backend_to_kernel_cls(backend):
+                supported, reason = k_cls.is_supported_config(
+                    k_cls, config, kMxfp4Static, activation_key, activation_format
+                )
+                if supported:
+                    logger.info_once(_make_log_backend(backend), scope="local")
+                    return backend, k_cls
+                else:
+                    logger.debug_once(
+                        _make_log_unsupported(backend, reason), scope="local"
+                    )
+
+        if current_platform.is_xpu():
+            backend = Mxfp4MoeBackend.XPU
+            logger.info_once(_make_log_backend(backend))
+            return backend, None
+
+        if current_platform.is_cuda() or current_platform.is_rocm():
+            raise NotImplementedError(
+                "No MXFP4 MoE backend supports the deployment configuration."
+            )
+
+        return Mxfp4MoeBackend.NONE, None
+
+    def round_up_hidden_size_and_intermediate_size(
+        self, backend: Mxfp4MoeBackend, hidden_size: int, intermediate_size: int
+    ) -> tuple[int, int]:
+        """Round up hidden_size and intermediate_size based on backend requirements."""
+        if backend in (Mxfp4MoeBackend.MARLIN, Mxfp4MoeBackend.BATCHED_MARLIN):
+            intermediate_size = round_up(intermediate_size, 128)
+            if current_platform.is_xpu():
+                hidden_size = round_up(hidden_size, 128)
+            else:
+                hidden_size = round_up(hidden_size, 256)
+        elif backend in TRTLLM_BACKENDS:
+            intermediate_size = round_up(intermediate_size, 256)
+            hidden_size = round_up(hidden_size, 256)
+        elif backend in (
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+        ):
+            intermediate_size = round_up(intermediate_size, 128)
+            hidden_size = round_up(hidden_size, 128)
+        elif current_platform.is_rocm():
+            pad_align = get_padding_alignment()
+            intermediate_size = round_up(intermediate_size, pad_align)
+            hidden_size = round_up(hidden_size, pad_align)
+        else:
+            intermediate_size = round_up(intermediate_size, 64)
+        return hidden_size, intermediate_size
+
+    def convert_to_kernel_format(
+        self,
+        mxfp4_backend: Mxfp4MoeBackend,
+        layer: torch.nn.Module,
+        w13_weight: torch.Tensor,
+        w2_weight: torch.Tensor,
+        w13_weight_scale: torch.Tensor,
+        w2_weight_scale: torch.Tensor,
+        w13_bias: torch.Tensor | None = None,
+        w2_bias: torch.Tensor | None = None,
+        _cache_permute_indices: dict[torch.Size, torch.Tensor] | None = None,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        Union[torch.Tensor, "PrecisionConfig"],
+        Union[torch.Tensor, "PrecisionConfig"],
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        """Convert loaded weights into backend-specific kernel format."""
+
+        num_experts = w13_weight.shape[0]
+        intermediate_size = w13_weight.shape[1] // 2
+        hidden_size = w13_weight.shape[2] * 2
+
+        sf_block_size = 32  # mxfp4 block size
+
+        if mxfp4_backend in (Mxfp4MoeBackend.MARLIN, Mxfp4MoeBackend.BATCHED_MARLIN):
+            from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+                prepare_moe_mxfp4_layer_for_marlin,
+            )
+
+            return prepare_moe_mxfp4_layer_for_marlin(
+                layer,
+                w13_weight,
+                w2_weight,
+                w13_weight_scale,
+                w2_weight_scale,
+                w13_bias,
+                w2_bias,
+            )
+
+        elif mxfp4_backend in TRTLLM_BACKENDS:
+            assert _cache_permute_indices is not None
+            from flashinfer.fp4_quantization import nvfp4_block_scale_interleave
+            from flashinfer.fused_moe.core import get_w2_permute_indices_with_cache
+
+            # gemm1_alpha/beta/clamp_limit are created by the expert class
+            # (TrtLlmMxfp4ExpertsBase), not on the layer.
+
+            w13_weight = w13_weight.data
+            w2_weight = w2_weight.data
+            w13_weight_scale = w13_weight_scale.data
+            w2_weight_scale = w2_weight_scale.data
+            assert w13_bias is not None and w2_bias is not None
+            w13_bias = w13_bias.data.to(torch.float32)
+            w2_bias = w2_bias.data.to(torch.float32)
+
+            # Swap w1 and w3 as the definition of swiglu is different in trtllm-gen
+            def swap_every_two_rows(x, axis=-1):
+                shape = x.shape
+                if axis < 0:
+                    axis = len(shape) + axis
+                new_shape = list(shape)
+                new_shape[axis] = shape[axis] // 2
+                new_shape.insert(axis + 1, 2)
+                x = x.reshape(*new_shape)
+                x = x.flip(axis + 1)
+                new_shape = list(shape)
+                return x.reshape(*new_shape)
+
+            w13_weight_scale = swap_every_two_rows(w13_weight_scale, -2)
+            w13_weight = swap_every_two_rows(w13_weight, -2)
+            w13_bias = swap_every_two_rows(w13_bias, -1)
+
+            # Shuffle weights and scaling factors for transposed mma output
+            gemm1_weights_shuffled = []
+            gemm1_scales_shuffled = []
+            gemm2_weights_shuffled = []
+            gemm2_scales_shuffled = []
+            gemm1_bias_shuffled = []
+            gemm2_bias_shuffled = []
+            epilogue_tile_m = 128
+            for i in range(num_experts):
+                # w13 weight
+                permute_indices = get_w2_permute_indices_with_cache(
+                    _cache_permute_indices,
+                    w13_weight[i].view(torch.uint8),
+                    epilogue_tile_m,
+                )
+                gemm1_weights_shuffled.append(
+                    w13_weight[i]
+                    .view(torch.uint8)[permute_indices.to(w13_weight.device)]
+                    .contiguous()
+                )
+                # w13 scale
+                permute_sf_indices = get_w2_permute_indices_with_cache(
+                    _cache_permute_indices,
+                    w13_weight_scale[i].view(torch.uint8),
+                    epilogue_tile_m,
+                    num_elts_per_sf=16,
+                )
+                gemm1_scales_shuffled.append(
+                    nvfp4_block_scale_interleave(
+                        w13_weight_scale[i]
+                        .view(torch.uint8)[
+                            permute_sf_indices.to(w13_weight_scale.device)
+                        ]
+                        .contiguous()
+                    )
+                )
+                # w13 bias
+                permute_bias_indices = get_w2_permute_indices_with_cache(
+                    _cache_permute_indices,
+                    w13_bias[i].clone().reshape(-1, 1),
+                    epilogue_tile_m,
+                )
+                gemm1_bias_shuffled.append(
+                    w13_bias[i]
+                    .clone()
+                    .reshape(-1, 1)[permute_bias_indices.to(w13_bias.device)]
+                    .contiguous()
+                )
+                # w2 weight
+                permute_indices = get_w2_permute_indices_with_cache(
+                    _cache_permute_indices,
+                    w2_weight[i].view(torch.uint8),
+                    epilogue_tile_m,
+                )
+                gemm2_weights_shuffled.append(
+                    w2_weight[i]
+                    .view(torch.uint8)[permute_indices.to(w2_weight.device)]
+                    .contiguous()
+                )
+                # w2 scale
+                permute_sf_indices = get_w2_permute_indices_with_cache(
+                    _cache_permute_indices,
+                    w2_weight_scale[i].view(torch.uint8),
+                    epilogue_tile_m,
+                    num_elts_per_sf=16,
+                )
+                gemm2_scales_shuffled.append(
+                    nvfp4_block_scale_interleave(
+                        w2_weight_scale[i]
+                        .view(torch.uint8)[
+                            permute_sf_indices.to(w2_weight_scale.device)
+                        ]
+                        .contiguous()
+                    )
+                )
+                # w2 bias
+                permute_indices = get_w2_permute_indices_with_cache(
+                    _cache_permute_indices,
+                    w2_bias[i].clone().reshape(-1, 1),
+                    epilogue_tile_m,
+                )
+                gemm2_bias_shuffled.append(
+                    w2_bias[i]
+                    .clone()
+                    .reshape(-1, 1)[permute_indices.to(w2_bias.device)]
+                    .contiguous()
+                )
+
+            w13_weight = torch.stack(gemm1_weights_shuffled)
+            w13_weight_scale = (
+                torch.stack(gemm1_scales_shuffled)
+                .reshape(
+                    num_experts, 2 * intermediate_size, hidden_size // sf_block_size
+                )
+                .view(torch.float8_e4m3fn)
+            )
+            w2_weight = torch.stack(gemm2_weights_shuffled)
+            w2_weight_scale = (
+                torch.stack(gemm2_scales_shuffled)
+                .reshape(num_experts, hidden_size, intermediate_size // sf_block_size)
+                .view(torch.float8_e4m3fn)
+            )
+            w13_bias = torch.stack(gemm1_bias_shuffled).reshape(num_experts, -1)
+            w2_bias = torch.stack(gemm2_bias_shuffled).reshape(num_experts, -1)
+
+            return (
+                w13_weight,
+                w2_weight,
+                w13_weight_scale,
+                w2_weight_scale,
+                w13_bias,
+                w2_bias,
+            )
+
+        elif mxfp4_backend in (
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+        ):
+            # De-interleave and swap for w13 weight, bias, and scales
+            w13_w = w13_weight.data
+            gate_w, up_w = w13_w[:, ::2, :], w13_w[:, 1::2, :]
+            deinterleaved_w13_w = torch.cat([gate_w, up_w], dim=1)
+            w1_w, w3_w = torch.chunk(deinterleaved_w13_w, 2, dim=1)
+            w13_weight_swapped = torch.cat([w3_w, w1_w], dim=1)
+
+            assert w13_bias is not None and w2_bias is not None
+            w13_b = w13_bias.data.to(torch.float32)
+            gate_b, up_b = w13_b[:, ::2], w13_b[:, 1::2]
+            deinterleaved_w13_b = torch.cat([gate_b, up_b], dim=1)
+            b1, b3 = torch.chunk(deinterleaved_w13_b, 2, dim=-1)
+            w13_bias_swapped = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
+
+            w13_s = w13_weight_scale.data
+            gate_s, up_s = w13_s[:, ::2, :], w13_s[:, 1::2, :]
+            deinterleaved_w13_s = torch.cat([gate_s, up_s], dim=1)
+            s1, s3 = torch.chunk(deinterleaved_w13_s, 2, dim=1)
+            w13_scale_swapped = torch.cat([s3, s1], dim=1)
+
+            if mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8:
+                from flashinfer import block_scale_interleave
+
+                orig_shape = w13_scale_swapped.shape
+                w13_scale_interleaved = block_scale_interleave(
+                    w13_scale_swapped.view(torch.uint8)
+                ).reshape(orig_shape)
+
+                w2_s = w2_weight_scale.data
+                orig_shape = w2_s.shape
+                w2_scale_interleaved = block_scale_interleave(
+                    w2_s.view(torch.uint8)
+                ).reshape(orig_shape)
+
+                return (
+                    w13_weight_swapped,
+                    w2_weight,
+                    w13_scale_interleaved,
+                    w2_scale_interleaved,
+                    w13_bias_swapped,
+                    w2_bias,
+                )
+
+            else:
+                assert mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16
+
+                def _interleave_mxfp4_cutlass_sm90(w):
+                    w_shape = w.shape
+                    w_interleaved = w.reshape(
+                        w_shape[0], w_shape[1], (w_shape[2] // 4), 4
+                    )
+                    w_interleaved = w_interleaved.permute(0, 2, 1, 3)
+                    w_interleaved = w_interleaved.reshape(
+                        w_shape[0], w_shape[2] // 4, w_shape[1] * 4
+                    )
+                    return w_interleaved
+
+                w31_scales = w13_scale_swapped.to(torch.uint8)
+                w31_scales_interleaved = _interleave_mxfp4_cutlass_sm90(w31_scales)
+
+                w2_scale = w2_weight_scale.data.to(torch.uint8)
+                w2_scale_interleaved = _interleave_mxfp4_cutlass_sm90(w2_scale)
+
+                return (
+                    w13_weight_swapped,
+                    w2_weight,
+                    w31_scales_interleaved,
+                    w2_scale_interleaved,
+                    w13_bias_swapped,
+                    w2_bias,
+                )
+
+        elif mxfp4_backend == Mxfp4MoeBackend.CK:
+            from vllm._aiter_ops import rocm_aiter_ops
+
+            if w13_bias is not None:
+                w13_bias = w13_bias.data.to(torch.float32)
+            if w2_bias is not None:
+                w2_bias = w2_bias.data.to(torch.float32)
+
+            e, n, k = w13_weight.shape
+
+            # De-interleave w13 rows: gate/up pairs -> contiguous gate, up blocks
+            w13_weight.view(torch.uint8).copy_(
+                w13_weight.data.view(torch.uint8)
+                .view(e, n // 2, 2, k)
+                .permute(0, 2, 1, 3)
+                .contiguous()
+                .view(e, n, k)
+            )
+            w13_weight_scale.data = (
+                w13_weight_scale.data.view(e, n // 2, 2, -1)
+                .permute(0, 2, 1, 3)
+                .contiguous()
+                .view(e, n, -1)
+            )
+
+            # View as native FP4 dtype for AITER shuffle
+            w13_weight.data = w13_weight.data.view(torch.float4_e2m1fn_x2)
+            w2_weight.data = w2_weight.data.view(torch.float4_e2m1fn_x2)
+
+            # Shuffle weights and scales for AITER CK kernel layout
+            w13_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w13_weight, 16, True)
+            shuffled_w13_scale = rocm_aiter_ops.shuffle_scale_a16w4(
+                w13_weight_scale.view(-1, w13_weight_scale.shape[-1]),
+                num_experts,
+                True,
+            )
+
+            w2_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w2_weight, 16, False)
+            shuffled_w2_scale = rocm_aiter_ops.shuffle_scale_a16w4(
+                w2_weight_scale.view(-1, w2_weight_scale.shape[-1]),
+                num_experts,
+                False,
+            )
+
+            # Permute bias to match de-interleaved weight layout
+            if w13_bias is not None:
+                w13_bias = (
+                    w13_bias.data.view(-1, n // 2, 2)
+                    .permute(0, 2, 1)
+                    .contiguous()
+                    .view(-1, n)
+                )
+
+            return (
+                w13_weight,
+                w2_weight,
+                shuffled_w13_scale,
+                shuffled_w2_scale,
+                w13_bias,
+                w2_bias,
+            )
+
+        elif mxfp4_backend in TRITON_BACKENDS:
+            from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
+
+            assert w13_bias is not None and w2_bias is not None
+            w13_bias = w13_bias.to(torch.float32)
+            w2_bias = w2_bias.to(torch.float32)
+
+            w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(
+                w13_weight,
+                w13_weight_scale,
+            )
+            w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(
+                w2_weight,
+                w2_weight_scale,
+            )
+
+            w13_precision_config = PrecisionConfig(
+                weight_scale=w13_scale, flex_ctx=FlexCtx(rhs_data=w13_flex)
+            )
+            w2_precision_config = PrecisionConfig(
+                weight_scale=w2_scale, flex_ctx=FlexCtx(rhs_data=w2_flex)
+            )
+
+            del layer.w13_weight
+            del layer.w2_weight
+
+            return (
+                w13_weight,
+                w2_weight,
+                w13_precision_config,
+                w2_precision_config,
+                w13_bias,
+                w2_bias,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported mxfp4_backend: {mxfp4_backend}: "
+                f"should be one of: {list(Mxfp4MoeBackend)}."
+            )
+
+    def make_quant_config(
+        self,
+        mxfp4_backend: Mxfp4MoeBackend,
+        w1_scale: Union[torch.Tensor, "PrecisionConfig"],
+        w2_scale: Union[torch.Tensor, "PrecisionConfig"],
+        w1_bias: torch.Tensor | None = None,
+        w2_bias: torch.Tensor | None = None,
+    ) -> FusedMoEQuantConfig | None:
+        """Create a FusedMoEQuantConfig for the given MXFP4 backend."""
+        if mxfp4_backend in (
+            Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+        ):
+            return mxfp4_mxfp8_moe_quant_config(
+                w1_bias=w1_bias,
+                w2_bias=w2_bias,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+            )
+        elif mxfp4_backend in (
+            Mxfp4MoeBackend.MARLIN,
+            Mxfp4MoeBackend.BATCHED_MARLIN,
+            Mxfp4MoeBackend.TRITON,
+            Mxfp4MoeBackend.TRITON_UNFUSED,
+            Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+            Mxfp4MoeBackend.CK,
+        ):
+            return mxfp4_w4a16_moe_quant_config(
+                w1_bias=w1_bias,
+                w2_bias=w2_bias,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+            )
+        else:
+            return ocp_mx_moe_quant_config(
+                quant_dtype="mxfp4",
+                w1_bias=w1_bias,
+                w2_bias=w2_bias,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+            )
+
+    def make_kernel(
+        self,
+        moe_quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        experts_cls: type[mk.FusedMoEExperts],
+        mxfp4_backend: Mxfp4MoeBackend,
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+        shared_experts: torch.nn.Module | None = None,
+    ) -> mk.FusedMoEKernel:
+        """Create a FusedMoEKernel for the given MXFP4 backend."""
+        is_monolithic = issubclass(experts_cls, mk.FusedMoEExpertsMonolithic)
+
+        # Create Prepare/Finalize.
+        prepare_finalize = maybe_make_prepare_finalize(
+            moe=moe_config,
+            quant_config=moe_quant_config,
+            routing_tables=routing_tables,
+            allow_new_interface=True,
+            use_monolithic=is_monolithic,
+        )
+        assert prepare_finalize is not None
+
+        logger.info_once("Using %s", prepare_finalize.__class__.__name__, scope="local")
+
+        # Create Experts.
+        if (
+            prepare_finalize.activation_format
+            == mk.FusedMoEActivationFormat.BatchedExperts
+        ):
+            max_num_tokens = prepare_finalize.max_num_tokens_per_rank()
+            assert max_num_tokens is not None
+            experts = experts_cls(
+                moe_config=moe_config,
+                quant_config=moe_quant_config,
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=prepare_finalize.num_dispatchers(),
+            )
+        else:
+            experts = experts_cls(
+                moe_config=moe_config,
+                quant_config=moe_quant_config,
+            )
+
+        kernel = mk.FusedMoEKernel(
+            prepare_finalize,
+            experts,
+            shared_experts=(
+                shared_experts
+                if moe_config.moe_parallel_config.use_deepep_ll_kernels
+                else None
+            ),
+            moe_parallel_config=moe_config.moe_parallel_config,
+            inplace=(
+                not moe_config.disable_inplace and mxfp4_backend not in TRTLLM_BACKENDS
+            ),
+        )
+
+        return kernel
+
+
+_oracle = Mxfp4MoEKernelOracle()
+
+
+def backend_to_kernel_cls(
+    backend: Mxfp4MoeBackend,
+) -> list[type[mk.FusedMoEExperts]]:
+    return _oracle.backend_to_kernel_cls(backend)
+
+
+def map_mxfp4_backend(runner_backend: str) -> Mxfp4MoeBackend:
+    """Map user's moe_backend string to Mxfp4MoeBackend."""
+    return _oracle.map_backend(runner_backend)
+
+
 def select_mxfp4_moe_backend(
     config: FusedMoEConfig,
 ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts] | None]:
@@ -199,194 +890,16 @@ def select_mxfp4_moe_backend(
     Select the primary MXFP4 MoE backend.
     Note: Shape-specific fallbacks may still occur at runtime.
     """
-    triton_kernels_supported = has_triton_kernels() and (
-        9,
-        0,
-    ) <= current_platform.get_device_capability() < (11, 0)
-
-    # LoRA: separate experts backend path
-    if config.is_lora_enabled:
-        if not current_platform.is_cuda():
-            raise NotImplementedError("Mxfp4 LoRA only supported on CUDA Platform.")
-        if envs.VLLM_MXFP4_USE_MARLIN is False and triton_kernels_supported:
-            logger.info_once("Using Triton backend for mxfp4 lora")
-            return Mxfp4MoeBackend.TRITON_UNFUSED, backend_to_kernel_cls(
-                Mxfp4MoeBackend.TRITON_UNFUSED
-            )[0]
-        logger.info_once("Using Marlin backend for mxfp4 lora")
-        return Mxfp4MoeBackend.MARLIN, backend_to_kernel_cls(Mxfp4MoeBackend.MARLIN)[0]
-
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
-    )
-
-    def _make_log_backend(backend: Mxfp4MoeBackend):
-        return f"Using '{backend.value}' Mxfp4 MoE backend."
-
-    def _make_log_unsupported(backend: Mxfp4MoeBackend, reason: str | None) -> str:
-        if reason:
-            return (
-                f"Mxfp4 MoE backend '{backend.value}' does not support the "
-                f"deployment configuration since {reason}."
-            )
-        return (
-            f"Mxfp4 MoE backend '{backend.value}' does not support the "
-            "deployment configuration."
-        )
-
-    def _return_or_raise(
-        backend: Mxfp4MoeBackend,
-        config: FusedMoEConfig,
-        weight_key: QuantKey | None,
-        activation_key: QuantKey | None,
-        activation_format: mk.FusedMoEActivationFormat,
-    ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
-        reason: str | None = None
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, weight_key, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
-                return backend, k_cls
-        raise ValueError(_make_log_unsupported(backend, reason))
-
-    runner_backend = config.moe_backend
-    if runner_backend != "auto":
-        requested_backend = map_mxfp4_backend(runner_backend)
-        if (
-            activation_format == mk.FusedMoEActivationFormat.BatchedExperts
-            and requested_backend == Mxfp4MoeBackend.MARLIN
-        ):
-            requested_backend = Mxfp4MoeBackend.BATCHED_MARLIN
-        return _return_or_raise(
-            requested_backend,
-            config,
-            kMxfp4Static,
-            _backend_activation_key(requested_backend),
-            activation_format,
-        )
-
-    # Select kernels in order of backend.
-    AVAILABLE_BACKENDS = _get_priority_backends()
-
-    # Handle explicit FlashInfer MXFP4 BF16 configuration.
-    if envs.is_set("VLLM_USE_FLASHINFER_MOE_MXFP4_BF16"):
-        if not envs.VLLM_USE_FLASHINFER_MOE_MXFP4_BF16:
-            AVAILABLE_BACKENDS.remove(Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16)
-            AVAILABLE_BACKENDS.remove(Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16)
-        else:
-            if current_platform.is_device_capability(90):
-                return _return_or_raise(
-                    Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
-                    config,
-                    kMxfp4Static,
-                    None,
-                    activation_format,
-                )
-            if current_platform.is_device_capability_family(100):
-                return _return_or_raise(
-                    Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
-                    config,
-                    kMxfp4Static,
-                    None,
-                    activation_format,
-                )
-            raise ValueError(
-                "VLLM_USE_FLASHINFER_MOE_MXFP4_BF16=1 is set but the "
-                "current device capability is not supported. "
-                "Only SM90 (CUTLASS) and SM100+ (TRTLLM) are supported."
-            )
-
-    # Handle explicit FlashInfer MXFP4 MXFP8 TRTLLM configuration.
-    if (
-        envs.is_set("VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8")
-        and envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8
-    ):
-        return _return_or_raise(
-            Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
-            config,
-            kMxfp4Static,
-            kMxfp8Dynamic,
-            activation_format,
-        )
-
-    # Handle explicit FlashInfer MXFP4 MXFP8 CUTLASS configuration.
-    if (
-        envs.is_set("VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS")
-        and envs.VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS
-    ):
-        return _return_or_raise(
-            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
-            config,
-            kMxfp4Static,
-            kMxfp8Dynamic,
-            activation_format,
-        )
-
-    # Handle explicit Marlin MXFP4 configuration.
-    if envs.is_set("VLLM_MXFP4_USE_MARLIN") and envs.VLLM_MXFP4_USE_MARLIN:
-        return _return_or_raise(
-            Mxfp4MoeBackend.MARLIN,
-            config,
-            kMxfp4Static,
-            None,
-            activation_format,
-        )
-
-    for backend in AVAILABLE_BACKENDS:
-        activation_key = _backend_activation_key(backend)
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, kMxfp4Static, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
-                return backend, k_cls
-            else:
-                logger.debug_once(_make_log_unsupported(backend, reason), scope="local")
-
-    if current_platform.is_xpu():
-        backend = Mxfp4MoeBackend.XPU
-        logger.info_once(_make_log_backend(backend))
-        return backend, None
-
-    if current_platform.is_cuda() or current_platform.is_rocm():
-        raise NotImplementedError(
-            "No MXFP4 MoE backend supports the deployment configuration."
-        )
-
-    return Mxfp4MoeBackend.NONE, None
+    return _oracle.select_backend(config)
 
 
 def mxfp4_round_up_hidden_size_and_intermediate_size(
     backend: Mxfp4MoeBackend, hidden_size: int, intermediate_size: int
 ) -> tuple[int, int]:
     """Round up hidden_size and intermediate_size based on backend requirements."""
-    if backend in (Mxfp4MoeBackend.MARLIN, Mxfp4MoeBackend.BATCHED_MARLIN):
-        intermediate_size = round_up(intermediate_size, 128)
-        if current_platform.is_xpu():
-            hidden_size = round_up(hidden_size, 128)
-        else:
-            hidden_size = round_up(hidden_size, 256)
-    elif backend in TRTLLM_BACKENDS:
-        intermediate_size = round_up(intermediate_size, 256)
-        hidden_size = round_up(hidden_size, 256)
-    elif backend in (
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
-    ):
-        intermediate_size = round_up(intermediate_size, 128)
-        hidden_size = round_up(hidden_size, 128)
-    elif current_platform.is_rocm():
-        pad_align = get_padding_alignment()
-        intermediate_size = round_up(intermediate_size, pad_align)
-        hidden_size = round_up(hidden_size, pad_align)
-    else:
-        intermediate_size = round_up(intermediate_size, 64)
-    return hidden_size, intermediate_size
+    return _oracle.round_up_hidden_size_and_intermediate_size(
+        backend, hidden_size, intermediate_size
+    )
 
 
 def convert_to_mxfp4_moe_kernel_format(
@@ -408,344 +921,17 @@ def convert_to_mxfp4_moe_kernel_format(
     torch.Tensor | None,
 ]:
     """Convert loaded weights into backend-specific kernel format."""
-
-    num_experts = w13_weight.shape[0]
-    intermediate_size = w13_weight.shape[1] // 2
-    hidden_size = w13_weight.shape[2] * 2
-
-    sf_block_size = 32  # mxfp4 block size
-
-    if mxfp4_backend in (Mxfp4MoeBackend.MARLIN, Mxfp4MoeBackend.BATCHED_MARLIN):
-        from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
-            prepare_moe_mxfp4_layer_for_marlin,
-        )
-
-        return prepare_moe_mxfp4_layer_for_marlin(
-            layer,
-            w13_weight,
-            w2_weight,
-            w13_weight_scale,
-            w2_weight_scale,
-            w13_bias,
-            w2_bias,
-        )
-
-    elif mxfp4_backend in TRTLLM_BACKENDS:
-        assert _cache_permute_indices is not None
-        from flashinfer.fp4_quantization import nvfp4_block_scale_interleave
-        from flashinfer.fused_moe.core import get_w2_permute_indices_with_cache
-
-        # gemm1_alpha/beta/clamp_limit are created by the expert class
-        # (TrtLlmMxfp4ExpertsBase), not on the layer.
-
-        w13_weight = w13_weight.data
-        w2_weight = w2_weight.data
-        w13_weight_scale = w13_weight_scale.data
-        w2_weight_scale = w2_weight_scale.data
-        assert w13_bias is not None and w2_bias is not None
-        w13_bias = w13_bias.data.to(torch.float32)
-        w2_bias = w2_bias.data.to(torch.float32)
-
-        # Swap w1 and w3 as the definition of swiglu is different in trtllm-gen
-        def swap_every_two_rows(x, axis=-1):
-            shape = x.shape
-            if axis < 0:
-                axis = len(shape) + axis
-            new_shape = list(shape)
-            new_shape[axis] = shape[axis] // 2
-            new_shape.insert(axis + 1, 2)
-            x = x.reshape(*new_shape)
-            x = x.flip(axis + 1)
-            new_shape = list(shape)
-            return x.reshape(*new_shape)
-
-        w13_weight_scale = swap_every_two_rows(w13_weight_scale, -2)
-        w13_weight = swap_every_two_rows(w13_weight, -2)
-        w13_bias = swap_every_two_rows(w13_bias, -1)
-
-        # Shuffle weights and scaling factors for transposed mma output
-        gemm1_weights_shuffled = []
-        gemm1_scales_shuffled = []
-        gemm2_weights_shuffled = []
-        gemm2_scales_shuffled = []
-        gemm1_bias_shuffled = []
-        gemm2_bias_shuffled = []
-        epilogue_tile_m = 128
-        for i in range(num_experts):
-            # w13 weight
-            permute_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w13_weight[i].view(torch.uint8),
-                epilogue_tile_m,
-            )
-            gemm1_weights_shuffled.append(
-                w13_weight[i]
-                .view(torch.uint8)[permute_indices.to(w13_weight.device)]
-                .contiguous()
-            )
-            # w13 scale
-            permute_sf_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w13_weight_scale[i].view(torch.uint8),
-                epilogue_tile_m,
-                num_elts_per_sf=16,
-            )
-            gemm1_scales_shuffled.append(
-                nvfp4_block_scale_interleave(
-                    w13_weight_scale[i]
-                    .view(torch.uint8)[permute_sf_indices.to(w13_weight_scale.device)]
-                    .contiguous()
-                )
-            )
-            # w13 bias
-            permute_bias_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w13_bias[i].clone().reshape(-1, 1),
-                epilogue_tile_m,
-            )
-            gemm1_bias_shuffled.append(
-                w13_bias[i]
-                .clone()
-                .reshape(-1, 1)[permute_bias_indices.to(w13_bias.device)]
-                .contiguous()
-            )
-            # w2 weight
-            permute_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w2_weight[i].view(torch.uint8),
-                epilogue_tile_m,
-            )
-            gemm2_weights_shuffled.append(
-                w2_weight[i]
-                .view(torch.uint8)[permute_indices.to(w2_weight.device)]
-                .contiguous()
-            )
-            # w2 scale
-            permute_sf_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w2_weight_scale[i].view(torch.uint8),
-                epilogue_tile_m,
-                num_elts_per_sf=16,
-            )
-            gemm2_scales_shuffled.append(
-                nvfp4_block_scale_interleave(
-                    w2_weight_scale[i]
-                    .view(torch.uint8)[permute_sf_indices.to(w2_weight_scale.device)]
-                    .contiguous()
-                )
-            )
-            # w2 bias
-            permute_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w2_bias[i].clone().reshape(-1, 1),
-                epilogue_tile_m,
-            )
-            gemm2_bias_shuffled.append(
-                w2_bias[i]
-                .clone()
-                .reshape(-1, 1)[permute_indices.to(w2_bias.device)]
-                .contiguous()
-            )
-
-        w13_weight = torch.stack(gemm1_weights_shuffled)
-        w13_weight_scale = (
-            torch.stack(gemm1_scales_shuffled)
-            .reshape(num_experts, 2 * intermediate_size, hidden_size // sf_block_size)
-            .view(torch.float8_e4m3fn)
-        )
-        w2_weight = torch.stack(gemm2_weights_shuffled)
-        w2_weight_scale = (
-            torch.stack(gemm2_scales_shuffled)
-            .reshape(num_experts, hidden_size, intermediate_size // sf_block_size)
-            .view(torch.float8_e4m3fn)
-        )
-        w13_bias = torch.stack(gemm1_bias_shuffled).reshape(num_experts, -1)
-        w2_bias = torch.stack(gemm2_bias_shuffled).reshape(num_experts, -1)
-
-        return (
-            w13_weight,
-            w2_weight,
-            w13_weight_scale,
-            w2_weight_scale,
-            w13_bias,
-            w2_bias,
-        )
-
-    elif mxfp4_backend in (
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
-    ):
-        # De-interleave and swap for w13 weight, bias, and scales
-        w13_w = w13_weight.data
-        gate_w, up_w = w13_w[:, ::2, :], w13_w[:, 1::2, :]
-        deinterleaved_w13_w = torch.cat([gate_w, up_w], dim=1)
-        w1_w, w3_w = torch.chunk(deinterleaved_w13_w, 2, dim=1)
-        w13_weight_swapped = torch.cat([w3_w, w1_w], dim=1)
-
-        assert w13_bias is not None and w2_bias is not None
-        w13_b = w13_bias.data.to(torch.float32)
-        gate_b, up_b = w13_b[:, ::2], w13_b[:, 1::2]
-        deinterleaved_w13_b = torch.cat([gate_b, up_b], dim=1)
-        b1, b3 = torch.chunk(deinterleaved_w13_b, 2, dim=-1)
-        w13_bias_swapped = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
-
-        w13_s = w13_weight_scale.data
-        gate_s, up_s = w13_s[:, ::2, :], w13_s[:, 1::2, :]
-        deinterleaved_w13_s = torch.cat([gate_s, up_s], dim=1)
-        s1, s3 = torch.chunk(deinterleaved_w13_s, 2, dim=1)
-        w13_scale_swapped = torch.cat([s3, s1], dim=1)
-
-        if mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8:
-            from flashinfer import block_scale_interleave
-
-            orig_shape = w13_scale_swapped.shape
-            w13_scale_interleaved = block_scale_interleave(
-                w13_scale_swapped.view(torch.uint8)
-            ).reshape(orig_shape)
-
-            w2_s = w2_weight_scale.data
-            orig_shape = w2_s.shape
-            w2_scale_interleaved = block_scale_interleave(
-                w2_s.view(torch.uint8)
-            ).reshape(orig_shape)
-
-            return (
-                w13_weight_swapped,
-                w2_weight,
-                w13_scale_interleaved,
-                w2_scale_interleaved,
-                w13_bias_swapped,
-                w2_bias,
-            )
-
-        else:
-            assert mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16
-
-            def _interleave_mxfp4_cutlass_sm90(w):
-                w_shape = w.shape
-                w_interleaved = w.reshape(w_shape[0], w_shape[1], (w_shape[2] // 4), 4)
-                w_interleaved = w_interleaved.permute(0, 2, 1, 3)
-                w_interleaved = w_interleaved.reshape(
-                    w_shape[0], w_shape[2] // 4, w_shape[1] * 4
-                )
-                return w_interleaved
-
-            w31_scales = w13_scale_swapped.to(torch.uint8)
-            w31_scales_interleaved = _interleave_mxfp4_cutlass_sm90(w31_scales)
-
-            w2_scale = w2_weight_scale.data.to(torch.uint8)
-            w2_scale_interleaved = _interleave_mxfp4_cutlass_sm90(w2_scale)
-
-            return (
-                w13_weight_swapped,
-                w2_weight,
-                w31_scales_interleaved,
-                w2_scale_interleaved,
-                w13_bias_swapped,
-                w2_bias,
-            )
-
-    elif mxfp4_backend == Mxfp4MoeBackend.CK:
-        from vllm._aiter_ops import rocm_aiter_ops
-
-        if w13_bias is not None:
-            w13_bias = w13_bias.data.to(torch.float32)
-        if w2_bias is not None:
-            w2_bias = w2_bias.data.to(torch.float32)
-
-        e, n, k = w13_weight.shape
-
-        # De-interleave w13 rows: gate/up pairs -> contiguous gate, up blocks
-        w13_weight.view(torch.uint8).copy_(
-            w13_weight.data.view(torch.uint8)
-            .view(e, n // 2, 2, k)
-            .permute(0, 2, 1, 3)
-            .contiguous()
-            .view(e, n, k)
-        )
-        w13_weight_scale.data = (
-            w13_weight_scale.data.view(e, n // 2, 2, -1)
-            .permute(0, 2, 1, 3)
-            .contiguous()
-            .view(e, n, -1)
-        )
-
-        # View as native FP4 dtype for AITER shuffle
-        w13_weight.data = w13_weight.data.view(torch.float4_e2m1fn_x2)
-        w2_weight.data = w2_weight.data.view(torch.float4_e2m1fn_x2)
-
-        # Shuffle weights and scales for AITER CK kernel layout
-        w13_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w13_weight, 16, True)
-        shuffled_w13_scale = rocm_aiter_ops.shuffle_scale_a16w4(
-            w13_weight_scale.view(-1, w13_weight_scale.shape[-1]),
-            num_experts,
-            True,
-        )
-
-        w2_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w2_weight, 16, False)
-        shuffled_w2_scale = rocm_aiter_ops.shuffle_scale_a16w4(
-            w2_weight_scale.view(-1, w2_weight_scale.shape[-1]),
-            num_experts,
-            False,
-        )
-
-        # Permute bias to match de-interleaved weight layout
-        if w13_bias is not None:
-            w13_bias = (
-                w13_bias.data.view(-1, n // 2, 2)
-                .permute(0, 2, 1)
-                .contiguous()
-                .view(-1, n)
-            )
-
-        return (
-            w13_weight,
-            w2_weight,
-            shuffled_w13_scale,
-            shuffled_w2_scale,
-            w13_bias,
-            w2_bias,
-        )
-
-    elif mxfp4_backend in TRITON_BACKENDS:
-        from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
-
-        assert w13_bias is not None and w2_bias is not None
-        w13_bias = w13_bias.to(torch.float32)
-        w2_bias = w2_bias.to(torch.float32)
-
-        w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(
-            w13_weight,
-            w13_weight_scale,
-        )
-        w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(
-            w2_weight,
-            w2_weight_scale,
-        )
-
-        w13_precision_config = PrecisionConfig(
-            weight_scale=w13_scale, flex_ctx=FlexCtx(rhs_data=w13_flex)
-        )
-        w2_precision_config = PrecisionConfig(
-            weight_scale=w2_scale, flex_ctx=FlexCtx(rhs_data=w2_flex)
-        )
-
-        del layer.w13_weight
-        del layer.w2_weight
-
-        return (
-            w13_weight,
-            w2_weight,
-            w13_precision_config,
-            w2_precision_config,
-            w13_bias,
-            w2_bias,
-        )
-    else:
-        raise ValueError(
-            f"Unsupported mxfp4_backend: {mxfp4_backend}: "
-            f"should be one of: {list(Mxfp4MoeBackend)}."
-        )
+    return _oracle.convert_to_kernel_format(
+        mxfp4_backend,
+        layer,
+        w13_weight,
+        w2_weight,
+        w13_weight_scale,
+        w2_weight_scale,
+        w13_bias,
+        w2_bias,
+        _cache_permute_indices,
+    )
 
 
 def make_mxfp4_moe_quant_config(
@@ -756,39 +942,9 @@ def make_mxfp4_moe_quant_config(
     w2_bias: torch.Tensor | None = None,
 ) -> FusedMoEQuantConfig | None:
     """Create a FusedMoEQuantConfig for the given MXFP4 backend."""
-    if mxfp4_backend in (
-        Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
-    ):
-        return mxfp4_mxfp8_moe_quant_config(
-            w1_bias=w1_bias,
-            w2_bias=w2_bias,
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-        )
-    elif mxfp4_backend in (
-        Mxfp4MoeBackend.MARLIN,
-        Mxfp4MoeBackend.BATCHED_MARLIN,
-        Mxfp4MoeBackend.TRITON,
-        Mxfp4MoeBackend.TRITON_UNFUSED,
-        Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
-        Mxfp4MoeBackend.CK,
-    ):
-        return mxfp4_w4a16_moe_quant_config(
-            w1_bias=w1_bias,
-            w2_bias=w2_bias,
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-        )
-    else:
-        return ocp_mx_moe_quant_config(
-            quant_dtype="mxfp4",
-            w1_bias=w1_bias,
-            w2_bias=w2_bias,
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-        )
+    return _oracle.make_quant_config(
+        mxfp4_backend, w1_scale, w2_scale, w1_bias, w2_bias
+    )
 
 
 def make_mxfp4_moe_kernel(
@@ -800,48 +956,11 @@ def make_mxfp4_moe_kernel(
     shared_experts: torch.nn.Module | None = None,
 ) -> mk.FusedMoEKernel:
     """Create a FusedMoEKernel for the given MXFP4 backend."""
-    is_monolithic = issubclass(experts_cls, mk.FusedMoEExpertsMonolithic)
-
-    # Create Prepare/Finalize.
-    prepare_finalize = maybe_make_prepare_finalize(
-        moe=moe_config,
-        quant_config=moe_quant_config,
-        routing_tables=routing_tables,
-        allow_new_interface=True,
-        use_monolithic=is_monolithic,
+    return _oracle.make_kernel(
+        moe_quant_config,
+        moe_config,
+        experts_cls,
+        mxfp4_backend,
+        routing_tables,
+        shared_experts,
     )
-    assert prepare_finalize is not None
-
-    logger.info_once("Using %s", prepare_finalize.__class__.__name__, scope="local")
-
-    # Create Experts.
-    if prepare_finalize.activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
-        max_num_tokens = prepare_finalize.max_num_tokens_per_rank()
-        assert max_num_tokens is not None
-        experts = experts_cls(
-            moe_config=moe_config,
-            quant_config=moe_quant_config,
-            max_num_tokens=max_num_tokens,
-            num_dispatchers=prepare_finalize.num_dispatchers(),
-        )
-    else:
-        experts = experts_cls(
-            moe_config=moe_config,
-            quant_config=moe_quant_config,
-        )
-
-    kernel = mk.FusedMoEKernel(
-        prepare_finalize,
-        experts,
-        shared_experts=(
-            shared_experts
-            if moe_config.moe_parallel_config.use_deepep_ll_kernels
-            else None
-        ),
-        moe_parallel_config=moe_config.moe_parallel_config,
-        inplace=(
-            not moe_config.disable_inplace and mxfp4_backend not in TRTLLM_BACKENDS
-        ),
-    )
-
-    return kernel

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -875,7 +875,7 @@ def backend_to_kernel_cls(
     return _oracle.backend_to_kernel_cls(backend)
 
 
-def map_mxfp4_backend(runner_backend: str) -> Mxfp4MoeBackend:
+def map_mxfp4_backend(runner_backend: MoEBackend) -> Mxfp4MoeBackend:
     """Map user's moe_backend string to Mxfp4MoeBackend."""
     return _oracle.map_backend(runner_backend)
 

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp8.py
@@ -4,6 +4,7 @@
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     Fp8MoeBackend,
     backend_to_kernel_cls,
@@ -26,31 +27,100 @@ _BACKEND_NAME_MAP: dict[str, Fp8MoeBackend] = {
 }
 
 
+class Mxfp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
+    """Oracle for MXFP8 MoE kernel selection."""
+
+    @property
+    def quant_type_name(self) -> str:
+        return "MxFp8"
+
+    def backend_to_kernel_cls(
+        self,
+        backend: Fp8MoeBackend,
+    ) -> list[type[mk.FusedMoEExperts]]:
+        return backend_to_kernel_cls(backend)
+
+    def map_backend(self, runner_backend: str) -> Fp8MoeBackend:
+        backend = _BACKEND_NAME_MAP.get(runner_backend)
+        if backend is None:
+            raise ValueError(
+                f"moe_backend='{runner_backend}' is not supported for "
+                f"MXFP8 MoE. Expected one of "
+                f"{list(_BACKEND_NAME_MAP.keys())}."
+            )
+        return backend
+
+    def _select_kernel_cls(
+        self,
+        backend: Fp8MoeBackend,
+        config: FusedMoEConfig,
+    ) -> type[mk.FusedMoEExperts]:
+        """Select the first supported expert class for the MXFP8 config."""
+        activation_format = (
+            mk.FusedMoEActivationFormat.BatchedExperts
+            if config.moe_parallel_config.use_batched_activation_format
+            else mk.FusedMoEActivationFormat.Standard
+        )
+        last_reason: str | None = None
+        for cls in self.backend_to_kernel_cls(backend):
+            supported, reason = cls.is_supported_config(
+                cls,
+                config,
+                kMxfp8Static,
+                kMxfp8Dynamic,
+                activation_format,
+            )
+            if supported:
+                return cls
+            last_reason = reason
+        raise ValueError(
+            f"No supported MXFP8 expert class for {backend.value}: {last_reason}"
+        )
+
+    def select_backend(
+        self,
+        config: FusedMoEConfig,
+    ) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts]]:
+        """Select the MXFP8 MoE backend and the best expert class.
+
+        Returns:
+            A tuple of (fp8_backend, experts_cls).
+        """
+        if config.is_lora_enabled:
+            raise NotImplementedError("LoRA is not supported for MXFP8 MoE.")
+
+        runner_backend = config.moe_backend
+        if runner_backend != "auto":
+            backend = _BACKEND_NAME_MAP.get(runner_backend)
+            if backend is None:
+                raise ValueError(
+                    f"moe_backend='{runner_backend}' is not supported for "
+                    f"MXFP8 MoE. Expected one of "
+                    f"{list(_BACKEND_NAME_MAP.keys())}."
+                )
+            logger.info_once(
+                "Using '%s' MxFp8 MoE backend (user-requested).",
+                backend.value,
+            )
+            return backend, self._select_kernel_cls(backend, config)
+
+        # Auto-select: pick the first supported backend.
+        for backend in _SUPPORTED_BACKENDS:
+            logger.info_once("Using '%s' MxFp8 MoE backend.", backend.value)
+            return backend, self._select_kernel_cls(backend, config)
+
+        raise ValueError("No MXFP8 MoE backends available.")
+
+
+_oracle = Mxfp8MoEKernelOracle()
+
+
 def _select_kernel_cls(
     backend: Fp8MoeBackend,
     config: FusedMoEConfig,
 ) -> type[mk.FusedMoEExperts]:
     """Select the first supported expert class for the MXFP8 config."""
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
-    )
-    last_reason: str | None = None
-    for cls in backend_to_kernel_cls(backend):
-        supported, reason = cls.is_supported_config(
-            cls,
-            config,
-            kMxfp8Static,
-            kMxfp8Dynamic,
-            activation_format,
-        )
-        if supported:
-            return cls
-        last_reason = reason
-    raise ValueError(
-        f"No supported MXFP8 expert class for {backend.value}: {last_reason}"
-    )
+    return _oracle._select_kernel_cls(backend, config)
 
 
 def select_mxfp8_moe_backend(
@@ -61,27 +131,4 @@ def select_mxfp8_moe_backend(
     Returns:
         A tuple of (fp8_backend, experts_cls).
     """
-    if config.is_lora_enabled:
-        raise NotImplementedError("LoRA is not supported for MXFP8 MoE.")
-
-    runner_backend = config.moe_backend
-    if runner_backend != "auto":
-        backend = _BACKEND_NAME_MAP.get(runner_backend)
-        if backend is None:
-            raise ValueError(
-                f"moe_backend='{runner_backend}' is not supported for "
-                f"MXFP8 MoE. Expected one of "
-                f"{list(_BACKEND_NAME_MAP.keys())}."
-            )
-        logger.info_once(
-            "Using '%s' MxFp8 MoE backend (user-requested).",
-            backend.value,
-        )
-        return backend, _select_kernel_cls(backend, config)
-
-    # Auto-select: pick the first supported backend.
-    for backend in _SUPPORTED_BACKENDS:
-        logger.info_once("Using '%s' MxFp8 MoE backend.", backend.value)
-        return backend, _select_kernel_cls(backend, config)
-
-    raise ValueError("No MXFP8 MoE backends available.")
+    return _oracle.select_backend(config)

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp8.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.config.kernel import MoEBackend
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
@@ -30,17 +31,13 @@ _BACKEND_NAME_MAP: dict[str, Fp8MoeBackend] = {
 class Mxfp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
     """Oracle for MXFP8 MoE kernel selection."""
 
-    @property
-    def quant_type_name(self) -> str:
-        return "MxFp8"
-
     def backend_to_kernel_cls(
         self,
         backend: Fp8MoeBackend,
     ) -> list[type[mk.FusedMoEExperts]]:
         return backend_to_kernel_cls(backend)
 
-    def map_backend(self, runner_backend: str) -> Fp8MoeBackend:
+    def map_backend(self, runner_backend: MoEBackend) -> Fp8MoeBackend:
         backend = _BACKEND_NAME_MAP.get(runner_backend)
         if backend is None:
             raise ValueError(
@@ -50,7 +47,7 @@ class Mxfp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
             )
         return backend
 
-    def _select_kernel_cls(
+    def select_kernel_cls(
         self,
         backend: Fp8MoeBackend,
         config: FusedMoEConfig,
@@ -102,12 +99,12 @@ class Mxfp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
                 "Using '%s' MxFp8 MoE backend (user-requested).",
                 backend.value,
             )
-            return backend, self._select_kernel_cls(backend, config)
+            return backend, self.select_kernel_cls(backend, config)
 
         # Auto-select: pick the first supported backend.
         for backend in _SUPPORTED_BACKENDS:
             logger.info_once("Using '%s' MxFp8 MoE backend.", backend.value)
-            return backend, self._select_kernel_cls(backend, config)
+            return backend, self.select_kernel_cls(backend, config)
 
         raise ValueError("No MXFP8 MoE backends available.")
 
@@ -115,12 +112,12 @@ class Mxfp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
 _oracle = Mxfp8MoEKernelOracle()
 
 
-def _select_kernel_cls(
+def select_kernel_cls(
     backend: Fp8MoeBackend,
     config: FusedMoEConfig,
 ) -> type[mk.FusedMoEExperts]:
     """Select the first supported expert class for the MXFP8 config."""
-    return _oracle._select_kernel_cls(backend, config)
+    return _oracle.select_kernel_cls(backend, config)
 
 
 def select_mxfp8_moe_backend(

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     nvfp4_moe_quant_config,
     nvfp4_w4a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
     prepare_nvfp4_moe_layer_for_fi_or_cutlass,
 )
@@ -63,67 +64,400 @@ def is_global_sf_supported_for_nvfp4_backend(backend: NvFp4MoeBackend) -> bool:
     return backend in FLASHINFER_NVFP4_MOE_BACKENDS
 
 
+class NvFp4MoEKernelOracle(MoEKernelOracle[NvFp4MoeBackend]):
+    @property
+    def quant_type_name(self) -> str:
+        return "NvFp4"
+
+    def backend_to_kernel_cls(
+        self,
+        backend: NvFp4MoeBackend,
+    ) -> list[type[mk.FusedMoEExperts]]:
+        if backend == NvFp4MoeBackend.FLASHINFER_TRTLLM:
+            from vllm.model_executor.layers.fused_moe.experts.trtllm_nvfp4_moe import (
+                TrtLlmNvFp4ExpertsModular,
+                TrtLlmNvFp4ExpertsMonolithic,
+            )
+
+            # NOTE: prefer Monolthic > Modular, so return Monolithic first.
+            return [
+                TrtLlmNvFp4ExpertsMonolithic,
+                TrtLlmNvFp4ExpertsModular,
+            ]
+
+        elif backend == NvFp4MoeBackend.FLASHINFER_CUTLASS:
+            from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
+                FlashInferExperts,
+            )
+
+            return [FlashInferExperts]
+
+        elif backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
+            from vllm.model_executor.layers.fused_moe.flashinfer_cutedsl_moe import (
+                FlashInferCuteDSLExperts,
+            )
+
+            return [FlashInferCuteDSLExperts]
+
+        elif backend == NvFp4MoeBackend.VLLM_CUTLASS:
+            from vllm.model_executor.layers.fused_moe.cutlass_moe import (
+                CutlassExpertsFp4,
+            )
+
+            return [CutlassExpertsFp4]
+
+        elif backend == NvFp4MoeBackend.MARLIN:
+            from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
+                MarlinExperts,
+            )
+
+            return [MarlinExperts]
+        else:
+            raise ValueError(f"Unknown NvFP4 MoE backend: {backend.value}")
+
+    def map_backend(self, runner_backend: MoEBackend) -> NvFp4MoeBackend:
+        """Map user's MoEBackend to NvFp4MoeBackend."""
+        mapping = {
+            "cutlass": NvFp4MoeBackend.VLLM_CUTLASS,
+            "flashinfer_trtllm": NvFp4MoeBackend.FLASHINFER_TRTLLM,
+            "flashinfer_cutlass": NvFp4MoeBackend.FLASHINFER_CUTLASS,
+            "flashinfer_cutedsl": NvFp4MoeBackend.FLASHINFER_CUTEDSL,
+            "marlin": NvFp4MoeBackend.MARLIN,
+        }
+        if backend := mapping.get(runner_backend):
+            return backend
+        raise ValueError(
+            f"moe_backend='{runner_backend}' is not supported for NvFP4 MoE. "
+            f"Expected one of {list(mapping.keys())}."
+        )
+
+    def select_backend(
+        self,
+        config: FusedMoEConfig,
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> tuple[NvFp4MoeBackend, type[mk.FusedMoEExperts]]:
+        """
+        Select the primary NvFP4 MoE backend
+        Note: Shape-specific fallbacks may still occur at runtime.
+        """
+
+        # NOTE: the kernels are selected in the following order.
+        AVAILABLE_BACKENDS = [
+            NvFp4MoeBackend.FLASHINFER_TRTLLM,
+            NvFp4MoeBackend.FLASHINFER_CUTEDSL,
+            NvFp4MoeBackend.FLASHINFER_CUTLASS,
+            NvFp4MoeBackend.VLLM_CUTLASS,
+            NvFp4MoeBackend.MARLIN,
+        ]
+
+        # NOTE(rob): this is kind of a hack. We need to peak into
+        # the prepare-finalize selection to determine if we are using
+        # the batched or standard expert format.
+        use_batched = config.moe_parallel_config.use_deepep_ll_kernels
+        activation_format = (
+            mk.FusedMoEActivationFormat.BatchedExperts
+            if use_batched
+            else mk.FusedMoEActivationFormat.Standard
+        )
+
+        def _make_log_backend(backend: NvFp4MoeBackend):
+            available_backend_strs = [b.value for b in AVAILABLE_BACKENDS]
+            return (
+                f"Using '{backend.value}' NvFp4 MoE backend out "
+                f"of potential backends: {available_backend_strs}."
+            )
+
+        def _make_log_unsupported(backend: NvFp4MoeBackend, reason: str | None) -> str:
+            if reason:
+                return (
+                    f"NvFp4 MoE backend '{backend.value}' does not support the "
+                    f"deployment configuration since {reason}."
+                )
+            else:
+                return (
+                    f"NvFp4 MoE backend '{backend.value}' does not support the "
+                    "deployment configuration."
+                )
+
+        def _return_or_raise(
+            backend: NvFp4MoeBackend,
+            config: FusedMoEConfig,
+            weight_key: QuantKey | None,
+            activation_key: QuantKey | None,
+            activation_format: mk.FusedMoEActivationFormat,
+        ) -> tuple[NvFp4MoeBackend, type[mk.FusedMoEExperts]]:
+            for k_cls in backend_to_kernel_cls(backend):
+                supported, reason = k_cls.is_supported_config(
+                    k_cls, config, weight_key, activation_key, activation_format
+                )
+                if supported:
+                    logger.info_once(_make_log_backend(backend))
+                    return backend, k_cls
+
+            raise ValueError(_make_log_unsupported(backend, reason))
+
+        # Handle explicit moe_backend from user.
+        runner_backend = config.moe_backend
+        if runner_backend != "auto":
+            requested_backend = map_nvfp4_backend(runner_backend)
+            return _return_or_raise(
+                requested_backend, config, weight_key, activation_key, activation_format
+            )
+
+        if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP4"):
+            if not envs.VLLM_USE_FLASHINFER_MOE_FP4:
+                # If the user rejects FlashInfer remove those backends.
+                for b in FLASHINFER_NVFP4_MOE_BACKENDS:
+                    AVAILABLE_BACKENDS.remove(b)
+
+            elif envs.is_set("VLLM_FLASHINFER_MOE_BACKEND"):
+                # If user is explicit about backend, validate it.
+                backend = fi_2_vllm_backend_map[get_flashinfer_moe_backend()]
+                return _return_or_raise(
+                    backend, config, weight_key, activation_key, activation_format
+                )
+            else:
+                # If the user is not explicit about the backend, try each.
+                for backend in FLASHINFER_NVFP4_MOE_BACKENDS:
+                    for k_cls in backend_to_kernel_cls(backend):
+                        supported, reason = k_cls.is_supported_config(
+                            k_cls,
+                            config,
+                            weight_key,
+                            activation_key,
+                            activation_format,
+                        )
+                        if supported:
+                            logger.info_once(_make_log_backend(backend), scope="local")
+                            return backend, k_cls
+                        else:
+                            logger.debug_once(
+                                _make_log_unsupported(backend, reason), scope="local"
+                            )
+
+                raise NotImplementedError(
+                    "Found VLLM_USE_FLASHINFER_MOE_FP4=1, but no "
+                    "FlashInfer NVFP4 MoE backend supports the configuration."
+                )
+
+        if envs.VLLM_TEST_FORCE_FP8_MARLIN:
+            backend = NvFp4MoeBackend.MARLIN
+            return _return_or_raise(
+                backend, config, weight_key, activation_key, activation_format
+            )
+
+        # Select kernels in order of backend.
+        for backend in AVAILABLE_BACKENDS:
+            for k_cls in backend_to_kernel_cls(backend):
+                supported, reason = k_cls.is_supported_config(
+                    k_cls,
+                    config,
+                    weight_key,
+                    activation_key,
+                    activation_format,
+                )
+
+                if supported:
+                    logger.info_once(_make_log_backend(backend), scope="local")
+                    return backend, k_cls
+                else:
+                    logger.debug_once(
+                        _make_log_unsupported(backend, reason), scope="local"
+                    )
+
+        raise NotImplementedError(
+            "No NvFp4 MoE backend supports the deployment configuration."
+        )
+
+    def convert_to_kernel_format(
+        self,
+        nvfp4_backend: NvFp4MoeBackend,
+        layer: torch.nn.Module,
+        w13: torch.Tensor,
+        w13_scale: torch.Tensor,
+        w13_scale_2: torch.Tensor,
+        a13_scale: torch.Tensor | None,
+        w2: torch.Tensor,
+        w2_scale: torch.Tensor,
+        w2_scale_2: torch.Tensor,
+        a2_scale: torch.Tensor | None,
+        is_act_and_mul: bool,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        if (
+            nvfp4_backend in FLASHINFER_NVFP4_MOE_BACKENDS
+            or nvfp4_backend == NvFp4MoeBackend.VLLM_CUTLASS
+        ):
+            (
+                w13,
+                w13_scale,
+                w13_scale_2,
+                a13_scale,
+                w2,
+                w2_scale,
+                w2_scale_2,
+                a2_scale,
+            ) = prepare_nvfp4_moe_layer_for_fi_or_cutlass(
+                backend=nvfp4_backend,
+                layer=layer,
+                w13=w13,
+                w13_scale=w13_scale,
+                w13_scale_2=w13_scale_2,
+                a13_scale=a13_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                w2_scale_2=w2_scale_2,
+                a2_scale=a2_scale,
+                is_act_and_mul=is_act_and_mul,
+            )
+        elif nvfp4_backend == NvFp4MoeBackend.MARLIN:
+            a13_scale = None
+            a2_scale = None
+            (
+                w13,
+                w13_scale,
+                w13_scale_2,
+                w2,
+                w2_scale,
+                w2_scale_2,
+            ) = prepare_nvfp4_moe_layer_for_marlin(
+                layer=layer,
+                w13=w13,
+                w13_scale=w13_scale,
+                w13_scale_2=w13_scale_2,
+                w2=w2,
+                w2_scale=w2_scale,
+                w2_scale_2=w2_scale_2,
+                is_act_and_mul=is_act_and_mul,
+            )
+        else:
+            raise ValueError(f"Unknown NvFp4 backend for MoE: {nvfp4_backend}")
+
+        return (
+            w13,
+            w13_scale,
+            w13_scale_2,
+            a13_scale,
+            w2,
+            w2_scale,
+            w2_scale_2,
+            a2_scale,
+        )
+
+    def make_quant_config(
+        self,
+        backend: NvFp4MoeBackend,
+        w13_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        w13_scale_2: torch.Tensor,
+        w2_scale_2: torch.Tensor,
+        a13_scale: torch.Tensor,
+        a2_scale: torch.Tensor,
+    ) -> FusedMoEQuantConfig:
+        if backend == NvFp4MoeBackend.MARLIN:
+            return nvfp4_w4a16_moe_quant_config(
+                g1_alphas=w13_scale_2,
+                g2_alphas=w2_scale_2,
+                w1_scale=w13_scale,
+                w2_scale=w2_scale,
+            )
+
+        # Pass w13_scale_2 / w2_scale_2 directly as g1/g2_alphas.
+        # The expert's process_weights_after_loading will fuse activation
+        # scales in-place. Since the quant config references the same tensor
+        # as the registered parameter, EPLB rearrangement stays in sync.
+        return nvfp4_moe_quant_config(
+            g1_alphas=w13_scale_2,
+            g2_alphas=w2_scale_2,
+            a1_gscale=(1.0 / a13_scale),
+            a2_gscale=(1.0 / a2_scale),
+            w1_scale=w13_scale,
+            w2_scale=w2_scale,
+            # NOTE(rob): this is a hack until the MoE kernels
+            # create their own quant configs. TRTLLM kernel
+            # does not accept swizzled input quant scales.
+            is_nvfp4_scale_swizzled=(backend != NvFp4MoeBackend.FLASHINFER_TRTLLM),
+        )
+
+    def make_kernel(
+        self,
+        moe_quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        experts_cls: type[mk.FusedMoEExperts],
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+        shared_experts: torch.nn.Module | None = None,
+    ) -> mk.FusedMoEKernel:
+        # Create Prepare/Finalize.
+        prepare_finalize = maybe_make_prepare_finalize(
+            moe=moe_config,
+            quant_config=moe_quant_config,
+            routing_tables=routing_tables,
+            allow_new_interface=True,
+            use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),
+        )
+        assert prepare_finalize is not None
+
+        logger.info_once("Using %s", prepare_finalize.__class__.__name__)
+
+        # Create Experts.
+        if (
+            prepare_finalize.activation_format
+            == mk.FusedMoEActivationFormat.BatchedExperts
+        ):
+            max_num_tokens = prepare_finalize.max_num_tokens_per_rank()
+            assert max_num_tokens is not None
+            experts = experts_cls(
+                moe_config=moe_config,
+                quant_config=moe_quant_config,
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=prepare_finalize.num_dispatchers(),
+            )
+        else:
+            experts = experts_cls(
+                moe_config=moe_config,
+                quant_config=moe_quant_config,
+            )
+
+        # NOTE(rob): we only want the mk to control the shared_expert
+        # if using all2all (for SBO). bnell is making this explicit in
+        # the new MoE runner class.
+        kernel = mk.FusedMoEKernel(
+            prepare_finalize,
+            experts,
+            shared_experts=(
+                shared_experts
+                if moe_config.moe_parallel_config.use_deepep_ll_kernels
+                else None
+            ),
+            moe_parallel_config=moe_config.moe_parallel_config,
+            inplace=False,
+        )
+
+        # TODO(rob): update inplace logic to be part of the kernel.
+        return kernel
+
+
+_oracle = NvFp4MoEKernelOracle()
+
+
 def backend_to_kernel_cls(
     backend: NvFp4MoeBackend,
 ) -> list[type[mk.FusedMoEExperts]]:
-    if backend == NvFp4MoeBackend.FLASHINFER_TRTLLM:
-        from vllm.model_executor.layers.fused_moe.experts.trtllm_nvfp4_moe import (
-            TrtLlmNvFp4ExpertsModular,
-            TrtLlmNvFp4ExpertsMonolithic,
-        )
-
-        # NOTE: prefer Monolthic > Modular, so return Monolithic first.
-        return [
-            TrtLlmNvFp4ExpertsMonolithic,
-            TrtLlmNvFp4ExpertsModular,
-        ]
-
-    elif backend == NvFp4MoeBackend.FLASHINFER_CUTLASS:
-        from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
-            FlashInferExperts,
-        )
-
-        return [FlashInferExperts]
-
-    elif backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
-        from vllm.model_executor.layers.fused_moe.flashinfer_cutedsl_moe import (
-            FlashInferCuteDSLExperts,
-        )
-
-        return [FlashInferCuteDSLExperts]
-
-    elif backend == NvFp4MoeBackend.VLLM_CUTLASS:
-        from vllm.model_executor.layers.fused_moe.cutlass_moe import (
-            CutlassExpertsFp4,
-        )
-
-        return [CutlassExpertsFp4]
-
-    elif backend == NvFp4MoeBackend.MARLIN:
-        from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
-            MarlinExperts,
-        )
-
-        return [MarlinExperts]
-    else:
-        raise ValueError(f"Unknown NvFP4 MoE backend: {backend.value}")
+    return _oracle.backend_to_kernel_cls(backend)
 
 
 def map_nvfp4_backend(runner_backend: MoEBackend) -> NvFp4MoeBackend:
     """Map user's MoEBackend to NvFp4MoeBackend."""
-    mapping = {
-        "cutlass": NvFp4MoeBackend.VLLM_CUTLASS,
-        "flashinfer_trtllm": NvFp4MoeBackend.FLASHINFER_TRTLLM,
-        "flashinfer_cutlass": NvFp4MoeBackend.FLASHINFER_CUTLASS,
-        "flashinfer_cutedsl": NvFp4MoeBackend.FLASHINFER_CUTEDSL,
-        "marlin": NvFp4MoeBackend.MARLIN,
-    }
-    if backend := mapping.get(runner_backend):
-        return backend
-    raise ValueError(
-        f"moe_backend='{runner_backend}' is not supported for NvFP4 MoE. "
-        f"Expected one of {list(mapping.keys())}."
-    )
+    return _oracle.map_backend(runner_backend)
 
 
 def select_nvfp4_moe_backend(
@@ -135,132 +469,7 @@ def select_nvfp4_moe_backend(
     Select the primary NvFP4 MoE backend
     Note: Shape-specific fallbacks may still occur at runtime.
     """
-
-    # NOTE: the kernels are selected in the following order.
-    AVAILABLE_BACKENDS = [
-        NvFp4MoeBackend.FLASHINFER_TRTLLM,
-        NvFp4MoeBackend.FLASHINFER_CUTEDSL,
-        NvFp4MoeBackend.FLASHINFER_CUTLASS,
-        NvFp4MoeBackend.VLLM_CUTLASS,
-        NvFp4MoeBackend.MARLIN,
-    ]
-
-    # NOTE(rob): this is kind of a hack. We need to peak into
-    # the prepare-finalize selection to determine if we are using
-    # the batched or standard expert format.
-    use_batched = config.moe_parallel_config.use_deepep_ll_kernels
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if use_batched
-        else mk.FusedMoEActivationFormat.Standard
-    )
-
-    def _make_log_backend(backend: NvFp4MoeBackend):
-        available_backend_strs = [b.value for b in AVAILABLE_BACKENDS]
-        return (
-            f"Using '{backend.value}' NvFp4 MoE backend out "
-            f"of potential backends: {available_backend_strs}."
-        )
-
-    def _make_log_unsupported(backend: NvFp4MoeBackend, reason: str | None) -> str:
-        if reason:
-            return (
-                f"NvFp4 MoE backend '{backend.value}' does not support the "
-                f"deployment configuration since {reason}."
-            )
-        else:
-            return (
-                f"NvFp4 MoE backend '{backend.value}' does not support the "
-                "deployment configuration."
-            )
-
-    def _return_or_raise(
-        backend: NvFp4MoeBackend,
-        config: FusedMoEConfig,
-        weight_key: QuantKey | None,
-        activation_key: QuantKey | None,
-        activation_format: mk.FusedMoEActivationFormat,
-    ) -> tuple[NvFp4MoeBackend, type[mk.FusedMoEExperts]]:
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, weight_key, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend))
-                return backend, k_cls
-
-        raise ValueError(_make_log_unsupported(backend, reason))
-
-    # Handle explicit moe_backend from user.
-    runner_backend = config.moe_backend
-    if runner_backend != "auto":
-        requested_backend = map_nvfp4_backend(runner_backend)
-        return _return_or_raise(
-            requested_backend, config, weight_key, activation_key, activation_format
-        )
-
-    if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP4"):
-        if not envs.VLLM_USE_FLASHINFER_MOE_FP4:
-            # If the user rejects FlashInfer remove those backends.
-            for b in FLASHINFER_NVFP4_MOE_BACKENDS:
-                AVAILABLE_BACKENDS.remove(b)
-
-        elif envs.is_set("VLLM_FLASHINFER_MOE_BACKEND"):
-            # If user is explicit about backend, validate it.
-            backend = fi_2_vllm_backend_map[get_flashinfer_moe_backend()]
-            return _return_or_raise(
-                backend, config, weight_key, activation_key, activation_format
-            )
-        else:
-            # If the user is not explicit about the backend, try each.
-            for backend in FLASHINFER_NVFP4_MOE_BACKENDS:
-                for k_cls in backend_to_kernel_cls(backend):
-                    supported, reason = k_cls.is_supported_config(
-                        k_cls,
-                        config,
-                        weight_key,
-                        activation_key,
-                        activation_format,
-                    )
-                    if supported:
-                        logger.info_once(_make_log_backend(backend), scope="local")
-                        return backend, k_cls
-                    else:
-                        logger.debug_once(
-                            _make_log_unsupported(backend, reason), scope="local"
-                        )
-
-            raise NotImplementedError(
-                "Found VLLM_USE_FLASHINFER_MOE_FP4=1, but no "
-                "FlashInfer NVFP4 MoE backend supports the configuration."
-            )
-
-    if envs.VLLM_TEST_FORCE_FP8_MARLIN:
-        backend = NvFp4MoeBackend.MARLIN
-        return _return_or_raise(
-            backend, config, weight_key, activation_key, activation_format
-        )
-
-    # Select kernels in order of backend.
-    for backend in AVAILABLE_BACKENDS:
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls,
-                config,
-                weight_key,
-                activation_key,
-                activation_format,
-            )
-
-            if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
-                return backend, k_cls
-            else:
-                logger.debug_once(_make_log_unsupported(backend, reason), scope="local")
-
-    raise NotImplementedError(
-        "No NvFp4 MoE backend supports the deployment configuration."
-    )
+    return _oracle.select_backend(config, weight_key, activation_key)
 
 
 def convert_to_nvfp4_moe_kernel_format(
@@ -285,56 +494,9 @@ def convert_to_nvfp4_moe_kernel_format(
     torch.Tensor,
     torch.Tensor,
 ]:
-    if (
-        nvfp4_backend in FLASHINFER_NVFP4_MOE_BACKENDS
-        or nvfp4_backend == NvFp4MoeBackend.VLLM_CUTLASS
-    ):
-        (
-            w13,
-            w13_scale,
-            w13_scale_2,
-            a13_scale,
-            w2,
-            w2_scale,
-            w2_scale_2,
-            a2_scale,
-        ) = prepare_nvfp4_moe_layer_for_fi_or_cutlass(
-            backend=nvfp4_backend,
-            layer=layer,
-            w13=w13,
-            w13_scale=w13_scale,
-            w13_scale_2=w13_scale_2,
-            a13_scale=a13_scale,
-            w2=w2,
-            w2_scale=w2_scale,
-            w2_scale_2=w2_scale_2,
-            a2_scale=a2_scale,
-            is_act_and_mul=is_act_and_mul,
-        )
-    elif nvfp4_backend == NvFp4MoeBackend.MARLIN:
-        a13_scale = None
-        a2_scale = None
-        (
-            w13,
-            w13_scale,
-            w13_scale_2,
-            w2,
-            w2_scale,
-            w2_scale_2,
-        ) = prepare_nvfp4_moe_layer_for_marlin(
-            layer=layer,
-            w13=w13,
-            w13_scale=w13_scale,
-            w13_scale_2=w13_scale_2,
-            w2=w2,
-            w2_scale=w2_scale,
-            w2_scale_2=w2_scale_2,
-            is_act_and_mul=is_act_and_mul,
-        )
-    else:
-        raise ValueError(f"Unknown NvFp4 backend for MoE: {nvfp4_backend}")
-
-    return (
+    return _oracle.convert_to_kernel_format(
+        nvfp4_backend,
+        layer,
         w13,
         w13_scale,
         w13_scale_2,
@@ -343,6 +505,7 @@ def convert_to_nvfp4_moe_kernel_format(
         w2_scale,
         w2_scale_2,
         a2_scale,
+        is_act_and_mul,
     )
 
 
@@ -355,29 +518,14 @@ def make_nvfp4_moe_quant_config(
     a13_scale: torch.Tensor,
     a2_scale: torch.Tensor,
 ) -> FusedMoEQuantConfig:
-    if backend == NvFp4MoeBackend.MARLIN:
-        return nvfp4_w4a16_moe_quant_config(
-            g1_alphas=w13_scale_2,
-            g2_alphas=w2_scale_2,
-            w1_scale=w13_scale,
-            w2_scale=w2_scale,
-        )
-
-    # Pass w13_scale_2 / w2_scale_2 directly as g1/g2_alphas.
-    # The expert's process_weights_after_loading will fuse activation
-    # scales in-place. Since the quant config references the same tensor
-    # as the registered parameter, EPLB rearrangement stays in sync.
-    return nvfp4_moe_quant_config(
-        g1_alphas=w13_scale_2,
-        g2_alphas=w2_scale_2,
-        a1_gscale=(1.0 / a13_scale),
-        a2_gscale=(1.0 / a2_scale),
-        w1_scale=w13_scale,
-        w2_scale=w2_scale,
-        # NOTE(rob): this is a hack until the MoE kernels
-        # create their own quant configs. TRTLLM kernel
-        # does not accept swizzled input quant scales.
-        is_nvfp4_scale_swizzled=(backend != NvFp4MoeBackend.FLASHINFER_TRTLLM),
+    return _oracle.make_quant_config(
+        backend,
+        w13_scale,
+        w2_scale,
+        w13_scale_2,
+        w2_scale_2,
+        a13_scale,
+        a2_scale,
     )
 
 
@@ -388,48 +536,10 @@ def make_nvfp4_moe_kernel(
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     shared_experts: torch.nn.Module | None = None,
 ) -> mk.FusedMoEKernel:
-    # Create Prepare/Finalize.
-    prepare_finalize = maybe_make_prepare_finalize(
-        moe=moe_config,
-        quant_config=moe_quant_config,
-        routing_tables=routing_tables,
-        allow_new_interface=True,
-        use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),
+    return _oracle.make_kernel(
+        moe_quant_config,
+        moe_config,
+        experts_cls,
+        routing_tables,
+        shared_experts,
     )
-    assert prepare_finalize is not None
-
-    logger.info_once("Using %s", prepare_finalize.__class__.__name__)
-
-    # Create Experts.
-    if prepare_finalize.activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
-        max_num_tokens = prepare_finalize.max_num_tokens_per_rank()
-        assert max_num_tokens is not None
-        experts = experts_cls(
-            moe_config=moe_config,
-            quant_config=moe_quant_config,
-            max_num_tokens=max_num_tokens,
-            num_dispatchers=prepare_finalize.num_dispatchers(),
-        )
-    else:
-        experts = experts_cls(
-            moe_config=moe_config,
-            quant_config=moe_quant_config,
-        )
-
-    # NOTE(rob): we only want the mk to control the shared_expert
-    # if using all2all (for SBO). bnell is making this explicit in
-    # the new MoE runner class.
-    kernel = mk.FusedMoEKernel(
-        prepare_finalize,
-        experts,
-        shared_experts=(
-            shared_experts
-            if moe_config.moe_parallel_config.use_deepep_ll_kernels
-            else None
-        ),
-        moe_parallel_config=moe_config.moe_parallel_config,
-        inplace=False,
-    )
-
-    # TODO(rob): update inplace logic to be part of the kernel.
-    return kernel

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -65,10 +65,6 @@ def is_global_sf_supported_for_nvfp4_backend(backend: NvFp4MoeBackend) -> bool:
 
 
 class NvFp4MoEKernelOracle(MoEKernelOracle[NvFp4MoeBackend]):
-    @property
-    def quant_type_name(self) -> str:
-        return "NvFp4"
-
     def backend_to_kernel_cls(
         self,
         backend: NvFp4MoeBackend,
@@ -187,7 +183,7 @@ class NvFp4MoEKernelOracle(MoEKernelOracle[NvFp4MoeBackend]):
             activation_key: QuantKey | None,
             activation_format: mk.FusedMoEActivationFormat,
         ) -> tuple[NvFp4MoeBackend, type[mk.FusedMoEExperts]]:
-            for k_cls in backend_to_kernel_cls(backend):
+            for k_cls in self.backend_to_kernel_cls(backend):
                 supported, reason = k_cls.is_supported_config(
                     k_cls, config, weight_key, activation_key, activation_format
                 )
@@ -200,7 +196,7 @@ class NvFp4MoEKernelOracle(MoEKernelOracle[NvFp4MoeBackend]):
         # Handle explicit moe_backend from user.
         runner_backend = config.moe_backend
         if runner_backend != "auto":
-            requested_backend = map_nvfp4_backend(runner_backend)
+            requested_backend = self.map_backend(runner_backend)
             return _return_or_raise(
                 requested_backend, config, weight_key, activation_key, activation_format
             )
@@ -220,7 +216,7 @@ class NvFp4MoEKernelOracle(MoEKernelOracle[NvFp4MoeBackend]):
             else:
                 # If the user is not explicit about the backend, try each.
                 for backend in FLASHINFER_NVFP4_MOE_BACKENDS:
-                    for k_cls in backend_to_kernel_cls(backend):
+                    for k_cls in self.backend_to_kernel_cls(backend):
                         supported, reason = k_cls.is_supported_config(
                             k_cls,
                             config,
@@ -249,7 +245,7 @@ class NvFp4MoEKernelOracle(MoEKernelOracle[NvFp4MoeBackend]):
 
         # Select kernels in order of backend.
         for backend in AVAILABLE_BACKENDS:
-            for k_cls in backend_to_kernel_cls(backend):
+            for k_cls in self.backend_to_kernel_cls(backend):
                 supported, reason = k_cls.is_supported_config(
                     k_cls,
                     config,

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe import (
     is_supported_config_trtllm_bf16,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.fused_moe.prepare_finalize import (
     MoEPrepareAndFinalizeNoDPEPModular,
 )
@@ -52,20 +53,271 @@ UNSUPPORTED_BACKEND = [
 ]
 
 
+class UnquantizedMoEKernelOracle(MoEKernelOracle[UnquantizedMoeBackend]):
+    """Oracle for unquantized MoE kernel selection."""
+
+    @property
+    def quant_type_name(self) -> str:
+        return "Unquantized"
+
+    def backend_to_kernel_cls(
+        self,
+        backend: UnquantizedMoeBackend,
+    ) -> list[type[mk.FusedMoEExperts]]:
+        if backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS:
+            from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
+                FlashInferExperts,
+            )
+
+            return [FlashInferExperts]
+
+        elif backend == UnquantizedMoeBackend.AITER:
+            from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+                AiterExperts,
+            )
+
+            return [AiterExperts]
+
+        elif backend == UnquantizedMoeBackend.TRITON:
+            from vllm.model_executor.layers.fused_moe.fused_moe import (
+                TritonExperts,
+            )
+
+            return [TritonExperts]
+
+        elif backend == UnquantizedMoeBackend.XPU:
+            from vllm.model_executor.layers.fused_moe.xpu_fused_moe import (
+                XPUExperts,
+            )
+
+            return [XPUExperts]
+
+        else:
+            raise ValueError(f"Unknown unquantized MoE backend: {backend.value}")
+
+    def map_backend(self, runner_backend: MoEBackend) -> UnquantizedMoeBackend:
+        """Map user's MoEBackend to UnquantizedMoeBackend."""
+        mapping = {
+            "triton": UnquantizedMoeBackend.TRITON,
+            "flashinfer_trtllm": UnquantizedMoeBackend.FLASHINFER_TRTLLM,
+            "flashinfer_cutlass": UnquantizedMoeBackend.FLASHINFER_CUTLASS,
+            "aiter": UnquantizedMoeBackend.AITER,
+        }
+        if backend := mapping.get(runner_backend):
+            return backend
+        raise ValueError(
+            f"moe_backend='{runner_backend}' is not supported for unquantized MoE. "
+            f"Expected one of {list(mapping.keys())}."
+        )
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        use_ep: bool,
+        use_dp: bool,
+    ) -> UnquantizedMoeBackend:
+        """
+        Select the primary Unquantized MoE backend
+        Note: Shape-specific fallbacks may still occur at runtime.
+        """
+
+        def _make_log_backend(backend: UnquantizedMoeBackend):
+            return f"Using {backend.value} backend for Unquantized MoE"
+
+        activation_format = (
+            mk.FusedMoEActivationFormat.BatchedExperts
+            if moe_config.moe_parallel_config.use_batched_activation_format
+            else mk.FusedMoEActivationFormat.Standard
+        )
+
+        # Check if FlashInfer TRTLLM BF16 MoE is supported
+        trtllm_supported, _ = is_supported_config_trtllm_bf16(
+            moe_config=moe_config,
+            activation_format=activation_format,
+        )
+        flashinfer_trtllm_available = has_flashinfer() and trtllm_supported
+        # FlashInfer CUTLASS MoE is only supported on Hopper and later GPUS
+        flashinfer_cutlass_available = (
+            has_flashinfer_cutlass_fused_moe()
+            and use_ep
+            and (not use_dp)
+            and current_platform.has_device_capability(90)
+        )
+        flashinfer_trtllm_moe_enabled = (
+            flashinfer_trtllm_available
+            and envs.VLLM_USE_FLASHINFER_MOE_FP16
+            and envs.VLLM_FLASHINFER_MOE_BACKEND == "latency"
+        )
+        flashinfer_cutlass_moe_enabled = (
+            flashinfer_cutlass_available and envs.VLLM_USE_FLASHINFER_MOE_FP16
+        )
+        rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
+
+        # Handle explicit moe_backend from user.
+        runner_backend = moe_config.moe_backend
+        if runner_backend != "auto":
+            requested_backend = self.map_backend(runner_backend)
+            if requested_backend == UnquantizedMoeBackend.FLASHINFER_TRTLLM:
+                if not flashinfer_trtllm_available:
+                    raise ValueError(
+                        "FlashInfer TRTLLM MoE backend is not available for this "
+                        "configuration."
+                    )
+            elif requested_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS:
+                if not flashinfer_cutlass_available:
+                    raise ValueError(
+                        "FlashInfer CUTLASS MoE backend is not available for this "
+                        "configuration."
+                    )
+            elif requested_backend == UnquantizedMoeBackend.AITER and not (
+                current_platform.is_rocm() and rocm_aiter_moe_enabled
+            ):
+                raise ValueError(
+                    "ROCm AITer MoE backend is not available for this configuration."
+                )
+            logger.info_once(_make_log_backend(requested_backend), scope="local")
+            return requested_backend
+
+        if current_platform.is_rocm():
+            if rocm_aiter_moe_enabled:
+                backend = UnquantizedMoeBackend.AITER
+            else:
+                backend = UnquantizedMoeBackend.TRITON
+        if current_platform.is_cuda():
+            if flashinfer_trtllm_moe_enabled:
+                backend = UnquantizedMoeBackend.FLASHINFER_TRTLLM
+            elif flashinfer_cutlass_moe_enabled:
+                backend = UnquantizedMoeBackend.FLASHINFER_CUTLASS
+                if trtllm_supported:
+                    logger.info_once(
+                        "FlashInfer TRTLLM MoE is available but not enabled, "
+                        "consider setting VLLM_FLASHINFER_MOE_BACKEND=latency "
+                        "to enable it for better performance.",
+                        scope="local",
+                    )
+            else:
+                if not envs.VLLM_USE_FLASHINFER_MOE_FP16 and trtllm_supported:
+                    logger.info_once(
+                        "FlashInfer TRTLLM MoE is available but not enabled, "
+                        "consider setting VLLM_USE_FLASHINFER_MOE_FP16=1 "
+                        "and VLLM_FLASHINFER_MOE_BACKEND=latency "
+                        "to enable it for better performance.",
+                        scope="local",
+                    )
+                elif use_ep and (not use_dp):
+                    logger.info_once(
+                        "FlashInfer MoE is available for EP"
+                        " but not enabled, consider setting"
+                        " VLLM_USE_FLASHINFER_MOE_FP16=1 to enable it.",
+                        scope="local",
+                    )
+                elif use_dp:
+                    logger.info_once(
+                        "FlashInfer CUTLASS MoE is currently not available for DP.",
+                        scope="local",
+                    )
+                backend = UnquantizedMoeBackend.TRITON
+        if current_platform.is_xpu():
+            backend = UnquantizedMoeBackend.XPU
+        if current_platform.is_cpu():
+            backend = UnquantizedMoeBackend.CPU
+        if current_platform.is_tpu():
+            backend = UnquantizedMoeBackend.TPU
+        if current_platform.is_out_of_tree():
+            backend = UnquantizedMoeBackend.OOT
+
+        logger.info_once(_make_log_backend(backend), scope="local")
+        return backend
+
+    def convert_to_kernel_format(
+        self,
+        unquantized_backend: UnquantizedMoeBackend,
+        layer: Module,
+        w13_weight: torch.Tensor | None = None,
+        w2_weight: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if unquantized_backend == UnquantizedMoeBackend.AITER:
+            w13_weight, w2_weight = rocm_aiter_ops.shuffle_weights(
+                layer.w13_weight.data, layer.w2_weight.data
+            )
+
+        elif unquantized_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS:
+            # Swap halves to arrange as [w3; w1] (kernel expectation)
+            w13_weight = swap_w13_to_w31(layer.w13_weight.data)
+
+        return w13_weight, w2_weight
+
+    def make_kernel(
+        self,
+        backend: UnquantizedMoeBackend,
+        quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+    ) -> mk.FusedMoEKernel | None:
+        if backend in UNSUPPORTED_BACKEND:
+            return None
+
+        if backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS:
+            from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
+                FlashInferExperts,
+            )
+
+            kernel = mk.FusedMoEKernel(
+                MoEPrepareAndFinalizeNoDPEPModular(),
+                FlashInferExperts(
+                    moe_config=moe_config,
+                    quant_config=quant_config,
+                ),
+                inplace=False,
+            )
+
+        elif backend == UnquantizedMoeBackend.AITER:
+            from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+                AiterExperts,
+            )
+
+            kernel = mk.FusedMoEKernel(
+                MoEPrepareAndFinalizeNoDPEPModular(),
+                AiterExperts(
+                    moe_config=moe_config,
+                    quant_config=quant_config,
+                ),
+                inplace=not moe_config.disable_inplace,
+            )
+        elif backend == UnquantizedMoeBackend.TRITON:
+            from vllm.model_executor.layers.fused_moe import TritonExperts
+
+            kernel = mk.FusedMoEKernel(
+                MoEPrepareAndFinalizeNoDPEPModular(),
+                TritonExperts(
+                    moe_config=moe_config,
+                    quant_config=quant_config,
+                ),
+                inplace=not moe_config.disable_inplace,
+            )
+        elif backend == UnquantizedMoeBackend.XPU:
+            from vllm.model_executor.layers.fused_moe import XPUExperts
+
+            kernel = mk.FusedMoEKernel(
+                MoEPrepareAndFinalizeNoDPEPModular(),
+                XPUExperts(
+                    moe_config=moe_config,
+                    quant_config=quant_config,
+                ),
+                inplace=not moe_config.disable_inplace,
+            )
+        return kernel
+
+
+# Module-level oracle instance.
+_oracle = UnquantizedMoEKernelOracle()
+
+
+# --- Backwards-compatible standalone function wrappers ---
+
+
 def map_unquantized_backend(runner_backend: MoEBackend) -> UnquantizedMoeBackend:
     """Map user's MoEBackend to UnquantizedMoeBackend."""
-    mapping = {
-        "triton": UnquantizedMoeBackend.TRITON,
-        "flashinfer_trtllm": UnquantizedMoeBackend.FLASHINFER_TRTLLM,
-        "flashinfer_cutlass": UnquantizedMoeBackend.FLASHINFER_CUTLASS,
-        "aiter": UnquantizedMoeBackend.AITER,
-    }
-    if backend := mapping.get(runner_backend):
-        return backend
-    raise ValueError(
-        f"moe_backend='{runner_backend}' is not supported for unquantized MoE. "
-        f"Expected one of {list(mapping.keys())}."
-    )
+    return _oracle.map_backend(runner_backend)
 
 
 def select_unquantized_moe_backend(
@@ -77,114 +329,7 @@ def select_unquantized_moe_backend(
     Select the primary Unquantized MoE backend
     Note: Shape-specific fallbacks may still occur at runtime.
     """
-
-    def _make_log_backend(backend: UnquantizedMoeBackend):
-        return f"Using {backend.value} backend for Unquantized MoE"
-
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if moe_config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
-    )
-
-    # Check if FlashInfer TRTLLM BF16 MoE is supported
-    trtllm_supported, _ = is_supported_config_trtllm_bf16(
-        moe_config=moe_config,
-        activation_format=activation_format,
-    )
-    flashinfer_trtllm_available = has_flashinfer() and trtllm_supported
-    # FlashInfer CUTLASS MoE is only supported on Hopper and later GPUS
-    flashinfer_cutlass_available = (
-        has_flashinfer_cutlass_fused_moe()
-        and use_ep
-        and (not use_dp)
-        and current_platform.has_device_capability(90)
-    )
-    flashinfer_trtllm_moe_enabled = (
-        flashinfer_trtllm_available
-        and envs.VLLM_USE_FLASHINFER_MOE_FP16
-        and envs.VLLM_FLASHINFER_MOE_BACKEND == "latency"
-    )
-    flashinfer_cutlass_moe_enabled = (
-        flashinfer_cutlass_available and envs.VLLM_USE_FLASHINFER_MOE_FP16
-    )
-    rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
-
-    # Handle explicit moe_backend from user.
-    runner_backend = moe_config.moe_backend
-    if runner_backend != "auto":
-        requested_backend = map_unquantized_backend(runner_backend)
-        if requested_backend == UnquantizedMoeBackend.FLASHINFER_TRTLLM:
-            if not flashinfer_trtllm_available:
-                raise ValueError(
-                    "FlashInfer TRTLLM MoE backend is not available for this "
-                    "configuration."
-                )
-        elif requested_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS:
-            if not flashinfer_cutlass_available:
-                raise ValueError(
-                    "FlashInfer CUTLASS MoE backend is not available for this "
-                    "configuration."
-                )
-        elif requested_backend == UnquantizedMoeBackend.AITER and not (
-            current_platform.is_rocm() and rocm_aiter_moe_enabled
-        ):
-            raise ValueError(
-                "ROCm AITer MoE backend is not available for this configuration."
-            )
-        logger.info_once(_make_log_backend(requested_backend), scope="local")
-        return requested_backend
-
-    if current_platform.is_rocm():
-        if rocm_aiter_moe_enabled:
-            backend = UnquantizedMoeBackend.AITER
-        else:
-            backend = UnquantizedMoeBackend.TRITON
-    if current_platform.is_cuda():
-        if flashinfer_trtllm_moe_enabled:
-            backend = UnquantizedMoeBackend.FLASHINFER_TRTLLM
-        elif flashinfer_cutlass_moe_enabled:
-            backend = UnquantizedMoeBackend.FLASHINFER_CUTLASS
-            if trtllm_supported:
-                logger.info_once(
-                    "FlashInfer TRTLLM MoE is available but not enabled, "
-                    "consider setting VLLM_FLASHINFER_MOE_BACKEND=latency "
-                    "to enable it for better performance.",
-                    scope="local",
-                )
-        else:
-            if not envs.VLLM_USE_FLASHINFER_MOE_FP16 and trtllm_supported:
-                logger.info_once(
-                    "FlashInfer TRTLLM MoE is available but not enabled, "
-                    "consider setting VLLM_USE_FLASHINFER_MOE_FP16=1 "
-                    "and VLLM_FLASHINFER_MOE_BACKEND=latency "
-                    "to enable it for better performance.",
-                    scope="local",
-                )
-            elif use_ep and (not use_dp):
-                logger.info_once(
-                    "FlashInfer MoE is available for EP"
-                    " but not enabled, consider setting"
-                    " VLLM_USE_FLASHINFER_MOE_FP16=1 to enable it.",
-                    scope="local",
-                )
-            elif use_dp:
-                logger.info_once(
-                    "FlashInfer CUTLASS MoE is currently not available for DP.",
-                    scope="local",
-                )
-            backend = UnquantizedMoeBackend.TRITON
-    if current_platform.is_xpu():
-        backend = UnquantizedMoeBackend.XPU
-    if current_platform.is_cpu():
-        backend = UnquantizedMoeBackend.CPU
-    if current_platform.is_tpu():
-        backend = UnquantizedMoeBackend.TPU
-    if current_platform.is_out_of_tree():
-        backend = UnquantizedMoeBackend.OOT
-
-    logger.info_once(_make_log_backend(backend), scope="local")
-    return backend
+    return _oracle.select_backend(moe_config, use_ep, use_dp)
 
 
 def convert_to_unquantized_kernel_format(
@@ -193,16 +338,9 @@ def convert_to_unquantized_kernel_format(
     w13_weight: torch.Tensor | None = None,
     w2_weight: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if unquantized_backend == UnquantizedMoeBackend.AITER:
-        w13_weight, w2_weight = rocm_aiter_ops.shuffle_weights(
-            layer.w13_weight.data, layer.w2_weight.data
-        )
-
-    elif unquantized_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS:
-        # Swap halves to arrange as [w3; w1] (kernel expectation)
-        w13_weight = swap_w13_to_w31(layer.w13_weight.data)
-
-    return w13_weight, w2_weight
+    return _oracle.convert_to_kernel_format(
+        unquantized_backend, layer, w13_weight, w2_weight
+    )
 
 
 def make_unquantized_moe_kernel(
@@ -210,56 +348,4 @@ def make_unquantized_moe_kernel(
     quant_config: FusedMoEQuantConfig,
     moe_config: FusedMoEConfig,
 ) -> mk.FusedMoEKernel | None:
-    if backend in UNSUPPORTED_BACKEND:
-        return None
-
-    if backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS:
-        from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
-            FlashInferExperts,
-        )
-
-        kernel = mk.FusedMoEKernel(
-            MoEPrepareAndFinalizeNoDPEPModular(),
-            FlashInferExperts(
-                moe_config=moe_config,
-                quant_config=quant_config,
-            ),
-            inplace=False,
-        )
-
-    elif backend == UnquantizedMoeBackend.AITER:
-        from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
-            AiterExperts,
-        )
-
-        kernel = mk.FusedMoEKernel(
-            MoEPrepareAndFinalizeNoDPEPModular(),
-            AiterExperts(
-                moe_config=moe_config,
-                quant_config=quant_config,
-            ),
-            inplace=not moe_config.disable_inplace,
-        )
-    elif backend == UnquantizedMoeBackend.TRITON:
-        from vllm.model_executor.layers.fused_moe import TritonExperts
-
-        kernel = mk.FusedMoEKernel(
-            MoEPrepareAndFinalizeNoDPEPModular(),
-            TritonExperts(
-                moe_config=moe_config,
-                quant_config=quant_config,
-            ),
-            inplace=not moe_config.disable_inplace,
-        )
-    elif backend == UnquantizedMoeBackend.XPU:
-        from vllm.model_executor.layers.fused_moe import XPUExperts
-
-        kernel = mk.FusedMoEKernel(
-            MoEPrepareAndFinalizeNoDPEPModular(),
-            XPUExperts(
-                moe_config=moe_config,
-                quant_config=quant_config,
-            ),
-            inplace=not moe_config.disable_inplace,
-        )
-    return kernel
+    return _oracle.make_kernel(backend, quant_config, moe_config)

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -56,10 +56,6 @@ UNSUPPORTED_BACKEND = [
 class UnquantizedMoEKernelOracle(MoEKernelOracle[UnquantizedMoeBackend]):
     """Oracle for unquantized MoE kernel selection."""
 
-    @property
-    def quant_type_name(self) -> str:
-        return "Unquantized"
-
     def backend_to_kernel_cls(
         self,
         backend: UnquantizedMoeBackend,
@@ -183,7 +179,7 @@ class UnquantizedMoEKernelOracle(MoEKernelOracle[UnquantizedMoeBackend]):
                 backend = UnquantizedMoeBackend.AITER
             else:
                 backend = UnquantizedMoeBackend.TRITON
-        if current_platform.is_cuda():
+        elif current_platform.is_cuda():
             if flashinfer_trtllm_moe_enabled:
                 backend = UnquantizedMoeBackend.FLASHINFER_TRTLLM
             elif flashinfer_cutlass_moe_enabled:
@@ -217,14 +213,18 @@ class UnquantizedMoEKernelOracle(MoEKernelOracle[UnquantizedMoeBackend]):
                         scope="local",
                     )
                 backend = UnquantizedMoeBackend.TRITON
-        if current_platform.is_xpu():
+        elif current_platform.is_xpu():
             backend = UnquantizedMoeBackend.XPU
-        if current_platform.is_cpu():
+        elif current_platform.is_cpu():
             backend = UnquantizedMoeBackend.CPU
-        if current_platform.is_tpu():
+        elif current_platform.is_tpu():
             backend = UnquantizedMoeBackend.TPU
-        if current_platform.is_out_of_tree():
+        elif current_platform.is_out_of_tree():
             backend = UnquantizedMoeBackend.OOT
+        else:
+            raise NotImplementedError(
+                "No unquantized MoE backend supports the current platform."
+            )
 
         logger.info_once(_make_log_backend(backend), scope="local")
         return backend
@@ -305,6 +305,8 @@ class UnquantizedMoEKernelOracle(MoEKernelOracle[UnquantizedMoeBackend]):
                 ),
                 inplace=not moe_config.disable_inplace,
             )
+        else:
+            raise ValueError(f"Unsupported unquantized MoE backend: {backend.value}")
         return kernel
 
 


### PR DESCRIPTION
## Purpose

Resolves #37753.

Introduces `MoEKernelOracle(ABC, Generic[BackendT])` as a base class for all MoE kernel selection oracles. Each oracle (FP8, NvFP4, MXFP4, MXFP8, Unquantized) now inherits from this base class, standardizing the 4 core operations:

- `select_backend` – choose the best kernel backend
- `convert_to_kernel_format` – shuffle weights for a backend
- `make_quant_config` – build a `FusedMoEQuantConfig`
- `make_kernel` – construct the `FusedMoEKernel`

Plus 2 shared helper methods (`backend_to_kernel_cls`, `map_backend`) as abstract methods.

**Key design decisions:**
- Module-level wrapper functions are preserved for full backward compatibility — zero changes required from external callers.
- Method signatures intentionally vary across subclasses (different quant types need different weight/scale parameters), documented in base class docstring.
- Optional methods (`convert_to_kernel_format`, `make_quant_config`, `make_kernel`) default to `NotImplementedError` for oracles that delegate (e.g. MXFP8 reuses FP8's kernel logic).

**Additional fixes:**
- Fixed class methods calling module-level wrapper functions instead of `self.method()` in fp8, nvfp4, mxfp4.
- Fixed `map_backend` type annotation inconsistency (`str` → `MoEBackend`) in mxfp8 and mxfp4.
- Fixed potential `UnboundLocalError` in `unquantized.py` `select_backend` (changed `if/if` chain to `if/elif` with `else` fallback).
- Fixed missing `else` branch in `unquantized.py` `make_kernel`.
- Renamed private `_select_kernel_cls` to `select_kernel_cls` in mxfp8.
- Exported `MoEKernelOracle` from `oracle/__init__.py`.

## Test Plan

```bash
pytest tests/kernels/moe/test_oracle_class_structure.py -v -s
pytest tests/kernels/moe/test_unquantized_backend_selection.py -v -s
```

## Test Result

```
tests/kernels/moe/test_oracle_class_structure.py: 20 passed
tests/kernels/moe/test_unquantized_backend_selection.py: 8 passed
Total: 28 passed, 0 failed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>