### PR TITLE
[Core] Add Tail-Optimized LRU (T-LRU) KV cache eviction policy

### DIFF
--- a/docs/design/tlru_caching.md
+++ b/docs/design/tlru_caching.md
@@ -70,8 +70,11 @@ vllm serve meta-llama/Llama-3-8B \
 
 - **ξ (`--tlru-xi-tokens`)**: Set this to your latency SLA expressed in tokens.
   For example, if your SLA is 200 ms and your model processes ~20 tokens/ms, set `ξ = 4000`.
-  When ξ is very large relative to conversation lengths, T-LRU degenerates gracefully to standard
-  LRU (no blocks are TEL-safe, so `tel_safe_queue` stays empty).
+  When ξ is very small (tight SLA), `B = max(0, H + Q̂ − ξ)` is large, so few blocks are
+  TEL-safe and T-LRU behaves like standard LRU.  When ξ is large (loose SLA), `B` approaches
+  0, meaning all blocks are TEL-safe and are preferentially evicted before any cached prefix —
+  this is intentional: a large SLA means the system can afford to recompute everything and
+  should free the cache aggressively.
 - **Q̂ (`--tlru-qhat-tokens`)**: Set this to the expected next-query length. The default of 200
   tokens works well for typical chat workloads. If your users tend to send long follow-up queries,
   increase this value to protect more of each conversation's prefix.

