### PR TITLE
[Frontend] Use unified Parser for chat completions non-streaming

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat_parser.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat_parser.py
@@ -1,0 +1,543 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+)
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine.protocol import FunctionCall
+from vllm.entrypoints.openai.models.serving import (
+    BaseModelPath,
+    OpenAIServingModels,
+)
+from vllm.inputs import TokensPrompt
+from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.v1.engine.async_llm import AsyncLLM
+
+MODEL_NAME = "test-model"
+BASE_MODEL_PATHS = [BaseModelPath(name=MODEL_NAME, model_path=MODEL_NAME)]
+
+
+class MockModelConfig:
+    task = "generate"
+    runner_type = "generate"
+    model = MODEL_NAME
+    tokenizer = MODEL_NAME
+    trust_remote_code = False
+    tokenizer_mode = "auto"
+    max_model_len = 100
+    tokenizer_revision = None
+    generation_config = "auto"
+    override_generation_config: dict[str, int] = {}
+    hf_config = type("HFConfig", (), {"model_type": "any"})()
+    hf_text_config = type("HFTextConfig", (), {"model_type": "any"})()
+    is_encoder_decoder = False
+    is_multimodal_model = False
+
+    def get_diff_sampling_param(self):
+        return {}
+
+
+def _build_serving_chat(engine: AsyncLLM) -> OpenAIServingChat:
+    models = OpenAIServingModels(
+        engine_client=engine,
+        base_model_paths=BASE_MODEL_PATHS,
+    )
+    return OpenAIServingChat(
+        engine,
+        models,
+        response_role="assistant",
+        openai_serving_render=MagicMock(),
+        chat_template="unused",
+        chat_template_content_format="auto",
+        request_logger=None,
+    )
+
+
+def _stub_mistral_tokenizer(monkeypatch):
+    mistral_module = types.ModuleType("vllm.tokenizers.mistral")
+    mistral_module.__dict__["MistralTokenizer"] = type("MistralTokenizer", (), {})
+    monkeypatch.setitem(sys.modules, "vllm.tokenizers.mistral", mistral_module)
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_chat_uses_unified_parser(monkeypatch):
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {}
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = MagicMock(tokenizer=tokenizer)
+
+    async def mock_generate(*args, **kwargs):
+        yield RequestOutput(
+            request_id="test-request",
+            prompt="test prompt",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="ignored by parser",
+                    token_ids=[4, 5, 6],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            ],
+            finished=True,
+        )
+
+    mock_engine.generate = mock_generate
+
+    serving_chat = _build_serving_chat(mock_engine)
+    serving_chat.enable_auto_tools = True
+    serving_chat.tool_parser = MagicMock()
+
+    async def render_chat_request(_request):
+        return ([], [TokensPrompt(prompt_token_ids=[1, 2, 3], prompt="test prompt")])
+
+    serving_chat.render_chat_request = render_chat_request
+
+    parser_init_kwargs = {}
+
+    class SpyReasoningParser:
+        def __init__(self, tokenizer, *args, **kwargs):
+            parser_init_kwargs["reasoning_parser_kwargs"] = kwargs
+
+        def is_reasoning_end(self, input_ids):
+            return False
+
+        def extract_reasoning(self, model_output, request):
+            raise AssertionError(
+                "non-streaming chat should use parser.extract_chat_completion_parts"
+            )
+
+    class SpyParser:
+        def __init__(self, tokenizer, *args, **kwargs):
+            parser_init_kwargs["parser_kwargs"] = kwargs
+
+        def extract_chat_completion_parts(
+            self,
+            *,
+            model_output: str,
+            request: ChatCompletionRequest,
+            enable_auto_tools: bool = False,
+        ):
+            assert model_output == "ignored by parser"
+            assert enable_auto_tools is True
+            return (
+                "thinking",
+                [
+                    FunctionCall(
+                        name="get_weather",
+                        arguments='{"location": "Rome"}',
+                    )
+                ],
+                None,
+            )
+
+    serving_chat.reasoning_parser_cls = SpyReasoningParser
+    serving_chat.parser_cls = SpyParser
+
+    _stub_mistral_tokenizer(monkeypatch)
+
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "What's the weather?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather in a given location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            }
+        ],
+        tool_choice="auto",
+        chat_template_kwargs={"foo": "bar"},
+    )
+
+    response = await serving_chat.create_chat_completion(req)
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert parser_init_kwargs["reasoning_parser_kwargs"] == {
+        "chat_template_kwargs": {"foo": "bar"}
+    }
+    assert parser_init_kwargs["parser_kwargs"] == {
+        "chat_template_kwargs": {"foo": "bar"}
+    }
+
+    choice = response.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    assert choice.index == 0
+    assert choice.message.role == "assistant"
+    assert choice.message.reasoning == "thinking"
+    assert choice.message.content is None
+    assert len(choice.message.tool_calls) == 1
+    assert choice.message.tool_calls[0].function.name == "get_weather"
+    assert choice.message.tool_calls[0].function.arguments == '{"location": "Rome"}'
+    assert choice.message.tool_calls[0].type == "function"
+    assert choice.message.tool_calls[0].id is not None
+    assert response.id.startswith("chatcmpl-")
+    assert response.model == MODEL_NAME
+    assert response.usage.prompt_tokens == 3
+    assert response.usage.completion_tokens == 3
+    assert response.usage.total_tokens == 6
+    assert response.prompt_token_ids is None
+    assert choice.token_ids is None
+    assert response.prompt_logprobs is None
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_chat_named_tool_choice_uses_parser_output(monkeypatch):
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {}
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = MagicMock(tokenizer=tokenizer)
+
+    async def mock_generate(*args, **kwargs):
+        yield RequestOutput(
+            request_id="test-request",
+            prompt="test prompt",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="ignored by parser",
+                    token_ids=[4, 5, 6],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            ],
+            finished=True,
+        )
+
+    mock_engine.generate = mock_generate
+    serving_chat = _build_serving_chat(mock_engine)
+
+    async def render_chat_request(_request):
+        return ([], [TokensPrompt(prompt_token_ids=[1, 2, 3], prompt="test prompt")])
+
+    class SpyParser:
+        def __init__(self, tokenizer, *args, **kwargs):
+            pass
+
+        def extract_chat_completion_parts(
+            self,
+            *,
+            model_output: str,
+            request: ChatCompletionRequest,
+            enable_auto_tools: bool = False,
+        ):
+            return (
+                None,
+                [FunctionCall(name="get_weather", arguments='{"location": "Rome"}')],
+                None,
+            )
+
+    serving_chat.render_chat_request = render_chat_request
+    serving_chat.parser_cls = SpyParser
+    _stub_mistral_tokenizer(monkeypatch)
+
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "What's the weather?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather in a given location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            }
+        ],
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+    )
+
+    response = await serving_chat.create_chat_completion(req)
+
+    assert isinstance(response, ChatCompletionResponse)
+    choice = response.choices[0]
+    assert choice.finish_reason == "stop"
+    assert choice.message.content == ""
+    assert len(choice.message.tool_calls) == 1
+    assert choice.message.tool_calls[0].function.name == "get_weather"
+    assert choice.message.tool_calls[0].function.arguments == '{"location": "Rome"}'
+    assert choice.message.tool_calls[0].id is not None
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_chat_required_tool_choice_uses_parser_output(
+    monkeypatch,
+):
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {}
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = MagicMock(tokenizer=tokenizer)
+
+    async def mock_generate(*args, **kwargs):
+        yield RequestOutput(
+            request_id="test-request",
+            prompt="test prompt",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="ignored by parser",
+                    token_ids=[4, 5, 6],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            ],
+            finished=True,
+        )
+
+    mock_engine.generate = mock_generate
+    serving_chat = _build_serving_chat(mock_engine)
+
+    async def render_chat_request(_request):
+        return ([], [TokensPrompt(prompt_token_ids=[1, 2, 3], prompt="test prompt")])
+
+    class SpyParser:
+        def __init__(self, tokenizer, *args, **kwargs):
+            pass
+
+        def extract_chat_completion_parts(
+            self,
+            *,
+            model_output: str,
+            request: ChatCompletionRequest,
+            enable_auto_tools: bool = False,
+        ):
+            return (
+                None,
+                [FunctionCall(name="get_weather", arguments='{"location": "Rome"}')],
+                None,
+            )
+
+    serving_chat.render_chat_request = render_chat_request
+    serving_chat.parser_cls = SpyParser
+    _stub_mistral_tokenizer(monkeypatch)
+
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "What's the weather?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather in a given location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            }
+        ],
+        tool_choice="required",
+    )
+
+    response = await serving_chat.create_chat_completion(req)
+
+    assert isinstance(response, ChatCompletionResponse)
+    choice = response.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.content == ""
+    assert len(choice.message.tool_calls) == 1
+    assert choice.message.tool_calls[0].function.name == "get_weather"
+    assert choice.message.tool_calls[0].function.arguments == '{"location": "Rome"}'
+    assert choice.message.tool_calls[0].id is not None
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_chat_named_tool_choice_without_parser_still_wraps_tool(
+    monkeypatch,
+):
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {}
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = MagicMock(tokenizer=tokenizer)
+
+    async def mock_generate(*args, **kwargs):
+        yield RequestOutput(
+            request_id="test-request",
+            prompt="test prompt",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text='{"location": "Rome"}',
+                    token_ids=[4, 5, 6],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            ],
+            finished=True,
+        )
+
+    mock_engine.generate = mock_generate
+    serving_chat = _build_serving_chat(mock_engine)
+    serving_chat.reasoning_parser_cls = None
+    serving_chat.parser_cls = None
+
+    async def render_chat_request(_request):
+        return ([], [TokensPrompt(prompt_token_ids=[1, 2, 3], prompt="test prompt")])
+
+    serving_chat.render_chat_request = render_chat_request
+    _stub_mistral_tokenizer(monkeypatch)
+
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "What's the weather?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather in a given location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            }
+        ],
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+    )
+
+    response = await serving_chat.create_chat_completion(req)
+
+    assert isinstance(response, ChatCompletionResponse)
+    choice = response.choices[0]
+    assert choice.finish_reason == "stop"
+    assert choice.message.content == ""
+    assert len(choice.message.tool_calls) == 1
+    assert choice.message.tool_calls[0].function.name == "get_weather"
+    assert choice.message.tool_calls[0].function.arguments == '{"location": "Rome"}'
+    assert choice.message.tool_calls[0].id is not None
+
+
+@pytest.mark.asyncio
+async def test_required_tool_choice_without_parser_still_parses_tools(
+    monkeypatch,
+):
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {}
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = MagicMock(tokenizer=tokenizer)
+
+    async def mock_generate(*args, **kwargs):
+        yield RequestOutput(
+            request_id="test-request",
+            prompt="test prompt",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text=('[{"name":"get_weather","parameters":{"location":"Rome"}}]'),
+                    token_ids=[4, 5, 6],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            ],
+            finished=True,
+        )
+
+    mock_engine.generate = mock_generate
+    serving_chat = _build_serving_chat(mock_engine)
+    serving_chat.reasoning_parser_cls = None
+    serving_chat.parser_cls = None
+
+    async def render_chat_request(_request):
+        return ([], [TokensPrompt(prompt_token_ids=[1, 2, 3], prompt="test prompt")])
+
+    serving_chat.render_chat_request = render_chat_request
+    _stub_mistral_tokenizer(monkeypatch)
+
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "What's the weather?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather in a given location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            }
+        ],
+        tool_choice="required",
+    )
+
+    response = await serving_chat.create_chat_completion(req)
+
+    assert isinstance(response, ChatCompletionResponse)
+    choice = response.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.content == ""
+    assert len(choice.message.tool_calls) == 1
+    assert choice.message.tool_calls[0].function.name == "get_weather"
+    assert choice.message.tool_calls[0].function.arguments == '{"location": "Rome"}'
+    assert choice.message.tool_calls[0].id is not None

