### PR TITLE
[compile] Add a fast serializer for aot save/load.

### DIFF
--- a/tests/compile/test_aot_compile.py
+++ b/tests/compile/test_aot_compile.py
@@ -179,7 +179,7 @@ def test_save_and_load_slice(monkeypatch: pytest.MonkeyPatch):
         payload = VllmSerializableFunction.serialize_graph_module(gm)
         fake_mode = FakeTensorMode(shape_env=ShapeEnv())
         loaded_gm = VllmSerializableFunction.deserialize_graph_module(
-            payload, fake_mode
+            payload, fake_mode, envs.VLLM_USE_MEGA_AOT_ARTIFACT
         )
 
     assert gm.code == loaded_gm.code

--- a/vllm/compilation/caching.py
+++ b/vllm/compilation/caching.py
@@ -18,6 +18,10 @@ from torch.utils import _pytree as pytree
 import vllm.envs as envs
 from vllm.compilation.compiler_interface import get_inductor_factors
 from vllm.compilation.counter import compilation_counter
+from vllm.compilation.graph_serialization import (
+    deserialize_graph_structure,
+    serialize_graph_structure,
+)
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.utils import hash_factors
 from vllm.logger import init_logger
@@ -214,6 +218,19 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
     def serialize_graph_module(cls, graph_module: torch.fx.GraphModule) -> bytes:
         import sympy
 
