### PR TITLE
[Attention][GPT-OSS] Prefer Triton on SM8x and narrow SM89 sink-prefill tuning

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention_tile_policy.py
+++ b/tests/kernels/attention/test_triton_unified_attention_tile_policy.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+from vllm.platforms import current_platform
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.ops.triton_unified_attention import (
+    _get_tile_size,
+    _use_small_sm8x_sink_tiles,
+)
+
+
+def test_sm89_sink_prefill_uses_smaller_tile():
+    assert (
+        _get_tile_size(
+            head_size=64,
+            sliding_window=0,
+            element_size=2,
+            is_prefill=True,
+            has_sinks=True,
+            device_capability=DeviceCapability(8, 9),
+        )
+        == 16
+    )
+
+
+def test_sm80_sink_prefill_keeps_default_tile():
+    assert (
+        _get_tile_size(
+            head_size=64,
+            sliding_window=0,
+            element_size=2,
+            is_prefill=True,
+            has_sinks=True,
+            device_capability=DeviceCapability(8, 0),
+        )
+        == 32
+    )
+
+
+def test_sink_decode_policy_is_unchanged():
+    assert (
+        _get_tile_size(
+            head_size=64,
+            sliding_window=0,
+            element_size=2,
+            is_prefill=False,
+            has_sinks=True,
+            device_capability=DeviceCapability(8, 9),
+        )
+        == 16
+    )
+
+
+def test_gemma3_special_case_wins_over_sm89_sink_policy():
+    assert (
+        _get_tile_size(
+            head_size=128,
+            sliding_window=1024,
+            element_size=2,
+            is_prefill=True,
+            has_sinks=True,
+            device_capability=DeviceCapability(8, 9),
+        )
+        == 32
+    )
+
+
+def test_sm89_sink_detection_uses_current_platform():
+    with (
+        patch.object(current_platform, "is_cuda", return_value=True),
+        patch.object(
+            current_platform,
+            "get_device_capability",
+            return_value=DeviceCapability(8, 9),
+        ),
+    ):
+        assert _use_small_sm8x_sink_tiles(
+            current_platform.get_device_capability(),
+            has_sinks=True,
+        )

--- a/tests/kernels/attention/test_triton_unified_attention_tile_policy.py
+++ b/tests/kernels/attention/test_triton_unified_attention_tile_policy.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.ops.triton_unified_attention import (
+    TRITON_ATTN_TILE_SIZE_DECODE_ENV,
+    TRITON_ATTN_TILE_SIZE_PREFILL_ENV,
     _get_tile_size,
+    _get_tile_size_override,
+    _is_gpt_oss_sm8x_sink_attention,
+    _use_gpt_oss_sm8x_large_prefill_tile,
     _use_small_sm8x_sink_tiles,
 )
 
@@ -16,10 +21,43 @@ def test_sm89_sink_prefill_uses_smaller_tile():
         _get_tile_size(
             head_size=64,
             sliding_window=0,
+            num_kv_heads=4,
             element_size=2,
             is_prefill=True,
             has_sinks=True,
             device_capability=DeviceCapability(8, 9),
+        )
+        == 16
+    )
+
+
+def test_gpt_oss_sm89_sink_prefill_keeps_default_tile():
+    assert (
+        _get_tile_size(
+            head_size=64,
+            sliding_window=128,
+            num_kv_heads=8,
+            element_size=2,
+            is_prefill=True,
+            has_sinks=True,
+            device_capability=DeviceCapability(8, 9),
+            max_seq_len=9000,
+        )
+        == 32
+    )
+
+
+def test_gpt_oss_sm89_long_prefill_uses_small_tile():
+    assert (
+        _get_tile_size(
+            head_size=64,
+            sliding_window=128,
+            num_kv_heads=8,
+            element_size=2,
+            is_prefill=True,
+            has_sinks=True,
+            device_capability=DeviceCapability(8, 9),
+            max_seq_len=22000,
         )
         == 16
     )
