### PR TITLE
[Performance] Fused rmsnorm fp8 quant for DeepSeek 

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -858,6 +858,24 @@ class CompilationConfig:
         if KEY not in self.inductor_compile_config:
             self.inductor_compile_config[KEY] = False
 
+        # Tie inductor runtime assertions to debug logging mode.
+        # These assertions add ~2ms overhead per forward pass on large
+        # models (e.g., DeepSeek-R1 671B: ~340 assert_size_stride + ~60
+        # assert_alignment calls per forward). PyTorch >= 2.12 has a
+        # native fix (assert-once), so we only apply this workaround on
+        # older versions. On torch < 2.12, enable asserts only when
+        # VLLM_LOGGING_LEVEL=DEBUG. Users can still override explicitly
+        # via --compilation-config '{"inductor_compile_config":
+        # {"size_asserts": true, ...}}'.
+        # See: https://github.com/pytorch/pytorch/issues/177719
+        enable_asserts = envs.VLLM_LOGGING_LEVEL == "DEBUG"
+        for key in (
+            "size_asserts",
+            "alignment_asserts",
+            "scalar_asserts",
+        ):
+            self.inductor_compile_config.setdefault(key, enable_asserts)
+
         for k, v in self.inductor_passes.items():
             if not isinstance(v, str):
                 assert callable(v), f"pass {k} should be callable or a qualified name"

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -87,6 +87,15 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         self.indexer_rope_emb = mla_modules.indexer_rotary_emb
         self.is_sparse = mla_modules.is_sparse
 
+        # Check if q_b_proj has fused RMSNorm+FP8Quant kernel.
+        # When True, skip standalone q_a_layernorm in forward.
+        self._fused_q_b = False
+        if self.q_b_proj is not None:
+            qm = getattr(self.q_b_proj, "quant_method", None)
+            if qm and hasattr(qm, "w8a8_block_fp8_linear"):
+                op = qm.w8a8_block_fp8_linear
+                self._fused_q_b = getattr(op, "norm_weight", None) is not None
+
         if self.indexer is not None:
             assert hasattr(self.indexer, "topk_tokens")
             self.topk_tokens = self.indexer.topk_tokens
@@ -135,7 +144,8 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
                 dim=-1,
             )
