### PR TITLE
[BugFix][kv_offload] Reduce memory blocks allocated for CPU offload 

### DIFF
--- a/vllm/v1/kv_offload/cpu.py
+++ b/vllm/v1/kv_offload/cpu.py
@@ -40,7 +40,6 @@ class CPUOffloadingSpec(OffloadingSpec):
         kv_bytes_per_block = (
             page_size_bytes
             * len(kv_cache_config.kv_cache_tensors)
-            * vllm_config.parallel_config.world_size
         )
 
         kv_bytes_per_offloaded_block = kv_bytes_per_block * self.block_size_factor


### PR DESCRIPTION
## Purpose
`kv_bytes_per_block `is currently being calculated as:
```python
kv_bytes_per_block = (
            page_size_bytes  # already tp sharded
            * len(kv_cache_config.kv_cache_tensors) # per rank
            * vllm_config.parallel_config.world_size
        )
```
We do not need `world_size` to be included in the calculation as the `num_blocks` that is allocated on the CPU is needed for per GPU -> CPU offload not all GPUs -> shared CPU.

This change removes `world size` from the `kv_bytes_per_block` calculation

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

