### PR TITLE
[Bugfix] Skip speculator auto-detection for non-Hub models

### DIFF
--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -14,6 +14,7 @@ from vllm.transformers_utils.utils import (
     is_azure,
     is_cloud_storage,
     is_gcs,
+    is_hub_model,
     is_s3,
 )
 
@@ -45,6 +46,22 @@ def test_is_cloud_storage():
     assert is_cloud_storage("az://model-container/path")
     assert not is_cloud_storage("/unix/local/path")
     assert not is_cloud_storage("nfs://nfs-fqdn.local")
+
+
+def test_is_hub_model():
+    # Valid HuggingFace Hub repo IDs
+    assert is_hub_model("meta-llama/Llama-3-8B")
+    assert is_hub_model("gpt2")
+    assert is_hub_model("Foo-BAR_foo.bar123")
+
+    # Local filesystem paths
+    assert not is_hub_model("/home/user/Models/my-model")
+    assert not is_hub_model("/opt/models/meta-llama--Llama-3-8B")
+
+    # Cloud storage URLs
+    assert not is_hub_model("s3://bucket/model")
+    assert not is_hub_model("gs://bucket/model")
+    assert not is_hub_model("az://container/model")
 
 
 class TestIsRemoteGGUF:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -101,7 +101,7 @@ from vllm.transformers_utils.config import (
 )
 from vllm.transformers_utils.gguf_utils import is_gguf
 from vllm.transformers_utils.repo_utils import get_model_path
-from vllm.transformers_utils.utils import is_cloud_storage
+from vllm.transformers_utils.utils import is_hub_model
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.network_utils import get_ip
@@ -1510,10 +1510,10 @@ class EngineArgs:
 
         # Check if the model is a speculator and override model/tokenizer/config
         # BEFORE creating ModelConfig, so the config is created with the target model
-        # Skip speculator detection for cloud storage models (eg: S3, GCS) since
-        # HuggingFace cannot load configs directly from S3 URLs. S3 models can still
-        # use speculators with explicit --speculative-config.
-        if not is_cloud_storage(self.model):
+        # Only attempt speculator auto-detection for HuggingFace Hub models.
+        # Non-Hub models (local paths, cloud storage URLs, etc.) can still use
+        # speculators with explicit --speculative-config.
+        if is_hub_model(self.model):
             (self.model, self.tokenizer, self.speculative_config) = (
                 maybe_override_with_speculators(
                     model=self.model,

--- a/vllm/transformers_utils/utils.py
+++ b/vllm/transformers_utils/utils.py
@@ -9,6 +9,9 @@ from os import PathLike
 from pathlib import Path
 from typing import Any
 
+import huggingface_hub.errors
+import huggingface_hub.utils
+
 import vllm.envs as envs
 from vllm.logger import init_logger
 
@@ -29,6 +32,15 @@ def is_azure(model_or_path: str) -> bool:
 
 def is_cloud_storage(model_or_path: str) -> bool:
     return is_s3(model_or_path) or is_gcs(model_or_path) or is_azure(model_or_path)
+
+
+def is_hub_model(model_or_path: str) -> bool:
+    """Check if the string is a valid HuggingFace Hub model identifier."""
+    try:
+        huggingface_hub.utils.validate_repo_id(model_or_path)
+        return True
+    except huggingface_hub.errors.HFValidationError:
+        return False
 
 
 def without_trust_remote_code(kwargs: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Fixes crash when loading models from local filesystem paths (e.g. `/home/user/Models/my-model`) caused by `PretrainedConfig.get_config_dict()` rejecting local paths as invalid HuggingFace repo IDs
- Replaces the `is_cloud_storage()` guard with a positive `is_hub_model()` check that uses HuggingFace's own `validate_repo_id()`, so speculator auto-detection is only attempted for valid Hub model identifiers
- Generalizes the prior fix from PR #27846 (which special-cased `s3://`, `gs://`, `az://`) to handle *any* non-Hub model path uniformly

Fixes #13707

## Context

`maybe_override_with_speculators()` calls `PretrainedConfig.get_config_dict()` to check for speculative decoding config. When the model is a local path, `huggingface_hub`'s `validate_repo_id()` rejects it (absolute paths contain multiple `/` characters), and the exception propagates up as an unhandled `OSError`.

The previous approach added `is_cloud_storage()` to skip specific URL schemes, but local paths were never addressed. Rather than adding another special case, this PR introduces `is_hub_model()` which reuses HF's own validator — any non-Hub identifier (local paths, cloud URLs, future schemes) is skipped automatically. Non-Hub models can still use speculators via explicit `--speculative-config`.

## Test plan

- [ ] `pytest tests/transformers_utils/test_utils.py -v -s -k test_is_hub_model` — new test covering valid Hub IDs, local paths, and cloud storage URLs
- [ ] `pytest tests/transformers_utils/test_utils.py -v -s` — existing tests remain passing
- [ ] Verify local model loading no longer crashes (manual)

## AI Disclosure

AI assistance was used (Claude). This is not duplicating an existing PR — issue #13707 was auto-closed without a fix, and the `is_cloud_storage()` approach from #27846 does not cover local paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)