### PR TITLE
Fix cudagraph max capture size upper bound

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -382,8 +382,9 @@ def test_should_split():
         ([1, 256], None, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
         ([], None, 1, False, 2048, CUDAGraphMode.NONE, 0),
         (None, 0, 1, False, 2048, CUDAGraphMode.NONE, 0),
-        # truncated to nearest multiple of 8 or 16
-        (None, 257, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
+        # include the exact configured max even when it is off the default step
+        (None, 257, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 257),
+        (None, 300, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 300),
         # max from list
         ([1, 2, 4, 15], None, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 15),
         # filtered out 15 due to SP

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -436,8 +436,9 @@ def test_should_split():
         ([1, 256], None, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
         ([], None, 1, False, 2048, CUDAGraphMode.NONE, 0),
         (None, 0, 1, False, 2048, CUDAGraphMode.NONE, 0),
-        # truncated to nearest multiple of 8 or 16
-        (None, 257, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
+        # include the exact configured max even when it is off the default step
+        (None, 257, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 257),
+        (None, 300, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 300),
         # max_num_batched_tokens <= max_cudagraph_capture_size should always be
         # captured even if not landing on a 16-stride step
         (None, 2048, 1, False, 257, CUDAGraphMode.FULL_AND_PIECEWISE, 257),

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1393,10 +1393,10 @@ class VllmConfig:
                     cudagraph_capture_sizes += list(
                         range(256, max_cudagraph_capture_size + 1, 16)
                     )
-                # de-duplicate and sort the sizes
-                cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
                 if max_cudagraph_capture_size not in cudagraph_capture_sizes:
                     cudagraph_capture_sizes.append(max_cudagraph_capture_size)
+                # de-duplicate and sort the sizes
+                cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
 
             if (
                 self.parallel_config.tensor_parallel_size > 1

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1395,6 +1395,8 @@ class VllmConfig:
                     )
                 # de-duplicate and sort the sizes
                 cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
+                if max_cudagraph_capture_size not in cudagraph_capture_sizes:
+                    cudagraph_capture_sizes.append(max_cudagraph_capture_size)
 
             if (
                 self.parallel_config.tensor_parallel_size > 1

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2149,6 +2149,8 @@ class VllmConfig:
                 ]
                 # de-duplicate and sort the sizes
                 cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
+                if max_cudagraph_capture_size not in cudagraph_capture_sizes:
+                    cudagraph_capture_sizes.append(max_cudagraph_capture_size)
 
             if (
                 self.parallel_config.tensor_parallel_size > 1

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2147,10 +2147,10 @@ class VllmConfig:
                 cudagraph_capture_sizes += [
                     size for size in uniform_decode_sizes if size <= max_num_tokens
                 ]
-                # de-duplicate and sort the sizes
-                cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
                 if max_cudagraph_capture_size not in cudagraph_capture_sizes:
                     cudagraph_capture_sizes.append(max_cudagraph_capture_size)
+                # de-duplicate and sort the sizes
+                cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
 
             if (
                 self.parallel_config.tensor_parallel_size > 1


### PR DESCRIPTION
## Summary

Ensure the default `cudagraph_capture_sizes` includes the exact `max_cudagraph_capture_size` value.

Previously, if the configured max was not aligned with the built-in step sizes, it could be silently truncated to the previous stepped value (for example, `257 -> 256`, `300 -> 288`).

## Fix

Append `max_cudagraph_capture_size` to the generated default capture-size list when it is not already present.

This preserves the existing stepped capture strategy while making the configured upper bound effective.