### PR TITLE
fix(security): replace unsafe eval() in tool-calling examples

### DIFF
--- a/examples/online_serving/openai_chat_completion_client_with_tools_xlam.py
+++ b/examples/online_serving/openai_chat_completion_client_with_tools_xlam.py
@@ -12,7 +12,9 @@ OR
 vllm serve --model Salesforce/xLAM-2-3b-fc-r --enable-auto-tool-choice --tool-call-parser xlam
 """
 
+import ast
 import json
+import operator
 import time
 
 from openai import OpenAI
@@ -27,9 +29,47 @@ def get_weather(location: str, unit: str):
     return f"Weather in {location} is 22 degrees {unit}."
 
 
+# Supported operators for safe math evaluation.
+# SECURITY: Never use eval() on LLM outputs — it allows arbitrary code
+# execution via prompt injection. This safe evaluator only permits basic
+# arithmetic operations on numeric values.
+_SAFE_OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.Mod: operator.mod,
+    ast.FloorDiv: operator.floordiv,
+    ast.USub: operator.neg,
+    ast.UAdd: operator.pos,
+}
+
+
+def _safe_eval_node(node: ast.AST):
+    """Recursively evaluate an AST node containing only numbers and
+    basic arithmetic operators."""
+    if isinstance(node, ast.Expression):
+        return _safe_eval_node(node.body)
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return node.value
+    if isinstance(node, ast.BinOp):
+        op_fn = _SAFE_OPERATORS.get(type(node.op))
+        if op_fn is None:
+            raise ValueError(f"Unsupported operator: {type(node.op).__name__}")
+        return op_fn(_safe_eval_node(node.left), _safe_eval_node(node.right))
+    if isinstance(node, ast.UnaryOp):
+        op_fn = _SAFE_OPERATORS.get(type(node.op))
+        if op_fn is None:
+            raise ValueError(f"Unsupported operator: {type(node.op).__name__}")
+        return op_fn(_safe_eval_node(node.operand))
+    raise ValueError(f"Unsupported expression node: {type(node).__name__}")
+
+
 def calculate_expression(expression: str):
     try:
-        result = eval(expression)
+        tree = ast.parse(expression, mode="eval")
+        result = _safe_eval_node(tree)
         return f"The result of {expression} is {result}"
     except Exception as e:
         return f"Could not calculate {expression}: {e}"
@@ -69,7 +109,7 @@ tools = [
                 "properties": {
                     "expression": {
                         "type": "string",
-                        "description": "Mathematical expression to evaluate, needs to be a valid python expression",
+                        "description": "Mathematical expression to evaluate, e.g., '25 * 17 + 31'",
                     }
                 },
                 "required": ["expression"],

--- a/examples/online_serving/openai_chat_completion_client_with_tools_xlam.py
+++ b/examples/online_serving/openai_chat_completion_client_with_tools_xlam.py
@@ -71,7 +71,7 @@ def calculate_expression(expression: str):
         tree = ast.parse(expression, mode="eval")
         result = _safe_eval_node(tree)
         return f"The result of {expression} is {result}"
-    except Exception as e:
+    except (SyntaxError, ValueError) as e:
         return f"Could not calculate {expression}: {e}"
 
 

--- a/examples/online_serving/openai_chat_completion_client_with_tools_xlam_streaming.py
+++ b/examples/online_serving/openai_chat_completion_client_with_tools_xlam_streaming.py
@@ -14,7 +14,9 @@ vllm serve --model Salesforce/xLAM-2-3b-fc-r --enable-auto-tool-choice --tool-ca
 This example demonstrates streaming tool calls with xLAM models.
 """
 
+import ast
 import json
+import operator
 import time
 
 from openai import OpenAI
@@ -29,9 +31,47 @@ def get_weather(location: str, unit: str):
     return f"Weather in {location} is 22 degrees {unit}."
 
 