--- a/tests/entrypoints/openai/parser/test_abstract_parser.py
+++ b/tests/entrypoints/openai/parser/test_abstract_parser.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import (
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.parser import ParserManager
+from vllm.parser.abstract_parser import DelegatingParser, _WrappedParser
+from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
+from vllm.tool_parsers.abstract_tool_parser import ToolParser
+
+MODEL_NAME = "fake-model"
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather in a given location",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+
+def _make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {}
+    return tokenizer
+
+
+def _make_request(**kwargs) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "What's the weather?"}],
+        **kwargs,
+    )
+
+
+def test_extract_chat_completion_parts_reasoning_only():
+    parser = DelegatingParser(_make_tokenizer())
+    reasoning_parser = MagicMock()
+    tool_parser = MagicMock()
+    reasoning_parser.extract_reasoning.return_value = ("thinking", "final answer")
+    parser.reasoning_parser = reasoning_parser
+    parser.tool_parser = tool_parser
+
+    reasoning, tool_calls, content = parser.extract_chat_completion_parts(
+        model_output="ignored",
+        request=_make_request(),
+    )
+
+    assert reasoning == "thinking"
+    assert tool_calls == []
+    assert content == "final answer"
+    tool_parser.extract_tool_calls.assert_not_called()
+
+
+def test_extract_chat_completion_parts_named_tool_choice():
+    parser = DelegatingParser(_make_tokenizer())
+    reasoning_parser = MagicMock()
+    reasoning_parser.extract_reasoning.return_value = (None, '{"location": "Rome"}')
+    parser.reasoning_parser = reasoning_parser
+
+    reasoning, tool_calls, content = parser.extract_chat_completion_parts(
+        model_output="ignored",
+        request=_make_request(
+            tools=TOOLS,
+            tool_choice={"type": "function", "function": {"name": "get_weather"}},
+        ),
+    )
+
+    assert reasoning is None
+    assert tool_calls == [
+        FunctionCall(name="get_weather", arguments='{"location": "Rome"}')
+    ]
+    assert content is None
+
+
+def test_extract_chat_completion_parts_required_tool_choice():
+    parser = DelegatingParser(_make_tokenizer())
+    reasoning_parser = MagicMock()
+    reasoning_parser.extract_reasoning.return_value = (
+        None,
+        '[{"name":"get_weather","parameters":{"location":"Rome"}}]',
+    )
+    parser.reasoning_parser = reasoning_parser
+
+    reasoning, tool_calls, content = parser.extract_chat_completion_parts(
+        model_output="ignored",
+        request=_make_request(tools=TOOLS, tool_choice="required"),
+    )
+
+    assert reasoning is None
+    assert tool_calls == [
+        FunctionCall(name="get_weather", arguments='{"location": "Rome"}')
+    ]
+    assert content is None
+
+
+def test_extract_chat_completion_parts_auto_tool_choice():
+    parser = DelegatingParser(_make_tokenizer())
+    reasoning_parser = MagicMock()
+    tool_parser = MagicMock()
+    reasoning_parser.extract_reasoning.return_value = ("thinking", "raw tool output")
+    tool_parser.extract_tool_calls.return_value = ExtractedToolCallInformation(
+        tools_called=True,
+        tool_calls=[
+            ToolCall(
+                id="call_auto",
+                function=FunctionCall(
+                    name="get_weather",
+                    arguments='{"location": "Rome"}',
+                ),
+            )
+        ],
+        content="   ",
+    )
+    parser.reasoning_parser = reasoning_parser
+    parser.tool_parser = tool_parser
+
+    reasoning, tool_calls, content = parser.extract_chat_completion_parts(
+        model_output="ignored",
+        request=_make_request(tools=TOOLS, tool_choice="auto"),
+        enable_auto_tools=True,
+    )
+
+    assert reasoning == "thinking"
+    assert tool_calls == [
+        FunctionCall(
+            id="call_auto",
+            name="get_weather",
+            arguments='{"location": "Rome"}',
+        )
+    ]
+    assert content is None
+    tool_parser.extract_tool_calls.assert_called_once()
+
+
+def test_get_parser_wrapped_parser_forwards_chat_template_kwargs(monkeypatch):
+    seen_kwargs: dict[str, object] = {}
+
+    class DummyReasoningParser(ReasoningParser):
+        def __init__(self, tokenizer, *args, **kwargs):
+            super().__init__(tokenizer, *args, **kwargs)
+            seen_kwargs["reasoning"] = kwargs
+
+        def is_reasoning_end(self, input_ids):
+            return False
+
+        def extract_content_ids(self, input_ids):
+            return input_ids
+
+        def extract_reasoning(self, model_output, request):
+            return None, model_output
+
+        def extract_reasoning_streaming(
+            self,
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+        ):
+            return None
+
+    class DummyToolParser(ToolParser):
+        def __init__(self, tokenizer, tools=None):
+            super().__init__(tokenizer, tools)
+            seen_kwargs["tool"] = "constructed"
+
+        def extract_tool_calls(self, model_output, request):
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output,
+            )
+
+    monkeypatch.setattr(
+        ParserManager,
+        "get_parser_internal",
+        classmethod(lambda cls, name: (_ for _ in ()).throw(KeyError(name))),
+    )
+    monkeypatch.setattr(
+        ParserManager,
+        "get_reasoning_parser",
+        classmethod(lambda cls, reasoning_parser_name: DummyReasoningParser),
+    )
+    monkeypatch.setattr(
+        ParserManager,
+        "get_tool_parser",
+        classmethod(
+            lambda cls, tool_parser_name, enable_auto_tools, model_name: DummyToolParser
+        ),
+    )
+
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="dummy_tool",
+        reasoning_parser_name="dummy_reasoning",
+        enable_auto_tools=True,
+        model_name=MODEL_NAME,
+    )
+
+    assert parser_cls is not None
+    parser = parser_cls(_make_tokenizer(), chat_template_kwargs={"foo": "bar"})
+
+    assert seen_kwargs["reasoning"] == {"chat_template_kwargs": {"foo": "bar"}}
+    assert seen_kwargs["tool"] == "constructed"
+    assert parser.reasoning_parser is not None
+    assert parser.tool_parser is not None
+
+
+def test_minimax_m2_parser_forwards_chat_template_kwargs(monkeypatch):
+    from vllm.parser import minimax_m2_parser as minimax_m2_parser_module
+
+    seen_kwargs: dict[str, object] = {}
+
+    class DummyReasoningParser(ReasoningParser):
+        def __init__(self, tokenizer, *args, **kwargs):
+            super().__init__(tokenizer, *args, **kwargs)
+            seen_kwargs["reasoning"] = kwargs
+
+        def is_reasoning_end(self, input_ids):
+            return False
+
+        def extract_content_ids(self, input_ids):
+            return input_ids
+
+        def extract_reasoning(self, model_output, request):
+            return None, model_output
+
+        def extract_reasoning_streaming(
+            self,
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+        ):
+            return None
+
+    class DummyToolParser(ToolParser):
+        def __init__(self, tokenizer, tools=None):
+            super().__init__(tokenizer, tools)
+            seen_kwargs["tool"] = "constructed"
+
+        def extract_tool_calls(self, model_output, request):
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output,
+            )
+
+    monkeypatch.setattr(
+        minimax_m2_parser_module,
+        "MiniMaxM2ReasoningParser",
+        DummyReasoningParser,
+    )
+    monkeypatch.setattr(
+        minimax_m2_parser_module,
+        "MinimaxM2ToolParser",
+        DummyToolParser,
+    )
+
+    parser = minimax_m2_parser_module.MiniMaxM2Parser(
+        _make_tokenizer(),
+        chat_template_kwargs={"foo": "bar"},
+    )
+
+    assert seen_kwargs["reasoning"] == {"chat_template_kwargs": {"foo": "bar"}}
+    assert seen_kwargs["tool"] == "constructed"
+    assert parser.reasoning_parser is not None
+    assert parser.tool_parser is not None
+
+
+def test_get_parser_preserves_distinct_reasoning_and_tool_parser_selection():
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="minimax_m2",
+        reasoning_parser_name="minimax_m2_append_think",
+        enable_auto_tools=True,
+        model_name=MODEL_NAME,
+    )
+
+    assert parser_cls is _WrappedParser
+    assert parser_cls.reasoning_parser_cls is ParserManager.get_reasoning_parser(
+        "minimax_m2_append_think"
+    )
+    assert parser_cls.tool_parser_cls is ParserManager.get_tool_parser(
+        "minimax_m2",
+        enable_auto_tools=True,
+        model_name=MODEL_NAME,
+    )
+
+
+def test_get_parser_tool_only_selection_preserves_reasoning_none():
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="minimax_m2",
+        reasoning_parser_name=None,
+        enable_auto_tools=True,
+        model_name=MODEL_NAME,
+    )
+
+    assert parser_cls is _WrappedParser
+    assert parser_cls.reasoning_parser_cls is None
+    assert parser_cls.tool_parser_cls is ParserManager.get_tool_parser(
+        "minimax_m2",
+        enable_auto_tools=True,
+        model_name=MODEL_NAME,
+    )
+
+
+def test_get_parser_reasoning_only_selection_preserves_tool_none():
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name=None,
+        reasoning_parser_name="minimax_m2",
+        enable_auto_tools=True,
+        model_name=MODEL_NAME,
+    )
+
+    assert parser_cls is _WrappedParser
+    assert parser_cls.reasoning_parser_cls is ParserManager.get_reasoning_parser(
+        "minimax_m2"
+    )
+    assert parser_cls.tool_parser_cls is None

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import contextlib
 import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
