### PR TITLE
[Bugfix] Fix GLM tool-call finish chunk suffix alignment in streaming

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2131,3 +2131,73 @@ class TestCreateRemainingArgsDelta:
         assert tc.type == "function"
         assert tc.function.name is None
         assert tc.function.arguments == '{"data": "value"}'
+
+
+class TestComputeRemainingToolArgs:
+    def test_handles_compact_prefix(self):
+        remaining = OpenAIServingChat._compute_remaining_tool_args(
+            expected_args={"a": 1},
+            streamed_args='{"a":1}',
+            latest_delta_len=1,
+        )
+
+        assert remaining == "}"
+
+    def test_handles_stringified_expected_args(self):
+        remaining = OpenAIServingChat._compute_remaining_tool_args(
+            expected_args='{"a":1}',
+            streamed_args='{"a":1}',
+            latest_delta_len=1,
+        )
+
+        assert remaining == "}"
+
+    def test_handles_glm_mixed_whitespace_prefix(self):
+        expected_args = {
+            "todos": [
+                {
+                    "content": "A",
+                    "activeForm": "B",
+                    "status": "in_progress",
+                }
+            ]
+        }
+
+        remaining = OpenAIServingChat._compute_remaining_tool_args(
+            expected_args=expected_args,
+            streamed_args=(
+                '{"todos":[{"content": "A", "activeForm": "B", '
+                '"status": "in_progress"}]}'
+            ),
+            latest_delta_len=1,
+        )
+
+        assert remaining == "}"
+
+    def test_backfills_missing_suffix_for_glm_partial_prefix(self):
+        expected_args = {
+            "todos": [
+                {
+                    "content": "A",
+                    "activeForm": "B",
+                    "status": "in_progress",
+                }
+            ]
+        }
+
+        remaining = OpenAIServingChat._compute_remaining_tool_args(
+            expected_args=expected_args,
+            streamed_args='{"todos":[{"content": "A"',
+            latest_delta_len=0,
+        )
+
+        assert remaining == ',"activeForm":"B","status":"in_progress"}]}'
+
+    def test_returns_empty_for_non_matching_prefix(self):
+        remaining = OpenAIServingChat._compute_remaining_tool_args(
+            expected_args={"a": 1},
+            streamed_args="not-json",
+            latest_delta_len=0,
+        )
+
+        assert remaining == ""

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -844,33 +844,15 @@ class OpenAIServingChat(OpenAIServing):
                                     delta_message.tool_calls[0].function.arguments
                                 )
 
-                            # get the expected call based on partial JSON
-                            # parsing which "autocompletes" the JSON.
-                            # Tool parsers (e.g. Qwen3Coder) store
-                            # arguments as a JSON string in
-                            # prev_tool_call_arr. Calling json.dumps()
-                            # on an already-serialized string would
-                            # double-serialize it (e.g. '{"k":1}' becomes
-                            # '"{\\"k\\":1}"'), which then causes the
-                            # replace() below to fail and append the
-                            # entire double-serialized string as a
-                            # spurious final delta.
-                            args = tool_parser.prev_tool_call_arr[index].get(
-                                "arguments", {}
+                            remaining_call = self._compute_remaining_tool_args(
+                                expected_args=tool_parser.prev_tool_call_arr[
+                                    index
+                                ].get("arguments", {}),
+                                streamed_args=tool_parser.streamed_args_for_tool[
+                                    index
+                                ],
+                                latest_delta_len=latest_delta_len,
                             )
-                            if isinstance(args, str):
-                                expected_call = args
-                            else:
-                                expected_call = json.dumps(args, ensure_ascii=False)
-
-                            # get what we've streamed so far for arguments
-                            # for the current tool
-                            actual_call = tool_parser.streamed_args_for_tool[index]
-                            if latest_delta_len > 0:
-                                actual_call = actual_call[:-latest_delta_len]
-
-                            # check to see if there's anything left to stream
-                            remaining_call = expected_call.replace(actual_call, "", 1)
                             # set that as a delta message
                             delta_message = self._create_remaining_args_delta(
                                 delta_message, remaining_call, index
@@ -1569,3 +1551,91 @@ class OpenAIServingChat(OpenAIServing):
                 )
             ]
         )
