### PR TITLE
[OpenAI] Fix reasoning_tokens accounting for MiniMax M2 chat completions

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -22,6 +22,7 @@ from vllm.config import MultiModalConfig
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
+    ChatCompletionStreamResponse,
 )
 from vllm.entrypoints.openai.chat_completion.serving import (
     OpenAIServingChat,
@@ -43,7 +44,7 @@ from vllm.exceptions import VLLMValidationError
 from vllm.inputs import TokensPrompt
 from vllm.multimodal.inputs import PlaceholderRange
 from vllm.outputs import CompletionOutput, RequestOutput
-from vllm.parser import HarmonyParser
+from vllm.parser import HarmonyParser, ParserManager
 from vllm.renderers.hf import HfRenderer
 from vllm.renderers.mistral import MistralRenderer
 from vllm.tokenizers import get_tokenizer
@@ -698,6 +699,171 @@ async def test_serving_chat_returns_correct_model_name():
     # Test that full name is returned when no model is specified
     req = ChatCompletionRequest(messages=messages)
     assert await serving_chat.create_chat_completion(req) == MODEL_NAME
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "parser_name",
+    ["minimax_m2", "minimax_m2_append_think"],
+)
+async def test_chat_usage_includes_reasoning_tokens_for_minimax_parser(
+    parser_name: str,
+):
+    class FakeTokenizer:
+        def __init__(self):
+            self._vocab = {"<think>": 1, "</think>": 2}
+
+        def get_vocab(self):
+            return self._vocab
+
+        def decode(self, token_ids):
+            if token_ids == [20]:
+                return "final"
+            return ""
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = MagicMock()
+
+    serving_chat = _build_serving_chat(mock_engine)
+
+    tokenizer = FakeTokenizer()
+    parser_cls = ParserManager.get_parser(reasoning_parser_name=parser_name)
+    assert parser_cls is not None
+    parser = parser_cls(tokenizer)
+    completion = CompletionOutput(
+        index=0,
+        text="reasoning</think>final",
+        token_ids=[10, 11, 2, 20],
+        cumulative_logprob=0.0,
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+    req_output = RequestOutput(
+        request_id="req",
+        prompt="hi",
+        prompt_token_ids=[7, 8],
+        prompt_logprobs=None,
+        outputs=[completion],
+        finished=True,
+        num_cached_tokens=0,
+    )
+
+    async def result_generator():
+        yield req_output
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    request_id = "req"
+
+    response = await serving_chat.chat_completion_full_generator(
+        request=request,
+        result_generator=result_generator(),
+        request_id=request_id,
+        model_name=MODEL_NAME,
+        conversation=[],
+        tokenizer=tokenizer,
+        request_metadata=RequestResponseMetadata(request_id=request_id),
+        parser=parser,
+    )
+
+    assert response.usage.completion_tokens == 4
+    assert response.usage.completion_tokens_details is not None
+    assert response.usage.completion_tokens_details.reasoning_tokens == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "parser_name",
+    ["minimax_m2", "minimax_m2_append_think"],
+)
+async def test_chat_stream_usage_includes_reasoning_tokens_for_minimax_parser(
+    parser_name: str,
+):
+    class FakeTokenizer:
+        def __init__(self):
+            self._vocab = {"<think>": 1, "</think>": 2}
+
+        def get_vocab(self):
+            return self._vocab
+
+        def decode(self, token_ids):
+            if token_ids == [20]:
+                return "final"
+            return ""
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = MagicMock()
+
+    serving_chat = _build_serving_chat(mock_engine)
+
+    tokenizer = FakeTokenizer()
+    parser_cls = ParserManager.get_parser(reasoning_parser_name=parser_name)
+    assert parser_cls is not None
+    serving_chat.parser_cls = parser_cls
+    completion = CompletionOutput(
+        index=0,
+        text="reasoning</think>final",
+        token_ids=[10, 11, 2, 20],
+        cumulative_logprob=0.0,
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+    req_output = RequestOutput(
+        request_id="req",
+        prompt="hi",
+        prompt_token_ids=[7, 8],
+        prompt_logprobs=None,
+        outputs=[completion],
+        finished=True,
+        num_cached_tokens=0,
+    )
+
+    async def result_generator():
+        yield req_output
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+    request_id = "req"
+    stream = serving_chat.chat_completion_stream_generator(
+        request=request,
+        result_generator=result_generator(),
+        request_id=request_id,
+        model_name=MODEL_NAME,
+        conversation=[],
+        tokenizer=tokenizer,
+        request_metadata=RequestResponseMetadata(request_id=request_id),
+    )
+
+    final_usage = None
+    async for chunk_str in stream:
+        if chunk_str.strip() == "data: [DONE]":
+            continue
+        chunk = ChatCompletionStreamResponse.model_validate_json(chunk_str[6:].strip())
+        if chunk.usage is not None and not chunk.choices:
+            final_usage = chunk.usage
+
+    assert final_usage is not None
+    assert final_usage.completion_tokens == 4
+    assert final_usage.completion_tokens_details is not None
+    assert final_usage.completion_tokens_details.reasoning_tokens == 2
 
 
 @pytest.mark.asyncio

--- a/tests/reasoning/test_minimax_m2_append_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m2_append_reasoning_parser.py
@@ -193,3 +193,41 @@ def test_reasoning(
     output_ids = minimax_m2_tokenizer.convert_tokens_to_ids(output)
     is_reasoning_end = parser.is_reasoning_end(output_ids)
     assert is_reasoning_end == param_dict["is_reasoning_end"]
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    ("output_text", "reasoning_text"),
+    [
+        pytest.param(
+            SIMPLE_OUTPUT["output"],
+            "This is reasoning",
+            id="reasoning-before-end-token",
+        ),
+        pytest.param(
+            NO_END_TOKEN["output"],
+            NO_END_TOKEN["output"],
+            id="all-tokens-are-reasoning-before-end-token",
+        ),
+        pytest.param(
+            ONLY_END_TOKEN["output"],
+            "",
+            id="end-token-first-means-no-reasoning-tokens",
+        ),
+    ],
+)
+def test_count_reasoning_tokens(
+    output_text: str,
+    reasoning_text: str,
+    minimax_m2_tokenizer,
+):
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        minimax_m2_tokenizer
+    )
+
+    output_ids = minimax_m2_tokenizer.encode(output_text, add_special_tokens=False)
+    reasoning_ids = minimax_m2_tokenizer.encode(
+        reasoning_text, add_special_tokens=False
+    )
+
+    assert parser.count_reasoning_tokens(output_ids) == len(reasoning_ids)

