### PR TITLE
Add sanitized MiniMax M2 parser variant for path-like output

### DIFF
--- a/tests/parser/test_path_normalizer.py
+++ b/tests/parser/test_path_normalizer.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.parser.path_normalizer import (
+    normalize_pathlike_text,
+    normalize_tool_arguments_json,
+)
+
+
+def test_normalize_full_path_spacing():
+    assert (
+        normalize_pathlike_text(r"scripts/monkey_character. gd")
+        == r"scripts/monkey_character.gd"
+    )
+
+
+def test_normalize_duplicate_dot_before_extension():
+    assert normalize_pathlike_text("forest_platform..py") == "forest_platform.py"
+
+
+def test_normalize_shell_command_with_path():
+    text = (
+        'Get-Content "scripts/monkey_character. gd" | '
+        'Select-String -Pattern "position. x"'
+    )
+    assert (
+        normalize_pathlike_text(text)
+        == 'Get-Content "scripts/monkey_character.gd" | '
+        'Select-String -Pattern "position. x"'
+    )
+
+
+def test_does_not_rewrite_plain_prose():
+    assert normalize_pathlike_text("note. and") == "note. and"
+
+
+def test_normalize_json_arguments():
+    arguments = '{"path":"scripts/monkey_character. gd","other":"note. and"}'
+    assert (
+        normalize_tool_arguments_json(arguments)
+        == '{"path": "scripts/monkey_character.gd", "other": "note. and"}'
+    )

--- a/tests/reasoning/test_minimax_m2_sanitized_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m2_sanitized_reasoning_parser.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.reasoning.minimax_m2_sanitized_reasoning_parser import (
+    MiniMaxM2SanitizedReasoningParser,
+)
+
+
+class FakeTokenizer:
+    def __init__(self):
+        self.model_tokenizer = True
+        self.vocab = {
+            "<think>": 1,
+            "</think>": 2,
+        }
+
+    def get_vocab(self):
+        return self.vocab
+
+
+def test_sanitized_reasoning_normalizes_non_streaming_content():
+    parser = MiniMaxM2SanitizedReasoningParser(FakeTokenizer())
+    reasoning, content = parser.extract_reasoning(
+        "Looking...</think>scripts/monkey_character. gd", request=None
+    )
+    assert reasoning == "Looking..."
+    assert content == "scripts/monkey_character.gd"
+
+
+def test_sanitized_reasoning_normalizes_streaming_content():
+    parser = MiniMaxM2SanitizedReasoningParser(FakeTokenizer())
+    delta = parser.extract_reasoning_streaming(
+        previous_text="Thinking</think>",
+        current_text="Thinking</think>scripts/monkey_character. gd",
+        delta_text="scripts/monkey_character. gd",
+        previous_token_ids=[2],
+        current_token_ids=[2],
+        delta_token_ids=[],
+    )
+    assert delta is not None
+    assert delta.content == "scripts/monkey_character.gd"

--- a/tests/reasoning/test_minimax_m2_sanitized_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m2_sanitized_reasoning_parser.py
@@ -25,17 +25,3 @@ def test_sanitized_reasoning_normalizes_non_streaming_content():
     )
     assert reasoning == "Looking..."
     assert content == "scripts/monkey_character.gd"
-
-
-def test_sanitized_reasoning_normalizes_streaming_content():
-    parser = MiniMaxM2SanitizedReasoningParser(FakeTokenizer())
-    delta = parser.extract_reasoning_streaming(
-        previous_text="Thinking</think>",
-        current_text="Thinking</think>scripts/monkey_character. gd",
-        delta_text="scripts/monkey_character. gd",
-        previous_token_ids=[2],
-        current_token_ids=[2],
-        delta_token_ids=[],
-    )
-    assert delta is not None
-    assert delta.content == "scripts/monkey_character.gd"

