### PR TITLE
[Frontend][Core] Add hierarchical cache salting for shared prefixes across tenants

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -994,25 +994,25 @@ async def test_serving_chat_did_set_correct_cache_salt(model_type):
     assert len(captured_inputs) == 1
     assert captured_inputs[0]["cache_salt"] == "test_salt"
 
-    captured_prompts.clear()
+    captured_inputs.clear()
 
     # Test with shared_prefix_tokens
     req.shared_prefix_tokens = 42
     with suppress(Exception):
         await serving_chat.create_chat_completion(req)
 
-    assert len(captured_prompts) == 1
-    assert captured_prompts[0].get("shared_prefix_tokens") == 42
+    assert len(captured_inputs) == 1
+    assert captured_inputs[0].get("shared_prefix_tokens") == 42
 
-    captured_prompts.clear()
+    captured_inputs.clear()
 
     # Test shared_prefix_tokens defaults to absent when 0
     req.shared_prefix_tokens = 0
     with suppress(Exception):
         await serving_chat.create_chat_completion(req)
 
-    assert len(captured_prompts) == 1
-    assert captured_prompts[0].get("shared_prefix_tokens", 0) == 0
+    assert len(captured_inputs) == 1
+    assert captured_inputs[0].get("shared_prefix_tokens", 0) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -994,6 +994,26 @@ async def test_serving_chat_did_set_correct_cache_salt(model_type):
     assert len(captured_inputs) == 1
     assert captured_inputs[0]["cache_salt"] == "test_salt"
 
+    captured_prompts.clear()
+
+    # Test with shared_prefix_tokens
+    req.shared_prefix_tokens = 42
+    with suppress(Exception):
+        await serving_chat.create_chat_completion(req)
+
+    assert len(captured_prompts) == 1
+    assert captured_prompts[0].get("shared_prefix_tokens") == 42
+
+    captured_prompts.clear()
+
+    # Test shared_prefix_tokens defaults to absent when 0
+    req.shared_prefix_tokens = 0
+    with suppress(Exception):
+        await serving_chat.create_chat_completion(req)
+
+    assert len(captured_prompts) == 1
+    assert captured_prompts[0].get("shared_prefix_tokens", 0) == 0
+
 
 @pytest.mark.asyncio
 async def test_serving_chat_data_parallel_rank_extraction():

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -73,6 +73,7 @@ def make_request(
     mm_hashes: list[str] | None = None,
     cache_salt: str | None = None,
     prompt_embeds: torch.Tensor | None = None,
+    shared_prefix_tokens: int = 0,
 ):
     mm_features = []
     if mm_positions is not None:
@@ -97,6 +98,7 @@ def make_request(
         pooling_params=None,
         lora_request=None,
         cache_salt=cache_salt,
+        shared_prefix_tokens=shared_prefix_tokens,
         block_hasher=get_request_block_hasher(block_size, hash_fn),
         prompt_embeds=prompt_embeds,
     )
@@ -515,6 +517,84 @@ def test_generate_block_hash_extra_keys_cache_salt():
     extra_keys, next_mm_idx = generate_block_hash_extra_keys(request_mm, 0, 5, 0)
     assert extra_keys == (("hash1", 0), "salt")
     assert next_mm_idx == 1
