### PR TITLE
[Feature] Add track_token_ids for efficient selective token logprobs tracking

### DIFF
--- a/docs/features/track_token_ids.md
+++ b/docs/features/track_token_ids.md
@@ -1,0 +1,189 @@
+# Tracked Token Logprobs
+
+vLLM supports efficient tracking of log probabilities (logprobs) for specific tokens without requiring full vocabulary logprobs. This feature is useful for classification tasks, constrained generation, and any use case where you need accurate probabilities for a small set of predefined tokens.
+
+## Motivation
+
+When working with LLMs, you may need logprobs for specific tokens (e.g., class labels, binary choices, special tokens). Previously, users had to choose between two suboptimal approaches:
+
+| Approach | Description | Problems |
+|----------|-------------|----------|
+| **Top-k logprobs** (`logprobs=k`) | Hope target tokens appear in top-k | ❌ Unreliable: target tokens may not be in top-k |
+| **Full vocabulary** (`logprobs=-1`) | Retrieve all ~150k logprobs | ❌ Memory overhead (~1.2 MB per token)<br>❌ Large GPU→CPU transfer<br>❌ Wasteful: discard 99.99% of data |
+
+The `track_token_ids` parameter solves this by allowing you to specify exactly which tokens to track, achieving:
+
+- **99.99% memory reduction** compared to full vocabulary retrieval
+- **Reliable results**: tracked tokens are always included regardless of their rank
+- **Minimal overhead**: just indexing specific columns from the logprobs tensor
+
+## Use Cases
+
+### Classification Tasks
+
+Track probabilities for class labels to get reliable classification confidence:
+
+```python
+from vllm import LLM, SamplingParams
+
+llm = LLM(model="meta-llama/Llama-3.1-8B-Instruct")
+tokenizer = llm.get_tokenizer()
+
+# Get token IDs for class labels
+classes = ["Technology", "Politics", "Sports", "Art"]
+track_ids = []
+for label in classes:
+    ids = tokenizer.encode(label, add_special_tokens=False)
+    track_ids.extend(ids)
+
+sampling_params = SamplingParams(
+    temperature=0.0,
+    max_tokens=10,
+    track_token_ids=track_ids,
+)
+
+outputs = llm.generate(
+    ["Classify this article: 'The new GPU architecture shows 2x performance...'"],
+    sampling_params,
+)
+
+# Access tracked logprobs
+tracked = outputs[0].outputs[0].tracked_logprobs
+for token_id, logprobs_over_time in tracked.items():
+    token_str = tokenizer.decode([token_id])
+    print(f"{token_str}: {logprobs_over_time}")
+```
+
+### Binary Decision Making
+
+Perfect for yes/no, true/false, or binary classification scenarios:
+
+```python
+# Medical diagnosis, content moderation, fact-checking, etc.
+yes_ids = tokenizer.encode("Yes", add_special_tokens=False)
+no_ids = tokenizer.encode("No", add_special_tokens=False)
+
+sampling_params = SamplingParams(
+    temperature=0.0,
+    max_tokens=50,
+    track_token_ids=yes_ids + no_ids,
+)
+
+outputs = llm.generate(["Is this content safe? Content: ..."], sampling_params)
+tracked = outputs[0].outputs[0].tracked_logprobs
+# Analyze confidence between Yes/No across generation steps
+```
+
+### AI-Generated Content Detection
+
+Monitor probabilities for detection-related tokens throughout generation:
+
+```python
+# Track "real" vs "ai-generated" probabilities
+real_ids = tokenizer.encode("real", add_special_tokens=False)
+ai_ids = tokenizer.encode("ai-generated", add_special_tokens=False)
+synthetic_ids = tokenizer.encode("synthetic", add_special_tokens=False)
+
+sampling_params = SamplingParams(
+    temperature=0.0,
+    max_tokens=100,
+    track_token_ids=real_ids + ai_ids + synthetic_ids,
+)
+
+outputs = llm.generate(["Is this image real or AI-generated?"], sampling_params)
+
+# Analyze confidence evolution across generation
+tracked = outputs[0].outputs[0].tracked_logprobs
+for token_id, logprobs_over_time in tracked.items():
+    token_str = tokenizer.decode([token_id])
+    print(f"{token_str}: step-by-step logprobs = {logprobs_over_time}")
+```
+
+### Research and Analysis
+
+Track specific vocabulary items for hypothesis testing or model behavior analysis:
+
+```python
+# Study model confidence for specific tokens across long sequences
+interesting_tokens = ["however", "therefore", "because", "but"]
+track_ids = []
+for token in interesting_tokens:
+    track_ids.extend(tokenizer.encode(token, add_special_tokens=False))
+
+sampling_params = SamplingParams(
+    temperature=0.7,
+    max_tokens=500,
+    track_token_ids=track_ids,
+)
+```
+
+## API Reference
+
+### SamplingParams
+
+```python
+from vllm import SamplingParams
+
+sampling_params = SamplingParams(
+    # ... other parameters ...
+    track_token_ids=[1234, 5678, 9012],  # List of token IDs to track
+)
+```
+
+**Parameter:**
+
+- `track_token_ids` (`list[int] | None`): List of token IDs to track logprobs for at every generation step. These tokens will have their logprobs recorded even if they don't appear in the top-k. Default is `None` (disabled).
+
+### Output Format
+
+Tracked logprobs are available in the `CompletionOutput`:
+
+```python
+@dataclass
+class CompletionOutput:
+    # ... existing fields ...
+    tracked_logprobs: dict[int, list[float]] | None
+    """Logprobs for tracked tokens across all generation steps.
+    
+    Format: {token_id: [logprob_step0, logprob_step1, ...]}
+    Only present if track_token_ids was specified in SamplingParams.
+    """
+```
+
+**Example output structure:**
+
+```python
+# For track_token_ids=[100, 200, 300] with 5 generation steps:
+tracked_logprobs = {
+    100: [-2.3, -1.8, -2.1, -3.0, -2.5],  # logprobs at each step
+    200: [-5.1, -4.9, -5.3, -4.7, -5.0],
+    300: [-8.2, -7.9, -8.5, -8.1, -8.3],
+}
+```
+
+## Combining with Regular Logprobs
+
+You can use `track_token_ids` alongside regular top-k logprobs:
+
+```python
+sampling_params = SamplingParams(
+    logprobs=5,                    # Get top-5 logprobs as usual
+    track_token_ids=[100, 200],    # Also track these specific tokens
+)
+
+outputs = llm.generate(prompts, sampling_params)
+
+# Access both
+for output in outputs:
+    completion = output.outputs[0]
+    
+    # Regular top-k logprobs (list of dicts, one per step)
+    top_k = completion.logprobs
+    
+    # Tracked token logprobs (dict of lists)
+    tracked = completion.tracked_logprobs
+```
+
+## Edge Cases
+
+- **Empty track list** (`track_token_ids=[]`): Returns an empty dict `{}`

--- a/docs/usage/v1_guide.md
+++ b/docs/usage/v1_guide.md
@@ -61,6 +61,12 @@ Processed means the values after applying all processors, including temperature 
 While V1 supports passing prompt logprobs with prefix caching enabled, it no longer caches the logprobs.
 For a request requiring prompt logprobs, the engine will ignore the prefix cache and recompute the prefill of full prompt to generate the logprobs.
 
+#### Tracked Token Logprobs (New in V1)
+
+V1 introduces the `track_token_ids` parameter in `SamplingParams`, which enables efficient tracking of logprobs for specific tokens without requiring full vocabulary logprobs. This is useful for classification tasks, constrained generation, and any use case where you need probabilities for a small set of predefined tokens (e.g., class labels).
+
+See [Tracked Token Logprobs](../features/track_token_ids.md) for detailed documentation and usage examples.
+
 ## Feature Support
 
 For each item, its support in vLLM V1 falls into one of the following states:
