### PR TITLE
[XPU] Support Intel XPU hardware information collection in usage stats

### DIFF
--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -136,6 +136,7 @@ class UsageMessage:
         self.total_memory: int | None = None
         self.architecture: str | None = None
         self.platform: str | None = None
+        self.xpu_runtime: str | None = None
         self.cuda_runtime: str | None = None
         self.gpu_count: int | None = None
         self.gpu_type: str | None = None
@@ -201,6 +202,11 @@ class UsageMessage:
             )
         if current_platform.is_cuda():
             self.cuda_runtime = torch.version.cuda
+        if current_platform.is_xpu():
+            self.xpu_runtime = torch.version.xpu
+            self.gpu_count = torch.xpu.device_count()
+            self.gpu_type = torch.xpu.get_device_name(0)
+            self.gpu_memory_per_device = torch.xpu.get_device_properties(0).total_memory
         if current_platform.is_tpu():  # noqa: SIM102
             if not self._report_tpu_inference_usage():
                 logger.exception("Failed to collect TPU information")


### PR DESCRIPTION



## Purpose
Currently, vLLM's usage stats reporting lacks specific hardware details when running on Intel XPU platforms, resulting in `gpu_type` and `gpu_count` being reported as `null`. 

This PR adds XPU platform detection in `vllm/usage/usage_lib.py` to correctly capture:
- `xpu_runtime` (torch.version.xpu)
- `gpu_count` (via torch.xpu)
- `gpu_type` (device name, e.g., "Intel(R) Arc(TM) Pro B60")
- `gpu_memory_per_device`
## Test Plan
python -m vllm.entrypoints.openai.api_server --model facebook/opt-125m --trust-remote-code --port 8000
## Test Result
{"uuid": "d8d661a8-cd12-45f4-bea6-107bd02c3c53", "provider": "UNKNOWN", "num_cpu": 192, "cpu_type": "Intel(R) Xeon(R) Platinum 8468", "cpu_family_model_stepping": "6,143,8", "total_memory": 1077262282752, "architecture": "x86_64", "platform": "Linux-6.14.0-22-generic-x86_64-with-glibc2.39", "xpu_runtime": "20250301", "cuda_runtime": null, "gpu_count": 8, "gpu_type": "Intel(R) Arc(TM) Pro B60 Graphics", "gpu_memory_per_device": 24385683456, "env_var_json": "{\"VLLM_USE_MODELSCOPE\": false, \"VLLM_USE_FLASHINFER_SAMPLER\": null, \"VLLM_PP_LAYER_PARTITION\": null, \"VLLM_USE_TRITON_AWQ\": false, \"VLLM_ENABLE_V1_MULTIPROCESSING\": true}", 
"model_architecture": "OPTForCausalLM", "vllm_version": "0.13.0rc2.dev2537+g006aea17d", "context": "ENGINE_CONTEXT", "log_time": 1774329998549204992, "source": "production", "dtype": "torch.float16", "block_size": 64, "gpu_memory_utilization": 0.9, "kv_cache_memory_bytes": null, "quantization": null, "kv_cache_dtype": "auto", "enable_lora": false, "enable_prefix_caching": true, "enforce_eager": false, "disable_custom_all_reduce": true, "tensor_parallel_size": 1, "data_parallel_size": 1, "pipeline_parallel_size": 1, "enable_expert_parallel": false, "all2all_backend": "allgather_reducescatter", "kv_connector": null}
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

