### PR TITLE
feat: Add OpenAI Conversations API support

### DIFF
--- a/vllm/entrypoints/openai/responses/api_router.py
+++ b/vllm/entrypoints/openai/responses/api_router.py
@@ -126,6 +126,13 @@ async def cancel_responses(response_id: str, raw_request: Request):
 # ---- Conversations API ----
 
 
+def _require_handler(raw_request: Request) -> OpenAIServingResponses:
+    handler = responses(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Responses API")
+    return handler
+
+
 def _json_or_error(result):
     """Return JSONResponse for success or error."""
     if isinstance(result, ErrorResponse):
@@ -141,23 +148,18 @@ def _json_or_error(result):
     },
 )
 @load_aware_call
-async def create_conversation(
-    request: CreateConversationRequest,
-    raw_request: Request,
-):
-    handler = responses(raw_request)
-    if handler is None:
-        raise NotImplementedError("The model does not support Responses API")
-    return _json_or_error(await handler.create_conversation(request))
+async def create_conversation(request: CreateConversationRequest, raw_request: Request):
+    return _json_or_error(
+        await _require_handler(raw_request).create_conversation(request)
+    )
 
 
 @router.get("/v1/conversations/{conv_id}")
 @load_aware_call
 async def retrieve_conversation(conv_id: str, raw_request: Request):
-    handler = responses(raw_request)
-    if handler is None:
-        raise NotImplementedError("The model does not support Responses API")
-    return _json_or_error(await handler.retrieve_conversation(conv_id))
+    return _json_or_error(
+        await _require_handler(raw_request).retrieve_conversation(conv_id)
+    )
 
 
 @router.post(
@@ -166,23 +168,19 @@ async def retrieve_conversation(conv_id: str, raw_request: Request):
 )
 @load_aware_call
 async def update_conversation(
-    conv_id: str,
-    request: UpdateConversationRequest,
-    raw_request: Request,
+    conv_id: str, request: UpdateConversationRequest, raw_request: Request
 ):
-    handler = responses(raw_request)
-    if handler is None:
-        raise NotImplementedError("The model does not support Responses API")
-    return _json_or_error(await handler.update_conversation(conv_id, request))
+    return _json_or_error(
+        await _require_handler(raw_request).update_conversation(conv_id, request)
+    )
 
 
 @router.delete("/v1/conversations/{conv_id}")
 @load_aware_call
 async def delete_conversation(conv_id: str, raw_request: Request):
-    handler = responses(raw_request)
-    if handler is None:
-        raise NotImplementedError("The model does not support Responses API")
-    return _json_or_error(await handler.delete_conversation(conv_id))
+    return _json_or_error(
+        await _require_handler(raw_request).delete_conversation(conv_id)
+    )
 
 
 @router.post(
@@ -191,14 +189,11 @@ async def delete_conversation(conv_id: str, raw_request: Request):
 )
 @load_aware_call
 async def add_conversation_items(
-    conv_id: str,
-    request: AddConversationItemsRequest,
-    raw_request: Request,
+    conv_id: str, request: AddConversationItemsRequest, raw_request: Request
 ):
-    handler = responses(raw_request)
-    if handler is None:
-        raise NotImplementedError("The model does not support Responses API")
-    return _json_or_error(await handler.add_conversation_items(conv_id, request))
+    return _json_or_error(
+        await _require_handler(raw_request).add_conversation_items(conv_id, request)
+    )
 
 
 @router.get("/v1/conversations/{conv_id}/items")
@@ -211,11 +206,8 @@ async def list_conversation_items(
     before: str | None = None,
     order: str = "asc",
 ):