+
+
+def test_generate_block_hash_extra_keys_hierarchical_salt():
+    """When shared_prefix_tokens > 0, salt is injected at the boundary block
+    instead of block 0.  Blocks before the boundary carry no salt and can be
+    shared across tenants."""
+    block_size = 5
+
+    # -- pre-boundary blocks: no salt
+    request = make_request(
+        request_id="0",
+        prompt_token_ids=[_ for _ in range(20)],
+        block_size=block_size,
+        cache_salt="tenant_A",
+        shared_prefix_tokens=10,
+    )
+    extra_keys, _ = generate_block_hash_extra_keys(request, 0, 5, 0)
+    assert extra_keys is None  # block [0,5) before boundary
+    extra_keys, _ = generate_block_hash_extra_keys(request, 5, 10, 0)
+    assert extra_keys is None  # block [5,10) before boundary
+
+    # -- boundary block: salt injected
+    extra_keys, _ = generate_block_hash_extra_keys(request, 10, 15, 0)
+    assert extra_keys == ("tenant_A",)  # block [10,15) is boundary
+
+    # -- post-boundary blocks: no extra salt (inherited via parent chain)
+    extra_keys, _ = generate_block_hash_extra_keys(request, 15, 20, 0)
+    assert extra_keys is None
+
+    # -- spt=0 falls back to flat salt (block 0 gets salt)
+    request_flat = make_request(
+        request_id="1",
+        prompt_token_ids=[_ for _ in range(20)],
+        block_size=block_size,
+        cache_salt="tenant_A",
+        shared_prefix_tokens=0,
+    )
+    extra_keys, _ = generate_block_hash_extra_keys(request_flat, 0, 5, 0)
+    assert extra_keys == ("tenant_A",)  # flat: block 0 gets salt
+
+    # -- no cache_salt with spt > 0: no salt anywhere
+    request_nosalt = make_request(
+        request_id="2",
+        prompt_token_ids=[_ for _ in range(20)],
+        block_size=block_size,
+        shared_prefix_tokens=10,
+    )
+    extra_keys, _ = generate_block_hash_extra_keys(request_nosalt, 10, 15, 0)
+    assert extra_keys is None
+
+    # -- spt mid-block: salt goes on the block containing spt
+    request_mid = make_request(
+        request_id="3",
+        prompt_token_ids=[_ for _ in range(20)],
+        block_size=block_size,
+        cache_salt="s",
+        shared_prefix_tokens=7,
+    )
+    extra_keys, _ = generate_block_hash_extra_keys(request_mid, 0, 5, 0)
+    assert extra_keys is None  # block [0,5): 0<=7<5 is False
+    extra_keys, _ = generate_block_hash_extra_keys(request_mid, 5, 10, 0)
+    assert extra_keys == ("s",)  # block [5,10): 5<=7<10 is True
+
+    # -- different salts produce different boundary blocks but same
+    #    pre-boundary blocks
+    request_b = make_request(
+        request_id="4",
+        prompt_token_ids=[_ for _ in range(20)],
+        block_size=block_size,
+        cache_salt="tenant_B",
+        shared_prefix_tokens=10,
+    )
+    ea, _ = generate_block_hash_extra_keys(request, 0, 5, 0)
+    eb, _ = generate_block_hash_extra_keys(request_b, 0, 5, 0)
+    assert ea == eb  # both None — pre-boundary shared
+    ea, _ = generate_block_hash_extra_keys(request, 10, 15, 0)
+    eb, _ = generate_block_hash_extra_keys(request_b, 10, 15, 0)
+    assert ea == ("tenant_A",) and eb == ("tenant_B",)
 
 
 def test_generate_block_hash_extra_keys_prompt_embeds():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -62,6 +62,7 @@ def make_request(
     prompt_logprobs: int | None = None,
     cache_salt: str | None = None,
     lora_request: LoRARequest | None = None,
+    shared_prefix_tokens: int = 0,
 ):
     mm_features = []
     if mm_positions is not None:
@@ -86,6 +87,7 @@ def make_request(
         pooling_params=None,
         lora_request=lora_request,
         cache_salt=cache_salt,
+        shared_prefix_tokens=shared_prefix_tokens,
         block_hasher=get_request_block_hasher(block_size, hash_fn),
     )
 
@@ -1710,6 +1712,86 @@ def test_cache_key_salting():
     assert block_hashes[2] == sha256(
         (block_hashes[1], tuple(token_ids[block_size * 2 : block_size * 3]), None)
     )
