### PR TITLE
[Parser] Pass tools via ToolParser.__init__ instead of reading from request

### DIFF
--- a/tests/tool_parsers/test_deepseekv32_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv32_tool_parser.py
@@ -274,7 +274,7 @@ class TestExtractToolCallsStreaming:
         content = "".join(d.content for d in deltas if d.content is not None)
         assert "Thinking" in content
 
-    def test_type_conversion_in_streaming(self, parser):
+    def test_type_conversion_in_streaming(self):
         tool = make_tool_param(
             "add",
             {
@@ -285,7 +285,7 @@ class TestExtractToolCallsStreaming:
                 },
             },
         )
-        parser.tools = [tool]
+        parser = DeepSeekV32ToolParser(MOCK_TOKENIZER, tools=[tool])
         full_text = build_tool_call("add", {"x": "3", "y": "4"})
         deltas = self._stream(parser, full_text)
         args_str = self._reconstruct_args(deltas)

--- a/tests/tool_parsers/test_deepseekv32_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv32_tool_parser.py
@@ -285,9 +285,9 @@ class TestExtractToolCallsStreaming:
                 },
             },
         )
-        request = make_request(tools=[tool])
+        parser.tools = [tool]
         full_text = build_tool_call("add", {"x": "3", "y": "4"})
-        deltas = self._stream(parser, full_text, request=request)
+        deltas = self._stream(parser, full_text)
         args_str = self._reconstruct_args(deltas)
         assert json.loads(args_str) == {"x": 3, "y": 4}
 

--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -24,31 +24,34 @@ def glm47_tokenizer():
     return get_tokenizer(tokenizer_name=MODEL)
 
 
+SAMPLE_TOOLS = [
+    ChatCompletionToolsParam(
+        function=FunctionDefinition(name="get_current_date", parameters={}),
+    ),
+    ChatCompletionToolsParam(
+        function=FunctionDefinition(
+            name="get_weather",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "date": {"type": "string"},
+                },
+            },
+        ),
+    ),
+]
+
+
 @pytest.fixture
 def glm47_tool_parser(glm47_tokenizer):
-    return Glm47MoeModelToolParser(glm47_tokenizer)
+    return Glm47MoeModelToolParser(glm47_tokenizer, tools=SAMPLE_TOOLS)
 
 
 @pytest.fixture
 def mock_request() -> ChatCompletionRequest:
     request = Mock(spec=ChatCompletionRequest)
-    request.tools = [
-        ChatCompletionToolsParam(
-            function=FunctionDefinition(name="get_current_date", parameters={}),
-        ),
-        ChatCompletionToolsParam(
-            function=FunctionDefinition(
-                name="get_weather",
-                parameters={
-                    "type": "object",
-                    "properties": {
-                        "city": {"type": "string"},
-                        "date": {"type": "string"},
-                    },
-                },
-            ),
-        ),
-    ]
+    request.tools = SAMPLE_TOOLS
     request.tool_choice = "auto"
     return request
 

--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -26,22 +26,25 @@ def glm4_moe_tokenizer():
     return get_tokenizer(tokenizer_name=MODEL)
 
 
+SAMPLE_TOOLS = [
+    ChatCompletionToolsParam(
+        function=FunctionDefinition(
+            name="get_weather",
+            parameters={"city": {"type": "string"}},
+        ),
+    ),
+]
+
+
 @pytest.fixture
 def glm4_moe_tool_parser(glm4_moe_tokenizer):
-    return Glm4MoeModelToolParser(glm4_moe_tokenizer)
+    return Glm4MoeModelToolParser(glm4_moe_tokenizer, tools=SAMPLE_TOOLS)
 
 
 @pytest.fixture
 def mock_request() -> ChatCompletionRequest:
     request = Mock(spec=ChatCompletionRequest)
-    request.tools = [  # GLM45 parser needs this attribute to enable tool parsing.
-        ChatCompletionToolsParam(
-            function=FunctionDefinition(
-                name="get_weather",
-                parameters={"city": {"type": "string"}},
-            ),
-        ),
-    ]
+    request.tools = SAMPLE_TOOLS
     return request
 
 
