### PR TITLE
[Bugfix][LoRA] Fix incorrect LoRA Log

### DIFF
--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -149,7 +149,8 @@ class WorkerLoRAManager:
             # Warn about adapter modules that will be ignored.
             target_modules = self.lora_config.target_modules
             for module_name in lora.loras:
-                if not is_supported_lora_module(module_name, supported_lora_modules):
+                expected_lora_modules_lst = list(expected_lora_modules)
+                if not is_supported_lora_module(module_name, expected_lora_modules_lst):
                     logger.warning_once(
                         "LoRA module '%s' in adapter '%s' is not in the "
                         "model's supported LoRA target modules [%s]. "
@@ -157,7 +158,7 @@ class WorkerLoRAManager:
                         "cause abnormal model behavior.",
                         module_name,
                         lora_request.lora_path,
-                        ", ".join(sorted(supported_lora_modules)),
+                        ", ".join(sorted(expected_lora_modules_lst)),
                     )
                 elif not is_in_target_modules(module_name, target_modules):
                     logger.warning_once(

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -148,8 +148,8 @@ class WorkerLoRAManager:
 
             # Warn about adapter modules that will be ignored.
             target_modules = self.lora_config.target_modules
+            expected_lora_modules_lst = list(expected_lora_modules)
             for module_name in lora.loras:
-                expected_lora_modules_lst = list(expected_lora_modules)
                 if not is_supported_lora_module(module_name, expected_lora_modules_lst):
                     logger.warning_once(
                         "LoRA module '%s' in adapter '%s' is not in the "


### PR DESCRIPTION



## Purpose

Fix the following log output

```
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.7.mlp.gate_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.7.mlp.up_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.7.self_attn.k_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.7.self_attn.q_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.7.self_attn.v_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.8.mlp.gate_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.8.mlp.up_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.8.self_attn.k_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.8.self_attn.q_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.8.self_attn.v_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.9.mlp.gate_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.9.mlp.up_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.9.self_attn.k_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.9.self_attn.q_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
(EngineCore pid=2823877) WARNING 03-23 09:31:14 [worker_manager.py:153] LoRA module 'model.layers.9.self_attn.v_proj' in adapter '/mnt/data2/Models/Qwen3-0.6B-LoRA/self_cognition_Alice' is not in the model's supported LoRA target modules [down_proj, embed_tokens, gate_up_proj, lm_head, o_proj, qkv_proj]. These parameters will be ignored, which may cause abnormal model behavior.
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