+
+
+def test_hierarchical_cache_key_salting():
+    """
+    When shared_prefix_tokens > 0, blocks before the boundary are unsalted
+    and can be shared across tenants, while blocks at/after the boundary are
+    isolated via the parent-hash chain.
+    """
+    block_size = 16
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, 20),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    # 3 shared-prefix blocks + 1 private block (11 tokens).
+    shared_len = 3 * block_size  # 48 tokens shared
+    common_token_ids = [i for i in range(3) for _ in range(block_size)]
+    token_ids_a = common_token_ids + [3] * 11
+    token_ids_b = common_token_ids + [3] * 11  # same content, different salt
+
+    req_a = make_request(
+        "a",
+        token_ids_a,
+        block_size,
+        sha256,
+        cache_salt="salt_A",
+        shared_prefix_tokens=shared_len,
+    )
+    req_b = make_request(
+        "b",
+        token_ids_b,
+        block_size,
+        sha256,
+        cache_salt="salt_B",
+        shared_prefix_tokens=shared_len,
+    )
+
+    # Pre-boundary block hashes should be identical (shared, no salt).
+    assert req_a.block_hashes[0] == req_b.block_hashes[0]
+    assert req_a.block_hashes[1] == req_b.block_hashes[1]
+    assert req_a.block_hashes[2] == req_b.block_hashes[2]
+
+    # Boundary block (block 3) should differ due to different salts.
+    # Block 3 starts at token 48 = shared_len, so salt is injected here.
+    # With 11 tokens in the 4th block it's incomplete so no block_hash[3]
+    # in the initial hashing. Instead verify via get_computed_blocks.
+
+    # Allocate blocks for req_a first.
+    computed_a, num_a = manager.get_computed_blocks(req_a)
+    assert len(computed_a.blocks[0]) == 0  # nothing cached yet
+    blocks_a = manager.allocate_slots(
+        req_a,
+        len(token_ids_a) - num_a,
+        num_a,
+        computed_a,
+    )
+    assert blocks_a is not None
+    req_a.num_computed_tokens = len(token_ids_a)
+
+    # Now req_b should share the first 3 blocks (pre-boundary).
+    # But NOT match after the boundary because salt differs.
+    computed_b, num_b = manager.get_computed_blocks(req_b)
+    # The first 3 blocks are shared (same hash, no salt).
+    assert len(computed_b.blocks[0]) == 3
+    assert num_b == 3 * block_size
+
+    # Compare with flat salt: nothing should be shared.
+    req_flat = make_request(
+        "c",
+        token_ids_b,
+        block_size,
+        sha256,
+        cache_salt="salt_B",
+        shared_prefix_tokens=0,
+    )
+    computed_flat, num_flat = manager.get_computed_blocks(req_flat)
+    assert len(computed_flat.blocks[0]) == 0  # flat salt: block 0 differs
+    assert num_flat == 0
 
 
 def test_prefill_not_enough_free_blocks_with_computed_blocks():

--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -43,12 +43,14 @@ class BeamSearchSequence:
         # Handle decoder-only inputs
         prompt_text = prompt.get("prompt")
         cache_salt = prompt.get("cache_salt")
+        shared_prefix_tokens = prompt.get("shared_prefix_tokens", 0)
 
         if prompt["type"] == "token":
             return tokens_input(
                 self.tokens,
                 prompt=prompt_text,
                 cache_salt=cache_salt,
+                shared_prefix_tokens=shared_prefix_tokens,
             )
 
         return mm_input(
@@ -58,6 +60,7 @@ class BeamSearchSequence:
             mm_placeholders=prompt["mm_placeholders"],
             prompt=prompt_text,
             cache_salt=cache_salt,
+            shared_prefix_tokens=shared_prefix_tokens,
         )
 
     def _build_encoder_decoder_inputs(
@@ -84,12 +87,14 @@ class BeamSearchSequence:
                 mm_placeholders=dec_prompt["mm_placeholders"],
                 prompt=dec_prompt.get("prompt"),
                 cache_salt=dec_prompt.get("cache_salt"),
+                shared_prefix_tokens=dec_prompt.get("shared_prefix_tokens", 0),
             )
         else:
             new_dec_prompt = tokens_input(
                 self.tokens,
                 prompt=dec_prompt.get("prompt"),
                 cache_salt=dec_prompt.get("cache_salt"),
+                shared_prefix_tokens=dec_prompt.get("shared_prefix_tokens", 0),
             )
 
         return EncoderDecoderInput(

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -332,6 +332,21 @@ class ChatCompletionRequest(OpenAIBaseModel):
         ),
     )
 
