### PR TITLE
[Perf] Fuse prefill conv output split into Q/K/V to reduce rearrange overhead

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -31,8 +31,13 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     initial_state_idx,  # (batch,)
     num_computed_tokens,  # (batch,)
     o_ptr,  # (dim, seqlen) - actually pointing to x_ptr
+    q_ptr,  # (seqlen, q_dim)
+    k_ptr,  # (seqlen, k_dim)
+    v_ptr,  # (seqlen, v_dim)
     # Matrix dimensions
     dim: tl.constexpr,
+    q_dim,
+    k_dim,
     seqlen: tl.int32,  # cu_seqlen
     num_cache_lines: tl.constexpr,  # added to support vLLM larger cache lines
     # Strides
@@ -46,6 +51,12 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     stride_cache_indices: tl.constexpr,
     stride_o_dim: tl.constexpr,
     stride_o_token: tl.constexpr,
+    stride_q_dim: tl.constexpr,
+    stride_q_token: tl.constexpr,
+    stride_k_dim: tl.constexpr,
+    stride_k_token: tl.constexpr,
+    stride_v_dim: tl.constexpr,
+    stride_v_token: tl.constexpr,
     stride_block_m: tl.constexpr,  # Stride block to align divided by BLOCK_M
     # others
     pad_slot_id: tl.constexpr,
@@ -58,6 +69,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     NP2_STATELEN: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    SPLIT_OUTPUT: tl.constexpr,
 ):
     conv_states_ptr = initial_states_ptr
     conv_state_indices_ptr = cache_indices_ptr
@@ -461,8 +473,25 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
             + (sequence_start_index + token_offset + idx_token) * stride_o_token
             + (idx_feats * stride_o_dim)
         )
+        if SPLIT_OUTPUT:
+            token_idx = sequence_start_index + token_offset + idx_token
+            qk_dim = q_dim + k_dim
 