@@ -30,6 +68,7 @@ def test_sm80_sink_prefill_keeps_default_tile():
         _get_tile_size(
             head_size=64,
             sliding_window=0,
+            num_kv_heads=8,
             element_size=2,
             is_prefill=True,
             has_sinks=True,
@@ -44,6 +83,22 @@ def test_sink_decode_policy_is_unchanged():
         _get_tile_size(
             head_size=64,
             sliding_window=0,
+            num_kv_heads=4,
+            element_size=2,
+            is_prefill=False,
+            has_sinks=True,
+            device_capability=DeviceCapability(8, 9),
+        )
+        == 16
+    )
+
+
+def test_gpt_oss_sm89_sink_decode_keeps_default_tile():
+    assert (
+        _get_tile_size(
+            head_size=64,
+            sliding_window=0,
+            num_kv_heads=8,
             element_size=2,
             is_prefill=False,
             has_sinks=True,
@@ -58,6 +113,7 @@ def test_gemma3_special_case_wins_over_sm89_sink_policy():
         _get_tile_size(
             head_size=128,
             sliding_window=1024,
+            num_kv_heads=8,
             element_size=2,
             is_prefill=True,
             has_sinks=True,
@@ -80,3 +136,116 @@ def test_sm89_sink_detection_uses_current_platform():
             current_platform.get_device_capability(),
             has_sinks=True,
         )
+
+
+def test_gpt_oss_sm89_sink_detection_uses_geometry():
+    assert _is_gpt_oss_sm8x_sink_attention(
+        head_size=64,
+        num_kv_heads=8,
+        device_capability=DeviceCapability(8, 9),
+        has_sinks=True,
+    )
+
+
+def test_gpt_oss_sm89_large_prefill_tile_is_length_gated():
+    assert _use_gpt_oss_sm8x_large_prefill_tile(
+        head_size=64,
+        num_kv_heads=8,
+        device_capability=DeviceCapability(8, 9),
+        has_sinks=True,
+        max_seq_len=9000,
+    )
+    assert not _use_gpt_oss_sm8x_large_prefill_tile(
+        head_size=64,
+        num_kv_heads=8,
+        device_capability=DeviceCapability(8, 9),
+        has_sinks=True,
+        max_seq_len=22000,
+    )
+
+
+def test_non_gpt_oss_sink_detection_rejects_other_kv_head_counts():
+    assert not _is_gpt_oss_sm8x_sink_attention(
+        head_size=64,
+        num_kv_heads=4,
+        device_capability=DeviceCapability(8, 9),
+        has_sinks=True,
+    )
+
+
+def test_prefill_tile_size_env_override_wins():
+    with patch.dict(
+        "os.environ",
+        {TRITON_ATTN_TILE_SIZE_PREFILL_ENV: "32"},
+        clear=False,
+    ):
+        assert _get_tile_size_override(is_prefill=True) == 32
+        assert (
+            _get_tile_size(
+                head_size=64,
+                sliding_window=0,
+                num_kv_heads=4,
+                element_size=2,
+                is_prefill=True,
+                has_sinks=True,
+                device_capability=DeviceCapability(8, 9),
+            )
+            == 32
+        )
+
+
+def test_decode_tile_size_env_override_wins():
+    with patch.dict(
+        "os.environ",
+        {TRITON_ATTN_TILE_SIZE_DECODE_ENV: "32"},
+        clear=False,
+    ):
+        assert _get_tile_size_override(is_prefill=False) == 32
+        assert (
+            _get_tile_size(
+                head_size=64,
+                sliding_window=0,
+                num_kv_heads=4,
+                element_size=2,
+                is_prefill=False,
+                has_sinks=True,
+                device_capability=DeviceCapability(8, 9),
+            )
+            == 32
+        )
+
+
+def test_tile_size_env_override_requires_power_of_two():
+    with patch.dict(
+        "os.environ",
+        {TRITON_ATTN_TILE_SIZE_PREFILL_ENV: "24"},
+        clear=False,
+    ):
+        try:
+            _get_tile_size_override(is_prefill=True)
+        except ValueError as exc:
+            assert TRITON_ATTN_TILE_SIZE_PREFILL_ENV in str(exc)
+        else:
+            raise AssertionError("Expected ValueError for invalid tile-size override")
+
+
+def test_fp8_tile_size_override_requires_minimum_tile():
+    with patch.dict(
+        "os.environ",
+        {TRITON_ATTN_TILE_SIZE_DECODE_ENV: "16"},
+        clear=False,
+    ):
+        try:
+            _get_tile_size(
+                head_size=64,
+                sliding_window=0,
+                num_kv_heads=4,
+                element_size=1,
+                is_prefill=False,
+                has_sinks=True,
+                device_capability=DeviceCapability(8, 9),
+            )
+        except ValueError as exc:
+            assert TRITON_ATTN_TILE_SIZE_DECODE_ENV in str(exc)
+        else:
+            raise AssertionError("Expected ValueError for invalid fp8 tile override")

--- a/tests/v1/attention/test_cuda_attention_backend_policy.py
+++ b/tests/v1/attention/test_cuda_attention_backend_policy.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for CUDA model-aware attention backend policy."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from vllm.config import set_current_vllm_config
+from vllm.platforms.cuda import _get_backend_priorities
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.attention.selector import get_attn_backend
+
+
+def setup_function():
+    _get_backend_priorities.cache_clear()
+
+
+def teardown_function():
+    _get_backend_priorities.cache_clear()
+
+
+def test_gpt_oss_sm89_prioritizes_triton_for_sink_attention():
+    priorities = _get_backend_priorities(
+        use_mla=False,
+        device_capability=DeviceCapability(8, 9),
+        model_architectures=("GptOssForCausalLM",),
+        has_sink=True,
+    )
+
+    assert priorities == [
+        AttentionBackendEnum.TRITON_ATTN,
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.FLASHINFER,
+        AttentionBackendEnum.FLEX_ATTENTION,
+    ]
+
+
+def test_gpt_oss_sm90_prioritizes_flash_attn_for_sink_attention():
+    priorities = _get_backend_priorities(
+        use_mla=False,
+        device_capability=DeviceCapability(9, 0),
+        model_architectures=("GptOssForCausalLM",),
+        has_sink=True,
+    )
+
+    assert priorities == [
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.TRITON_ATTN,
+        AttentionBackendEnum.FLASHINFER,
+        AttentionBackendEnum.FLEX_ATTENTION,
+    ]
+
+
+def test_gpt_oss_sm100_prioritizes_flashinfer_for_sink_attention():
+    priorities = _get_backend_priorities(
+        use_mla=False,
+        device_capability=DeviceCapability(10, 0),
+        model_architectures=("GptOssForCausalLM",),
+        has_sink=True,
+    )
+
+    assert priorities == [
+        AttentionBackendEnum.FLASHINFER,
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.TRITON_ATTN,
+        AttentionBackendEnum.FLEX_ATTENTION,
+    ]
+
+
+def test_non_gpt_oss_or_sinkless_configs_keep_generic_policy():
+    priorities = _get_backend_priorities(
+        use_mla=False,
+        device_capability=DeviceCapability(8, 9),
+        model_architectures=("GptOssForCausalLM",),
+        has_sink=False,
+    )
+
+    assert priorities == [
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.FLASHINFER,
+        AttentionBackendEnum.TRITON_ATTN,
+        AttentionBackendEnum.FLEX_ATTENTION,
+    ]
+
+
+def test_get_attn_backend_uses_declared_architectures_for_policy():
+    sentinel = object()
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            user_specified_block_size=False,
+            block_size=16,
+        ),
+        model_config=SimpleNamespace(
+            architectures=["GptOssForCausalLM"],
+            architecture="StaleWrappedArchitecture",
+        ),
+        attention_config=SimpleNamespace(backend=None),
+    )
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.v1.attention.selector._cached_get_attn_backend",
+            return_value=sentinel,
+        ) as mock_cached_get_attn_backend,
+    ):
+        backend = get_attn_backend(
+            128,
+            torch.bfloat16,
+            None,
+            has_sink=True,
+        )
+
+    assert backend is sentinel
+    attn_selector_config = mock_cached_get_attn_backend.call_args.kwargs[
+        "attn_selector_config"
+    ]
+    assert attn_selector_config.model_architectures == (
+        "GptOssForCausalLM",
+        "StaleWrappedArchitecture",
+    )