@@ -705,26 +708,27 @@ if __name__ == "__main__":
     sorted_arr = bubble_sort(test_arr.copy())
     print(f"Sorted: {sorted_arr}")'''
 
-    # Create a request with tool schema to enable string type detection
+    # Set tool schema on parser to enable string type detection
     # This is required for incremental streaming of string values
+    write_tools = [
+        ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="write_to_file",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                },
+            ),
+        ),
+    ]
+    glm4_moe_tool_parser.tools = write_tools
     request = ChatCompletionRequest(
         model=MODEL,
         messages=[],
-        tools=[
-            {
-                "type": "function",
-                "function": {
-                    "name": "write_to_file",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "file_path": {"type": "string"},
-                            "content": {"type": "string"},
-                        },
-                    },
-                },
-            }
-        ],
+        tools=write_tools,
     )  # type: ignore
 
     # Simulate token-based streaming (special tags as single tokens)

--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -674,7 +674,7 @@ def test_streaming_json_escape_in_string(glm4_moe_tool_parser, mock_request):
     assert '"' in parsed["message"] or "world" in parsed["message"]
 
 
-def test_streaming_long_content_incremental(glm4_moe_tool_parser):
+def test_streaming_long_content_incremental(glm4_moe_tokenizer):
     """Test incremental streaming of long content (Issue #32829).
 
     This is the core fix: for long string values like code (4000+ chars),
@@ -724,7 +724,7 @@ if __name__ == "__main__":
             ),
         ),
     ]
-    glm4_moe_tool_parser.tools = write_tools
+    parser = Glm4MoeModelToolParser(glm4_moe_tokenizer, tools=write_tools)
     request = ChatCompletionRequest(
         model=MODEL,
         messages=[],
@@ -749,7 +749,7 @@ if __name__ == "__main__":
     # Count argument fragments
     fragment_count = 0
     for chunk in chunks:
-        result = glm4_moe_tool_parser.extract_tool_calls_streaming(
+        result = parser.extract_tool_calls_streaming(
             previous_text="",
             current_text="",
             delta_text=chunk,
@@ -777,8 +777,8 @@ if __name__ == "__main__":
     )
 
     # Verify final result is valid JSON
-    assert len(glm4_moe_tool_parser.streamed_args_for_tool) == 1
-    args_json = glm4_moe_tool_parser.streamed_args_for_tool[0]
+    assert len(parser.streamed_args_for_tool) == 1
+    args_json = parser.streamed_args_for_tool[0]
     parsed = json.loads(args_json)
     assert parsed["file_path"] == "/tmp/bubble_sort.py"
     assert "def bubble_sort" in parsed["content"]

--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -342,6 +342,7 @@ def test_extract_tool_calls(
     expected_tool_calls,
     expected_content,
 ):
+    qwen3_tool_parser_parametrized.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
     extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
         model_output, request=request
@@ -366,6 +367,7 @@ TX
 </parameter>
 </function>"""
 
+    qwen3_tool_parser_parametrized.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
     extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
         model_output, request=request
@@ -417,6 +419,7 @@ hello world
 </function>
 </tool_call>"""
 
+    qwen3_tool_parser_parametrized.tools = tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
     extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
         model_output, request=request
@@ -614,6 +617,7 @@ def test_extract_tool_calls_streaming(
     expected_content,
 ):
     """Test incremental streaming behavior including typed parameters"""
+    qwen3_tool_parser_parametrized.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
@@ -702,6 +706,7 @@ fahrenheit
 </function>
 </tool_call>"""
 
+    qwen3_tool_parser_parametrized.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
     extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
         model_output, request=request
@@ -744,6 +749,7 @@ fahrenheit
 </function>
 </tool_call>"""
 
+    qwen3_tool_parser_parametrized.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
@@ -815,6 +821,7 @@ TX
 </function>
 </tool_call>"""
 
+    qwen3_tool_parser_parametrized.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     chunks = []
@@ -889,6 +896,7 @@ def test_extract_tool_calls_complex_type_with_single_quote(
 </function>
 </tool_call>"""
 
+    qwen3_tool_parser_parametrized.tools = tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
     extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
         model_output, request=request
@@ -921,6 +929,7 @@ fahrenheit
 </function>
 </tool_call>"""
 
+    qwen3_tool_parser_parametrized.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""

--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -30,23 +30,19 @@ def qwen3_tokenizer():
     return get_tokenizer(tokenizer_name=MODEL)
 
 
-@pytest.fixture
-def qwen3_tool_parser(qwen3_tokenizer):
-    return Qwen3CoderToolParser(qwen3_tokenizer)
-
-
-@pytest.fixture
-def qwen3_xml_tool_parser(qwen3_tokenizer):
-    return Qwen3XMLToolParser(qwen3_tokenizer)
-
-
 @pytest.fixture(params=["xml"])
-def qwen3_tool_parser_parametrized(qwen3_tool_parser, qwen3_xml_tool_parser, request):
-    """Parameterized fixture that provides both parser types for testing"""
+def qwen3_parser_cls(request):
+    """Parameterized fixture that provides parser class for testing"""
     if request.param == "original":
-        return qwen3_tool_parser
+        return Qwen3CoderToolParser
     else:
-        return qwen3_xml_tool_parser
+        return Qwen3XMLToolParser
+
+
+@pytest.fixture
+def qwen3_tool_parser_parametrized(qwen3_tokenizer, qwen3_parser_cls):
+    """Parser instance without tools (for tests that don't need them)"""
+    return qwen3_parser_cls(qwen3_tokenizer)
 
 
 @pytest.fixture
@@ -336,17 +332,16 @@ circle
     ],
 )
 def test_extract_tool_calls(
-    qwen3_tool_parser_parametrized,
+    qwen3_parser_cls,
+    qwen3_tokenizer,
     sample_tools,
     model_output,
     expected_tool_calls,
     expected_content,
 ):
-    qwen3_tool_parser_parametrized.tools = sample_tools
+    parser = qwen3_parser_cls(qwen3_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
-    extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
     assert extracted_tool_calls.tools_called
 
     assert_tool_calls(extracted_tool_calls.tool_calls, expected_tool_calls)
@@ -355,7 +350,7 @@ def test_extract_tool_calls(
 
 
 def test_extract_tool_calls_fallback_no_tags(
-    qwen3_tool_parser_parametrized, sample_tools
+    qwen3_parser_cls, qwen3_tokenizer, sample_tools
 ):
     """Test fallback parsing when XML tags are missing"""
     model_output = """<function=get_current_weather>
@@ -367,18 +362,16 @@ TX
 </parameter>
 </function>"""
 
-    qwen3_tool_parser_parametrized.tools = sample_tools
+    parser = qwen3_parser_cls(qwen3_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
-    extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     assert extracted_tool_calls.tools_called
     assert len(extracted_tool_calls.tool_calls) == 1
     assert extracted_tool_calls.tool_calls[0].function.name == "get_current_weather"
 
 
-def test_extract_tool_calls_type_conversion(qwen3_tool_parser_parametrized):
+def test_extract_tool_calls_type_conversion(qwen3_parser_cls, qwen3_tokenizer):
     """Test parameter type conversion based on tool schema"""
     tools = [
         ChatCompletionToolsParam(
@@ -419,11 +412,9 @@ hello world
 </function>
 </tool_call>"""
 
-    qwen3_tool_parser_parametrized.tools = tools
+    parser = qwen3_parser_cls(qwen3_tokenizer, tools=tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
-    extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     args = json.loads(extracted_tool_calls.tool_calls[0].function.arguments)
     assert args["int_param"] == 42
@@ -609,7 +600,7 @@ circle
     ],
 )
 def test_extract_tool_calls_streaming(
-    qwen3_tool_parser_parametrized,
+    qwen3_parser_cls,
     qwen3_tokenizer,
     sample_tools,
     model_output,
@@ -617,14 +608,14 @@ def test_extract_tool_calls_streaming(
     expected_content,
 ):
     """Test incremental streaming behavior including typed parameters"""
-    qwen3_tool_parser_parametrized.tools = sample_tools
+    parser = qwen3_parser_cls(qwen3_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
     tool_states = {}  # Track state per tool index
 
     for delta_message in stream_delta_message_generator(
-        qwen3_tool_parser_parametrized, qwen3_tokenizer, model_output, request
+        parser, qwen3_tokenizer, model_output, request
     ):
         # role should never be streamed from tool parser
         assert not delta_message.role
@@ -668,9 +659,7 @@ def test_extract_tool_calls_streaming(
 
     # Verify we got all expected tool calls
     assert len(tool_states) == len(expected_tool_calls)
-    assert len(qwen3_tool_parser_parametrized.prev_tool_call_arr) == len(
-        expected_tool_calls
-    )
+    assert len(parser.prev_tool_call_arr) == len(expected_tool_calls)
 
     # Verify each tool call
     for idx, expected_tool in enumerate(expected_tool_calls):
@@ -688,7 +677,7 @@ def test_extract_tool_calls_streaming(
 
 
 def test_extract_tool_calls_missing_closing_parameter_tag(
-    qwen3_tool_parser_parametrized, sample_tools
+    qwen3_parser_cls, qwen3_tokenizer, sample_tools
 ):
     """Test handling of missing closing </parameter> tag"""
     # Using get_current_weather from sample_tools but with malformed XML
@@ -706,11 +695,9 @@ fahrenheit
 </function>
 </tool_call>"""
 
-    qwen3_tool_parser_parametrized.tools = sample_tools
+    parser = qwen3_parser_cls(qwen3_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
-    extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     # The parser should handle the malformed XML gracefully
     assert extracted_tool_calls.tools_called
@@ -731,7 +718,7 @@ fahrenheit
 
 
 def test_extract_tool_calls_streaming_missing_closing_tag(
-    qwen3_tool_parser_parametrized, qwen3_tokenizer, sample_tools
+    qwen3_parser_cls, qwen3_tokenizer, sample_tools
 ):
     """Test streaming with missing closing </parameter> tag"""
     # Using get_current_weather from sample_tools but with malformed XML
@@ -749,14 +736,14 @@ fahrenheit
 </function>
 </tool_call>"""
 
-    qwen3_tool_parser_parametrized.tools = sample_tools
+    parser = qwen3_parser_cls(qwen3_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
     tool_states = {}
 
     for delta_message in stream_delta_message_generator(
-        qwen3_tool_parser_parametrized, qwen3_tokenizer, model_output, request
+        parser, qwen3_tokenizer, model_output, request
     ):
         if delta_message.content:
             other_content += delta_message.content
@@ -791,7 +778,7 @@ fahrenheit
     assert "Let me check the weather for you:" in other_content
     # Verify we got the tool call
     assert len(tool_states) == 1
-    assert len(qwen3_tool_parser_parametrized.prev_tool_call_arr) == 1
+    assert len(parser.prev_tool_call_arr) == 1
 
     state = tool_states[0]
     assert state["id"] is not None
@@ -807,7 +794,7 @@ fahrenheit
 
 
 def test_extract_tool_calls_streaming_incremental(
-    qwen3_tool_parser_parametrized, qwen3_tokenizer, sample_tools
+    qwen3_parser_cls, qwen3_tokenizer, sample_tools
 ):
     """Test that streaming is truly incremental"""
     model_output = """I'll check the weather.<tool_call>
@@ -821,12 +808,12 @@ TX
 </function>
 </tool_call>"""
 
-    qwen3_tool_parser_parametrized.tools = sample_tools
+    parser = qwen3_parser_cls(qwen3_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     chunks = []
     for delta_message in stream_delta_message_generator(
-        qwen3_tool_parser_parametrized, qwen3_tokenizer, model_output, request
+        parser, qwen3_tokenizer, model_output, request
     ):
         chunks.append(delta_message)
 
@@ -866,7 +853,8 @@ TX
 
 
 def test_extract_tool_calls_complex_type_with_single_quote(
-    qwen3_tool_parser_parametrized,
+    qwen3_parser_cls,
+    qwen3_tokenizer,
 ):
     """Test parameter type conversion based on tool schema"""
     tools = [
@@ -896,18 +884,16 @@ def test_extract_tool_calls_complex_type_with_single_quote(
 </function>
 </tool_call>"""
 
-    qwen3_tool_parser_parametrized.tools = tools
+    parser = qwen3_parser_cls(qwen3_tokenizer, tools=tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
-    extracted_tool_calls = qwen3_tool_parser_parametrized.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     args = json.loads(extracted_tool_calls.tool_calls[0].function.arguments)
     assert args["obj_param"] == {"key": "value"}
 
 
 def test_extract_tool_calls_streaming_missing_opening_tag(
-    qwen3_tool_parser_parametrized, qwen3_tokenizer, sample_tools
+    qwen3_parser_cls, qwen3_tokenizer, sample_tools
 ):
     """Test streaming with missing opening <tool_call> tag
 
@@ -929,14 +915,14 @@ fahrenheit
 </function>
 </tool_call>"""
 
-    qwen3_tool_parser_parametrized.tools = sample_tools
+    parser = qwen3_parser_cls(qwen3_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
     tool_states = {}
 
     for delta_message in stream_delta_message_generator(
-        qwen3_tool_parser_parametrized, qwen3_tokenizer, model_output, request
+        parser, qwen3_tokenizer, model_output, request
     ):
         if delta_message.content:
             other_content += delta_message.content
@@ -972,7 +958,7 @@ fahrenheit
 
     # Verify we got the tool call
     assert len(tool_states) == 1
-    assert len(qwen3_tool_parser_parametrized.prev_tool_call_arr) == 1
+    assert len(parser.prev_tool_call_arr) == 1
 
     state = tool_states[0]
     assert state["id"] is not None

--- a/tests/tool_parsers/test_seed_oss_tool_parser.py
+++ b/tests/tool_parsers/test_seed_oss_tool_parser.py
@@ -218,17 +218,15 @@ def test_extract_tool_calls_no_tools(seed_oss_tool_parser):
     ],
 )
 def test_extract_tool_calls(
-    seed_oss_tool_parser,
+    seed_oss_tokenizer,
     sample_tools,
     model_output,
     expected_tool_calls,
     expected_content,
 ):
-    seed_oss_tool_parser.tools = sample_tools
+    parser = SeedOssToolParser(seed_oss_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
-    extracted_tool_calls = seed_oss_tool_parser.extract_tool_calls(
-        model_output, request=request
-    )  # type: ignore[arg-type]
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)  # type: ignore[arg-type]
     assert extracted_tool_calls.tools_called
 
     assert_tool_calls(extracted_tool_calls.tool_calls, expected_tool_calls)
@@ -424,7 +422,6 @@ def stream_delta_message_generator(
     ],
 )
 def test_streaming_tool_calls(
-    seed_oss_tool_parser,
     seed_oss_tokenizer,
     sample_tools,
     model_output,
@@ -432,14 +429,14 @@ def test_streaming_tool_calls(
     expected_content,
 ):
     """Test incremental streaming behavior"""
-    seed_oss_tool_parser.tools = sample_tools
+    parser = SeedOssToolParser(seed_oss_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
     tool_states = {}  # Track state per tool index
 
     for delta_message in stream_delta_message_generator(
-        seed_oss_tool_parser, seed_oss_tokenizer, model_output, request
+        parser, seed_oss_tokenizer, model_output, request
     ):
         # role should never be streamed from tool parser
         assert not delta_message.role

--- a/tests/tool_parsers/test_seed_oss_tool_parser.py
+++ b/tests/tool_parsers/test_seed_oss_tool_parser.py
@@ -224,6 +224,7 @@ def test_extract_tool_calls(
     expected_tool_calls,
     expected_content,
 ):
+    seed_oss_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
     extracted_tool_calls = seed_oss_tool_parser.extract_tool_calls(
         model_output, request=request
@@ -431,6 +432,7 @@ def test_streaming_tool_calls(
     expected_content,
 ):
     """Test incremental streaming behavior"""
+    seed_oss_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""

--- a/tests/tool_parsers/test_step3p5_tool_parser.py
+++ b/tests/tool_parsers/test_step3p5_tool_parser.py
@@ -85,7 +85,7 @@ def assert_tool_calls(
 
 
 def stream_delta_message_generator(
-    step3p5_tool_parser,
+    parser,
     step3p5_tokenizer: TokenizerLike,
     model_output: str,
     request: ChatCompletionRequest | None = None,
@@ -115,7 +115,7 @@ def stream_delta_message_generator(
 
         current_text = previous_text + delta_text
 
-        delta_message = step3p5_tool_parser.extract_tool_calls_streaming(
+        delta_message = parser.extract_tool_calls_streaming(
             previous_text,
             current_text,
             delta_text,
@@ -136,7 +136,7 @@ def stream_delta_message_generator(
 
 
 def stream_delta_message_generator_from_chunks(
-    step3p5_tool_parser,
+    parser,
     step3p5_tokenizer: TokenizerLike,
     delta_text_chunks: list[str],
     request: ChatCompletionRequest | None = None,
@@ -149,7 +149,7 @@ def stream_delta_message_generator_from_chunks(
         current_text = previous_text + delta_text
         current_token_ids = previous_token_ids + delta_token_ids
 
-        delta_message = step3p5_tool_parser.extract_tool_calls_streaming(
+        delta_message = parser.extract_tool_calls_streaming(
             previous_text,
             current_text,
             delta_text,
@@ -348,17 +348,15 @@ circle
     ],
 )
 def test_extract_tool_calls(
-    step3p5_tool_parser,
+    step3p5_tokenizer,
     sample_tools,
     model_output,
     expected_tool_calls,
     expected_content,
 ):
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
-    extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
     assert extracted_tool_calls.tools_called
 
     assert_tool_calls(extracted_tool_calls.tool_calls, expected_tool_calls)
@@ -366,7 +364,7 @@ def test_extract_tool_calls(
     assert extracted_tool_calls.content == expected_content
 
 
-def test_extract_tool_calls_fallback_no_tags(step3p5_tool_parser, sample_tools):
+def test_extract_tool_calls_fallback_no_tags(step3p5_tokenizer, sample_tools):
     """Test fallback parsing when XML tags are missing"""
     model_output = """<function=get_current_weather>
 <parameter=city>
@@ -377,18 +375,16 @@ TX
 </parameter>
 </function>"""
 
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
-    extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     assert extracted_tool_calls.tools_called
     assert len(extracted_tool_calls.tool_calls) == 1
     assert extracted_tool_calls.tool_calls[0].function.name == "get_current_weather"
 
 
-def test_extract_tool_calls_type_conversion(step3p5_tool_parser):
+def test_extract_tool_calls_type_conversion(step3p5_tokenizer):
     """Test parameter type conversion based on tool schema"""
     tools = [
         ChatCompletionToolsParam(
@@ -429,11 +425,9 @@ hello world
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
-    extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     args = json.loads(extracted_tool_calls.tool_calls[0].function.arguments)
     assert args["int_param"] == 42
@@ -619,7 +613,6 @@ circle
     ],
 )
 def test_extract_tool_calls_streaming(
-    step3p5_tool_parser,
     step3p5_tokenizer,
     sample_tools,
     model_output,
@@ -627,14 +620,14 @@ def test_extract_tool_calls_streaming(
     expected_content,
 ):
     """Test incremental streaming behavior including typed parameters"""
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
     tool_states = {}  # Track state per tool index
 
     for delta_message in stream_delta_message_generator(
-        step3p5_tool_parser, step3p5_tokenizer, model_output, request
+        parser, step3p5_tokenizer, model_output, request
     ):
         # role should never be streamed from tool parser
         assert not delta_message.role
@@ -695,7 +688,7 @@ def test_extract_tool_calls_streaming(
 
 
 def test_extract_tool_calls_missing_closing_parameter_tag(
-    step3p5_tool_parser, sample_tools
+    step3p5_tokenizer, sample_tools
 ):
     """Test handling of missing closing </parameter> tag"""
     # Using get_current_weather from sample_tools but with malformed XML
@@ -713,11 +706,9 @@ fahrenheit
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
-    extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     # The parser should handle the malformed XML gracefully
     assert extracted_tool_calls.tools_called
@@ -738,7 +729,7 @@ fahrenheit
 
 
 def test_extract_tool_calls_streaming_missing_closing_tag(
-    step3p5_tool_parser, step3p5_tokenizer, sample_tools
+    step3p5_tokenizer, sample_tools
 ):
     """Test streaming with missing closing </parameter> tag"""
     # Using get_current_weather from sample_tools but with malformed XML
@@ -756,14 +747,14 @@ fahrenheit
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
     tool_states = {}
 
     for delta_message in stream_delta_message_generator(
-        step3p5_tool_parser, step3p5_tokenizer, model_output, request
+        parser, step3p5_tokenizer, model_output, request
     ):
         if delta_message.content:
             other_content += delta_message.content
@@ -812,9 +803,7 @@ fahrenheit
     assert args["unit"] == "fahrenheit"
 
 
-def test_extract_tool_calls_streaming_incremental(
-    step3p5_tool_parser, step3p5_tokenizer, sample_tools
-):
+def test_extract_tool_calls_streaming_incremental(step3p5_tokenizer, sample_tools):
     """Test that streaming is truly incremental"""
     model_output = """I'll check the weather.<tool_call>
 <function=get_current_weather>
@@ -827,12 +816,12 @@ TX
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     chunks = []
     for delta_message in stream_delta_message_generator(
-        step3p5_tool_parser, step3p5_tokenizer, model_output, request
+        parser, step3p5_tokenizer, model_output, request
     ):
         chunks.append(delta_message)
 
@@ -871,7 +860,7 @@ TX
     assert parsed_args["state"] == "TX"
 
 
-def test_extract_tool_calls_complex_type_with_single_quote(step3p5_tool_parser):
+def test_extract_tool_calls_complex_type_with_single_quote(step3p5_tokenizer):
     """Test parameter type conversion based on tool schema"""
     tools = [
         ChatCompletionToolsParam(
@@ -900,18 +889,16 @@ def test_extract_tool_calls_complex_type_with_single_quote(step3p5_tool_parser):
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
-    extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     args = json.loads(extracted_tool_calls.tool_calls[0].function.arguments)
     assert args["obj_param"] == {"key": "value"}
 
 
 def test_extract_tool_calls_streaming_mixed_content_and_multiple_tool_calls(
-    step3p5_tool_parser, step3p5_tokenizer, sample_tools
+    step3p5_tokenizer, sample_tools
 ):
     """Test mixed content with multiple complete tool calls.
 
@@ -940,14 +927,14 @@ rectangle
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
     tool_states = {}
 
     for delta_message in stream_delta_message_generator(
-        step3p5_tool_parser, step3p5_tokenizer, model_output, request
+        parser, step3p5_tokenizer, model_output, request
     ):
         if delta_message.content:
             other_content += delta_message.content
@@ -1018,7 +1005,7 @@ rectangle
 
 
 def test_extract_tool_calls_non_streaming_mixed_content_and_multiple_tool_calls(
-    step3p5_tool_parser, sample_tools
+    step3p5_tokenizer, sample_tools
 ):
     """Test non-streaming extraction with mixed content and multiple tool calls.
 
@@ -1047,12 +1034,10 @@ rectangle
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
-    extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     # Should have exactly two complete tool calls
     assert extracted_tool_calls.tools_called
@@ -1096,7 +1081,7 @@ rectangle
 
 
 def test_extract_tool_calls_streaming_full_input_mixed_content_and_multiple_tool_calls(
-    step3p5_tool_parser, step3p5_tokenizer, sample_tools
+    step3p5_tokenizer, sample_tools
 ):
     """Test streaming with entire input as single delta_text.
 
@@ -1126,7 +1111,7 @@ rectangle
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
@@ -1154,7 +1139,7 @@ rectangle
     delta_text = current_text
 
     # Call parser once with all tokens including EOS
-    delta_result = step3p5_tool_parser.extract_tool_calls_streaming(
+    delta_result = parser.extract_tool_calls_streaming(
         previous_text,
         current_text,
         delta_text,
@@ -1228,7 +1213,7 @@ rectangle
 
 
 def test_extract_tool_calls_streaming_multiple_tool_calls_no_content_between(
-    step3p5_tool_parser, step3p5_tokenizer, sample_tools
+    step3p5_tokenizer, sample_tools
 ):
     """Test multiple tool calls with no content between them.
 
@@ -1258,14 +1243,14 @@ rectangle
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
     tool_states = {}
 
     for delta_message in stream_delta_message_generator(
-        step3p5_tool_parser, step3p5_tokenizer, model_output, request
+        parser, step3p5_tokenizer, model_output, request
     ):
         if delta_message.content:
             other_content += delta_message.content
@@ -1327,10 +1312,10 @@ rectangle
 
 
 def test_extract_tool_calls_streaming_multi_token_chunk_boundary(
-    step3p5_tool_parser, step3p5_tokenizer, sample_tools
+    step3p5_tokenizer, sample_tools
 ):
     """Ensure fallback doesn't close a new tool_call when boundary is in one chunk."""
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
     delta_text_chunks = [
         """<tool_call>
@@ -1355,7 +1340,7 @@ rectangle""",
 
     tool_states = {}
     for delta_message in stream_delta_message_generator_from_chunks(
-        step3p5_tool_parser, step3p5_tokenizer, delta_text_chunks, request
+        parser, step3p5_tokenizer, delta_text_chunks, request
     ):
         print(delta_message)
         if delta_message.tool_calls:
@@ -1379,7 +1364,7 @@ rectangle""",
 
 
 def test_extract_tool_calls_non_streaming_multiple_tool_calls_no_content_between(
-    step3p5_tool_parser, sample_tools
+    step3p5_tokenizer, sample_tools
 ):
     """Test non-streaming extraction with tool calls and no content between them.
 
@@ -1409,12 +1394,10 @@ rectangle
 </function>
 </tool_call>"""
 
-    step3p5_tool_parser.tools = sample_tools
+    parser = Step3p5ToolParser(step3p5_tokenizer, tools=sample_tools)
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
-    extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     # Should have exactly two complete tool calls
     assert extracted_tool_calls.tools_called

--- a/tests/tool_parsers/test_step3p5_tool_parser.py
+++ b/tests/tool_parsers/test_step3p5_tool_parser.py
@@ -354,6 +354,7 @@ def test_extract_tool_calls(
     expected_tool_calls,
     expected_content,
 ):
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
     extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
         model_output, request=request
@@ -376,6 +377,7 @@ TX
 </parameter>
 </function>"""
 
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
     extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
         model_output, request=request
@@ -427,6 +429,7 @@ hello world
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
     extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
         model_output, request=request
@@ -624,6 +627,7 @@ def test_extract_tool_calls_streaming(
     expected_content,
 ):
     """Test incremental streaming behavior including typed parameters"""
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
@@ -709,6 +713,7 @@ fahrenheit
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
     extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
         model_output, request=request
@@ -751,6 +756,7 @@ fahrenheit
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
@@ -821,6 +827,7 @@ TX
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     chunks = []
@@ -893,6 +900,7 @@ def test_extract_tool_calls_complex_type_with_single_quote(step3p5_tool_parser):
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
     extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
         model_output, request=request
@@ -932,6 +940,7 @@ rectangle
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
@@ -1038,6 +1047,7 @@ rectangle
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(
@@ -1116,6 +1126,7 @@ rectangle
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
@@ -1247,6 +1258,7 @@ rectangle
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     other_content = ""
@@ -1318,6 +1330,7 @@ def test_extract_tool_calls_streaming_multi_token_chunk_boundary(
     step3p5_tool_parser, step3p5_tokenizer, sample_tools
 ):
     """Ensure fallback doesn't close a new tool_call when boundary is in one chunk."""
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
     delta_text_chunks = [
         """<tool_call>
@@ -1396,6 +1409,7 @@ rectangle
 </function>
 </tool_call>"""
 
+    step3p5_tool_parser.tools = sample_tools
     request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
 
     extracted_tool_calls = step3p5_tool_parser.extract_tool_calls(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -565,7 +565,7 @@ class OpenAIServingChat(OpenAIServing):
                     )
 
                 tool_parsers: list[ToolParser | None] = [
-                    self.tool_parser(tokenizer)
+                    self.tool_parser(tokenizer, request.tools)
                 ] * num_choices
             else:
                 tool_parsers = [None] * num_choices
@@ -1331,7 +1331,7 @@ class OpenAIServingChat(OpenAIServing):
                             "Tokenizer not available when `skip_tokenizer_init=True`"
                         )
 
-                    tool_parser = self.tool_parser(tokenizer)
+                    tool_parser = self.tool_parser(tokenizer, request.tools)
                     # NOTE: We use token_ids for openai tool parser
                     tool_call_info = tool_parser.extract_tool_calls(
                         "",

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -929,7 +929,7 @@ class OpenAIServing:
 
             # Automatic Tool Call Parsing
             try:
-                tool_parser = tool_parser_cls(tokenizer)
+                tool_parser = tool_parser_cls(tokenizer, request.tools)  # type: ignore[arg-type,call-arg]
             except RuntimeError as e:
                 logger.exception("Error in tool parser creation.")
                 raise e

--- a/vllm/entrypoints/openai/parser/responses_parser.py
+++ b/vllm/entrypoints/openai/parser/responses_parser.py
@@ -52,7 +52,7 @@ class ResponsesParser:
         self.reasoning_parser_instance = reasoning_parser_cls(tokenizer)
         self.tool_parser_instance = None
         if tool_parser_cls is not None:
-            self.tool_parser_instance = tool_parser_cls(tokenizer)
+            self.tool_parser_instance = tool_parser_cls(tokenizer, request.tools)  # type: ignore[arg-type,call-arg]
 
         # Store the last finish_reason to determine response status
         self.finish_reason: str | None = None

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1005,7 +1005,7 @@ class OpenAIServingResponses(OpenAIServing):
 
         # Use parser to extract and create response output items
         if self.parser:
-            parser = self.parser(tokenizer)
+            parser = self.parser(tokenizer, tools=request.tools)  # type: ignore[arg-type]
             return parser.extract_response_outputs(
                 model_output=final_output.text,
                 model_output_token_ids=final_output.token_ids,
@@ -1348,7 +1348,7 @@ class OpenAIServingResponses(OpenAIServing):
             reasoning_parser = self.parser.reasoning_parser_cls(tokenizer)
         tool_parser = None
         if self.parser and self.parser.tool_parser_cls:
-            tool_parser = self.parser.tool_parser_cls(tokenizer)
+            tool_parser = self.parser.tool_parser_cls(tokenizer, request.tools)  # type: ignore[arg-type]
         reasoning_ended = False
         tool_call_text_started = False
         previous_text = ""

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -547,6 +547,7 @@ class OpenAIServingRender:
                     )
                     raise NotImplementedError(msg)
                 tokenizer = renderer.get_tokenizer()
-                request = tool_parser(tokenizer).adjust_request(request=request)  # type: ignore[arg-type]
+                parser = tool_parser(tokenizer, request.tools)  # type: ignore[arg-type,call-arg]
+                request = parser.adjust_request(request=request)  # type: ignore[arg-type]
 
         return conversation, [engine_prompt]

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -542,10 +542,10 @@ class _WrappedParser(DelegatingParser):
     reasoning_parser_cls: type[ReasoningParser] | None = None
     tool_parser_cls: type[ToolParser] | None = None
 
-    def __init__(self, tokenizer: TokenizerLike):
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
         super().__init__(tokenizer)
         # Instantiate the underlying parsers from class attributes
         if self.__class__.reasoning_parser_cls is not None:
             self._reasoning_parser = self.__class__.reasoning_parser_cls(tokenizer)
         if self.__class__.tool_parser_cls is not None:
-            self._tool_parser = self.__class__.tool_parser_cls(tokenizer)
+            self._tool_parser = self.__class__.tool_parser_cls(tokenizer, tools=tools)

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -11,7 +11,10 @@ from openai.types.responses import (
     ResponseTextConfig,
 )
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
     ExtractedToolCallInformation,
@@ -38,7 +41,11 @@ class ToolParser:
     derived classes.
     """
 
-    def __init__(self, tokenizer: TokenizerLike):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         self.prev_tool_call_arr: list[dict] = []
         # the index of the tool call that is currently being parsed
         self.current_tool_id: int = -1
@@ -46,6 +53,7 @@ class ToolParser:
         self.streamed_args_for_tool: list[str] = []
 
         self.model_tokenizer = tokenizer
+        self.tools = tools
 
     @cached_property
     def vocab(self) -> dict[str, int]:

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -44,7 +44,11 @@ class DeepSeekV32ToolParser(ToolParser):
     </｜DSML｜function_calls>
     """
 
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
 
         self.prev_tool_call_arr: list[dict] = []

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -10,6 +10,7 @@ import regex as re
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
@@ -43,8 +44,8 @@ class DeepSeekV32ToolParser(ToolParser):
     </｜DSML｜function_calls>
     """
 
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
 
         self.prev_tool_call_arr: list[dict] = []
 
@@ -136,12 +137,12 @@ class DeepSeekV32ToolParser(ToolParser):
         self,
         function_name: str,
         param_dict: dict[str, str],
-        request: ChatCompletionRequest | None,
+        tools: list[ChatCompletionToolsParam] | None = None,
     ) -> dict[str, Any]:
         """Convert raw string param values using the tool schema types."""
         param_config: dict = {}
-        if request and request.tools:
-            for tool in request.tools:
+        if tools:
+            for tool in tools:
                 if (
                     hasattr(tool, "function")
                     and tool.function.name == function_name
@@ -221,7 +222,6 @@ class DeepSeekV32ToolParser(ToolParser):
     def _extract_delta_tool_calls(
         self,
         current_text: str,
-        request: ChatCompletionRequest | None,
     ) -> list[DeltaToolCall]:
         """Extract DeltaToolCalls from newly completed <invoke> blocks.
 
@@ -236,7 +236,7 @@ class DeepSeekV32ToolParser(ToolParser):
             param_dict = self._parse_invoke_params(invoke_body)
 
             converted = self._convert_params_with_schema(
-                invoke_name, param_dict, request
+                invoke_name, param_dict, self.tools
             )
             args_json = json.dumps(converted, ensure_ascii=False)
             idx = self.current_tool_index
@@ -298,7 +298,7 @@ class DeepSeekV32ToolParser(ToolParser):
             return DeltaMessage(content=delta_text) if delta_text else None
 
         # Inside tool-call region: emit any newly completed invokes.
-        delta_tool_calls = self._extract_delta_tool_calls(current_text, request)
+        delta_tool_calls = self._extract_delta_tool_calls(current_text)
 
         if delta_tool_calls or content_before:
             return DeltaMessage(

--- a/vllm/tool_parsers/glm47_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm47_moe_tool_parser.py
@@ -22,8 +22,8 @@ logger = init_logger(__name__)
 
 
 class Glm47MoeModelToolParser(Glm4MoeModelToolParser):
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
         # GLM-4.7 format: <tool_call>func_name[<arg_key>...]*</tool_call>
         # The function name can be followed by a newline, whitespace, or
         # directly by <arg_key> tags (no separator).  The arg section is

--- a/vllm/tool_parsers/glm47_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm47_moe_tool_parser.py
@@ -14,6 +14,9 @@ This parser overrides the parent regex patterns to handle both formats.
 
 import regex as re
 
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionToolsParam,
+)
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.glm4_moe_tool_parser import Glm4MoeModelToolParser
@@ -22,7 +25,11 @@ logger = init_logger(__name__)
 
 
 class Glm47MoeModelToolParser(Glm4MoeModelToolParser):
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
         # GLM-4.7 format: <tool_call>func_name[<arg_key>...]*</tool_call>
         # The function name can be followed by a newline, whitespace, or

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -48,7 +48,11 @@ class Glm4MoeModelToolParser(ToolParser):
     rather than waiting for the complete </arg_value> tag.
     """
 
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
         # Stateful streaming fields
         self.current_tool_name_sent: bool = False

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -48,8 +48,8 @@ class Glm4MoeModelToolParser(ToolParser):
     rather than waiting for the complete </arg_value> tag.
     """
 
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
         # Stateful streaming fields
         self.current_tool_name_sent: bool = False
         self.prev_tool_call_arr: list[dict[str, Any]] = []
@@ -140,16 +140,9 @@ class Glm4MoeModelToolParser(ToolParser):
         logger.debug("No tool named '%s'.", tool_name)
         return False
 
-    @staticmethod
-    def _tools_enabled(request: ChatCompletionRequest) -> bool:
-        """Return whether tool parsing should be applied for this request."""
-        try:
-            tools = getattr(request, "tools", None)
-            tool_choice = getattr(request, "tool_choice", None)
-            return bool(tools) and tool_choice != "none"
-        except Exception:
-            logger.exception("Failed to determine if tools are enabled.")
-            return False
+    def _tools_enabled(self) -> bool:
+        """Return whether tool parsing should be applied."""
+        return bool(self.tools)
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
         """Adjust request parameters for tool call token handling."""
@@ -186,7 +179,7 @@ class Glm4MoeModelToolParser(ToolParser):
                 for key, value in pairs:
                     arg_key = key.strip()
                     arg_val = value.strip()
-                    if not self._is_string_type(tc_name, arg_key, request.tools):
+                    if not self._is_string_type(tc_name, arg_key, self.tools):
                         arg_val = self._deserialize(arg_val)
                     logger.debug("arg_key = %s, arg_val = %s", arg_key, arg_val)
                     arg_dct[arg_key] = arg_val
@@ -229,7 +222,7 @@ class Glm4MoeModelToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        if not self._tools_enabled(request):
+        if not self._tools_enabled():
             return DeltaMessage(content=delta_text) if delta_text else None
 
         self._buffer += delta_text
@@ -327,7 +320,7 @@ class Glm4MoeModelToolParser(ToolParser):
                 key = (self._pending_key or "").strip()
 
                 is_string = self._is_string_type(
-                    self._current_tool_name, key, request.tools
+                    self._current_tool_name, key, self.tools
                 )
 
                 if is_string:

--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -30,8 +30,8 @@ logger = init_logger(__name__)
 
 
 class Internlm2ToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
         self.position = 0
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
@@ -196,7 +196,7 @@ class Internlm2ToolParser(ToolParser):
         request: ChatCompletionRequest,
     ) -> ExtractedToolCallInformation:
         text = model_output
-        tools = request.tools
+        tools = self.tools
         if "<|action_start|><|plugin|>" in text:
             text, action = text.split("<|action_start|><|plugin|>")
             action = action.split("<|action_end|>".strip())[0]

--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -10,6 +10,7 @@ from partial_json_parser.core.options import Allow
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
@@ -30,7 +31,11 @@ logger = init_logger(__name__)
 
 
 class Internlm2ToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
         self.position = 0
 

--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -29,8 +29,8 @@ logger = init_logger(__name__)
 
 
 class MinimaxM2ToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
 
         self.prev_tool_call_arr: list[dict] = []
 
@@ -293,7 +293,6 @@ class MinimaxM2ToolParser(ToolParser):
     def _extract_delta_tool_calls(
         self,
         current_text: str,
-        request: ChatCompletionRequest | None,
     ) -> list[DeltaToolCall]:
         """Extract DeltaToolCalls from newly completed <invoke> blocks.
 
@@ -307,7 +306,7 @@ class MinimaxM2ToolParser(ToolParser):
             invoke_str = complete_invokes[self.current_tool_index]
             tool_call = self._parse_single_invoke(
                 invoke_str,
-                request.tools if request else None,
+                self.tools,
             )
             if not tool_call:
                 self.current_tool_index += 1
@@ -357,9 +356,7 @@ class MinimaxM2ToolParser(ToolParser):
             for tool_call_match in self.tool_call_complete_regex.findall(model_output):
                 # Find all invokes within this tool_call
                 for invoke_match in self.invoke_complete_regex.findall(tool_call_match):
-                    tool_call = self._parse_single_invoke(
-                        invoke_match, request.tools if request else None
-                    )
+                    tool_call = self._parse_single_invoke(invoke_match, self.tools)
                     if tool_call:
                         tool_calls.append(tool_call)
 
@@ -430,7 +427,7 @@ class MinimaxM2ToolParser(ToolParser):
             content_before = before or None
 
         # Extract newly completed <invoke> blocks as DeltaToolCalls.
-        delta_tool_calls = self._extract_delta_tool_calls(current_text, request)
+        delta_tool_calls = self._extract_delta_tool_calls(current_text)
 
         if delta_tool_calls or content_before:
             return DeltaMessage(

--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -10,6 +10,7 @@ import regex as re
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
@@ -29,7 +30,11 @@ logger = init_logger(__name__)
 
 
 class MinimaxM2ToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
 
         self.prev_tool_call_arr: list[dict] = []

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -30,8 +30,8 @@ logger = init_logger(__name__)
 
 
 class Qwen3CoderToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
 
         self.current_tool_name_sent: bool = False
         self.prev_tool_call_arr: list[dict] = []
@@ -107,7 +107,6 @@ class Qwen3CoderToolParser(ToolParser):
         self.json_closed = False
         # Store accumulated parameters for type conversion
         self.accumulated_params = {}
-        self.streaming_request = None
 
     def _get_arguments_config(
         self, func_name: str, tools: list[ChatCompletionToolsParam] | None
@@ -316,7 +315,7 @@ class Qwen3CoderToolParser(ToolParser):
                 )
 
             tool_calls = [
-                self._parse_xml_function_call(function_call_str, request.tools)
+                self._parse_xml_function_call(function_call_str, self.tools)
                 for function_call_str in function_calls
             ]
             # Populate prev_tool_call_arr for serving layer to set finish_reason
@@ -361,7 +360,6 @@ class Qwen3CoderToolParser(ToolParser):
         # Store request for type conversion
         if not previous_text:
             self._reset_streaming_state()
-            self.streaming_request = request
 
         # If no delta text, return None unless it's an EOS token after tools
         if not delta_text:
@@ -609,7 +607,7 @@ class Qwen3CoderToolParser(ToolParser):
 
                 param_config = self._get_arguments_config(
                     self.current_function_name or "",
-                    self.streaming_request.tools if self.streaming_request else None,
+                    self.tools,
                 )
 
                 converted_value = self._convert_param_value(
@@ -668,9 +666,7 @@ class Qwen3CoderToolParser(ToolParser):
                     try:
                         parsed_tool = self._parse_xml_function_call(
                             func_content,
-                            self.streaming_request.tools
-                            if self.streaming_request
-                            else None,
+                            self.tools,
                         )
                         if parsed_tool and self.current_tool_index < len(
                             self.prev_tool_call_arr

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -30,7 +30,11 @@ logger = init_logger(__name__)
 
 
 class Qwen3CoderToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
 
         self.current_tool_name_sent: bool = False

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -1167,7 +1167,11 @@ class StreamingXMLToolCallParser:
 
 
 class Qwen3XMLToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
         self.parser = StreamingXMLToolCallParser()
         if self.tools:

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -1167,9 +1167,11 @@ class StreamingXMLToolCallParser:
 
 
 class Qwen3XMLToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
         self.parser = StreamingXMLToolCallParser()
+        if self.tools:
+            self.parser.set_tools(self.tools)
 
         # Add missing attributes for compatibility with serving_chat.py
         self.prev_tool_call_arr: list[dict] = []
@@ -1188,8 +1190,8 @@ class Qwen3XMLToolParser(ToolParser):
         # Reset tool call tracking arrays for new extraction
         self.prev_tool_call_arr = []
         self.streamed_args_for_tool = []
-        if request:
-            self.parser.set_tools(request.tools)
+        if self.tools:
+            self.parser.set_tools(self.tools)
         result = self.parser.parse_single_streaming_chunks(model_output)
         if not result.tool_calls:
             return ExtractedToolCallInformation(
@@ -1260,8 +1262,8 @@ class Qwen3XMLToolParser(ToolParser):
             # Reset tool call tracking arrays for new streaming session
             self.prev_tool_call_arr = []
             self.streamed_args_for_tool = []
-            if request:
-                self.parser.set_tools(request.tools)
+            if self.tools:
+                self.parser.set_tools(self.tools)
 
         # Model sometimes outputs separately causing delta_text to be empty.
         # If there were tool_calls before and all current tool_calls have ended,

--- a/vllm/tool_parsers/seed_oss_tool_parser.py
+++ b/vllm/tool_parsers/seed_oss_tool_parser.py
@@ -36,8 +36,8 @@ class SeedOssToolParser(ToolParser):
     TOOL_CALL_START = "<seed:tool_call>"
     TOOL_CALL_END = "</seed:tool_call>"
 
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
 
         # --- streaming state ---
         self._reset_streaming_state()
@@ -312,7 +312,7 @@ class SeedOssToolParser(ToolParser):
                 )
 
             tool_calls = [
-                self._parse_xml_function_call(function_call_str, request.tools)
+                self._parse_xml_function_call(function_call_str, self.tools)
                 for function_call_str in function_calls
             ]
 
@@ -566,7 +566,7 @@ class SeedOssToolParser(ToolParser):
                     # Parse to get the complete arguments
                     try:
                         parsed_tool = self._parse_xml_function_call(
-                            func_content, request.tools if request else None
+                            func_content, self.tools
                         )
                         if parsed_tool:
                             # Update existing entry in prev_tool_call_arr with complete arguments

--- a/vllm/tool_parsers/seed_oss_tool_parser.py
+++ b/vllm/tool_parsers/seed_oss_tool_parser.py
@@ -36,7 +36,11 @@ class SeedOssToolParser(ToolParser):
     TOOL_CALL_START = "<seed:tool_call>"
     TOOL_CALL_END = "</seed:tool_call>"
 
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
 
         # --- streaming state ---

--- a/vllm/tool_parsers/step3_tool_parser.py
+++ b/vllm/tool_parsers/step3_tool_parser.py
@@ -43,8 +43,8 @@ class Step3ToolParser(ToolParser):
     TOOL_SEP = "<｜tool_sep｜>"
     SPECIAL_TOKENS = [TOOL_CALLS_BEGIN, TOOL_CALLS_END, TOOL_CALL_BEGIN, TOOL_CALL_END]
 
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
         self.position = 0
         # Explicit state flags for robust streaming
         self.tool_block_started = False
@@ -78,9 +78,8 @@ class Step3ToolParser(ToolParser):
         self,
         func_name: str,
         params: dict[str, Any],
-        request: ChatCompletionRequest,
     ) -> dict[str, Any]:
-        for tool in request.tools or []:
+        for tool in self.tools or []:
             if tool.function.name == func_name:
                 schema = tool.function.parameters or {}
                 properties = schema.get("properties", {})
@@ -230,7 +229,6 @@ class Step3ToolParser(ToolParser):
                     final_args = self._cast_arguments(
                         function_name,
                         tool_call_arr.get("parameters", {}),  # type: ignore
-                        request,
                     )
                     if final_args:
                         final_args_json = json.dumps(final_args, ensure_ascii=False)
@@ -287,7 +285,7 @@ class Step3ToolParser(ToolParser):
             function_name, params_dict = self._parse_steptml_invoke(invoke_part)
 
             if function_name and params_dict is not None:
-                params_dict = self._cast_arguments(function_name, params_dict, request)
+                params_dict = self._cast_arguments(function_name, params_dict)
                 params_str = json.dumps(params_dict, ensure_ascii=False)
                 tool_calls.append(
                     ToolCall(

--- a/vllm/tool_parsers/step3_tool_parser.py
+++ b/vllm/tool_parsers/step3_tool_parser.py
@@ -10,6 +10,7 @@ import regex as re
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
@@ -43,7 +44,11 @@ class Step3ToolParser(ToolParser):
     TOOL_SEP = "<｜tool_sep｜>"
     SPECIAL_TOKENS = [TOOL_CALLS_BEGIN, TOOL_CALLS_END, TOOL_CALL_BEGIN, TOOL_CALL_END]
 
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
         self.position = 0
         # Explicit state flags for robust streaming

--- a/vllm/tool_parsers/step3p5_tool_parser.py
+++ b/vllm/tool_parsers/step3p5_tool_parser.py
@@ -1365,7 +1365,11 @@ class StreamingXMLToolCallParser:
 
 
 class Step3p5ToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike, tools=None):
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[ChatCompletionToolsParam] | None = None,
+    ):
         super().__init__(tokenizer, tools=tools)
         self.parser = StreamingXMLToolCallParser()
         if self.tools:

--- a/vllm/tool_parsers/step3p5_tool_parser.py
+++ b/vllm/tool_parsers/step3p5_tool_parser.py
@@ -1365,9 +1365,11 @@ class StreamingXMLToolCallParser:
 
 
 class Step3p5ToolParser(ToolParser):
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools=None):
+        super().__init__(tokenizer, tools=tools)
         self.parser = StreamingXMLToolCallParser()
+        if self.tools:
+            self.parser.set_tools(self.tools)
 
         # Add missing attributes for compatibility with serving_chat.py
         self.prev_tool_call_arr: list[dict] = []
@@ -1386,8 +1388,8 @@ class Step3p5ToolParser(ToolParser):
         # Reset tool call tracking arrays for new extraction
         self.prev_tool_call_arr = []
         self.streamed_args_for_tool = []
-        if request:
-            self.parser.set_tools(request.tools)
+        if self.tools:
+            self.parser.set_tools(self.tools)
         result = self.parser.parse_single_streaming_chunks(model_output)
         if not result.tool_calls:
             return ExtractedToolCallInformation(
@@ -1458,8 +1460,8 @@ class Step3p5ToolParser(ToolParser):
             # Reset tool call tracking arrays for new streaming session
             self.prev_tool_call_arr = []
             self.streamed_args_for_tool = []
-            if request:
-                self.parser.set_tools(request.tools)
+            if self.tools:
+                self.parser.set_tools(self.tools)
 
         # Model sometimes outputs separately causing delta_text to be empty.
         # If there were tool_calls before and all current tool_calls have ended,


### PR DESCRIPTION
## Purpose
Tool parsers should not depend on the API request object to access the tools list. The parser's job is to extract tool calls from model output. Any request-level config that affects parsing behavior should be resolved at parser construction time, since a new parser instance is created per request.

### This PR
- Add a `tools` parameter to `ToolParser.__init__` and store it as `self.tools`, passed from the serving layer at construction time
- Update all tool parser subclasses to read `self.tools` instead of `request.tools` during parsing

## Test Plan
```
pytest tests/tool_parsers/ -v
```