+# Supported operators for safe math evaluation.
+# SECURITY: Never use eval() on LLM outputs — it allows arbitrary code
+# execution via prompt injection. This safe evaluator only permits basic
+# arithmetic operations on numeric values.
+_SAFE_OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.Mod: operator.mod,
+    ast.FloorDiv: operator.floordiv,
+    ast.USub: operator.neg,
+    ast.UAdd: operator.pos,
+}
+
+
+def _safe_eval_node(node: ast.AST):
+    """Recursively evaluate an AST node containing only numbers and
+    basic arithmetic operators."""
+    if isinstance(node, ast.Expression):
+        return _safe_eval_node(node.body)
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return node.value
+    if isinstance(node, ast.BinOp):
+        op_fn = _SAFE_OPERATORS.get(type(node.op))
+        if op_fn is None:
+            raise ValueError(f"Unsupported operator: {type(node.op).__name__}")
+        return op_fn(_safe_eval_node(node.left), _safe_eval_node(node.right))
+    if isinstance(node, ast.UnaryOp):
+        op_fn = _SAFE_OPERATORS.get(type(node.op))
+        if op_fn is None:
+            raise ValueError(f"Unsupported operator: {type(node.op).__name__}")
+        return op_fn(_safe_eval_node(node.operand))
+    raise ValueError(f"Unsupported expression node: {type(node).__name__}")
+
+
 def calculate_expression(expression: str):
     try:
-        result = eval(expression)
+        tree = ast.parse(expression, mode="eval")
+        result = _safe_eval_node(tree)
         return f"The result of {expression} is {result}"
     except Exception as e:
         return f"Could not calculate {expression}: {e}"
@@ -71,7 +111,7 @@ tools = [
                 "properties": {
                     "expression": {
                         "type": "string",
-                        "description": "Mathematical expression to evaluate, needs to be a valid Python expression",
+                        "description": "Mathematical expression to evaluate, e.g., '25 * 17 + 31'",
                     }
                 },
                 "required": ["expression"],

--- a/examples/online_serving/openai_chat_completion_client_with_tools_xlam_streaming.py
+++ b/examples/online_serving/openai_chat_completion_client_with_tools_xlam_streaming.py
@@ -73,7 +73,7 @@ def calculate_expression(expression: str):
         tree = ast.parse(expression, mode="eval")
         result = _safe_eval_node(tree)
         return f"The result of {expression} is {result}"
-    except Exception as e:
+    except (SyntaxError, ValueError) as e:
         return f"Could not calculate {expression}: {e}"
 
 


### PR DESCRIPTION
## Summary

- Replace `eval()` with a safe AST-based math evaluator in two xLAM tool-calling example files
- `eval()` on LLM-generated expressions allows arbitrary code execution via prompt injection (e.g., `__import__("os").system("rm -rf /")`)
- Example code is frequently copied verbatim by users into production, so it should demonstrate secure practices

## Details

**Affected files:**
- `examples/online_serving/openai_chat_completion_client_with_tools_xlam.py`
- `examples/online_serving/openai_chat_completion_client_with_tools_xlam_streaming.py`

Both files define a `calculate_expression()` tool that passes LLM output directly to `eval()`. The replacement uses `ast.parse()` to build an AST, then walks it with a recursive evaluator that only permits:
- Numeric literals (`int`, `float`)
- Binary operators: `+`, `-`, `*`, `/`, `//`, `%`, `**`
- Unary operators: `-`, `+`

Any other AST node (function calls, attribute access, name lookups, etc.) raises a `ValueError`. The calculator tool still works correctly for all arithmetic expressions.

Found by static analysis.

## Test plan

- [x] Verified safe evaluator produces correct results for `25 * 17 + 31`, `3.14 * 2`, `-5 + 3`, `10 / 3`, `2 ** 8`
- [x] Verified malicious inputs like `__import__("os").system("id")` and `open("/etc/passwd").read()` are blocked with `ValueError`
- [ ] Run existing CI checks