--- a/tests/reasoning/test_minimax_m2_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m2_reasoning_parser.py
@@ -202,3 +202,41 @@ def test_reasoning(
     else:
         content = parser.extract_content_ids(output)
         assert content == []
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    ("output_text", "reasoning_text"),
+    [
+        pytest.param(
+            SIMPLE_REASONING["output"],
+            SIMPLE_REASONING["reasoning"],
+            id="reasoning-before-end-token",
+        ),
+        pytest.param(
+            NO_END_TOKEN["output"],
+            NO_END_TOKEN["output"],
+            id="all-tokens-are-reasoning-before-end-token",
+        ),
+        pytest.param(
+            SHORTEST_REASONING_STREAMING["output"],
+            "",
+            id="end-token-first-means-no-reasoning-tokens",
+        ),
+    ],
+)
+def test_count_reasoning_tokens(
+    output_text: str,
+    reasoning_text: str,
+    minimax_m2_tokenizer,
+):
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        minimax_m2_tokenizer
+    )
+
+    output_ids = minimax_m2_tokenizer.encode(output_text, add_special_tokens=False)
+    reasoning_ids = minimax_m2_tokenizer.encode(
+        reasoning_text, add_special_tokens=False
+    )
+
+    assert parser.count_reasoning_tokens(output_ids) == len(reasoning_ids)

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -34,6 +34,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatMessage,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    CompletionTokenUsageInfo,
     DeltaMessage,
     ErrorResponse,
     FunctionCall,
@@ -60,6 +61,7 @@ from vllm.logprobs import Logprob
 from vllm.outputs import RequestOutput
 from vllm.parser import ParserManager
 from vllm.parser.abstract_parser import Parser
+from vllm.reasoning import ReasoningParser
 from vllm.renderers import ChatParams
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
@@ -183,6 +185,40 @@ class OpenAIServingChat(OpenAIServing):
         # Please use the Responses API instead.
         self.supports_code_interpreter = False
         self.python_tool = None
