### PR TITLE
[LinearAttention] Introduce non_spec_query_start_loc_cpu in GDN metadata

### DIFF
--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -48,6 +48,11 @@ class GDNAttentionMetadata:
     non_spec_query_start_loc: torch.Tensor | None = (
         None  # shape: [batch - num_spec_decodes + 1,]
     )
+    # CPU tensor which is identical to non_spec_query_start_loc; It allows us
+    # to compute without cuda sync (e.g. prepare_chunk_indices)
+    non_spec_query_start_loc_cpu: torch.Tensor | None = (
+        None  # shape: [batch - num_spec_decodes + 1,]
+    )
 
     spec_state_indices_tensor: torch.Tensor | None = None  # shape: [batch, num_spec]
     non_spec_state_indices_tensor: torch.Tensor | None = (
@@ -403,6 +408,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             has_initial_state=has_initial_state,
             spec_query_start_loc=spec_query_start_loc,
             non_spec_query_start_loc=non_spec_query_start_loc,
+            non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
             spec_state_indices_tensor=spec_state_indices_tensor,
             non_spec_state_indices_tensor=non_spec_state_indices_tensor,
             spec_sequence_masks=spec_sequence_masks,


### PR DESCRIPTION
## Purpose

After introducing the CPU tensor, we could switch to use CPU tensor to compute prepare_chunk_indices and prepare_chunk_offsets without cuda sync (which significantly improved the effectiveness of async scheduling when linear attention is on).

https://github.com/Jialin/vllm/blob/0d0c929f2360cde5bae6817ad0f555641329e79d/vllm/model_executor/layers/fla/ops/index.py#L22-L41

## Test Plan

Verified after some additional internal modification, prepare_chunk_indices cuda sync in the first layer of the model is gone. 

## Test Result

Internal

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