+    shared_prefix_tokens: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When positive and cache_salt is set, the salt is applied "
+            "starting at the block containing this token offset instead of "
+            "block 0. Blocks before this boundary are hashed without the "
+            "salt and can be shared across tenants (e.g., a common system "
+            "prompt). Blocks at and after the boundary inherit tenant "
+            "isolation through the parent-hash chain. The offset refers to "
+            "the final tokenized prompt; the effective shared region is "
+            "rounded down to the nearest block boundary."
+        ),
+    )
+
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None,
         description="KVTransfer parameters used for disaggregated serving.",

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -154,6 +154,21 @@ class CompletionRequest(OpenAIBaseModel):
         ),
     )
 
+    shared_prefix_tokens: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When positive and cache_salt is set, the salt is applied "
+            "starting at the block containing this token offset instead of "
+            "block 0. Blocks before this boundary are hashed without the "
+            "salt and can be shared across tenants (e.g., a common system "
+            "prompt). Blocks at and after the boundary inherit tenant "
+            "isolation through the parent-hash chain. The offset refers to "
+            "the final tokenized prompt; the effective shared region is "
+            "rounded down to the nearest block boundary."
+        ),
+    )
+
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None,
         description="KVTransfer parameters used for disaggregated serving.",

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -224,6 +224,21 @@ class ResponsesRequest(OpenAIBaseModel):
         ),
     )
 
+    shared_prefix_tokens: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When positive and cache_salt is set, the salt is applied "
+            "starting at the block containing this token offset instead of "
+            "block 0. Blocks before this boundary are hashed without the "
+            "salt and can be shared across tenants (e.g., a common system "
+            "prompt). Blocks at and after the boundary inherit tenant "
+            "isolation through the parent-hash chain. The offset refers to "
+            "the final tokenized prompt; the effective shared region is "
+            "rounded down to the nearest block boundary."
+        ),
+    )
+
     enable_response_messages: bool = Field(
         default=False,
         description=(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -716,6 +716,9 @@ class OpenAIServingResponses(OpenAIServing):
         engine_input = tokens_input(prompt_token_ids, cache_salt=request.cache_salt)
         engine_input["arrival_time"] = arrival_time
 
+        if getattr(request, "shared_prefix_tokens", 0) > 0:
+            engine_input["shared_prefix_tokens"] = request.shared_prefix_tokens
+
         return messages, [engine_input]
 
     async def _initialize_tool_sessions(

--- a/vllm/entrypoints/serve/disagg/protocol.py
+++ b/vllm/entrypoints/serve/disagg/protocol.py
@@ -92,6 +92,20 @@ class GenerateRequest(BaseModel):
             "to 256 bit)."
         ),
     )
+    shared_prefix_tokens: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When positive and cache_salt is set, the salt is applied "
+            "starting at the block containing this token offset instead of "
+            "block 0. Blocks before this boundary are hashed without the "
+            "salt and can be shared across tenants (e.g., a common system "
+            "prompt). Blocks at and after the boundary inherit tenant "
+            "isolation through the parent-hash chain. The offset refers to "
+            "the final tokenized prompt; the effective shared region is "
+            "rounded down to the nearest block boundary."
+        ),
+    )
     priority: int = Field(
         default=0,
         ge=-(2**63),

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -171,6 +171,7 @@ class OpenAIServingRender:
             stream=bool(request.stream),
             stream_options=(request.stream_options if request.stream else None),
             cache_salt=request.cache_salt,
+            shared_prefix_tokens=getattr(request, "shared_prefix_tokens", 0),
             priority=request.priority,
         )
 
@@ -304,6 +305,7 @@ class OpenAIServingRender:
                     stream=bool(request.stream),
                     stream_options=(request.stream_options if request.stream else None),
                     cache_salt=request.cache_salt,
+                    shared_prefix_tokens=getattr(request, "shared_prefix_tokens", 0),
                     priority=request.priority,
                 )
             )
@@ -408,6 +410,9 @@ class OpenAIServingRender:
         prompt_token_ids = render_for_completion(messages)
         engine_input = tokens_input(prompt_token_ids, cache_salt=request.cache_salt)
 