--- a/tests/v1/attention/test_cuda_attention_backend_policy.py
+++ b/tests/v1/attention/test_cuda_attention_backend_policy.py
@@ -70,12 +70,44 @@ def test_gpt_oss_sm100_prioritizes_flashinfer_for_sink_attention():
     ]
 
 
+def test_gpt_oss_sm110_prioritizes_flashinfer_for_sink_attention():
+    priorities = _get_backend_priorities(
+        use_mla=False,
+        device_capability=DeviceCapability(11, 0),
+        model_architectures=("GptOssForCausalLM",),
+        has_sink=True,
+    )
+
+    assert priorities == [
+        AttentionBackendEnum.FLASHINFER,
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.TRITON_ATTN,
+        AttentionBackendEnum.FLEX_ATTENTION,
+    ]
+
+
 def test_non_gpt_oss_or_sinkless_configs_keep_generic_policy():
     priorities = _get_backend_priorities(
         use_mla=False,
         device_capability=DeviceCapability(8, 9),
         model_architectures=("GptOssForCausalLM",),
         has_sink=False,
+    )
+
+    assert priorities == [
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.FLASHINFER,
+        AttentionBackendEnum.TRITON_ATTN,
+        AttentionBackendEnum.FLEX_ATTENTION,
+    ]
+
+
+def test_non_target_cuda_families_fall_back_to_generic_policy():
+    priorities = _get_backend_priorities(
+        use_mla=False,
+        device_capability=DeviceCapability(7, 5),
+        model_architectures=("GptOssForCausalLM",),
+        has_sink=True,
     )
 
     assert priorities == [

--- a/tests/v1/attention/test_cuda_attention_backend_policy.py
+++ b/tests/v1/attention/test_cuda_attention_backend_policy.py
@@ -3,15 +3,15 @@
 """Tests for CUDA model-aware attention backend policy."""
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 
 from vllm.config import set_current_vllm_config
-from vllm.platforms.cuda import _get_backend_priorities
+from vllm.platforms.cuda import CudaPlatform, _get_backend_priorities
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
-from vllm.v1.attention.selector import get_attn_backend
+from vllm.v1.attention.selector import AttentionSelectorConfig, get_attn_backend
 
 
 def setup_function():
@@ -121,4 +121,36 @@ def test_get_attn_backend_uses_declared_architectures_for_policy():
     assert attn_selector_config.model_architectures == (
         "GptOssForCausalLM",
         "StaleWrappedArchitecture",
+    )
+
+
+def test_cuda_validation_excludes_policy_only_model_architectures():
+    backend = Mock()
+    backend_class = Mock()
+    backend.get_class.return_value = backend_class
+    backend_class.validate_configuration.return_value = []
+
+    attn_selector_config = AttentionSelectorConfig(
+        head_size=128,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=None,
+        block_size=None,
+        has_sink=True,
+        model_architectures=("GptOssForCausalLM",),
+    )
+
+    with patch(
+        "vllm.platforms.cuda._get_backend_priorities",
+        return_value=[backend],
+    ):
+        valid, invalid = CudaPlatform.get_valid_backends(
+            device_capability=DeviceCapability(8, 9),
+            attn_selector_config=attn_selector_config,
+        )
+
+    assert valid == [(backend, 0)]
+    assert invalid == {}
+    assert (
+        "model_architectures"
+        not in backend_class.validate_configuration.call_args.kwargs
     )

--- a/tests/v1/attention/test_triton_attn_policy.py
+++ b/tests/v1/attention/test_triton_attn_policy.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backends.triton_attn import _get_seq_threshold_3d
+
+
+def test_gpt_oss_sm89_keeps_default_seq_threshold_3d():
+    assert (
+        _get_seq_threshold_3d(
+            16,
+            device_capability=DeviceCapability(8, 9),
+            model_type="gpt_oss",
+            head_size=64,
+            num_heads_kv=8,
+            sliding_window=128,
+        )
+        == 16
+    )
+
+
+def test_non_gpt_oss_keeps_default_seq_threshold_3d():
+    assert (
+        _get_seq_threshold_3d(
+            16,
+            device_capability=DeviceCapability(8, 9),
+            model_type="llama",
+            head_size=64,
+            num_heads_kv=8,
+            sliding_window=128,
+        )
+        == 16
+    )
+
+
+def test_non_target_geometry_keeps_default_seq_threshold_3d():
+    assert (
+        _get_seq_threshold_3d(
+            16,
+            device_capability=DeviceCapability(8, 9),
+            model_type="gpt_oss",
+            head_size=64,
+            num_heads_kv=8,
+            sliding_window=0,
+        )
+        == 16
+    )

--- a/tests/v1/attention/test_triton_attn_threshold_override.py
+++ b/tests/v1/attention/test_triton_attn_threshold_override.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+from vllm.v1.attention.backends.triton_attn import (
+    TRITON_ATTN_SEQ_THRESHOLD_3D_ENV,
+    _maybe_override_seq_threshold_3d,
+)
+
+
+def test_seq_threshold_override_uses_env_value():
+    with patch.dict(
+        "os.environ",
+        {TRITON_ATTN_SEQ_THRESHOLD_3D_ENV: "8"},
+        clear=False,
+    ):
+        assert _maybe_override_seq_threshold_3d(16) == 8
+
+
+def test_seq_threshold_override_keeps_default_when_unset():
+    with patch.dict("os.environ", {}, clear=True):
+        assert _maybe_override_seq_threshold_3d(16) == 16
+
+
+def test_seq_threshold_override_requires_positive_integer():
+    with patch.dict(
+        "os.environ",
+        {TRITON_ATTN_SEQ_THRESHOLD_3D_ENV: "0"},
+        clear=False,
+    ):
+        try:
+            _maybe_override_seq_threshold_3d(16)
+        except ValueError as exc:
+            assert TRITON_ATTN_SEQ_THRESHOLD_3D_ENV in str(exc)
+        else:
+            raise AssertionError(
+                "Expected ValueError for invalid seq-threshold override"
+            )

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -37,6 +37,8 @@ else:
 
 logger = init_logger(__name__)
 
+_GPT_OSS_MODEL_ARCH = "GptOssForCausalLM"
+
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
@@ -53,8 +55,54 @@ def _get_backend_priorities(
     device_capability: DeviceCapability,
     num_heads: int | None = None,
     kv_cache_dtype: CacheDType | None = None,
+    model_architectures: tuple[str, ...] = (),
+    has_sink: bool = False,
 ) -> list[AttentionBackendEnum]:
     """Get backend priorities with lazy import to avoid circular dependency."""
+    if not use_mla and has_sink and _GPT_OSS_MODEL_ARCH in model_architectures:
+        if device_capability.major == 10:
+            logger.info_once(
+                "Using GPT-OSS CUDA attention policy for SM100+: "
+                "prioritizing FlashInfer/TRTLLM because GPT-OSS requires "
+                "attention sinks.",
+                scope="local",
+            )
+            return [
+                AttentionBackendEnum.FLASHINFER,
+                AttentionBackendEnum.FLASH_ATTN,
+                AttentionBackendEnum.TRITON_ATTN,
+                AttentionBackendEnum.FLEX_ATTENTION,
+            ]
+
+        if device_capability >= DeviceCapability(9, 0):
+            logger.info_once(
+                "Using GPT-OSS CUDA attention policy for SM90/SM9x: "
+                "prioritizing FlashAttention because GPT-OSS requires "
+                "attention sinks and FlashInfer sink support depends on "
+                "TRTLLM attention.",
+                scope="local",
+            )
+            return [
+                AttentionBackendEnum.FLASH_ATTN,
+                AttentionBackendEnum.TRITON_ATTN,
+                AttentionBackendEnum.FLASHINFER,
+                AttentionBackendEnum.FLEX_ATTENTION,
+            ]
+
+        logger.info_once(
+            "Using GPT-OSS CUDA attention policy for SM8x: "
+            "prioritizing Triton because GPT-OSS requires attention sinks, "
+            "FlashAttention sink support starts at SM90, and FlashInfer "
+            "sink support depends on TRTLLM attention.",
+            scope="local",
+        )
+        return [
+            AttentionBackendEnum.TRITON_ATTN,
+            AttentionBackendEnum.FLASH_ATTN,
+            AttentionBackendEnum.FLASHINFER,
+            AttentionBackendEnum.FLEX_ATTENTION,
+        ]
+
     if use_mla:
         if device_capability.major == 10:
             # Sparse MLA backend priorities
@@ -228,6 +276,8 @@ class CudaPlatformBase(Platform):
             device_capability,
             num_heads,
             attn_selector_config.kv_cache_dtype,
+            attn_selector_config.model_architectures,
+            attn_selector_config.has_sink,
         )
         for priority, backend in enumerate(backend_priorities):
             try:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -60,7 +60,7 @@ def _get_backend_priorities(
 ) -> list[AttentionBackendEnum]:
     """Get backend priorities with lazy import to avoid circular dependency."""
     if not use_mla and has_sink and _GPT_OSS_MODEL_ARCH in model_architectures:
