### PR TITLE
[Parser] Remove unused request parameter from extract_reasoning()

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -284,7 +284,6 @@ You can add a new `ReasoningParser` similar to [vllm/reasoning/deepseek_r1_reaso
         def extract_reasoning(
             self,
             model_output: str,
-            request: ChatCompletionRequest | ResponsesRequest,
         ) -> tuple[str | None, str | None]:
             """
             Extract reasoning content from a complete model-generated string.
@@ -295,9 +294,6 @@ You can add a new `ReasoningParser` similar to [vllm/reasoning/deepseek_r1_reaso
             Parameters:
             model_output: str
                 The model-generated string to extract reasoning content from.
-
-            request: ChatCompletionRequest
-                The request object that was used to generate the model_output.
 
             Returns:
             tuple[Optional[str], Optional[str]]

--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -5,7 +5,6 @@ import pytest
 from transformers import AutoTokenizer
 
 from tests.reasoning.utils import run_reasoning_extraction
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 
 
@@ -216,10 +215,9 @@ class TestBaseThinkingReasoningParserExtraction:
     def test_extract_reasoning_with_both_tokens(self, test_tokenizer):
         """Test extraction when both start and end tokens are present."""
         parser = TestThinkingReasoningParser(test_tokenizer)
-        request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = "<test:think>This is reasoning</test:think>This is content"
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning, content = parser.extract_reasoning(model_output)
 
         assert reasoning == "This is reasoning"
         assert content == "This is content"
@@ -227,10 +225,9 @@ class TestBaseThinkingReasoningParserExtraction:
     def test_extract_reasoning_only_end_token(self, test_tokenizer):
         """Test extraction when only end token is present."""
         parser = TestThinkingReasoningParser(test_tokenizer)
-        request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = "This is reasoning</test:think>This is content"
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning, content = parser.extract_reasoning(model_output)
 
         assert reasoning == "This is reasoning"
         assert content == "This is content"
@@ -238,10 +235,9 @@ class TestBaseThinkingReasoningParserExtraction:
     def test_extract_reasoning_no_end_token(self, test_tokenizer):
         """Test extraction when no end token is present."""
         parser = TestThinkingReasoningParser(test_tokenizer)
-        request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = "This is just content"
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning, content = parser.extract_reasoning(model_output)
 
         assert reasoning == "This is just content"
         assert content is None
@@ -249,10 +245,9 @@ class TestBaseThinkingReasoningParserExtraction:
     def test_extract_reasoning_empty_output(self, test_tokenizer):
         """Test extraction with empty output."""
         parser = TestThinkingReasoningParser(test_tokenizer)
-        request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = ""
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning, content = parser.extract_reasoning(model_output)
 
         assert reasoning == ""
         assert content is None
@@ -260,10 +255,9 @@ class TestBaseThinkingReasoningParserExtraction:
     def test_extract_reasoning_only_tokens(self, test_tokenizer):
         """Test extraction with only tokens and no content."""
         parser = TestThinkingReasoningParser(test_tokenizer)
-        request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = "<test:think></test:think>"
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning, content = parser.extract_reasoning(model_output)
 
         assert reasoning == ""
         assert content is None

--- a/tests/reasoning/test_deepseekv3_reasoning_parser.py
+++ b/tests/reasoning/test_deepseekv3_reasoning_parser.py
@@ -4,7 +4,6 @@
 import pytest
 from transformers import AutoTokenizer
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
 from vllm.reasoning.deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
@@ -47,8 +46,7 @@ def test_identity_reasoning_parser_basic(tokenizer):
     assert parser.extract_content_ids(input_ids) == input_ids
 
     # Test extract_reasoning returns (None, model_output)
-    request = ChatCompletionRequest(model="test-model", messages=[], temperature=1.0)
-    reasoning, content = parser.extract_reasoning(input_text, request)
+    reasoning, content = parser.extract_reasoning(input_text)
     assert reasoning is None
     assert content == input_text
 

--- a/tests/reasoning/test_kimi_k2_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k2_reasoning_parser.py
@@ -3,7 +3,6 @@
 
 import pytest
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning.identity_reasoning_parser import IdentityReasoningParser
 from vllm.reasoning.kimi_k2_reasoning_parser import KimiK2ReasoningParser
@@ -33,10 +32,9 @@ def test_parser_selection_thinking_disabled(kimi_k2_tokenizer):
 
 def test_extract_reasoning_with_think_tags(kimi_k2_tokenizer):
     parser = KimiK2ReasoningParser(kimi_k2_tokenizer)
-    request = ChatCompletionRequest(model="test-model", messages=[], temperature=1.0)
 
     reasoning, content = parser.extract_reasoning(
-        "<think>step by step reasoning</think>final answer", request
+        "<think>step by step reasoning</think>final answer"
     )
     assert reasoning == "step by step reasoning"
     assert content == "final answer"
@@ -44,11 +42,8 @@ def test_extract_reasoning_with_think_tags(kimi_k2_tokenizer):
 
 def test_extract_reasoning_empty_thinking(kimi_k2_tokenizer):
     parser = KimiK2ReasoningParser(kimi_k2_tokenizer)
-    request = ChatCompletionRequest(model="test-model", messages=[], temperature=1.0)
 
-    reasoning, content = parser.extract_reasoning(
-        "<think></think>final answer", request
-    )
+    reasoning, content = parser.extract_reasoning("<think></think>final answer")
     assert reasoning == ""
     assert content == "final answer"
 
@@ -56,11 +51,8 @@ def test_extract_reasoning_empty_thinking(kimi_k2_tokenizer):
 def test_extract_reasoning_implicit_start(kimi_k2_tokenizer):
     """When there's no <think> tag, everything is treated as reasoning."""
     parser = KimiK2ReasoningParser(kimi_k2_tokenizer)
-    request = ChatCompletionRequest(model="test-model", messages=[], temperature=1.0)
 
-    reasoning, content = parser.extract_reasoning(
-        "implicit reasoning with no tags", request
-    )
+    reasoning, content = parser.extract_reasoning("implicit reasoning with no tags")
     assert reasoning == "implicit reasoning with no tags"
     assert content is None
 
@@ -68,10 +60,9 @@ def test_extract_reasoning_implicit_start(kimi_k2_tokenizer):
 def test_extract_reasoning_tool_section_ends_reasoning(kimi_k2_tokenizer):
     """<|tool_calls_section_begin|> implicitly ends reasoning."""
     parser = KimiK2ReasoningParser(kimi_k2_tokenizer)
-    request = ChatCompletionRequest(model="test-model", messages=[], temperature=1.0)
 
     text = "some reasoning<|tool_calls_section_begin|>tool call data"
-    reasoning, content = parser.extract_reasoning(text, request)
+    reasoning, content = parser.extract_reasoning(text)
     assert reasoning == "some reasoning"
     assert content == "<|tool_calls_section_begin|>tool call data"
 

--- a/tests/reasoning/test_nemotron_v3_reasoning_parser.py
+++ b/tests/reasoning/test_nemotron_v3_reasoning_parser.py
@@ -7,7 +7,6 @@ import pytest
 import regex as re
 
 from tests.reasoning.utils import run_reasoning_extraction
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
 parser_name = "nemotron_v3"
@@ -110,17 +109,11 @@ def test_nemotron_v3_without_thinking_returns_content(
     tokenizer: FakeNemotronTokenizer,
 ):
     parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
-    parser = parser_cls(tokenizer)
-    request = ChatCompletionRequest(
-        model="test-model",
-        messages=[],
-        chat_template_kwargs={"enable_thinking": False},
-    )
+    parser = parser_cls(tokenizer, chat_template_kwargs={"enable_thinking": False})
 
     reasoning, content = run_reasoning_extraction(
         parser,
         ["This is plain content"],
-        request=request,
         streaming=False,
     )
 
@@ -132,17 +125,13 @@ def test_nemotron_v3_force_nonempty_content_returns_content(
     tokenizer: FakeNemotronTokenizer,
 ):
     parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
-    parser = parser_cls(tokenizer)
-    request = ChatCompletionRequest(
-        model="test-model",
-        messages=[],
-        chat_template_kwargs={"force_nonempty_content": True},
+    parser = parser_cls(
+        tokenizer, chat_template_kwargs={"force_nonempty_content": True}
     )
 
     reasoning, content = run_reasoning_extraction(
         parser,
         ["<think>This is plain content"],
-        request=request,
         streaming=False,
     )
 
@@ -154,17 +143,11 @@ def test_nemotron_v3_with_thinking_keeps_truncated_reasoning(
     tokenizer: FakeNemotronTokenizer,
 ):
     parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
-    parser = parser_cls(tokenizer)
-    request = ChatCompletionRequest(
-        model="test-model",
-        messages=[],
-        chat_template_kwargs={"enable_thinking": True},
-    )
+    parser = parser_cls(tokenizer, chat_template_kwargs={"enable_thinking": True})
 
     reasoning, content = run_reasoning_extraction(
         parser,
         ["This is truncated reasoning"],
-        request=request,
         streaming=False,
     )
 

--- a/tests/reasoning/test_qwen3_reasoning_parser.py
+++ b/tests/reasoning/test_qwen3_reasoning_parser.py
@@ -9,7 +9,6 @@ from tests.reasoning.utils import (
     run_reasoning_extraction,
     run_reasoning_extraction_streaming,
 )
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 
 parser_name = "qwen3"
@@ -316,7 +315,6 @@ def test_reasoning_thinking_disabled(
 
     reasoning, content = parser.extract_reasoning(
         model_output=output,
-        request=ChatCompletionRequest(messages=[], model="test-model"),
     )
 
     assert reasoning == expected_reasoning

--- a/tests/reasoning/utils.py
+++ b/tests/reasoning/utils.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning import ReasoningParser
 from vllm.utils.mistral import is_mistral_tokenizer
@@ -33,14 +32,12 @@ class StreamingReasoningReconstructor:
 def run_reasoning_extraction(
     reasoning_parser: ReasoningParser,
     model_output: list[str],
-    request: ChatCompletionRequest | None = None,
     streaming: bool = False,
 ) -> tuple[str | None, str | None]:
     if streaming:
         reconstructor = run_reasoning_extraction_streaming(
             reasoning_parser,
             model_output,
-            request,
         )
         return (
             reconstructor.reasoning,
@@ -56,7 +53,6 @@ def run_reasoning_extraction(
 def run_reasoning_extraction_mistral(
     reasoning_parser: ReasoningParser,
     model_output: list[int],
-    request: ChatCompletionRequest | None = None,
     streaming: bool = False,
 ) -> tuple[str | None, str | None]:
     assert is_mistral_tokenizer(reasoning_parser.model_tokenizer), type(
@@ -66,7 +62,6 @@ def run_reasoning_extraction_mistral(
         reconstructor = run_reasoning_extraction_streaming_mistral(
             reasoning_parser,
             model_output,
-            request,
         )
         return (
             reconstructor.reasoning,
@@ -92,9 +87,7 @@ def run_reasoning_extraction_nonstreaming(
 def run_reasoning_extraction_streaming(
     reasoning_parser: ReasoningParser,
     model_deltas: list[str],
-    request: ChatCompletionRequest | None = None,
 ) -> StreamingReasoningReconstructor:
-    request = request or ChatCompletionRequest(messages=[], model="test-model")
     reconstructor = StreamingReasoningReconstructor()
     previous_text = ""
     previous_tokens: list[int] = []
@@ -124,12 +117,10 @@ def run_reasoning_extraction_streaming(
 def run_reasoning_extraction_streaming_mistral(
     reasoning_parser: ReasoningParser,
     model_deltas: list[int],
-    request: ChatCompletionRequest | None = None,
 ) -> StreamingReasoningReconstructor:
     assert is_mistral_tokenizer(reasoning_parser.model_tokenizer), type(
         reasoning_parser.model_tokenizer
     )
-    request = request or ChatCompletionRequest(messages=[], model="test-model")
     reconstructor = StreamingReasoningReconstructor()
     previous_text = ""
     previous_tokens: list[int] = []

--- a/tests/reasoning/utils.py
+++ b/tests/reasoning/utils.py
@@ -48,7 +48,7 @@ def run_reasoning_extraction(
         )
     else:
         reasoning, content = run_reasoning_extraction_nonstreaming(
-            reasoning_parser, model_output, request
+            reasoning_parser, model_output
         )
         return reasoning, content
 
@@ -77,7 +77,7 @@ def run_reasoning_extraction_mistral(
             model_output
         )
         reasoning, content = run_reasoning_extraction_nonstreaming(
-            reasoning_parser, str_output, request
+            reasoning_parser, str_output
         )
         return reasoning, content
 
@@ -85,12 +85,8 @@ def run_reasoning_extraction_mistral(
 def run_reasoning_extraction_nonstreaming(
     reasoning_parser: ReasoningParser,
     model_output: list[str],
-    request: ChatCompletionRequest | None = None,
 ) -> tuple[str | None, str | None]:
-    request = request or ChatCompletionRequest(messages=[], model="test-model")
-    return reasoning_parser.extract_reasoning(
-        model_output="".join(model_output), request=request
-    )
+    return reasoning_parser.extract_reasoning(model_output="".join(model_output))
 
 
 def run_reasoning_extraction_streaming(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1374,9 +1374,7 @@ class OpenAIServingChat(OpenAIServing):
             if reasoning_parser:
                 # If the reasoning parser is enabled,
                 # tool calls are extracted exclusively from the content.
-                reasoning, content = reasoning_parser.extract_reasoning(
-                    output.text, request=request
-                )
+                reasoning, content = reasoning_parser.extract_reasoning(output.text)
                 if not request.include_reasoning:
                     reasoning = None
             else:

--- a/vllm/entrypoints/openai/parser/responses_parser.py
+++ b/vllm/entrypoints/openai/parser/responses_parser.py
@@ -62,7 +62,7 @@ class ResponsesParser:
         self.finish_reason = output.finish_reason
 
         reasoning, content = self.reasoning_parser_instance.extract_reasoning(
-            output.text, request=self.request
+            output.text
         )
         if reasoning:
             self.response_messages.append(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -186,7 +186,6 @@ class Parser:
     def extract_reasoning(
         self,
         model_output: str,
-        request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
         """
         Extract reasoning content from a complete model-generated string.
@@ -196,7 +195,6 @@ class Parser:
 
         Args:
             model_output: The complete model-generated string.
-            request: The request object used to generate the output.
 
         Returns:
             A tuple of (reasoning, response_content).
@@ -308,11 +306,10 @@ class DelegatingParser(Parser):
     def extract_reasoning(
         self,
         model_output: str,
-        request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
         if self._reasoning_parser is None:
             return None, model_output
-        return self._reasoning_parser.extract_reasoning(model_output, request)
+        return self._reasoning_parser.extract_reasoning(model_output)
 
     def extract_response_outputs(
         self,
@@ -325,7 +322,7 @@ class DelegatingParser(Parser):
         logprobs: list[Logprob] | None = None,
     ) -> list[ResponseOutputItem]:
         # First extract reasoning
-        reasoning, content = self.extract_reasoning(model_output, request)
+        reasoning, content = self.extract_reasoning(model_output)
 
         # Then parse tool calls from the content
         tool_calls, content = self._parse_tool_calls(

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -14,9 +14,7 @@ from vllm.utils.collection_utils import is_list_of
 from vllm.utils.import_utils import import_from_path
 
 if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
     from vllm.entrypoints.openai.engine.protocol import DeltaMessage
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
     from vllm.tokenizers import TokenizerLike
 
 logger = init_logger(__name__)
@@ -116,7 +114,6 @@ class ReasoningParser:
     def extract_reasoning(
         self,
         model_output: str,
-        request: "ChatCompletionRequest | ResponsesRequest",
     ) -> tuple[str | None, str | None]:
         """
         Extract reasoning content from a complete model-generated string.
@@ -126,7 +123,6 @@ class ReasoningParser:
 
         Parameters:
             model_output: The model-generated string to extract reasoning content from.
-            request: The request object that was used to generate the model_output.
 
         Returns:
             A tuple containing the reasoning content and the content.
@@ -298,6 +294,7 @@ class ReasoningParserManager:
             if isinstance(name, str):
                 names = [name]
             elif is_list_of(name, str):
+                assert isinstance(name, list)
                 names = name
             else:
                 names = [class_name]

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -4,15 +4,10 @@
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
 from itertools import islice
-from typing import TYPE_CHECKING
 
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
 from vllm.tokenizers import TokenizerLike
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 
 class BaseThinkingReasoningParser(ReasoningParser):
@@ -146,9 +141,7 @@ class BaseThinkingReasoningParser(ReasoningParser):
             # not find thinking start token
             return DeltaMessage(content=delta_text)
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         """
         Extract reasoning content from the model output.
 

--- a/vllm/reasoning/deepseek_v3_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_v3_reasoning_parser.py
@@ -13,9 +13,7 @@ from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParse
 from .identity_reasoning_parser import IdentityReasoningParser
 
 if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
     from vllm.entrypoints.openai.engine.protocol import DeltaMessage
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 logger = init_logger(__name__)
 
@@ -51,10 +49,8 @@ class DeepSeekV3ReasoningParser(ReasoningParser):
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         return self._parser.extract_content_ids(input_ids)
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
-        return self._parser.extract_reasoning(model_output, request)
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
+        return self._parser.extract_reasoning(model_output)
 
     def extract_reasoning_streaming(
         self,

--- a/vllm/reasoning/ernie45_reasoning_parser.py
+++ b/vllm/reasoning/ernie45_reasoning_parser.py
@@ -2,17 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 from transformers import PreTrainedTokenizerBase
 
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.logger import init_logger
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 logger = init_logger(__name__)
 
@@ -137,9 +132,7 @@ class Ernie45ReasoningParser(BaseThinkingReasoningParser):
             # no </think> in previous or delta, reasoning content continues
             return DeltaMessage(reasoning=delta_text)
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         """
         Extract reasoning content from the model output.
         The Ernie45 thinking model output format is
@@ -150,7 +143,7 @@ class Ernie45ReasoningParser(BaseThinkingReasoningParser):
         Returns:
             tuple[Optional[str], Optional[str]]: reasoning content and content
         """
-        reasoning, content = super().extract_reasoning(model_output, request)
+        reasoning, content = super().extract_reasoning(model_output)
         if content:
             start_idx = content.find(self.response_start_token)
             end_idx = content.rfind(self.response_end_token)

--- a/vllm/reasoning/gptoss_reasoning_parser.py
+++ b/vllm/reasoning/gptoss_reasoning_parser.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import json
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 from transformers import PreTrainedTokenizerBase
 
@@ -11,10 +10,6 @@ from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.entrypoints.openai.parser.harmony_utils import parse_chat_output
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 logger = init_logger(__name__)
 
@@ -150,7 +145,6 @@ class GptOssReasoningParser(ReasoningParser):
     def extract_reasoning(
         self,
         model_output: str,
-        request: "ChatCompletionRequest | ResponsesRequest",
     ) -> tuple[str | None, str | None]:
         raise NotImplementedError(
             "gpt-oss has a special branch for parsing reasoning in non-streaming mode. This method shouldn't be used."  # noqa: E501

--- a/vllm/reasoning/granite_reasoning_parser.py
+++ b/vllm/reasoning/granite_reasoning_parser.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 import regex as re
 from transformers import PreTrainedTokenizerBase
@@ -10,10 +9,6 @@ from transformers import PreTrainedTokenizerBase
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 logger = init_logger(__name__)
 
@@ -54,16 +49,13 @@ class GraniteReasoningParser(ReasoningParser):
             len(think_start) for think_start in self.valid_think_starts
         )
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
         something else, all content is considered non-reasoning content.
 
         Args:
             model_output (str): Output of the model to be parsed.
-            request (ChatCompletionRequest): Request being processed.
 
         Returns:
             tuple[Optional[str], Optional[str]]: Tuple pair containing the

--- a/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
+++ b/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 import regex as re
 from transformers import PreTrainedTokenizerBase
@@ -10,10 +9,6 @@ from transformers import PreTrainedTokenizerBase
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 logger = init_logger(__name__)
 
@@ -91,16 +86,13 @@ class HunyuanA13BReasoningParser(ReasoningParser):
         # this id is not part of content, so just return [] here.
         return []
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
         something else, all content is considered non-reasoning content.
 
         Args:
             model_output (str): Output of the model to be parsed.
-            request (ChatCompletionRequest): Request being processed.
 
         Returns:
             tuple[Optional[str], Optional[str]]: Tuple pair containing the

--- a/vllm/reasoning/identity_reasoning_parser.py
+++ b/vllm/reasoning/identity_reasoning_parser.py
@@ -2,17 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING
 
 from transformers import PreTrainedTokenizerBase
 
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 logger = init_logger(__name__)
 
@@ -60,9 +55,7 @@ class IdentityReasoningParser(ReasoningParser):
             return DeltaMessage(content=delta_text)
         return None
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         # No reasoning separation: return None for reasoning,
         # and full model_output as content
         return None, model_output

--- a/vllm/reasoning/kimi_k2_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k2_reasoning_parser.py
@@ -2,17 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING
 
 from transformers import PreTrainedTokenizerBase
 
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
 from vllm.reasoning.identity_reasoning_parser import IdentityReasoningParser
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 
 class KimiK2ReasoningParser(ReasoningParser):
@@ -146,14 +141,12 @@ class KimiK2ReasoningParser(ReasoningParser):
         # still reasoning (no content)
         return []
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         """
         Extract reasoning content from the model output.
         """
         if self._identity_parser is not None:
-            return self._identity_parser.extract_reasoning(model_output, request)
+            return self._identity_parser.extract_reasoning(model_output)
 
         # thinking does not require a think start token but consume it if present
         start_token_index = model_output.find(self._start_token)

--- a/vllm/reasoning/minimax_m2_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_reasoning_parser.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
@@ -11,10 +10,6 @@ from vllm.logger import init_logger
 from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 from vllm.tokenizers import TokenizerLike
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 logger = init_logger(__name__)
 
@@ -112,7 +107,5 @@ class MiniMaxM2AppendThinkReasoningParser(ReasoningParser):
             delta_text = "<think>" + delta_text
         return DeltaMessage(content=delta_text)
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         return None, "<think>" + model_output

--- a/vllm/reasoning/mistral_reasoning_parser.py
+++ b/vllm/reasoning/mistral_reasoning_parser.py
@@ -3,16 +3,11 @@
 
 from collections.abc import Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING
 
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 from vllm.tokenizers.mistral import MistralTokenizer
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 logger = init_logger(__name__)
 
@@ -111,9 +106,7 @@ class MistralReasoningParser(BaseThinkingReasoningParser):
         else:
             return input_ids[:eot_token_index] + input_ids[eot_token_index + 1 :]
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         """
         Extract reasoning content from the model output.
         """

--- a/vllm/reasoning/nemotron_v3_reasoning_parser.py
+++ b/vllm/reasoning/nemotron_v3_reasoning_parser.py
@@ -12,7 +12,7 @@ class NemotronV3ReasoningParser(DeepSeekR1ReasoningParser):
     def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
         super().__init__(tokenizer, *args, **kwargs)
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        self._enable_thinking = chat_kwargs.get("enable_thinking", None)
+        self._enable_thinking = chat_kwargs.get("enable_thinking", True)
         self._force_nonempty_content = chat_kwargs.get("force_nonempty_content", False)
 
     def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:

--- a/vllm/reasoning/nemotron_v3_reasoning_parser.py
+++ b/vllm/reasoning/nemotron_v3_reasoning_parser.py
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionRequest,
-)
-from vllm.entrypoints.openai.responses.protocol import (
-    ResponsesRequest,
-)
 from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+from vllm.tokenizers import TokenizerLike
 
 
 class NemotronV3ReasoningParser(DeepSeekR1ReasoningParser):
@@ -14,20 +9,18 @@ class NemotronV3ReasoningParser(DeepSeekR1ReasoningParser):
     Reasoning parser for Nemotron V3 models.
     """
 
-    def extract_reasoning(
-        self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
-    ) -> tuple[str | None, str | None]:
-        reasoning, final_content = super().extract_reasoning(model_output, request)
-        chat_template_kwargs = getattr(request, "chat_template_kwargs", None)
+    def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
+        chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
+        self._enable_thinking = chat_kwargs.get("enable_thinking", None)
+        self._force_nonempty_content = chat_kwargs.get("force_nonempty_content", False)
+
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
+        reasoning, final_content = super().extract_reasoning(model_output)
 
         if (
-            chat_template_kwargs
-            and (
-                chat_template_kwargs.get("enable_thinking") is False
-                or chat_template_kwargs.get("force_nonempty_content") is True
-            )
-            and final_content is None
-        ):
+            self._enable_thinking is False or self._force_nonempty_content is True
+        ) and final_content is None:
             reasoning, final_content = final_content, reasoning
 
         return reasoning, final_content

--- a/vllm/reasoning/olmo3_reasoning_parser.py
+++ b/vllm/reasoning/olmo3_reasoning_parser.py
@@ -4,18 +4,13 @@
 import dataclasses as dt
 import enum
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 import regex as re
 
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
-    from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers import TokenizerLike
 
 logger = init_logger(__name__)
 
@@ -251,7 +246,6 @@ class Olmo3ReasoningParser(ReasoningParser):
     def extract_reasoning(
         self,
         model_output: str,
-        request: "ChatCompletionRequest | ResponsesRequest",
     ) -> tuple[str | None, str | None]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
@@ -259,8 +253,6 @@ class Olmo3ReasoningParser(ReasoningParser):
 
         Args:
             model_output: Output of the model to be parsed.
-            request: Request being
-                processed.
 
         Returns:
             tuple[Optional[str], Optional[str]]: Tuple pair containing the

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
-    from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers import TokenizerLike
 
 
 class Qwen3ReasoningParser(BaseThinkingReasoningParser):
@@ -51,9 +46,7 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         """The token that ends reasoning content."""
         return "</think>"
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         """
         Extract reasoning content from the model output.
 

--- a/vllm/reasoning/step3_reasoning_parser.py
+++ b/vllm/reasoning/step3_reasoning_parser.py
@@ -3,7 +3,6 @@
 
 from collections.abc import Iterable, Sequence
 from itertools import islice
-from typing import TYPE_CHECKING
 
 import regex as re
 from transformers import PreTrainedTokenizerBase
@@ -11,10 +10,6 @@ from transformers import PreTrainedTokenizerBase
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 logger = init_logger(__name__)
 
@@ -84,9 +79,7 @@ class Step3ReasoningParser(ReasoningParser):
             # No </think> seen yet, everything is reasoning
             return DeltaMessage(reasoning=delta_text)
 
-    def extract_reasoning(
-        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
-    ) -> tuple[str | None, str | None]:
+    def extract_reasoning(self, model_output: str) -> tuple[str | None, str | None]:
         # Check if the model output contains the </think> token
         if self.think_end_token not in model_output:
             # If no </think> token, everything is reasoning content

--- a/vllm/reasoning/step3p5_reasoning_parser.py
+++ b/vllm/reasoning/step3p5_reasoning_parser.py
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING
 
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 from vllm.tokenizers import TokenizerLike
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 
 class Step3p5ReasoningParser(BaseThinkingReasoningParser):
@@ -95,9 +90,8 @@ class Step3p5ReasoningParser(BaseThinkingReasoningParser):
     def extract_reasoning(
         self,
         model_output: str,
-        request: "ChatCompletionRequest | ResponsesRequest",
     ) -> tuple[str | None, str | None]:
-        reasoning, content = super().extract_reasoning(model_output, request)
+        reasoning, content = super().extract_reasoning(model_output)
         if reasoning is not None:
             reasoning = reasoning.removesuffix("\n")
         if content is not None:


### PR DESCRIPTION
## Purpose
Reasoning parsers should not depend on the API request object. The parser's job is to split model output into reasoning and content. Any request-level config that affects parsing behavior should be resolved at  parser construction time via chat_template_kwargs, which is already passed to __init__.

### This PR
- Remove the "request" parameter from extract_reasoning() across all reasoning parsers — it was threaded through ~20 files but only consumed by NemotronV3ReasoningParser
- For Nemotron: move enable_thinking and force_nonempty_content reads from per-call (request.chat_template_kwargs) to __init__ (**kwargs). This is safe because a new parser instance is created per request with the appropriate chat_template_kwargs
- Clean up now-unused TYPE_CHECKING imports and protocol references

## Test Plan
```
pytest tests/reasoning/ -v
```