### PR TITLE
[Model] Add GGUF support for Qwen3.5 hybrid models

### DIFF
--- a/tests/models/quantization/test_gguf.py
+++ b/tests/models/quantization/test_gguf.py
@@ -90,6 +90,12 @@ GEMMA3_CONFIG = GGUFTestConfig(
     gguf_filename="gemma-3-270m-it-qat-Q4_0.gguf",
 )
 
+QWEN3_5_CONFIG = GGUFTestConfig(
+    original_model="Qwen/Qwen3.5-0.8B",
+    gguf_repo="ddh0/Qwen3.5-GGUF",
+    gguf_filename="Qwen3.5-0.8B-9.71bpw.gguf",
+)
+
 MODELS = [
     # LLAMA_CONFIG, # broken: https://github.com/vllm-project/vllm/issues/19458
     QWEN2_CONFIG,
@@ -100,6 +106,7 @@ MODELS = [
     DOLPHIN_CONFIG,
     GEMMA3_CONFIG,
     # STARCODER_CONFIG, # broken
+    # QWEN3_5_CONFIG, # hybrid Mamba/Attention model, needs GDN attention support
 ]
 
 

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -141,6 +141,37 @@ class GGUFModelLoader(BaseModelLoader):
                         r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
                     )
                 )
+        if model_type in ("qwen3_5_text", "qwen3_5_moe_text"):
+            is_moe = model_type == "qwen3_5_moe_text"
+            model_type = "qwen35moe" if is_moe else "qwen35"
+            # Qwen3.5 hybrid models have bare nn.Parameter tensors (A_log,
+            # dt_bias) that lack .weight/.bias suffixes in HF state_dict.
+            # Additionally, the gguf tensor map uses "dt_proj" while HF uses
+            # "dt_bias". Both issues require manual GGUF-to-HF mapping.
+            for idx in range(text_config.num_hidden_layers):
+                gguf_to_hf_name_map[f"blk.{idx}.ssm_a.weight"] = (
+                    f"model.layers.{idx}.linear_attn.A_log"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ssm_dt.weight"] = (
+                    f"model.layers.{idx}.linear_attn.dt_bias"
+                )
+            if is_moe:
+                for idx in range(text_config.num_hidden_layers):
+                    gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
+                        f"model.layers.{idx}.mlp.experts.0.down_proj.weight"
+                    )
+                    gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_exps.weight"] = (
+                        f"model.layers.{idx}.mlp.experts.0.gate_proj.weight"
+                    )
+                    gguf_to_hf_name_map[f"blk.{idx}.ffn_up_exps.weight"] = (
+                        f"model.layers.{idx}.mlp.experts.0.up_proj.weight"
+                    )
+                    sideload_params.append(
+                        re.compile(
+                            f"model\\.layers\\.{idx}"
+                            r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
+                        )
+                    )
 
         arch = None
         for key, value in gguf.MODEL_ARCH_NAMES.items():


### PR DESCRIPTION
## Summary

Add GGUF loading support for the Qwen3.5 hybrid Mamba/Attention model family, including both dense and MoE variants.

### Changes

- **GGUF loader (`gguf_loader.py`)**: Bridge HF `model_type` to gguf-py architecture names (`qwen3_5_text` -> `qwen35`, `qwen3_5_moe_text` -> `qwen35moe`). Add manual tensor name mappings for:
  - Bare `nn.Parameter` tensors (`A_log`, `dt_bias`) that lack `.weight`/`.bias` suffixes in HF state_dict
  - `dt_bias` vs `dt_proj` naming mismatch between HF and gguf-py
  - MoE merged expert weight mappings for the `qwen3_5_moe_text` variant

- **Test config (`test_gguf.py`)**: Add `QWEN3_5_CONFIG` for Qwen3.5-0.8B with GGUF from `ddh0/Qwen3.5-GGUF` (commented out in MODELS list pending GDN attention runtime validation)

### Background

The gguf-py library already defines `MODEL_ARCH.QWEN35` and `MODEL_ARCH.QWEN35MOE` with full tensor mappings covering both standard attention and linear attention (SSM) weights. This PR wires up vLLM's GGUF loader to leverage these existing mappings.

Qwen3.5 uses a hybrid architecture where each decoder layer is either a full attention layer (`self_attn.*`) or a linear attention / Gated Delta Net layer (`linear_attn.*`), plus a standard MLP (dense) or Sparse MoE block per layer. The gguf tensor map correctly handles per-layer type dispatch since only parameters for the actual layer type exist in the state_dict.

## Test plan

- [ ] Verify weight mapping correctness by loading a Qwen3.5-0.8B GGUF file and checking all parameters map successfully
- [ ] Run inference with the loaded GGUF model and compare output quality against the HF checkpoint
- [ ] Test with MoE variant (Qwen3.5-35B-A3B) if available