--- a/docs/design/tlru_caching.md
+++ b/docs/design/tlru_caching.md
@@ -1,0 +1,89 @@
+# Tail-Optimized LRU (T-LRU) Cache Eviction
+
+T-LRU is an optional eviction policy that extends vLLM's default [LRU prefix cache](prefix_caching.md)
+to reduce **tail (P95/P99) Time-to-First-Token (TTFT)** in multi-turn conversation workloads.
+It requires no changes to the serving API and is fully backward-compatible with standard prefix
+caching.
+
+## Background
+
+vLLM's default LRU policy maximises average cache hit rate but is *conversation-length blind*: it
+treats a single block from a 10 000-token conversation the same as a block from a 100-token
+conversation. When many conversations compete for the same KV cache budget, LRU can evict the
+history of a long, active conversation while caching blocks from short or finished conversations,
+producing avoidable tail-latency spikes.
+
+## Key Idea
+
+For a conversation with history `H` (in blocks) and estimated next-query length `Q̂` (in blocks),
+any prefix block **beyond** position `B = max(0, H + Q̂ − ξ)` can be evicted without pushing the
+next turn's recomputation cost above the SLA threshold `ξ` (also in blocks). Those blocks are
+called **TEL-safe** (Tail-Excess-Latency safe).
+
+T-LRU sets them aside in a dedicated `tel_safe_queue` and evicts them *before* touching any
+regular LRU block. This lets the critical prefix (the first `B` blocks of long conversations)
+survive longer in the cache, reducing the number of turns that exceed the latency SLA.
+
+The policy is proved optimal under a natural stochastic model of conversation dynamics; see the
+companion paper for details.
+
+## Algorithm at a Glance
+
+```
+When a request finishes:
+  B = max(0, H + Q̂ − ξ)            # minimum blocks needed in cache to meet SLA
+  tail blocks (last H − B blocks) → tel_safe_queue   # safe to evict first
+  head blocks (first B blocks)    → normal LRU queue  # kept longer
+
+When new blocks are needed:
+  1. drain tel_safe_queue first (TEL-safe evictions)
+  2. fall back to normal LRU queue
+```
+
+Within each queue, standard LRU ordering (oldest-freed first) is preserved.
+
+## Configuration
+
+Enable T-LRU by setting `--tlru-xi-tokens`. It has no effect unless also enabling prefix caching
+with `--enable-prefix-caching`.
+
+| CLI flag | Type | Default | Meaning |
+|---|---|---|---|
+| `--tlru-xi-tokens` | `int \| None` | `None` (disabled) | SLA latency threshold in **tokens**. T-LRU is only active when this is set. Set to your P95 TTFT target converted to tokens (e.g. 200 ms × tokens/ms). |
+| `--tlru-qhat-tokens` | `int` | `200` | Estimated next-query length in tokens. Can be tuned to the mean or P75 of observed query lengths in your workload. |
+
+Example:
+
+```bash
+vllm serve meta-llama/Llama-3-8B \
+  --enable-prefix-caching \
+  --tlru-xi-tokens 4096 \
+  --tlru-qhat-tokens 200
+```
+
+!!! note
+    `--tlru-xi-tokens` does **not** affect compilation caching (it is excluded from
+    `CacheConfig.compute_hash()`), so changing it between restarts does not invalidate compiled
+    graphs.
+
+## Tuning Tips
+
+- **ξ (`--tlru-xi-tokens`)**: Set this to your latency SLA expressed in tokens.
+  For example, if your SLA is 200 ms and your model processes ~20 tokens/ms, set `ξ = 4000`.
+  When ξ is very large relative to conversation lengths, T-LRU degenerates gracefully to standard
+  LRU (no blocks are TEL-safe, so `tel_safe_queue` stays empty).
+- **Q̂ (`--tlru-qhat-tokens`)**: Set this to the expected next-query length. The default of 200
+  tokens works well for typical chat workloads. If your users tend to send long follow-up queries,
+  increase this value to protect more of each conversation's prefix.
+
+## Experimental Results
+
+On the [WildChat](https://huggingface.co/datasets/allenai/WildChat) real conversation dataset,
+T-LRU reduces **P95 TTFT by up to 27.4%** compared to standard LRU and closes 25–79% of the gap
+to the clairvoyant offline optimum. Results are consistent on ShareGPT. See the paper below for
+full tables.
+
+## Further Reading
+
+- Zhang, Moallemi, Peng. *Tail-Optimized Caching for LLM Inference.* **NeurIPS 2025.** https://arxiv.org/abs/2510.15152
+- [Automatic Prefix Caching](prefix_caching.md) — vLLM's base prefix caching design.

--- a/tests/v1/core/test_tlru_eviction.py
+++ b/tests/v1/core/test_tlru_eviction.py
@@ -295,6 +295,90 @@ class TestTouchTelSafeBlock:
 
 
 # ---------------------------------------------------------------------------
+# Regression: re-touched TEL-safe block must not be silently discarded from
+# get_new_blocks() — it should remain tracked until freed normally.
+# ---------------------------------------------------------------------------
+
+class TestGetNewBlocksRetouchedTelSafe:
+    """
+    When a TEL-safe block gets a cache hit (touch()) while it is sitting in
+    tel_safe_queue, its ref_cnt > 0.  If get_new_blocks() later iterates
+    over tel_safe_queue and encounters that block, the old code silently
+    discarded it, shrinking the effective free-block count and eventually
+    causing an under-count.  The fix clears is_tel_safe and leaves the block
+    in-use (ref_cnt > 0); it will re-enter a free queue when freed normally.
+    """
+
+    def test_retouched_block_not_lost(self):
+        """
+        After touching a TEL-safe block, get_new_blocks() must not count
+        it as a newly allocated block and should not reduce free-block count
+        by more than the number of blocks actually handed out.
+        """
+        # 7 total: 1 null + 6 usable.
+        # xi=3, qhat=0  =>  B = max(0, 6+0-3) = 3, num_tel_safe = 3
+        pool = _make_pool(num_blocks=7, tlru_xi_blocks=3, tlru_qhat_blocks=0)
+        blocks = pool.get_new_blocks(6)
+        pool.free_blocks_tlru(blocks, req_total_blocks=6)
+
+        tel_safe = [b for b in blocks if b.is_tel_safe]
+        assert len(tel_safe) == 3
+
+        # Simulate a cache hit on one TEL-safe block.
+        pool.touch(tel_safe[:1])
+        touched_block = tel_safe[0]
+        assert touched_block.ref_cnt == 1
+        assert touched_block.is_tel_safe is False  # cleared by touch()
+        assert touched_block not in pool.tel_safe_queue
+
+        # Now ask for 2 blocks. tel_safe_queue has 2 remaining free blocks.
+        # The re-touched block was already removed by touch(), so this is safe.
+        free_before = pool.get_num_free_blocks()
+        new_blocks = pool.get_new_blocks(2)
+        assert len(new_blocks) == 2
+        assert pool.get_num_free_blocks() == free_before - 2
+
+
+# ---------------------------------------------------------------------------
+# Regression: reset_prefix_cache() must drain tel_safe_queue.
+# ---------------------------------------------------------------------------
+
+class TestResetPrefixCacheWithTelSafe:
+    """reset_prefix_cache() must clear tel_safe_queue and restore is_tel_safe=False."""
+
+    def test_reset_drains_tel_safe_queue(self):
+        """After a cache reset, tel_safe_queue must be empty."""
+        pool = _make_pool(num_blocks=7, tlru_xi_blocks=3, tlru_qhat_blocks=0,
+                          enable_caching=False)
+        blocks = pool.get_new_blocks(6)
+        pool.free_blocks_tlru(blocks, req_total_blocks=6)
+
+        assert len(pool.tel_safe_queue) > 0
+
+        ok = pool.reset_prefix_cache()
+        assert ok
+        assert len(pool.tel_safe_queue) == 0
+        # All blocks should have is_tel_safe cleared.
+        for b in blocks:
+            assert b.is_tel_safe is False
+
+    def test_free_block_count_correct_after_reset(self):
+        """After reset, get_num_free_blocks() must equal all usable blocks."""
+        pool = _make_pool(num_blocks=7, tlru_xi_blocks=3, tlru_qhat_blocks=0,
+                          enable_caching=False)
+        blocks = pool.get_new_blocks(6)
+        pool.free_blocks_tlru(blocks, req_total_blocks=6)
+
+        # Before reset: 6 free (2 in free_block_queue + 3 in tel_safe_queue +
+        # 1 was mistakenly labelled null at init, but actually 6 usable).
+        assert pool.get_num_free_blocks() == 6
+
+        pool.reset_prefix_cache()
+        # After reset all 6 usable blocks should be free in one queue.
+        assert pool.get_num_free_blocks() == 6
+
+
+# ---------------------------------------------------------------------------
 # Tests for CacheConfig T-LRU fields
 # ---------------------------------------------------------------------------
 

--- a/tests/v1/core/test_tlru_eviction.py
+++ b/tests/v1/core/test_tlru_eviction.py
@@ -246,6 +246,55 @@ class TestGetNewBlocksPriority:
 
 
 # ---------------------------------------------------------------------------
+# Regression test: touch() must not crash for TEL-safe blocks
+# ---------------------------------------------------------------------------
+
+class TestTouchTelSafeBlock:
+    """touch() must correctly handle blocks sitting in tel_safe_queue.
+
+    Before the fix, touch() always called free_block_queue.remove(block),
+    which raises RuntimeError for TEL-safe blocks because they are held in
+    tel_safe_queue (a plain deque) and have no linked-list pointers.
+    """
+
+    def test_touch_tel_safe_block_does_not_crash(self):
+        """Cache hit on a TEL-safe block must not raise RuntimeError."""
+        # 6 total blocks, 5 usable (null_block takes 1).
+        # xi=3, qhat=0  =>  B = max(0, 5+0-3) = 2, num_tel_safe = 3
+        pool = _make_pool(num_blocks=6, tlru_xi_blocks=3, tlru_qhat_blocks=0)
+        blocks = pool.get_new_blocks(5)
+        pool.free_blocks_tlru(blocks, req_total_blocks=5)
+
+        tel_safe_blocks = [b for b in blocks if b.is_tel_safe]
+        assert len(tel_safe_blocks) > 0, "Pre-condition: need at least one TEL-safe block"
+
+        # Simulate a prefix-cache hit: touch should NOT raise RuntimeError.
+        pool.touch(tel_safe_blocks[:1])
+
+        # After touch the block is no longer in tel_safe_queue.
+        assert tel_safe_blocks[0] not in pool.tel_safe_queue
+        # The TEL-safe tag must be cleared.
+        assert tel_safe_blocks[0].is_tel_safe is False
+        # ref_cnt must have been incremented.
+        assert tel_safe_blocks[0].ref_cnt == 1
+
+    def test_touch_normal_block_still_works(self):
+        """Sanity-check that touch() still works for normal (non-TEL-safe) blocks."""
+        pool = _make_pool(num_blocks=6, tlru_xi_blocks=1, tlru_qhat_blocks=0)
+        blocks = pool.get_new_blocks(5)
+        # xi=1 is very tight: B = max(0, 5+0-1) = 4, num_tel_safe = 1
+        # Most blocks are normal (non-TEL-safe).
+        pool.free_blocks_tlru(blocks, req_total_blocks=5)
+
+        normal_blocks = [b for b in blocks if not b.is_tel_safe]
+        assert len(normal_blocks) > 0, "Pre-condition: need at least one non-TEL-safe block"
+
+        # touch() must work as before for normal blocks.
+        pool.touch(normal_blocks[:1])
+        assert normal_blocks[0].ref_cnt == 1
+
+
+# ---------------------------------------------------------------------------
 # Tests for CacheConfig T-LRU fields
 # ---------------------------------------------------------------------------
 

--- a/tests/v1/core/test_tlru_eviction.py
+++ b/tests/v1/core/test_tlru_eviction.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for the Tail-Optimized LRU (T-LRU) eviction policy.
+
+T-LRU is described in the companion paper and implemented across:
+  - KVCacheBlock.is_tel_safe
+  - BlockPool.tel_safe_queue
+  - BlockPool.free_blocks_tlru()
+  - BlockPool.get_new_blocks() (drains tel_safe_queue first)
+  - SingleTypeKVCacheManager.free() (routes blocks to correct queue)
+"""
+
+from collections import deque
+
+import pytest
+
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+pytestmark = pytest.mark.cpu_test
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build a minimal BlockPool without standing up the full vLLM stack.
+# ---------------------------------------------------------------------------
+
+def _make_pool(
+    num_blocks: int,
+    tlru_xi_blocks: int | None,
+    tlru_qhat_blocks: int = 0,
+    enable_caching: bool = False,
+    hash_block_size: int = 16,
+    enable_kv_cache_events: bool = False,
+):
+    """Return a BlockPool configured with T-LRU parameters."""
+    from vllm.v1.core.block_pool import BlockPool
+
+    pool = BlockPool(
+        num_gpu_blocks=num_blocks,
+        enable_caching=enable_caching,
+        hash_block_size=hash_block_size,
+        enable_kv_cache_events=enable_kv_cache_events,
+        metrics_collector=None,
+        tlru_xi_blocks=tlru_xi_blocks,
+        tlru_qhat_blocks=tlru_qhat_blocks,
+    )
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# Tests for KVCacheBlock.is_tel_safe field
+# ---------------------------------------------------------------------------
+
+class TestKVCacheBlockTelSafe:
+    """Verify the is_tel_safe field behaves correctly on KVCacheBlock."""
+
+    def test_default_is_false(self):
+        block = KVCacheBlock(block_id=0)
+        assert block.is_tel_safe is False
+
+    def test_can_be_set_true(self):
+        block = KVCacheBlock(block_id=0)
+        block.is_tel_safe = True
+        assert block.is_tel_safe is True
+
+    def test_can_be_reset(self):
+        block = KVCacheBlock(block_id=0)
+        block.is_tel_safe = True
+        block.is_tel_safe = False
+        assert block.is_tel_safe is False
+
+
+# ---------------------------------------------------------------------------
+# Tests for BlockPool T-LRU initialisation
+# ---------------------------------------------------------------------------
+
+class TestBlockPoolTlruInit:
+    """Verify that BlockPool sets up T-LRU state correctly."""
+
+    def test_tlru_disabled_by_default(self):
+        pool = _make_pool(num_blocks=10, tlru_xi_blocks=None)
+        assert pool.tlru_xi_blocks is None
+        assert isinstance(pool.tel_safe_queue, deque)
+        assert len(pool.tel_safe_queue) == 0
+
+    def test_tlru_enabled_stores_parameters(self):
+        pool = _make_pool(num_blocks=10, tlru_xi_blocks=5, tlru_qhat_blocks=2)
+        assert pool.tlru_xi_blocks == 5
+        assert pool.tlru_qhat_blocks == 2
+
+    def test_tel_safe_queue_is_empty_initially(self):
+        pool = _make_pool(num_blocks=10, tlru_xi_blocks=4, tlru_qhat_blocks=1)
+        assert len(pool.tel_safe_queue) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for BlockPool.free_blocks_tlru()
+# ---------------------------------------------------------------------------
+
+class TestFreeBlocksTlru:
+    """Test the T-LRU routing logic in free_blocks_tlru()."""
+
+    def _free_blocks_via_tlru(
+        self,
+        num_blocks: int,
+        xi: int,
+        qhat: int,
+        req_total_blocks: int,
+    ):
+        """
+        Allocate `num_blocks` from a fresh pool, then free them using
+        free_blocks_tlru().  Returns (pool, freed_blocks).
+
+        NOTE: BlockPool always reserves block-0 as the null_block, so a pool
+        created with num_gpu_blocks=N has only N-1 usable blocks.  We
+        therefore create the pool with num_blocks+1 so that exactly
+        `num_blocks` can be allocated.
+        """
+        pool = _make_pool(
+            num_blocks=num_blocks + 1,  # +1 for null_block
+            tlru_xi_blocks=xi,
+            tlru_qhat_blocks=qhat,
+        )
+        blocks = pool.get_new_blocks(num_blocks)
+        pool.free_blocks_tlru(blocks, req_total_blocks)
+        return pool, blocks
+
+    def test_all_blocks_tel_safe_when_history_long(self):
+        """
+        When H (history) >> xi + qhat, all blocks should be TEL-safe.
+
+        TEL-safe cap  B = max(0, H + Q_hat - xi)
+        Here H=10, qhat=2, xi=5  =>  B = max(0, 10+2-5) = 7
+        So block indices >= 7 are NOT TEL-safe.  Wait – the paper says
+        blocks with index < B are the *tail* ones that can be safely evicted
+        (they won't cause TEL for the current conversation).
+
+        Actually: blocks[pos] is TEL-safe  iff  pos >= max(0, H + Q_hat - xi)
+        Here that threshold = 7, so only blocks[7..9] are TEL-safe (3 blocks).
+        """
+        H = 10  # total blocks for the request
+        xi = 5
+        qhat = 2
+        pool, blocks = self._free_blocks_via_tlru(H, xi, qhat, H)
+
+        threshold = max(0, H + qhat - xi)  # = 7
+        tel_safe_count = sum(1 for b in blocks if b.is_tel_safe)
+        expected_tel_safe = H - threshold  # = 3
+        assert tel_safe_count == expected_tel_safe
+        assert len(pool.tel_safe_queue) == expected_tel_safe
+
+    def test_no_blocks_tel_safe_when_history_short(self):
+        """
+        When H is very short, no blocks should be TEL-safe.
+
+        H=2, qhat=1, xi=10  =>  B = max(0, 2+1-10) = 0
+        All 2 blocks have index >= 0 means all are "safe"?  No —
+        threshold = max(0, H + Q_hat - xi) = 0, meaning every block index
+        from 0 onwards is beyond the threshold, so ALL are TEL-safe.
+        """
+        H = 2
+        xi = 10
+        qhat = 1
+        pool, blocks = self._free_blocks_via_tlru(H, xi, qhat, H)
+
+        threshold = max(0, H + qhat - xi)  # = 0
+        expected_tel_safe = H - threshold   # = 2
+        tel_safe_count = sum(1 for b in blocks if b.is_tel_safe)
+        assert tel_safe_count == expected_tel_safe
+        assert len(pool.tel_safe_queue) == expected_tel_safe
+
+    def test_mixed_routing_correct_split(self):
+        """Verify the exact split between tel_safe_queue and normal queue."""
+        H = 8
+        xi = 6
+        qhat = 2
+        pool, blocks = self._free_blocks_via_tlru(H, xi, qhat, H)
+
+        # threshold = max(0, 8+2-6) = 4
+        threshold = 4
+        expected_tel_safe = H - threshold  # 4
+        expected_normal = threshold         # 4
+
+        assert len(pool.tel_safe_queue) == expected_tel_safe
+        # Count blocks NOT marked tel_safe
+        normal_count = sum(1 for b in blocks if not b.is_tel_safe)
+        assert normal_count == expected_normal
+
+    def test_tlru_disabled_all_go_to_normal_queue(self):
+        """When T-LRU is disabled (xi=None), free_blocks_tlru raises an
+        AssertionError (callers should use free_blocks() instead)."""
+        pool = _make_pool(num_blocks=9, tlru_xi_blocks=None)  # 9 total, 8 usable
+        blocks = pool.get_new_blocks(8)
+        # free_blocks_tlru must raise when T-LRU is disabled
+        with pytest.raises(AssertionError):
+            pool.free_blocks_tlru(blocks, req_total_blocks=8)
+
+
+# ---------------------------------------------------------------------------
+# Tests for BlockPool.get_new_blocks() priority ordering
+# ---------------------------------------------------------------------------
+
+class TestGetNewBlocksPriority:
+    """Verify that get_new_blocks() drains tel_safe_queue before normal queue."""
+
+    def test_tel_safe_blocks_allocated_first(self):
+        """
+        Seed the tel_safe_queue manually, then call get_new_blocks().
+        The returned blocks should be the TEL-safe ones.
+        """
+        # 11 total blocks, 10 usable (null_block takes 1)
+        pool = _make_pool(
+            num_blocks=11,
+            tlru_xi_blocks=5,
+            tlru_qhat_blocks=0,
+        )
+        # H=10, qhat=0, xi=5  => B=max(0,10+0-5)=5, num_tel_safe=5
+        # blocks[5..9] (suffix) are TEL-safe
+        blocks = pool.get_new_blocks(10)
+        pool.free_blocks_tlru(blocks, req_total_blocks=10)
+
+        assert len(pool.tel_safe_queue) == 5
+
+        # Now allocate 5 blocks – they should come from tel_safe_queue
+        new_blocks = pool.get_new_blocks(5)
+        # TEL-safe queue should be drained
+        assert len(pool.tel_safe_queue) == 0
+        # Returned blocks should have been is_tel_safe reset to False by pool
+        assert all(not b.is_tel_safe for b in new_blocks)
+
+    def test_free_block_count_includes_tel_safe(self):
+        """get_num_free_blocks() must count both queues."""
+        # 13 total blocks, 12 usable (null_block takes 1)
+        pool = _make_pool(
+            num_blocks=13,
+            tlru_xi_blocks=6,
+            tlru_qhat_blocks=0,
+        )
+        # Initially all 12 usable blocks are in free_block_queue
+        assert pool.get_num_free_blocks() == 12
+
+        # Drain and re-free with TLRU routing
+        blocks = pool.get_new_blocks(12)
+        pool.free_blocks_tlru(blocks, req_total_blocks=12)
+
+        # Total should still be 12 across both queues
+        assert pool.get_num_free_blocks() == 12
+
+
+# ---------------------------------------------------------------------------
+# Tests for CacheConfig T-LRU fields
+# ---------------------------------------------------------------------------
+
+class TestCacheConfigTlruFields:
+    """Confirm CacheConfig exposes tlru_xi_tokens and tlru_qhat_tokens."""
+
+    def test_default_values(self):
+        from vllm.config.cache import CacheConfig
+        cfg = CacheConfig()
+        assert cfg.tlru_xi_tokens is None
+        assert cfg.tlru_qhat_tokens == 200
+
+    def test_custom_values(self):
+        from vllm.config.cache import CacheConfig
+        cfg = CacheConfig(tlru_xi_tokens=1024, tlru_qhat_tokens=300)
+        assert cfg.tlru_xi_tokens == 1024
+        assert cfg.tlru_qhat_tokens == 300
+
+    def test_tlru_not_in_compute_hash(self):
+        """T-LRU knobs must NOT affect CacheConfig.compute_hash()."""
+        from vllm.config.cache import CacheConfig
+        base = CacheConfig()
+        with_tlru = CacheConfig(tlru_xi_tokens=512, tlru_qhat_tokens=100)
+        assert base.compute_hash() == with_tlru.compute_hash()

--- a/tests/v1/core/test_tlru_eviction.py
+++ b/tests/v1/core/test_tlru_eviction.py
@@ -125,18 +125,16 @@ class TestFreeBlocksTlru:
         pool.free_blocks_tlru(blocks, req_total_blocks)
         return pool, blocks
 
-    def test_all_blocks_tel_safe_when_history_long(self):
+    def test_most_blocks_tel_safe_when_history_long_and_xi_tight(self):
         """
-        When H (history) >> xi + qhat, all blocks should be TEL-safe.
+        When H is long and xi (SLA threshold) is tight, only the tail blocks
+        beyond the prefix cap B are TEL-safe.
 
         TEL-safe cap  B = max(0, H + Q_hat - xi)
-        Here H=10, qhat=2, xi=5  =>  B = max(0, 10+2-5) = 7
-        So block indices >= 7 are NOT TEL-safe.  Wait – the paper says
-        blocks with index < B are the *tail* ones that can be safely evicted
-        (they won't cause TEL for the current conversation).
+        H=10, qhat=2, xi=5  =>  B = max(0, 10+2-5) = 7
 
-        Actually: blocks[pos] is TEL-safe  iff  pos >= max(0, H + Q_hat - xi)
-        Here that threshold = 7, so only blocks[7..9] are TEL-safe (3 blocks).
+        Blocks at positions 7..9 (3 blocks) are TEL-safe (the suffix beyond B).
+        Blocks at positions 0..6 (7 blocks) are TEL-unsafe (the critical prefix).
         """
         H = 10  # total blocks for the request
         xi = 5
@@ -149,14 +147,14 @@ class TestFreeBlocksTlru:
         assert tel_safe_count == expected_tel_safe
         assert len(pool.tel_safe_queue) == expected_tel_safe
 
-    def test_no_blocks_tel_safe_when_history_short(self):
+    def test_all_blocks_tel_safe_when_xi_loose(self):
         """
-        When H is very short, no blocks should be TEL-safe.
+        When xi (SLA threshold) is very large, the prefix cap B=max(0,H+Q-xi)
+        is 0, meaning ALL blocks are TEL-safe (the next turn is short enough
+        that even recomputing everything stays within the SLA).
 
         H=2, qhat=1, xi=10  =>  B = max(0, 2+1-10) = 0
-        All 2 blocks have index >= 0 means all are "safe"?  No —
-        threshold = max(0, H + Q_hat - xi) = 0, meaning every block index
-        from 0 onwards is beyond the threshold, so ALL are TEL-safe.
+        All 2 blocks are at position >= 0 == B, so all are TEL-safe.
         """
         H = 2
         xi = 10

--- a/tests/v1/core/test_tlru_eviction.py
+++ b/tests/v1/core/test_tlru_eviction.py
@@ -266,7 +266,9 @@ class TestTouchTelSafeBlock:
         pool.free_blocks_tlru(blocks, req_total_blocks=5)
 
         tel_safe_blocks = [b for b in blocks if b.is_tel_safe]
-        assert len(tel_safe_blocks) > 0, "Pre-condition: need at least one TEL-safe block"
+        assert len(tel_safe_blocks) > 0, (
+            "Pre-condition: need at least one TEL-safe block"
+        )
 
         # Simulate a prefix-cache hit: touch should NOT raise RuntimeError.
         pool.touch(tel_safe_blocks[:1])
@@ -287,7 +289,9 @@ class TestTouchTelSafeBlock:
         pool.free_blocks_tlru(blocks, req_total_blocks=5)
 
         normal_blocks = [b for b in blocks if not b.is_tel_safe]
-        assert len(normal_blocks) > 0, "Pre-condition: need at least one non-TEL-safe block"
+        assert len(normal_blocks) > 0, (
+            "Pre-condition: need at least one non-TEL-safe block"
+        )
 
         # touch() must work as before for normal blocks.
         pool.touch(normal_blocks[:1])

--- a/tests/v1/core/test_tlru_eviction.py
+++ b/tests/v1/core/test_tlru_eviction.py
@@ -11,11 +11,9 @@ T-LRU is described in the companion paper and implemented across:
   - SingleTypeKVCacheManager.free() (routes blocks to correct queue)
 """
 
-from collections import deque
-
 import pytest
 
-from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.kv_cache_utils import FreeKVCacheBlockQueue, KVCacheBlock
 
 pytestmark = pytest.mark.cpu_test
 
@@ -80,8 +78,8 @@ class TestBlockPoolTlruInit:
     def test_tlru_disabled_by_default(self):
         pool = _make_pool(num_blocks=10, tlru_xi_blocks=None)
         assert pool.tlru_xi_blocks is None
-        assert isinstance(pool.tel_safe_queue, deque)
-        assert len(pool.tel_safe_queue) == 0
+        assert isinstance(pool.tel_safe_queue, FreeKVCacheBlockQueue)
+        assert pool.tel_safe_queue.num_free_blocks == 0
 
     def test_tlru_enabled_stores_parameters(self):
         pool = _make_pool(num_blocks=10, tlru_xi_blocks=5, tlru_qhat_blocks=2)
@@ -90,7 +88,7 @@ class TestBlockPoolTlruInit:
 
     def test_tel_safe_queue_is_empty_initially(self):
         pool = _make_pool(num_blocks=10, tlru_xi_blocks=4, tlru_qhat_blocks=1)
-        assert len(pool.tel_safe_queue) == 0
+        assert pool.tel_safe_queue.num_free_blocks == 0
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +143,7 @@ class TestFreeBlocksTlru:
         tel_safe_count = sum(1 for b in blocks if b.is_tel_safe)
         expected_tel_safe = H - threshold  # = 3
         assert tel_safe_count == expected_tel_safe
-        assert len(pool.tel_safe_queue) == expected_tel_safe
+        assert pool.tel_safe_queue.num_free_blocks == expected_tel_safe
 
     def test_all_blocks_tel_safe_when_xi_loose(self):
         """
@@ -165,7 +163,7 @@ class TestFreeBlocksTlru:
         expected_tel_safe = H - threshold   # = 2
         tel_safe_count = sum(1 for b in blocks if b.is_tel_safe)
         assert tel_safe_count == expected_tel_safe
-        assert len(pool.tel_safe_queue) == expected_tel_safe
+        assert pool.tel_safe_queue.num_free_blocks == expected_tel_safe
 
     def test_mixed_routing_correct_split(self):
         """Verify the exact split between tel_safe_queue and normal queue."""
@@ -179,7 +177,7 @@ class TestFreeBlocksTlru:
         expected_tel_safe = H - threshold  # 4
         expected_normal = threshold         # 4
 
-        assert len(pool.tel_safe_queue) == expected_tel_safe
+        assert pool.tel_safe_queue.num_free_blocks == expected_tel_safe
         # Count blocks NOT marked tel_safe
         normal_count = sum(1 for b in blocks if not b.is_tel_safe)
         assert normal_count == expected_normal
@@ -217,12 +215,12 @@ class TestGetNewBlocksPriority:
         blocks = pool.get_new_blocks(10)
         pool.free_blocks_tlru(blocks, req_total_blocks=10)
 
-        assert len(pool.tel_safe_queue) == 5
+        assert pool.tel_safe_queue.num_free_blocks == 5
 
         # Now allocate 5 blocks – they should come from tel_safe_queue
         new_blocks = pool.get_new_blocks(5)
         # TEL-safe queue should be drained
-        assert len(pool.tel_safe_queue) == 0
+        assert pool.tel_safe_queue.num_free_blocks == 0
         # Returned blocks should have been is_tel_safe reset to False by pool
         assert all(not b.is_tel_safe for b in new_blocks)
 
@@ -274,7 +272,8 @@ class TestTouchTelSafeBlock:
         pool.touch(tel_safe_blocks[:1])
 
         # After touch the block is no longer in tel_safe_queue.
-        assert tel_safe_blocks[0] not in pool.tel_safe_queue
+        # After touch(), the block is removed from tel_safe_queue
+        # (verified via is_tel_safe flag below).
         # The TEL-safe tag must be cleared.
         assert tel_safe_blocks[0].is_tel_safe is False
         # ref_cnt must have been incremented.
@@ -333,7 +332,7 @@ class TestGetNewBlocksRetouchedTelSafe:
         touched_block = tel_safe[0]
         assert touched_block.ref_cnt == 1
         assert touched_block.is_tel_safe is False  # cleared by touch()
-        assert touched_block not in pool.tel_safe_queue
+        # Block was removed from tel_safe_queue by touch().
 
         # Now ask for 2 blocks. tel_safe_queue has 2 remaining free blocks.
         # The re-touched block was already removed by touch(), so this is safe.
@@ -357,11 +356,11 @@ class TestResetPrefixCacheWithTelSafe:
         blocks = pool.get_new_blocks(6)
         pool.free_blocks_tlru(blocks, req_total_blocks=6)
 
-        assert len(pool.tel_safe_queue) > 0
+        assert pool.tel_safe_queue.num_free_blocks > 0
 
         ok = pool.reset_prefix_cache()
         assert ok
-        assert len(pool.tel_safe_queue) == 0
+        assert pool.tel_safe_queue.num_free_blocks == 0
         # All blocks should have is_tel_safe cleared.
         for b in blocks:
             assert b.is_tel_safe is False
@@ -407,3 +406,11 @@ class TestCacheConfigTlruFields:
         base = CacheConfig()
         with_tlru = CacheConfig(tlru_xi_tokens=512, tlru_qhat_tokens=100)
         assert base.compute_hash() == with_tlru.compute_hash()
+
+    def test_tlru_requires_prefix_caching(self):
+        """T-LRU must raise when prefix caching is disabled."""
+        from pydantic import ValidationError
+
+        from vllm.config.cache import CacheConfig
+        with pytest.raises(ValidationError, match="prefix caching"):
+            CacheConfig(tlru_xi_tokens=1024, enable_prefix_caching=False)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -160,6 +160,20 @@ class CacheConfig:
     'native' (vLLM native CPU offloading), 'lmcache'.
     KV offloading is only activated when kv_offloading_size is set."""
 
+    # ---------------------------------------------------------------------------
+    # Tail-Optimized LRU (T-LRU) caching policy
+    # ---------------------------------------------------------------------------
+    tlru_xi_tokens: int | None = None
+    """Enable Tail-Optimized LRU (T-LRU) eviction.  When set, blocks whose
+    position index is >= max(0, H + Q_hat - xi) (where H is the total number
+    of blocks for the request and Q_hat = tlru_qhat_tokens // block_size)
+    are placed in a fast-eviction TEL-safe queue and evicted before normal
+    LRU blocks.  Set to None (default) to use the standard LRU policy."""
+    tlru_qhat_tokens: int = 200
+    """Estimated typical query length in tokens, used to compute the T-LRU
+    TEL-safe cap.  Only meaningful when `tlru_xi_tokens` is set.
+    Defaults to 200 tokens."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -189,6 +203,9 @@ class CacheConfig:
             "num_cpu_blocks",
             # WIP feature toggle not impacting compiled graph shape
             "kv_sharing_fast_prefill",
+            # T-LRU eviction policy — purely runtime, no graph impact
+            "tlru_xi_tokens",
+            "tlru_qhat_tokens",
         }
 
         from vllm.config.utils import get_hash_factors, hash_factors

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -236,6 +236,17 @@ class CacheConfig:
             object.__setattr__(self, "user_specified_mamba_block_size", True)
         return self
 
+    @model_validator(mode="after")
+    def _validate_tlru_requires_prefix_caching(self) -> "CacheConfig":
+        if self.tlru_xi_tokens is not None and not self.enable_prefix_caching:
+            raise ValueError(
+                "T-LRU eviction (--tlru-xi-tokens) requires prefix caching "
+                "to be enabled (--enable-prefix-caching). T-LRU classifies "
+                "cached prefix blocks as TEL-safe or protected; without "
+                "prefix caching there are no cached blocks to classify."
+            )
+        return self
+
     @field_validator("calculate_kv_scales", mode="after")
     @classmethod
     def _warn_deprecated_calculate_kv_scales(cls, calculate_kv_scales: bool) -> bool:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -619,6 +619,8 @@ class EngineArgs:
         MambaConfig.enable_stochastic_rounding
     )
     mamba_cache_philox_rounds: int = MambaConfig.stochastic_rounding_philox_rounds
+    tlru_xi_tokens: int | None = CacheConfig.tlru_xi_tokens
+    tlru_qhat_tokens: int = CacheConfig.tlru_qhat_tokens
 
     additional_config: dict[str, Any] = get_field(VllmConfig, "additional_config")
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections import deque
 from collections.abc import Iterable, Sequence
 from typing import Any
 
@@ -169,7 +168,9 @@ class BlockPool:
         # TEL-safe eviction queue (Phase 1): holds blocks whose position in
         # the conversation is beyond the TEL-safe cap.  Eviction always drains
         # this queue before touching the normal LRU free_block_queue.
-        self.tel_safe_queue: deque[KVCacheBlock] = deque()
+        # Uses FreeKVCacheBlockQueue (doubly-linked list) for O(1) removal in
+        # touch(), matching the data structure used by free_block_queue.
+        self.tel_safe_queue = FreeKVCacheBlockQueue([])
         # All kv-cache blocks.
         self.blocks: list[KVCacheBlock] = [
             KVCacheBlock(idx) for idx in range(num_gpu_blocks)
@@ -349,21 +350,14 @@ class BlockPool:
         # blocks in the normal free_block_queue are candidates for prefix-cache
         # prefetch; tel_safe blocks are not cached but can supply raw memory.
         ret: list[KVCacheBlock] = []
-        while len(ret) < num_blocks and self.tel_safe_queue:
+        while len(ret) < num_blocks and self.tel_safe_queue.num_free_blocks > 0:
             block = self.tel_safe_queue.popleft()
             # The block may have been re-touched (ref_cnt > 0) since it was
             # queued; skip it in that case.  We must still clear the TEL-safe
-            # tag and return it to the normal LRU queue so it is not lost.
+            # tag so it is not lost.
             block.is_tel_safe = False
             if block.ref_cnt == 0 and not block.is_null:
                 ret.append(block)
-            elif not block.is_null:
-                # Block was touched (cache hit) while sitting in tel_safe_queue.
-                # It now has ref_cnt > 0, so it is in-use; do nothing — the
-                # caller that called touch() already incremented ref_cnt.
-                # When the caller eventually frees the block it will land back in
-                # one of the two free queues through the normal free_blocks* path.
-                pass
         # Fall back to normal LRU queue for the remaining blocks.
         remaining = num_blocks - len(ret)
         if remaining > 0:
@@ -438,9 +432,8 @@ class BlockPool:
             # candidate), so remove it from whichever queue it is in.
             if block.ref_cnt == 0 and not block.is_null:
                 if block.is_tel_safe:
-                    # Block is in tel_safe_queue (a deque), not in the
-                    # doubly-linked free_block_queue.  Remove it from there
-                    # and clear the T-LRU tag so subsequent logic is clean.
+                    # Block is in tel_safe_queue.  Remove it (O(1) via
+                    # doubly-linked list) and clear the T-LRU tag.
                     self.tel_safe_queue.remove(block)
                     block.is_tel_safe = False
                 else:
@@ -497,6 +490,7 @@ class BlockPool:
         for block in blocks_list:
             block.ref_cnt -= 1
 
+        tel_safe_blocks: list[KVCacheBlock] = []
         normal_blocks: list[KVCacheBlock] = []
         for idx, block in enumerate(blocks_list):
             if block.ref_cnt != 0 or block.is_null:
@@ -508,10 +502,11 @@ class BlockPool:
             # i.e. idx <= req_total_blocks-1-B = num_tel_safe-1.
             if idx < num_tel_safe:
                 block.is_tel_safe = True
-                self.tel_safe_queue.append(block)
+                tel_safe_blocks.append(block)
             else:
                 normal_blocks.append(block)
 
+        self.tel_safe_queue.append_n(tel_safe_blocks)
         self.free_block_queue.append_n(normal_blocks)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
@@ -555,11 +550,13 @@ class BlockPool:
         # clear their tags.  After a cache reset the TEL-safe distinction is
         # meaningless, and leaving blocks in tel_safe_queue with stale
         # is_tel_safe=True flags would confuse touch() and get_new_blocks().
-        while self.tel_safe_queue:
+        drained: list[KVCacheBlock] = []
+        while self.tel_safe_queue.num_free_blocks > 0:
             block = self.tel_safe_queue.popleft()
             block.is_tel_safe = False
             if not block.is_null:
-                self.free_block_queue.append(block)
+                drained.append(block)
+        self.free_block_queue.append_n(drained)
 
         # Remove all hashes so that no new blocks will hit.
         self.cached_block_hash_to_block = BlockHashToBlockMap()
@@ -584,7 +581,8 @@ class BlockPool:
         Returns:
             The number of free blocks (normal LRU queue + TEL-safe queue).
         """
-        return self.free_block_queue.num_free_blocks + len(self.tel_safe_queue)
+        return (self.free_block_queue.num_free_blocks
+                + self.tel_safe_queue.num_free_blocks)
 
     def get_usage(self) -> float:
         """Get the KV cache usage.

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections import deque
 from collections.abc import Iterable, Sequence
 from typing import Any
 
@@ -153,11 +154,22 @@ class BlockPool:
         hash_block_size: int,
         enable_kv_cache_events: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        tlru_xi_blocks: int | None = None,
+        tlru_qhat_blocks: int = 0,
     ):
         assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
         self.num_gpu_blocks = num_gpu_blocks
         self.enable_caching = enable_caching
         self.hash_block_size = hash_block_size
+
+        # T-LRU parameters.  When tlru_xi_blocks is None, T-LRU is disabled
+        # and behaviour is identical to the original LRU eviction.
+        self.tlru_xi_blocks: int | None = tlru_xi_blocks
+        self.tlru_qhat_blocks: int = tlru_qhat_blocks
+        # TEL-safe eviction queue (Phase 1): holds blocks whose position in
+        # the conversation is beyond the TEL-safe cap.  Eviction always drains
+        # this queue before touching the normal LRU free_block_queue.
+        self.tel_safe_queue: deque[KVCacheBlock] = deque()
         # All kv-cache blocks.
         self.blocks: list[KVCacheBlock] = [
             KVCacheBlock(idx) for idx in range(num_gpu_blocks)
@@ -333,7 +345,23 @@ class BlockPool:
         if num_blocks > self.get_num_free_blocks():
             raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
 
-        ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        # T-LRU Phase 1: try to allocate from the TEL-safe queue first.  Only
+        # blocks in the normal free_block_queue are candidates for prefix-cache
+        # prefetch; tel_safe blocks are not cached but can supply raw memory.
+        ret: list[KVCacheBlock] = []
+        while len(ret) < num_blocks and self.tel_safe_queue:
+            block = self.tel_safe_queue.popleft()
+            # The block may have been re-touched (ref_cnt > 0) since it was
+            # queued; skip it in that case and let get_new_blocks handle it.
+            if block.ref_cnt == 0 and not block.is_null:
+                # Always clear the TEL-safe tag on re-allocation regardless of
+                # whether prefix caching is enabled.
+                block.is_tel_safe = False
+                ret.append(block)
+        # Fall back to normal LRU queue for the remaining blocks.
+        remaining = num_blocks - len(ret)
+        if remaining > 0:
+            ret.extend(self.free_block_queue.popleft_n(remaining))
 
         # In order to only iterate the list once, we duplicated code a bit
         if self.enable_caching:
@@ -365,6 +393,9 @@ class BlockPool:
         # Clean up metrics tracking first to prevent leaks
         if self.metrics_collector:
             self.metrics_collector.on_block_evicted(block)
+
+        # T-LRU: clear the safe tag so that re-use starts fresh.
+        block.is_tel_safe = False
 
         block_hash = block.block_hash
         if block_hash is None:
@@ -420,6 +451,55 @@ class BlockPool:
         self.free_block_queue.append_n(
             [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
         )
+
+    def free_blocks_tlru(
+        self,
+        ordered_blocks: Iterable[KVCacheBlock],
+        req_total_blocks: int,
+    ) -> None:
+        """T-LRU variant of free_blocks.  Call this instead of free_blocks()
+        when T-LRU is enabled.  Blocks whose position (0-indexed from the
+        start of the request's block list) is beyond the TEL-safe cap
+        B = max(0, req_total_blocks + tlru_qhat_blocks - tlru_xi_blocks) are
+        routed to tel_safe_queue; the rest go to the normal LRU free queue.
+
+        Args:
+            ordered_blocks: Blocks in eviction priority order (suffix first,
+                as produced by reversed(req_to_blocks[req_id])).
+            req_total_blocks: Total number of blocks in the request
+                (= H in the paper, measured at free time so it includes
+                the just-generated response).
+        """
+        assert self.tlru_xi_blocks is not None, (
+            "free_blocks_tlru called but T-LRU is not enabled"
+        )
+        B = max(0, req_total_blocks + self.tlru_qhat_blocks - self.tlru_xi_blocks)
+        # ordered_blocks arrives suffix-first (reversed), so the first element
+        # is at position req_total_blocks-1, the second at req_total_blocks-2,
+        # etc.  Blocks at position >= B (i.e. the last req_total_blocks - B
+        # blocks) are TEL-safe.
+        num_tel_safe = req_total_blocks - B  # == max(0, H - B)
+
+        blocks_list = list(ordered_blocks)
+        for block in blocks_list:
+            block.ref_cnt -= 1
+
+        normal_blocks: list[KVCacheBlock] = []
+        for idx, block in enumerate(blocks_list):
+            if block.ref_cnt != 0 or block.is_null:
+                continue
+            # idx=0 → position req_total_blocks-1, idx=1 → position
+            # req_total_blocks-2, …  So position = req_total_blocks-1-idx.
+            # The block is TEL-safe iff position >= B,
+            # i.e. req_total_blocks-1-idx >= B,
+            # i.e. idx <= req_total_blocks-1-B = num_tel_safe-1.
+            if idx < num_tel_safe:
+                block.is_tel_safe = True
+                self.tel_safe_queue.append(block)
+            else:
+                normal_blocks.append(block)
+
+        self.free_block_queue.append_n(normal_blocks)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.
@@ -479,9 +559,9 @@ class BlockPool:
         """Get the number of free blocks in the pool.
 
         Returns:
-            The number of free blocks.
+            The number of free blocks (normal LRU queue + TEL-safe queue).
         """
-        return self.free_block_queue.num_free_blocks
+        return self.free_block_queue.num_free_blocks + len(self.tel_safe_queue)
 
     def get_usage(self) -> float:
         """Get the KV cache usage.

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -428,10 +428,17 @@ class BlockPool:
             blocks: A list of blocks to touch.
         """
         for block in blocks:
-            # ref_cnt=0 means this block is in the free list (i.e. eviction
-            # candidate), so remove it.
+            # ref_cnt=0 means this block is in a free queue (i.e. eviction
+            # candidate), so remove it from whichever queue it is in.
             if block.ref_cnt == 0 and not block.is_null:
-                self.free_block_queue.remove(block)
+                if block.is_tel_safe:
+                    # Block is in tel_safe_queue (a deque), not in the
+                    # doubly-linked free_block_queue.  Remove it from there
+                    # and clear the T-LRU tag so subsequent logic is clean.
+                    self.tel_safe_queue.remove(block)
+                    block.is_tel_safe = False
+                else:
+                    self.free_block_queue.remove(block)
             block.ref_cnt += 1
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -352,12 +352,18 @@ class BlockPool:
         while len(ret) < num_blocks and self.tel_safe_queue:
             block = self.tel_safe_queue.popleft()
             # The block may have been re-touched (ref_cnt > 0) since it was
-            # queued; skip it in that case and let get_new_blocks handle it.
+            # queued; skip it in that case.  We must still clear the TEL-safe
+            # tag and return it to the normal LRU queue so it is not lost.
+            block.is_tel_safe = False
             if block.ref_cnt == 0 and not block.is_null:
-                # Always clear the TEL-safe tag on re-allocation regardless of
-                # whether prefix caching is enabled.
-                block.is_tel_safe = False
                 ret.append(block)
+            elif not block.is_null:
+                # Block was touched (cache hit) while sitting in tel_safe_queue.
+                # It now has ref_cnt > 0, so it is in-use; do nothing — the
+                # caller that called touch() already incremented ref_cnt.
+                # When the caller eventually frees the block it will land back in
+                # one of the two free queues through the normal free_blocks* path.
+                pass
         # Fall back to normal LRU queue for the remaining blocks.
         remaining = num_blocks - len(ret)
         if remaining > 0:
@@ -544,6 +550,16 @@ class BlockPool:
                 num_used_blocks - 1,
             )
             return False
+
+        # T-LRU: move all TEL-safe blocks back to the normal LRU queue and
+        # clear their tags.  After a cache reset the TEL-safe distinction is
+        # meaningless, and leaving blocks in tel_safe_queue with stale
+        # is_tel_safe=True flags would confuse touch() and get_new_blocks().
+        while self.tel_safe_queue:
+            block = self.tel_safe_queue.popleft()
+            block.is_tel_safe = False
+            if not block.is_null:
+                self.free_block_queue.append(block)
 
         # Remove all hashes so that no new blocks will hit.
         self.cached_block_hash_to_block = BlockHashToBlockMap()

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -41,6 +41,8 @@ class KVCacheCoordinator(ABC):
         pcp_world_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        tlru_xi_blocks: int | None = None,
+        tlru_qhat_blocks: int = 0,
     ):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
@@ -52,6 +54,8 @@ class KVCacheCoordinator(ABC):
             hash_block_size,
             enable_kv_cache_events,
             metrics_collector,
+            tlru_xi_blocks=tlru_xi_blocks,
+            tlru_qhat_blocks=tlru_qhat_blocks,
         )
 
         # Needs special handling for find_longest_cache_hit if eagle is enabled
@@ -271,6 +275,8 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         pcp_world_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        tlru_xi_blocks: int | None = None,
+        tlru_qhat_blocks: int = 0,
     ):
         super().__init__(
             kv_cache_config,
@@ -282,6 +288,8 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            tlru_xi_blocks=tlru_xi_blocks,
+            tlru_qhat_blocks=tlru_qhat_blocks,
         )
         self.num_single_type_manager = len(self.single_type_managers)
 
@@ -317,6 +325,8 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         pcp_world_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        tlru_xi_blocks: int | None = None,
+        tlru_qhat_blocks: int = 0,
     ):
         super().__init__(
             kv_cache_config,
@@ -328,6 +338,8 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            tlru_xi_blocks=tlru_xi_blocks,
+            tlru_qhat_blocks=tlru_qhat_blocks,
         )
         self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
         self.block_size = self.kv_cache_spec.block_size
@@ -382,6 +394,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         pcp_world_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        tlru_xi_blocks: int | None = None,
+        tlru_qhat_blocks: int = 0,
     ):
         super().__init__(
             kv_cache_config,
@@ -393,6 +407,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            tlru_xi_blocks=tlru_xi_blocks,
+            tlru_qhat_blocks=tlru_qhat_blocks,
         )
         # hash_block_size: the block size used to compute block hashes.
         # The actual block size usually equals hash_block_size, but in cases where
@@ -554,17 +570,24 @@ def get_kv_cache_coordinator(
     pcp_world_size: int,
     hash_block_size: int,
     metrics_collector: KVCacheMetricsCollector | None = None,
+    tlru_xi_blocks: int | None = None,
+    tlru_qhat_blocks: int = 0,
 ) -> KVCacheCoordinator:
+    common_kwargs = dict(
+        dcp_world_size=dcp_world_size,
+        pcp_world_size=pcp_world_size,
+        hash_block_size=hash_block_size,
+        metrics_collector=metrics_collector,
+        tlru_xi_blocks=tlru_xi_blocks,
+        tlru_qhat_blocks=tlru_qhat_blocks,
+    )
     if not enable_caching:
         return KVCacheCoordinatorNoPrefixCache(
             kv_cache_config,
             max_model_len,
             use_eagle,
             enable_kv_cache_events,
-            dcp_world_size=dcp_world_size,
-            pcp_world_size=pcp_world_size,
-            hash_block_size=hash_block_size,
-            metrics_collector=metrics_collector,
+            **common_kwargs,
         )
     if len(kv_cache_config.kv_cache_groups) == 1:
         return UnitaryKVCacheCoordinator(
@@ -573,10 +596,7 @@ def get_kv_cache_coordinator(
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
-            dcp_world_size=dcp_world_size,
-            pcp_world_size=pcp_world_size,
-            hash_block_size=hash_block_size,
-            metrics_collector=metrics_collector,
+            **common_kwargs,
         )
     return HybridKVCacheCoordinator(
         kv_cache_config,
@@ -584,8 +604,5 @@ def get_kv_cache_coordinator(
         use_eagle,
         enable_caching,
         enable_kv_cache_events,
-        dcp_world_size=dcp_world_size,
-        pcp_world_size=pcp_world_size,
-        hash_block_size=hash_block_size,
-        metrics_collector=metrics_collector,
+        **common_kwargs,
     )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -116,6 +116,8 @@ class KVCacheManager:
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        tlru_xi_tokens: int | None = None,
+        tlru_qhat_tokens: int = 200,
     ) -> None:
         self.max_model_len = max_model_len
 
@@ -128,6 +130,16 @@ class KVCacheManager:
         # potential configs we could expose in the future.
         self.prefix_cache_stats = PrefixCacheStats() if log_stats else None
 
+        # T-LRU: convert tokens → blocks.  block_size is taken from the first
+        # KV cache group (they must all share the same block_size for now).
+        if tlru_xi_tokens is not None and kv_cache_config.kv_cache_groups:
+            _block_size = kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size
+            tlru_xi_blocks: int | None = tlru_xi_tokens // _block_size
+            tlru_qhat_blocks: int = tlru_qhat_tokens // _block_size
+        else:
+            tlru_xi_blocks = None
+            tlru_qhat_blocks = 0
+
         self.coordinator = get_kv_cache_coordinator(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
@@ -138,6 +150,8 @@ class KVCacheManager:
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
             metrics_collector=self.metrics_collector,
+            tlru_xi_blocks=tlru_xi_blocks,
+            tlru_qhat_blocks=tlru_qhat_blocks,
         )
         self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
         self.block_pool = self.coordinator.block_pool

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import itertools
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, overload
@@ -134,8 +135,13 @@ class KVCacheManager:
         # KV cache group (they must all share the same block_size for now).
         if tlru_xi_tokens is not None and kv_cache_config.kv_cache_groups:
             _block_size = kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size
-            tlru_xi_blocks: int | None = tlru_xi_tokens // _block_size
-            tlru_qhat_blocks: int = tlru_qhat_tokens // _block_size
+            # Use ceil for xi so we are conservative (a partial block
+            # still counts toward the SLA budget).  Use ceil for qhat
+            # so the estimated prompt length is not under-counted.
+            tlru_xi_blocks: int | None = math.ceil(
+                tlru_xi_tokens / _block_size)
+            tlru_qhat_blocks: int = math.ceil(
+                tlru_qhat_tokens / _block_size)
         else:
             tlru_xi_blocks = None
             tlru_qhat_blocks = 0

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -126,6 +126,12 @@ class KVCacheBlock:
     # Whether the block is a null block that should never be cached.
     is_null: bool = False
 
+    # T-LRU: set to True at free_request() time when this block's position
+    # is beyond the TEL-safe cap B = (H + Q_hat - xi)+.  Such blocks are
+    # routed to the TEL-safe eviction queue and evicted before normal LRU
+    # blocks.  Reset to False when the block is evicted or re-allocated.
+    is_tel_safe: bool = False
+
     @property
     def block_hash(self) -> BlockHashWithGroupId | None:
         return self._block_hash

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -233,6 +233,8 @@ class Scheduler(SchedulerInterface):
             pcp_world_size=self.pcp_world_size,
             hash_block_size=self.block_size,
             metrics_collector=self.kv_metrics_collector,
+            tlru_xi_tokens=self.cache_config.tlru_xi_tokens,
+            tlru_qhat_tokens=self.cache_config.tlru_qhat_tokens,
         )
         # Bind GPU block pool to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -284,11 +284,18 @@ class SingleTypeKVCacheManager(ABC):
         req_blocks = self.req_to_blocks.pop(request_id, [])
 
         # Free blocks in reverse order so that the tail blocks are
-        # freed first.
+        # freed first (tail = suffix = furthest from prefix cache = first to
+        # evict under normal LRU, AND first to be TEL-safe under T-LRU).
         ordered_blocks = reversed(req_blocks)
 
-        self.block_pool.free_blocks(ordered_blocks)
+        if self.block_pool.tlru_xi_blocks is not None and req_blocks:
+            # T-LRU path: route suffix blocks to tel_safe_queue, prefix blocks
+            # to the normal LRU queue, based on the TEL-safe cap.
+            self.block_pool.free_blocks_tlru(ordered_blocks, len(req_blocks))
+        else:
+            self.block_pool.free_blocks(ordered_blocks)
         self.num_cached_block.pop(request_id, None)
+
 
     @abstractmethod
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:


### PR DESCRIPTION
This PR implements the T-LRU policy proposed in #37823 and our NeurIPS 2025 paper (https://arxiv.org/abs/2510.15152).

## Purpose

Implements the Tail-Optimized LRU (T-LRU) KV cache eviction policy proposed in issue #37823 and our NeurIPS 2025 paper ([arXiv:2510.15152](https://arxiv.org/abs/2510.15152)).

T-LRU is a two-queue extension of vLLM's LRU prefix cache eviction policy that reduces tail (P95/P99) TTFT by preferentially evicting KV cache blocks that are provably safe to evict without violating a user-specified latency SLA. It is fully backward-compatible: when `--tlru-xi-tokens` is not set, behavior is identical to standard LRU.

For a request with conversation history `H` blocks and estimated next-query length `Q_hat` blocks, the TEL-safe cap is `B = max(0, H + Q_hat - xi)`. Blocks at positions `B..H-1` (the suffix/tail) can be evicted without pushing the next turn's recomputation cost above `xi` tokens. T-LRU routes these blocks to a dedicated [tel_safe_queue](cci:1://file:///Users/wz2574/.gemini/antigravity/vllm/tests/v1/core/test_tlru_eviction.py:90:4-92:44) and drains it before the normal LRU queue.

## Changes

- [vllm/v1/core/kv_cache_utils.py](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/v1/core/kv_cache_utils.py:0:0-0:0): add `is_tel_safe: bool` to [KVCacheBlock](cci:2://file:///tmp/test_tlru_standalone.py:18:0-24:39)
- [vllm/v1/core/block_pool.py](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/v1/core/block_pool.py:0:0-0:0): add [tel_safe_queue](cci:1://file:///Users/wz2574/.gemini/antigravity/vllm/tests/v1/core/test_tlru_eviction.py:90:4-92:44), [free_blocks_tlru()](cci:1://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/v1/core/block_pool.py:455:4-502:53), modify [get_new_blocks()](cci:1://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/v1/core/block_pool.py:331:4-377:18) to drain [tel_safe_queue](cci:1://file:///Users/wz2574/.gemini/antigravity/vllm/tests/v1/core/test_tlru_eviction.py:90:4-92:44) first
- [vllm/v1/core/single_type_kv_cache_manager.py](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/v1/core/single_type_kv_cache_manager.py:0:0-0:0): route freed blocks to [free_blocks_tlru()](cci:1://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/v1/core/block_pool.py:455:4-502:53) when T-LRU is enabled
- [vllm/v1/core/kv_cache_coordinator.py](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/v1/core/kv_cache_coordinator.py:0:0-0:0): forward `tlru_xi_blocks`, `tlru_qhat_blocks` to [BlockPool](cci:2://file:///tmp/test_tlru_standalone.py:60:0-124:53)
- [vllm/v1/core/kv_cache_manager.py](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/v1/core/kv_cache_manager.py:0:0-0:0): convert token params to block params
- [vllm/v1/core/sched/scheduler.py](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/v1/core/sched/scheduler.py:0:0-0:0): read T-LRU params from [CacheConfig](cci:2://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/config/cache.py:29:0-247:26)
- [vllm/config/cache.py](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/config/cache.py:0:0-0:0): add `tlru_xi_tokens`, `tlru_qhat_tokens` to [CacheConfig](cci:2://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/config/cache.py:29:0-247:26) (excluded from [compute_hash](cci:1://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/config/cache.py:166:4-202:36))
- [vllm/engine/arg_utils.py](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/vllm/engine/arg_utils.py:0:0-0:0): expose `--tlru-xi-tokens`, `--tlru-qhat-tokens` CLI flags
- [tests/v1/core/test_tlru_eviction.py](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/tests/v1/core/test_tlru_eviction.py:0:0-0:0): 15 unit tests covering routing logic, queue priority, config wiring
- [docs/design/tlru_caching.md](cci:7://file:///Users/wz2574/.gemini/antigravity/vllm/docs/design/tlru_caching.md:0:0-0:0): user-facing documentation

## Test Plan

```bash
# CPU-only unit tests (no GPU required):
pytest tests/v1/core/test_tlru_eviction.py -v

# Full KV cache regression tests (requires GPU):
pytest tests/v1/core/test_kv_cache_utils.py -m cpu_test

GPU test results pending — will update