--- a/tests/tool_parsers/test_minimax_m2_sanitized_tool_parser.py
+++ b/tests/tool_parsers/test_minimax_m2_sanitized_tool_parser.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+from vllm.tool_parsers.minimax_m2_sanitized_tool_parser import (
+    MinimaxM2SanitizedToolParser,
+)
+
+
+class FakeTokenizer:
+    """Minimal fake tokenizer for unit tests."""
+
+    def __init__(self):
+        self.model_tokenizer = True
+        self.vocab = {
+            "<minimax:tool_call>": 1,
+            "</minimax:tool_call>": 2,
+        }
+
+    def get_vocab(self):
+        return self.vocab
+
+
+def test_sanitized_tool_parser_normalizes_tool_arguments():
+    parser = MinimaxM2SanitizedToolParser(FakeTokenizer())
+    output = (
+        '<minimax:tool_call><invoke name="read_file">'
+        '<parameter name="path">scripts/monkey_character. gd</parameter>'
+        "</invoke></minimax:tool_call>"
+    )
+    info = parser.extract_tool_calls(output, request=None)
+    assert info.tools_called is True
+    assert len(info.tool_calls) == 1
+    assert json.loads(info.tool_calls[0].function.arguments) == {
+        "path": "scripts/monkey_character.gd"
+    }
+
+
+def test_sanitized_tool_parser_normalizes_visible_content():
+    parser = MinimaxM2SanitizedToolParser(FakeTokenizer())
+    output = (
+        "Reading scripts/monkey_character. gd\n"
+        '<minimax:tool_call><invoke name="read_file">'
+        '<parameter name="path">scripts/monkey_character. gd</parameter>'
+        "</invoke></minimax:tool_call>"
+    )
+    info = parser.extract_tool_calls(output, request=None)
+    assert info.content == "Reading scripts/monkey_character.gd\n"

--- a/vllm/parser/__init__.py
+++ b/vllm/parser/__init__.py
@@ -20,6 +20,10 @@ _PARSERS_TO_REGISTER = {
         "minimax_m2_parser",  # filename
         "MiniMaxM2Parser",  # class_name
     ),
+    "minimax_m2_sanitized": (
+        "minimax_m2_sanitized_parser",
+        "MiniMaxM2SanitizedParser",
+    ),
 }
 
 

--- a/vllm/parser/minimax_m2_sanitized_parser.py
+++ b/vllm/parser/minimax_m2_sanitized_parser.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.logger import init_logger
+from vllm.parser.abstract_parser import DelegatingParser
+from vllm.reasoning.minimax_m2_sanitized_reasoning_parser import (
+    MiniMaxM2SanitizedReasoningParser,
+)
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.minimax_m2_sanitized_tool_parser import (
+    MinimaxM2SanitizedToolParser,
+)
+
+logger = init_logger(__name__)
+
+
+class MiniMaxM2SanitizedParser(DelegatingParser):
+    """Unified MiniMax M2 parser with conservative path normalization."""
+
+    reasoning_parser_cls = MiniMaxM2SanitizedReasoningParser
+    tool_parser_cls = MinimaxM2SanitizedToolParser
+
+    def __init__(self, tokenizer: TokenizerLike):
+        super().__init__(tokenizer)
+        self._reasoning_parser = MiniMaxM2SanitizedReasoningParser(tokenizer)
+        self._tool_parser = MinimaxM2SanitizedToolParser(tokenizer)
+        logger.debug("Successfully initialized parser %s!", self.__class__.__name__)

--- a/vllm/parser/path_normalizer.py
+++ b/vllm/parser/path_normalizer.py
@@ -114,7 +114,7 @@ def normalize_tool_arguments_json(arguments: str | None) -> str | None:
         return None
     try:
         parsed = json.loads(arguments)
-    except Exception:
+    except json.JSONDecodeError:
         return normalize_pathlike_text(arguments)
     normalized = _normalize_jsonish(parsed)
     return json.dumps(normalized, ensure_ascii=False)

