### PR TITLE
[Perf] Optimize glm4.xv VIT

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -758,11 +758,10 @@ class Glm4vVisionTransformer(nn.Module):
             grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
         ).cumsum(dim=0, dtype=torch.int32)
         cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
-        cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
-
         # pre-compute max_seqlen for attn mask to reduce cuMemcpy operations
         max_seqlen = self.compute_attn_mask_seqlen(cu_seqlens)
         seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
         x = self.embeddings(
             x, seqlens, grid_thw, image_type_ids[:, 0], image_type_ids[:, 1]
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

`Glm4vVisionTransformer.forward()` has 24 unnecessary CUDA D2H                                                                                                                                                     
  synchronizations caused by `max_seqlen.item()` being called on a                                                                                                                                                   
  GPU tensor inside each VisionBlock's attention.

## Purpose

## Test Plan

## Test Result

<img width="990" height="364" alt="image" src="https://github.com/user-attachments/assets/9ce9a705-9ab9-40a4-8543-e86ecc012f5a" />
<img width="888" height="425" alt="image" src="https://github.com/user-attachments/assets/35a6b223-3414-4b7e-9ebc-fc624c210d1a" />

<img width="442" height="521" alt="image" src="https://github.com/user-attachments/assets/6aa98e15-50e0-48a2-a8a3-e009d5b978ec" />
<img width="416" height="518" alt="image" src="https://github.com/user-attachments/assets/1d52069b-b5a5-4b3a-b85a-6e5bb227cc54" />

<img width="634" height="516" alt="image" src="https://github.com/user-attachments/assets/01e8acdb-6452-46a0-bab0-57f25284d4a1" />
<img width="607" height="513" alt="image" src="https://github.com/user-attachments/assets/c5896ab4-26f3-4b9c-9cef-6211d056a9ee" />


### Benchmark (Perfetto SQL on profiler trace)                                                                                                                                                                      
                                                                                                                                                                                                                     
  | Metric | Before | After |                                                                                                                                                                                        
  |--------|--------|-------|                                                                                                                                                                                      
  | VIT wall time | 78.0ms | 42.3ms |                                                                                                                                                                                
  | cudaStreamSync in VIT | 49.0ms (62.8%) | 0.3ms (0.6%) |                                                                                                                                                          
  | Per-block sync calls | 24 × ~2ms | 0 |                                                                                                                                                                           
  | Prefill e2e | 121.3ms | 96.9ms |                                                                                                                                                                                 
  | **VIT speedup** | | **1.84x** |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