-        if device_capability.major == 10:
+        if device_capability.major >= 10:
             logger.info_once(
                 "Using GPT-OSS CUDA attention policy for SM100+: "
                 "prioritizing FlashInfer/TRTLLM because GPT-OSS requires "
@@ -74,7 +74,7 @@ def _get_backend_priorities(
                 AttentionBackendEnum.FLEX_ATTENTION,
             ]
 
-        if device_capability >= DeviceCapability(9, 0):
+        if device_capability.major == 9:
             logger.info_once(
                 "Using GPT-OSS CUDA attention policy for SM90/SM9x: "
                 "prioritizing FlashAttention because GPT-OSS requires "
@@ -89,19 +89,20 @@ def _get_backend_priorities(
                 AttentionBackendEnum.FLEX_ATTENTION,
             ]
 
-        logger.info_once(
-            "Using GPT-OSS CUDA attention policy for SM8x: "
-            "prioritizing Triton because GPT-OSS requires attention sinks, "
-            "FlashAttention sink support starts at SM90, and FlashInfer "
-            "sink support depends on TRTLLM attention.",
-            scope="local",
-        )
-        return [
-            AttentionBackendEnum.TRITON_ATTN,
-            AttentionBackendEnum.FLASH_ATTN,
-            AttentionBackendEnum.FLASHINFER,
-            AttentionBackendEnum.FLEX_ATTENTION,
-        ]
+        if device_capability.major == 8:
+            logger.info_once(
+                "Using GPT-OSS CUDA attention policy for SM8x: "
+                "prioritizing Triton because GPT-OSS requires attention sinks, "
+                "FlashAttention sink support starts at SM90, and FlashInfer "
+                "sink support depends on TRTLLM attention.",
+                scope="local",
+            )
+            return [
+                AttentionBackendEnum.TRITON_ATTN,
+                AttentionBackendEnum.FLASH_ATTN,
+                AttentionBackendEnum.FLASHINFER,
+                AttentionBackendEnum.FLEX_ATTENTION,
+            ]
 
     if use_mla:
         if device_capability.major == 10:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -284,7 +284,7 @@ class CudaPlatformBase(Platform):
                 backend_class = backend.get_class()
                 invalid_reasons_i = backend_class.validate_configuration(
                     device_capability=device_capability,
-                    **attn_selector_config._asdict(),
+                    **attn_selector_config.validation_kwargs(),
                 )
             except ImportError:
                 invalid_reasons_i = ["ImportError"]
@@ -311,7 +311,7 @@ class CudaPlatformBase(Platform):
                 backend_class = selected_backend.get_class()
                 invalid_reasons = backend_class.validate_configuration(
                     device_capability=device_capability,
-                    **attn_selector_config._asdict(),
+                    **attn_selector_config.validation_kwargs(),
                 )
             except ImportError:
                 invalid_reasons = ["ImportError"]

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """High-Performance Triton-only Attention layer."""
 
+import os
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -41,6 +42,44 @@ logger = init_logger(__name__)
 # constants
 MIN_LAUNCH_GRID_SIZE_2D = 128  # Minimum launch grid size of 2D kernel
 NUM_PAR_SOFTMAX_SEGMENTS = 16  # Number of parallel tiled softmax segments
+TRITON_ATTN_SEQ_THRESHOLD_3D_ENV = "VLLM_TRITON_ATTN_SEQ_THRESHOLD_3D"
+
+
+def _maybe_override_seq_threshold_3d(seq_threshold_3d: int) -> int:
+    raw_value = os.environ.get(TRITON_ATTN_SEQ_THRESHOLD_3D_ENV)
+    if raw_value in (None, ""):
+        return seq_threshold_3d
+    assert raw_value is not None
+
+    try:
+        override = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{TRITON_ATTN_SEQ_THRESHOLD_3D_ENV} must be a positive integer, "
+            f"got {raw_value!r}."
+        ) from exc
+
+    if override <= 0:
+        raise ValueError(
+            f"{TRITON_ATTN_SEQ_THRESHOLD_3D_ENV} must be a positive integer, "
+            f"got {raw_value!r}."
+        )
+
+    return override
+
+
+def _get_seq_threshold_3d(
+    seq_threshold_3d: int,
+    *,
+    device_capability: DeviceCapability | None,
+    model_type: str | None,
+    head_size: int,
+    num_heads_kv: int,
+    sliding_window: int,
+) -> int:
+    """Return the configured Triton 3D threshold unchanged."""
+    del device_capability, model_type, head_size, num_heads_kv, sliding_window
+    return seq_threshold_3d
 
 
 @dataclass
@@ -134,6 +173,13 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         )
         self.num_heads_kv = model_config.get_num_kv_heads(vllm_config.parallel_config)
         self.headdim = model_config.get_head_size()
