### PR TITLE
[ROCm][CI] Remove redundant common.txt from rocm-test.txt

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -1,6 +1,3 @@
-# Common dependencies
--r common.txt
-
 # Test infrastructure
 tblib==3.1.0
 pytest==8.3.5


### PR DESCRIPTION
The AMD Docker image build fails because `rocm-test.txt` includes `-r common.txt`,  which pins `compressed-tensors == 0.14.0.1`. That package requires `transformers < 5.0.0`,  conflicting with the transformers version pinned in `rocm-test.txt`.

This inclusion is redundant however because `Dockerfile.rocm` already installs `rocm.txt`  (which includes `common.txt`) before `rocm-test.txt`:

```dockerfile
uv pip install --system -r requirements/rocm.txt        # includes common.txt
uv pip install --system -r requirements/rocm-test.txt   # also included common.txt (redundant)
```

The CUDA test path (test.txt) does not have this problem because it is a compiled lockfile generated by uv pip compile that does not include common.txt directly.

cc @kenroche 