### PR TITLE
fix: add qk_layernorm support for Phi models

### DIFF
--- a/vllm/model_executor/models/phi.py
+++ b/vllm/model_executor/models/phi.py
@@ -107,6 +107,11 @@ class PhiAttention(nn.Module):
             prefix=f"{prefix}.dense",
         )
 
+        self.qk_layernorm = getattr(config, "qk_layernorm", False)
+        if self.qk_layernorm:
+            self.q_layernorm = nn.LayerNorm(self.head_size)
+            self.k_layernorm = nn.LayerNorm(self.head_size)
+
         scaling = self.head_size**-0.5
 
         max_position_embeddings = getattr(config, "max_position_embeddings", 2048)
@@ -131,6 +136,14 @@ class PhiAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.chunk(chunks=3, dim=-1)
+        if self.qk_layernorm:
+            # Reshape to [seq_length, num_heads, head_dim] for per-head
+            # LayerNorm, then merge back to [seq_length, hidden_size].
+            seq_len = q.shape[0]
+            q = self.q_layernorm(q.view(seq_len, self.num_heads, self.head_size))
+            k = self.k_layernorm(k.view(seq_len, self.num_heads, self.head_size))
+            q = q.view(seq_len, self.num_heads * self.head_size)
+            k = k.view(seq_len, self.num_heads * self.head_size)
         q, k = self.rotary_emb(position_ids, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.dense(attn_output)


### PR DESCRIPTION
## Summary

- Fixes #37852 — Phi `qk_layernorm` was unsupported in vLLM, causing silent correctness issues for Phi checkpoints with `config.qk_layernorm=True`.
- Adds conditional `q_layernorm` / `k_layernorm` (`nn.LayerNorm(head_dim)`) modules to `PhiAttention`, applied after QKV projection and split, before rotary embedding — matching the Transformers reference implementation exactly.
- No-op for existing models where `qk_layernorm` is `False` (the default).

## Transformers reference

In `transformers/models/phi/modeling_phi.py`, `PhiAttention` does:

```python
# __init__
self.qk_layernorm = config.qk_layernorm
if self.qk_layernorm:
    self.q_layernorm = nn.LayerNorm(self.head_dim, ...)
    self.k_layernorm = nn.LayerNorm(self.head_dim, ...)

# forward
if self.qk_layernorm:
    query_states = self.q_layernorm(query_states)
    key_states = self.k_layernorm(key_states)
```

This PR mirrors the same behavior in vLLM, following the existing pattern used by `PersimmonAttention` in `vllm/model_executor/models/persimmon.py`.

## Changes

In `vllm/model_executor/models/phi.py` (`PhiAttention`):

**`__init__`**: Read `config.qk_layernorm` (defaults to `False`). If `True`, create `self.q_layernorm` and `self.k_layernorm` as `nn.LayerNorm(head_size)`.

**`forward`**: After `qkv.chunk(3)`, if `qk_layernorm` is enabled:
1. Reshape `q`/`k` from `[seq_len, hidden_size]` to `[seq_len, num_heads, head_dim]`
2. Apply per-head LayerNorm
3. Merge back to `[seq_len, hidden_size]`
4. Then proceed to rotary embedding as before

## Test plan

- [ ] Verify with a Phi model checkpoint that has `qk_layernorm=True` (e.g., compare logits against HF Transformers output)
- [ ] Verify existing Phi models (`qk_layernorm=False`) are unaffected (no new modules created, identical code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)