+        sliding_window = model_config.get_sliding_window() or 0
+        model_type = getattr(model_config.hf_config, "model_type", None)
+        device_capability = (
+            current_platform.get_device_capability()
+            if current_platform.is_cuda()
+            else None
+        )
 
         # Check if CUDA Graphs are enabled for decode
         self.decode_cudagraph_enabled = (
@@ -165,6 +211,16 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
                 capture_sizes,
                 key=lambda x: abs(x - self.seq_threshold_3D),
             )
+
+        self.seq_threshold_3D = _get_seq_threshold_3d(
+            self.seq_threshold_3D,
+            device_capability=device_capability,
+            model_type=model_type,
+            head_size=self.headdim,
+            num_heads_kv=self.num_heads_kv,
+            sliding_window=sliding_window,
+        )
+        self.seq_threshold_3D = _maybe_override_seq_threshold_3d(self.seq_threshold_3D)
 
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -12,6 +12,7 @@ import torch
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.platforms.interface import DeviceCapability
 from vllm.triton_utils import tl, triton
 
 logger = init_logger(__name__)
@@ -859,11 +860,30 @@ def _is_gemma3_attention(head_size: int, sliding_window: int) -> bool:
     return sliding_window == 1024 and head_size in (128, 256)
 
 
+def _use_small_sm8x_sink_tiles(
+    device_capability: DeviceCapability | None,
+    has_sinks: bool,
+) -> bool:
+    """Prefer smaller sink tiles on Ada/GA10x-class SM8x GPUs.
+
+    SM86/SM89 parts have materially less shared memory per SM than SM80,
+    so the sink-capable unified Triton path benefits from a smaller tile.
+    """
+    return (
+        has_sinks
+        and device_capability is not None
+        and device_capability.major == 8
+        and device_capability.minor in (6, 9)
+    )
+
+
 def _get_tile_size(
     head_size: int,
     sliding_window: int,
     element_size: int,
     is_prefill: bool,
+    has_sinks: bool = False,
+    device_capability: DeviceCapability | None = None,
 ) -> int:
     """Select tile size with Gemma3-specific optimization.
 
@@ -874,6 +894,9 @@ def _get_tile_size(
     if _is_gemma3_attention(head_size, sliding_window):
         # Gemma3: use 32 for decode (default is 16)
         return 32
+
+    if is_prefill and _use_small_sm8x_sink_tiles(device_capability, has_sinks):
+        return 16
 
     # Default behavior
     if is_prefill:
@@ -958,17 +981,24 @@ def unified_attention(
     # Tile sizes for prefill and decode. Gemma3 models use optimized values.
     # Note: tile size must be at least 32 for fp8 (element_size == 1).
     sliding_window_val = 1 + window_size[0] if window_size[0] >= 0 else 0
+    device_capability = (
+        current_platform.get_device_capability() if current_platform.is_cuda() else None
+    )
     TILE_SIZE_PREFILL = _get_tile_size(
         head_size,
         sliding_window_val,
         q.element_size(),
         is_prefill=True,
+        has_sinks=sinks is not None,
+        device_capability=device_capability,
     )
     TILE_SIZE_DECODE = _get_tile_size(
         head_size,
         sliding_window_val,
         q.element_size(),
         is_prefill=False,
+        has_sinks=sinks is not None,
+        device_capability=device_capability,
     )
 
     # Launch the 2D kernel if

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -7,6 +7,8 @@
 #  - Chih-Chieh Yang <chih.chieh.yang@ibm.com>
 #  - Thomas Parnell <tpa@zurich.ibm.com>
 
+import os
+
 import torch
 
 import vllm.envs as envs
@@ -18,6 +20,36 @@ from vllm.triton_utils import tl, triton
 logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
+
+TRITON_ATTN_TILE_SIZE_PREFILL_ENV = "VLLM_TRITON_ATTN_TILE_SIZE_PREFILL"
+TRITON_ATTN_TILE_SIZE_DECODE_ENV = "VLLM_TRITON_ATTN_TILE_SIZE_DECODE"
+_GPT_OSS_SM8X_LARGE_PREFILL_TILE_MAX_SEQ_LEN = 16384
+
+
+def _get_tile_size_override(*, is_prefill: bool) -> int | None:
+    env_name = (
+        TRITON_ATTN_TILE_SIZE_PREFILL_ENV
+        if is_prefill
+        else TRITON_ATTN_TILE_SIZE_DECODE_ENV
+    )
+    raw_value = os.environ.get(env_name)
+    if raw_value in (None, ""):
+        return None
+    assert raw_value is not None
+
+    try:
+        override = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{env_name} must be a positive power-of-two integer, got {raw_value!r}."
+        ) from exc
+
+    if override <= 0 or override & (override - 1) != 0:
+        raise ValueError(
+            f"{env_name} must be a positive power-of-two integer, got {raw_value!r}."
+        )
+
+    return override
 
 
 @triton.jit
@@ -860,6 +892,47 @@ def _is_gemma3_attention(head_size: int, sliding_window: int) -> bool:
     return sliding_window == 1024 and head_size in (128, 256)
 
 
+def _is_gpt_oss_sm8x_sink_attention(
+    head_size: int,
+    num_kv_heads: int,
+    device_capability: DeviceCapability | None,
+    has_sinks: bool,
+) -> bool:
+    """Detect GPT-OSS attention geometry on Ada/GA10x-class SM8x GPUs.
+
+    GPT-OSS uses head_size=64, num_kv_heads=8, and attention sinks on every
+    layer. On SM86/SM89, the prefill path performs better with the larger
+    Triton tile size than the generic sink heuristic.
+    """
+    return (
+        has_sinks
+        and device_capability is not None
+        and device_capability.major == 8
+        and device_capability.minor in (6, 9)
+        and head_size == 64
+        and num_kv_heads == 8
+    )
+
+
+def _use_gpt_oss_sm8x_large_prefill_tile(
+    head_size: int,
+    num_kv_heads: int,
+    device_capability: DeviceCapability | None,
+    has_sinks: bool,
+    max_seq_len: int | None,
+) -> bool:
+    return (
+        max_seq_len is not None
+        and max_seq_len <= _GPT_OSS_SM8X_LARGE_PREFILL_TILE_MAX_SEQ_LEN
+        and _is_gpt_oss_sm8x_sink_attention(
+            head_size,
+            num_kv_heads,
+            device_capability,
+            has_sinks,
+        )
+    )
+
+
 def _use_small_sm8x_sink_tiles(
     device_capability: DeviceCapability | None,
     has_sinks: bool,
@@ -880,10 +953,12 @@ def _use_small_sm8x_sink_tiles(
 def _get_tile_size(
     head_size: int,
     sliding_window: int,
+    num_kv_heads: int,
     element_size: int,
     is_prefill: bool,
     has_sinks: bool = False,
     device_capability: DeviceCapability | None = None,
+    max_seq_len: int | None = None,
 ) -> int:
     """Select tile size with Gemma3-specific optimization.
 