+        if getattr(request, "shared_prefix_tokens", 0) > 0:
+            engine_input["shared_prefix_tokens"] = request.shared_prefix_tokens
+
         return messages, [engine_input]
 
     def create_error_response(
@@ -484,7 +489,7 @@ class OpenAIServingRender:
             tok_params,
             prompt_extras={
                 k: v
-                for k in ("mm_processor_kwargs", "cache_salt")
+                for k in ("mm_processor_kwargs", "cache_salt", "shared_prefix_tokens")
                 if (v := getattr(request, k, None)) is not None
             },
         )
@@ -526,7 +531,7 @@ class OpenAIServingRender:
             tok_params,
             prompt_extras={
                 k: v
-                for k in ("mm_processor_kwargs", "cache_salt")
+                for k in ("mm_processor_kwargs", "cache_salt", "shared_prefix_tokens")
                 if (v := getattr(request, k, None)) is not None
             },
         )

--- a/vllm/inputs/engine.py
+++ b/vllm/inputs/engine.py
@@ -25,6 +25,9 @@ class _InputOptions(TypedDict):
     cache_salt: NotRequired[str]
     """Optional cache salt to be used for prefix caching."""
 
+    shared_prefix_tokens: NotRequired[int]
+    """When positive, shifts cache_salt injection to the boundary block."""
+
 
 class TokensInput(_InputOptions):
     """Represents token-based input to the engine."""
@@ -44,6 +47,7 @@ def tokens_input(
     *,
     prompt: str | None = None,
     cache_salt: str | None = None,
+    shared_prefix_tokens: int = 0,
 ) -> TokensInput:
     """
     Construct [`TokensInput`][vllm.inputs.engine.TokensInput]
@@ -55,6 +59,8 @@ def tokens_input(
         inputs["prompt"] = prompt
     if cache_salt is not None:
         inputs["cache_salt"] = cache_salt
+    if shared_prefix_tokens > 0:
+        inputs["shared_prefix_tokens"] = shared_prefix_tokens
 
     return inputs
 
@@ -77,6 +83,7 @@ def embeds_input(
     *,
     prompt: str | None = None,
     cache_salt: str | None = None,
+    shared_prefix_tokens: int = 0,
 ) -> EmbedsInput:
     """
     Construct [`EmbedsInput`][vllm.inputs.engine.EmbedsInput]