@@ -13,6 +14,7 @@ import partial_json_parser
 import regex as re
 from fastapi import Request
 from partial_json_parser.core.options import Allow
+from pydantic import TypeAdapter, ValidationError
 
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
@@ -45,6 +47,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaToolCall,
     ErrorResponse,
     FunctionCall,
+    FunctionDefinition,
     PromptTokenUsageInfo,
     RequestResponseMetadata,
     ToolCall,
@@ -126,6 +129,12 @@ class OpenAIServingChat(OpenAIServing):
         # set up reasoning parser
         self.reasoning_parser_cls = ParserManager.get_reasoning_parser(
             reasoning_parser_name=reasoning_parser
+        )
+        self.parser_cls = ParserManager.get_parser(
+            tool_parser_name=tool_parser,
+            reasoning_parser_name=reasoning_parser,
+            enable_auto_tools=enable_auto_tools,
+            model_name=self.model_config.model,
         )
         # set up tool use
         self.enable_auto_tools: bool = enable_auto_tools
@@ -232,6 +241,14 @@ class OpenAIServingChat(OpenAIServing):
                 tokenizer,
                 chat_template_kwargs=chat_template_kwargs,  # type: ignore[call-arg]
             )
+        parser = (
+            self.parser_cls(
+                tokenizer,
+                chat_template_kwargs=chat_template_kwargs,  # type: ignore[call-arg]
+            )
+            if self.parser_cls
+            else None
+        )
         result = await self.render_chat_request(request)
         if isinstance(result, ErrorResponse):
             return result