@@ -891,8 +966,31 @@ def _get_tile_size(
     the larger head dimension (128/256). For other models, use
     the default vLLM behavior.
     """
+    override = _get_tile_size_override(is_prefill=is_prefill)
+    if override is not None:
+        if element_size == 1 and override < 32:
+            env_name = (
+                TRITON_ATTN_TILE_SIZE_PREFILL_ENV
+                if is_prefill
+                else TRITON_ATTN_TILE_SIZE_DECODE_ENV
+            )
+            raise ValueError(
+                f"{env_name}={override} is invalid for fp8 attention; "
+                "tile size must be >= 32."
+            )
+        return override
+
     if _is_gemma3_attention(head_size, sliding_window):
         # Gemma3: use 32 for decode (default is 16)
+        return 32
+
+    if is_prefill and _use_gpt_oss_sm8x_large_prefill_tile(
+        head_size,
+        num_kv_heads,
+        device_capability,
+        has_sinks,
+        max_seq_len,
+    ):
         return 32
 
     if is_prefill and _use_small_sm8x_sink_tiles(device_capability, has_sinks):
@@ -987,14 +1085,17 @@ def unified_attention(
     TILE_SIZE_PREFILL = _get_tile_size(
         head_size,
         sliding_window_val,
+        num_kv_heads,
         q.element_size(),
         is_prefill=True,
         has_sinks=sinks is not None,
         device_capability=device_capability,
+        max_seq_len=max_seqlen_k,
     )
     TILE_SIZE_DECODE = _get_tile_size(
         head_size,
         sliding_window_val,
+        num_kv_heads,
         q.element_size(),
         is_prefill=False,
         has_sinks=sinks is not None,

--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -46,6 +46,11 @@ class AttentionSelectorConfig(NamedTuple):
             f"model_architectures={self.model_architectures})"
         )
 
+    def validation_kwargs(self) -> dict[str, object]:
+        config = self._asdict()
+        config.pop("model_architectures", None)
+        return config
+
 
 def get_attn_backend(
     head_size: int,

--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -29,6 +29,7 @@ class AttentionSelectorConfig(NamedTuple):
     use_mm_prefix: bool = False
     use_per_head_quant_scales: bool = False
     attn_type: str = AttentionType.DECODER
+    model_architectures: tuple[str, ...] = ()
 
     def __repr__(self):
         return (
@@ -41,7 +42,8 @@ class AttentionSelectorConfig(NamedTuple):
             f"use_sparse={self.use_sparse}, "
             f"use_mm_prefix={self.use_mm_prefix}, "
             f"use_per_head_quant_scales={self.use_per_head_quant_scales}, "
-            f"attn_type={self.attn_type})"
+            f"attn_type={self.attn_type}, "
+            f"model_architectures={self.model_architectures})"
         )
 
 
@@ -69,12 +71,23 @@ def get_attn_backend(
     from vllm.config import get_current_vllm_config
 
     vllm_config = get_current_vllm_config()
+    model_config = vllm_config.model_config
 
     cache_config = vllm_config.cache_config
     if cache_config is not None and cache_config.user_specified_block_size:
         block_size = cache_config.block_size
     else:
         block_size = None
+
+    model_architectures: list[str] = []
+    if model_config is not None:
+        model_architectures.extend(model_config.architectures or [])
+        resolved_architecture = model_config.architecture
+        if (
+            resolved_architecture is not None
+            and resolved_architecture not in model_architectures
+        ):
+            model_architectures.append(resolved_architecture)
 
     attn_selector_config = AttentionSelectorConfig(
         head_size=head_size,
@@ -87,6 +100,7 @@ def get_attn_backend(
         use_mm_prefix=use_mm_prefix,
         use_per_head_quant_scales=use_per_head_quant_scales,
         attn_type=attn_type or AttentionType.DECODER,
+        model_architectures=tuple(model_architectures),
     )
 
     return _cached_get_attn_backend(


### PR DESCRIPTION
## Summary

This PR does two things for GPT-OSS on CUDA:

- prefer Triton on SM8x when attention sinks are required
- narrow the SM89 sink-prefill Triton tuning so it only applies to the medium-length prefills that were wins in offline validation

Concretely, the change keeps the GPT-OSS CUDA backend policy explicit in `vllm/platforms/cuda.py`, keeps selector validation compatible with policy-only fields in `vllm/v1/attention/selector.py`, and updates the Triton attention heuristics in `vllm/v1/attention/backends/triton_attn.py` and `vllm/v1/attention/ops/triton_unified_attention.py`.

The main heuristic change in this revision is that the larger sink-prefill tile is no longer applied broadly. Decode behavior and the in-code 3D-threshold behavior stay unchanged.

## Why This Isn't Duplicate Work

- Not a duplicate of #24856: that PR adds FlashInfer sink support; this PR keeps GPT-OSS on Triton for SM8x and tunes that path.
- Not a duplicate of #28497: that PR is generic unified-attention tuning; this PR is GPT-OSS- and SM89-specific.
- Not a duplicate of #33594: that PR changes GPT-OSS layer scheduling semantics; this PR does not.

## Validation

```bash
source .venv/bin/activate
pytest tests/kernels/attention/test_triton_unified_attention_tile_policy.py \
  tests/v1/attention/test_triton_attn_policy.py \
  tests/v1/attention/test_triton_attn_threshold_override.py \
  tests/v1/attention/test_cuda_attention_backend_policy.py -q

source .venv/bin/activate
pre-commit run --files \
  vllm/v1/attention/ops/triton_unified_attention.py \
  vllm/v1/attention/backends/triton_attn.py \
  tests/kernels/attention/test_triton_unified_attention_tile_policy.py \
  tests/v1/attention/test_triton_attn_policy.py \
  tests/v1/attention/test_triton_attn_threshold_override.py \
  tests/v1/attention/test_cuda_attention_backend_policy.py
```

Results:

- `pytest ... -q` -> `29 passed`
- `pre-commit run --files ...` -> passed

Offline Modal L40S validation on the clean branch:

- Prefix suite:
  - `support_prefix_p50`: `-5.31%` elapsed
  - `support_prefix_p90`: `-0.52%` elapsed
  - `support_prefix_p95`: `-2.51%` elapsed
- Random suite:
  - `support_random_p50`: `-4.42%` elapsed
  - `support_random_p95`: `-1.14%` elapsed
- `support_random_p90` was the only noisy case, so I reran it with median-of-3 aggregation:
  - median `-1.30%` elapsed
  - per-run elapsed deltas: `-2.32%`, `+0.58%`, `-1.30%`

This PR remains draft because the tuning is still GPT-OSS- and SM89-specific, and I want feedback on whether upstream wants this heuristic as-is or prefers a broader autotuned path.

## AI Assistance

AI assistance was used to help implement the change, write the focused tests, and analyze the L40S benchmark results. I reviewed every changed line and ran the commands above.