@@ -88,6 +95,8 @@ def embeds_input(
         inputs["prompt"] = prompt
     if cache_salt is not None:
         inputs["cache_salt"] = cache_salt
+    if shared_prefix_tokens > 0:
+        inputs["shared_prefix_tokens"] = shared_prefix_tokens
 
     return inputs
 
@@ -137,6 +146,7 @@ def mm_input(
     *,
     prompt: str | None = None,
     cache_salt: str | None = None,
+    shared_prefix_tokens: int = 0,
 ) -> MultiModalInput:
     inputs = MultiModalInput(
         type="multimodal",
@@ -150,6 +160,8 @@ def mm_input(
         inputs["prompt"] = prompt
     if cache_salt is not None:
         inputs["cache_salt"] = cache_salt
+    if shared_prefix_tokens > 0:
+        inputs["shared_prefix_tokens"] = shared_prefix_tokens
 
     return inputs
 
@@ -192,6 +204,8 @@ def mm_enc_dec_input(
         inputs["encoder_prompt"] = encoder_inputs["prompt"]
     if "cache_salt" in encoder_inputs:
         inputs["cache_salt"] = encoder_inputs["cache_salt"]
+    if (spt := encoder_inputs.get("shared_prefix_tokens", 0)) > 0:
+        inputs["shared_prefix_tokens"] = spt
 
     return inputs
 
@@ -335,6 +349,8 @@ def build_enc_dec_input(
 
     if cache_salt := enc_input.get("cache_salt"):
         dec_input_new["cache_salt"] = cache_salt
+    if (spt := enc_input.get("shared_prefix_tokens", 0)) > 0:
+        dec_input_new["shared_prefix_tokens"] = spt
 
     return EncoderDecoderInput(
         type="enc_dec",

--- a/vllm/inputs/llm.py
+++ b/vllm/inputs/llm.py
@@ -95,6 +95,12 @@ class _PromptOptions(TypedDict):
     Optional cache salt to be used for prefix caching.
     """
 
+    shared_prefix_tokens: NotRequired[int]
+    """
+    When positive and cache_salt is set, the salt is applied starting at
+    the block containing this token offset instead of block 0.
+    """
+
 
 class TextPrompt(_PromptOptions):
     """Schema for a text prompt."""

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -155,6 +155,8 @@ class InputPreprocessor:
             inputs["prompt"] = prompt_text
         if cache_salt := parsed_content.get("cache_salt"):
             inputs["cache_salt"] = cache_salt
+        if (spt := parsed_content.get("shared_prefix_tokens", 0)) > 0:
+            inputs["shared_prefix_tokens"] = spt
 
         return inputs
 
@@ -184,6 +186,8 @@ class InputPreprocessor:
 
         if cache_salt := parsed_content.get("cache_salt"):
             inputs["cache_salt"] = cache_salt
+        if (spt := parsed_content.get("shared_prefix_tokens", 0)) > 0:
+            inputs["shared_prefix_tokens"] = spt
 
         return inputs
 

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -648,6 +648,8 @@ class BaseRenderer(ABC, Generic[_T]):
             engine_input["prompt"] = prompt_text
         if cache_salt := prompt.get("cache_salt"):
             engine_input["cache_salt"] = cache_salt
+        if (spt := prompt.get("shared_prefix_tokens", 0)) > 0:
+            engine_input["shared_prefix_tokens"] = spt
 
         return engine_input
 
@@ -677,6 +679,7 @@ class BaseRenderer(ABC, Generic[_T]):
         return embeds_input(
             prompt_embeds=prompt_embeds,
             cache_salt=prompt.get("cache_salt"),
+            shared_prefix_tokens=prompt.get("shared_prefix_tokens", 0),
         )
 
     def _process_singleton(self, prompt: SingletonTokPrompt) -> SingletonInput:

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -286,7 +286,8 @@ class BlockPool:
 
             # Generate extra keys for each block individually.
             # Each block may have different extra_keys (e.g., different MM
-            # features, or cache_salt only for the first block).
+            # features, or cache_salt at block 0 for flat salt / at the
+            # boundary block for hierarchical salt).
             # Skip null blocks to match the length of new_hashes.
             extra_keys_list: list[tuple[Any, ...] | None] = []
             curr_mm_idx = 0

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -515,9 +515,24 @@ def generate_block_hash_extra_keys(
         request, start_token_idx, end_token_idx, start_mm_idx
     )
     lora_extra_keys: list[str] = _gen_lora_extra_hash_keys(request)
-    cache_salt_keys: list[str] = (
-        [request.cache_salt] if (start_token_idx == 0 and request.cache_salt) else []
-    )
+    # Hierarchical cache salt: when shared_prefix_tokens > 0, apply the
+    # tenant salt only at the boundary block (first block at or after the
+    # shared prefix length).  Blocks before the boundary carry no salt and
+    # can be reused across tenants.  Blocks after the boundary inherit
+    # isolation through the parent-hash chain.
+    _shared = getattr(request, "shared_prefix_tokens", 0)
+    if request.cache_salt and _shared > 0:
+        # Salt goes on the boundary block, not block 0
+        cache_salt_keys = (
+            [request.cache_salt] if (start_token_idx <= _shared < end_token_idx) else []
+        )
+    else:
+        # Legacy flat salt: inject on block 0 only
+        cache_salt_keys = (
+            [request.cache_salt]
+            if (start_token_idx == 0 and request.cache_salt)
+            else []
+        )
     prompt_embeds_keys = _gen_prompt_embeds_extra_hash_keys(
         request, start_token_idx, end_token_idx
     )

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -77,7 +77,8 @@ class EngineCoreRequest(
     arrival_time: float
     lora_request: LoRARequest | None
     cache_salt: str | None
-    data_parallel_rank: int | None
+    shared_prefix_tokens: int = 0
+    data_parallel_rank: int | None = None
     prompt_embeds: torch.Tensor | None = None
 
     # Index of the client, used to ensure outputs are sent back to the same

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -77,8 +77,7 @@ class EngineCoreRequest(
     arrival_time: float
     lora_request: LoRARequest | None
     cache_salt: str | None
-    shared_prefix_tokens: int = 0
-    data_parallel_rank: int | None = None
+    data_parallel_rank: int | None
     prompt_embeds: torch.Tensor | None = None
 
     # Index of the client, used to ensure outputs are sent back to the same
@@ -101,6 +100,7 @@ class EngineCoreRequest(
     external_req_id: str | None = None
 
     reasoning_ended: bool | None = None
+    shared_prefix_tokens: int = 0
 
     @property
     def params(self) -> SamplingParams | PoolingParams:

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -328,6 +328,12 @@ class InputProcessor:
             arrival_time=arrival_time,
             lora_request=lora_request,
             cache_salt=decoder_inputs.get("cache_salt"),
+            shared_prefix_tokens=min(
+                int(decoder_inputs.get("shared_prefix_tokens", 0)),
+                len(prompt_token_ids)
+                if prompt_token_ids
+                else (prompt_embeds.shape[0] if prompt_embeds is not None else 0),
+            ),
             priority=priority,
             data_parallel_rank=data_parallel_rank,
             trace_headers=trace_headers,

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -135,7 +135,9 @@ class Request:
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: str | None = cache_salt
-        self.shared_prefix_tokens: int = shared_prefix_tokens
+        self.shared_prefix_tokens: int = min(
+            shared_prefix_tokens, self.num_prompt_tokens
+        )
 
         # Multi-modal related
         self.mm_features = mm_features or []

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -68,6 +68,7 @@ class Request:
         mm_features: list[MultiModalFeatureSpec] | None = None,
         lora_request: "LoRARequest | None" = None,
         cache_salt: str | None = None,
+        shared_prefix_tokens: int = 0,
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
         block_hasher: Callable[["Request"], list["BlockHash"]] | None = None,
@@ -134,6 +135,7 @@ class Request:
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: str | None = cache_salt
+        self.shared_prefix_tokens: int = shared_prefix_tokens
 
         # Multi-modal related
         self.mm_features = mm_features or []
@@ -193,6 +195,7 @@ class Request:
             arrival_time=request.arrival_time,
             lora_request=request.lora_request,
             cache_salt=request.cache_salt,
+            shared_prefix_tokens=getattr(request, "shared_prefix_tokens", 0),
             priority=request.priority,
             trace_headers=request.trace_headers,
             block_hasher=block_hasher,


### PR DESCRIPTION
# Background

[RFC #16016](https://github.com/vllm-project/vllm/issues/16016) proposed two designs for cache salting:

- **(A) Single-barrier** — one salt per request, injected at block 0. Implemented in [#17045](https://github.com/vllm-project/vllm/pull/17045) and later extended to `/v1/completions` and `/v1/responses` in [#20981](https://github.com/vllm-project/vllm/pull/20981).
- **(B) Multi-barrier** — per-message salts via `cache_salt_map`, allowing shared prefix reuse while isolating tenant-specific suffixes. Left as future work when the RFC was [closed](https://github.com/vllm-project/vllm/issues/16016#issuecomment-2854434683): *"Closing now and getting back to multi barrier design (part B) only if needed."*

The single-barrier design works well for full isolation, but in multi-tenant deployments where tenants share a common system prompt, it forces redundant recomputation of the shared prefix for every tenant. With 256 tenants, this means 256x duplicate prefill of the same system prompt blocks — `cache_salt` effectively disables prefix caching for shared content.

# Suggested change

This PR implements a simplified version of Option B by adding a single `shared_prefix_tokens` parameter. Instead of the full `cache_salt_map` with per-message granularity, it uses a token offset to define the boundary:

- Blocks before the boundary are hashed without salt and can be shared across tenants (e.g., common system prompt)
- The boundary block (containing the offset) gets the `cache_salt` injected
- Blocks after the boundary inherit tenant isolation through the parent-hash chain

```json
{
  "model": "Qwen/Qwen2.5-7B-Instruct",
  "messages": [
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "Tell me about ..."}
  ],
  "cache_salt": "tenant_abc",
  "shared_prefix_tokens": 512
}
```

```python
response = client.chat.completions.create(
    model=model,
    messages=messages,
    extra_body={
        "cache_salt": "tenant_abc",
        "shared_prefix_tokens": 512,
    },
)
```

Key properties:
- Backward compatible: `shared_prefix_tokens=0` (default) preserves existing flat salt behavior
- The offset refers to the final tokenized prompt; the effective shared region is rounded down to the nearest block boundary
- Values exceeding prompt length are clamped
- Propagated through all V1 generation paths (completions, chat, responses, disagg, beam search, embeds)

E2E verification (Qwen2.5-7B, 4 tenants, RTX PRO 6000 Blackwell, this branch):

| Mode | Computed | Cache hit | Latency (B/C/D) |
|---|---|---|---|
| no_salt | 96 | 96 | 69-70ms |
| flat_salt (#17045) | 192 | 0 | 72-74ms |
| hier_salt (this PR) | 144 | 48 | 70-72ms |

hier_salt: tenants B/C/D each reuse the 16-token shared prefix block → 48 tokens cache hit.
flat_salt: all blocks isolated → 0 cache hit, 2x compute.

Under load (Qwen2.5-7B, 16 tenants, 4 trials averaged, same GPU):

| Mode | Concurrency | Cache hit | Throughput | Avg latency |
|---|---|---|---|---|
| no_salt | 8 | 67.3% | 177 rps | 43ms |
| hier_salt (this PR) | 8 | 62.7% | 174 rps | 44ms |
| flat_salt (#17045) | 8 | 58.2% | 180 rps | 44ms |
| no_salt | 16 | 67.3% | 261 rps | 55ms |
| hier_salt (this PR) | 16 | 62.8% | 233 rps | 63ms |
| flat_salt (#17045) | 16 | 58.2% | 211 rps | 69ms |
| no_salt | 32 | 67.3% | 340 rps | 80ms |
| hier_salt (this PR) | 32 | 62.8% | 316 rps | 84ms |
| flat_salt (#17045) | 32 | 58.2% | 290 rps | 92ms |

Cache hit follows theory: no_salt 67% > hier_salt 63% > flat_salt 58%. At higher concurrency, hier_salt tracks no_salt while flat_salt falls behind.

Changes:

| File | Change |
|------|--------|
| `v1/core/kv_cache_utils.py` | Boundary-based salt injection in `generate_block_hash_extra_keys()` |
| `v1/request.py`, `v1/engine/__init__.py`, `v1/engine/input_processor.py` | `shared_prefix_tokens` field propagation + clamp |
| `entrypoints/openai/{completion,chat_completion,responses}/protocol.py` | API field (`ge=0`, default 0) |
| `entrypoints/serve/render/serving.py`, `renderers/base.py` | Passthrough (tokens + embeds paths) |
| `entrypoints/serve/disagg/protocol.py` | `GenerateRequest` field |
| `inputs/data.py`, `multimodal/inputs.py` | TypedDict + helper functions |
| `beam_search.py` | Propagation in decoder-only and enc-dec paths |
| `v1/core/block_pool.py` | Stale comment fix |

## Test Plan

```bash
pytest tests/v1/core/test_kv_cache_utils.py -v -s -k test_generate_block_hash_extra_keys
pytest tests/v1/core/test_prefix_caching.py -v -s -k "test_cache_key_salting or test_hierarchical"
pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py -v -s -k test_serving_chat_did_set_correct_cache_salt
```

## Test Result

```
tests/v1/core/test_kv_cache_utils.py::test_generate_block_hash_extra_keys_cache_salt PASSED
tests/v1/core/test_kv_cache_utils.py::test_generate_block_hash_extra_keys_hierarchical_salt PASSED
tests/v1/core/test_prefix_caching.py::test_cache_key_salting PASSED
tests/v1/core/test_prefix_caching.py::test_hierarchical_cache_key_salting PASSED
tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_serving_chat_did_set_correct_cache_salt PASSED

Full suite (test_kv_cache_utils.py + test_prefix_caching.py): 100 passed
pre-commit run --all-files: all passed
```

---

- [x] Purpose with linked RFC (#16016) and prior PR (#17045)
- [x] Test plan with commands
- [x] Test result