### PR TITLE
[Frontend][Bugfix] Pass default_chat_template_kwargs to AnthropicServingMessages

### DIFF
--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -72,6 +72,7 @@ class AnthropicServingMessages(OpenAIServingChat):
         tool_parser: str | None = None,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
     ):
         super().__init__(
             engine_client=engine_client,
@@ -87,6 +88,7 @@ class AnthropicServingMessages(OpenAIServingChat):
             tool_parser=tool_parser,
             enable_prompt_tokens_details=enable_prompt_tokens_details,
             enable_force_include_usage=enable_force_include_usage,
+            default_chat_template_kwargs=default_chat_template_kwargs,
         )
         self.stop_reason_map = {
             "stop": "end_turn",

--- a/vllm/entrypoints/openai/generate/api_router.py
+++ b/vllm/entrypoints/openai/generate/api_router.py
@@ -150,6 +150,7 @@ async def init_generate_state(
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
+            default_chat_template_kwargs=args.default_chat_template_kwargs,
         )
         if "generate" in supported_tasks
         else None


### PR DESCRIPTION
This fixes an issue where default_chat_template_kwargs was not being passed to AnthropicServingMessages when initializing the generate state.

Co-authored-by: gemini-code-assist

## Purpose
Fix an issue where `default_chat_template_kwargs` was not being passed to `AnthropicServingMessages` during frontend state initialization in [vllm/entrypoints/openai/generate/api_router.py](cci:7://file:///Users/zhangxuetao/Developer/learn/vllm/vllm/entrypoints/openai/generate/api_router.py:0:0-0:0). This ensures that any default parameters configured for chat templates via CLI (`--default-chat-template-kwargs`) are correctly applied when handling Anthropic endpoint (`/v1/messages`) requests.

## Test Plan

1. serve `Qwen3.5-0.8B` and set `default-chat-template-kwargs = '{"enable_thinking": false}'`

```
vllm serve ./Qwen3.5-0.8B \
    --gpu-memory-utilization 0.5 \
    --reasoning-parser qwen3 \
    --default-chat-template-kwargs '{"enable_thinking": false}'
```

2. request `/v1/messages`
```
curl --location '127.0.0.1:8000/v1/messages' \
--header 'Authorization: Bear' \
--header 'Content-Type: application/json' \
--data '{
    "model": "./Qwen3.5-0.8B",
    "messages": [
        {
            "role": "user",
            "content": "How to calculate 1+1?"
        }
    ],
    "max_tokens": 100
}'
```


## Test Result

### Before
The parameter `default-chat-template-kwargs = '{"enable_thinking": false}'` was ignored, unexpectedly return _thinking_
```
{
    "id": "chatcmpl-b58ac3852d2750f8",
    "type": "message",
    "role": "assistant",
    "content": [
        {
            "type": "thinking",
            "thinking": "Calculating **1 + 1** is extremely simple because addition is just combining two equal (or opposite) values to find a total:\n\n*   **Step 1:** Take the first number (1).\n*   **Step 2:** Take the second number (1).\n*   **Step 3:** Add them together: $1 + 1 = 2$.\n\nSo, **1 + 1 = 2**.",
            "signature": "6c857d5d0aa743c0b37abb4c39258604"
        }
    ],
    "model": "./Qwen3.5-0.8B",
    "stop_reason": "end_turn",
    "usage": {
        "input_tokens": 20,
        "output_tokens": 92
    }
}
```

### After
return _text_
```
{
    "id": "chatcmpl-a7f21bfb505fb4c2",
    "type": "message",
    "role": "assistant",
    "content": [
        {
            "type": "text",
            "text": "One and one are **mathematicy** (or in classical arithmetic) defined as:\n\n$$ 1 + 1 = 2 $$\n\n### Reasoning\n\nThis is the fundamental definition of addition in mathematics. It represents the count of items that, when together, make a single additional group. There are two ways to add it:\n\n1.  **Direct Summation**:\n    $$ 1 + 1 = 1 + 1 = 2 $$\n    \n2"
        }
    ],
    "model": "./Qwen3.5-0.8B",
    "stop_reason": "max_tokens",
    "usage": {
        "input_tokens": 20,
        "output_tokens": 100
    }
}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

