### PR TITLE
[MRV2] Use FP64 for Gumbel noise

### DIFF
--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -50,6 +50,21 @@ def apply_temperature(
 
 
 @triton.jit
+def tl_rand64(seed, offset, includes_zero: tl.constexpr):
+    lo, hi, _, _ = tl.randint4x(seed, offset)
+    lo = lo.to(tl.uint32, bitcast=True).to(tl.uint64)
+    hi = hi.to(tl.uint32, bitcast=True).to(tl.uint64)
+    r = (hi << 32) | lo
+
+    # 1 / 2**64
+    scale = 5.421010862427522170037e-20
+    u = r.to(tl.float64) * scale
+    if not includes_zero:
+        u = tl.maximum(u, 2.2250738585072014e-308)  # float64 tiny
+    return u
+
+
+@triton.jit
 def _gumbel_sample_kernel(
     local_argmax_ptr,
     local_argmax_stride,
@@ -104,11 +119,7 @@ def _gumbel_sample_kernel(
 
         # tl.rand returns fp32, so build a true fp64 uniform from 64 random
         # bits before applying the double-log transform.
-        lo, hi, _, _ = tl.randint4x(gumbel_seed, block)
-        lo = lo.to(tl.uint32, bitcast=True).to(tl.uint64)
-        hi = hi.to(tl.uint32, bitcast=True).to(tl.uint64)
-        u = tl.uint_to_uniform_float((hi << 32) | lo)
-        u = tl.maximum(u, 2.2250738585072014e-308)  # float64 tiny
+        u = tl_rand64(gumbel_seed, block, includes_zero=False)
         gumbel_noise = -tl.log(-tl.log(u))
 
         # Apply gumbel noise.

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -95,15 +95,20 @@ def _gumbel_sample_kernel(
             mask=mask,
         )
 
+    logits = logits.to(tl.float64)
     if temp != 0.0:
         # Calculate the seed for gumbel noise.
         seed = tl.load(seeds_ptr + req_state_idx)
         pos = tl.load(pos_ptr + token_idx)
         gumbel_seed = tl.randint(seed, pos)
 
-        # Generate gumbel noise in FP32.
-        u = tl.rand(gumbel_seed, block)
-        u = tl.maximum(u, 1e-7)
+        # tl.rand returns fp32, so build a true fp64 uniform from 64 random
+        # bits before applying the double-log transform.
+        lo, hi, _, _ = tl.randint4x(gumbel_seed, block)
+        lo = lo.to(tl.uint32, bitcast=True).to(tl.uint64)
+        hi = hi.to(tl.uint32, bitcast=True).to(tl.uint64)
+        u = tl.uint_to_uniform_float((hi << 32) | lo)
+        u = tl.maximum(u, 2.2250738585072014e-308)  # float64 tiny
         gumbel_noise = -tl.log(-tl.log(u))
 
         # Apply gumbel noise.
@@ -128,7 +133,7 @@ def gumbel_sample(
     BLOCK_SIZE = 1024
     num_blocks = triton.cdiv(vocab_size, BLOCK_SIZE)
     local_argmax = logits.new_empty(num_tokens, num_blocks, dtype=torch.int64)
-    local_max = logits.new_empty(num_tokens, num_blocks, dtype=torch.float32)
+    local_max = logits.new_empty(num_tokens, num_blocks, dtype=torch.float64)
     _gumbel_sample_kernel[(num_tokens, num_blocks)](
         local_argmax,
         local_argmax.stride(0),

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -6,7 +6,7 @@ from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.metrics.logits import get_num_nans
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample, tl_rand64
 from vllm.v1.worker.gpu.sample.logprob import compute_topk_logprobs
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.sampler import Sampler
@@ -217,10 +217,7 @@ def _probabilistic_rejection_kernel(
                 ).to(tl.float64)
                 pos = tl.load(pos_ptr + logit_idx)
 
-                lo, hi, _, _ = tl.randint4x(seed, pos + tl.arange(0, 1))
-                lo = lo.to(tl.uint32, bitcast=True).to(tl.uint64)
-                hi = hi.to(tl.uint32, bitcast=True).to(tl.uint64)
-                u = tl.uint_to_uniform_float((hi << 32) | lo)
+                u = tl_rand64(seed, pos + tl.arange(0, 1), includes_zero=False)
                 u = tl.sum(u)
 
                 accepted &= target_prob > u * draft_prob

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -211,12 +211,18 @@ def _probabilistic_rejection_kernel(
             else:
                 target_prob = tl.load(
                     target_probs_ptr + logit_idx * target_probs_stride + draft_sampled
-                )
+                ).to(tl.float64)
                 draft_prob = tl.load(
                     draft_probs_ptr + logit_idx * draft_probs_stride + draft_sampled
-                )
+                ).to(tl.float64)
                 pos = tl.load(pos_ptr + logit_idx)
-                u = tl.sum(tl.rand(seed, pos + tl.arange(0, 1)))
+
+                lo, hi, _, _ = tl.randint4x(seed, pos + tl.arange(0, 1))
+                lo = lo.to(tl.uint32, bitcast=True).to(tl.uint64)
+                hi = hi.to(tl.uint32, bitcast=True).to(tl.uint64)
+                u = tl.uint_to_uniform_float((hi << 32) | lo)
+                u = tl.sum(u)
+
                 accepted &= target_prob > u * draft_prob
             tl.store(sampled_ptr + req_idx * sampled_stride + i, draft_sampled)
             rejected_step += accepted

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -216,10 +216,7 @@ def _probabilistic_rejection_kernel(
                     draft_probs_ptr + logit_idx * draft_probs_stride + draft_sampled
                 ).to(tl.float64)
                 pos = tl.load(pos_ptr + logit_idx)
-
-                u = tl_rand64(seed, pos + tl.arange(0, 1), includes_zero=False)
-                u = tl.sum(u)
-
+                u = tl_rand64(seed, pos, includes_zero=False)
                 accepted &= target_prob > u * draft_prob
             tl.store(sampled_ptr + req_idx * sampled_stride + i, draft_sampled)
             rejected_step += accepted


### PR DESCRIPTION
This PR essentially reverts #34854 and uses FP64 for the Gumbel noise again for numerical stability.

For greedy sampling, there's no performance difference, as expected.
For random sampling, there's up to 1.8x slowdown for large batches, while the performance for small batches remains the same.

| Batch Size | Is Greedy | FP32 Time (us) | FP64 Time (us) | Slowdown (FP64 / FP32) |
|------------|-----------|----------------|----------------|------------------------|
| 1          | True      | 72.11          | 70.30          | 0.97                   |
| 8          | True      | 69.96          | 71.54          | 1.02                   |
| 32         | True      | 69.17          | 72.93          | 1.05                   |
| 128        | True      | 75.76          | 71.35          | 0.94                   |
| 1024       | True      | 234.41         | 241.75         | 1.03                   |
| 1          | False     | 70.45          | 67.79          | 0.96                   |
| 8          | False     | 72.58          | 69.08          | 0.95                   |
| 32         | False     | 75.06          | 71.79          | 0.96                   |
| 128        | False     | 133.87         | 227.71         | **1.70**                   |
| 1024       | False     | 919.46         | 1664.59        | **1.81**                   |