@@ -355,6 +372,7 @@ class OpenAIServingChat(OpenAIServing):
             tokenizer,
             request_metadata,
             reasoning_parser,
+            parser,
         )
 
     def get_chat_request_role(self, request: ChatCompletionRequest) -> str:
@@ -1190,6 +1208,7 @@ class OpenAIServingChat(OpenAIServing):
         tokenizer: TokenizerLike,
         request_metadata: RequestResponseMetadata,
         reasoning_parser: ReasoningParser | None = None,
+        parser: "Parser | None" = None,
     ) -> ErrorResponse | ChatCompletionResponse:
         from vllm.tokenizers.mistral import MistralTokenizer
 
@@ -1287,28 +1306,51 @@ class OpenAIServingChat(OpenAIServing):
                 choices.append(choice_data)
                 continue
 
-            if reasoning_parser:
-                # If the reasoning parser is enabled,
-                # tool calls are extracted exclusively from the content.
-                reasoning, content = reasoning_parser.extract_reasoning(
-                    output.text, request=request
+            if parser is not None:
+                reasoning, tool_calls, content = parser.extract_chat_completion_parts(
+                    model_output=output.text,
+                    request=request,
+                    enable_auto_tools=self.enable_auto_tools,
                 )
                 if not request.include_reasoning:
                     reasoning = None
             else:
                 reasoning = None
                 content = output.text
+                tool_calls = []
+
+                # Preserve pre-parser forced tool-call handling when chat
+                # completions are valid without a unified parser configured.
+                if request.tool_choice and isinstance(
+                    request.tool_choice, ChatCompletionNamedToolChoiceParam
+                ):
+                    assert content is not None
+                    tool_calls = [
+                        FunctionCall(
+                            name=request.tool_choice.function.name,
+                            arguments=content,
+                        )
+                    ]
+                    content = None
+                elif request.tool_choice == "required":
+                    parsed_tool_calls = []
+                    with contextlib.suppress(ValidationError):
+                        content = content or ""
+                        parsed_tool_calls = TypeAdapter(
+                            list[FunctionDefinition]
+                        ).validate_json(content)
+                    for parsed_tool_call in parsed_tool_calls:
+                        tool_calls.append(
+                            FunctionCall(
+                                name=parsed_tool_call.name,
+                                arguments=json.dumps(
+                                    parsed_tool_call.parameters, ensure_ascii=False
+                                ),
+                            )
+                        )
+                    content = None
 
             auto_tools_called = False
-            # if auto tools are not enabled, and a named tool choice using
-            #   outlines is not being used
-            tool_calls, content = self._parse_tool_calls_from_content(
-                request=request,
-                tokenizer=tokenizer,
-                content=content,
-                enable_auto_tools=self.enable_auto_tools,
-                tool_parser_cls=self.tool_parser,
-            )
             tool_call_class = (
                 MistralToolCall if is_mistral_tokenizer(tokenizer) else ToolCall
             )
@@ -1318,9 +1360,8 @@ class OpenAIServingChat(OpenAIServing):
             ):
                 message = ChatMessage(role=role, reasoning=reasoning, content=content)
 