-    handler = responses(raw_request)
-    if handler is None:
-        raise NotImplementedError("The model does not support Responses API")
     return _json_or_error(
-        await handler.list_conversation_items(
+        await _require_handler(raw_request).list_conversation_items(
             conv_id, limit=limit, after=after, before=before, order=order
         )
     )
@@ -223,28 +215,18 @@ async def list_conversation_items(
 
 @router.get("/v1/conversations/{conv_id}/items/{item_id}")
 @load_aware_call
-async def retrieve_conversation_item(
-    conv_id: str,
-    item_id: str,
-    raw_request: Request,
-):
-    handler = responses(raw_request)
-    if handler is None:
-        raise NotImplementedError("The model does not support Responses API")
-    return _json_or_error(await handler.retrieve_conversation_item(conv_id, item_id))
+async def retrieve_conversation_item(conv_id: str, item_id: str, raw_request: Request):
+    return _json_or_error(
+        await _require_handler(raw_request).retrieve_conversation_item(conv_id, item_id)
+    )
 
 
 @router.delete("/v1/conversations/{conv_id}/items/{item_id}")
 @load_aware_call
-async def delete_conversation_item(
-    conv_id: str,
-    item_id: str,
-    raw_request: Request,
-):
-    handler = responses(raw_request)
-    if handler is None:
-        raise NotImplementedError("The model does not support Responses API")
-    return _json_or_error(await handler.delete_conversation_item(conv_id, item_id))
+async def delete_conversation_item(conv_id: str, item_id: str, raw_request: Request):
+    return _json_or_error(
+        await _require_handler(raw_request).delete_conversation_item(conv_id, item_id)
+    )
 
 
 def attach_router(app: FastAPI):

--- a/vllm/entrypoints/openai/responses/api_router.py
+++ b/vllm/entrypoints/openai/responses/api_router.py
@@ -10,9 +10,12 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.openai.responses.protocol import (
+    AddConversationItemsRequest,
+    CreateConversationRequest,
     ResponsesRequest,
     ResponsesResponse,
     StreamingResponsesResponse,
+    UpdateConversationRequest,
 )
 from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
 from vllm.entrypoints.openai.utils import validate_json_request
@@ -118,6 +121,130 @@ async def cancel_responses(response_id: str, raw_request: Request):
             content=response.model_dump(), status_code=response.error.code
         )
     return JSONResponse(content=response.model_dump())
+
+
+# ---- Conversations API ----
+
+
+def _json_or_error(result):
+    """Return JSONResponse for success or error."""
+    if isinstance(result, ErrorResponse):
+        return JSONResponse(content=result.model_dump(), status_code=result.error.code)
+    return JSONResponse(content=result.model_dump())
+
+
+@router.post(
+    "/v1/conversations",
+    dependencies=[Depends(validate_json_request)],
+    responses={
+        HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
+    },
+)
+@load_aware_call
+async def create_conversation(
+    request: CreateConversationRequest,
+    raw_request: Request,
+):
+    handler = responses(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Responses API")
+    return _json_or_error(await handler.create_conversation(request))
+
+
+@router.get("/v1/conversations/{conv_id}")
+@load_aware_call
+async def retrieve_conversation(conv_id: str, raw_request: Request):
+    handler = responses(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Responses API")
+    return _json_or_error(await handler.retrieve_conversation(conv_id))
+
+
+@router.post(
+    "/v1/conversations/{conv_id}",
+    dependencies=[Depends(validate_json_request)],
+)
+@load_aware_call
+async def update_conversation(
+    conv_id: str,
+    request: UpdateConversationRequest,
+    raw_request: Request,
+):
+    handler = responses(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Responses API")
+    return _json_or_error(await handler.update_conversation(conv_id, request))
+
+
+@router.delete("/v1/conversations/{conv_id}")
+@load_aware_call
+async def delete_conversation(conv_id: str, raw_request: Request):
+    handler = responses(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Responses API")
+    return _json_or_error(await handler.delete_conversation(conv_id))
+
+
+@router.post(
+    "/v1/conversations/{conv_id}/items",
+    dependencies=[Depends(validate_json_request)],
+)
+@load_aware_call
+async def add_conversation_items(
+    conv_id: str,
+    request: AddConversationItemsRequest,
+    raw_request: Request,
+):
+    handler = responses(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Responses API")
+    return _json_or_error(await handler.add_conversation_items(conv_id, request))
+
+
+@router.get("/v1/conversations/{conv_id}/items")
+@load_aware_call
+async def list_conversation_items(
+    conv_id: str,
+    raw_request: Request,
+    limit: int = 20,
+    after: str | None = None,
+    before: str | None = None,
+    order: str = "asc",
+):
+    handler = responses(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Responses API")
+    return _json_or_error(
+        await handler.list_conversation_items(
+            conv_id, limit=limit, after=after, before=before, order=order
+        )
+    )
+
+
+@router.get("/v1/conversations/{conv_id}/items/{item_id}")
+@load_aware_call
+async def retrieve_conversation_item(
+    conv_id: str,
+    item_id: str,
+    raw_request: Request,
+):
+    handler = responses(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Responses API")
+    return _json_or_error(await handler.retrieve_conversation_item(conv_id, item_id))
+
+
+@router.delete("/v1/conversations/{conv_id}/items/{item_id}")
+@load_aware_call
+async def delete_conversation_item(
+    conv_id: str,
+    item_id: str,
+    raw_request: Request,
+):
+    handler = responses(raw_request)
+    if handler is None:
+        raise NotImplementedError("The model does not support Responses API")
+    return _json_or_error(await handler.delete_conversation_item(conv_id, item_id))
 
 
 def attach_router(app: FastAPI):

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -157,6 +157,7 @@ class ResponsesRequest(OpenAIBaseModel):
     logit_bias: dict[str, float] | None = None
     parallel_tool_calls: bool | None = True
     previous_response_id: str | None = None
+    conversation: str | dict[str, str] | None = None
     prompt: ResponsePrompt | None = None
     reasoning: Reasoning | None = None
     service_tier: Literal["auto", "default", "flex", "scale", "priority"] = "auto"
@@ -404,6 +405,17 @@ class ResponsesRequest(OpenAIBaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def validate_conversation_exclusivity(cls, data):
+        conv = data.get("conversation")
+        if conv and data.get("previous_response_id"):
+            raise VLLMValidationError(
+                "`conversation` and `previous_response_id` cannot be used together.",
+                parameter="conversation",
+            )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def validate_prompt(cls, data):
         if data.get("prompt") is not None:
             raise VLLMValidationError(
@@ -467,6 +479,28 @@ class ResponsesRequest(OpenAIBaseModel):
         return data
 
 
+def _extract_conversation_response(
+    conversation: str | dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Normalize the conversation field for the response object."""
+    if conversation is None:
+        return None
+    if isinstance(conversation, str):
+        return {"id": conversation}
+    return conversation
+
+
+def extract_conversation_id(
+    conversation: str | dict[str, str] | None,
+) -> str | None:
+    """Extract a plain conversation ID string from the request field."""
+    if conversation is None:
+        return None
+    if isinstance(conversation, str):
+        return conversation
+    return conversation.get("id")
+
+
 class ResponsesResponse(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"resp_{random_uuid()}")
     created_at: int = Field(default_factory=lambda: int(time.time()))
@@ -486,6 +520,7 @@ class ResponsesResponse(OpenAIBaseModel):
     max_output_tokens: int
     max_tool_calls: int | None = None
     previous_response_id: str | None = None
+    conversation: dict[str, str] | None = None
     prompt: ResponsePrompt | None = None
     reasoning: Reasoning | None = None
     service_tier: Literal["auto", "default", "flex", "scale", "priority"]
@@ -571,6 +606,7 @@ class ResponsesResponse(OpenAIBaseModel):
             max_output_tokens=sampling_params.max_tokens,
             max_tool_calls=request.max_tool_calls,
             previous_response_id=request.previous_response_id,
+            conversation=_extract_conversation_response(request.conversation),
             prompt=request.prompt,
             reasoning=request.reasoning,
             service_tier=request.service_tier,
@@ -667,3 +703,88 @@ StreamingResponsesResponse: TypeAlias = (
     | ResponseMcpCallInProgressEvent
     | ResponseMcpCallCompletedEvent
 )
+
+
+# ---- Conversations API ----
+
+
+class ConversationObject(OpenAIBaseModel):
+    id: str = Field(default_factory=lambda: f"conv_{random_uuid()}")
+    object: Literal["conversation"] = "conversation"
+    created_at: int = Field(default_factory=lambda: int(time.time()))
+    metadata: Metadata | None = None
+
+
+class DeletedConversationObject(OpenAIBaseModel):
+    id: str
+    object: Literal["conversation.deleted"] = "conversation.deleted"
+    deleted: bool = True
+
+
+class ConversationItemObject(OpenAIBaseModel):
+    """A stored conversation item wrapping a ResponseInputOutputItem."""
+
+    id: str = Field(default_factory=lambda: f"item_{random_uuid()}")
+    object: Literal["conversation.item"] = "conversation.item"
+    type: str = "message"
+    item: ResponseInputOutputItem
+
+    @model_validator(mode="before")
+    @classmethod
+    def extract_type(cls, data):
+        if isinstance(data, dict):
+            item = data.get("item")
+            if isinstance(item, dict):
+                data["type"] = item.get("type", "message")
+            elif hasattr(item, "type"):
+                data["type"] = item.type
+        return data
+
+
+class ConversationItemList(OpenAIBaseModel):
+    object: Literal["list"] = "list"
+    data: list[ConversationItemObject]
+    first_id: str | None = None
+    last_id: str | None = None
+    has_more: bool = False
+
+
+class DeletedConversationItemObject(OpenAIBaseModel):
+    id: str
+    object: Literal["conversation.item.deleted"] = "conversation.item.deleted"
+    deleted: bool = True
+
+
+class CreateConversationRequest(OpenAIBaseModel):
+    metadata: Metadata | None = None
+    items: list[ResponseInputOutputItem] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_items_limit(cls, data):
+        items = data.get("items")
+        if items is not None and len(items) > 20:
+            raise VLLMValidationError(
+                "Conversations may have at most 20 seed items.",
+                parameter="items",
+            )
+        return data
+
+
+class UpdateConversationRequest(OpenAIBaseModel):
+    metadata: Metadata | None = None
+
+
+class AddConversationItemsRequest(OpenAIBaseModel):
+    items: list[ResponseInputOutputItem]
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_items_limit(cls, data):
+        items = data.get("items", [])
+        if len(items) > 20:
+            raise VLLMValidationError(
+                "May add at most 20 items per call.",
+                parameter="items",
+            )
+        return data

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -112,6 +112,7 @@ from vllm.entrypoints.openai.responses.streaming_events import (
     emit_tool_action_events,
 )
 from vllm.entrypoints.openai.responses.utils import (
+    construct_chat_messages_with_tool_call,
     construct_input_messages,
     construct_tool_dicts,
     extract_tool_types,
@@ -627,10 +628,6 @@ class OpenAIServingResponses(OpenAIServing):
 
         # Build prev_msg from conversation items if provided.
         if conv_items is not None:
-            from vllm.entrypoints.openai.responses.utils import (
-                construct_chat_messages_with_tool_call,
-            )
-
             prev_msg = construct_chat_messages_with_tool_call(conv_items)
         elif prev_response:
             prev_msg = self.msg_store.get(prev_response.id)
@@ -1560,14 +1557,11 @@ class OpenAIServingResponses(OpenAIServing):
 
         if after:
             idx = next((i for i, ci in enumerate(items) if ci.id == after), -1)
-            items = items[idx + 1 :] if idx >= 0 else items
+            items = items[idx + 1 :] if idx >= 0 else []
 
         if before:
-            idx = next(
-                (i for i, ci in enumerate(items) if ci.id == before),
-                len(items),
-            )
-            items = items[:idx]
+            idx = next((i for i, ci in enumerate(items) if ci.id == before), -1)
+            items = items[:idx] if idx >= 0 else []
 
         has_more = len(items) > limit
         page = items[:limit]

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -82,6 +82,13 @@ from vllm.entrypoints.openai.responses.harmony import (
     response_input_to_harmony,
 )
 from vllm.entrypoints.openai.responses.protocol import (
+    AddConversationItemsRequest,
+    ConversationItemList,
+    ConversationItemObject,
+    ConversationObject,
+    CreateConversationRequest,
+    DeletedConversationItemObject,
+    DeletedConversationObject,
     InputTokensDetails,
     OutputTokensDetails,
     ResponseCompletedEvent,
@@ -95,6 +102,8 @@ from vllm.entrypoints.openai.responses.protocol import (
     ResponsesResponse,
     ResponseUsage,
     StreamingResponsesResponse,
+    UpdateConversationRequest,
+    extract_conversation_id,
 )
 from vllm.entrypoints.openai.responses.streaming_events import (
     StreamingState,
@@ -265,6 +274,11 @@ class OpenAIServingResponses(OpenAIServing):
 
         self.background_tasks: dict[str, asyncio.Task] = {}
 
+        # Conversations API stores (same pattern as response_store/msg_store)
+        self.conversation_store: dict[str, ConversationObject] = {}
+        self.conversation_store_lock = asyncio.Lock()
+        self.conversation_items_store: dict[str, list[ConversationItemObject]] = {}
+
         self.tool_server = tool_server
 
     def _validate_generator_input(
@@ -321,6 +335,25 @@ class OpenAIServingResponses(OpenAIServing):
                 status_code=HTTPStatus.BAD_REQUEST,
                 param="previous_response_id",
             )
+        conv_id = extract_conversation_id(request.conversation)
+        if conv_id is not None:
+            if not self.enable_store:
+                return self.create_error_response(
+                    err_type="invalid_request_error",
+                    message=(
+                        "`conversation` requires `VLLM_ENABLE_RESPONSES_API_STORE=1`."
+                    ),
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    param="conversation",
+                )
+            if request.previous_input_messages:
+                return self.create_error_response(
+                    err_type="invalid_request_error",
+                    message="`conversation` and `previous_input_messages` "
+                    "cannot be used together.",
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    param="conversation",
+                )
         return None
 
     async def create_responses(
@@ -365,15 +398,27 @@ class OpenAIServingResponses(OpenAIServing):
         else:
             prev_response = None
 
+        # Handle the conversation parameter.
+        conv_id = extract_conversation_id(request.conversation)
+        conv_items: list[ResponseInputOutputItem] | None = None
+        if conv_id is not None:
+            async with self.conversation_store_lock:
+                if conv_id not in self.conversation_store:
+                    return self._make_conversation_not_found_error(conv_id)
+                raw_items = self.conversation_items_store.get(conv_id, [])
+                conv_items = [ci.item for ci in raw_items]
+
         lora_request = self._maybe_get_adapters(request)
         model_name = self.models.model_name(lora_request)
 
         if self.use_harmony:
             messages, engine_prompts = self._make_request_with_harmony(
-                request, prev_response
+                request, prev_response, conv_items=conv_items
             )
         else:
-            messages, engine_prompts = await self._make_request(request, prev_response)
+            messages, engine_prompts = await self._make_request(
+                request, prev_response, conv_items=conv_items
+            )
 
         request_metadata = RequestResponseMetadata(request_id=request.request_id)
         if raw_request:
@@ -576,14 +621,30 @@ class OpenAIServingResponses(OpenAIServing):
         self,
         request: ResponsesRequest,
         prev_response: ResponsesResponse | None,
+        conv_items: list[ResponseInputOutputItem] | None = None,
     ):
         tool_dicts = construct_tool_dicts(request.tools, request.tool_choice)
+
+        # Build prev_msg from conversation items if provided.
+        if conv_items is not None:
+            from vllm.entrypoints.openai.responses.utils import (
+                construct_chat_messages_with_tool_call,
+            )
+
+            prev_msg = construct_chat_messages_with_tool_call(conv_items)
+        elif prev_response:
+            prev_msg = self.msg_store.get(prev_response.id)
+        else:
+            prev_msg = None
+
         # Construct the input messages.
         messages = construct_input_messages(
             request_instructions=request.instructions,
             request_input=request.input,
-            prev_msg=self.msg_store.get(prev_response.id) if prev_response else None,
-            prev_response_output=prev_response.output if prev_response else None,
+            prev_msg=prev_msg,
+            prev_response_output=(
+                prev_response.output if prev_response and conv_items is None else None
+            ),
         )
 
         _, engine_prompts = await self.openai_serving_render.preprocess_chat(
@@ -704,13 +765,16 @@ class OpenAIServingResponses(OpenAIServing):
         self,
         request: ResponsesRequest,
         prev_response: ResponsesResponse | None,
+        conv_items: list[ResponseInputOutputItem] | None = None,
     ):
         if request.tool_choice != "auto":
             raise NotImplementedError(
                 "Only 'auto' tool_choice is supported in response API with Harmony"
             )
 
-        messages = self._construct_input_messages_with_harmony(request, prev_response)
+        messages = self._construct_input_messages_with_harmony(
+            request, prev_response, conv_items=conv_items
+        )
         prompt_token_ids = render_for_completion(messages)
         engine_prompt = token_inputs(prompt_token_ids)
 
@@ -882,7 +946,49 @@ class OpenAIServingResponses(OpenAIServing):
                 # If the response is already cancelled, don't update it.
                 if stored_response is None or stored_response.status != "cancelled":
                     self.response_store[response.id] = response
+
+        # Auto-append input + output to conversation store.
+        conv_id = extract_conversation_id(request.conversation)
+        if conv_id is not None and response.status not in (
+            "cancelled",
+            "failed",
+        ):
+            await self._append_response_to_conversation(conv_id, request, response)
+
         return response
+
+    async def _append_response_to_conversation(
+        self,
+        conv_id: str,
+        request: ResponsesRequest,
+        response: ResponsesResponse,
+    ) -> None:
+        """Append request input + response output items to conversation."""
+        new_items: list[ConversationItemObject] = []
+
+        # Input items
+        if isinstance(request.input, str):
+            new_items.append(
+                ConversationItemObject(
+                    type="message",
+                    item={
+                        "role": "user",
+                        "content": request.input,
+                        "type": "message",
+                    },
+                )
+            )
+        else:
+            for item in request.input:
+                new_items.append(ConversationItemObject(item=item))
+
+        # Output items
+        for output_item in response.output:
+            new_items.append(ConversationItemObject(item=output_item))
+
+        async with self.conversation_store_lock:
+            if conv_id in self.conversation_store:
+                self.conversation_items_store.setdefault(conv_id, []).extend(new_items)
 
     def _topk_logprobs(
         self,
@@ -1126,9 +1232,33 @@ class OpenAIServingResponses(OpenAIServing):
         self,
         request: ResponsesRequest,
         prev_response: ResponsesResponse | None,
+        conv_items: list[ResponseInputOutputItem] | None = None,
     ) -> list[OpenAIHarmonyMessage]:
         messages: list[OpenAIHarmonyMessage] = []
-        if prev_response is None:
+        if conv_items is not None:
+            # Conversation mode: build system message + convert conv_items
+            # to harmony messages, then append new input.
+            tool_types = extract_tool_types(request.tools)
+            with_custom_tools = has_custom_tools(tool_types)
+            sys_msg = self._construct_harmony_system_input_message(
+                request, with_custom_tools, tool_types
+            )
+            messages.append(sys_msg)
+            if with_custom_tools:
+                dev_msg = get_developer_message(
+                    instructions=request.instructions, tools=request.tools
+                )
+                messages.append(dev_msg)
+            # Convert conversation items to harmony messages.
+            prev_outputs: list[ResponseInputOutputItem] = []
+            for item in conv_items:
+                new_msg = response_input_to_harmony(item, prev_outputs)
+                if new_msg is not None and new_msg.author.role != "system":
+                    messages.append(new_msg)
+                if isinstance(item, ResponseFunctionToolCall):
+                    prev_outputs.append(item)
+
+        elif prev_response is None:
             # New conversation.
             tool_types = extract_tool_types(request.tools)
             with_custom_tools = has_custom_tools(tool_types)
@@ -1322,6 +1452,167 @@ class OpenAIServingResponses(OpenAIServing):
             message=f"Response with id '{response_id}' not found.",
             status_code=HTTPStatus.NOT_FOUND,
             param="response_id",
+        )
+
+    # ---- Conversations API CRUD ----
+
+    def _make_conversation_not_found_error(self, conv_id: str) -> ErrorResponse:
+        return self.create_error_response(
+            err_type="invalid_request_error",
+            message=f"Conversation with id '{conv_id}' not found.",
+            status_code=HTTPStatus.NOT_FOUND,
+            param="conversation_id",
+        )
+
+    async def create_conversation(
+        self,
+        request: CreateConversationRequest,
+    ) -> ConversationObject | ErrorResponse:
+        if not self.enable_store:
+            return self.create_error_response(
+                err_type="invalid_request_error",
+                message="Conversations require `VLLM_ENABLE_RESPONSES_API_STORE=1`.",
+                status_code=HTTPStatus.BAD_REQUEST,
+                param="store",
+            )
+
+        conv = ConversationObject(metadata=request.metadata)
+        items: list[ConversationItemObject] = []
+        if request.items:
+            for item in request.items:
+                items.append(ConversationItemObject(item=item))
+
+        async with self.conversation_store_lock:
+            self.conversation_store[conv.id] = conv
+            self.conversation_items_store[conv.id] = items
+        return conv
+
+    async def retrieve_conversation(
+        self,
+        conv_id: str,
+    ) -> ConversationObject | ErrorResponse:
+        async with self.conversation_store_lock:
+            conv = self.conversation_store.get(conv_id)
+        if conv is None:
+            return self._make_conversation_not_found_error(conv_id)
+        return conv
+
+    async def update_conversation(
+        self,
+        conv_id: str,
+        request: UpdateConversationRequest,
+    ) -> ConversationObject | ErrorResponse:
+        async with self.conversation_store_lock:
+            conv = self.conversation_store.get(conv_id)
+            if conv is None:
+                return self._make_conversation_not_found_error(conv_id)
+            conv.metadata = request.metadata
+        return conv
+
+    async def delete_conversation(
+        self,
+        conv_id: str,
+    ) -> DeletedConversationObject | ErrorResponse:
+        async with self.conversation_store_lock:
+            conv = self.conversation_store.pop(conv_id, None)
+        if conv is None:
+            return self._make_conversation_not_found_error(conv_id)
+        # Items survive deletion per OpenAI spec.
+        return DeletedConversationObject(id=conv_id)
+
+    async def add_conversation_items(
+        self,
+        conv_id: str,
+        request: AddConversationItemsRequest,
+    ) -> ConversationItemList | ErrorResponse:
+        async with self.conversation_store_lock:
+            if conv_id not in self.conversation_store:
+                return self._make_conversation_not_found_error(conv_id)
+            new_items: list[ConversationItemObject] = []
+            for item in request.items:
+                new_items.append(ConversationItemObject(item=item))
+            self.conversation_items_store.setdefault(conv_id, []).extend(new_items)
+        return ConversationItemList(
+            data=new_items,
+            first_id=new_items[0].id if new_items else None,
+            last_id=new_items[-1].id if new_items else None,
+            has_more=False,
+        )
+
+    async def list_conversation_items(
+        self,
+        conv_id: str,
+        limit: int = 20,
+        after: str | None = None,
+        before: str | None = None,
+        order: str = "asc",
+    ) -> ConversationItemList | ErrorResponse:
+        async with self.conversation_store_lock:
+            if conv_id not in self.conversation_store:
+                return self._make_conversation_not_found_error(conv_id)
+            items = list(self.conversation_items_store.get(conv_id, []))
+
+        # Apply cursors on insertion-order list first, then reverse.
+        if after:
+            idx = next((i for i, ci in enumerate(items) if ci.id == after), -1)
+            items = items[idx + 1 :] if idx >= 0 else items
+
+        if before:
+            idx = next(
+                (i for i, ci in enumerate(items) if ci.id == before),
+                len(items),
+            )
+            items = items[:idx]
+
+        if order == "desc":
+            items = list(reversed(items))
+
+        has_more = len(items) > limit
+        page = items[:limit]
+        return ConversationItemList(
+            data=page,
+            first_id=page[0].id if page else None,
+            last_id=page[-1].id if page else None,
+            has_more=has_more,
+        )
+
+    async def retrieve_conversation_item(
+        self,
+        conv_id: str,
+        item_id: str,
+    ) -> ConversationItemObject | ErrorResponse:
+        async with self.conversation_store_lock:
+            if conv_id not in self.conversation_store:
+                return self._make_conversation_not_found_error(conv_id)
+            items = self.conversation_items_store.get(conv_id, [])
+            for ci in items:
+                if ci.id == item_id:
+                    return ci
+        return self.create_error_response(
+            err_type="invalid_request_error",
+            message=f"Item with id '{item_id}' not found.",
+            status_code=HTTPStatus.NOT_FOUND,
+            param="item_id",
+        )
+
+    async def delete_conversation_item(
+        self,
+        conv_id: str,
+        item_id: str,
+    ) -> DeletedConversationItemObject | ErrorResponse:
+        async with self.conversation_store_lock:
+            if conv_id not in self.conversation_store:
+                return self._make_conversation_not_found_error(conv_id)
+            items = self.conversation_items_store.get(conv_id, [])
+            for i, ci in enumerate(items):
+                if ci.id == item_id:
+                    items.pop(i)
+                    return DeletedConversationItemObject(id=item_id)
+        return self.create_error_response(
+            err_type="invalid_request_error",
+            message=f"Item with id '{item_id}' not found.",
+            status_code=HTTPStatus.NOT_FOUND,
+            param="item_id",
         )
 
     async def _process_simple_streaming_events(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1314,7 +1314,9 @@ class OpenAIServingResponses(OpenAIServing):
             if request.input or not request.previous_input_messages:
                 messages.append(get_user_message(request.input))
         else:
-            if prev_response is not None:
+            if conv_items is not None:
+                prev_outputs = list(conv_items)
+            elif prev_response is not None:
                 prev_outputs = copy(prev_response.output)
             else:
                 prev_outputs = []
@@ -1552,7 +1554,10 @@ class OpenAIServingResponses(OpenAIServing):
                 return self._make_conversation_not_found_error(conv_id)
             items = list(self.conversation_items_store.get(conv_id, []))
 
-        # Apply cursors on insertion-order list first, then reverse.
+        # Reverse first so cursors operate on the client-visible order.
+        if order == "desc":
+            items = list(reversed(items))
+
         if after:
             idx = next((i for i, ci in enumerate(items) if ci.id == after), -1)
             items = items[idx + 1 :] if idx >= 0 else items
@@ -1563,9 +1568,6 @@ class OpenAIServingResponses(OpenAIServing):
                 len(items),
             )
             items = items[:idx]
-
-        if order == "desc":
-            items = list(reversed(items))
 
         has_more = len(items) > limit
         page = items[:limit]


### PR DESCRIPTION
## Purpose

Implement the full OpenAI Conversations API (`/v1/conversations`) for vLLM's Responses API, enabling server-side multi-turn conversation state management.

- Related issue: #24479
- `conversation` parameter on `POST /v1/responses`: conversation items prepended to input, response input+output auto-appended after completion
- Mutually exclusive with `previous_response_id` (per OpenAI spec)
- In-memory stores gated by `VLLM_ENABLE_RESPONSES_API_STORE=1` (same pattern as existing `response_store`/`msg_store`)
- 8 CRUD endpoints: create/retrieve/update/delete conversations, add/list/retrieve/delete items
- Both harmony and non-harmony model paths supported

## Test Plan

```bash
# Start server with store enabled
VLLM_ENABLE_RESPONSES_API_STORE=1 vllm serve meta-llama/Llama-3.1-8B-Instruct

# CRUD
curl -X POST /v1/conversations -d '{"metadata":{"topic":"test"}}'
curl -X GET /v1/conversations/{conv_id}
curl -X POST /v1/conversations/{conv_id} -d '{"metadata":{"topic":"updated"}}'
curl -X DELETE /v1/conversations/{conv_id}
curl -X POST /v1/conversations/{conv_id}/items -d '{"items":[...]}'
curl -X GET /v1/conversations/{conv_id}/items
curl -X DELETE /v1/conversations/{conv_id}/items/{item_id}

# Multi-turn with conversation
curl -X POST /v1/responses -d '{"model":"...","input":"My name is Bob.","conversation":"conv_xxx"}'
curl -X POST /v1/responses -d '{"model":"...","input":"What is my name?","conversation":"conv_xxx"}'

# Validation
curl -X POST /v1/responses -d '{"conversation":"conv_xxx","previous_response_id":"resp_xxx"}'  # --> 400
curl -X POST /v1/responses -d '{"conversation":"conv_nonexistent"}'  # --> 404
```

## Test Result

E2E tested on MI250 with `meta-llama/Llama-3.1-8B-Instruct` (TP=1), `VLLM_ENABLE_RESPONSES_API_STORE=1`:

| Category | Tests | Result |
|---|---|---|
| CRUD - Conversation | create, retrieve, update, delete, 404 after delete | 5/5 ✅ |
| CRUD - Items | add, list, retrieve, delete, empty after delete | 5/5 ✅ |
| Pagination | limit, has_more, after, before, order=desc | 5/5 ✅ |
| Validation | mutual exclusivity, non-existent conv 404, 21 items limit | 3/3 ✅ |
| Multi-turn (3 turns) | completed, context recall (name+fruit), items accumulated | 4/4 ✅ |
| Streaming | SSE + conversation, items auto-appended | 2/2 ✅ |
| Edge cases | empty conv, deleted conv 404, seed items | 4/4 ✅ |
| **Total** | | **28/28 PASS** |

Token usage across turns (prefix caching observed):

| Turn | input_tokens | cached_tokens | output_tokens |
|---|---|---|---|
| 1 | 120 | 32 | 31 |
| 2 | 166 | 112 | 30 |
| 3 | 217 | 192 | 22 |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.
</details>