-        tl.store(o_ptrs, acc, mask=mask_1d)
+            mask_q = mask_1d & (idx_feats < q_dim)
+            q_ptrs = q_ptr + token_idx * stride_q_token + idx_feats * stride_q_dim
+            tl.store(q_ptrs, acc, mask=mask_q)
+
+            mask_k = mask_1d & (idx_feats >= q_dim) & (idx_feats < qk_dim)
+            k_feat_idx = idx_feats - q_dim
+            k_ptrs = k_ptr + token_idx * stride_k_token + k_feat_idx * stride_k_dim
+            tl.store(k_ptrs, acc, mask=mask_k)
+
+            mask_v = mask_1d & (idx_feats >= qk_dim)
+            v_feat_idx = idx_feats - qk_dim
+            v_ptrs = v_ptr + token_idx * stride_v_token + v_feat_idx * stride_v_dim
+            tl.store(v_ptrs, acc, mask=mask_v)
+        else:
+            tl.store(o_ptrs, acc, mask=mask_1d)
 
 
 def causal_conv1d_fn(
@@ -482,6 +511,7 @@ def causal_conv1d_fn(
     block_size_to_align=0,
     metadata=None,
     validate_data=False,
+    split_output_sizes: tuple[int, int, int] | None = None,
 ):
     """support varlen + continuous batching when x is 2D tensor
 
@@ -533,6 +563,10 @@ def causal_conv1d_fn(
     block_size_to_align: int
         The block size to align the cached states to
     out: same shape as `x`
+    split_output_sizes: Optional[tuple[int, int, int]]
+        If provided as (q_dim, k_dim, v_dim), convolution output is split
+        directly into three 2D tensors of shapes
+        `(cu_seqlen, q_dim)`, `(cu_seqlen, k_dim)`, `(cu_seqlen, v_dim)`.
     """
     if isinstance(activation, bool) and activation:
         activation = "silu"
@@ -541,7 +575,7 @@ def causal_conv1d_fn(
     # Store original dtype to cast back at the end
     original_x_dtype = x.dtype
     x = x.to(conv_states.dtype)
-    out = torch.empty_like(x)
+    split_output = split_output_sizes is not None
     if metadata is not None:
         nums_dict = metadata.nums_dict
         args = nums_dict
@@ -561,6 +595,23 @@ def causal_conv1d_fn(
 
     is_channel_last = (x.stride(0) == 1) & (x.stride(1) > 1)
     dim, cu_seqlen = x.shape
+    out = x if split_output else torch.empty_like(x)
+    if split_output_sizes is not None:
+        q_dim, k_dim, v_dim = split_output_sizes
+        if q_dim + k_dim + v_dim != dim:
+            raise ValueError(
+                "split_output_sizes must sum to input dim: "
+                f"{q_dim} + {k_dim} + {v_dim} != {dim}"
+            )
+        q_out = torch.empty((cu_seqlen, q_dim), dtype=x.dtype, device=x.device)
+        k_out = torch.empty((cu_seqlen, k_dim), dtype=x.dtype, device=x.device)
+        v_out = torch.empty((cu_seqlen, v_dim), dtype=x.dtype, device=x.device)
+    else:
+        q_dim = 0
+        k_dim = 0
+        q_out = x
+        k_out = x
+        v_out = x
     _, width = weight.shape
     state_len = width - 1
     np2_statelen = triton.next_power_of_2(state_len)
@@ -597,6 +648,12 @@ def causal_conv1d_fn(
     else:
         stride_o_dim = out.stride(1)
         stride_o_token = out.stride(2)
+    stride_q_dim = q_out.stride(1)
+    stride_q_token = q_out.stride(0)
+    stride_k_dim = k_out.stride(1)
+    stride_k_token = k_out.stride(0)
+    stride_v_dim = v_out.stride(1)
+    stride_v_token = v_out.stride(0)
     stride_cache_indices = cache_indices.stride(0) if cache_indices is not None else 0
 
     if validate_data:
@@ -712,8 +769,13 @@ def causal_conv1d_fn(
         initial_state_idx,
         num_computed_tokens,
         out,
+        q_out,
+        k_out,
+        v_out,
         # Matrix dimensions
         dim,
+        q_dim,
+        k_dim,
         cu_seqlen,
         num_cache_lines,
         # stride
@@ -727,6 +789,12 @@ def causal_conv1d_fn(
         stride_cache_indices,
         stride_o_dim,
         stride_o_token,
+        stride_q_dim,
+        stride_q_token,
+        stride_k_dim,
+        stride_k_token,
+        stride_v_dim,
+        stride_v_token,
         block_size_to_align // BLOCK_M,
         # others
         pad_slot_id,
@@ -740,8 +808,15 @@ def causal_conv1d_fn(
         # launch_cooperative_grid=True
         BLOCK_M=BLOCK_M,
         BLOCK_N=256,
+        SPLIT_OUTPUT=split_output,
         num_stages=2,
     )
+    if split_output:
+        return (
+            q_out.to(original_x_dtype),
+            k_out.to(original_x_dtype),
+            v_out.to(original_x_dtype),
+        )
     return out.to(original_x_dtype)
 
 

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -896,11 +896,12 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             )
 
         # 1.2: Process the remaining part
+        query_non_spec, key_non_spec, value_non_spec = None, None, None
         if attn_metadata.num_prefills > 0:
             mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
             # - "cache_indices" updates the conv_state cache in positions
             #   pointed to by "state_indices_tensor"
-            mixed_qkv_non_spec = causal_conv1d_fn(
+            query_non_spec_2d, key_non_spec_2d, value_non_spec_2d = causal_conv1d_fn(
                 mixed_qkv_non_spec_T,
                 conv_weights,
                 self.conv1d.bias,
@@ -910,7 +911,30 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 cache_indices=non_spec_state_indices_tensor,
                 query_start_loc=non_spec_query_start_loc,
                 metadata=attn_metadata,
-            ).transpose(0, 1)
+                split_output_sizes=(
+                    self.key_dim // self.tp_size,
+                    self.key_dim // self.tp_size,
+                    self.value_dim // self.tp_size,
+                ),
+            )
+            query_non_spec = query_non_spec_2d.view(
+                1,
+                -1,
+                self.num_k_heads // self.tp_size,
+                self.head_k_dim,
+            )
+            key_non_spec = key_non_spec_2d.view(
+                1,
+                -1,
+                self.num_k_heads // self.tp_size,
+                self.head_k_dim,
+            )
+            value_non_spec = value_non_spec_2d.view(
+                1,
+                -1,
+                self.num_v_heads // self.tp_size,
+                self.head_v_dim,
+            )
         elif attn_metadata.num_decodes > 0:
             mixed_qkv_non_spec = causal_conv1d_update(
                 mixed_qkv_non_spec,
@@ -927,9 +951,10 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             mixed_qkv_non_spec = None
 
         query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
-        query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(
-            mixed_qkv_non_spec
-        )
+        if query_non_spec is None:
+            query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(
+                mixed_qkv_non_spec
+            )
 
         if attn_metadata.num_prefills > 0:
             g, beta = fused_gdn_gating(self.A_log, a, b, self.dt_bias)


### PR DESCRIPTION



## Purpose

Before
<img width="966" height="53" alt="image" src="https://github.com/user-attachments/assets/60b4b0df-7a10-4036-8aee-d1b88c0ebf70" />

Now

<img width="623" height="57" alt="image" src="https://github.com/user-attachments/assets/de3f7452-6359-4332-a076-8b45ee51313c" />

cc @vadiklyutiy @ywang96 @tdoublep 

Note: I'm not a fan of this approach because `causal_conv1d_fn` is already too complex, given how many models share it. I'd prefer to implement a separate kernel specifically for GDN.

## Test Plan

```
vllm serve Qwen/Qwen3.5-35B-A3B --gdn-prefill-backend triton

vllm bench serve \
--backend vllm \
--base-url http://localhost:8000 \
--model Qwen/Qwen3.5-35B-A3B \
--dataset-name random \
--random-input-len 8192 \
--random-output-len 2 \
--max-concurrency 256 \
--num-prompts 256 \
--num-warmups 1
```

## Test Result
pr

```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Maximum request concurrency:             256       
Benchmark duration (s):                  114.61    
Total input tokens:                      2097152   
Total generated tokens:                  512       
Request throughput (req/s):              2.23      
Output token throughput (tok/s):         4.47      
Peak output token throughput (tok/s):    7.00      
Peak concurrent requests:                256.00    
Total token throughput (tok/s):          18302.90  
---------------Time to First Token----------------
Mean TTFT (ms):                          58362.70  
Median TTFT (ms):                        58350.67  
P99 TTFT (ms):                           113985.41 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          438.65    
Median TPOT (ms):                        445.33    
P99 TPOT (ms):                           451.35    
---------------Inter-token Latency----------------
Mean ITL (ms):                           438.65    
Median ITL (ms):                         445.33    
P99 ITL (ms):                            451.35    
==================================================
```
main
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Failed requests:                         0         
Maximum request concurrency:             256       
Benchmark duration (s):                  116.02    
Total input tokens:                      2097152   
Total generated tokens:                  512       
Request throughput (req/s):              2.21      
Output token throughput (tok/s):         4.41      
Peak output token throughput (tok/s):    6.00      
Peak concurrent requests:                256.00    
Total token throughput (tok/s):          18080.61  
---------------Time to First Token----------------
Mean TTFT (ms):                          58905.09  
Median TTFT (ms):                        58899.04  
P99 TTFT (ms):                           115399.46 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          447.26    
Median TPOT (ms):                        452.35    
P99 TPOT (ms):                           456.12    
---------------Inter-token Latency----------------
Mean ITL (ms):                           447.26    
Median ITL (ms):                         452.35    
P99 ITL (ms):                            456.12    
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