+
+    @staticmethod
+    def _count_reasoning_tokens_for_usage(
+        token_ids: GenericSequence[int],
+        reasoning_parser: ReasoningParser | None,
+    ) -> int | None:
+        if reasoning_parser is None:
+            return None
+        return reasoning_parser.count_reasoning_tokens(token_ids)
+
+    def _make_usage_info(
+        self,
+        *,
+        prompt_tokens: int,
+        completion_tokens: int,
+        num_cached_tokens: int | None = None,
+        mm_token_counts: dict[str, int] | None = None,
+        reasoning_tokens: int | None = None,
+    ) -> UsageInfo:
+        usage = UsageInfo(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        )
+        if reasoning_tokens is not None:
+            usage.completion_tokens_details = CompletionTokenUsageInfo(
+                reasoning_tokens=max(0, min(reasoning_tokens, completion_tokens))
+            )
+        usage.prompt_tokens_details = _make_prompt_tokens_details(
+            self.enable_prompt_tokens_details,
+            num_cached_tokens,
+            mm_token_counts,
+        )
+        return usage
 
     def warmup(self) -> None:
         self.renderer.warmup(
@@ -425,6 +461,7 @@ class OpenAIServingChat(OpenAIServing):
         # Send response for each token for each request.n (index)
         num_choices = 1 if request.n is None else request.n
         previous_num_tokens = [0] * num_choices
+        raw_output_token_ids: list[list[int]] = [[] for _ in range(num_choices)]
         finish_reason_sent = [False] * num_choices
         num_prompt_tokens = 0
         num_cached_tokens = None
@@ -463,6 +500,9 @@ class OpenAIServingChat(OpenAIServing):
                         p._stream_state.history_tool_call_cnt = history_tool_call_cnt
             else:
                 parsers = [None] * num_choices
+            reasoning_parsers = [
+                p.reasoning_parser if p is not None else None for p in parsers
+            ]
         except Exception as e:
             logger.exception("Error in parser creation.")
             data = self.create_streaming_error_response(e)
@@ -497,6 +537,7 @@ class OpenAIServingChat(OpenAIServing):
                     # NOTE num_choices defaults to 1 so this usually executes
                     # once per request
                     for i in range(num_choices):
+                        reasoning_parser = reasoning_parsers[i]
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=i,
                             delta=DeltaMessage(
@@ -524,10 +565,12 @@ class OpenAIServingChat(OpenAIServing):
 
                         # if continuous usage stats are requested, add it
                         if include_continuous_usage:
-                            chunk.usage = UsageInfo(
+                            chunk.usage = self._make_usage_info(
                                 prompt_tokens=num_prompt_tokens,
                                 completion_tokens=0,
-                                total_tokens=num_prompt_tokens,
+                                reasoning_tokens=self._count_reasoning_tokens_for_usage(
+                                    raw_output_token_ids[i], reasoning_parser
+                                ),
                             )
 
                         data = chunk.model_dump_json(exclude_unset=True)
@@ -546,6 +589,7 @@ class OpenAIServingChat(OpenAIServing):
 
                         if last_msg_content:
                             for i in range(num_choices):
+                                reasoning_parser = reasoning_parsers[i]
                                 choice_data = ChatCompletionResponseStreamChoice(
                                     index=i,
                                     delta=DeltaMessage(content=last_msg_content),
@@ -560,10 +604,13 @@ class OpenAIServingChat(OpenAIServing):
                                     model=model_name,
                                 )
                                 if include_continuous_usage:
-                                    chunk.usage = UsageInfo(
+                                    chunk.usage = self._make_usage_info(
                                         prompt_tokens=num_prompt_tokens,
                                         completion_tokens=0,
-                                        total_tokens=num_prompt_tokens,
+                                        reasoning_tokens=self._count_reasoning_tokens_for_usage(
+                                            raw_output_token_ids[i],
+                                            reasoning_parser,
+                                        ),
                                     )
 
                                 data = chunk.model_dump_json(exclude_unset=True)
@@ -573,6 +620,7 @@ class OpenAIServingChat(OpenAIServing):
                 for output in res.outputs:
                     i = output.index
                     parser = parsers[i]
+                    reasoning_parser = reasoning_parsers[i]
                     if finish_reason_sent[i]:
                         continue
 
@@ -630,6 +678,7 @@ class OpenAIServingChat(OpenAIServing):
 
                     # set the previous values for the next iteration
                     previous_num_tokens[i] += len(output.token_ids)
+                    raw_output_token_ids[i].extend(as_list(output.token_ids))
 
                     # if the message delta is None (e.g. because it was a
                     # "control token" for tool calls or the parser otherwise
@@ -742,10 +791,12 @@ class OpenAIServingChat(OpenAIServing):
                     # handle usage stats if requested & if continuous
                     if include_continuous_usage:
                         completion_tokens = previous_num_tokens[i]
-                        chunk.usage = UsageInfo(
+                        chunk.usage = self._make_usage_info(
                             prompt_tokens=num_prompt_tokens,
                             completion_tokens=completion_tokens,
-                            total_tokens=num_prompt_tokens + completion_tokens,
+                            reasoning_tokens=self._count_reasoning_tokens_for_usage(
+                                raw_output_token_ids[i], reasoning_parser
+                            ),
                         )
 
                     data = chunk.model_dump_json(exclude_unset=True)
@@ -755,15 +806,23 @@ class OpenAIServingChat(OpenAIServing):
             # is sent, send the usage
             if include_usage:
                 completion_tokens = sum(previous_num_tokens)
-                final_usage = UsageInfo(
+                reasoning_tokens = None
+                if any(parser is not None for parser in reasoning_parsers):
+                    reasoning_tokens = sum(
+                        self._count_reasoning_tokens_for_usage(
+                            token_ids, reasoning_parser
+                        )
+                        or 0
+                        for token_ids, reasoning_parser in zip(
+                            raw_output_token_ids, reasoning_parsers
+                        )
+                    )
+                final_usage = self._make_usage_info(
                     prompt_tokens=num_prompt_tokens,
                     completion_tokens=completion_tokens,
-                    total_tokens=num_prompt_tokens + completion_tokens,
-                )
-                final_usage.prompt_tokens_details = _make_prompt_tokens_details(
-                    self.enable_prompt_tokens_details,
-                    num_cached_tokens,
-                    mm_token_counts,
+                    num_cached_tokens=num_cached_tokens,
+                    mm_token_counts=mm_token_counts,
+                    reasoning_tokens=reasoning_tokens,
                 )
 
                 final_usage_chunk = ChatCompletionStreamResponse(
@@ -782,10 +841,19 @@ class OpenAIServingChat(OpenAIServing):
 
             # report to FastAPI middleware aggregate usage across all choices
             num_completion_tokens = sum(previous_num_tokens)
-            request_metadata.final_usage_info = UsageInfo(
+            reasoning_tokens = None
+            if any(parser is not None for parser in reasoning_parsers):
+                reasoning_tokens = sum(
+                    self._count_reasoning_tokens_for_usage(token_ids, reasoning_parser)
+                    or 0
+                    for token_ids, reasoning_parser in zip(
+                        raw_output_token_ids, reasoning_parsers
+                    )
+                )
+            request_metadata.final_usage_info = self._make_usage_info(
                 prompt_tokens=num_prompt_tokens,
                 completion_tokens=num_completion_tokens,
-                total_tokens=num_prompt_tokens + num_completion_tokens,
+                reasoning_tokens=reasoning_tokens,
             )
 
             # Log complete streaming response if output logging is enabled
@@ -1043,15 +1111,22 @@ class OpenAIServingChat(OpenAIServing):
         num_generated_tokens = sum(
             len(output.token_ids) for output in final_res.outputs
         )
-        usage = UsageInfo(
+        reasoning_tokens = None
+        reasoning_parser = parser.reasoning_parser if parser is not None else None
+        if reasoning_parser is not None:
+            reasoning_tokens = sum(
+                self._count_reasoning_tokens_for_usage(
+                    as_list(output.token_ids), reasoning_parser
+                )
+                or 0
+                for output in final_res.outputs
+            )
+        usage = self._make_usage_info(
             prompt_tokens=num_prompt_tokens,
             completion_tokens=num_generated_tokens,
-            total_tokens=num_prompt_tokens + num_generated_tokens,
-        )
-        usage.prompt_tokens_details = _make_prompt_tokens_details(
-            self.enable_prompt_tokens_details,
-            final_res.num_cached_tokens,
-            mm_token_counts,
+            num_cached_tokens=final_res.num_cached_tokens,
+            mm_token_counts=mm_token_counts,
+            reasoning_tokens=reasoning_tokens,
         )
 
         request_metadata.final_usage_info = usage

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -108,10 +108,18 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
     request has no multimodal input."""
 
 
+class CompletionTokenUsageInfo(OpenAIBaseModel):
+    reasoning_tokens: int | None = None
+    audio_tokens: int | None = None
+    accepted_prediction_tokens: int | None = None
+    rejected_prediction_tokens: int | None = None
+
+
 class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: int | None = 0
+    completion_tokens_details: CompletionTokenUsageInfo | None = None
     prompt_tokens_details: PromptTokenUsageInfo | None = None
 
 

--- a/vllm/reasoning/minimax_m2_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_reasoning_parser.py
@@ -16,6 +16,18 @@ if TYPE_CHECKING:
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 
+def _count_minimax_reasoning_tokens(
+    token_ids: Sequence[int], end_token_id: int | None
+) -> int:
+    if end_token_id is None:
+        return 0
+
+    for idx, token_id in enumerate(token_ids):
+        if token_id == end_token_id:
+            return idx
+    return len(token_ids)
+
+
 class MiniMaxM2ReasoningParser(MinimaxM2ParserReasoningAdapter):  # type: ignore[valid-type, misc]
     """
     Reasoning parser for MiniMax M2 model.
@@ -24,6 +36,9 @@ class MiniMaxM2ReasoningParser(MinimaxM2ParserReasoningAdapter):  # type: ignore
     token. All content before </think> is reasoning, content after is the
     actual response.
     """
+
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        return _count_minimax_reasoning_tokens(token_ids, self.vocab.get("</think>"))
 
 
 class MiniMaxM2AppendThinkReasoningParser(ReasoningParser):
@@ -64,3 +79,6 @@ class MiniMaxM2AppendThinkReasoningParser(ReasoningParser):
         self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
     ) -> tuple[str | None, str | None]:
         return None, "<think>" + model_output
+
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        return _count_minimax_reasoning_tokens(token_ids, self.end_token_id)


### PR DESCRIPTION
## Summary

Fixes #37988.

This PR adds `completion_tokens_details.reasoning_tokens` to OpenAI chat-completions usage for MiniMax M2 reasoning parsers.

#45701 reimplemented the MiniMax M2 parser using the parser engine, so this PR has been retested against latest main with #45701 merged. It is still needed because MiniMax M2 output is start-token-less: real output has reasoning tokens before the first `</think>`, while the generic parser-engine counter only counts tokens between `<think>` and `</think>`. The MiniMax M2 reasoning parser therefore still needs a model-specific count override, and chat completions still need to include that count in usage.

## Duplicate-work check

- `gh issue view 37988 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "37988 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "MiniMax M2 reasoning_tokens usage accounting"`

Result: only this open PR addresses #37988 / MiniMax M2 chat-completions `reasoning_tokens` usage accounting.

## Testing

```bash
.venv/bin/python -m py_compile vllm/entrypoints/openai/chat_completion/serving.py vllm/entrypoints/openai/engine/protocol.py vllm/reasoning/minimax_m2_reasoning_parser.py tests/entrypoints/openai/chat_completion/test_serving_chat.py tests/reasoning/test_minimax_m2_reasoning_parser.py tests/reasoning/test_minimax_m2_append_reasoning_parser.py
ruff check vllm/entrypoints/openai/chat_completion/serving.py vllm/entrypoints/openai/engine/protocol.py vllm/reasoning/minimax_m2_reasoning_parser.py tests/entrypoints/openai/chat_completion/test_serving_chat.py tests/reasoning/test_minimax_m2_reasoning_parser.py tests/reasoning/test_minimax_m2_append_reasoning_parser.py
.venv/bin/python -m pytest -q tests/entrypoints/openai/chat_completion/test_serving_chat.py -k 'test_chat_usage_includes_reasoning_tokens_for_minimax_parser or test_chat_stream_usage_includes_reasoning_tokens_for_minimax_parser'
.venv/bin/python -m pytest -q tests/reasoning/test_minimax_m2_reasoning_parser.py tests/reasoning/test_minimax_m2_append_reasoning_parser.py -k count_reasoning_tokens
```

Results:

- `py_compile`: passed
- `ruff check`: passed
- chat usage tests: `4 passed, 39 deselected`
- parser count tests: `6 passed, 28 deselected`

## AI assistance

AI assistance was used to re-evaluate this PR after #45701 and rebase it onto latest main. The human submitter should review every changed line and the CI result.