+        if envs.VLLM_USE_MEGA_AOT_ARTIFACT:
+            # Fast path: serialise only graph topology, skip metadata.
+            return serialize_graph_structure(graph_module)
+
+        for node in graph_module.graph.nodes:
+            node.meta.pop("source_fn_stack", None)
+            node.meta.pop("nn_module_stack", None)
+        for name, submod in graph_module.named_children():
+            if hasattr(submod, "graph"):
+                for node in submod.graph.nodes:
+                    node.meta.pop("source_fn_stack", None)
+                    node.meta.pop("nn_module_stack", None)
+
         graph_reducer_override = GraphPickler.reducer_override
 
         def _graph_reducer_override(
@@ -237,10 +254,16 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
 
     @classmethod
     def deserialize_graph_module(
-        cls, data: bytes, fake_mode: FakeTensorMode
+        cls, data: bytes, fake_mode: FakeTensorMode, use_fast: bool
     ) -> torch.fx.GraphModule:
+        if use_fast:
+            # Fast path: graph was serialised with serialize_graph_structure.
+            return deserialize_graph_structure(data)
+
         with patch_pytree_map_over_slice():
-            return GraphPickler.loads(data, fake_mode)
+            graph_module = GraphPickler.loads(data, fake_mode)
+            graph_module.recompile()
+            return graph_module
 
     @classmethod
     def serialize_compile_artifacts(
@@ -251,14 +274,6 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
         state.pop("shape_env")
         state.pop("vllm_backend", None)
         state.pop("_fake_mode", None)
-        for node in state["graph_module"].graph.nodes:
-            node.meta.pop("source_fn_stack", None)
-            node.meta.pop("nn_module_stack", None)
-        for name, submod in state["graph_module"].named_children():
-            if hasattr(submod, "graph"):
-                for node in submod.graph.nodes:
-                    node.meta.pop("source_fn_stack", None)
-                    node.meta.pop("nn_module_stack", None)
 
         if state.get("sym_tensor_indices"):
             # put tensor inputs on meta device since their data
@@ -277,6 +292,8 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
             )
 
         state["graph_module"] = cls.serialize_graph_module(state["graph_module"])
+        if envs.VLLM_USE_MEGA_AOT_ARTIFACT:
+            state["_fast_graph"] = True
         state["example_inputs"] = GraphPickler.dumps(state["example_inputs"])
 
         if compiled_fn.vllm_backend:
@@ -299,9 +316,8 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
         fake_mode = FakeTensorMode(shape_env=ShapeEnv())
 
         state["graph_module"] = cls.deserialize_graph_module(
-            state["graph_module"], fake_mode
+            state["graph_module"], fake_mode, state.pop("_fast_graph", False)
         )
-        state["graph_module"].recompile()
         state["example_inputs"] = GraphPickler.loads(state["example_inputs"], fake_mode)
 
         standalone_compile_artifacts = state.pop("standalone_compile_artifacts", None)

--- a/vllm/compilation/graph_serialization.py
+++ b/vllm/compilation/graph_serialization.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fast, lean GraphModule serialization.
+
+GraphPickler is general-purpose but expensive.  For the vLLM compilation
+cache we only need the graph *topology* (node ops, targets, connectivity)
+and the submodule hierarchy -- no node metadata such as ``example_value``,
+``source_fn_stack``, or ``nn_module_stack``.
+
+The format is a compact JSON blob (C-level json encoder/decoder) that can
+be round-tripped much faster than GraphPickler for the graphs we care
+about.
+"""
+
+import importlib
+import json
+from typing import Any
+
+import torch
+import torch.fx as fx
+
+# Sentinel keys used in the JSON representation.
+_NODE_REF = "__r"
+_TUPLE_TAG = "__t"
+
+
+# ---------------------------------------------------------------------------
+# Argument serialization
+# ---------------------------------------------------------------------------
+
+
+def _serialize_arg(arg: Any) -> Any:
+    """Encode an fx.Node argument for JSON serialisation."""
+    if isinstance(arg, fx.Node):
+        return {_NODE_REF: arg.name}
+    if isinstance(arg, tuple):
+        return {_TUPLE_TAG: [_serialize_arg(a) for a in arg]}
+    if isinstance(arg, list):
+        return [_serialize_arg(a) for a in arg]
+    if isinstance(arg, dict):
+        return {k: _serialize_arg(v) for k, v in arg.items()}
+    if isinstance(arg, slice):
+        return {
+            "__slice": [
+                _serialize_arg(arg.start),
+                _serialize_arg(arg.stop),
+                _serialize_arg(arg.step),
+            ]
+        }
+    if isinstance(arg, torch.dtype):
+        return {"__dtype": str(arg)}
+    if isinstance(arg, torch.device):
+        return {"__device": str(arg)}
+    if isinstance(arg, torch.layout):
+        return {"__layout": str(arg)}
+    if isinstance(arg, torch.memory_format):
+        return {"__memory_format": str(arg)}
+    if arg is ...:
+        return {"__ellipsis": True}
+    # JSON-primitive types (int, float, str, bool, None) pass through.
+    if arg is None or isinstance(arg, (int, float, str, bool)):
+        return arg
+    raise TypeError(f"Unsupported argument type for graph serialization: {type(arg)}")
+
+
+def _deserialize_arg(arg: Any, node_map: dict[str, fx.Node]) -> Any:
+    """Decode an argument produced by ``_serialize_arg``."""
+    if isinstance(arg, dict):
+        if _NODE_REF in arg:
+            return node_map[arg[_NODE_REF]]
+        if _TUPLE_TAG in arg:
+            return tuple(_deserialize_arg(a, node_map) for a in arg[_TUPLE_TAG])
+        if "__slice" in arg:
+            s = arg["__slice"]
+            return slice(
+                _deserialize_arg(s[0], node_map),
+                _deserialize_arg(s[1], node_map),
+                _deserialize_arg(s[2], node_map),
+            )
+        if "__dtype" in arg:
+            return getattr(torch, arg["__dtype"].split(".")[-1])
+        if "__device" in arg:
+            return torch.device(arg["__device"])
+        if "__layout" in arg:
+            return getattr(torch, arg["__layout"].split(".")[-1])
+        if "__memory_format" in arg:
+            return getattr(torch, arg["__memory_format"].split(".")[-1])
+        if "__ellipsis" in arg:
+            return ...
+        return {k: _deserialize_arg(v, node_map) for k, v in arg.items()}
+    if isinstance(arg, list):
+        return [_deserialize_arg(a, node_map) for a in arg]
+    return arg
+
+
+# ---------------------------------------------------------------------------
+# Target serialization
+# ---------------------------------------------------------------------------
+
+
+def _target_to_str(op: str, target: Any) -> str:
+    """Convert a node target to a string for serialisation."""
+    if op in ("placeholder", "call_module", "call_method", "get_attr", "output"):
+        return str(target)
+    if op == "call_function":
+        from torch.fx.node import _get_qualified_name
+
+        return _get_qualified_name(target)
+    raise ValueError(f"Unknown fx op: {op}")
+
+
+def _str_to_target(op: str, target_str: str) -> Any:
+    """Resolve a serialised target string back to its runtime object."""
+    if op in ("placeholder", "call_module", "call_method", "get_attr", "output"):
+        return target_str
+    if op == "call_function":
+        # Resolve the qualified name to the actual callable.
+        parts = target_str.rsplit(".", 1)
+        if len(parts) == 1:
+            # Builtins (e.g. ``getattr``).
+            import builtins
+
+            return getattr(builtins, target_str)
+        module_name, attr_name = parts
+        # torch.ops.* is a dynamic namespace (not a real module), so
+        # resolve it via attribute traversal instead of importlib.
+        if module_name.startswith("torch.ops."):
+            obj: Any = torch.ops
+            for part in module_name.split(".")[2:]:
+                obj = getattr(obj, part)
+            return getattr(obj, attr_name)
+        module = importlib.import_module(module_name)
+        return getattr(module, attr_name)
+    raise ValueError(f"Unknown fx op: {op}")
+
+
+# ---------------------------------------------------------------------------
+# Graph / GraphModule serialization
+# ---------------------------------------------------------------------------
+
+
+def _serialize_graph(graph: fx.Graph) -> list[list[Any]]:
+    """Serialise an ``fx.Graph`` as a list of node descriptors."""
+    nodes: list[list[Any]] = []
+    for node in graph.nodes:
+        nodes.append(
+            [
+                node.op,
+                node.name,
+                _target_to_str(node.op, node.target),
+                _serialize_arg(node.args),
+                _serialize_arg(node.kwargs),
+            ]
+        )
+    return nodes
+
+
+def _deserialize_graph(
+    node_list: list[list[Any]],
+) -> tuple[fx.Graph, dict[str, fx.Node]]:
+    """Reconstruct an ``fx.Graph`` from the compact node list."""
+    graph = fx.Graph()
+    node_map: dict[str, fx.Node] = {}
+    for op, name, target_str, raw_args, raw_kwargs in node_list:
+        target = _str_to_target(op, target_str)
+        args = _deserialize_arg(raw_args, node_map)
+        # _deserialize_arg returns a list for the top-level args; create_node
+        # expects a tuple.
+        if isinstance(args, list):
+            args = tuple(args)
+        kwargs = _deserialize_arg(raw_kwargs, node_map)
+        node = graph.create_node(op, target, args, kwargs, name=name)
+        node_map[name] = node
+    return graph, node_map
+
+
+def _serialize_gm(gm: fx.GraphModule) -> dict[str, Any]:
+    """Recursively serialise a ``GraphModule`` (graph + submodules)."""
+    submodules: dict[str, dict[str, Any]] = {}
+    for child_name, child in gm.named_children():
+        if isinstance(child, fx.GraphModule):
+            submodules[child_name] = _serialize_gm(child)
+    return {
+        "nodes": _serialize_graph(gm.graph),
+        "submodules": submodules,
+    }
+
+
+def _deserialize_gm(data: dict[str, Any]) -> fx.GraphModule:
+    """Reconstruct a ``GraphModule`` from the dict produced by
+    ``_serialize_gm``."""
+    # Reconstruct child submodules first so they're available as attributes.
+    root = torch.nn.Module()
+    for child_name, child_data in data["submodules"].items():
+        root.add_module(child_name, _deserialize_gm(child_data))
+
+    graph, _ = _deserialize_graph(data["nodes"])
+    gm = fx.GraphModule(root, graph)
+    return gm
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def serialize_graph_structure(gm: fx.GraphModule) -> bytes:
+    """Serialise the topology of *gm* to bytes (fast, no metadata).
+
+    Only the graph structure (node ops/targets/connectivity) and the
+    submodule hierarchy are preserved.  Node metadata such as
+    ``example_value`` is **not** included.
+
+    This is intended as a drop-in replacement for
+    ``GraphPickler.dumps(gm, ...)`` in the vLLM compilation cache path
+    where the full generality of ``GraphPickler`` is not needed.
+    """
+    return json.dumps(_serialize_gm(gm), separators=(",", ":")).encode()
+
+
+def deserialize_graph_structure(data: bytes) -> fx.GraphModule:
+    """Reconstruct a ``GraphModule`` from bytes produced by
+    :func:`serialize_graph_structure`.
+
+    The returned ``GraphModule`` has ``recompile()`` already called.
+    """
+    obj = json.loads(data)
+    gm = _deserialize_gm(obj)
+    gm.recompile()
+    return gm


### PR DESCRIPTION
Summary:

In AOT compialtion mode we used to serialize FX graphs using GraphPickler
which by design is slow for our use case because it tried to save all the
metadata including fake tensors and symbolic ints. For our purpose we
don't need anything other than nodes and submodules, so in this case we
could get away with serializing metadata by implementing our own serializer
which is liter and faster. As an impl detail we use JSON but this can be
changed to anything.

Test Plan:

pytest tests/compile

Reviewers:

Subscribers:

Tasks:

Tags:

Signed-off-by: zhxchen17 <zhxchen17@fb.com>




## Purpose

## Test Plan

## Test Result

Before this change (w/ torch 2.12), torch.compile warm start time:

```
Model                   Cold Start (s)  Warm Start Avg (s)
----------------------  --------------  ------------------
DeepSeek-V3.2           63.92           6.06
GLM-4.7-FP8             61.43           7.55
gpt-oss-120b            14.63           1.95
Llama-3.3-70B-Instruct  26.01           3.90
Qwen3.5-35B-A3B         60.78           3.47
```
After the change (w/ torch 2.12), torch.compile warm start time:
```
Model                   Cold Start (s)  Warm Start Avg (s)
----------------------  --------------  ------------------
DeepSeek-V3.2           53.66           1.18 (5.14x)
GLM-4.7-FP8             49.80           1.52 (4.97x)
gpt-oss-120b            11.89           0.41 (4.76x)
Llama-3.3-70B-Instruct  19.62           0.76 (5.13x)
Qwen3.5-35B-A3B         57.86           2.40 (1.45x)
```

Note that Qwen3.5 has a regression on trunk tracked in https://github.com/vllm-project/vllm/issues/37919 so in theory it should be under 1 sec in warm start but we will fix it separately.

Testing script here: https://github.com/zhxchen17/scripts/blob/main/vllm/compile_time_bench.py

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

