### PR TITLE
Fix missing logprobs for <tool_call> in streaming chat completions (#37737)

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1027,12 +1027,13 @@ class OpenAIServingChat(OpenAIServing):
                     # wasn't ready to send a token, then
                     #   get the next token without streaming a chunk
                     if delta_message is None:
-                        # NOTE: If return_token_ids is enabled, we still need to
-                        # send a chunk with token_ids even if delta_message is None
-                        # to ensure all tokens are included in the response
+                        # NOTE: If return_token_ids or logprobs is enabled, we still
+                        # need to send a chunk even if delta_message is None
+                        # to ensure all tokens/logprobs are included in the response
                         if (
                             output.finish_reason is None
                             and not request.return_token_ids
+                            and logprobs is None
                         ):
                             continue
                         delta_message = DeltaMessage()


### PR DESCRIPTION
Fixes #37737. When streaming chat completions, if `<tool_call>` falls into a chunk that only contains tool-call control tokens, the parser suppresses that chunk by returning `None`. The chat streaming path skipped the whole chunk, including the `logprobs`. This PR ensures the chunk is still emitted if `logprobs` are requested.