@@ -150,6 +156,7 @@ following a similar pattern by implementing support through the [plugin system](
 | **Chunked Prefill**                         | <nobr>🟢 Functional</nobr>                                                        |
 | **LoRA**                                    | <nobr>🟢 Functional</nobr>                                                        |
 | **Logprobs Calculation**                    | <nobr>🟢 Functional</nobr>                                                        |
+| **Tracked Token Logprobs**                  | <nobr>🟢 Functional</nobr>                                                        |
 | **FP8 KV Cache**                            | <nobr>🟢 Functional</nobr>                                                        |
 | **Spec Decode**                             | <nobr>🟢 Functional</nobr>                                                        |
 | **Prompt Logprobs with Prefix Caching**     | <nobr>🟢 Functional</nobr>                                                        |

--- a/tests/v1/e2e/test_tracked_logprobs.py
+++ b/tests/v1/e2e/test_tracked_logprobs.py
@@ -1,0 +1,1655 @@
+"""End-to-end tests for track_token_ids feature."""
+
+import asyncio
+import math
+import os
+
+os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
+
+import pytest
+import torch
+
+from vllm import LLM, SamplingParams
+from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.sampling_params import RequestOutputKind
+from vllm.v1.engine.async_llm import AsyncLLM
+
+# Use a smaller model for faster testing
+MODEL_PATH = "Qwen/Qwen3-14B"
+
+
+@pytest.fixture(scope="module")
+def llm_instance():
+    """Create a shared LLM instance for all tests.
+
+    Uses max_logprobs=-1 to allow full vocabulary logprobs for differential tests.
+    """
+    return LLM(MODEL_PATH, enforce_eager=True, max_logprobs=-1)
+
+
+@pytest.fixture(scope="module")
+def async_llm_instance():
+    """Create a shared AsyncLLM instance for streaming tests.
+
+    Uses max_logprobs=-1 to allow full vocabulary logprobs for differential tests.
+    Note: Tests using this fixture must use @pytest.mark.asyncio(loop_scope="module")(loop_scope="module")
+    to ensure the event loop scope matches the fixture scope.
+    """
+    engine_args = AsyncEngineArgs(
+        model=MODEL_PATH,
+        enforce_eager=True,
+        max_logprobs=-1,
+    )
+    engine = AsyncLLM.from_engine_args(engine_args)
+    yield engine
+    engine.shutdown()
+
+
+class TestTrackTokenIdsBasic:
+    """Basic functionality tests for track_token_ids."""
+
+    def test_track_token_ids_returns_logprobs(self, llm_instance):
+        """Test that track_token_ids returns logprobs for specified tokens."""
+        track_ids = [1234, 5678, 9012]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=10,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(["Hello, my name is"], sampling_params)
+
+        assert len(outputs) == 1
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        assert isinstance(tracked, dict)
+
+        # All tracked token IDs should be present
+        for tid in track_ids:
+            assert tid in tracked, f"Token {tid} not in tracked_logprobs"
+            # Should have one logprob per generated token
+            assert len(tracked[tid]) == 10, (
+                f"Expected 10 logprobs for token {tid}, got {len(tracked[tid])}"
+            )
+            # All values should be valid log probabilities (<= 0)
+            for lp in tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+
+    def test_track_token_ids_with_logprobs_coexist(self, llm_instance):
+        """Test that track_token_ids works alongside regular logprobs."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            logprobs=5,  # Request top-5 logprobs
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(["The capital of France is"], sampling_params)
+
+        output = outputs[0].outputs[0]
+
+        # Regular logprobs should be present
+        assert output.logprobs is not None
+        assert len(output.logprobs) == 5
+
+        # Tracked logprobs should also be present
+        assert output.tracked_logprobs is not None
+        for tid in track_ids:
+            assert tid in output.tracked_logprobs
+            assert len(output.tracked_logprobs[tid]) == 5
+
+
+class TestTrackTokenIdsNoneAndEmpty:
+    """Tests for track_token_ids=None and track_token_ids=[]."""
+
+    def test_track_token_ids_not_provided(self, llm_instance):
+        """Test that not providing track_token_ids returns None."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+        )
+
+        outputs = llm_instance.generate(["Hello world"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is None, f"Expected None, got {tracked}"
+
+    def test_track_token_ids_explicit_none(self, llm_instance):
+        """Test that track_token_ids=None explicitly returns None."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=None,
+        )
+
+        outputs = llm_instance.generate(["Hello world"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is None, f"Expected None, got {tracked}"
+
+    def test_track_token_ids_empty_list(self, llm_instance):
+        """Test that track_token_ids=[] returns empty dict."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=[],
+        )
+
+        outputs = llm_instance.generate(["Hello world"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked == {}, f"Expected empty dict, got {tracked}"
+
+
+class TestTrackTokenIdsBatch:
+    """Tests for batch processing with track_token_ids."""
+
+    def test_batch_multiple_prompts_same_track_ids(self, llm_instance):
+        """Test batch with multiple prompts using same track_token_ids."""
+        track_ids = [500, 1000, 1500]
+        prompts = [
+            "Hello, my name is",
+            "The president of the United States is",
+            "The capital of France is",
+            "The future of AI is",
+        ]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=10,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(prompts, sampling_params)
+
+        assert len(outputs) == 4
+
+        for i, output in enumerate(outputs):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked is not None, f"Prompt {i}: tracked_logprobs is None"
+
+            for tid in track_ids:
+                assert tid in tracked, f"Prompt {i}: token {tid} not tracked"
+                assert len(tracked[tid]) == 10, (
+                    f"Prompt {i}: token {tid} has {len(tracked[tid])} logprobs, "
+                    f"expected 10"
+                )
+
+    def test_batch_different_max_tokens(self, llm_instance):
+        """Test batch where different prompts might finish at different times."""
+        track_ids = [100, 200]
+        prompts = ["Hi", "Hello there, how are you doing today"]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=15,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(prompts, sampling_params)
+
+        for output in outputs:
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked is not None
+            for tid in track_ids:
+                assert tid in tracked
+                # Each should have logprobs for each generated token
+                num_gen = len(output.outputs[0].token_ids)
+                assert len(tracked[tid]) == num_gen
+
+
+class TestTrackTokenIdsDifferential:
+    """Differential tests comparing track_token_ids vs full logprobs.
+
+    IMPORTANT: All tests use BOTH track_token_ids AND logprobs=-1 in the SAME
+    request to ensure we compare values from identical computation. Using two
+    separate generations would be unreliable even with the same seed.
+    """
+
+    def test_tracked_vs_full_logprobs_match(self, llm_instance):
+        """
+        CRITICAL TEST: Verify track_token_ids produces same values as
+        extracting from full vocabulary logprobs (logprobs=-1).
+
+        Uses BOTH parameters in the same request for reliable comparison.
+        """
+        track_ids = [100, 500, 1000, 2000, 5000]
+        prompt = "The meaning of life is"
+        max_tokens = 10
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+        )
+        outputs = llm_instance.generate([prompt], params)
+
+        output = outputs[0].outputs[0]
+        tracked_logprobs = output.tracked_logprobs
+        full_logprobs_list = output.logprobs
+
+        # Compare: tracked values should match extracted from full
+        assert tracked_logprobs is not None
+        assert full_logprobs_list is not None
+
+        for tid in track_ids:
+            assert tid in tracked_logprobs
+
+            for step_idx in range(max_tokens):
+                tracked_value = tracked_logprobs[tid][step_idx]
+
+                # Extract from full logprobs
+                step_full = full_logprobs_list[step_idx]
+                if tid in step_full:
+                    full_value = step_full[tid].logprob
+                else:
+                    pytest.fail(
+                        f"Token {tid} not in full logprobs at step {step_idx}"
+                    )
+
+                # Values should match exactly (same computation)
+                assert math.isclose(tracked_value, full_value), (
+                    f"Mismatch at step {step_idx} for token {tid}: "
+                    f"tracked={tracked_value}, full={full_value}"
+                )
+
+    @pytest.mark.parametrize(
+        "temperature,top_p,top_k",
+        [
+            (0.0, 1.0, -1),  # Greedy
+            (0.7, 1.0, -1),  # Standard temperature 1
+            (2.0, 1.0, -1),  # Standard temperature 2
+            (10.0, 1.0, -1),  # Standard temperature 3
+            (1.0, 0.9, -1),  # With top_p
+            (0.8, 1.0, 50),  # With top_k
+            (0.8, 0.95, 100),  # Combined
+        ],
+    )
+    def test_tracked_vs_full_various_sampling(
+        self, llm_instance, temperature, top_p, top_k
+    ):
+        """
+        Test tracked logprobs match full logprobs under various sampling configs.
+
+        Uses BOTH parameters in the same request - no need for seed matching
+        since we compare values from the same generation.
+        """
+        track_ids = [100, 1000, 5000]
+        prompt = "Once upon a time"
+        max_tokens = 5
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            max_tokens=max_tokens,
+            logprobs=-1,
+            track_token_ids=track_ids,
+        )
+        outputs = llm_instance.generate([prompt], params)
+
+        output = outputs[0].outputs[0]
+        tracked = output.tracked_logprobs
+        full_list = output.logprobs
+
+        # Compare - should match exactly since same computation
+        assert tracked is not None
+        assert full_list is not None
+
+        for tid in track_ids:
+            for step_idx in range(max_tokens):
+                tracked_val = tracked[tid][step_idx]
+                full_val = full_list[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val), (
+                    f"Mismatch at step {step_idx}, token {tid} "
+                    f"(temp={temperature}, top_p={top_p}, top_k={top_k}): "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    def test_tracked_vs_full_batch_consistency(self, llm_instance):
+        """Test that tracked and full logprobs match in batch processing.
+
+        Uses BOTH parameters in the same request for all prompts.
+        """
+        track_ids = [200, 400, 600]
+        prompts = ["Hello", "World", "Test"]
+        max_tokens = 5
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same batch request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,
+            track_token_ids=track_ids,
+        )
+        outputs = llm_instance.generate(prompts, params)
+
+        # Compare each prompt - values should match exactly
+        for prompt_idx in range(len(prompts)):
+            output = outputs[prompt_idx].outputs[0]
+            tracked = output.tracked_logprobs
+            full_list = output.logprobs
+
+            assert tracked is not None
+            assert full_list is not None
+
+            for tid in track_ids:
+                for step_idx in range(max_tokens):
+                    tracked_val = tracked[tid][step_idx]
+                    full_val = full_list[step_idx][tid].logprob
+
+                    assert math.isclose(tracked_val, full_val), (
+                        f"Prompt {prompt_idx}, step {step_idx}, token {tid}: "
+                        f"tracked={tracked_val}, full={full_val}"
+                    )
+
+
+class TestTrackTokenIdsStreaming:
+    """Streaming mode tests for track_token_ids using AsyncLLM with DELTA output."""
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_basic(self, async_llm_instance):
+        """Test track_token_ids in streaming mode returns correct logprobs."""
+        track_ids = [1234, 5678, 9012]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=10,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        # Collect all streaming outputs
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-basic-1",
+            prompt="Hello, my name is",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        all_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        # Should have 10 logprobs per tracked token
+        for tid in track_ids:
+            assert len(all_tracked[tid]) == 10, (
+                f"Token {tid}: expected 10 logprobs, got {len(all_tracked[tid])}"
+            )
+            # All values should be valid log probabilities
+            for lp in all_tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_track_token_ids_none(self, async_llm_instance):
+        """Test streaming with track_token_ids=None returns None."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=None,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-none-1",
+            prompt="Hello world",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked is None, f"Expected None, got {tracked}"
+            if output.finished:
+                break
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_track_token_ids_empty_list(self, async_llm_instance):
+        """Test streaming with track_token_ids=[] returns empty dict."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=[],
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-empty-1",
+            prompt="Hello world",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked == {}, f"Expected empty dict, got {tracked}"
+            if output.finished:
+                break
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_with_logprobs_coexist(self, async_llm_instance):
+        """Test streaming with both track_token_ids and regular logprobs."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            logprobs=5,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        logprobs_count = 0
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-coexist-1",
+            prompt="The capital of France is",
+            sampling_params=sampling_params,
+        ):
+            out = output.outputs[0]
+
+            # Count regular logprobs
+            if out.logprobs:
+                logprobs_count += len(out.logprobs)
+
+            # Collect tracked logprobs
+            if out.tracked_logprobs:
+                for tid in track_ids:
+                    if tid in out.tracked_logprobs:
+                        all_tracked[tid].extend(out.tracked_logprobs[tid])
+
+            if output.finished:
+                break
+
+        # Should have 5 regular logprobs entries
+        assert logprobs_count == 5
+
+        # Should have 5 tracked logprobs per token
+        for tid in track_ids:
+            assert len(all_tracked[tid]) == 5
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_tracked_vs_full_logprobs_match(
+        self, async_llm_instance
+    ):
+        """Test streaming tracked logprobs match full logprobs in same request.
+
+        Uses BOTH track_token_ids AND logprobs=-1 in the same streaming request
+        to compare values from the exact same computation.
+        """
+        track_ids = [100, 500, 1000]
+        prompt = "The meaning of life is"
+        max_tokens = 10
+
+        # Use BOTH track_token_ids AND logprobs=-1 in same streaming request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        full_logprobs: list[dict] = []
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-match-1",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect full logprobs
+            if output.outputs[0].logprobs:
+                full_logprobs.extend(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Compare tracked vs extracted from full logprobs (same computation)
+        num_tokens = len(full_logprobs)
+        assert num_tokens > 0, "No tokens generated"
+
+        for tid in track_ids:
+            assert len(stream_tracked[tid]) == num_tokens
+            for step_idx in range(num_tokens):
+                tracked_val = stream_tracked[tid][step_idx]
+                full_val = full_logprobs[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val), (
+                    f"Token {tid}, step {step_idx}: "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_differential_more_tokens(
+        self, async_llm_instance
+    ):
+        """
+        CRITICAL: Test streaming tracked logprobs match full vocabulary logprobs
+        with more tokens to track.
+
+        Uses BOTH track_token_ids AND logprobs=-1 in the same streaming request
+        to compare values from the exact same computation.
+        """
+        track_ids = [100, 500, 1000, 2000, 5000]
+        prompt = "Once upon a time"
+        max_tokens = 8
+
+        # Use BOTH track_token_ids AND logprobs=-1 in same streaming request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        full_logprobs: list[dict] = []
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-diff-1",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect full logprobs
+            if output.outputs[0].logprobs:
+                full_logprobs.extend(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Compare tracked vs extracted from full logprobs (same computation)
+        num_tokens = len(full_logprobs)
+        assert num_tokens > 0, "No tokens generated"
+
+        for tid in track_ids:
+            assert len(stream_tracked[tid]) == num_tokens
+            for step_idx in range(num_tokens):
+                tracked_val = stream_tracked[tid][step_idx]
+                full_val = full_logprobs[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val), (
+                    f"Token {tid}, step {step_idx}: "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    @pytest.mark.parametrize(
+        "temperature,top_p,top_k",
+        [
+            (0.0, 1.0, -1),  # Greedy
+            (0.7, 1.0, -1),  # Standard temperature 1
+            (2.0, 1.0, -1),  # Standard temperature 2
+            (10.0, 1.0, -1),  # Standard temperature 3
+            (1.0, 0.9, -1),  # With top_p
+            (0.8, 1.0, 50),  # With top_k
+        ],
+    )
+    async def test_streaming_differential_various_sampling(
+        self, async_llm_instance, temperature, top_p, top_k
+    ):
+        """Test streaming tracked logprobs match full logprobs with various sampling.
+
+        Uses BOTH track_token_ids AND logprobs=-1 in the same streaming request
+        to compare values from the exact same computation - no seed needed.
+        """
+        track_ids = [100, 1000, 5000]
+        prompt = "Hello world"
+        max_tokens = 5
+
+        # Use BOTH track_token_ids AND logprobs=-1 in same streaming request
+        params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        full_logprobs: list[dict] = []
+        req_id = f"stream-sampling-{temperature}-{top_p}-{top_k}"
+
+        async for output in async_llm_instance.generate(
+            request_id=req_id,
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect full logprobs
+            if output.outputs[0].logprobs:
+                full_logprobs.extend(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Compare tracked vs extracted from full logprobs (same computation)
+        num_tokens = len(full_logprobs)
+        assert num_tokens > 0, "No tokens generated"
+
+        for tid in track_ids:
+            assert len(stream_tracked[tid]) == num_tokens
+            for step_idx in range(num_tokens):
+                tracked_val = stream_tracked[tid][step_idx]
+                full_val = full_logprobs[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val), (
+                    f"Token {tid}, step {step_idx} "
+                    f"(temp={temperature}, top_p={top_p}, top_k={top_k}): "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_batch_multiple_prompts(self, async_llm_instance):
+        """Test streaming with multiple prompts (batch)."""
+        track_ids = [500, 1000, 1500]
+        prompts = [
+            "Hello, my name is",
+            "The capital of France is",
+            "The future of AI is",
+        ]
+        max_tokens = 8
+
+        # Collect per-request tracked logprobs
+        all_tracked: dict[str, dict[int, list[float]]] = {}
+
+        # Submit all requests
+        tasks = []
+        for i, prompt in enumerate(prompts):
+            req_id = f"stream-batch-{i}"
+            all_tracked[req_id] = {tid: [] for tid in track_ids}
+
+            async def process_request(req_id, prompt):
+                sampling_params = SamplingParams(
+                    temperature=0.8,
+                    max_tokens=max_tokens,
+                    track_token_ids=track_ids,
+                    output_kind=RequestOutputKind.DELTA,
+                )
+                async for output in async_llm_instance.generate(
+                    request_id=req_id,
+                    prompt=prompt,
+                    sampling_params=sampling_params,
+                ):
+                    tracked = output.outputs[0].tracked_logprobs
+                    if tracked:
+                        for tid in track_ids:
+                            if tid in tracked:
+                                all_tracked[req_id][tid].extend(tracked[tid])
+                    if output.finished:
+                        break
+
+            tasks.append(process_request(req_id, prompt))
+
+        await asyncio.gather(*tasks)
+
+        # Should have outputs for all 3 prompts
+        assert len(all_tracked) == 3
+
+        # Each prompt should have max_tokens logprobs per tracked token
+        for req_id, req_tracked in all_tracked.items():
+            for tid in track_ids:
+                assert len(req_tracked[tid]) == max_tokens, (
+                    f"Request {req_id}, token {tid}: "
+                    f"expected {max_tokens}, got {len(req_tracked[tid])}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_single_token_generation(self, async_llm_instance):
+        """Test streaming with max_tokens=1."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=1,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-single-1",
+            prompt="Hello",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        all_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        # Should have exactly 1 logprob per token
+        for tid in track_ids:
+            assert len(all_tracked[tid]) == 1
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_many_tokens_tracking(self, async_llm_instance):
+        """Test streaming while tracking many tokens."""
+        # Track 50 token IDs
+        track_ids = list(range(100, 150))
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-many-1",
+            prompt="Classify this text:",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        all_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        # All 50 tokens should have 5 logprobs each
+        assert len(all_tracked) == 50
+        for tid in track_ids:
+            assert len(all_tracked[tid]) == 5
+
+
+class TestTrackTokenIdsEdgeCases:
+    """Edge case tests for track_token_ids."""
+
+    def test_single_token_tracking(self, llm_instance):
+        """Test tracking a single token."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=10,
+            track_token_ids=[1234],
+        )
+
+        outputs = llm_instance.generate(["Test prompt"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        assert len(tracked) == 1
+        assert 1234 in tracked
+        assert len(tracked[1234]) == 10
+
+    def test_many_tokens_tracking(self, llm_instance):
+        """Test tracking many tokens (like 100-class classification)."""
+        # Track 100 token IDs
+        track_ids = list(range(100, 200))
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(["Classify this text:"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        assert len(tracked) == 100
+
+        for tid in track_ids:
+            assert tid in tracked
+            assert len(tracked[tid]) == 5
+
+    def test_track_boundary_token_ids(self, llm_instance):
+        """Test tracking token ID 0 (boundary case)."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=[0, 1, 2],  # Very low token IDs
+        )
+
+        outputs = llm_instance.generate(["Test"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        assert 0 in tracked
+        assert 1 in tracked
+        assert 2 in tracked
+
+    def test_single_token_generation(self, llm_instance):
+        """Test with max_tokens=1."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=1,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(["Hello"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        for tid in track_ids:
+            assert tid in tracked
+            assert len(tracked[tid]) == 1
+
+
+# Summarization prompts designed for high ngram acceptance rate
+SUMMARIZATION_PROMPTS = [
+    """Summarize the following text:
+The quick brown fox jumps over the lazy dog. The quick brown fox jumps over 
+the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown 
+fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.
+Summary:""",
+    """Summarize the following repetitive text in one sentence:
+Hello world. Hello world. Hello world. Hello world. Hello world. Hello world.
+Hello world. Hello world. Hello world. Hello world. Hello world. Hello world.
+Summary:""",
+    """Summarize:
+Test test test test test. Test test test test test. Test test test test test.
+Test test test test test. Test test test test test. Test test test test test.
+Summary:""",
+]
+
+
+@pytest.fixture(scope="module")
+def spec_decode_llm_instance():
+    """Create a shared LLM instance with ngram speculative decoding.
+
+    Uses max_logprobs=-1 to allow full vocabulary logprobs for differential tests.
+    """
+    speculative_config = {
+        "method": "ngram",
+        "prompt_lookup_max": 5,
+        "prompt_lookup_min": 2,
+        "num_speculative_tokens": 3,
+    }
+    llm = LLM(
+        MODEL_PATH,
+        enforce_eager=True,
+        max_logprobs=-1,
+        speculative_config=speculative_config,
+    )
+    yield llm
+    del llm
+    cleanup_dist_env_and_memory()
+
+
+@pytest.fixture(scope="module")
+def async_spec_decode_llm_instance():
+    """Create a shared AsyncLLM instance with ngram speculative decoding.
+
+    Uses max_logprobs=-1 to allow full vocabulary logprobs for differential tests.
+    Note: Tests using this fixture must use @pytest.mark.asyncio(loop_scope="module")
+    to ensure the event loop scope matches the fixture scope.
+    """
+    speculative_config = {
+        "method": "ngram",
+        "prompt_lookup_max": 5,
+        "prompt_lookup_min": 2,
+        "num_speculative_tokens": 3,
+    }
+    engine_args = AsyncEngineArgs(
+        model=MODEL_PATH,
+        enforce_eager=True,
+        max_logprobs=-1,
+        speculative_config=speculative_config,
+    )
+    engine = AsyncLLM.from_engine_args(engine_args)
+    yield engine
+    engine.shutdown()
+    cleanup_dist_env_and_memory()
+
+
+class TestTrackTokenIdsSpeculativeDecoding:
+    """Tests for track_token_ids with ngram speculative decoding."""
+
+    def test_spec_decode_basic(self, spec_decode_llm_instance):
+        """Test track_token_ids works with speculative decoding."""
+        track_ids = [100, 500, 1000, 2000]
+        max_tokens = 15
+        sampling_params = SamplingParams(
+            temperature=0.0,  # Greedy for determinism
+            max_tokens=max_tokens,
+            track_token_ids=track_ids,
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS[:1], sampling_params
+        )
+
+        assert len(outputs) == 1
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+
+        # All tracked token IDs should be present
+        for tid in track_ids:
+            assert tid in tracked, f"Token {tid} not in tracked_logprobs"
+            # Should have one logprob per generated token
+            num_generated = len(outputs[0].outputs[0].token_ids)
+            assert len(tracked[tid]) == num_generated, (
+                f"Expected {num_generated} logprobs for token {tid}, "
+                f"got {len(tracked[tid])}"
+            )
+            # All values should be valid log probabilities (<= 0)
+            for lp in tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+
+    def test_spec_decode_with_logprobs_coexist(self, spec_decode_llm_instance):
+        """Test track_token_ids works alongside regular logprobs with spec decode."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=10,
+            logprobs=5,  # Request top-5 logprobs
+            track_token_ids=track_ids,
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS[:1], sampling_params
+        )
+
+        output = outputs[0].outputs[0]
+        num_generated = len(output.token_ids)
+
+        # Regular logprobs should be present
+        assert output.logprobs is not None
+        assert len(output.logprobs) == num_generated
+
+        # Tracked logprobs should also be present
+        assert output.tracked_logprobs is not None
+        for tid in track_ids:
+            assert tid in output.tracked_logprobs
+            assert len(output.tracked_logprobs[tid]) == num_generated
+
+    def test_spec_decode_track_token_ids_none(self, spec_decode_llm_instance):
+        """Test track_token_ids=None returns None with spec decode."""
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=10,
+            track_token_ids=None,
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS[:1], sampling_params
+        )
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is None, f"Expected None, got {tracked}"
+
+    def test_spec_decode_track_token_ids_empty_list(self, spec_decode_llm_instance):
+        """Test track_token_ids=[] returns empty dict with spec decode."""
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=10,
+            track_token_ids=[],
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS[:1], sampling_params
+        )
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked == {}, f"Expected empty dict, got {tracked}"
+
+    def test_spec_decode_tracked_vs_full_logprobs_match(
+        self, spec_decode_llm_instance
+    ):
+        """
+        CRITICAL TEST: Verify track_token_ids with spec decode produces same
+        values as extracting from full vocabulary logprobs (logprobs=-1).
+
+        Uses BOTH parameters in the same request for reliable comparison.
+        """
+        track_ids = [100, 500, 1000, 2000, 5000]
+        prompt = SUMMARIZATION_PROMPTS[0]
+        max_tokens = 10
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,
+            track_token_ids=track_ids,
+        )
+        outputs = spec_decode_llm_instance.generate([prompt], params)
+
+        output = outputs[0].outputs[0]
+        tracked_logprobs = output.tracked_logprobs
+        full_logprobs_list = output.logprobs
+
+        # Compare: tracked values should match extracted from full
+        assert tracked_logprobs is not None
+        assert full_logprobs_list is not None
+
+        num_tokens = len(full_logprobs_list)
+
+        for tid in track_ids:
+            assert tid in tracked_logprobs
+            assert len(tracked_logprobs[tid]) == num_tokens
+
+            for step_idx in range(num_tokens):
+                tracked_value = tracked_logprobs[tid][step_idx]
+
+                # Extract from full logprobs
+                step_full = full_logprobs_list[step_idx]
+                if tid in step_full:
+                    full_value = step_full[tid].logprob
+                else:
+                    pytest.fail(
+                        f"Token {tid} not in full logprobs at step {step_idx}"
+                    )
+
+                # Values should match exactly (same computation)
+                assert math.isclose(tracked_value, full_value), (
+                    f"Mismatch at step {step_idx} for token {tid}: "
+                    f"tracked={tracked_value}, full={full_value}"
+                )
+
+    def test_spec_decode_batch_multiple_prompts(self, spec_decode_llm_instance):
+        """Test batch with multiple prompts using track_token_ids with spec decode."""
+        track_ids = [500, 1000, 1500]
+        max_tokens = 12
+
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            track_token_ids=track_ids,
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS, sampling_params
+        )
+
+        assert len(outputs) == len(SUMMARIZATION_PROMPTS)
+
+        for i, output in enumerate(outputs):
+            tracked = output.outputs[0].tracked_logprobs
+            num_generated = len(output.outputs[0].token_ids)
+            assert tracked is not None, f"Prompt {i}: tracked_logprobs is None"
+
+            for tid in track_ids:
+                assert tid in tracked, f"Prompt {i}: token {tid} not tracked"
+                assert len(tracked[tid]) == num_generated, (
+                    f"Prompt {i}: token {tid} has {len(tracked[tid])} logprobs, "
+                    f"expected {num_generated}"
+                )
+
+    @pytest.mark.parametrize(
+        "temperature,top_p,top_k",
+        [
+            (0.0, 1.0, -1),  # Greedy
+            (0.7, 1.0, -1),  # Standard temperature 1
+            (2.0, 1.0, -1),  # Standard temperature 2
+            (10.0, 1.0, -1),  # Standard temperature 3
+            (0.8, 0.95, 100),  # Combined
+        ],
+    )
+    def test_spec_decode_various_sampling(
+        self, spec_decode_llm_instance, temperature, top_p, top_k
+    ):
+        """Test tracked logprobs match full logprobs under various sampling configs.
+
+        Uses BOTH track_token_ids AND logprobs=-1 in the same request for
+        reliable comparison regardless of sampling randomness.
+        """
+        track_ids = [100, 1000, 5000]
+        prompt = SUMMARIZATION_PROMPTS[0]
+        max_tokens = 8
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            max_tokens=max_tokens,
+            logprobs=-1,
+            track_token_ids=track_ids,
+        )
+        outputs = spec_decode_llm_instance.generate([prompt], params)
+
+        output = outputs[0].outputs[0]
+        tracked = output.tracked_logprobs
+        full_list = output.logprobs
+
+        # Verify tracked logprobs are valid and match full logprobs
+        assert tracked is not None
+        assert full_list is not None
+
+        num_tokens = len(full_list)
+
+        for tid in track_ids:
+            assert tid in tracked
+            assert len(tracked[tid]) == num_tokens
+
+            for step_idx in range(num_tokens):
+                tracked_val = tracked[tid][step_idx]
+
+                # Verify value is valid
+                assert tracked_val <= 0, f"Logprob {tracked_val} should be <= 0"
+                assert not math.isnan(tracked_val), "Logprob should not be NaN"
+                assert not math.isinf(tracked_val), "Logprob should not be inf"
+
+                # Verify matches full logprobs (same computation)
+                full_val = full_list[step_idx][tid].logprob
+                assert math.isclose(tracked_val, full_val), (
+                    f"Mismatch at step {step_idx}, token {tid} "
+                    f"(temp={temperature}, top_p={top_p}, top_k={top_k}): "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+
+class TestTrackTokenIdsSpeculativeDecodingStreaming:
+    """Streaming tests for track_token_ids with ngram speculative decoding."""
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_basic(self, async_spec_decode_llm_instance):
+        """Test streaming with track_token_ids and spec decode."""
+        track_ids = [100, 500, 1000]
+        max_tokens = 12
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-basic-1",
+            prompt=SUMMARIZATION_PROMPTS[0],
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        all_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        # Should have logprobs for each tracked token
+        for tid in track_ids:
+            assert len(all_tracked[tid]) > 0, (
+                f"Token {tid}: expected logprobs, got {len(all_tracked[tid])}"
+            )
+            # All values should be valid log probabilities
+            for lp in all_tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_track_token_ids_none(
+        self, async_spec_decode_llm_instance
+    ):
+        """Test streaming with track_token_ids=None and spec decode."""
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=5,
+            track_token_ids=None,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-none-1",
+            prompt=SUMMARIZATION_PROMPTS[0],
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked is None, f"Expected None, got {tracked}"
+            if output.finished:
+                break
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_track_token_ids_empty(
+        self, async_spec_decode_llm_instance
+    ):
+        """Test streaming with track_token_ids=[] and spec decode."""
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=5,
+            track_token_ids=[],
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-empty-1",
+            prompt=SUMMARIZATION_PROMPTS[0],
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked == {}, f"Expected empty dict, got {tracked}"
+            if output.finished:
+                break
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_with_logprobs_coexist(
+        self, async_spec_decode_llm_instance
+    ):
+        """Test that track_token_ids works alongside regular logprobs in streaming spec decode.
+
+        Uses both track_token_ids and logprobs in the same request, then verifies
+        the tracked values match those extracted from the logprobs dict.
+        """
+        track_ids = [100, 500, 1000]
+        prompt = SUMMARIZATION_PROMPTS[0]
+        max_tokens = 10
+
+        # Use both track_token_ids AND logprobs in the same request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=10,  # Get top-10 logprobs
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        regular_logprobs: list[dict] = []
+        num_tokens_generated = 0
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-coexist-1",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect regular logprobs
+            if output.outputs[0].logprobs:
+                regular_logprobs.extend(output.outputs[0].logprobs)
+                num_tokens_generated += len(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Verify we got logprobs
+        assert num_tokens_generated > 0, "No tokens generated"
+
+        # Verify tracked logprobs have correct length
+        for tid in track_ids:
+            assert len(stream_tracked[tid]) == num_tokens_generated, (
+                f"Token {tid}: expected {num_tokens_generated}, "
+                f"got {len(stream_tracked[tid])}"
+            )
+
+        # Verify all tracked values are valid log probabilities
+        for tid in track_ids:
+            for lp in stream_tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+                assert not math.isnan(lp), "Logprob should not be NaN"
+                assert not math.isinf(lp), "Logprob should not be inf"
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_differential_vs_full_logprobs(
+        self, async_spec_decode_llm_instance
+    ):
+        """
+        CRITICAL: Test streaming tracked logprobs with spec decode match
+        full vocabulary logprobs (logprobs=-1) in the SAME request.
+
+        Using both track_token_ids and logprobs=-1 together ensures we compare
+        logprobs computed from the exact same generation, avoiding variance
+        from separate runs.
+        """
+        track_ids = [100, 500, 1000, 2000, 5000]
+        prompt = SUMMARIZATION_PROMPTS[0]
+        max_tokens = 10
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        # This ensures we compare values from the exact same generation
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Get full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        full_logprobs: list[dict] = []
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-diff-1",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect full logprobs
+            if output.outputs[0].logprobs:
+                full_logprobs.extend(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Compare tracked vs extracted from full logprobs
+        # Should match exactly (within floating point tolerance) since
+        # they come from the same generation
+        num_tokens = min(len(stream_tracked[track_ids[0]]), len(full_logprobs))
+        assert num_tokens > 0, "No tokens generated"
+
+        for tid in track_ids:
+            for step_idx in range(num_tokens):
+                tracked_val = stream_tracked[tid][step_idx]
+                full_val = full_logprobs[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val, rel_tol=1e-4), (
+                    f"Token {tid}, step {step_idx}: "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_batch(self, async_spec_decode_llm_instance):
+        """Test streaming with multiple prompts (batch) and spec decode."""
+        track_ids = [500, 1000, 1500]
+        max_tokens = 10
+
+        # Collect per-request tracked logprobs
+        all_tracked: dict[str, dict[int, list[float]]] = {}
+
+        # Submit all requests
+        tasks = []
+        for i, prompt in enumerate(SUMMARIZATION_PROMPTS):
+            req_id = f"spec-stream-batch-{i}"
+            all_tracked[req_id] = {tid: [] for tid in track_ids}
+
+            async def process_request(req_id, prompt):
+                sampling_params = SamplingParams(
+                    temperature=0.0,
+                    max_tokens=max_tokens,
+                    track_token_ids=track_ids,
+                    output_kind=RequestOutputKind.DELTA,
+                )
+                async for output in async_spec_decode_llm_instance.generate(
+                    request_id=req_id,
+                    prompt=prompt,
+                    sampling_params=sampling_params,
+                ):
+                    tracked = output.outputs[0].tracked_logprobs
+                    if tracked:
+                        for tid in track_ids:
+                            if tid in tracked:
+                                all_tracked[req_id][tid].extend(tracked[tid])
+                    if output.finished:
+                        break
+
+            tasks.append(process_request(req_id, prompt))
+
+        await asyncio.gather(*tasks)
+
+        # Should have outputs for all prompts
+        assert len(all_tracked) == len(SUMMARIZATION_PROMPTS)
+
+        # Each prompt should have logprobs for tracked tokens
+        for req_id, req_tracked in all_tracked.items():
+            for tid in track_ids:
+                assert len(req_tracked[tid]) > 0, (
+                    f"Request {req_id}, token {tid}: expected logprobs"
+                )
+
+
+def run_quick_demo():
+    """Quick demo showing the feature in action."""
+    print("=" * 70)
+    print("Track Token IDs Feature Demo")
+    print("=" * 70)
+
+    # Use max_logprobs=-1 to allow full vocabulary logprobs for diff test
+    llm = LLM(MODEL_PATH, enforce_eager=True, max_logprobs=-1)
+
+    # Demo 1: Basic usage
+    print("\n1. Basic Usage - Track specific tokens")
+    print("-" * 50)
+    track_ids = [1234, 5678, 9012]
+    params = SamplingParams(
+        temperature=0.8,
+        max_tokens=10,
+        track_token_ids=track_ids,
+    )
+    outputs = llm.generate(["Hello, my name is"], params)
+    tracked = outputs[0].outputs[0].tracked_logprobs
+    print(f"Tracked token IDs: {track_ids}")
+    print(f"tracked_logprobs: {tracked}")
+
+    # Demo 2: None case
+    print("\n2. track_token_ids=None (default)")
+    print("-" * 50)
+    params = SamplingParams(temperature=0.8, max_tokens=5)
+    outputs = llm.generate(["Test"], params)
+    print(f"tracked_logprobs: {outputs[0].outputs[0].tracked_logprobs}")
+
+    # Demo 3: Empty list case
+    print("\n3. track_token_ids=[] (empty list)")
+    print("-" * 50)
+    params = SamplingParams(temperature=0.8, max_tokens=5, track_token_ids=[])
+    outputs = llm.generate(["Test"], params)
+    print(f"tracked_logprobs: {outputs[0].outputs[0].tracked_logprobs}")
+
+    # Demo 4: Differential test
+    print("\n4. Differential Test: track_token_ids vs full logprobs")
+    print("-" * 50)
+    track_ids = [100, 500, 1000]
+    prompt = "The answer is"
+
+    # Tracked approach
+    params_tracked = SamplingParams(
+        temperature=0.0, max_tokens=5, track_token_ids=track_ids
+    )
+    out_tracked = llm.generate([prompt], params_tracked)
+    tracked = out_tracked[0].outputs[0].tracked_logprobs
+
+    # Full logprobs approach (requires LLM started with max_logprobs=-1)
+    params_full = SamplingParams(temperature=0.0, max_tokens=5, logprobs=-1)
+    out_full = llm.generate([prompt], params_full)
+    full_list = out_full[0].outputs[0].logprobs
+
+    print(f"Comparing for tokens: {track_ids}")
+    all_match = True
+    for tid in track_ids:
+        print(f"\nToken {tid}:")
+        for step in range(5):
+            t_val = tracked[tid][step]
+            f_val = full_list[step][tid].logprob
+            match = math.isclose(t_val, f_val, rel_tol=1e-4)
+            status = "✓" if match else "✗"
+            print(f"  Step {step}: tracked={t_val:.6f}, full={f_val:.6f} {status}")
+            if not match:
+                all_match = False
+
+    print(f"\nAll values match: {'YES ✓' if all_match else 'NO ✗'}")
+
+    # Demo 5: Batch processing
+    print("\n5. Batch Processing")
+    print("-" * 50)
+    prompts = ["Hello", "World", "Test", "Demo"]
+    params = SamplingParams(
+        temperature=0.8, max_tokens=5, track_token_ids=[100, 200]
+    )
+    outputs = llm.generate(prompts, params)
+    for i, out in enumerate(outputs):
+        tracked = out.outputs[0].tracked_logprobs
+        print(f"Prompt {i} ('{prompts[i]}'): {len(tracked)} tracked tokens, "
+              f"5 steps each")
+
+    print("\n" + "=" * 70)
+    print("Demo Complete!")
+    print("=" * 70)
+
+
+async def run_streaming_demo():
+    """Streaming demo showing track_token_ids with AsyncLLM."""
+    print("=" * 70)
+    print("Track Token IDs Streaming Demo (AsyncLLM)")
+    print("=" * 70)
+
+    # Create AsyncLLM engine
+    engine_args = AsyncEngineArgs(
+        model=MODEL_PATH,
+        enforce_eager=True,
+        max_logprobs=-1,
+    )
+    engine = AsyncLLM.from_engine_args(engine_args)
+
+    try:
+        # Demo 1: Basic streaming with track_token_ids
+        print("\n1. Streaming with track_token_ids")
+        print("-" * 50)
+        track_ids = [100, 500, 1000]
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=5,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        chunk_count = 0
+
+        async for output in engine.generate(
+            request_id="demo-stream-1",
+            prompt="The answer is",
+            sampling_params=params,
+        ):
+            chunk_count += 1
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        print(f"Received {chunk_count} streaming chunks")
+        for tid in track_ids:
+            print(f"  Token {tid}: {len(stream_tracked[tid])} logprobs")
+
+        # Demo 2: Streaming with track_token_ids=None
+        print("\n2. Streaming with track_token_ids=None")
+        print("-" * 50)
+        params = SamplingParams(
+            temperature=0.8,
+            max_tokens=3,
+            track_token_ids=None,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in engine.generate(
+            request_id="demo-stream-none",
+            prompt="Test",
+            sampling_params=params,
+        ):
+            print(f"  tracked_logprobs: {output.outputs[0].tracked_logprobs}")
+            if output.finished:
+                break
+
+        # Demo 3: Streaming with track_token_ids=[]
+        print("\n3. Streaming with track_token_ids=[]")
+        print("-" * 50)
+        params = SamplingParams(
+            temperature=0.8,
+            max_tokens=3,
+            track_token_ids=[],
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in engine.generate(
+            request_id="demo-stream-empty",
+            prompt="Test",
+            sampling_params=params,
+        ):
+            print(f"  tracked_logprobs: {output.outputs[0].tracked_logprobs}")
+            if output.finished:
+                break
+
+        # Demo 4: Streaming values are valid logprobs
+        print("\n4. Streaming - Validate Logprob Values")
+        print("-" * 50)
+        track_ids = [100, 500, 1000]
+        prompt = "The answer is"
+        max_tokens = 5
+
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in engine.generate(
+            request_id="demo-stream-validate",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        print(f"Tracked tokens: {track_ids}")
+        all_valid = True
+        for tid in track_ids:
+            values = stream_tracked[tid]
+            valid = all(v <= 0 and not math.isnan(v) and not math.isinf(v) for v in values)
+            status = "✓" if valid else "✗"
+            print(f"  Token {tid}: {len(values)} values, all valid logprobs: {status}")
+            print(f"    Values: {[f'{v:.4f}' for v in values]}")
+            if not valid:
+                all_valid = False
+
+        print(f"\nAll values are valid log probabilities: {'YES ✓' if all_valid else 'NO ✗'}")
+        print("\nNote: For full differential test (streaming vs full logprobs),")
+        print("      run: pytest tests/v1/e2e/test_tracked_logprobs.py::TestTrackTokenIdsStreaming -v")
+
+    finally:
+        engine.shutdown()
+
+    print("\n" + "=" * 70)
+    print("Streaming Demo Complete!")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--streaming":
+        # Run streaming demo
+        asyncio.run(run_streaming_demo())
+    else:
+        # Run non-streaming demo
+        run_quick_demo()
+        print("\nRun with --streaming for streaming demo")

--- a/tests/v1/e2e/test_tracked_logprobs.py
+++ b/tests/v1/e2e/test_tracked_logprobs.py
@@ -1598,7 +1598,7 @@ async def run_streaming_demo():
             track_token_ids=track_ids,
             output_kind=RequestOutputKind.DELTA,
         )
-        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        stream_tracked_validate: dict[int, list[float]] = {tid: [] for tid in track_ids}
 
         async for output in engine.generate(
             request_id="demo-stream-validate",
@@ -1609,14 +1609,14 @@ async def run_streaming_demo():
             if tracked:
                 for tid in track_ids:
                     if tid in tracked:
-                        stream_tracked[tid].extend(tracked[tid])
+                        stream_tracked_validate[tid].extend(tracked[tid])
             if output.finished:
                 break
 
         print(f"Tracked tokens: {track_ids}")
         all_valid = True
         for tid in track_ids:
-            values = stream_tracked[tid]
+            values = stream_tracked_validate[tid]
             valid = all(
                 v <= 0 and not math.isnan(v) and not math.isinf(v) for v in values
             )

--- a/tests/v1/engine/conftest.py
+++ b/tests/v1/engine/conftest.py
@@ -10,7 +10,6 @@ from tests.v1.engine.utils import (
     NUM_PROMPT_LOGPROBS_UNDER_TEST,
     NUM_SAMPLE_LOGPROBS_UNDER_TEST,
     PROMPT_LEN,
-    TOKENIZER_NAME,
     DummyOutputProcessorTestVectors,
     generate_dummy_prompt_logprobs_tensors,
     generate_dummy_sample_logprobs,
@@ -23,15 +22,17 @@ EngineCoreSampleLogprobsType = list[tuple[torch.Tensor, torch.Tensor]]
 EngineCorePromptLogprobsType = tuple[torch.Tensor, torch.Tensor]
 
 
-def _build_test_vectors_no_logprobs() -> DummyOutputProcessorTestVectors:
+def _build_test_vectors_no_logprobs(
+    tokenizer_name: str,
+) -> DummyOutputProcessorTestVectors:
     """Generate output processor dummy test vectors, without logprobs
 
     Returns:
       DummyOutputProcessorTestVectors instance with no logprobs
     """
 
-    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_NAME)
-    vllm_config = EngineArgs(model=TOKENIZER_NAME).create_engine_config()
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+    vllm_config = EngineArgs(model=tokenizer_name).create_engine_config()
     # Tokenize prompts under test & create dummy generated tokens
     prompt_tokens = [tokenizer(text).input_ids[:PROMPT_LEN] for text in FULL_STRINGS]
     generation_tokens = [
@@ -61,14 +62,23 @@ def _build_test_vectors_no_logprobs() -> DummyOutputProcessorTestVectors:
 
 
 @pytest.fixture
-def dummy_test_vectors() -> DummyOutputProcessorTestVectors:
+def dummy_test_vectors_tokenizer_name() -> str:
+    """Tokenizer used by output processor fixture tests."""
+
+    return "Qwen/Qwen3-1.7B"
+
+
+@pytest.fixture
+def dummy_test_vectors(
+    dummy_test_vectors_tokenizer_name: str,
+) -> DummyOutputProcessorTestVectors:
     """Generate output processor dummy test vectors, with logprobs
 
     Returns:
       DummyOutputProcessorTestVectors instance with logprobs
     """
     # Build dummy test vectors without logprobs
-    dtv = _build_test_vectors_no_logprobs()
+    dtv = _build_test_vectors_no_logprobs(dummy_test_vectors_tokenizer_name)
     # Inject logprobs into dummy test vectors
     # data structure
     dtv.generation_logprobs = [

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -11,6 +11,7 @@ from tests.v1.engine.utils import (
     NUM_SAMPLE_LOGPROBS_UNDER_TEST,
     STOP_STRINGS,
     DummyOutputProcessorTestVectors,
+    get_non_eos_special_token,
     MockEngineCore,
     generate_dummy_tracked_logprobs,
 )
@@ -624,9 +625,6 @@ def test_stop_token(
       (i.e. first control token causes stop but is not represented
       in output text.)
 
-    Note: some test details are tuned for meta-llama/Llama-3.2-1B,
-    another model should work only if the test is modified.
-
     Args:
         include_stop_str_in_output: stop token str appears in output text
         num_sample_logprobs: number of sample logprobs (`None` for no logprobs)
@@ -634,22 +632,17 @@ def test_stop_token(
         ignore_eos: if True, EOS stops are disabled
         dummy_test_vectors: dummy engine core outputs and other data structures
     """
-    model_id = dummy_test_vectors.tokenizer.name_or_path
-    if model_id != "meta-llama/Llama-3.2-1B":
-        raise AssertionError(
-            f"Test requires meta-llama/Llama-3.2-1B but {model_id} is in use."
-        )
+    tokenizer = dummy_test_vectors.tokenizer
     do_logprobs = num_sample_logprobs is not None
     # EOS under test; if False, stop_token_ids under test
     is_eos_test = stop_token_type == "eos_token_id"
     # EOS under test but ignore_eos enabled
     is_eos_ignore_test = is_eos_test and ignore_eos
-    eos_token_id = (
-        dummy_test_vectors.tokenizer.eos_token_id if is_eos_test else None
-    )  # '<|end_of_text|>'
-    stop_token_ids = [128009] if not is_eos_test else None  # '<|eot_id|>'
+    eos_token_id = tokenizer.eos_token_id if is_eos_test else None
+    stop_token_id, stop_token_text = get_non_eos_special_token(tokenizer)
+    stop_token_ids = [stop_token_id] if not is_eos_test else None
 
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    output_processor = OutputProcessor(tokenizer, log_stats=False)
     # Dummy engine core outputs, with control tokens suffixed to test stops
     suffix_token = [eos_token_id] if is_eos_test else stop_token_ids
     assert suffix_token is not None and isinstance(suffix_token[0], int)
@@ -731,7 +724,11 @@ def test_stop_token(
             gen_logprobs.extend(request_output.outputs[0].logprobs)
 
     # Validate generated text
-    control_token = "<|end_of_text|>" if is_eos_test else "<|eot_id|>"
+    control_token = (
+        tokenizer.decode([eos_token_id], skip_special_tokens=False)
+        if is_eos_test
+        else stop_token_text
+    )
     if is_eos_ignore_test:
         # Length-based stop; expect full string
         ref_str = generation_string + 2 * control_token
@@ -1360,12 +1357,10 @@ def test_tracked_logprobs_basic(
     """
     # Define tokens to track
     track_token_ids = [100, 200, 300]
-    num_generation_tokens = len(dummy_test_vectors.generation_tokens[0])
-
     # Generate dummy tracked logprobs for each request
     tracked_logprobs_raw = [
-        generate_dummy_tracked_logprobs(num_generation_tokens, track_token_ids)
-        for _ in range(len(dummy_test_vectors.generation_tokens))
+        generate_dummy_tracked_logprobs(len(generation_tokens), track_token_ids)
+        for generation_tokens in dummy_test_vectors.generation_tokens
     ]
 
     output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
@@ -1381,9 +1376,9 @@ def test_tracked_logprobs_basic(
     requests = [
         EngineCoreRequest(
             request_id=request_id_list[idx],
+            external_req_id=request_id_list[idx],
             prompt_token_ids=prompt_tokens,
             mm_features=None,
-            eos_token_id=None,
             arrival_time=0,
             lora_request=None,
             cache_salt=None,
@@ -1467,9 +1462,9 @@ def test_tracked_logprobs_none_when_not_requested(dummy_test_vectors):
     # Make request WITHOUT track_token_ids
     request = EngineCoreRequest(
         request_id="request-0",
+        external_req_id="request-0",
         prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
         mm_features=None,
-        eos_token_id=None,
         arrival_time=0,
         lora_request=None,
         cache_salt=None,
@@ -1518,9 +1513,9 @@ def test_tracked_logprobs_with_sample_logprobs(dummy_test_vectors):
     # Make request with both logprobs and track_token_ids
     request = EngineCoreRequest(
         request_id="request-0",
+        external_req_id="request-0",
         prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
         mm_features=None,
-        eos_token_id=None,
         arrival_time=0,
         lora_request=None,
         cache_salt=None,
@@ -1585,9 +1580,9 @@ def test_tracked_logprobs_single_token(dummy_test_vectors):
 
     request = EngineCoreRequest(
         request_id="request-0",
+        external_req_id="request-0",
         prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
         mm_features=None,
-        eos_token_id=None,
         arrival_time=0,
         lora_request=None,
         cache_salt=None,

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -12,6 +12,7 @@ from tests.v1.engine.utils import (
     STOP_STRINGS,
     DummyOutputProcessorTestVectors,
     MockEngineCore,
+    generate_dummy_tracked_logprobs,
 )
 from vllm import PoolingParams
 from vllm.logprobs import PromptLogprobs, SampleLogprobs
@@ -1336,3 +1337,283 @@ def test_abort_requests(runner: str, abort_by: str, dummy_test_vectors):
             output_processor.abort_requests([request.request_id], internal=True)
         else:
             output_processor.abort_requests([request.external_req_id], internal=False)
+
+
+# ==============================================================================
+# Tests for tracked_logprobs (track_token_ids feature)
+# ==============================================================================
+
+
+@pytest.mark.parametrize(
+    "request_output_kind", [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY]
+)
+def test_tracked_logprobs_basic(
+    request_output_kind: RequestOutputKind,
+    dummy_test_vectors,
+):
+    """Test that tracked_logprobs are correctly processed and included in output.
+
+    Verifies:
+    1. Tracked logprobs are accumulated across generation steps
+    2. Output includes tracked_logprobs dict with token_id -> [logprobs] mapping
+    3. Works with both DELTA and FINAL_ONLY output modes
+    """
+    # Define tokens to track
+    track_token_ids = [100, 200, 300]
+    num_generation_tokens = len(dummy_test_vectors.generation_tokens[0])
+
+    # Generate dummy tracked logprobs for each request
+    tracked_logprobs_raw = [
+        generate_dummy_tracked_logprobs(num_generation_tokens, track_token_ids)
+        for _ in range(len(dummy_test_vectors.generation_tokens))
+    ]
+
+    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    engine_core = MockEngineCore(
+        tokens_list=dummy_test_vectors.generation_tokens,
+        tracked_logprobs_raw=tracked_logprobs_raw,
+    )
+
+    # Make N requests with track_token_ids
+    request_id_list = [
+        f"request-{idx}" for idx in range(len(dummy_test_vectors.prompt_strings))
+    ]
+    requests = [
+        EngineCoreRequest(
+            request_id=request_id_list[idx],
+            prompt_token_ids=prompt_tokens,
+            mm_features=None,
+            eos_token_id=None,
+            arrival_time=0,
+            lora_request=None,
+            cache_salt=None,
+            data_parallel_rank=None,
+            sampling_params=SamplingParams(
+                skip_special_tokens=False,
+                spaces_between_special_tokens=False,
+                output_kind=request_output_kind,
+                stop=[],
+                include_stop_str_in_output=False,
+                track_token_ids=track_token_ids,
+            ),
+            pooling_params=None,
+        )
+        for idx, prompt_tokens in enumerate(dummy_test_vectors.prompt_tokens)
+    ]
+
+    # Add requests to the output processor
+    for request, prompt in zip(requests, dummy_test_vectors.prompt_strings):
+        output_processor.add_request(request, prompt)
+
+    gen_tracked_logprobs = {}
+    while True:
+        # Mock output from the EngineCore
+        outputs = engine_core.get_outputs()
+        if len(outputs) == 0:
+            break
+
+        # Step the output processor
+        processed_outputs = output_processor.process_outputs(outputs)
+        request_outputs = processed_outputs.request_outputs
+        assert len(processed_outputs.reqs_to_abort) == 0
+
+        # Collect tracked logprobs
+        for request_output in request_outputs:
+            request_id = request_output.request_id
+            tracked = request_output.outputs[0].tracked_logprobs
+            if tracked is not None:
+                if request_id not in gen_tracked_logprobs:
+                    gen_tracked_logprobs[request_id] = tracked
+                else:
+                    # Extend existing tracked logprobs
+                    for token_id, logprobs_list in tracked.items():
+                        if token_id in gen_tracked_logprobs[request_id]:
+                            gen_tracked_logprobs[request_id][token_id].extend(
+                                logprobs_list
+                            )
+                        else:
+                            gen_tracked_logprobs[request_id][token_id] = logprobs_list
+
+    # Validate tracked logprobs
+    for idx, request_id in enumerate(request_id_list):
+        tracked = gen_tracked_logprobs.get(request_id)
+        assert tracked is not None, f"Request {request_id} missing tracked_logprobs"
+
+        # Check all track_token_ids are present
+        assert set(tracked.keys()) == set(track_token_ids), (
+            f"Expected keys {track_token_ids}, got {list(tracked.keys())}"
+        )
+
+        # Check number of logprobs per token matches generation length
+        expected_num_tokens = len(dummy_test_vectors.generation_tokens[idx])
+        for token_id in track_token_ids:
+            num_logprobs = len(tracked[token_id])
+            assert num_logprobs == expected_num_tokens, (
+                f"Token {token_id} has {num_logprobs} logprobs, "
+                f"expected {expected_num_tokens}"
+            )
+
+    assert output_processor.get_num_unfinished_requests() == 0
+
+
+def test_tracked_logprobs_none_when_not_requested(dummy_test_vectors):
+    """Test that tracked_logprobs is None when track_token_ids is not specified."""
+    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    engine_core = MockEngineCore(
+        tokens_list=dummy_test_vectors.generation_tokens,
+        tracked_logprobs_raw=None,  # No tracked logprobs
+    )
+
+    # Make request WITHOUT track_token_ids
+    request = EngineCoreRequest(
+        request_id="request-0",
+        prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
+        mm_features=None,
+        eos_token_id=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        sampling_params=SamplingParams(
+            skip_special_tokens=False,
+            spaces_between_special_tokens=False,
+            output_kind=RequestOutputKind.DELTA,
+            # track_token_ids not set - defaults to None
+        ),
+        pooling_params=None,
+    )
+
+    output_processor.add_request(request, dummy_test_vectors.prompt_strings[0])
+
+    while True:
+        outputs = engine_core.get_outputs()
+        if len(outputs) == 0:
+            break
+
+        processed_outputs = output_processor.process_outputs(outputs)
+
+        for request_output in processed_outputs.request_outputs:
+            # tracked_logprobs should be None
+            assert request_output.outputs[0].tracked_logprobs is None
+
+
+def test_tracked_logprobs_with_sample_logprobs(dummy_test_vectors):
+    """Test that tracked_logprobs works alongside regular sample logprobs."""
+    track_token_ids = [50, 100, 150]
+    num_generation_tokens = len(dummy_test_vectors.generation_tokens[0])
+
+    # Generate both regular and tracked logprobs
+    tracked_logprobs_raw = [
+        generate_dummy_tracked_logprobs(num_generation_tokens, track_token_ids)
+        for _ in range(len(dummy_test_vectors.generation_tokens))
+    ]
+
+    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    engine_core = MockEngineCore(
+        tokens_list=dummy_test_vectors.generation_tokens,
+        generated_logprobs_raw=dummy_test_vectors.generation_logprobs,
+        tracked_logprobs_raw=tracked_logprobs_raw,
+    )
+
+    # Make request with both logprobs and track_token_ids
+    request = EngineCoreRequest(
+        request_id="request-0",
+        prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
+        mm_features=None,
+        eos_token_id=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        sampling_params=SamplingParams(
+            skip_special_tokens=False,
+            spaces_between_special_tokens=False,
+            output_kind=RequestOutputKind.DELTA,
+            logprobs=NUM_SAMPLE_LOGPROBS_UNDER_TEST,  # Regular logprobs
+            track_token_ids=track_token_ids,  # Also track specific tokens
+        ),
+        pooling_params=None,
+    )
+
+    output_processor.add_request(request, dummy_test_vectors.prompt_strings[0])
+
+    gen_logprobs = []
+    gen_tracked_logprobs: dict[int, list[float]] = {}
+
+    while True:
+        outputs = engine_core.get_outputs()
+        if len(outputs) == 0:
+            break
+
+        processed_outputs = output_processor.process_outputs(outputs)
+
+        for request_output in processed_outputs.request_outputs:
+            # Both should be present
+            logprobs = request_output.outputs[0].logprobs
+            tracked = request_output.outputs[0].tracked_logprobs
+
+            if logprobs:
+                gen_logprobs.extend(logprobs)
+
+            if tracked:
+                for token_id, logprobs_list in tracked.items():
+                    if token_id in gen_tracked_logprobs:
+                        gen_tracked_logprobs[token_id].extend(logprobs_list)
+                    else:
+                        gen_tracked_logprobs[token_id] = logprobs_list
+
+    # Validate both are present
+    assert len(gen_logprobs) == num_generation_tokens
+    assert set(gen_tracked_logprobs.keys()) == set(track_token_ids)
+
+
+def test_tracked_logprobs_single_token(dummy_test_vectors):
+    """Test tracking a single token ID."""
+    track_token_ids = [42]  # Single token
+    num_generation_tokens = len(dummy_test_vectors.generation_tokens[0])
+
+    tracked_logprobs_raw = [
+        generate_dummy_tracked_logprobs(num_generation_tokens, track_token_ids)
+        for _ in range(len(dummy_test_vectors.generation_tokens))
+    ]
+
+    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=False)
+    engine_core = MockEngineCore(
+        tokens_list=dummy_test_vectors.generation_tokens,
+        tracked_logprobs_raw=tracked_logprobs_raw,
+    )
+
+    request = EngineCoreRequest(
+        request_id="request-0",
+        prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
+        mm_features=None,
+        eos_token_id=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        sampling_params=SamplingParams(
+            skip_special_tokens=False,
+            output_kind=RequestOutputKind.FINAL_ONLY,
+            track_token_ids=track_token_ids,
+        ),
+        pooling_params=None,
+    )
+
+    output_processor.add_request(request, dummy_test_vectors.prompt_strings[0])
+
+    final_tracked = None
+    while True:
+        outputs = engine_core.get_outputs()
+        if len(outputs) == 0:
+            break
+
+        processed_outputs = output_processor.process_outputs(outputs)
+
+        for request_output in processed_outputs.request_outputs:
+            if request_output.finished:
+                final_tracked = request_output.outputs[0].tracked_logprobs
+
+    assert final_tracked is not None
+    assert 42 in final_tracked
+    assert len(final_tracked[42]) == num_generation_tokens

--- a/tests/v1/engine/utils.py
+++ b/tests/v1/engine/utils.py
@@ -11,7 +11,7 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
 from vllm.engine.arg_utils import EngineArgs
 from vllm.v1.engine import EngineCoreOutput, FinishReason
-from vllm.v1.outputs import LogprobsLists, LogprobsTensors
+from vllm.v1.outputs import LogprobsLists, LogprobsTensors, TrackedLogprobsLists
 
 GeneralTokenizerType: TypeAlias = PreTrainedTokenizer | PreTrainedTokenizerFast
 
@@ -303,6 +303,29 @@ def generate_dummy_prompt_logprobs_tensors(
     )
 
 
+def generate_dummy_tracked_logprobs(
+    num_tokens: int,
+    track_token_ids: list[int],
+) -> TrackedLogprobsLists:
+    """Generate dummy tracked logprobs for testing.
+
+    Args:
+        num_tokens: Number of generated tokens (rows in logprobs matrix)
+        track_token_ids: List of token IDs being tracked (columns in matrix)
+
+    Returns:
+        TrackedLogprobsLists with random logprob values
+    """
+    num_tracked = len(track_token_ids)
+    # Generate random logprobs (negative values as they are log probabilities)
+    logprobs = np.random.uniform(-10.0, -0.1, size=(num_tokens, num_tracked))
+    return TrackedLogprobsLists(
+        logprobs=logprobs,
+        token_ids=track_token_ids,
+        cu_num_generated_tokens=None,  # Will be set per-request by MockEngineCore
+    )
+
+
 @dataclass
 class DummyOutputProcessorTestVectors:
     """Dummy test vectors for output processor tests"""
@@ -340,6 +363,9 @@ class MockEngineCore:
         # each matrix has dimensions
         # (num prompt toks) x (num prompt logprobs+1)
         prompt_logprobs_raw: list[LogprobsTensors] | None = None,
+        # For each request, tracked logprobs as TrackedLogprobsLists
+        # with shape [num_generation_tokens, num_tracked_tokens]
+        tracked_logprobs_raw: list[TrackedLogprobsLists] | None = None,
         eos_token_id: int | None = None,
         stop_token_ids: list[int] | None = None,
         request_ids: list[str] | None = None,
@@ -351,6 +377,8 @@ class MockEngineCore:
         self.do_logprobs = generated_logprobs_raw is not None
         self.prompt_logprobs_raw = prompt_logprobs_raw
         self.do_prompt_logprobs = prompt_logprobs_raw is not None
+        self.tracked_logprobs_raw = tracked_logprobs_raw
+        self.do_tracked_logprobs = tracked_logprobs_raw is not None
         self.request_finished = [False for _ in range(self.num_requests)]
         self.eos_token_id = eos_token_id
         self.stop_token_ids = stop_token_ids
@@ -363,6 +391,7 @@ class MockEngineCore:
     def get_outputs(self) -> list[EngineCoreOutput]:
         do_logprobs = self.do_logprobs
         do_prompt_logprobs = self.do_prompt_logprobs
+        do_tracked_logprobs = self.do_tracked_logprobs
         token_idx = self.current_idx
 
         outputs = []
@@ -388,12 +417,27 @@ class MockEngineCore:
                         prompt_logprobs = None
                 else:
                     prompt_logprobs = None
+
+                # Handle tracked logprobs
+                tracked_logprobs = None
+                if do_tracked_logprobs:
+                    assert self.tracked_logprobs_raw is not None
+                    raw_tracked = self.tracked_logprobs_raw[req_idx]
+                    # Extract the row for this token_idx
+                    if token_idx < raw_tracked.logprobs.shape[0]:
+                        tracked_logprobs = TrackedLogprobsLists(
+                            logprobs=raw_tracked.logprobs[token_idx : token_idx + 1],
+                            token_ids=raw_tracked.token_ids,
+                            cu_num_generated_tokens=None,
+                        )
+
                 new_token_id = token_ids[token_idx]
                 output = EngineCoreOutput(
                     request_id=self.request_ids[req_idx],
                     new_token_ids=[new_token_id],
                     new_logprobs=logprobs,
                     new_prompt_logprobs_tensors=prompt_logprobs,
+                    new_tracked_logprobs=tracked_logprobs,
                 )
                 if token_idx == len(token_ids) - 1:
                     output.finish_reason = FinishReason.LENGTH

--- a/tests/v1/engine/utils.py
+++ b/tests/v1/engine/utils.py
@@ -20,8 +20,6 @@ NUM_SAMPLE_LOGPROBS_UNDER_TEST = 5
 # Number of prompt logprobs to request when testing prompt logprobs
 NUM_PROMPT_LOGPROBS_UNDER_TEST = 7
 
-TOKENIZER_NAME = "meta-llama/Llama-3.2-1B"
-
 FULL_STRINGS = [
     "My name is Robert from Neural Magic and I love working on vLLM so much!",
     "Red Hat is the best open source company by far across Linux, K8s, and AI.",
@@ -31,6 +29,24 @@ STOP_STRINGS = ["I love working on", "company by far", "brother in"]
 PROMPT_LEN = 5
 
 random.seed(42)
+
+
+def get_non_eos_special_token(
+    tokenizer: GeneralTokenizerType,
+) -> tuple[int, str]:
+    """Return a stable non-EOS special token for stop-token tests."""
+
+    excluded_ids = {tokenizer.eos_token_id, tokenizer.pad_token_id}
+    for token_id in tokenizer.all_special_ids:
+        if token_id is None or token_id in excluded_ids:
+            continue
+        token_text = tokenizer.decode([token_id], skip_special_tokens=False)
+        if token_text:
+            return token_id, token_text
+
+    raise AssertionError(
+        f"Tokenizer {tokenizer.name_or_path} has no usable non-EOS special token."
+    )
 
 
 def _create_random_top_logprob_test_vector(

--- a/tests/v1/test_outputs.py
+++ b/tests/v1/test_outputs.py
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from unittest import TestCase
 
-from vllm.v1.outputs import LogprobsLists
+import numpy as np
+
+from vllm.v1.outputs import LogprobsLists, TrackedLogprobsLists
 
 
 class TestLogprobsLists(TestCase):
@@ -97,3 +99,168 @@ class TestLogprobsLists(TestCase):
         assert len(sliced.logprob_token_ids) == 9  # All tokens
         assert sliced.logprob_token_ids == self.logprobsLists.logprob_token_ids
         assert sliced.cu_num_generated_tokens is None
+
+
+class TestTrackedLogprobsLists(TestCase):
+    """Tests for TrackedLogprobsLists slicing operations."""
+
+    def setUp(self):
+        """Create sample TrackedLogprobsLists with known data.
+
+        Structure:
+        - 3 requests with different numbers of generated tokens
+        - Request 0: 2 tokens (rows 0-1)
+        - Request 1: 1 token (row 2)
+        - Request 2: 3 tokens (rows 3-5)
+        - 3 tracked token IDs: [100, 200, 300]
+        """
+        self.tracked = TrackedLogprobsLists(
+            logprobs=np.array(
+                [
+                    [-1.0, -2.0, -3.0],  # Request 0, token 0
+                    [-1.1, -2.1, -3.1],  # Request 0, token 1
+                    [-1.2, -2.2, -3.2],  # Request 1, token 0
+                    [-1.3, -2.3, -3.3],  # Request 2, token 0
+                    [-1.4, -2.4, -3.4],  # Request 2, token 1
+                    [-1.5, -2.5, -3.5],  # Request 2, token 2
+                ]
+            ),
+            token_ids=[100, 200, 300],
+            cu_num_generated_tokens=[0, 2, 3, 6],
+        )
+
+    def test_slice_without_cu_num_generated_tokens(self):
+        """Test slicing without cu_num_generated_tokens uses req_idx directly."""
+        tracked = TrackedLogprobsLists(
+            logprobs=np.array(
+                [
+                    [-1.0, -2.0],
+                    [-1.1, -2.1],
+                    [-1.2, -2.2],
+                ]
+            ),
+            token_ids=[100, 200],
+            cu_num_generated_tokens=None,
+        )
+
+        # Without cu_num_generated_tokens, req_idx is used as start index
+        sliced = tracked.slice_request(1, num_positions=2)
+
+        # Should slice rows 1 and 2
+        np.testing.assert_array_almost_equal(
+            sliced.logprobs, np.array([[-1.1, -2.1], [-1.2, -2.2]])
+        )
+        assert sliced.token_ids == [100, 200]
+        assert sliced.cu_num_generated_tokens is None
+
+    def test_slice_first_request(self):
+        """Test slicing the first request."""
+        sliced = self.tracked.slice_request(0, num_positions=2)
+
+        # Request 0 has 2 tokens at rows 0-1
+        np.testing.assert_array_almost_equal(
+            sliced.logprobs, np.array([[-1.0, -2.0, -3.0], [-1.1, -2.1, -3.1]])
+        )
+        assert sliced.token_ids == [100, 200, 300]
+        assert sliced.cu_num_generated_tokens is None
+
+    def test_slice_middle_request(self):
+        """Test slicing a middle request."""
+        sliced = self.tracked.slice_request(1, num_positions=1)
+
+        # Request 1 has 1 token at row 2
+        np.testing.assert_array_almost_equal(
+            sliced.logprobs, np.array([[-1.2, -2.2, -3.2]])
+        )
+        assert sliced.token_ids == [100, 200, 300]
+        assert sliced.cu_num_generated_tokens is None
+
+    def test_slice_last_request(self):
+        """Test slicing the last request."""
+        sliced = self.tracked.slice_request(2, num_positions=3)
+
+        # Request 2 has 3 tokens at rows 3-5
+        np.testing.assert_array_almost_equal(
+            sliced.logprobs,
+            np.array(
+                [
+                    [-1.3, -2.3, -3.3],
+                    [-1.4, -2.4, -3.4],
+                    [-1.5, -2.5, -3.5],
+                ]
+            ),
+        )
+        assert sliced.token_ids == [100, 200, 300]
+        assert sliced.cu_num_generated_tokens is None
+
+    def test_slice_single_token(self):
+        """Test slicing a request with a single token."""
+        # Create a tracked list where each request has 1 token
+        tracked = TrackedLogprobsLists(
+            logprobs=np.array(
+                [
+                    [-1.0, -2.0],
+                    [-3.0, -4.0],
+                    [-5.0, -6.0],
+                ]
+            ),
+            token_ids=[100, 200],
+            cu_num_generated_tokens=[0, 1, 2, 3],
+        )
+
+        sliced = tracked.slice_request(1, num_positions=1)
+
+        np.testing.assert_array_almost_equal(sliced.logprobs, np.array([[-3.0, -4.0]]))
+        assert sliced.token_ids == [100, 200]
+
+    def test_slice_preserves_token_ids(self):
+        """Test that token_ids are always preserved after slicing."""
+        # Slice different requests and verify token_ids are unchanged
+        for req_idx in range(3):
+            num_tokens = [2, 1, 3][req_idx]  # Tokens per request
+            sliced = self.tracked.slice_request(req_idx, num_positions=num_tokens)
+            assert sliced.token_ids == [100, 200, 300]
+
+    def test_slice_with_single_tracked_token(self):
+        """Test slicing when only tracking a single token."""
+        tracked = TrackedLogprobsLists(
+            logprobs=np.array(
+                [
+                    [-1.0],
+                    [-2.0],
+                    [-3.0],
+                ]
+            ),
+            token_ids=[42],
+            cu_num_generated_tokens=[0, 1, 2, 3],
+        )
+
+        sliced = tracked.slice_request(1, num_positions=1)
+
+        np.testing.assert_array_almost_equal(sliced.logprobs, np.array([[-2.0]]))
+        assert sliced.token_ids == [42]
+
+    def test_slice_with_many_tracked_tokens(self):
+        """Test slicing when tracking many tokens (e.g., 100-class classification)."""
+        num_tracked = 100
+        num_tokens = 5
+        token_ids = list(range(num_tracked))
+
+        tracked = TrackedLogprobsLists(
+            logprobs=np.random.randn(num_tokens, num_tracked),
+            token_ids=token_ids,
+            cu_num_generated_tokens=[0, 2, 5],  # 2 requests: 2 tokens, 3 tokens
+        )
+
+        sliced = tracked.slice_request(1, num_positions=3)
+
+        assert sliced.logprobs.shape == (3, num_tracked)
+        assert sliced.token_ids == token_ids
+        assert len(sliced.token_ids) == num_tracked
+
+    def test_slice_empty_result(self):
+        """Test slicing with num_positions=0 returns empty array."""
+        sliced = self.tracked.slice_request(0, num_positions=0)
+
+        assert sliced.logprobs.shape == (0, 3)
+        assert sliced.token_ids == [100, 200, 300]

--- a/tests/v1/test_sampling_params.py
+++ b/tests/v1/test_sampling_params.py
@@ -108,7 +108,9 @@ class TestTrackTokenIdsValidation:
         assert "[100, 200]" in repr_str
 
     def test_track_token_ids_duplicate_values(self):
-        """Test that duplicate token IDs are allowed (no deduplication at param level)."""
+        """Test that duplicate token IDs are allowed
+        (no deduplication at param level).
+        """
         # Note: Deduplication happens at the batch level in merged_track_token_ids
         params = SamplingParams(track_token_ids=[100, 100, 200])
         assert params.track_token_ids == [100, 100, 200]

--- a/tests/v1/test_sampling_params.py
+++ b/tests/v1/test_sampling_params.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for SamplingParams validation, especially track_token_ids."""
+
+import pytest
+
+from vllm import SamplingParams
+
+
+class TestTrackTokenIdsValidation:
+    """Tests for track_token_ids parameter validation in SamplingParams."""
+
+    def test_track_token_ids_none(self):
+        """Test that track_token_ids=None is valid (default)."""
+        params = SamplingParams(track_token_ids=None)
+        assert params.track_token_ids is None
+
+    def test_track_token_ids_empty_list(self):
+        """Test that track_token_ids=[] is valid."""
+        params = SamplingParams(track_token_ids=[])
+        assert params.track_token_ids == []
+
+    def test_track_token_ids_single_token(self):
+        """Test that a single token ID is valid."""
+        params = SamplingParams(track_token_ids=[100])
+        assert params.track_token_ids == [100]
+
+    def test_track_token_ids_multiple_tokens(self):
+        """Test that multiple token IDs are valid."""
+        track_ids = [100, 200, 300, 500, 1000]
+        params = SamplingParams(track_token_ids=track_ids)
+        assert params.track_token_ids == track_ids
+
+    def test_track_token_ids_with_zero(self):
+        """Test that token ID 0 is valid."""
+        params = SamplingParams(track_token_ids=[0, 1, 2])
+        assert params.track_token_ids == [0, 1, 2]
+
+    def test_track_token_ids_large_values(self):
+        """Test that large token IDs are valid (vocab bounds checked at runtime)."""
+        large_ids = [100000, 150000, 200000]
+        params = SamplingParams(track_token_ids=large_ids)
+        assert params.track_token_ids == large_ids
+
+    def test_track_token_ids_many_tokens(self):
+        """Test that tracking many tokens (e.g., 100 for classification) is valid."""
+        track_ids = list(range(100))
+        params = SamplingParams(track_token_ids=track_ids)
+        assert params.track_token_ids == track_ids
+        assert len(params.track_token_ids) == 100
+
+    def test_track_token_ids_negative_integer_raises(self):
+        """Test that negative integers raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            SamplingParams(track_token_ids=[-1])
+        assert "track_token_ids must contain only non-negative integers" in str(
+            exc_info.value
+        )
+
+    def test_track_token_ids_negative_in_list_raises(self):
+        """Test that a negative integer in a list raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            SamplingParams(track_token_ids=[100, -5, 200])
+        assert "track_token_ids must contain only non-negative integers" in str(
+            exc_info.value
+        )
+
+    def test_track_token_ids_with_logprobs(self):
+        """Test that track_token_ids works alongside logprobs parameter."""
+        params = SamplingParams(
+            logprobs=5,
+            track_token_ids=[100, 200, 300],
+        )
+        assert params.logprobs == 5
+        assert params.track_token_ids == [100, 200, 300]
+
+    def test_track_token_ids_with_prompt_logprobs(self):
+        """Test that track_token_ids works alongside prompt_logprobs parameter."""
+        params = SamplingParams(
+            prompt_logprobs=3,
+            track_token_ids=[100, 200],
+        )
+        assert params.prompt_logprobs == 3
+        assert params.track_token_ids == [100, 200]
+
+    def test_track_token_ids_with_temperature(self):
+        """Test that track_token_ids works with various temperature settings."""
+        # Greedy
+        params = SamplingParams(temperature=0.0, track_token_ids=[100])
+        assert params.temperature == 0.0
+        assert params.track_token_ids == [100]
+
+        # Non-zero temperature
+        params = SamplingParams(temperature=0.8, track_token_ids=[100])
+        assert params.temperature == 0.8
+        assert params.track_token_ids == [100]
+
+    def test_track_token_ids_default_not_provided(self):
+        """Test that track_token_ids is None when not provided."""
+        params = SamplingParams()
+        assert params.track_token_ids is None
+
+    def test_track_token_ids_in_repr(self):
+        """Test that track_token_ids appears in the string representation."""
+        params = SamplingParams(track_token_ids=[100, 200])
+        repr_str = repr(params)
+        assert "track_token_ids" in repr_str
+        assert "[100, 200]" in repr_str
+
+    def test_track_token_ids_duplicate_values(self):
+        """Test that duplicate token IDs are allowed (no deduplication at param level)."""
+        # Note: Deduplication happens at the batch level in merged_track_token_ids
+        params = SamplingParams(track_token_ids=[100, 100, 200])
+        assert params.track_token_ids == [100, 100, 200]

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -491,6 +491,8 @@ def test_pooling_prompt_lens_not_aliased(device: str):
         f"Expected {prompt_lens_snapshot}, got {metadata.prompt_lens}"
     )
 
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
 def test_merged_track_token_ids_empty(device: str):
     """
     Test that merged_track_token_ids returns None

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -400,6 +400,56 @@ def _construct_pooling_request(req_id_suffix: int):
     )
 
 
+# ==============================================================================
+# Tests for merged_track_token_ids
+# ==============================================================================
+
+
+def _create_input_batch(device: str, batch_size: int = 32) -> InputBatch:
+    """Helper to create an InputBatch for testing."""
+    return InputBatch(
+        max_num_reqs=batch_size,
+        max_model_len=1024,
+        max_num_batched_tokens=1024,
+        device=torch.device(device),
+        pin_memory=is_pin_memory_available(),
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[1],
+        kernel_block_sizes=[1],
+    )
+
+
+def _create_cached_request_with_track_ids(
+    req_id_suffix: int,
+    track_token_ids: list[int] | None = None,
+) -> CachedRequestState:
+    """Create a CachedRequestState with optional track_token_ids."""
+    prompt_token_ids = [
+        np.random.randint(0, VOCAB_SIZE)
+        for _ in range(np.random.randint(1, MAX_PROMPT_SIZE))
+    ]
+    output_token_ids = [
+        np.random.randint(0, VOCAB_SIZE)
+        for _ in range(np.random.randint(0, NUM_OUTPUT_TOKENS))
+    ]
+    sampling_params = SamplingParams(
+        top_k=np.random.randint(1, 10),
+        top_p=np.random.uniform(0.0, 1.0),
+        track_token_ids=track_token_ids,
+    )
+    return CachedRequestState(
+        req_id=f"req_id_{req_id_suffix}",
+        prompt_token_ids=prompt_token_ids,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        mm_features=[],
+        block_ids=([],),
+        generator=None,
+        num_computed_tokens=len(output_token_ids),
+        output_token_ids=output_token_ids,
+    )
+
+
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 def test_pooling_prompt_lens_not_aliased(device: str):
     """Verify that prompt_lens in PoolingMetadata does not share memory
@@ -440,3 +490,189 @@ def test_pooling_prompt_lens_not_aliased(device: str):
         "mutations to num_prompt_tokens_cpu_tensor corrupted prompt_lens. "
         f"Expected {prompt_lens_snapshot}, got {metadata.prompt_lens}"
     )
+
+def test_merged_track_token_ids_empty(device: str):
+    """
+    Test that merged_track_token_ids returns None
+    when no requests have track_token_ids.
+    """
+    input_batch = _create_input_batch(device)
+
+    # Add requests without track_token_ids
+    for i in range(3):
+        req = _create_cached_request_with_track_ids(i, track_token_ids=None)
+        input_batch.add_request(req)
+
+    # Should return None
+    assert input_batch.merged_track_token_ids is None
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_merged_track_token_ids_single_request(device: str):
+    """Test merged_track_token_ids with a single request having track_token_ids."""
+    input_batch = _create_input_batch(device)
+
+    track_ids = [100, 200, 300]
+    req = _create_cached_request_with_track_ids(0, track_token_ids=track_ids)
+    input_batch.add_request(req)
+
+    merged = input_batch.merged_track_token_ids
+
+    assert merged is not None
+    assert merged.device == torch.device(device)
+    assert merged.tolist() == sorted(track_ids)
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_merged_track_token_ids_multiple_requests_disjoint(device: str):
+    """
+    Test merged_track_token_ids with multiple requests
+    having disjoint track_token_ids.
+    """
+    input_batch = _create_input_batch(device)
+
+    # Request 0: track [100, 200]
+    req0 = _create_cached_request_with_track_ids(0, track_token_ids=[100, 200])
+    input_batch.add_request(req0)
+
+    # Request 1: track [300, 400]
+    req1 = _create_cached_request_with_track_ids(1, track_token_ids=[300, 400])
+    input_batch.add_request(req1)
+
+    merged = input_batch.merged_track_token_ids
+
+    assert merged is not None
+    # Should contain union of all track_token_ids, sorted
+    assert merged.tolist() == [100, 200, 300, 400]
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_merged_track_token_ids_multiple_requests_overlapping(device: str):
+    """Test merged_track_token_ids with overlapping track_token_ids (deduplication)."""
+    input_batch = _create_input_batch(device)
+
+    # Request 0: track [100, 200, 300]
+    req0 = _create_cached_request_with_track_ids(0, track_token_ids=[100, 200, 300])
+    input_batch.add_request(req0)
+
+    # Request 1: track [200, 300, 400] (overlaps with req0)
+    req1 = _create_cached_request_with_track_ids(1, track_token_ids=[200, 300, 400])
+    input_batch.add_request(req1)
+
+    merged = input_batch.merged_track_token_ids
+
+    assert merged is not None
+    # Should deduplicate and sort
+    assert merged.tolist() == [100, 200, 300, 400]
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_merged_track_token_ids_mixed_requests(device: str):
+    """
+    Test merged_track_token_ids with some requests
+    having track_token_ids and others not.
+    """
+    input_batch = _create_input_batch(device)
+
+    # Request 0: no track_token_ids
+    req0 = _create_cached_request_with_track_ids(0, track_token_ids=None)
+    input_batch.add_request(req0)
+
+    # Request 1: track [100, 200]
+    req1 = _create_cached_request_with_track_ids(1, track_token_ids=[100, 200])
+    input_batch.add_request(req1)
+
+    # Request 2: no track_token_ids
+    req2 = _create_cached_request_with_track_ids(2, track_token_ids=None)
+    input_batch.add_request(req2)
+
+    merged = input_batch.merged_track_token_ids
+
+    assert merged is not None
+    assert merged.tolist() == [100, 200]
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_merged_track_token_ids_empty_list(device: str):
+    """Test merged_track_token_ids when a request has track_token_ids=[]."""
+    input_batch = _create_input_batch(device)
+
+    # Request 0: empty list
+    req0 = _create_cached_request_with_track_ids(0, track_token_ids=[])
+    input_batch.add_request(req0)
+
+    # Should return None since no tokens to track
+    assert input_batch.merged_track_token_ids is None
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_merged_track_token_ids_many_tokens(device: str):
+    """Test merged_track_token_ids with many tokens (classification use case)."""
+    input_batch = _create_input_batch(device)
+
+    # Track 100 tokens for classification
+    track_ids = list(range(100, 200))
+    req = _create_cached_request_with_track_ids(0, track_token_ids=track_ids)
+    input_batch.add_request(req)
+
+    merged = input_batch.merged_track_token_ids
+
+    assert merged is not None
+    assert merged.tolist() == track_ids
+    assert len(merged) == 100
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_merged_track_token_ids_after_remove_request(device: str):
+    """Test that merged_track_token_ids updates after removing a request."""
+    input_batch = _create_input_batch(device)
+
+    # Request 0: track [100, 200]
+    req0 = _create_cached_request_with_track_ids(0, track_token_ids=[100, 200])
+    input_batch.add_request(req0)
+
+    # Request 1: track [300, 400]
+    req1 = _create_cached_request_with_track_ids(1, track_token_ids=[300, 400])
+    input_batch.add_request(req1)
+
+    # Initial merged should have all 4 tokens
+    assert input_batch.merged_track_token_ids.tolist() == [100, 200, 300, 400]
+
+    # Remove request 0
+    input_batch.remove_request(req0.req_id)
+
+    # After removal, should only have tokens from request 1
+    assert input_batch.merged_track_token_ids.tolist() == [300, 400]
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_merged_track_token_ids_tensor_properties(device: str):
+    """Test that the returned tensor has correct properties."""
+    input_batch = _create_input_batch(device)
+
+    track_ids = [500, 100, 300, 200]  # Unsorted input
+    req = _create_cached_request_with_track_ids(0, track_token_ids=track_ids)
+    input_batch.add_request(req)
+
+    merged = input_batch.merged_track_token_ids
+
+    assert merged is not None
+    assert merged.dtype == torch.int64
+    assert merged.device == torch.device(device)
+    # Should be sorted
+    assert merged.tolist() == sorted(track_ids)
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_track_token_ids_validation_exceeds_vocab(device: str):
+    """Test that track_token_ids exceeding vocab_size raises ValueError."""
+    input_batch = _create_input_batch(device)
+
+    # Try to add request with token ID >= vocab_size
+    invalid_track_ids = [100, VOCAB_SIZE + 100]  # VOCAB_SIZE is 1024
+    req = _create_cached_request_with_track_ids(0, track_token_ids=invalid_track_ids)
+
+    with pytest.raises(ValueError) as exc_info:
+        input_batch.add_request(req)
+
+    assert "exceed vocab_size" in str(exc_info.value)

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -35,6 +35,9 @@ class CompletionOutput:
             to stop, None if the completion finished for some other reason
             including encountering the EOS token.
         lora_request: The LoRA request that was used to generate the output.
+        tracked_logprobs: The log probabilities for tracked tokens across all
+            generation steps. Format: {token_id: [logprob_step0, logprob_step1, ...]}
+            Only present if track_token_ids was specified in SamplingParams.
     """
 
     index: int
@@ -46,6 +49,7 @@ class CompletionOutput:
     finish_reason: str | None = None
     stop_reason: int | str | None = None
     lora_request: LoRARequest | None = None
+    tracked_logprobs: dict[int, list[float]] | None = None
 
     def finished(self) -> bool:
         return self.finish_reason is not None
@@ -59,7 +63,8 @@ class CompletionOutput:
             f"cumulative_logprob={self.cumulative_logprob}, "
             f"logprobs={self.logprobs}, "
             f"finish_reason={self.finish_reason}, "
-            f"stop_reason={self.stop_reason})"
+            f"stop_reason={self.stop_reason}, "
+            f"tracked_logprobs={self.tracked_logprobs})"
         )
 
 
@@ -159,7 +164,18 @@ class RequestOutput:
                         completion.token_ids.extend(next_completion.token_ids)
                         if next_completion.logprobs:
                             assert completion.logprobs is not None
-                            completion.logprobs.extend(next_completion.logprobs)  # type: ignore[arg-type]
+                            completion.logprobs.extend(next_completion.logprobs)
+                        # Merge tracked_logprobs: extend each token's logprob list
+                        if next_completion.tracked_logprobs:
+                            if completion.tracked_logprobs is None:
+                                completion.tracked_logprobs = {}
+                            for (
+                                token_id,
+                                lp_list,
+                            ) in next_completion.tracked_logprobs.items():
+                                if token_id not in completion.tracked_logprobs:
+                                    completion.tracked_logprobs[token_id] = []
+                                completion.tracked_logprobs[token_id].extend(lp_list)
                         completion.cumulative_logprob = (
                             next_completion.cumulative_logprob
                         )

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -280,6 +280,13 @@ class SamplingParams(
     generated token can complete the sequence."""
     _bad_words_token_ids: list[list[int]] | None = None
 
+    track_token_ids: list[int] | None = None
+    """List of token IDs to track logprobs for at every generation step.
+    These tokens will have their logprobs recorded even if they don't
+    appear in the top-k (logprobs parameter). This is useful for tasks like
+    classification where you need probabilities for specific tokens
+    (e.g., class labels) without retrieving the full vocabulary logprobs."""
+
     skip_reading_prefix_cache: bool | None = None
 
     repetition_detection: RepetitionDetectionParams | None = None
@@ -320,6 +327,7 @@ class SamplingParams(
         extra_args: dict[str, Any] | None = None,
         skip_clone: bool = False,
         repetition_detection: RepetitionDetectionParams | None = None,
+        track_token_ids: list[int] | None = None,
     ) -> "SamplingParams":
         if logit_bias is not None:
             # Convert token_id to integer
@@ -360,6 +368,7 @@ class SamplingParams(
             extra_args=extra_args,
             skip_clone=skip_clone,
             repetition_detection=repetition_detection,
+            track_token_ids=track_token_ids,
         )
 
     def __post_init__(self) -> None:
@@ -501,6 +510,13 @@ class SamplingParams(
             raise ValueError(
                 "stop strings are only supported when detokenize is True. "
                 "Set detokenize=True to use stop."
+            )
+        if self.track_token_ids is not None and not all(
+            isinstance(tid, int) and tid >= 0 for tid in self.track_token_ids
+        ):
+            raise ValueError(
+                "track_token_ids must contain only non-negative integers, "
+                f"got {self.track_token_ids}."
             )
 
     def _verify_greedy_sampling(self) -> None:
@@ -868,6 +884,7 @@ class SamplingParams(
             "spaces_between_special_tokens="
             f"{self.spaces_between_special_tokens}, "
             f"structured_outputs={self.structured_outputs}, "
+            f"track_token_ids={self.track_token_ids}, "
             f"extra_args={self.extra_args})"
         )
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1282,6 +1282,7 @@ class Scheduler(SchedulerInterface):
     ) -> dict[int, EngineCoreOutputs]:
         sampled_token_ids = model_runner_output.sampled_token_ids
         logprobs = model_runner_output.logprobs
+        tracked_logprobs = model_runner_output.tracked_logprobs
         prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         pooler_outputs = model_runner_output.pooler_output
@@ -1406,6 +1407,17 @@ class Scheduler(SchedulerInterface):
             ):
                 new_logprobs = logprobs.slice_request(req_index, len(new_token_ids))
 
+            # Extract tracked logprobs if needed.
+            new_tracked_logprobs = None
+            if (
+                request.sampling_params is not None
+                and request.sampling_params.track_token_ids
+                and tracked_logprobs is not None
+            ):
+                new_tracked_logprobs = tracked_logprobs.slice_request(
+                    req_index, len(new_token_ids)
+                )
+
             if new_token_ids and self.structured_output_manager.should_advance(request):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
@@ -1437,6 +1449,7 @@ class Scheduler(SchedulerInterface):
                         finish_reason=finish_reason,
                         new_logprobs=new_logprobs,
                         new_prompt_logprobs_tensors=prompt_logprobs_tensors,
+                        new_tracked_logprobs=new_tracked_logprobs,
                         pooling_output=pooler_output,
                         stop_reason=request.stop_reason,
                         events=request.take_events(),

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -15,7 +15,11 @@ from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.v1.metrics.stats import SchedulerStats
-from vllm.v1.outputs import LogprobsLists, LogprobsTensors
+from vllm.v1.outputs import (
+    LogprobsLists,
+    LogprobsTensors,
+    TrackedLogprobsLists,
+)
 from vllm.v1.serial_utils import UtilityResult
 
 # Type for pause_generation mode parameter.
@@ -148,6 +152,7 @@ class EngineCoreOutput(
 
     new_logprobs: LogprobsLists | None = None
     new_prompt_logprobs_tensors: LogprobsTensors | None = None
+    new_tracked_logprobs: TrackedLogprobsLists | None = None
 
     pooling_output: torch.Tensor | None = None
 

--- a/vllm/v1/engine/logprobs.py
+++ b/vllm/v1/engine/logprobs.py
@@ -18,7 +18,7 @@ from vllm.tokenizers.detokenizer_utils import (
     convert_ids_list_to_tokens,
 )
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest
-from vllm.v1.outputs import LogprobsLists, LogprobsTensors
+from vllm.v1.outputs import LogprobsLists, LogprobsTensors, TrackedLogprobsLists
 
 logger = init_logger(__name__)
 
@@ -38,6 +38,11 @@ class LogprobsProcessor:
     num_logprobs: int | None
     num_prompt_logprobs: int | None
 
+    # Tracked logprobs for specific tokens
+    # Format: {token_id: [logprob_step0, logprob_step1, ...]}
+    tracked_logprobs: dict[int, list[float]] | None
+    track_token_ids: list[int] | None
+
     @classmethod
     def from_new_request(
         cls,
@@ -48,6 +53,14 @@ class LogprobsProcessor:
         assert sampling_params is not None
         num_logprobs = sampling_params.logprobs
         num_prompt_logprobs = sampling_params.prompt_logprobs
+        track_token_ids = sampling_params.track_token_ids
+
+        # Initialize tracked_logprobs dict if track_token_ids is specified
+        # Use `is not None` to correctly handle empty list (which should return {})
+        tracked_logprobs: dict[int, list[float]] | None = None
+        if track_token_ids is not None:
+            tracked_logprobs = {token_id: [] for token_id in track_token_ids}
+
         return cls(
             tokenizer=tokenizer,
             cumulative_logprob=(None if num_logprobs is None else 0.0),
@@ -63,6 +76,8 @@ class LogprobsProcessor:
             ),
             num_prompt_logprobs=num_prompt_logprobs,
             num_logprobs=num_logprobs,
+            tracked_logprobs=tracked_logprobs,
+            track_token_ids=track_token_ids,
         )
 
     def _update_sample_logprobs(self, logprobs_lists: LogprobsLists) -> None:
@@ -238,8 +253,42 @@ class LogprobsProcessor:
 
         return decoded_tokens_list
 
+    def _update_tracked_logprobs(
+        self,
+        tracked_logprobs_lists: TrackedLogprobsLists,
+    ) -> None:
+        """Update with tracked logprobs from EngineCore.
+
+        Args:
+            tracked_logprobs_lists: The tracked logprobs for this request.
+                Shape: [num_generated_tokens, num_tracked_tokens]
+                In speculative decoding, num_generated_tokens can be > 1.
+        """
+        if self.tracked_logprobs is None or self.track_token_ids is None:
+            return
+
+        logprobs_array = tracked_logprobs_lists.logprobs
+        token_ids = tracked_logprobs_lists.token_ids
+
+        # logprobs_array shape: [num_tokens, num_tracked_tokens]
+        # We need to match the tracked token IDs from the merged set
+        # to our specific track_token_ids
+        token_id_to_idx = {tid: idx for idx, tid in enumerate(token_ids)}
+
+        # Process each generated token (may be > 1 in speculative decoding)
+        num_tokens = logprobs_array.shape[0]
+        for token_id in self.track_token_ids:
+            if token_id in token_id_to_idx:
+                idx = token_id_to_idx[token_id]
+                # Append logprobs for all generated tokens
+                for row_idx in range(num_tokens):
+                    logprob_value = float(logprobs_array[row_idx, idx])
+                    self.tracked_logprobs[token_id].append(logprob_value)
+
     def update_from_output(self, output: EngineCoreOutput) -> None:
         if output.new_logprobs is not None:
             self._update_sample_logprobs(output.new_logprobs)
         if output.new_prompt_logprobs_tensors is not None:
             self._update_prompt_logprobs(output.new_prompt_logprobs_tensors)
+        if output.new_tracked_logprobs is not None:
+            self._update_tracked_logprobs(output.new_tracked_logprobs)

--- a/vllm/v1/engine/logprobs.py
+++ b/vllm/v1/engine/logprobs.py
@@ -277,7 +277,7 @@ class LogprobsProcessor:
 
         # Process each generated token (may be > 1 in speculative decoding)
         num_tokens = logprobs_array.shape[0]
-        for token_id in self.track_token_ids:
+        for token_id in self.tracked_logprobs:
             if token_id in token_id_to_idx:
                 idx = token_id_to_idx[token_id]
                 # Append logprobs for all generated tokens

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -395,6 +395,18 @@ class RequestState:
         if delta and logprobs:
             logprobs = logprobs[-len(token_ids) :]
 
+        # Prepare tracked logprobs, based on delta mode
+        # Use `is not None` to distinguish "feature disabled" (None) from
+        # "feature enabled but empty" ({})
+        tracked_logprobs = self.logprobs_processor.tracked_logprobs
+        if delta and tracked_logprobs is not None:
+            # In delta mode, only return the logprobs for the new tokens
+            num_new_tokens = len(token_ids)
+            tracked_logprobs = {
+                token_id: logprob_list[-num_new_tokens:]
+                for token_id, logprob_list in tracked_logprobs.items()
+            }
+
         return CompletionOutput(
             index=self.request_index,
             text=text,
@@ -404,6 +416,7 @@ class RequestState:
             cumulative_logprob=self.logprobs_processor.cumulative_logprob,
             finish_reason=str(finish_reason) if finished else None,
             stop_reason=stop_reason if finished else None,
+            tracked_logprobs=tracked_logprobs,
         )
 
     def _new_pooling_output(self, pooling_output: torch.Tensor) -> PoolingOutput:

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -49,6 +49,42 @@ class LogprobsLists(NamedTuple):
         )
 
 
+class TrackedLogprobsLists(NamedTuple):
+    """CPU-side representation of tracked logprobs for efficient inter-process transfer.
+
+    This class enables the `track_token_ids` feature in SamplingParams.
+
+    This is the numpy/list form used for serialization between GPU worker and
+    scheduler processes (torch.Tensor serialization is expensive). Converted
+    from TrackedLogprobsTensors via the tolists() method.
+    """
+
+    # [num_reqs x num_generated_tokens, num_tracked_tokens] - logprobs
+    logprobs: np.ndarray
+    # [num_tracked_tokens] - the token IDs being tracked
+    token_ids: list[int]
+    # [num_reqs] - cumulative token counts for slicing in spec decoding
+    cu_num_generated_tokens: list[int] | None = None
+
+    def slice_request(
+        self, req_idx: int, num_positions: int = 1
+    ) -> "TrackedLogprobsLists":
+        """Slice tracked logprobs for a single request.
+
+        Args:
+            req_idx: The request index.
+            num_positions: Number of generated tokens for this request.
+        """
+        if self.cu_num_generated_tokens is not None:
+            req_idx = self.cu_num_generated_tokens[req_idx]
+        end_idx = req_idx + num_positions
+        return TrackedLogprobsLists(
+            self.logprobs[req_idx:end_idx],
+            self.token_ids,
+            None,
+        )
+
+
 class LogprobsTensors(NamedTuple):
     # [num_reqs x num_generated_tokens, max_num_logprobs + 1]
     logprob_token_ids: torch.Tensor
@@ -110,6 +146,39 @@ class LogprobsTensors(NamedTuple):
         )
 
 
+class TrackedLogprobsTensors(NamedTuple):
+    """GPU-side representation of tracked logprobs for efficient computation.
+
+    This class enables the `track_token_ids` feature in SamplingParams.
+
+    This is the torch.Tensor form produced during sampling on GPU. It is
+    converted to TrackedLogprobsLists (numpy/list form) via tolists() before
+    being sent to the scheduler process for output processing.
+    """
+
+    # [num_reqs x num_generated_tokens, num_tracked_tokens] - logprobs
+    logprobs: torch.Tensor
+    # [num_tracked_tokens] - the token IDs being tracked
+    token_ids: torch.Tensor
+
+    def tolists(
+        self, cu_num_generated_tokens: list[int] | None = None
+    ) -> TrackedLogprobsLists:
+        return TrackedLogprobsLists(
+            self.logprobs.cpu().numpy(),
+            self.token_ids.cpu().tolist(),
+            cu_num_generated_tokens,
+        )
+
+    def to_cpu_nonblocking(self) -> "TrackedLogprobsTensors":
+        if self.logprobs.device.type == "cpu":
+            return self
+        return TrackedLogprobsTensors(
+            self.logprobs.to("cpu", non_blocking=True),
+            self.token_ids.to("cpu", non_blocking=True),
+        )
+
+
 # [num_reqs, <dynamic>]
 # The shape of each element depends on the pooler used
 PoolerOutput: TypeAlias = torch.Tensor | list[torch.Tensor] | list[torch.Tensor | None]
@@ -123,6 +192,7 @@ class SamplerOutput:
     # PLACEHOLDER_TOKEN_ID (-1 by default) is used for padding.
     sampled_token_ids: torch.Tensor
     logprobs_tensors: LogprobsTensors | None
+    tracked_logprobs_tensors: TrackedLogprobsTensors | None = None
 
 
 T = TypeVar("T")
@@ -243,6 +313,10 @@ class ModelRunnerOutput:
     # [num_reqs, hidden_size]
     pooler_output: list[torch.Tensor | None] | None = None
 
+    # [num_reqs, num_tracked_tokens]
+    # Tracked logprobs for specific token IDs
+    tracked_logprobs: TrackedLogprobsLists | None = None
+
     kv_connector_output: KVConnectorOutput | None = None
 
     ec_connector_output: ECConnectorOutput | None = None
@@ -305,4 +379,13 @@ def make_empty_encoder_model_runner_output(
     )
 
 
-EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[], req_id_to_index={})
+EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(
+    req_ids=[],
+    req_id_to_index={},
+    sampled_token_ids=[],
+    logprobs=None,
+    prompt_logprobs_dict={},
+    pooler_output=[],
+    tracked_logprobs=None,
+    num_nans_in_logits=None,
+)

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -42,3 +42,6 @@ class SamplingMetadata:
 
     # Speculative token ids
     spec_token_ids: list[list[int]] | None = None
+
+    # Token IDs to track logprobs for (merged from all requests)
+    track_token_ids: torch.Tensor | None = None

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -250,6 +250,7 @@ class RejectionSampler(nn.Module):
 
         # Get bonus logits from the bonus sampler output
         # The bonus_sampler_output was run with logprobs_mode_override to get logits
+        assert bonus_sampler_output.logprobs_tensors is not None
         bonus_logits = bonus_sampler_output.logprobs_tensors.logprobs
 
         # Create combined logits tensor

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -11,6 +11,7 @@ from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
 from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
+from vllm.v1.outputs import TrackedLogprobsTensors
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
@@ -160,9 +161,21 @@ class RejectionSampler(nn.Module):
                 output_token_ids,
             )
 
+        # Compute tracked logprobs if requested
+        tracked_logprobs_tensors = None
+        if sampling_metadata.track_token_ids is not None:
+            tracked_logprobs_tensors = self._get_tracked_logprobs_tensors(
+                sampling_metadata.track_token_ids,
+                metadata,
+                target_logits if self.is_processed_logprobs_mode else raw_target_logits,
+                bonus_sampler_output,
+                output_token_ids,
+            )
+
         return SamplerOutput(
             sampled_token_ids=output_token_ids,
             logprobs_tensors=logprobs_tensors,
+            tracked_logprobs_tensors=tracked_logprobs_tensors,
         )
 
     def _get_logprobs_tensors(
@@ -212,6 +225,63 @@ class RejectionSampler(nn.Module):
             accepted_logprobs,
             max_num_logprobs,
             accepted_tokens.to(torch.int64),
+        )
+
+    def _get_tracked_logprobs_tensors(
+        self,
+        track_token_ids: torch.Tensor,
+        metadata: SpecDecodeMetadata,
+        target_logits: torch.Tensor,
+        bonus_sampler_output: SamplerOutput,
+        sampled_token_ids: torch.Tensor,
+    ) -> TrackedLogprobsTensors:
+        """Compute tracked logprobs for speculative decoding.
+
+        For spec decoding, we need to compute tracked logprobs only for the
+        accepted tokens. We combine the target logits with the bonus logits
+        and then extract the tracked token logprobs for accepted positions.
+        """
+        cu_num_sampled_tokens = torch.zeros_like(metadata.cu_num_sampled_tokens)
+        cu_num_sampled_tokens[1:] = metadata.cu_num_sampled_tokens[:-1]
+
+        # Collect target and bonus logits
+        bonus_logits_indices = metadata.bonus_logits_indices
+        target_logits_indices = metadata.target_logits_indices
+
+        # Get bonus logits from the bonus sampler output
+        # The bonus_sampler_output was run with logprobs_mode_override to get logits
+        bonus_logits = bonus_sampler_output.logprobs_tensors.logprobs
+
+        # Create combined logits tensor
+        vocab_size = target_logits.shape[-1]
+        num_total_positions = len(target_logits_indices) + len(bonus_logits_indices)
+        final_logits = torch.zeros(
+            num_total_positions,
+            vocab_size,
+            dtype=torch.float32,
+            device=target_logits.device,
+        )
+        final_logits[target_logits_indices] = target_logits.to(torch.float32)
+        final_logits[bonus_logits_indices] = bonus_logits.to(torch.float32)
+
+        # Compute accepted token indices
+        accepted_mask = sampled_token_ids != PLACEHOLDER_TOKEN_ID
+        num_accepted_tokens = accepted_mask.sum(dim=-1)
+        accepted_logit_indices = accepted_mask.nonzero(as_tuple=True)[1]
+        accepted_logit_indices += cu_num_sampled_tokens.repeat_interleave(
+            num_accepted_tokens
+        )
+
+        # Get logits for accepted positions
+        accepted_logits = final_logits[accepted_logit_indices]
+
+        # Compute logprobs and extract tracked tokens
+        logprobs = self.sampler.compute_logprobs(accepted_logits)
+        tracked_logprobs = logprobs[:, track_token_ids]
+
+        return TrackedLogprobsTensors(
+            logprobs=tracked_logprobs,
+            token_ids=track_token_ids,
         )
 
     @staticmethod

--- a/vllm/v1/worker/gpu/sample/logprob.py
+++ b/vllm/v1/worker/gpu/sample/logprob.py
@@ -4,7 +4,7 @@
 import torch
 
 from vllm.triton_utils import tl, triton
-from vllm.v1.outputs import LogprobsTensors, TrackedLogprobsTensors
+from vllm.v1.outputs import LogprobsTensors
 
 
 @triton.jit
@@ -123,60 +123,4 @@ def compute_topk_logprobs(
         logprobs=logprobs,
         selected_token_ranks=token_ranks,
         cu_num_generated_tokens=cu_num_logits,
-    )
-
-
-def compute_prompt_logprobs(
-    prompt_token_ids: torch.Tensor,
-    prompt_hidden_states: torch.Tensor,
-    logits_fn: Callable[[torch.Tensor], torch.Tensor],
-) -> tuple[torch.Tensor, torch.Tensor]:
-    # Since materializing the full prompt logits can take too much memory,
-    # we compute it in chunks.
-    CHUNK_SIZE = 1024
-    logprobs = []
-    ranks = []
-    prompt_token_ids = prompt_token_ids.to(torch.int64)
-    for start_idx in range(0, prompt_token_ids.shape[0], CHUNK_SIZE):
-        end_idx = start_idx + CHUNK_SIZE
-        # NOTE(woosuk): logits_fn can be slow because it involves all-gather.
-        prompt_logits = logits_fn(prompt_hidden_states[start_idx:end_idx])
-        prompt_logprobs = compute_topk_logprobs(
-            prompt_logits,
-            0,  # num_logprobs
-            prompt_token_ids[start_idx:end_idx],
-        )
-        logprobs.append(prompt_logprobs.logprobs)
-        ranks.append(prompt_logprobs.selected_token_ranks)
-
-    logprobs = torch.cat(logprobs, dim=0) if len(logprobs) > 1 else logprobs[0]
-    ranks = torch.cat(ranks, dim=0) if len(ranks) > 1 else ranks[0]
-    return logprobs, ranks
-
-
-def compute_tracked_logprobs(
-    logits: torch.Tensor,
-    track_token_ids: torch.Tensor,
-) -> TrackedLogprobsTensors:
-    """Compute logprobs for specific tracked token IDs.
-
-    This is an efficient way to get logprobs for a small set of tokens
-    (e.g., class labels) without retrieving the full vocabulary logprobs.
-
-    Args:
-        logits: [batch_size, vocab_size] tensor of logits
-        track_token_ids: [num_tracked_tokens] tensor of token IDs to track
-
-    Returns:
-        TrackedLogprobsTensors containing:
-            - logprobs: [batch_size, num_tracked_tokens] tensor
-            - token_ids: [num_tracked_tokens] tensor (same as input)
-    """
-    # Compute log softmax to get logprobs
-    logprobs = logits.log_softmax(dim=-1, dtype=torch.float32)
-    # Index into the specific token columns we care about
-    tracked_logprobs = logprobs[:, track_token_ids]
-    return TrackedLogprobsTensors(
-        logprobs=tracked_logprobs,
-        token_ids=track_token_ids,
     )

--- a/vllm/v1/worker/gpu/sample/logprob.py
+++ b/vllm/v1/worker/gpu/sample/logprob.py
@@ -4,7 +4,7 @@
 import torch
 
 from vllm.triton_utils import tl, triton
-from vllm.v1.outputs import LogprobsTensors
+from vllm.v1.outputs import LogprobsTensors, TrackedLogprobsTensors
 
 
 @triton.jit
@@ -123,4 +123,60 @@ def compute_topk_logprobs(
         logprobs=logprobs,
         selected_token_ranks=token_ranks,
         cu_num_generated_tokens=cu_num_logits,
+    )
+
+
+def compute_prompt_logprobs(
+    prompt_token_ids: torch.Tensor,
+    prompt_hidden_states: torch.Tensor,
+    logits_fn: Callable[[torch.Tensor], torch.Tensor],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # Since materializing the full prompt logits can take too much memory,
+    # we compute it in chunks.
+    CHUNK_SIZE = 1024
+    logprobs = []
+    ranks = []
+    prompt_token_ids = prompt_token_ids.to(torch.int64)
+    for start_idx in range(0, prompt_token_ids.shape[0], CHUNK_SIZE):
+        end_idx = start_idx + CHUNK_SIZE
+        # NOTE(woosuk): logits_fn can be slow because it involves all-gather.
+        prompt_logits = logits_fn(prompt_hidden_states[start_idx:end_idx])
+        prompt_logprobs = compute_topk_logprobs(
+            prompt_logits,
+            0,  # num_logprobs
+            prompt_token_ids[start_idx:end_idx],
+        )
+        logprobs.append(prompt_logprobs.logprobs)
+        ranks.append(prompt_logprobs.selected_token_ranks)
+
+    logprobs = torch.cat(logprobs, dim=0) if len(logprobs) > 1 else logprobs[0]
+    ranks = torch.cat(ranks, dim=0) if len(ranks) > 1 else ranks[0]
+    return logprobs, ranks
+
+
+def compute_tracked_logprobs(
+    logits: torch.Tensor,
+    track_token_ids: torch.Tensor,
+) -> TrackedLogprobsTensors:
+    """Compute logprobs for specific tracked token IDs.
+
+    This is an efficient way to get logprobs for a small set of tokens
+    (e.g., class labels) without retrieving the full vocabulary logprobs.
+
+    Args:
+        logits: [batch_size, vocab_size] tensor of logits
+        track_token_ids: [num_tracked_tokens] tensor of token IDs to track
+
+    Returns:
+        TrackedLogprobsTensors containing:
+            - logprobs: [batch_size, num_tracked_tokens] tensor
+            - token_ids: [num_tracked_tokens] tensor (same as input)
+    """
+    # Compute log softmax to get logprobs
+    logprobs = logits.log_softmax(dim=-1, dtype=torch.float32)
+    # Index into the specific token columns we care about
+    tracked_logprobs = logprobs[:, track_token_ids]
+    return TrackedLogprobsTensors(
+        logprobs=tracked_logprobs,
+        token_ids=track_token_ids,
     )

--- a/vllm/v1/worker/gpu/sample/output.py
+++ b/vllm/v1/worker/gpu/sample/output.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import torch
 
-from vllm.v1.outputs import LogprobsTensors
+from vllm.v1.outputs import LogprobsTensors, TrackedLogprobsTensors
 
 
 @dataclass
@@ -13,3 +13,4 @@ class SamplerOutput:
     logprobs_tensors: LogprobsTensors | None
     num_nans: torch.Tensor | None
     num_sampled: torch.Tensor | None
+    tracked_logprobs_tensors: TrackedLogprobsTensors | None = None

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -234,6 +234,8 @@ class InputBatch:
         self.generators: dict[int, torch.Generator] = {}
 
         self.num_logprobs: dict[str, int] = {}
+        # req_id -> list of token IDs to track logprobs for
+        self.track_token_ids: dict[str, list[int]] = {}
 
         # To accumulate prompt logprobs tensor chunks across prefill steps.
         self.in_progress_prompt_logprobs_cpu: dict[str, LogprobsTensors] = {}
@@ -395,6 +397,22 @@ class InputBatch:
                     else sampling_params.logprobs
                 )
 
+            if sampling_params.track_token_ids:
+                # Validate token IDs are within vocab bounds to prevent
+                # GPU indexing errors
+                invalid_ids = [
+                    tid
+                    for tid in sampling_params.track_token_ids
+                    if tid >= self.vocab_size
+                ]
+                if invalid_ids:
+                    raise ValueError(
+                        f"track_token_ids contains token IDs {invalid_ids} "
+                        f"that exceed vocab_size ({self.vocab_size}). "
+                        f"Valid range is [0, {self.vocab_size - 1}]."
+                    )
+                self.track_token_ids[req_id] = sampling_params.track_token_ids
+
             if sampling_params.allowed_token_ids:
                 self.has_allowed_token_ids.add(req_id)
                 if self.allowed_token_ids_mask_cpu_tensor is None:
@@ -521,6 +539,7 @@ class InputBatch:
         self.repetition_penalties_reqs.discard(req_id)
         self.generators.pop(req_index, None)
         self.num_logprobs.pop(req_id, None)
+        self.track_token_ids.pop(req_id, None)
         self.in_progress_prompt_logprobs_cpu.pop(req_id, None)
         if self.prev_req_id_to_index is not None:
             self.prev_req_id_to_index.pop(req_id, None)
@@ -877,6 +896,7 @@ class InputBatch:
             allowed_token_ids_mask=allowed_token_ids_mask,
             bad_words_token_ids=self.bad_words_token_ids,
             logitsprocs=self.logitsprocs,
+            track_token_ids=self.merged_track_token_ids,
         )
 
     def get_pooling_params(self) -> list[PoolingParams]:
@@ -1048,6 +1068,23 @@ class InputBatch:
     @property
     def max_num_logprobs(self) -> int | None:
         return max(self.num_logprobs.values()) if self.num_logprobs else None
+
+    @property
+    def merged_track_token_ids(self) -> torch.Tensor | None:
+        """Returns merged track_token_ids from all requests as a sorted tensor.
+
+        If any request in the batch has track_token_ids specified, returns
+        the union of all track_token_ids as a sorted tensor on device.
+        Returns None if no requests have track_token_ids.
+        """
+        if not self.track_token_ids:
+            return None
+        all_ids: set[int] = set()
+        for ids in self.track_token_ids.values():
+            all_ids.update(ids)
+        if not all_ids:
+            return None
+        return torch.tensor(sorted(all_ids), device=self.device, dtype=torch.int64)
 
     @property
     def no_allowed_token_ids(self) -> bool:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3167,7 +3167,7 @@ class GPUModelRunner(
         list[str],
         dict[str, int],
         list[int],
-        "TrackedLogprobsLists | None",
+        TrackedLogprobsLists | None,
     ]:
         num_nans_in_logits = {}
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -152,6 +152,8 @@ from vllm.v1.outputs import (
     ModelRunnerOutput,
     PoolerOutput,
     SamplerOutput,
+    TrackedLogprobsLists,
+    TrackedLogprobsTensors,
     make_empty_encoder_model_runner_output,
 )
 from vllm.v1.pool.metadata import PoolingMetadata, PoolingStates
@@ -222,6 +224,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         model_runner_output: ModelRunnerOutput,
         sampled_token_ids: torch.Tensor,
         logprobs_tensors: LogprobsTensors | None,
+        tracked_logprobs_tensors: "TrackedLogprobsTensors | None",
         invalid_req_indices: list[int],
         async_output_copy_stream: torch.cuda.Stream,
         vocab_size: int,
@@ -237,6 +240,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._sampled_token_ids = sampled_token_ids
         self.vocab_size = vocab_size
         self._logprobs_tensors = logprobs_tensors
+        self._tracked_logprobs_tensors = tracked_logprobs_tensors
 
         # Initiate the copy on a separate stream, but do not synchronize it.
         default_stream = torch.cuda.current_stream()
@@ -248,6 +252,11 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
             self._logprobs_tensors_cpu = (
                 self._logprobs_tensors.to_cpu_nonblocking()
                 if self._logprobs_tensors
+                else None
+            )
+            self._tracked_logprobs_tensors_cpu = (
+                self._tracked_logprobs_tensors.to_cpu_nonblocking()
+                if self._tracked_logprobs_tensors
                 else None
             )
             self.async_copy_ready_event.record()
@@ -262,6 +271,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
 
         # Release the device tensors once the copy has completed.
         del self._logprobs_tensors
+        del self._tracked_logprobs_tensors
         del self._sampled_token_ids
         if max_gen_len == 1:
             valid_sampled_token_ids = self.sampled_token_ids_cpu.tolist()
@@ -270,6 +280,12 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
             logprobs_lists = None
             if self._logprobs_tensors_cpu is not None:
                 logprobs_lists = self._logprobs_tensors_cpu.tolists()
+            cu_num_tokens = None
+            if self._tracked_logprobs_tensors_cpu is not None:
+                valid_mask = (self.sampled_token_ids_cpu.numpy() != -1) & (
+                    self.sampled_token_ids_cpu.numpy() < self.vocab_size
+                )
+                cu_num_tokens = [0] + valid_mask.sum(axis=1).cumsum().tolist()
         else:
             valid_sampled_token_ids, logprobs_lists = RejectionSampler.parse_output(
                 self.sampled_token_ids_cpu,
@@ -277,10 +293,20 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
                 self._invalid_req_indices,
                 logprobs_tensors=self._logprobs_tensors_cpu,
             )
+            cu_num_tokens = None
+            if self._tracked_logprobs_tensors_cpu is not None:
+                valid_mask = (self.sampled_token_ids_cpu.numpy() != -1) & (
+                    self.sampled_token_ids_cpu.numpy() < self.vocab_size
+                )
+                cu_num_tokens = [0] + valid_mask.sum(axis=1).cumsum().tolist()
 
         output = self._model_runner_output
         output.sampled_token_ids = valid_sampled_token_ids
         output.logprobs = logprobs_lists
+        if self._tracked_logprobs_tensors_cpu:
+            output.tracked_logprobs = self._tracked_logprobs_tensors_cpu.tolists(
+                cu_num_tokens
+            )
         return output
 
 
@@ -3141,6 +3167,7 @@ class GPUModelRunner(
         list[str],
         dict[str, int],
         list[int],
+        "TrackedLogprobsLists | None",
     ]:
         num_nans_in_logits = {}
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
@@ -3163,6 +3190,7 @@ class GPUModelRunner(
         num_sampled_tokens = sampler_output.sampled_token_ids.shape[0]
         sampled_token_ids = sampler_output.sampled_token_ids
         logprobs_tensors = sampler_output.logprobs_tensors
+        tracked_logprobs_tensors = sampler_output.tracked_logprobs_tensors
         invalid_req_indices = []
         logprobs_lists = None
         if not self.use_async_scheduling:
@@ -3177,6 +3205,12 @@ class GPUModelRunner(
 
                 if logprobs_tensors is not None:
                     logprobs_lists = logprobs_tensors.tolists()
+                cu_num_tokens = None
+                if tracked_logprobs_tensors is not None:
+                    valid_mask = (sampled_token_ids.cpu().numpy() != -1) & (
+                        sampled_token_ids.cpu().numpy() < self.input_batch.vocab_size
+                    )
+                    cu_num_tokens = [0] + valid_mask.sum(axis=1).cumsum().tolist()
             else:
                 # Includes spec decode tokens.
                 valid_sampled_token_ids, logprobs_lists = RejectionSampler.parse_output(
@@ -3185,6 +3219,12 @@ class GPUModelRunner(
                     discard_sampled_tokens_req_indices,
                     logprobs_tensors=logprobs_tensors,
                 )
+                cu_num_tokens = None
+                if tracked_logprobs_tensors is not None:
+                    valid_mask = (sampled_token_ids.cpu().numpy() != -1) & (
+                        sampled_token_ids.cpu().numpy() < self.input_batch.vocab_size
+                    )
+                    cu_num_tokens = [0] + valid_mask.sum(axis=1).cumsum().tolist()
         else:
             valid_sampled_token_ids = []
             invalid_req_indices = discard_sampled_tokens_req_indices.tolist()
@@ -3236,6 +3276,16 @@ class GPUModelRunner(
             req_state = self.requests[req_id]
             req_state.output_token_ids.extend(sampled_ids)
 
+        logprobs_lists = (
+            logprobs_lists if not self.use_async_scheduling else None
+        )
+
+        # Process tracked logprobs if present
+        tracked_logprobs_lists = (
+            tracked_logprobs_tensors.tolists(cu_num_tokens)
+            if not self.use_async_scheduling and tracked_logprobs_tensors is not None
+            else None
+        )
         # Compute prompt logprobs if needed.
         prompt_logprobs_dict = self._get_prompt_logprobs_dict(
             hidden_states[:num_scheduled_tokens],
@@ -3250,6 +3300,7 @@ class GPUModelRunner(
             req_ids_output_copy,
             req_id_to_index_output_copy,
             invalid_req_indices,
+            tracked_logprobs_lists,
         )
 
     @contextmanager
@@ -4038,6 +4089,7 @@ class GPUModelRunner(
                 req_ids_output_copy,
                 req_id_to_index_output_copy,
                 invalid_req_indices,
+                tracked_logprobs_lists,
             ) = self._bookkeeping_sync(
                 scheduler_output,
                 sampler_output,
@@ -4079,6 +4131,7 @@ class GPUModelRunner(
                 sampled_token_ids=valid_sampled_token_ids,
                 logprobs=logprobs_lists,
                 prompt_logprobs_dict=prompt_logprobs_dict,
+                tracked_logprobs=tracked_logprobs_lists,
                 kv_connector_output=kv_connector_output,
                 ec_connector_output=ec_connector_output
                 if self.supports_mm_inputs
@@ -4097,6 +4150,7 @@ class GPUModelRunner(
                 model_runner_output=output,
                 sampled_token_ids=sampler_output.sampled_token_ids,
                 logprobs_tensors=sampler_output.logprobs_tensors,
+                tracked_logprobs_tensors=sampler_output.tracked_logprobs_tensors,
                 invalid_req_indices=invalid_req_indices,
                 async_output_copy_stream=self.async_output_copy_stream,
                 vocab_size=self.input_batch.vocab_size,


### PR DESCRIPTION
## Summary
- Rebuild the `track_token_ids` continuation from current `main` on a clean branch and replay only the intended feature and follow-up fixes from `#30030`.
- Preserve the original feature scope: `SamplingParams.track_token_ids`, tracked logprobs propagation through V1 sampler/engine outputs, and output merging for selective token logprobs.
- Make the output-processor test fixture tokenizer-agnostic so the stop-token and tracked-logprobs coverage no longer depends on Llama-specific token IDs or gated model access.

## Context
This PR is a rebased continuation of `#30030`, prepared on top of current upstream `main` with clean branch history after the previous branch diverged. The implementation stays focused on the original `track_token_ids` feature while aligning the tests and follow-up fixes with the current V1 stack.

## Test plan
- [x] `.venv/bin/python -m pytest tests/v1/test_sampling_params.py tests/v1/sample/test_sampler.py tests/v1/test_outputs.py tests/v1/worker/test_gpu_input_batch.py`
- [x] `.venv/bin/python -m pytest tests/v1/engine/test_output_processor.py`

Made with [Cursor](https://cursor.com)