### PR TITLE
[Bugfix][Frontend] Pass default_chat_template_kwargs to Anthropic endpoint

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -635,3 +635,36 @@ class TestThinkingBlockConversion:
         # Redacted thinking is ignored, normal thinking still becomes reasoning.
         assert asst.get("reasoning") == "Thinking..."
         assert asst.get("content") == "Hi!"
+
+
+# ======================================================================
+# default_chat_template_kwargs passthrough
+# ======================================================================
+
+
+class TestDefaultChatTemplateKwargs:
+    """Verify that _convert_anthropic_to_openai_request correctly applies
+    server-level default_chat_template_kwargs to the converted request.
+    """
+
+    def test_no_kwargs_by_default(self):
+        """Without default_chat_template_kwargs, converted requests should
+        not have chat_template_kwargs set."""
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+        )
+        result = _convert(request)
+        assert result.chat_template_kwargs is None
+
+    def test_server_defaults_applied(self):
+        """Server defaults should appear on the converted request."""
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+        )
+        result = _convert(
+            request,
+            default_chat_template_kwargs={
+                "enable_thinking": False,
+            },
+        )
+        assert result.chat_template_kwargs == {"enable_thinking": False}

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -119,7 +119,9 @@ class AnthropicServingMessages(OpenAIServingChat):
 
     @classmethod
     def _convert_anthropic_to_openai_request(
-        cls, anthropic_request: AnthropicMessagesRequest | AnthropicCountTokensRequest
+        cls,
+        anthropic_request: AnthropicMessagesRequest | AnthropicCountTokensRequest,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
     ) -> ChatCompletionRequest:
         """Convert Anthropic message format to OpenAI format"""
         openai_messages: list[dict[str, Any]] = []
@@ -130,6 +132,10 @@ class AnthropicServingMessages(OpenAIServingChat):
         cls._handle_streaming_options(req, anthropic_request)
         cls._convert_tool_choice(anthropic_request, req)
         cls._convert_tools(anthropic_request, req)
+        if default_chat_template_kwargs:
+            req.chat_template_kwargs = default_chat_template_kwargs | (
+                req.chat_template_kwargs or {}
+            )
         return req
 
     @classmethod
@@ -419,7 +425,9 @@ class AnthropicServingMessages(OpenAIServingChat):
         """
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Received messages request %s", request.model_dump_json())
-        chat_req = self._convert_anthropic_to_openai_request(request)
+        chat_req = self._convert_anthropic_to_openai_request(
+            request, self.default_chat_template_kwargs
+        )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Convert to OpenAI request %s", chat_req.model_dump_json())
         generator = await self.create_chat_completion(chat_req, raw_request)
@@ -792,7 +800,9 @@ class AnthropicServingMessages(OpenAIServingChat):
         raw_request: Request | None = None,
     ) -> AnthropicCountTokensResponse | ErrorResponse:
         """Implements Anthropic's messages.count_tokens endpoint."""
-        chat_req = self._convert_anthropic_to_openai_request(request)
+        chat_req = self._convert_anthropic_to_openai_request(
+            request, self.default_chat_template_kwargs
+        )
         result = await self.render_chat_request(chat_req)
         if isinstance(result, ErrorResponse):
             return result


### PR DESCRIPTION
## Purpose

Building on #37899, this ensures that `default_chat_template_kwargs` is actually applied to the `ChatCompletionRequest` during Anthropic-to-OpenAI request conversion.

#37899 correctly passes `default_chat_template_kwargs` through to the `AnthropicServingMessages` init, but the kwargs are not injected into the `ChatCompletionRequest` objects created by `_convert_anthropic_to_openai_request()`. This means `render_chat_request()` and `count_tokens()` don't see them — the chat template is still rendered without the server defaults.

## Changes

1. **`vllm/entrypoints/anthropic/serving.py`**:
   - Add optional `default_chat_template_kwargs` parameter to `_convert_anthropic_to_openai_request()` — applied to the request at the end of conversion
   - Pass `self.default_chat_template_kwargs` from both call sites (`create_messages()` and `count_tokens()`)

2. **`tests/entrypoints/anthropic/test_anthropic_messages_conversion.py`**:
   - Add unit tests verifying default behavior (no kwargs) and kwargs injection

Note: This PR also includes the #37899 init changes since that PR hasn't merged yet. Once #37899 lands, the diff will shrink to just the conversion-level fix + tests.

## Test Plan

Tested on a 4-node DGX Spark cluster running Qwen3.5-397B-A17B-NVFP4 (vLLM 0.18.1rc1) with `--default-chat-template-kwargs '{"enable_thinking": false}'`:

| Test | Before (tokens) | After (tokens) | Thinking block? |
|------|-----------------|----------------|-----------------|
| `POST /v1/messages` "Say hello" | 157 | 10 | Before: YES → After: NO |
| `POST /v1/messages` tool call | 275-505 | 27 | Before: YES → After: NO |
| `POST /v1/chat/completions` (control) | Already worked | Still works | Respects kwargs |

Unit tests: 28 passed (26 existing + 2 new), 0 failures.

## Essential Elements Checklist

- [x] The purpose of the PR: Bugfix — `--default-chat-template-kwargs` values not applied to converted requests in Anthropic endpoint
- [x] The test plan: Unit tests + manual testing on multi-node cluster with Qwen3.5-397B
- [x] The test results: 85-95% token reduction; 28/28 tests pass