+
+    @staticmethod
+    def _compact_json_fragment(fragment: str) -> str:
+        """Strip insignificant JSON whitespace while preserving string content."""
+        compact_chars: list[str] = []
+        in_string = False
+        escaped = False
+
+        for ch in fragment:
+            if in_string:
+                compact_chars.append(ch)
+                if escaped:
+                    escaped = False
+                elif ch == "\\":
+                    escaped = True
+                elif ch == '"':
+                    in_string = False
+                continue
+
+            if ch in " \t\r\n":
+                continue
+
+            compact_chars.append(ch)
+            if ch == '"':
+                in_string = True
+
+        return "".join(compact_chars)
+
+    @classmethod
+    def _compute_remaining_tool_args(
+        cls,
+        expected_args: Any,
+        streamed_args: str,
+        latest_delta_len: int,
+    ) -> str:
+        """
+        Compute the unstreamed suffix for the finish chunk.
+
+        GLM parsers can emit prefixes whose whitespace differs from
+        ``json.dumps`` output, including mixed styles within the same object.
+        Try exact prefix matches first, then fall back to comparing
+        whitespace-minified prefixes against compact JSON.
+        """
+        actual_call = (
+            streamed_args[:-latest_delta_len]
+            if latest_delta_len > 0
+            else streamed_args
+        )
+
+        expected_call_candidates: list[str] = []
+        parsed_expected_args: Any = expected_args
+
+        if isinstance(expected_args, str):
+            expected_call_candidates.append(expected_args)
+            try:
+                parsed_expected_args = json.loads(expected_args)
+            except json.JSONDecodeError:
+                parsed_expected_args = expected_args
+        else:
+            expected_call_candidates.append(
+                json.dumps(expected_args, ensure_ascii=False)
+            )
+
+        expected_compact = ""
+        if not isinstance(parsed_expected_args, str):
+            expected_compact = json.dumps(
+                parsed_expected_args,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            if expected_compact not in expected_call_candidates:
+                expected_call_candidates.append(expected_compact)
+
+        for expected_call in expected_call_candidates:
+            if expected_call.startswith(actual_call):
+                return expected_call[len(actual_call) :]
+
+        if expected_compact:
+            actual_compact = cls._compact_json_fragment(actual_call)
+            if expected_compact.startswith(actual_compact):
+                return expected_compact[len(actual_compact) :]
+
+        if actual_call:
+            logger.debug(
+                "Unable to align streamed tool args with expected suffix; "
+                "skip finish backfill.",
+            )
+        return ""


### PR DESCRIPTION
## Summary

Fix the streaming finish-chunk logic for GLM tool calls when the parser's streamed JSON prefix does not exactly match `json.dumps(...)` formatting.

Current `OpenAIServingChat` computes the final tool-argument delta by serializing the parser state and calling `replace()` against the streamed prefix. That is brittle for GLM parsers because the streamed prefix is not always serialized in a single stable style:

- some runs are compact, e.g. `{"a":1}`
- some are default-spaced, e.g. `{"a": 1}`
- some GLM outputs are mixed, e.g. the outer object is compact but nested objects keep default whitespace

When `replace()` cannot align the prefix, the finish chunk either re-emits the full object (duplicated-value malformed JSON) or fails to backfill the missing suffix.

This PR fixes the suffix computation centrally in `OpenAIServingChat` by:

1. trying exact prefix matches against string-backed, default `json.dumps`, and compact `json.dumps(..., separators=(",", ":"))` candidates;
2. falling back to whitespace-minified prefix comparison for mixed-whitespace GLM fragments;
3. returning an empty suffix if nothing aligns, instead of re-emitting the whole object.

This keeps the existing GLM parser contract unchanged and fixes the finish-chunk backfill in the serving layer rather than mutating parser state.

Rebased on latest `upstream/main` at `1c8e9c039` on 2026-05-17. The issue still exists on that commit: the upstream `expected_call.replace(actual_call, "", 1)` path still re-emits the full expected object for a mixed-whitespace GLM prefix.

Fixes #36857

## Duplicate-work check

Commands run on 2026-05-17:

```bash
gh issue view 36857 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "36857 in:body"
gh pr list --repo vllm-project/vllm --state open --search "GLM tool finish suffix alignment"
```

Results: the open-PR searches returned only this PR, #37845. Issue comments mention earlier parser-side PRs and later GLM5.1 reports, but I did not find another open PR covering this serving-layer mixed-whitespace suffix fix.

## Tests

Commands run:

```bash
.venv/bin/python -m py_compile \
  vllm/entrypoints/openai/chat_completion/serving.py \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py

git diff --check upstream/main...HEAD

.venv/bin/python - <<'PY'
# Focused suffix-alignment check: legacy upstream logic re-emits the full
# expected object for mixed-whitespace GLM prefixes; the rebased helper returns
# only the missing suffix and returns empty for non-matching prefixes.
PY

.venv/bin/python -m pytest \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py \
  -k "TestCreateRemainingArgsDelta or TestComputeRemainingToolArgs" -q
```

Results:

- `py_compile`: passed
- `git diff --check`: passed
- focused suffix-alignment check: passed; legacy logic re-emits the full object, rebased helper returns `}` / the compact missing suffix / `''` for a bad prefix
- targeted pytest: not completed in this fresh venv because collection loads `tests/conftest.py`, which requires runtime dependencies not installed here (`torch`; after installing `pytest`, `tblib`, and `numpy`)

AI assistance was used for this PR update; the submitter should review the rebased diff and test results before merge.