--- a/vllm/parser/path_normalizer.py
+++ b/vllm/parser/path_normalizer.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Conservative normalization for path-like model output."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+_COMMON_EXTENSIONS = {
+    "c",
+    "cc",
+    "cfg",
+    "conf",
+    "cpp",
+    "cs",
+    "css",
+    "csv",
+    "gd",
+    "go",
+    "h",
+    "hpp",
+    "html",
+    "ini",
+    "java",
+    "js",
+    "json",
+    "jsx",
+    "lua",
+    "md",
+    "php",
+    "py",
+    "rb",
+    "rs",
+    "scss",
+    "sh",
+    "sql",
+    "svg",
+    "swift",
+    "toml",
+    "ts",
+    "tscn",
+    "tsx",
+    "txt",
+    "xml",
+    "yaml",
+    "yml",
+}
+
+_PATH_WITH_SEP_RE = re.compile(
+    r"(?P<path>(?:[A-Za-z]:)?(?:[^\s\"'`<>|]+[\\/])+[^\s\"'`<>|]+?)"
+    r"(?P<sep>\s*\.(?:\s*\.)*\s*)"
+    r"(?P<ext>[A-Za-z0-9]{1,16})(?=$|[\s\"'`),;:\]|[\\/])"
+)
+
+_STANDALONE_NAME_RE = re.compile(
+    r"(?<![A-Za-z0-9_/\\\\.-])"
+    r"(?P<base>[A-Za-z0-9][A-Za-z0-9_-]{0,255})"
+    r"(?P<sep>\s*\.(?:\s*\.)*\s*)"
+    r"(?P<ext>[A-Za-z0-9]{1,16})"
+    r"(?![A-Za-z0-9_])"
+)
+
+
+def _normalize_match(base: str, ext: str) -> str:
+    return f"{base}.{ext}"
+
+
+def _normalize_paths_with_separators(text: str) -> str:
+    def repl(match: re.Match[str]) -> str:
+        return _normalize_match(match.group("path"), match.group("ext"))
+
+    return _PATH_WITH_SEP_RE.sub(repl, text)
+
+
+def _normalize_standalone_filenames(text: str) -> str:
+    def repl(match: re.Match[str]) -> str:
+        base = match.group("base")
+        ext = match.group("ext")
+        if (
+            ext.lower() not in _COMMON_EXTENSIONS
+            and "_" not in base
+            and "-" not in base
+            and not any(ch.isdigit() for ch in base)
+        ):
+            return match.group(0)
+        return _normalize_match(base, ext)
+
+    return _STANDALONE_NAME_RE.sub(repl, text)
+
+
+def normalize_pathlike_text(text: str | None) -> str | None:
+    if text is None or "." not in text:
+        return text
+    normalized = _normalize_paths_with_separators(text)
+    normalized = _normalize_standalone_filenames(normalized)
+    return normalized
+
+
+def _normalize_jsonish(value: Any) -> Any:
+    if isinstance(value, str):
+        return normalize_pathlike_text(value)
+    if isinstance(value, list):
+        return [_normalize_jsonish(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _normalize_jsonish(item) for key, item in value.items()}
+    return value
+
+
+def normalize_tool_arguments_json(arguments: str | None) -> str | None:
+    if arguments is None:
+        return None
+    try:
+        parsed = json.loads(arguments)
+    except Exception:
+        return normalize_pathlike_text(arguments)
+    normalized = _normalize_jsonish(parsed)
+    return json.dumps(normalized, ensure_ascii=False)

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -60,6 +60,10 @@ _REASONING_PARSERS_TO_REGISTER = {
         "minimax_m2_reasoning_parser",
         "MiniMaxM2ReasoningParser",
     ),
+    "minimax_m2_sanitized": (
+        "minimax_m2_sanitized_reasoning_parser",
+        "MiniMaxM2SanitizedReasoningParser",
+    ),
     "minimax_m2_append_think": (
         "minimax_m2_reasoning_parser",
         "MiniMaxM2AppendThinkReasoningParser",

--- a/vllm/reasoning/minimax_m2_sanitized_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_sanitized_reasoning_parser.py
@@ -3,10 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.path_normalizer import normalize_pathlike_text
 from vllm.reasoning.minimax_m2_reasoning_parser import MiniMaxM2ReasoningParser
@@ -14,29 +11,6 @@ from vllm.reasoning.minimax_m2_reasoning_parser import MiniMaxM2ReasoningParser
 
 class MiniMaxM2SanitizedReasoningParser(MiniMaxM2ReasoningParser):
     """MiniMax M2 reasoning parser with conservative path normalization."""
-
-    def extract_reasoning_streaming(
-        self,
-        previous_text: str,
-        current_text: str,
-        delta_text: str,
-        previous_token_ids: Sequence[int],
-        current_token_ids: Sequence[int],
-        delta_token_ids: Sequence[int],
-    ) -> DeltaMessage | None:
-        delta = super().extract_reasoning_streaming(
-            previous_text,
-            current_text,
-            delta_text,
-            previous_token_ids,
-            current_token_ids,
-            delta_token_ids,
-        )
-        if delta is None:
-            return None
-        if delta.content is not None:
-            delta.content = normalize_pathlike_text(delta.content)
-        return delta
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest | ResponsesRequest

--- a/vllm/reasoning/minimax_m2_sanitized_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_sanitized_reasoning_parser.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.parser.path_normalizer import normalize_pathlike_text
+from vllm.reasoning.minimax_m2_reasoning_parser import MiniMaxM2ReasoningParser
+
+
+class MiniMaxM2SanitizedReasoningParser(MiniMaxM2ReasoningParser):
+    """MiniMax M2 reasoning parser with conservative path normalization."""
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        delta = super().extract_reasoning_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+        )
+        if delta is None:
+            return None
+        if delta.content is not None:
+            delta.content = normalize_pathlike_text(delta.content)
+        return delta
+
+    def extract_reasoning(
+        self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
+    ) -> tuple[str | None, str | None]:
+        reasoning, content = super().extract_reasoning(model_output, request)
+        return reasoning, normalize_pathlike_text(content)

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -98,6 +98,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "minimax_m2_tool_parser",
         "MinimaxM2ToolParser",
     ),
