### PR TITLE
[CI/Build] Fix LMCache KV connector install path for CUDA 13 images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -805,26 +805,59 @@ ARG torch_cuda_arch_list='7.0 7.5 8.0 8.9 9.0 10.0 12.0'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=requirements/kv_connectors.txt,target=/tmp/kv_connectors.txt,ro \
+    --mount=type=bind,source=tools/resolve_kv_connector_requirements.py,target=/tmp/resolve_kv_connector_requirements.py,ro \
     CUDA_MAJOR="${CUDA_VERSION%%.*}"; \
     CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-'); \
     CUDA_HOME=/usr/local/cuda; \
     # lmcache requires explicit specifying CUDA_HOME
-    BUILD_PKGS="libcusparse-dev-${CUDA_VERSION_DASH} \
+    BUILD_PKGS="git \
+                libcusparse-dev-${CUDA_VERSION_DASH} \
                 libcublas-dev-${CUDA_VERSION_DASH} \
                 libcusolver-dev-${CUDA_VERSION_DASH}"; \
     if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
         if [ "$CUDA_MAJOR" -ge 13 ]; then \
-            uv pip install --system nixl-cu13; \
-        fi; \
-        uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
-            # if the above fails, install from source
             apt-get update -y && \
             apt-get install -y --no-install-recommends ${BUILD_PKGS} && \
-            uv pip install --system -r /tmp/kv_connectors.txt --no-build-isolation && \
+            python3 /tmp/resolve_kv_connector_requirements.py \
+                --input /tmp/kv_connectors.txt \
+                --output /tmp/kv_connectors_cuda13_runtime.txt \
+                --cuda-major "${CUDA_MAJOR}" \
+                --skip-package lmcache && \
+            uv pip install --system cupy-cuda13x && \
+            uv pip install --system \
+                -r /tmp/kv_connectors_cuda13_runtime.txt \
+                --no-build || \
+            uv pip install --system \
+                -r /tmp/kv_connectors_cuda13_runtime.txt \
+                --no-build-isolation && \
+            LM_TORCH_CUDA_ARCH_LIST="$(printf '%s\n' "${TORCH_CUDA_ARCH_LIST}" | \
+                awk 'BEGIN { first = 1 } \
+                    { for (i = 1; i <= NF; ++i) \
+                        if ($i != "7.0" && $i != "7.0+PTX") { \
+                            if (!first) { printf " " } \
+                            printf "%s", $i; \
+                            first = 0; \
+                        } } \
+                    END { print "" }')" && \
+            TORCH_CUDA_ARCH_LIST="${LM_TORCH_CUDA_ARCH_LIST}" \
+                uv pip install --system \
+                --no-binary lmcache \
+                --no-build-isolation \
+                --no-deps \
+                "lmcache>=0.3.9" && \
             apt-get purge -y ${BUILD_PKGS} && \
