### PR TITLE
[ROCm] Fix fused RMS norm quant test failures on gfx90a

### DIFF
--- a/csrc/layernorm_quant_kernels.cu
+++ b/csrc/layernorm_quant_kernels.cu
@@ -69,7 +69,7 @@ __global__ void rms_norm_static_fp8_quant_kernel(
       // Without this, the compiler may optimize away the half-precision
       // truncation in the Half*Half->float chain, keeping extra float32
       // precision that causes 1-ULP FP8 mismatches on some architectures.
-      scalar_t out_norm = ((scalar_t)(x * s_variance)) * src2.val[j];
+      scalar_t const out_norm = ((scalar_t)(x * s_variance)) * src2.val[j];
       out[blockIdx.x * hidden_size + idx * VEC_SIZE + j] =
           scaled_fp8_conversion<true, fp8_type>(static_cast<float>(out_norm),
                                                 scale_inv);
@@ -181,7 +181,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
     float x = (float)residual[blockIdx.x * hidden_size + idx];
-    scalar_t out_norm = ((scalar_t)(x * s_variance)) * weight[idx];
+    scalar_t const out_norm = ((scalar_t)(x * s_variance)) * weight[idx];
     out[blockIdx.x * hidden_size + idx] = scaled_fp8_conversion<true, fp8_type>(
         static_cast<float>(out_norm), scale_inv);
   }

--- a/csrc/layernorm_quant_kernels.cu
+++ b/csrc/layernorm_quant_kernels.cu
@@ -65,9 +65,14 @@ __global__ void rms_norm_static_fp8_quant_kernel(
 #pragma unroll
     for (int j = 0; j < VEC_SIZE; j++) {
       float x = static_cast<float>(src1.val[j]);
-      float const out_norm = ((scalar_t)(x * s_variance)) * src2.val[j];
+      // Store as scalar_t to match the unfused rms_norm kernel's precision.
+      // Without this, the compiler may optimize away the half-precision
+      // truncation in the Half*Half->float chain, keeping extra float32
+      // precision that causes 1-ULP FP8 mismatches on some architectures.
+      scalar_t out_norm = ((scalar_t)(x * s_variance)) * src2.val[j];
       out[blockIdx.x * hidden_size + idx * VEC_SIZE + j] =
-          scaled_fp8_conversion<true, fp8_type>(out_norm, scale_inv);
+          scaled_fp8_conversion<true, fp8_type>(static_cast<float>(out_norm),
+                                                scale_inv);
     }
   }
 }
@@ -176,9 +181,9 @@ fused_add_rms_norm_static_fp8_quant_kernel(
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
     float x = (float)residual[blockIdx.x * hidden_size + idx];
-    float const out_norm = ((scalar_t)(x * s_variance)) * weight[idx];
-    out[blockIdx.x * hidden_size + idx] =
-        scaled_fp8_conversion<true, fp8_type>(out_norm, scale_inv);
+    scalar_t out_norm = ((scalar_t)(x * s_variance)) * weight[idx];
+    out[blockIdx.x * hidden_size + idx] = scaled_fp8_conversion<true, fp8_type>(
+        static_cast<float>(out_norm), scale_inv);
   }
 }
 


### PR DESCRIPTION
On gfx90a, `test_fused_rms_norm_quant` fails for ~7-9 elements out of millions with a 1-ULP FP8 difference (0.001953125) against the unfused path.

The root cause is in `rms_norm_static_fp8_quant_kernel` and the generic `fused_add_rms_norm_static_fp8_quant_kernel`. Both compute:

```
    float const out_norm = ((scalar_t)(x * s_variance)) * src2.val[j];
```

Since `c10::Half::operator*` promotes to float32 and returns Half, the full inlined chain is `__half2float(__float2half(f1 * f2))`. When the result is assigned to `float`, hipcc on gfx90a can optimize away the half truncation round-trip, keeping extra float32 precision. The unfused `rms_norm` kernel stores the same expression as `scalar_t`, which forces the truncation. This precision difference causes a few values near FP8 rounding boundaries to quantize to adjacent FP8 values.

The fix changes the intermediate from `float` to `scalar_t`, making the truncation explicit and matching the unfused kernel. This does not affect performance since the kernel is memory-bandwidth bound and the extra conversion is at most one cycle per element (and on architectures where the compiler was already materializing the Half, codegen is unchanged).

Failing tests on gfx90a (all pass on gfx950):
- test_fused_rms_norm_quant[*-dtype0-False-{768,5120,8192}-4096]


cc @kenroche 