### PR TITLE
[Bugfix] Force continuous usage stats when CLI override is enabled

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_enable_force_include_usage.py
+++ b/tests/entrypoints/openai/chat_completion/test_enable_force_include_usage.py
@@ -54,21 +54,19 @@ async def test_chat_with_enable_force_include_usage(
     )
     last_completion_tokens = 0
     async for chunk in stream:
-        if not len(chunk.choices):
-            assert chunk.usage.prompt_tokens >= 0
-            assert (
-                last_completion_tokens == 0
-                or chunk.usage.completion_tokens > last_completion_tokens
-                or (
-                    not chunk.choices
-                    and chunk.usage.completion_tokens == last_completion_tokens
-                )
+        assert chunk.usage.prompt_tokens >= 0
+        assert (
+            last_completion_tokens == 0
+            or chunk.usage.completion_tokens > last_completion_tokens
+            or (
+                not chunk.choices
+                and chunk.usage.completion_tokens == last_completion_tokens
             )
-            assert chunk.usage.total_tokens == (
-                chunk.usage.prompt_tokens + chunk.usage.completion_tokens
-            )
-        else:
-            assert chunk.usage is None
+        )
+        assert chunk.usage.total_tokens == (
+            chunk.usage.prompt_tokens + chunk.usage.completion_tokens
+        )
+        last_completion_tokens = chunk.usage.completion_tokens
 
 
 @pytest.fixture(scope="module")

--- a/tests/entrypoints/test_utils.py
+++ b/tests/entrypoints/test_utils.py
@@ -3,7 +3,9 @@
 
 import pytest
 
+from vllm.entrypoints.openai.engine.protocol import StreamOptions
 from vllm.entrypoints.utils import get_max_tokens, sanitize_message
+from vllm.entrypoints.utils import should_include_usage
 
 
 def test_sanitize_message():
@@ -11,6 +13,25 @@ def test_sanitize_message():
         sanitize_message("<_io.BytesIO object at 0x7a95e299e750>")
         == "<_io.BytesIO object>"
     )
+
+
+@pytest.mark.parametrize(
+    ("stream_options", "expected"),
+    [
+        (None, (True, True)),
+        (StreamOptions(include_usage=False), (True, True)),
+        (
+            StreamOptions(include_usage=False, continuous_usage_stats=False),
+            (True, True),
+        ),
+        (
+            StreamOptions(include_usage=True, continuous_usage_stats=False),
+            (True, True),
+        ),
+    ],
+)
+def test_should_include_usage_force_enables_continuous_usage(stream_options, expected):
+    assert should_include_usage(stream_options, True) == expected
 
 
 class TestGetMaxTokens:

--- a/tests/entrypoints/test_utils.py
+++ b/tests/entrypoints/test_utils.py
@@ -4,8 +4,11 @@
 import pytest
 
 from vllm.entrypoints.openai.engine.protocol import StreamOptions
-from vllm.entrypoints.utils import get_max_tokens, sanitize_message
-from vllm.entrypoints.utils import should_include_usage
+from vllm.entrypoints.utils import (
+    get_max_tokens,
+    sanitize_message,
+    should_include_usage,
+)
 
 
 def test_sanitize_message():

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -236,13 +236,15 @@ def log_non_default_args(args: Namespace | EngineArgs):
 def should_include_usage(
     stream_options: "StreamOptions | None", enable_force_include_usage: bool
 ) -> tuple[bool, bool]:
+    if enable_force_include_usage:
+        return True, True
     if stream_options:
-        include_usage = stream_options.include_usage or enable_force_include_usage
+        include_usage = bool(stream_options.include_usage)
         include_continuous_usage = include_usage and bool(
             stream_options.continuous_usage_stats
         )
     else:
-        include_usage, include_continuous_usage = enable_force_include_usage, False
+        include_usage, include_continuous_usage = False, False
     return include_usage, include_continuous_usage
 
 


### PR DESCRIPTION
## Summary
- make `--enable-force-include-usage` return `(True, True)` from `should_include_usage()` so the server-level override always enables both final usage and continuous usage stats
- add regression coverage in `tests/entrypoints/test_utils.py` for forced usage behavior, including cases where request `stream_options` explicitly disable usage
- this is not duplicating existing work: I checked open PRs for `force include usage`, `continuous usage stats`, and `entrypoints utils usage stream_options`; the closest match is #24477, which adds token-details fields to continuous usage stats, while this PR changes the CLI override semantics

## Test Plan
- `python3 - <<'PY' ... PY` to compile `vllm/entrypoints/utils.py` and `tests/entrypoints/test_utils.py`, then execute isolated assertions for the new forced-override behavior
- attempted `pytest tests/entrypoints/test_utils.py -v -s`, but `pytest` is not installed in the current environment
- attempted `uv run pytest tests/entrypoints/test_utils.py -v -s`, but dependency resolution failed in this local environment because `uv` created a Python 3.13 env and hit the existing `smg-grpc-servicer[vllm]` self-dependency resolution issue

## Results
- isolated Python validation passed for the updated `should_include_usage()` behavior
- file compilation passed for both modified files

## AI Assistance
- this PR was prepared with AI assistance; the submitting human should review every changed line and run any additional relevant tests before merge