-            # clean up -dev packages, keep runtime libraries
-            rm -rf /var/lib/apt/lists/* \
-        ); \
+            rm -rf /var/lib/apt/lists/*; \
+        else \
+            uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
+                # if the above fails, install from source
+                apt-get update -y && \
+                apt-get install -y --no-install-recommends ${BUILD_PKGS} && \
+                uv pip install --system -r /tmp/kv_connectors.txt --no-build-isolation && \
+                apt-get purge -y ${BUILD_PKGS} && \
+                # clean up -dev packages, keep runtime libraries
+                rm -rf /var/lib/apt/lists/* \
+            ); \
+        fi; \
     fi
 
 ENV VLLM_USAGE_SOURCE production-docker-image

--- a/tests/tools/test_resolve_kv_connector_requirements.py
+++ b/tests/tools/test_resolve_kv_connector_requirements.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+from tools.resolve_kv_connector_requirements import resolve_requirements
+
+
+DOCKERFILE = Path(__file__).resolve().parents[2] / "docker" / "Dockerfile"
+
+
+def _section_between(text: str, start_marker: str, end_marker: str) -> str:
+    start = text.index(start_marker)
+    end = text.index(end_marker, start)
+    return text[start:end]
+
+
+def test_rewrites_nixl_for_cuda12():
+    content = "lmcache >= 0.3.9\nnixl >= 0.7.1, < 0.10.0 # Required\n"
+
+    resolved = resolve_requirements(content, cuda_major=12)
+
+    assert resolved == (
+        "lmcache >= 0.3.9\n"
+        "nixl-cu12 >= 0.7.1, < 0.10.0 # Required\n"
+    )
+
+
+def test_rewrites_nixl_for_cuda13():
+    content = "nixl >= 0.7.1, < 0.10.0 # Required\n"
+
+    resolved = resolve_requirements(content, cuda_major=13)
+
+    assert resolved == "nixl-cu13 >= 0.7.1, < 0.10.0 # Required\n"
+
+
+def test_skips_requested_packages():
+    content = (
+        "# comment\n"
+        "lmcache >= 0.3.9\n"
+        "nixl >= 0.7.1, < 0.10.0 # Required\n"
+        "mooncake-transfer-engine >= 0.3.8\n"
+    )
+
+    resolved = resolve_requirements(
+        content,
+        cuda_major=13,
+        skip_packages={"lmcache"},
+    )
+
+    assert resolved == (
+        "# comment\n"
+        "nixl-cu13 >= 0.7.1, < 0.10.0 # Required\n"
+        "mooncake-transfer-engine >= 0.3.8\n"
+    )
+
+
+def test_cuda13_resolution_never_emits_any_cu12_packages():
+    content = (
+        "lmcache >= 0.3.9\n"
+        "nixl >= 0.7.1, < 0.10.0 # Required for disaggregated prefill\n"
+        "mooncake-transfer-engine >= 0.3.8\n"
+    )
+
+    resolved = resolve_requirements(
+        content,
+        cuda_major=13,
+        skip_packages={"lmcache"},
+    )
+
+    assert "lmcache" not in resolved
+    assert "nixl-cu13" in resolved
+    assert "\nnixl >=" not in f"\n{resolved}"
+    assert re.search(r"\b[a-z0-9._-]*cu12[a-z0-9._-]*\b", resolved, re.IGNORECASE) is None
+
+
+def test_repo_kv_connector_requirements_resolve_cleanly_for_cuda13():
+    requirements_path = (
+        Path(__file__).resolve().parents[2] / "requirements" / "kv_connectors.txt"
+    )
+
+    resolved = resolve_requirements(
+        requirements_path.read_text(),
+        cuda_major=13,
+        skip_packages={"lmcache"},
+    )
+
+    assert "lmcache" not in resolved
+    assert "nixl-cu13" in resolved
+    assert re.search(r"\b[a-z0-9._-]*cu12[a-z0-9._-]*\b", resolved, re.IGNORECASE) is None
+
+
+def test_cli_resolves_cuda13_requirements(tmp_path):
+    input_path = tmp_path / "kv_connectors.txt"
+    output_path = tmp_path / "kv_connectors.resolved.txt"
+    input_path.write_text(
+        "lmcache >= 0.3.9\n"
+        "nixl >= 0.7.1, < 0.10.0 # Required for disaggregated prefill\n"
+        "mooncake-transfer-engine >= 0.3.8\n"
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(
+                Path(__file__).resolve().parents[2]
+                / "tools"
+                / "resolve_kv_connector_requirements.py"
+            ),
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--cuda-major",
+            "13",
+            "--skip-package",
+            "lmcache",
+        ],
+        check=True,
+    )
+
+    resolved = output_path.read_text()
+    assert "lmcache" not in resolved
+    assert "nixl-cu13" in resolved
+    assert "nixl-cu12" not in resolved
+    assert "\nnixl >=" not in f"\n{resolved}"
+
+
+def test_dockerfile_uses_resolved_cuda13_requirements():
+    dockerfile = DOCKERFILE.read_text()
+    kv_section = _section_between(
+        dockerfile,
+        "# install kv_connectors if requested",
+        "ENV VLLM_USAGE_SOURCE production-docker-image",
+    )
+    cuda13_branch = kv_section.split(
+        'if [ "$CUDA_MAJOR" -ge 13 ]; then \\',
+        maxsplit=1,
+    )[1].split("else \\", maxsplit=1)[0]
+    cuda12_branch = kv_section.split("else \\", maxsplit=1)[1]
+
+    assert "tools/resolve_kv_connector_requirements.py" in dockerfile
+    assert "/tmp/resolve_kv_connector_requirements.py" in dockerfile
+    assert "/tmp/kv_connectors_cuda13_runtime.txt" in dockerfile
+    assert '--cuda-major "${CUDA_MAJOR}"' in cuda13_branch
+    assert "--skip-package lmcache" in cuda13_branch
+    assert "uv pip install --system cupy-cuda13x" in cuda13_branch
+    assert "--no-binary lmcache \\" in cuda13_branch
+    assert "--no-deps \\" in cuda13_branch
+    assert "--no-build ||" in cuda13_branch
+    assert "--no-build-isolation &&" in cuda13_branch
+    assert "cu12" not in cuda13_branch.lower()
+    assert "uv pip install --system -r /tmp/kv_connectors.txt --no-build" in cuda12_branch
+    assert "uv pip install --system -r /tmp/kv_connectors.txt --no-build-isolation" in cuda12_branch
+    assert "cupy-cuda13x" not in cuda12_branch
+    assert "nixl-cu13" not in cuda12_branch
+
+
+def test_preserves_blank_lines():
+    content = "\n# comment\n\nnixl >= 0.7.1\n"
+
+    resolved = resolve_requirements(content, cuda_major=13)
+
+    assert resolved == "\n# comment\n\nnixl-cu13 >= 0.7.1\n"

--- a/tools/resolve_kv_connector_requirements.py
+++ b/tools/resolve_kv_connector_requirements.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Resolve CUDA-specific kv connector dependencies for Docker builds."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+_REQ_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def _normalize_name(name: str) -> str:
+    return name.lower().replace("_", "-")
+
+
+def _package_name(line: str) -> str | None:
+    stripped = line.lstrip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    match = _REQ_NAME_RE.match(line)
+    if match is None:
+        return None
+    return _normalize_name(match.group(1))
+
+
+def _replace_package_name(line: str, replacement: str) -> str:
+    return _REQ_NAME_RE.sub(replacement, line, count=1)
+
+
+def resolve_requirements(
+    content: str,
+    cuda_major: int,
+    skip_packages: set[str] | None = None,
+) -> str:
+    skip_packages = skip_packages or set()
+    output_lines: list[str] = []
+    nixl_runtime = "nixl-cu13" if cuda_major >= 13 else "nixl-cu12"
+
+    for line in content.splitlines():
+        package_name = _package_name(line)
+        if package_name is None:
+            output_lines.append(line)
+            continue
+
+        if package_name in skip_packages:
+            continue
+
+        if package_name == "nixl":
+            line = _replace_package_name(line, nixl_runtime)
+
+        output_lines.append(line)
+
+    return "\n".join(output_lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Rewrite kv connector requirements to use CUDA-runtime-specific "
+            "packages during Docker builds."
+        )
+    )
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--cuda-major", required=True, type=int)
+    parser.add_argument(
+        "--skip-package",
+        action="append",
+        default=[],
+        help="Normalized package name to omit from the output.",
+    )
+    args = parser.parse_args()
+
+    content = args.input.read_text()
+    resolved = resolve_requirements(
+        content=content,
+        cuda_major=args.cuda_major,
+        skip_packages={_normalize_name(name) for name in args.skip_package},
+    )
+    args.output.write_text(resolved)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

Fixes #37801.

This updates the CUDA 13 KV-connector install path so `vllm/vllm-openai:latest-cu130` can be layered with LMCache without pulling CUDA 12-oriented artifacts.

Related cross-project issue: LMCache/LMCache#2843.

This is not duplicating an existing PR. Before opening this PR I checked for open vLLM PRs/issues covering this CUDA 13 LMCache packaging fix and did not find an open PR addressing the same path.

Concretely, the CUDA 13 branch now:
- resolves `nixl` to `nixl-cu13`
- skips the generic `lmcache` wheel
- installs `cupy-cuda13x`
- rebuilds LMCache from source with `--no-build-isolation --no-deps`

The CUDA 12 path remains unchanged.

## Test Plan

- `pytest -q --noconftest tests/tools/test_resolve_kv_connector_requirements.py`
- build/runtime validation of the CUDA 12 KV-connector path
- build/runtime validation of a CUDA 13 image layered on top of `vllm/vllm-openai:latest-cu130`

## Test Result

Targeted tests:

```text
$ pytest -q --noconftest tests/tools/test_resolve_kv_connector_requirements.py
8 passed
```

CUDA 12 validation:
- verified the default CUDA 12 branch still resolves/install the existing CUDA 12 package set
- runtime import of `lmcache.integration.vllm.vllm_v1_adapter` succeeded
- end-to-end LMCache validation succeeded with CPU+disk backends, disk offload, and replay hits

CUDA 13 validation:
- built a CUDA 13 image on top of `vllm/vllm-openai:latest-cu130`
- served `Qwen/Qwen3-0.6B`
- enabled `LMCacheConnectorV1`
- confirmed `LocalCPUBackend` and `LocalDiskBackend` creation
- confirmed disk offload writes
- confirmed replay hits
- confirmed OpenAI-compatible responses expose `usage.prompt_tokens_details.cached_tokens` on replay when both:
  - `--enable-prompt-tokens-details`
  - `kv_connector_extra_config.enable_cache_usage_details_in_response=true`

Representative runtime result:
- first replay request: `prompt_tokens_details = null`
- second replay request: `prompt_tokens_details.cached_tokens = 6144`

## AI Assistance

This PR was prepared with AI assistance. I reviewed every changed line, reproduced the problem, ran the listed tests, and validated the runtime behavior end-to-end myself.
