### PR TITLE
Revert "[Bug][MoE] Fix TRTLLM NVFP4 Routing Kernel Precision" (#36725)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -303,7 +303,10 @@ class TrtLlmNvFp4ExpertsMonolithic(
             and self.routing_method_type != RoutingMethodType.Llama4
         )
 
-        # Prepare router logits for kernel format.
+        # Prepare routing bias into kernel format.
+        routing_bias = e_score_correction_bias
+        if routing_bias is not None:
+            routing_bias = routing_bias.to(torch.bfloat16)
         router_logits = (
             router_logits.to(torch.float32)
             if self.routing_method_type == RoutingMethodType.DeepSeekV3
@@ -313,7 +316,7 @@ class TrtLlmNvFp4ExpertsMonolithic(
         # Invoke kernel.
         return flashinfer.fused_moe.trtllm_fp4_block_scale_moe(
             routing_logits=router_logits,
-            routing_bias=e_score_correction_bias,
+            routing_bias=routing_bias,
             hidden_states=hidden_states,
             hidden_states_scale=a1q_scale.view(torch.float8_e4m3fn).reshape(
                 *hidden_states.shape[:-1], -1


### PR DESCRIPTION
## Revert of #36725

This reverts commit 5bf3c42d4c7e99f4898b18a715be515f44a22f44.

**Original PR:** https://github.com/vllm-project/vllm/pull/36725
**Failures linked:** 1 new CI failure in build [#57650](https://buildkite.com/vllm/ci/builds/57650)

### Failed tests
- Fusion E2E Config Sweep (B200)

### Root cause
The PR changed `vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py`. After this change, the `test_tp1_fp4_fusions` test for `nvidia/Llama-4-Scout-17B-16E-Instruct-NVFP4` with FLASHINFER backend on B200 fails with `RuntimeError: Engine core initialization failed` (the EngineCore process crashes silently during model loading).

---
*Auto-generated by CI failure analyzer*