-            elif (
-                request.tool_choice
-                and type(request.tool_choice) is ChatCompletionNamedToolChoiceParam
+            elif request.tool_choice and isinstance(
+                request.tool_choice, ChatCompletionNamedToolChoiceParam
             ):
                 assert tool_calls is not None and len(tool_calls) > 0
                 tool_call_class_items = []

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
-import contextlib
 import json
 import time
 from collections.abc import AsyncGenerator, Mapping
@@ -11,8 +10,7 @@ from typing import Any, ClassVar, Generic, Protocol, TypeAlias, TypeVar
 
 import numpy as np
 from fastapi import Request
-from openai.types.responses import ToolChoiceFunction
-from pydantic import ConfigDict, TypeAdapter, ValidationError
+from pydantic import ConfigDict
 from starlette.datastructures import Headers
 
 import vllm.envs as envs
@@ -23,7 +21,6 @@ from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.chat_completion.protocol import (
     BatchChatCompletionRequest,
-    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
@@ -33,8 +30,6 @@ from vllm.entrypoints.openai.completion.protocol import (
 )
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
-    FunctionCall,
-    FunctionDefinition,
     GenerationError,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
@@ -64,7 +59,6 @@ from vllm.renderers.inputs.preprocess import (
 )
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
-from vllm.tool_parsers import ToolParser
 from vllm.tracing import (
     contains_trace_headers,
     extract_trace_headers,
@@ -601,85 +595,6 @@ class OpenAIServing:
             return int(rank_str)
         except ValueError:
             return None
-
-    @staticmethod
-    def _parse_tool_calls_from_content(
-        request: ResponsesRequest | ChatCompletionRequest,
-        tokenizer: TokenizerLike | None,
-        enable_auto_tools: bool,
-        tool_parser_cls: type[ToolParser] | None,
-        content: str | None = None,
-    ) -> tuple[list[FunctionCall] | None, str | None]:
-        function_calls = list[FunctionCall]()
-        if request.tool_choice and isinstance(request.tool_choice, ToolChoiceFunction):
-            assert content is not None
-            # Forced Function Call
-            function_calls.append(
-                FunctionCall(name=request.tool_choice.name, arguments=content)
-            )
-            content = None  # Clear content since tool is called.
-        elif request.tool_choice and isinstance(
-            request.tool_choice, ChatCompletionNamedToolChoiceParam
-        ):
-            assert content is not None
-            # Forced Function Call
-            function_calls.append(
-                FunctionCall(name=request.tool_choice.function.name, arguments=content)
-            )
-            content = None  # Clear content since tool is called.
-        elif request.tool_choice == "required":
-            tool_calls = []
-            with contextlib.suppress(ValidationError):
-                content = content or ""
-                tool_calls = TypeAdapter(list[FunctionDefinition]).validate_json(
-                    content
-                )
-            for tool_call in tool_calls:
-                function_calls.append(
-                    FunctionCall(
-                        name=tool_call.name,
-                        arguments=json.dumps(tool_call.parameters, ensure_ascii=False),
-                    )
-                )
-            content = None  # Clear content since tool is called.
-        elif (
-            tool_parser_cls
-            and enable_auto_tools
-            and (request.tool_choice == "auto" or request.tool_choice is None)
-        ):
-            if tokenizer is None:
-                raise ValueError(
-                    "Tokenizer not available when `skip_tokenizer_init=True`"
-                )
-
-            # Automatic Tool Call Parsing
-            try:
-                tool_parser = tool_parser_cls(tokenizer, request.tools)
-            except RuntimeError as e:
-                logger.exception("Error in tool parser creation.")
-                raise e
-            tool_call_info = tool_parser.extract_tool_calls(
-                content if content is not None else "",
-                request=request,  # type: ignore
-            )
-            if tool_call_info is not None and tool_call_info.tools_called:
-                # extract_tool_calls() returns a list of tool calls.
-                function_calls.extend(
-                    FunctionCall(
-                        id=tool_call.id,
-                        name=tool_call.function.name,
-                        arguments=tool_call.function.arguments,
-                    )
-                    for tool_call in tool_call_info.tool_calls
-                )
-                content = tool_call_info.content
-                if content and content.strip() == "":
-                    content = None
-            else:
-                # No tool calls.
-                return None, content
-
-        return function_calls, content
 
     @staticmethod
     def _get_decoded_token(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -194,6 +194,79 @@ class Parser:
             A list of ResponseOutputItem objects.
         """
 
+    def extract_chat_completion_parts(
+        self,
+        *,
+        model_output: str,
+        request: ChatCompletionRequest,
+        enable_auto_tools: bool = False,
+    ) -> tuple[str | None, list[FunctionCall], str | None]:
+        """
+        Extract reasoning, tool calls, and remaining content from a complete
+        model-generated string for Chat Completions.
+
+        Used for non-streaming chat completion responses where we have the
+        entire model output available before constructing the final message.
+
+        Args:
+            model_output: The complete model-generated string.
+            request: The chat completion request used to generate the output.
+            enable_auto_tools: Whether to enable automatic tool call parsing.
+
+        Returns:
+            A tuple of (reasoning_content, function_calls, remaining_content).
+        """
+        reasoning, content = self.extract_reasoning(model_output, request)
+        function_calls: list[FunctionCall] = []
+
+        if request.tool_choice and isinstance(
+            request.tool_choice, ChatCompletionNamedToolChoiceParam
+        ):
+            assert content is not None
+            function_calls.append(
+                FunctionCall(name=request.tool_choice.function.name, arguments=content)
+            )
+            return reasoning, function_calls, None
+
+        if request.tool_choice == "required":
+            tool_calls = []
+            with contextlib.suppress(ValidationError):
+                content = content or ""
+                tool_calls = TypeAdapter(list[FunctionDefinition]).validate_json(
+                    content
+                )
+            for tool_call in tool_calls:
+                function_calls.append(
+                    FunctionCall(
+                        name=tool_call.name,
+                        arguments=json.dumps(tool_call.parameters, ensure_ascii=False),
+                    )
+                )
+            return reasoning, function_calls, None
+
+        if enable_auto_tools and (
+            request.tool_choice == "auto" or request.tool_choice is None
+        ):
+            tool_call_info = self.extract_tool_calls(
+                content if content is not None else "",
+                request=request,
+            )
+            if tool_call_info is not None and tool_call_info.tools_called:
+                function_calls.extend(
+                    FunctionCall(
+                        id=tool_call.id,
+                        name=tool_call.function.name,
+                        arguments=tool_call.function.arguments,
+                    )
+                    for tool_call in tool_call_info.tool_calls
+                )
+                remaining_content = tool_call_info.content
+                if remaining_content and remaining_content.strip() == "":
+                    remaining_content = None
+                return reasoning, function_calls, remaining_content
+
+        return reasoning, [], content
+
     @abstractmethod
     def extract_reasoning(
         self,
@@ -350,11 +423,8 @@ class DelegatingParser(Parser):
         tool_call_id_type: str = "random",
         logprobs: list[Logprob] | None = None,
     ) -> list[ResponseOutputItem]:
-        # First extract reasoning
         reasoning, content = self.extract_reasoning(model_output, request)
-
-        # Then parse tool calls from the content
-        tool_calls, content = self._parse_tool_calls(
+        tool_calls, content = self._parse_function_calls(
             request=request,
             content=content,
             enable_auto_tools=enable_auto_tools,
@@ -417,15 +487,28 @@ class DelegatingParser(Parser):
 
         return outputs
 
-    def _parse_tool_calls(
+    def extract_chat_completion_parts(
         self,
-        request: ResponsesRequest,
+        *,
+        model_output: str,
+        request: ChatCompletionRequest,
+        enable_auto_tools: bool = False,
+    ) -> tuple[str | None, list[FunctionCall], str | None]:
+        reasoning, content = self.extract_reasoning(model_output, request)
+        function_calls, content = self._parse_function_calls(
+            request=request,
+            content=content,
+            enable_auto_tools=enable_auto_tools,
+        )
+        return reasoning, function_calls, content
+
+    def _parse_function_calls(
+        self,
+        request: ResponsesRequest | ChatCompletionRequest,
         content: str | None,
         enable_auto_tools: bool,
     ) -> tuple[list[FunctionCall], str | None]:
         """
-        TODO(qandrew): merge _parse_tool_calls_from_content
-        for ChatCompletions into this function
         Parse tool calls from content based on request tool_choice settings.
 
         Returns:

--- a/vllm/parser/minimax_m2_parser.py
+++ b/vllm/parser/minimax_m2_parser.py
@@ -43,11 +43,13 @@ class MiniMaxM2Parser(DelegatingParser):
     reasoning_parser_cls = MiniMaxM2ReasoningParser
     tool_parser_cls = MinimaxM2ToolParser
 
-    def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
+    def __init__(
+        self, tokenizer: TokenizerLike, tools: list[Tool] | None = None, **kwargs
+    ):
         super().__init__(tokenizer)
 
         # Initialize the underlying parsers
-        self._reasoning_parser = MiniMaxM2ReasoningParser(tokenizer)
+        self._reasoning_parser = MiniMaxM2ReasoningParser(tokenizer, **kwargs)
         self._tool_parser = MinimaxM2ToolParser(tokenizer, tools)
 
         logger.debug(

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import importlib
 import os
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from vllm.logger import init_logger
 from vllm.utils.collection_utils import is_list_of
@@ -159,7 +159,7 @@ class ParserManager:
             if isinstance(name, str):
                 names = [name]
             elif is_list_of(name, str):
-                names = name
+                names = cast(list[str], name)
             else:
                 names = [class_name]
 
@@ -279,20 +279,7 @@ class ParserManager:
             except KeyError:
                 pass  # No unified parser with this name
 
-        # Strategy 2: Check for parser with either name
-        for name in [tool_parser_name, reasoning_parser_name]:
-            if name:
-                try:
-                    parser = cls.get_parser_internal(name)
-                    logger.info(
-                        "Using unified parser '%s' for reasoning and tool parsing.",
-                        name,
-                    )
-                    return parser
-                except KeyError:
-                    pass
-
-        # Strategy 3: Create a DelegatingParser with the individual parser classes
+        # Strategy 2: Create a DelegatingParser with the individual parser classes
         reasoning_parser_cls = cls.get_reasoning_parser(reasoning_parser_name)
         tool_parser_cls = cls.get_tool_parser(
             tool_parser_name, enable_auto_tools, model_name


### PR DESCRIPTION
## Purpose
This PR moves chat completions non-streaming output parsing into the unified `Parser` path, implementing the chat non-streaming slice of [#32713](https://github.com/vllm-project/vllm/issues/32713).

There are no intended behavior changes. The PR also preserves existing behavior by fixing migration regressions around forced named and `tool_choice="required"` handling without a unified parser, mixed reasoning/tool parser selection, and one-sided parser selection.

## Test Plan
pytest -q tests/entrypoints/openai/parser/test_abstract_parser.py \
  tests/entrypoints/openai/chat_completion/test_serving_chat_parser.py
## Test Result
14 passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