-            q_c = self.q_a_layernorm(q_c)
+            if not self._fused_q_b:
+                q_c = self.q_a_layernorm(q_c)
             q = self.q_b_proj(q_c)[0]
         else:
             assert self.kv_a_proj_with_mqa is not None, (

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -3,6 +3,8 @@
 
 from typing import TYPE_CHECKING, Any
 
+import os
+
 import torch
 from torch.nn import Module
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -185,6 +187,18 @@ class Fp8Config(QuantizationConfig):
             else:
                 offline_method = Fp8LinearMethod(self)
                 offline_method.marlin_input_dtype = get_marlin_input_dtype(prefix)
+                # Enable native aten quant for norm-adjacent linears.
+                # Only q_b_proj benefits from fused RMSNorm+FP8Quant kernel.
+                # Other linears (qkv_a, kv_b) keep CUDA CustomOp because
+                # native quant (triton_red + triton_per) is 2 kernels vs
+                # 1 CUDA kernel, net slower.
+                if (
+                    os.environ.get("VLLM_SKIP_NATIVE_QUANT", "0") != "1"
+                    and offline_method.block_quant
+                    and hasattr(offline_method, "w8a8_block_fp8_linear")
+                    and "q_b_proj" in prefix
+                ):
+                    offline_method.w8a8_block_fp8_linear.use_native_quant = True
                 return offline_method
         elif isinstance(layer, FusedMoE):
             if is_layer_skipped(

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -345,6 +345,125 @@ direct_register_custom_op(
 )
 
 
+@triton.jit
+def _fused_rmsnorm_fp8_quant_kernel(
+    x_ptr,
+    weight_ptr,
+    out_ptr,
+    scale_ptr,
+    hidden_dim,
+    batch_size,
+    num_groups,
+    eps,
+    fp8_min,
+    fp8_max,
+    min_scale,
+    GROUP_SIZE: tl.constexpr,
+):
+    """Fused RMSNorm + per-block FP8 quantization in a single kernel.
+
+    Two-pass algorithm:
+      Pass 1: Read x, compute variance = mean(x^2) per row
+      Pass 2: Read x again (L1 cache hit), normalize (x * rsqrt(var+eps) * weight),
+              per-group quantize (amax, scale, fp8 cast)
+
+    Column-major scales: stores into [num_groups, batch_size] contiguous
+    tensor, which equals [batch_size, num_groups] col-major via .t() view.
+    """
+    pid = tl.program_id(0)
+
+    sum_sq = 0.0
+    for g in range(num_groups):
+        offs = tl.arange(0, GROUP_SIZE)
+        idx = pid.to(tl.int64) * hidden_dim + g * GROUP_SIZE + offs
+        x = tl.load(x_ptr + idx).to(tl.float32)
+        sum_sq += tl.sum(x * x)
+
+    inv_rms = tl.math.rsqrt(sum_sq / hidden_dim + eps)
+
+    for g in range(num_groups):
+        offs = tl.arange(0, GROUP_SIZE)
+        idx = pid.to(tl.int64) * hidden_dim + g * GROUP_SIZE + offs
+
+        x = tl.load(x_ptr + idx).to(tl.float32)
+        w = tl.load(weight_ptr + g * GROUP_SIZE + offs).to(tl.float32)
+
+        x_norm = x * inv_rms * w
+
+        amax = tl.max(tl.abs(x_norm))
+        scale = tl.maximum(amax / fp8_max, min_scale)
+
+        x_q = tl.clamp(x_norm / scale, fp8_min, fp8_max)
+        x_q = x_q.to(out_ptr.dtype.element_ty)
+
+        tl.store(out_ptr + idx, x_q)
+        tl.store(scale_ptr + g * batch_size + pid, scale)
+
+
+def _fused_rmsnorm_fp8_quant_impl(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    fp8_dtype = current_platform.fp8_dtype()
+    fp8_max = torch.finfo(fp8_dtype).max
+    fp8_min = -fp8_max
+    min_scale = 1.0 / (fp8_max * 512.0)
+
+    batch_size = x.shape[0]
+    hidden_dim = x.shape[-1]
+    num_groups = hidden_dim // group_size
+
+    x_quant = torch.empty_like(x, dtype=fp8_dtype)
+    scales = torch.empty(
+        num_groups, batch_size, device=x.device, dtype=torch.float32
+    )
+
+    grid = (batch_size,)
+    _fused_rmsnorm_fp8_quant_kernel[grid](
+        x,
+        norm_weight,
+        x_quant,
+        scales,
+        hidden_dim,
+        batch_size,
+        num_groups,
+        eps,
+        fp8_min,
+        fp8_max,
+        min_scale,
+        GROUP_SIZE=group_size,
+    )
+
+    return x_quant, scales.t()
+
+
+def _fused_rmsnorm_fp8_quant_fake(
+    x: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    fp8_dtype = current_platform.fp8_dtype()
+    batch_size = x.shape[0]
+    hidden_dim = x.shape[-1]
+    num_groups = hidden_dim // group_size
+    x_quant = torch.empty_like(x, dtype=fp8_dtype)
+    scales = torch.empty(
+        num_groups, batch_size, device=x.device, dtype=torch.float32
+    ).t()
+    return x_quant, scales
+
+
+direct_register_custom_op(
+    op_name="fused_rmsnorm_fp8_quant",
+    op_func=_fused_rmsnorm_fp8_quant_impl,
+    mutates_args=[],
+    fake_impl=_fused_rmsnorm_fp8_quant_fake,
+)
+
+
 # TODO fix ROCm->Triton custom path:
 #  https://github.com/vllm-project/vllm/issues/14397
 class W8A8BlockFp8LinearOp:
@@ -367,6 +486,24 @@ class W8A8BlockFp8LinearOp:
         self.use_deep_gemm_e8m0 = is_deep_gemm_e8m0_used()
         self.is_flashinfer_supported = is_flashinfer_fp8_blockscale_gemm_supported()
 
+        # When True, use pure aten ops for input quantization instead of
+        # the QuantFP8 CustomOp. This allows Inductor to see through the
+        # quant ops and fuse them with a preceding RMSNorm.
+        # Only set True for norm-adjacent linear layers.
+        self.use_native_quant = False
+
+        # When set, the fused Triton kernel is used to combine RMSNorm +
+        # FP8 quant into a single kernel, eliminating the intermediate
+        # DRAM round-trip between norm and quant.
+        self.norm_weight: torch.Tensor | None = None
+        self.norm_eps: float | None = None
+
+        _FP8_DTYPE = current_platform.fp8_dtype()
+        self._FP8_MAX = torch.finfo(_FP8_DTYPE).max
+        self._FP8_MIN = -self._FP8_MAX
+        self._FP8_MIN_SCALING_FACTOR = 1.0 / (self._FP8_MAX * 512.0)
+        self._FP8_DTYPE = _FP8_DTYPE
+
         # Get the correct blockscale mul and input quant operations.
         # We can't use _dispatch_w8a8_blockscale_op to figure out if we want
         # to use deepgemm because we don't know the shape of weights (and
@@ -387,6 +524,51 @@ class W8A8BlockFp8LinearOp:
             if self.is_deep_gemm_supported
             else None
         )
+
+    def _quantize_input_native(
+        self, x: torch.Tensor, column_major_scales: bool = True
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Pure aten ops for group FP8 quantization.
+
+        When used instead of QuantFP8 CustomOp, Inductor can see these ops
+        and fuse them with a preceding decomposed RMSNorm.
+
+        Column-major scales are produced without .contiguous() by computing
+        amax on a transposed view: [B,G,128] -> permute(1,0,2) -> [G,B,128]
+        -> amax(dim=-1) -> [G,B] contiguous = [B,G] col-major via .t() view.
+        """
+        group_size = self.act_quant_group_shape.col
+        orig_shape = x.shape
+        hidden_dim = x.shape[-1]
+        num_groups = hidden_dim // group_size
+
+        x_grouped = x.reshape(-1, num_groups, group_size).float()
+
+        if column_major_scales:
+            x_for_scale = x_grouped.permute(1, 0, 2)
+            absmax = x_for_scale.abs().amax(dim=-1, keepdim=True)
+            scales = (absmax / self._FP8_MAX).clamp(
+                min=self._FP8_MIN_SCALING_FACTOR
+            )
+            x_quant = (x_grouped / scales.permute(1, 0, 2)).clamp(
+                self._FP8_MIN, self._FP8_MAX
+            ).to(self._FP8_DTYPE)
+            x_quant = x_quant.reshape(orig_shape)
+            scales_out = scales.squeeze(-1).t()
+        else:
+            absmax = x_grouped.abs().amax(dim=-1, keepdim=True)
+            scales = (absmax / self._FP8_MAX).clamp(
+                min=self._FP8_MIN_SCALING_FACTOR
+            )
+            x_quant = (x_grouped / scales).clamp(
+                self._FP8_MIN, self._FP8_MAX
+            ).to(self._FP8_DTYPE)
+            x_quant = x_quant.reshape(orig_shape)
+            scales_out = scales.squeeze(-1).reshape(
+                orig_shape[:-1] + (num_groups,)
+            )
+
+        return x_quant, scales_out
 
     def apply(
         self,
@@ -428,8 +610,15 @@ class W8A8BlockFp8LinearOp:
         weight: torch.Tensor,
         weight_scale: torch.Tensor,
     ) -> torch.Tensor:
-        assert self.deepgemm_input_quant_op is not None
-        q_input, input_scale = self.deepgemm_input_quant_op(input_2d)
+        if self.use_native_quant and self.norm_weight is not None:
+            q_input, input_scale = torch.ops.vllm.fused_rmsnorm_fp8_quant(
+                input_2d, self.norm_weight, self.norm_eps,
+                self.act_quant_group_shape.col)
+        elif self.use_native_quant:
+            q_input, input_scale = self._quantize_input_native(input_2d)
+        else:
+            assert self.deepgemm_input_quant_op is not None
+            q_input, input_scale = self.deepgemm_input_quant_op(input_2d)
         output = torch.empty(
             (q_input.shape[0], weight.shape[0]),
             dtype=torch.bfloat16,
@@ -449,7 +638,14 @@ class W8A8BlockFp8LinearOp:
     ) -> torch.Tensor:
         assert input_scale is None
         assert self.input_quant_op is not None
-        q_input, input_scale = self.input_quant_op(input_2d)
+        if self.use_native_quant and self.norm_weight is not None:
+            q_input, input_scale = torch.ops.vllm.fused_rmsnorm_fp8_quant(
+                input_2d, self.norm_weight, self.norm_eps,
+                self.act_quant_group_shape.col)
+        elif self.use_native_quant:
+            q_input, input_scale = self._quantize_input_native(input_2d)
+        else:
+            q_input, input_scale = self.input_quant_op(input_2d)
         if self.is_hopper:
             return torch.ops.vllm.padded_cutlass(
                 q_input,
@@ -513,7 +709,14 @@ class W8A8BlockFp8LinearOp:
     ) -> torch.Tensor:
         assert input_scale is None
         assert self.input_quant_op is not None
-        q_input, input_scale = self.input_quant_op(input_2d)
+        if self.use_native_quant and self.norm_weight is not None:
+            q_input, input_scale = torch.ops.vllm.fused_rmsnorm_fp8_quant(
+                input_2d, self.norm_weight, self.norm_eps,
+                self.act_quant_group_shape.col)
+        elif self.use_native_quant:
+            q_input, input_scale = self._quantize_input_native(input_2d)
+        else:
+            q_input, input_scale = self.input_quant_op(input_2d)
         return torch.ops.vllm.w8a8_triton_block_scaled_mm_func(
             q_input,
             weight,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -416,6 +416,36 @@ def _get_llama_4_scaling(
     return scaling[..., None, None]
 
 
+def _enable_native_quant(linear: nn.Module) -> None:
+    """Enable native aten quant for a linear layer so Inductor can fuse
+    with a preceding RMSNorm. Only effective for block FP8 quantized layers."""
+    qm = getattr(linear, "quant_method", None)
+    if qm is not None and hasattr(qm, "w8a8_block_fp8_linear"):
+        qm.w8a8_block_fp8_linear.use_native_quant = True
+
+
+def _set_fused_norm(linear: nn.Module, layernorm: nn.Module) -> bool:
+    """Set norm params on a linear layer for fused RMSNorm+FP8Quant.
+
+    When the fused Triton kernel is used, the standalone RMSNorm should
+    be skipped in the forward pass — the linear layer will do both
+    RMSNorm and FP8 quant in a single kernel.
+
+    Returns True if fused norm was successfully set.
+    """
+    qm = getattr(linear, "quant_method", None)
+    if (
+        qm is not None
+        and hasattr(qm, "w8a8_block_fp8_linear")
+        and qm.w8a8_block_fp8_linear.use_native_quant
+    ):
+        op = qm.w8a8_block_fp8_linear
+        op.norm_weight = layernorm.weight
+        op.norm_eps = layernorm.variance_epsilon
+        return True
+    return False
+
+
 class DeepseekV2Attention(nn.Module):
     def __init__(
         self,
@@ -891,6 +921,12 @@ class DeepseekV2MLAAttention(nn.Module):
                 quant_config=quant_config,
                 prefix=f"{prefix}.q_b_proj",
             )
+            # q_b_proj native quant is set by get_quant_method() based on prefix
+            # Don't hardcode _enable_native_quant here — it would override
+            # VLLM_SKIP_NATIVE_QUANT env var control
+            self._fused_q_b = _set_fused_norm(
+                self.q_b_proj, self.q_a_layernorm
+            )
         else:
             self.q_proj = ColumnParallelLinear(
                 proj_input_size,
@@ -907,6 +943,7 @@ class DeepseekV2MLAAttention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.kv_b_proj",
         )
+        # kv_b_proj: keep CUDA CustomOp (native quant = 2 kernels > 1 CUDA kernel)
         self.o_proj = RowParallelLinear(
             self.num_heads * self.v_head_dim,
             self.hidden_size,


### PR DESCRIPTION
fixes: https://github.com/vllm-project/vllm/issues/37832

- Fused Triton kernel: Combines RMSNorm + FP8 per-block quantization into a single kernel for q_b_proj, eliminating the intermediate DRAM round-trip between norm and quant.
- Native aten decomposition: Replaces the opaque CUDA CustomOp with native aten ops for norm-adjacent linears, enabling Inductor to automatically fuse normalize + quantize (requires companion PyTorch PR [#178237](https://github.com/pytorch/pytorch/pull/178237) to fix Reduction+Pointwise fusion).


Summary:
Introduces a custom Triton kernel that fuses RMSNorm and per-block FP8
quantization into a single kernel for norm-adjacent linear layers, along
with selective native quantization that enables Inductor to fuse
normalize + quantize operations. Together these reduce E2E latency significantly on DeepSeek-R1 671B FP8 with TP=8. see:

<img width="831" height="649" alt="Screenshot 2026-03-27 at 10 00 48 PM" src="https://github.com/user-attachments/assets/54a1444d-cf13-4904-8f4a-5273bb475560" />

<img width="1669" height="661" alt="Screenshot 2026-03-27 at 10 01 13 PM" src="https://github.com/user-attachments/assets/4d036857-2692-4762-aa69-d68b823c13e9" />





**Companion PyTorch PR:** [inductor] Enable Reduction+Pointwise fusion when
reduction output has opaque consumers (fixes Inductor scheduler to allow
fusing Reduction epilogues when the output feeds an opaque consumer like
cutlass_scaled_mm).

## Problem

Under torch.compile with Inductor, DeepSeek-R1 FP8 inference has a
performance gap between RMSNorm and per-block FP8 quantization:

1. The QuantFP8 CustomOp is opaque to Inductor, preventing fusion with
   the preceding RMSNorm. This forces an unnecessary DRAM round-trip
   (write normalized output, read it back for quantization).

2. Even when quantization uses native aten ops (Inductor-visible), the
   variance reduction (rnumel=hidden_dim) and quant reduction
   (rnumel=128) have different iteration spaces. Inductor scheduler
   requires rnumel1 == rnumel2 (simd.py:1337) and MixOrderReduction
   requires no producer-consumer relationship (scheduler.py:296).
   Neither can fuse them.

## Solution (3 layers)

### 1. Selective native quantization (fp8.py + fp8_utils.py)

For norm-adjacent linear layers (q_a_proj, q_b_proj, kv_a_proj,
kv_b_proj), replace the opaque QuantFP8 CustomOp with pure aten ops
(`_quantize_input_native`). Non-norm-adjacent layers (o_proj, MoE)
keep the optimized CUDA CustomOp.

Key technique: transposed-amax produces column-major scales without
.contiguous() copy — compute amax on permute(1,0,2) view so output
[G,B] contiguous = [B,G] col-major via .t() view.

### 2. Fused RMSNorm+FP8Quant Triton kernel (fp8_utils.py)

`_fused_rmsnorm_fp8_quant_kernel` — a two-pass persistent reduction:
- Pass 1: Read x, compute variance = mean(x^2) per row
- Pass 2: Read x again (L1 cache hit), normalize * weight, per-group
  amax -> scale -> FP8 cast, write column-major scales directly

Registered as `vllm::fused_rmsnorm_fp8_quant` custom_op. Replaces 2
Inductor kernels (triton_red + triton_per) with 1 custom kernel.

Applied to q_b_proj (preceded by q_a_layernorm). kv_b_proj cannot be
fused because kv_c_normed is stored in the KV cache.

### 3. Model integration (deepseek_v2.py + mla.py)

`_set_fused_norm()` stores RMSNorm weight/eps on the linear ops quant
op. The MLA forward skips standalone q_a_layernorm when the downstream
q_b_proj has fused norm (norm is done inside the fused kernel).

## E2E Codegen Verification

DeepSeek-R1 671B FP8, TP=8, compiled graph (rank0):

  fused_rmsnorm_fp8_quant calls:     6  (q_b_proj across layers)
  per_token_group_fp8_quant calls:   2  (non-norm-adjacent, CustomOp)
  triton_per (native quant):         9  (kv_b, q_a, kv_a)
  Scale layout: (s72, 12) strides (1, s72) — column-major confirmed

## Benchmark

DeepSeek-R1 671B FP8, TP=8, BS=1, input=128, output=8 (vllm bench latency):
rate = 15, num requests=600
  Baseline (all CUDA CustomOp):  98.15 ms
  This PR (fused Triton kernel): 95.91 ms  (-2.24 ms, -2.3%)

## Numerical Correctness

  BS=1:  q_diff=0.0 vs float32 reference (exact match)
  BS=8:  q_diff=0.0 (Triton reduction ordering, within FP8 precision)
  BS=64: q_diff=0.0 (within FP8 precision bounds)

The fused kernel operates in float32 throughout (no intermediate bf16
truncation), giving equal or better precision than separate norm->quant.

Test Plan:
## Codegen verification (quick, ~5 min compile)
```
VLLM_SKIP_NATIVE_QUANT=0 TORCH_LOGS=output_code \
vllm bench latency --model deepseek-ai/DeepSeek-R1 \
  --tensor-parallel-size 8 \
  --compilation-config '"'"'{"custom_ops": ["-rms_norm"]}'"'"' \
  --input-len 128 --output-len 2 --batch-size 1 \
  --num-iters 1 --num-iters-warmup 0 2>&1 | \
  grep "fused_rmsnorm_fp8_quant"
# Expected: 6 fused_rmsnorm_fp8_quant calls in compiled graph
```

## A/B benchmark
```
for SKIP in 1 0; do
  echo "=== SKIP=$SKIP ==="
  VLLM_SKIP_NATIVE_QUANT=$SKIP \
  vllm bench latency --model deepseek-ai/DeepSeek-R1 \
    --tensor-parallel-size 8 \
    --compilation-config '"'"'{"custom_ops": ["-rms_norm"]}'"'"' \
    --input-len 128 --output-len 8 --batch-size 1 \
    --num-iters 3 --num-iters-warmup 1
done
# SKIP=1 (baseline) vs SKIP=0 (fused): expect ~2% improvement
```

## Standalone numerical correctness test
```
python test_fused_rmsnorm_quant.py
# Tests fused kernel vs float32 reference across BS=1/8/64
# and hidden_dim=512/1536/7168
```

NOTE: Requires companion PyTorch PR for Inductor scheduler fix
(choices.py + scheduler.py). Without it, the native quant path for
kv_b/q_a/kv_a will produce extra triton_poi kernels.
' 2>&1

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

