### PR TITLE
[Bugfix][Perf]: avoid Range allocation and dict hashing in _find_range_for_shape

### DIFF
--- a/tests/compile/test_piecewise_dispatch.py
+++ b/tests/compile/test_piecewise_dispatch.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for PiecewiseBackend._find_range_for_shape hotpath dispatch.
+
+These tests use object.__new__ to construct a minimal PiecewiseBackend without
+requiring a full VllmConfig, FX graph, or GPU — making them fast and CI-safe.
+"""
+
+import types
+
+from vllm.compilation.backends import _SHAPE_CACHE_UNSET
+from vllm.compilation.piecewise_backend import PiecewiseBackend, RangeEntry
+from vllm.config.utils import Range
+
+
+def _make_backend(
+    compile_sizes: list[int] | None,
+    compile_ranges: list[Range],
+    vllm_backend: object | None = None,
+) -> PiecewiseBackend:
+    """
+    Construct a PiecewiseBackend with only the attributes needed by
+    _find_range_for_shape, mirroring the population logic in __init__.
+
+    Pass a shared *vllm_backend* stub (e.g. a SimpleNamespace with
+    _shape_dispatch_cache) to exercise the cross-instance cache path.
+    """
+    b = object.__new__(PiecewiseBackend)
+    b.compile_sizes = compile_sizes
+    b.compile_ranges = compile_ranges
+    if vllm_backend is not None:
+        b.vllm_backend = vllm_backend
+
+    # Mirror __init__ range_entries population
+    b.range_entries = {}
+    if compile_sizes is not None:
+        for s in compile_sizes:
+            if isinstance(s, int):
+                r = Range(start=s, end=s)
+                if r not in compile_ranges:
+                    b.range_entries[r] = RangeEntry(compile_range=r)
+    for r in compile_ranges:
+        b.range_entries[r] = RangeEntry(compile_range=r)
+
+    b._build_find_range_caches()
+    return b
+
+
+def test_exact_compile_size_returns_single_point_entry():
+    """An exact compile size returns its own single-point RangeEntry."""
+    b = _make_backend(compile_sizes=[128, 256, 512], compile_ranges=[Range(1, 1024)])
+    entry = b._find_range_for_shape(256)
+    assert entry is not None
+    assert entry.compile_range == Range(256, 256)
+
+
+def test_exact_compile_size_covered_by_compile_range():
+    """When Range(s,s) equals a compile_range entry, dispatch still works."""
+    b = _make_backend(
+        compile_sizes=[64],
+        compile_ranges=[Range(64, 64), Range(1, 1024)],
+    )
+    entry = b._find_range_for_shape(64)
+    assert entry is not None
+    assert entry.compile_range == Range(64, 64)
+
+
+def test_non_exact_shape_falls_through_to_range():
+    """A shape not in compile_sizes but inside a compile_range returns that entry."""
+    b = _make_backend(compile_sizes=[512], compile_ranges=[Range(1, 1024)])
+    entry = b._find_range_for_shape(300)
+    assert entry is not None
+    assert entry.compile_range == Range(1, 1024)
+
+
+def test_shape_outside_all_ranges_returns_none():
+    """A shape outside all compile_ranges returns None."""
+    b = _make_backend(compile_sizes=[512], compile_ranges=[Range(1, 1024)])
+    assert b._find_range_for_shape(2000) is None
+
+
+def test_compile_sizes_none_returns_none():
+    """When compile_sizes is None, _find_range_for_shape always returns None."""
+    b = _make_backend(compile_sizes=None, compile_ranges=[Range(1, 2048)])
+    assert b._find_range_for_shape(100) is None
+
+
+def test_multiple_ranges_first_match_returned():
+    """Overlapping ranges: the first matching range in compile_ranges is returned."""
+    b = _make_backend(
+        compile_sizes=[],
+        compile_ranges=[Range(1, 100), Range(50, 200)],
+    )
+    entry = b._find_range_for_shape(75)
+    assert entry is not None
+    assert entry.compile_range == Range(1, 100)
+
+
+def test_exact_size_entry_distinct_from_range_entry():
+    """compile_size entry and compile_range entry are distinct RangeEntry objects."""
+    b = _make_backend(compile_sizes=[256], compile_ranges=[Range(1, 1024)])
+    exact_entry = b._find_range_for_shape(256)
+    range_entry = b._find_range_for_shape(300)
+    assert exact_entry is not None
+    assert range_entry is not None
+    assert exact_entry is not range_entry
+    assert exact_entry.compile_range == Range(256, 256)
+    assert range_entry.compile_range == Range(1, 1024)
+
+
+def test_empty_compile_sizes_uses_range_only():
+    """Empty compile_sizes list falls through to range scan for all shapes."""
+    b = _make_backend(compile_sizes=[], compile_ranges=[Range(1, 512)])
+    entry = b._find_range_for_shape(200)
+    assert entry is not None
+    assert entry.compile_range == Range(1, 512)
+
+
+def test_multiple_non_overlapping_ranges():
+    """Shape is dispatched to the correct non-overlapping range."""
+    b = _make_backend(
+        compile_sizes=[],
+        compile_ranges=[Range(1, 8), Range(9, 64), Range(65, 512)],
+    )
+    entry_5 = b._find_range_for_shape(5)
+    assert entry_5 is not None
+    assert entry_5.compile_range == Range(1, 8)
+    entry_32 = b._find_range_for_shape(32)
+    assert entry_32 is not None
+    assert entry_32.compile_range == Range(9, 64)
+    entry_200 = b._find_range_for_shape(200)
+    assert entry_200 is not None
+    assert entry_200.compile_range == Range(65, 512)
+    assert b._find_range_for_shape(1000) is None
+
+
+def test_shared_dispatch_cache_across_instances():
+    """All instances sharing the same vllm_backend share one dispatch cache.
+
+    Simulates the Llama3-70B scenario where 81 subgraph PiecewiseBackend
+    instances share a single VllmBackend.  The first instance to look up a
+    shape pays the O(#ranges) scan; subsequent ones get an O(1) list hit.
+    """
+    # A minimal stub for VllmBackend — preallocated list large enough
+    # for all test shapes (max index used is 9999).
+    _MAX = 10000
+    fake_backend = types.SimpleNamespace(
+        _shape_dispatch_cache=[_SHAPE_CACHE_UNSET] * (_MAX + 1)
+    )
+    ranges = [Range(1, 8), Range(9, 64), Range(65, 512)]
+
+    # Build two independent PiecewiseBackend instances that share fake_backend.
+    b1 = _make_backend(
+        compile_sizes=[], compile_ranges=ranges, vllm_backend=fake_backend
+    )
+    b2 = _make_backend(
+        compile_sizes=[], compile_ranges=ranges, vllm_backend=fake_backend
+    )
+
+    # Both must reference the SAME underlying list.
+    assert b1._shape_dispatch_cache is b2._shape_dispatch_cache
+
+    # b1 performs the range scan and populates the shared cache.
+    entry1 = b1._find_range_for_shape(32)
+    assert entry1 is not None
+    assert entry1.compile_range == Range(9, 64)
+    assert fake_backend._shape_dispatch_cache[32] == Range(9, 64)  # cache written
+
+    # b2 sees the same shape: it gets an O(1) list hit, no scan.
+    entry2 = b2._find_range_for_shape(32)
+    assert entry2 is not None
+    assert entry2.compile_range == Range(9, 64)
+
+    # A shape that matches no range is also cached (as None) after first scan.
+    none_entry = b1._find_range_for_shape(9999)
+    assert none_entry is None
+    assert fake_backend._shape_dispatch_cache[9999] is None  # cached as miss
+    assert b2._find_range_for_shape(9999) is None

--- a/tests/compile/test_piecewise_dispatch.py
+++ b/tests/compile/test_piecewise_dispatch.py
@@ -9,9 +9,46 @@ requiring a full VllmConfig, FX graph, or GPU — making them fast and CI-safe.
 
 import types
 
-from vllm.compilation.backends import _SHAPE_CACHE_UNSET
 from vllm.compilation.piecewise_backend import PiecewiseBackend, RangeEntry
 from vllm.config.utils import Range
+
+# Upper bound for preallocated index mapping in tests.
+_TEST_MAX_TOKENS = 10000
+
+
+def _build_size_to_range_index(
+    compile_sizes: list[int] | None,
+    compile_ranges: list[Range],
+    max_tokens: int = _TEST_MAX_TOKENS,
+) -> tuple[list[int], int]:
+    """Build a (size_to_range_index, num_range_entries) pair.
+
+    Mirrors the eager mapping logic in VllmBackend.__init__.
+    """
+    next_idx = len(compile_ranges)
+    extra_size_indices: dict[int, int] = {}
+    if compile_sizes is not None:
+        for s in compile_sizes:
+            if isinstance(s, int):
+                r = Range(start=s, end=s)
+                if r not in compile_ranges and s not in extra_size_indices:
+                    extra_size_indices[s] = next_idx
+                    next_idx += 1
+
+    num_range_entries = next_idx
+
+    mapping: list[int] = [-1] * (max_tokens + 1)
+    for i in range(len(compile_ranges) - 1, -1, -1):
+        cr = compile_ranges[i]
+        lo = max(0, cr.start)
+        hi = min(max_tokens, cr.end)
+        for size in range(lo, hi + 1):
+            mapping[size] = i
+    for s, idx in extra_size_indices.items():
+        if 0 <= s <= max_tokens:
+            mapping[s] = idx
+
+    return mapping, num_range_entries
 
 
 def _make_backend(
@@ -24,13 +61,22 @@ def _make_backend(
     _find_range_for_shape, mirroring the population logic in __init__.
 
     Pass a shared *vllm_backend* stub (e.g. a SimpleNamespace with
-    _shape_dispatch_cache) to exercise the cross-instance cache path.
+    _size_to_range_index and _num_range_entries) to exercise the
+    cross-instance cache path.  When omitted, a local stub is created
+    automatically.
     """
     b = object.__new__(PiecewiseBackend)
     b.compile_sizes = compile_sizes
     b.compile_ranges = compile_ranges
-    if vllm_backend is not None:
-        b.vllm_backend = vllm_backend
+
+    # Auto-create a local index mapping when no shared backend is provided.
+    if vllm_backend is None:
+        mapping, num_entries = _build_size_to_range_index(compile_sizes, compile_ranges)
+        vllm_backend = types.SimpleNamespace(
+            _size_to_range_index=mapping,
+            _num_range_entries=num_entries,
+        )
+    b.vllm_backend = vllm_backend
 
     # Mirror __init__ range_entries population
     b.range_entries = {}
@@ -136,19 +182,21 @@ def test_multiple_non_overlapping_ranges():
 
 
 def test_shared_dispatch_cache_across_instances():
-    """All instances sharing the same vllm_backend share one dispatch cache.
+    """All instances sharing the same vllm_backend share one index mapping.
 
     Simulates the Llama3-70B scenario where 81 subgraph PiecewiseBackend
-    instances share a single VllmBackend.  The first instance to look up a
-    shape pays the O(#ranges) scan; subsequent ones get an O(1) list hit.
+    instances share a single VllmBackend.  Both backends use the same shared
+    _size_to_range_index list but have independent _range_index_to_entry arrays.
     """
-    # A minimal stub for VllmBackend — preallocated list large enough
-    # for all test shapes (max index used is 9999).
-    _MAX = 10000
-    fake_backend = types.SimpleNamespace(
-        _shape_dispatch_cache=[_SHAPE_CACHE_UNSET] * (_MAX + 1)
-    )
     ranges = [Range(1, 8), Range(9, 64), Range(65, 512)]
+
+    mapping, num_entries = _build_size_to_range_index(
+        compile_sizes=[], compile_ranges=ranges
+    )
+    fake_backend = types.SimpleNamespace(
+        _size_to_range_index=mapping,
+        _num_range_entries=num_entries,
+    )
 
     # Build two independent PiecewiseBackend instances that share fake_backend.
     b1 = _make_backend(
@@ -158,22 +206,21 @@ def test_shared_dispatch_cache_across_instances():
         compile_sizes=[], compile_ranges=ranges, vllm_backend=fake_backend
     )
 
-    # Both must reference the SAME underlying list.
-    assert b1._shape_dispatch_cache is b2._shape_dispatch_cache
+    # Both must reference the SAME underlying index list.
+    assert b1._size_to_range_index is b2._size_to_range_index
 
-    # b1 performs the range scan and populates the shared cache.
+    # But each has its own entry array (different RangeEntry objects).
+    assert b1._range_index_to_entry is not b2._range_index_to_entry
+
+    # Both dispatch shape 32 to the Range(9, 64) entry.
     entry1 = b1._find_range_for_shape(32)
     assert entry1 is not None
     assert entry1.compile_range == Range(9, 64)
-    assert fake_backend._shape_dispatch_cache[32] == Range(9, 64)  # cache written
 
-    # b2 sees the same shape: it gets an O(1) list hit, no scan.
     entry2 = b2._find_range_for_shape(32)
     assert entry2 is not None
     assert entry2.compile_range == Range(9, 64)
 
-    # A shape that matches no range is also cached (as None) after first scan.
-    none_entry = b1._find_range_for_shape(9999)
-    assert none_entry is None
-    assert fake_backend._shape_dispatch_cache[9999] is None  # cached as miss
+    # A shape that matches no range returns None.
+    assert b1._find_range_for_shape(9999) is None
     assert b2._find_range_for_shape(9999) is None

--- a/tests/compile/test_piecewise_dispatch.py
+++ b/tests/compile/test_piecewise_dispatch.py
@@ -206,8 +206,8 @@ def test_shared_dispatch_cache_across_instances():
         compile_sizes=[], compile_ranges=ranges, vllm_backend=fake_backend
     )
 
-    # Both must reference the SAME underlying index list.
-    assert b1._size_to_range_index is b2._size_to_range_index
+    # Both must reference the SAME underlying index list (owned by VllmBackend).
+    assert b1.vllm_backend._size_to_range_index is b2.vllm_backend._size_to_range_index
 
     # But each has its own entry array (different RangeEntry objects).
     assert b1._range_index_to_entry is not b2._range_index_to_entry

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -806,8 +806,9 @@ class VllmBackend:
     inductor_config: dict[str, Any]
     # Shared size → range-entry index map, eagerly built once at init time.
     # _size_to_range_index[runtime_shape] gives a non-negative index into each
-    # PiecewiseBackend's _range_index_to_entry list. Compile ranges always
-    # cover [1, max_tokens] so every valid in-bounds shape has a valid index.
+    # PiecewiseBackend's _range_index_to_entry list, or -1 if no compile range
+    # covers that size (e.g. shape=0, or configs where endpoints don't reach
+    # max_tokens). Callers must guard against -1 before using the index.
     # Preallocated to max_num_batched_tokens+1 so lookup is a plain list index.
     _size_to_range_index: list[int]
     _num_range_entries: int
@@ -881,10 +882,10 @@ class VllmBackend:
 
         self._num_range_entries = next_idx
 
-        # Map every size in [1, max_tokens] to its range index.
-        # Compile ranges cover the full domain so every valid shape gets a
-        # non-negative index. Iterate in reverse so earlier ranges (lower
-        # index) overwrite later ones, preserving first-match-wins semantics.
+        # Map every size in [1, max_tokens] to its range index (-1 = no match).
+        # In typical production configs compile ranges tile the full [1, max_tokens]
+        # domain, but -1 can remain for shape=0 or configs with gaps. Iterate in
+        # reverse so earlier ranges (lower index) take priority over later ones.
         self._size_to_range_index: list[int] = [-1] * (max_tokens + 1)
         for i in range(len(compile_ranges) - 1, -1, -1):
             cr = compile_ranges[i]

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -49,10 +49,6 @@ from .passes.pass_manager import PostGradPassManager
 
 logger = init_logger(__name__)
 
-# Sentinel stored in _shape_dispatch_cache to distinguish "not yet computed"
-# from a cached None (shape matched no compile range).
-_SHAPE_CACHE_UNSET: object = object()
-
 
 def make_copy_and_call(
     sym_tensor_indices: list[int],
@@ -808,12 +804,12 @@ class VllmBackend:
     # Copy of CompilationConfig.inductor_compile_config +
     # an entry for PostGradPassManager
     inductor_config: dict[str, Any]
-    # Shared runtime-shape -> compile Range dispatch cache.
-    # Preallocated to max_num_batched_tokens+1 so lookup is a pure list index
-    # (no hashing). Stores Range on hit, None on miss, _SHAPE_CACHE_UNSET when
-    # not yet computed. Populated lazily: the first of the N subgraph backends
-    # pays the O(#ranges) scan; the remaining N-1 get an O(1) list lookup.
-    _shape_dispatch_cache: list[object]
+    # Shared size → range-entry index map, eagerly built once at init time.
+    # _size_to_range_index[runtime_shape] gives a non-negative index into each
+    # PiecewiseBackend's _range_index_to_entry list, or -1 for no match.
+    # Preallocated to max_num_batched_tokens+1 so lookup is a plain list index.
+    _size_to_range_index: list[int]
+    _num_range_entries: int
 
     def __init__(
         self,
@@ -851,11 +847,54 @@ class VllmBackend:
         # in future we need PostGradPassManager.uuid() to be executed
         # only at compile time.
         self.inductor_config = deepcopy(self.compilation_config.inductor_compile_config)
-        # Shared dispatch cache — see _shape_dispatch_cache class annotation.
+
+        # Build the shared size → range-entry index mapping eagerly.
+        # Every possible runtime_shape in [0, max_tokens] is mapped to the
+        # index of its matching compile range / exact size (or -1 for miss).
+        # Each PiecewiseBackend then keeps a parallel index → RangeEntry array
+        # so dispatch is two plain list dereferences — zero hashing.
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        self._shape_dispatch_cache: list[object] = [_SHAPE_CACHE_UNSET] * (
-            max_tokens + 1
-        )
+
+        compile_ranges = self.compilation_config.get_compile_ranges()
+        if self.is_encoder:
+            # Encoder compilation extends the last range to max_int32,
+            # mirroring the logic in PiecewiseBackend.__init__.
+            max_int32 = 2**31 - 1
+            last = compile_ranges[-1]
+            compile_ranges[-1] = Range(start=last.start, end=max_int32)
+
+        compile_sizes = self.compilation_config.compile_sizes
+
+        # Index assignment:
+        #   0 .. len(compile_ranges)-1  →  one per compile range
+        #   len(compile_ranges) ..      →  exact sizes not in compile_ranges
+        next_idx = len(compile_ranges)
+        extra_size_indices: dict[int, int] = {}
+        if compile_sizes is not None:
+            for s in compile_sizes:
+                if isinstance(s, int):
+                    r = Range(start=s, end=s)
+                    if r not in compile_ranges and s not in extra_size_indices:
+                        extra_size_indices[s] = next_idx
+                        next_idx += 1
+
+        self._num_range_entries = next_idx
+
+        # Map every size → index (-1 = no match).
+        # Iterate in reverse so that earlier ranges (lower index) overwrite
+        # later ones, preserving first-match-wins semantics for overlaps.
+        self._size_to_range_index: list[int] = [-1] * (max_tokens + 1)
+        for i in range(len(compile_ranges) - 1, -1, -1):
+            cr = compile_ranges[i]
+            lo = max(0, cr.start)
+            hi = min(max_tokens, cr.end)
+            for size in range(lo, hi + 1):
+                self._size_to_range_index[size] = i
+
+        # Exact-size entries override the broader range entry.
+        for s, idx in extra_size_indices.items():
+            if 0 <= s <= max_tokens:
+                self._size_to_range_index[s] = idx
         # `torch.compile` is JIT compiled, so we don't need to
         # do anything here
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -49,6 +49,10 @@ from .passes.pass_manager import PostGradPassManager
 
 logger = init_logger(__name__)
 
+# Sentinel stored in _shape_dispatch_cache to distinguish "not yet computed"
+# from a cached None (shape matched no compile range).
+_SHAPE_CACHE_UNSET: object = object()
+
 
 def make_copy_and_call(
     sym_tensor_indices: list[int],
@@ -804,6 +808,12 @@ class VllmBackend:
     # Copy of CompilationConfig.inductor_compile_config +
     # an entry for PostGradPassManager
     inductor_config: dict[str, Any]
+    # Shared runtime-shape -> compile Range dispatch cache.
+    # Preallocated to max_num_batched_tokens+1 so lookup is a pure list index
+    # (no hashing). Stores Range on hit, None on miss, _SHAPE_CACHE_UNSET when
+    # not yet computed. Populated lazily: the first of the N subgraph backends
+    # pays the O(#ranges) scan; the remaining N-1 get an O(1) list lookup.
+    _shape_dispatch_cache: list[object]
 
     def __init__(
         self,
@@ -841,6 +851,11 @@ class VllmBackend:
         # in future we need PostGradPassManager.uuid() to be executed
         # only at compile time.
         self.inductor_config = deepcopy(self.compilation_config.inductor_compile_config)
+        # Shared dispatch cache — see _shape_dispatch_cache class annotation.
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self._shape_dispatch_cache: list[object] = [_SHAPE_CACHE_UNSET] * (
+            max_tokens + 1
+        )
         # `torch.compile` is JIT compiled, so we don't need to
         # do anything here
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -806,7 +806,8 @@ class VllmBackend:
     inductor_config: dict[str, Any]
     # Shared size → range-entry index map, eagerly built once at init time.
     # _size_to_range_index[runtime_shape] gives a non-negative index into each
-    # PiecewiseBackend's _range_index_to_entry list, or -1 for no match.
+    # PiecewiseBackend's _range_index_to_entry list. Compile ranges always
+    # cover [1, max_tokens] so every valid in-bounds shape has a valid index.
     # Preallocated to max_num_batched_tokens+1 so lookup is a plain list index.
     _size_to_range_index: list[int]
     _num_range_entries: int
@@ -849,8 +850,8 @@ class VllmBackend:
         self.inductor_config = deepcopy(self.compilation_config.inductor_compile_config)
 
         # Build the shared size → range-entry index mapping eagerly.
-        # Every possible runtime_shape in [0, max_tokens] is mapped to the
-        # index of its matching compile range / exact size (or -1 for miss).
+        # Every possible runtime_shape in [1, max_tokens] is mapped to the
+        # index of its matching compile range / exact size.
         # Each PiecewiseBackend then keeps a parallel index → RangeEntry array
         # so dispatch is two plain list dereferences — zero hashing.
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
@@ -880,9 +881,10 @@ class VllmBackend:
 
         self._num_range_entries = next_idx
 
-        # Map every size → index (-1 = no match).
-        # Iterate in reverse so that earlier ranges (lower index) overwrite
-        # later ones, preserving first-match-wins semantics for overlaps.
+        # Map every size in [1, max_tokens] to its range index.
+        # Compile ranges cover the full domain so every valid shape gets a
+        # non-negative index. Iterate in reverse so earlier ranges (lower
+        # index) overwrite later ones, preserving first-match-wins semantics.
         self._size_to_range_index: list[int] = [-1] * (max_tokens + 1)
         for i in range(len(compile_ranges) - 1, -1, -1):
             cr = compile_ranges[i]

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -14,7 +14,7 @@ import torch.fx as fx
 from torch._inductor.runtime.triton_heuristics import CachingAutotuner
 from torch._logging._internal import trace_structured
 
-from vllm.compilation.backends import VllmBackend
+from vllm.compilation.backends import _SHAPE_CACHE_UNSET, VllmBackend
 from vllm.config import VllmConfig
 from vllm.config.utils import Range
 from vllm.logger import init_logger
@@ -83,6 +83,10 @@ class RangeEntry:
 
 
 class PiecewiseBackend:
+    # Shared runtime-shape dispatch cache aliased from VllmBackend.
+    # Declared here so mypy has a single canonical definition.
+    _shape_dispatch_cache: list[object]
+
     def __init__(
         self,
         graph: fx.GraphModule | None,
@@ -184,6 +188,8 @@ class PiecewiseBackend:
 
         # Track whether we've logged the graph for this subgraph (only log once)
         self._graph_logged = False
+
+        self._build_find_range_caches()
 
         if self.graph is not None:
             self.compile_all_ranges()
@@ -337,19 +343,82 @@ class PiecewiseBackend:
             )
             range_entry.compiled = True
 
+    def _build_find_range_caches(self) -> None:
+        """Precompute lookup structures used by _find_range_for_shape.
+
+        Called once at the end of __init__ after range_entries is finalized.
+        Avoids per-call Range allocation and hashing on the dispatch hotpath.
+        """
+        # Pre-zip ranges+entries once so _find_range_for_shape never re-hashes.
+        # Built unconditionally; _find_range_for_shape returns None early when
+        # compile_sizes is None, so this list is never consulted in that case.
+        self._compile_ranges_and_entries: list[tuple[Range, RangeEntry]] = [
+            (r, self.range_entries[r]) for r in self.compile_ranges
+        ]
+
+        # Exact compile-size -> RangeEntry dict (O(1) int lookup, no Range alloc).
+        self._compile_size_to_entry: dict[int, RangeEntry] = {}
+        if self.compile_sizes is not None:
+            for s in self.compile_sizes:
+                if isinstance(s, int):
+                    # Every int in compile_sizes is guaranteed to have a
+                    # Range(s,s) entry in range_entries by __init__ construction.
+                    self._compile_size_to_entry[s] = self.range_entries[
+                        Range(start=s, end=s)
+                    ]
+
+        # Shared range-dispatch cache across all PiecewiseBackend instances
+        # that share the same vllm_backend (e.g. all 81 subgraph backends for
+        # Llama3-70B). The first subgraph to see a runtime_shape pays the
+        # O(#compile_ranges) scan; the remaining 80 get an O(1) list lookup.
+        # Maps runtime_shape -> matched Range (or None if no range matched).
+        vllm_backend = getattr(self, "vllm_backend", None)
+        if vllm_backend is not None:
+            self._shape_dispatch_cache = vllm_backend._shape_dispatch_cache
+        else:
+            # Fallback for tests that construct PiecewiseBackend without a
+            # real vllm_backend (object.__new__ + manual attribute setting).
+            # Size-1 list: all real shapes are out-of-bounds → uncached scan.
+            self._shape_dispatch_cache = [_SHAPE_CACHE_UNSET]
+
     def _find_range_for_shape(self, runtime_shape: int) -> RangeEntry | None:
-        # First we try to find the range entry for the concrete compile size
-        # If not found, we search for the range entry
-        # that contains the runtime shape.
+        # fast path: O(1) exact-size dict, no Range allocation or hashing.
         if self.compile_sizes is None:
             return None
 
-        if runtime_shape in self.compile_sizes:
-            return self.range_entries[Range(start=runtime_shape, end=runtime_shape)]
-        else:
-            for range in self.compile_ranges:
-                if runtime_shape in range:
-                    return self.range_entries[range]
+        # Normalize to a plain int so that SymInt / numpy-int keys hash and
+        # compare correctly against the pre-built int-keyed dict and list index.
+        runtime_shape = int(runtime_shape)
+
+        entry = self._compile_size_to_entry.get(runtime_shape)
+        if entry is not None:
+            return entry
+
+        # Shared list cache: index by runtime_shape — pure integer dereference,
+        # no hashing. All subgraph backends for the same model share one list.
+        # The first subgraph to see a shape pays the O(#ranges) scan; the rest
+        # get an O(1) list lookup.
+        cache = self._shape_dispatch_cache
+        if 0 <= runtime_shape < len(cache):
+            cached = cache[runtime_shape]
+            if cached is _SHAPE_CACHE_UNSET:
+                found: Range | None = None
+                for r, _ in self._compile_ranges_and_entries:
+                    if runtime_shape in r:
+                        found = r
+                        break
+                cache[runtime_shape] = found
+                cached = found
+            if cached is None:
+                return None
+            assert isinstance(cached, Range)
+            return self.range_entries[cached]
+
+        # runtime_shape is out of the preallocated cache bounds — do an
+        # uncached scan (should never happen in normal operation).
+        for r, e in self._compile_ranges_and_entries:
+            if runtime_shape in r:
+                return e
         return None
 
     def __call__(self, *args: Any) -> Any:

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -14,7 +14,7 @@ import torch.fx as fx
 from torch._inductor.runtime.triton_heuristics import CachingAutotuner
 from torch._logging._internal import trace_structured
 
-from vllm.compilation.backends import _SHAPE_CACHE_UNSET, VllmBackend
+from vllm.compilation.backends import VllmBackend
 from vllm.config import VllmConfig
 from vllm.config.utils import Range
 from vllm.logger import init_logger
@@ -83,9 +83,10 @@ class RangeEntry:
 
 
 class PiecewiseBackend:
-    # Shared runtime-shape dispatch cache aliased from VllmBackend.
-    # Declared here so mypy has a single canonical definition.
-    _shape_dispatch_cache: list[object]
+    # Shared size → range-entry index mapping, aliased from VllmBackend.
+    _size_to_range_index: list[int]
+    # Per-subgraph array mapping range-entry index → RangeEntry.
+    _range_index_to_entry: list[RangeEntry | None]
 
     def __init__(
         self,
@@ -347,78 +348,63 @@ class PiecewiseBackend:
         """Precompute lookup structures used by _find_range_for_shape.
 
         Called once at the end of __init__ after range_entries is finalized.
-        Avoids per-call Range allocation and hashing on the dispatch hotpath.
+        The shared _size_to_range_index (built eagerly by VllmBackend) maps
+        every possible runtime_shape to a range-entry index.  This method
+        builds the per-subgraph _range_index_to_entry array so that dispatch
+        in __call__ is just two plain list dereferences.
         """
-        # Pre-zip ranges+entries once so _find_range_for_shape never re-hashes.
-        # Built unconditionally; _find_range_for_shape returns None early when
-        # compile_sizes is None, so this list is never consulted in that case.
-        self._compile_ranges_and_entries: list[tuple[Range, RangeEntry]] = [
-            (r, self.range_entries[r]) for r in self.compile_ranges
-        ]
-
-        # Exact compile-size -> RangeEntry dict (O(1) int lookup, no Range alloc).
-        self._compile_size_to_entry: dict[int, RangeEntry] = {}
-        if self.compile_sizes is not None:
-            for s in self.compile_sizes:
-                if isinstance(s, int):
-                    # Every int in compile_sizes is guaranteed to have a
-                    # Range(s,s) entry in range_entries by __init__ construction.
-                    self._compile_size_to_entry[s] = self.range_entries[
-                        Range(start=s, end=s)
-                    ]
-
-        # Shared range-dispatch cache across all PiecewiseBackend instances
-        # that share the same vllm_backend (e.g. all 81 subgraph backends for
-        # Llama3-70B). The first subgraph to see a runtime_shape pays the
-        # O(#compile_ranges) scan; the remaining 80 get an O(1) list lookup.
-        # Maps runtime_shape -> matched Range (or None if no range matched).
         vllm_backend = getattr(self, "vllm_backend", None)
         if vllm_backend is not None:
-            self._shape_dispatch_cache = vllm_backend._shape_dispatch_cache
+            self._size_to_range_index = vllm_backend._size_to_range_index
+            num_entries = vllm_backend._num_range_entries
         else:
-            # Fallback for tests that construct PiecewiseBackend without a
-            # real vllm_backend (object.__new__ + manual attribute setting).
-            # Size-1 list: all real shapes are out-of-bounds → uncached scan.
-            self._shape_dispatch_cache = [_SHAPE_CACHE_UNSET]
+            # Fallback for tests without a real VllmBackend.
+            self._size_to_range_index = []
+            num_entries = 0
+
+        # Build per-subgraph index → RangeEntry array.
+        self._range_index_to_entry = [None] * num_entries
+
+        # Indices 0 .. len(compile_ranges)-1 correspond to compile ranges.
+        for i, r in enumerate(self.compile_ranges):
+            if i < num_entries and r in self.range_entries:
+                self._range_index_to_entry[i] = self.range_entries[r]
+
+        # Remaining indices correspond to exact compile sizes not in
+        # compile_ranges, assigned in iteration order of compile_sizes.
+        if self.compile_sizes is not None:
+            idx = len(self.compile_ranges)
+            seen: set[int] = set()
+            for s in self.compile_sizes:
+                if isinstance(s, int):
+                    r = Range(start=s, end=s)
+                    if r not in self.compile_ranges and s not in seen:
+                        seen.add(s)
+                        if idx < num_entries and r in self.range_entries:
+                            self._range_index_to_entry[idx] = self.range_entries[r]
+                        idx += 1
 
     def _find_range_for_shape(self, runtime_shape: int) -> RangeEntry | None:
-        # fast path: O(1) exact-size dict, no Range allocation or hashing.
         if self.compile_sizes is None:
             return None
 
-        # Normalize to a plain int so that SymInt / numpy-int keys hash and
-        # compare correctly against the pre-built int-keyed dict and list index.
+        # Normalize to a plain int so that SymInt / numpy-int values work
+        # correctly as a list index.
         runtime_shape = int(runtime_shape)
 
-        entry = self._compile_size_to_entry.get(runtime_shape)
-        if entry is not None:
-            return entry
-
-        # Shared list cache: index by runtime_shape — pure integer dereference,
-        # no hashing. All subgraph backends for the same model share one list.
-        # The first subgraph to see a shape pays the O(#ranges) scan; the rest
-        # get an O(1) list lookup.
-        cache = self._shape_dispatch_cache
+        # Two list dereferences: size → index, index → RangeEntry.
+        cache = self._size_to_range_index
         if 0 <= runtime_shape < len(cache):
-            cached = cache[runtime_shape]
-            if cached is _SHAPE_CACHE_UNSET:
-                found: Range | None = None
-                for r, _ in self._compile_ranges_and_entries:
-                    if runtime_shape in r:
-                        found = r
-                        break
-                cache[runtime_shape] = found
-                cached = found
-            if cached is None:
+            idx = cache[runtime_shape]
+            if idx < 0:
                 return None
-            assert isinstance(cached, Range)
-            return self.range_entries[cached]
+            return self._range_index_to_entry[idx]
 
-        # runtime_shape is out of the preallocated cache bounds — do an
-        # uncached scan (should never happen in normal operation).
-        for r, e in self._compile_ranges_and_entries:
+        # runtime_shape exceeds preallocated cache (rare — e.g. encoder shapes
+        # beyond max_num_batched_tokens). Fall back to a linear scan.
+        for r, entry in self.range_entries.items():
             if runtime_shape in r:
-                return e
+                return entry
         return None
 
     def __call__(self, *args: Any) -> Any:

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -381,9 +381,20 @@ class PiecewiseBackend:
             return None
 
         # Two list dereferences: size → index, index → RangeEntry.
+        # Guard against idx < 0: the mapping is initialised with -1 as a
+        # sentinel for "no range covers this size" (e.g. shape=0, or shapes
+        # outside compile-range endpoints in test / non-standard configs).
+        # Without the guard, Python would silently return list[-1] (the last
+        # element), giving a wrong dispatch with no error.
         cache = self.vllm_backend._size_to_range_index
         if 0 <= runtime_shape < len(cache):
-            return self._range_index_to_entry[cache[runtime_shape]]
+            idx = cache[runtime_shape]
+            if idx < 0:
+                return None
+            entry = self._range_index_to_entry[idx]
+            if entry is None:
+                return None
+            return entry
 
         # runtime_shape exceeds preallocated cache (rare — e.g. encoder shapes
         # beyond max_num_batched_tokens). Fall back to a linear scan.

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -83,9 +83,8 @@ class RangeEntry:
 
 
 class PiecewiseBackend:
-    # Shared size → range-entry index mapping, aliased from VllmBackend.
-    _size_to_range_index: list[int]
     # Per-subgraph array mapping range-entry index → RangeEntry.
+    # The shared size → range-entry index lives on VllmBackend.
     _range_index_to_entry: list[RangeEntry | None]
 
     def __init__(
@@ -353,14 +352,7 @@ class PiecewiseBackend:
         builds the per-subgraph _range_index_to_entry array so that dispatch
         in __call__ is just two plain list dereferences.
         """
-        vllm_backend = getattr(self, "vllm_backend", None)
-        if vllm_backend is not None:
-            self._size_to_range_index = vllm_backend._size_to_range_index
-            num_entries = vllm_backend._num_range_entries
-        else:
-            # Fallback for tests without a real VllmBackend.
-            self._size_to_range_index = []
-            num_entries = 0
+        num_entries = self.vllm_backend._num_range_entries
 
         # Build per-subgraph index → RangeEntry array.
         self._range_index_to_entry = [None] * num_entries
@@ -388,15 +380,11 @@ class PiecewiseBackend:
         if self.compile_sizes is None:
             return None
 
-        # Normalize to a plain int so that SymInt / numpy-int values work
-        # correctly as a list index.
-        runtime_shape = int(runtime_shape)
-
         # Two list dereferences: size → index, index → RangeEntry.
-        cache = self._size_to_range_index
+        cache = self.vllm_backend._size_to_range_index
         if 0 <= runtime_shape < len(cache):
             idx = cache[runtime_shape]
-            if idx < 0:
+            if idx < 0:  # -1 means no compile range covers this size
                 return None
             return self._range_index_to_entry[idx]
 

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -383,10 +383,7 @@ class PiecewiseBackend:
         # Two list dereferences: size → index, index → RangeEntry.
         cache = self.vllm_backend._size_to_range_index
         if 0 <= runtime_shape < len(cache):
-            idx = cache[runtime_shape]
-            if idx < 0:  # -1 means no compile range covers this size
-                return None
-            return self._range_index_to_entry[idx]
+            return self._range_index_to_entry[cache[runtime_shape]]
 
         # runtime_shape exceeds preallocated cache (rare — e.g. encoder shapes
         # beyond max_num_batched_tokens). Fall back to a linear scan.


### PR DESCRIPTION
Fixes #37222. Replaces #37281 (closed due to accidental branch deletion during rebase).

`_find_range_for_shape` is in the hotpath of `PiecewiseBackend.__call__` - called on every forward pass for every subgraph. Each call was allocating a new `Range`, scanning a list, and hashing it twice through `range_entries`.

**Fix - two structures precomputed once at init:**

- `_compile_size_to_entry: dict[int, RangeEntry]` - exact compile-size hits become a plain `int` lookup, no `Range` allocation
- `_shape_dispatch_cache: list[object]` on `VllmBackend` - preallocated and shared across all N subgraph backends. First subgraph to see a shape pays the O(#ranges) scan; the remaining N-1 get an O(1) list index. For Llama3-70B (~81 subgraphs): 81×O(R) → 1×O(R) + 80×O(1) per forward, O(1)×81 after warmup.

Memory: ~256KB at 32k `max_num_batched_tokens`.

Semantics preserved exactly - same `None` guard, same range ordering, same first-match behavior.

Added `tests/compile/test_piecewise_dispatch.py` (9 tests, no GPU needed).
<img width="433" height="70" alt="image" src="https://github.com/user-attachments/assets/d0aaa489-3502-4d15-aab2-6aac047e1a38" />
<img width="795" height="493" alt="image" src="https://github.com/user-attachments/assets/ad0b7c30-d6ef-45cd-96ba-40be85977ba8" />


cc: @ProExpertProg @zou3519