+    "minimax_m2_sanitized": (
+        "minimax_m2_sanitized_tool_parser",
+        "MinimaxM2SanitizedToolParser",
+    ),
     "minimax": (
         "minimax_tool_parser",
         "MinimaxToolParser",

--- a/vllm/tool_parsers/minimax_m2_sanitized_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_sanitized_tool_parser.py
@@ -3,10 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.parser.path_normalizer import (
     normalize_pathlike_text,
     normalize_tool_arguments_json,
@@ -31,34 +28,3 @@ class MinimaxM2SanitizedToolParser(MinimaxM2ToolParser):
                 or tool_call.function.arguments
             )
         return info
-
-    def extract_tool_calls_streaming(
-        self,
-        previous_text: str,
-        current_text: str,
-        delta_text: str,
-        previous_token_ids: Sequence[int],
-        current_token_ids: Sequence[int],
-        delta_token_ids: Sequence[int],
-        request: ChatCompletionRequest,
-    ) -> DeltaMessage | None:
-        delta = super().extract_tool_calls_streaming(
-            previous_text,
-            current_text,
-            delta_text,
-            previous_token_ids,
-            current_token_ids,
-            delta_token_ids,
-            request,
-        )
-        if delta is None:
-            return None
-        if delta.content is not None:
-            delta.content = normalize_pathlike_text(delta.content)
-        for tool_call in delta.tool_calls:
-            if tool_call.function and tool_call.function.arguments is not None:
-                tool_call.function.arguments = (
-                    normalize_pathlike_text(tool_call.function.arguments)
-                    or tool_call.function.arguments
-                )
-        return delta

--- a/vllm/tool_parsers/minimax_m2_sanitized_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_sanitized_tool_parser.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.parser.path_normalizer import (
+    normalize_pathlike_text,
+    normalize_tool_arguments_json,
+)
+from vllm.tool_parsers.minimax_m2_tool_parser import MinimaxM2ToolParser
+
+
+class MinimaxM2SanitizedToolParser(MinimaxM2ToolParser):
+    """MiniMax M2 tool parser with conservative path normalization."""
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ):
+        info = super().extract_tool_calls(model_output, request)
+        if info.content is not None:
+            info.content = normalize_pathlike_text(info.content)
+        for tool_call in info.tool_calls:
+            tool_call.function.arguments = (
+                normalize_tool_arguments_json(tool_call.function.arguments)
+                or tool_call.function.arguments
+            )
+        return info
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        delta = super().extract_tool_calls_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+            request,
+        )
+        if delta is None:
+            return None
+        if delta.content is not None:
+            delta.content = normalize_pathlike_text(delta.content)
+        for tool_call in delta.tool_calls:
+            if tool_call.function and tool_call.function.arguments is not None:
+                tool_call.function.arguments = (
+                    normalize_pathlike_text(tool_call.function.arguments)
+                    or tool_call.function.arguments
+                )
+        return delta


### PR DESCRIPTION
## Summary

This PR adds an opt-in MiniMax M2 parser variant, `minimax_m2_sanitized`, that conservatively normalizes malformed path-like output in assistant content and tool-call arguments.

It is intended to mitigate formatting issues where the model emits file paths such as:

- `scripts/monkey_character. gd`
- `main_menu. tscn`
- `forest_platform..py`

and rewrites them to:

- `scripts/monkey_character.gd`
- `main_menu.tscn`
- `forest_platform.py`

Default `minimax_m2` behavior is unchanged.

## What this adds

- `vllm/parser/path_normalizer.py`
  - conservative normalization helpers for path-like text
- `MiniMaxM2SanitizedReasoningParser`
- `MinimaxM2SanitizedToolParser`
- `MiniMaxM2SanitizedParser`
- registry wiring for:
  - `minimax_m2_sanitized` reasoning parser
  - `minimax_m2_sanitized` tool parser
  - `minimax_m2_sanitized` unified parser
- focused unit tests for:
  - path normalization
  - reasoning parser content normalization
  - tool parser content / argument normalization

## Design notes

- This is opt-in only.
- The stock `minimax_m2` parser is untouched.
- The normalizer is intentionally conservative:
  - it rewrites full path-like strings more confidently
  - it avoids aggressively rewriting ordinary prose

## Motivation

In some coding-agent workflows, MiniMax M2.5 can emit malformed file paths with whitespace before extensions or duplicate dots before extensions. Since downstream tools often require exact path strings, this can break file operations or produce invalid tool arguments.

This parser variant provides a server-side mitigation without changing default MiniMax behavior.

## Validation

Locally validated with targeted tests covering:
- path spacing normalization
- duplicate dot normalization
- non-streaming reasoning content normalization
- tool argument normalization
- visible content normalization

## Usage

```bash
--tool-call-parser minimax_m2_sanitized
--reasoning-parser minimax_m2_sanitized
