### PR TITLE
[Bug] Serialize xgrammar compilation for parallel structured outputs

### DIFF
--- a/tests/v1/structured_output/test_backend_xgrammar.py
+++ b/tests/v1/structured_output/test_backend_xgrammar.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import DeviceConfig, StructuredOutputsConfig, VllmConfig
+from vllm.v1.structured_output import backend_xgrammar
+from vllm.v1.structured_output.backend_types import StructuredOutputOptions
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.skip_global_cleanup
+def test_xgrammar_backend_serializes_compile_calls(monkeypatch):
+    compiler_state = {
+        "active_calls": 0,
+        "max_active_calls": 0,
+    }
+    compiler_state_lock = threading.Lock()
+
+    class FakeTokenizerInfo:
+        @staticmethod
+        def from_huggingface(tokenizer, vocab_size):
+            return (tokenizer, vocab_size)
+
+    class FakeGrammarCompiler:
+        def __init__(self, tokenizer_info, **kwargs):
+            self.tokenizer_info = tokenizer_info
+            self.kwargs = kwargs
+
+        def compile_grammar(self, grammar_spec):
+            with compiler_state_lock:
+                compiler_state["active_calls"] += 1
+                compiler_state["max_active_calls"] = max(
+                    compiler_state["max_active_calls"],
+                    compiler_state["active_calls"],
+                )
+            try:
+                time.sleep(0.1)
+                return grammar_spec
+            finally:
+                with compiler_state_lock:
+                    compiler_state["active_calls"] -= 1
+
+    class FakeGrammarMatcher:
+        def __init__(self, ctx, max_rollback_tokens):
+            self.ctx = ctx
+            self.max_rollback_tokens = max_rollback_tokens
+
+        def accept_token(self, token):
+            return True
+
+        def rollback(self, num_tokens):
+            pass
+
+        def fill_next_token_bitmask(self, bitmask, idx):
+            pass
+
+        def is_terminated(self):
+            return False
+
+        def reset(self):
+            pass
+
+    monkeypatch.setattr(
+        backend_xgrammar,
+        "xgr",
+        SimpleNamespace(
+            TokenizerInfo=FakeTokenizerInfo,
+            GrammarCompiler=FakeGrammarCompiler,
+            GrammarMatcher=FakeGrammarMatcher,
+        ),
+    )
+    monkeypatch.setattr(
+        backend_xgrammar, "is_mistral_tokenizer", lambda tokenizer: False
+    )
+
+    backend = backend_xgrammar.XgrammarBackend(
+        VllmConfig(
+            structured_outputs_config=StructuredOutputsConfig(backend="xgrammar"),
+            device_config=DeviceConfig("cpu"),
+        ),
+        tokenizer=object(),
+        vocab_size=32,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(
+                backend.compile_grammar,
+                StructuredOutputOptions.GRAMMAR,
+                'root ::= "ok"',
+            )
+            for _ in range(2)
+        ]
+        grammars = [future.result() for future in futures]
+
+    assert compiler_state["max_active_calls"] == 1
+    assert grammars[0].matcher is not grammars[1].matcher

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -3,6 +3,7 @@
 
 import json
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -33,7 +34,15 @@ logger = init_logger(__name__)
 
 @dataclass
 class XgrammarBackend(StructuredOutputBackend):
+    _compiler_lock: Lock = field(init=False, repr=False, hash=False)
+
     def __post_init__(self):
+        # Async grammar initialization can submit multiple requests that share
+        # the same GrammarCompiler instance (for example, parallel sampling
+        # with n > 1). Serialize compiler access so each request gets an
+        # independently-initialized grammar.
+        self._compiler_lock = Lock()
+
         self.disable_any_whitespace = (
             self.vllm_config.structured_outputs_config.disable_any_whitespace
         )
@@ -77,49 +86,54 @@ class XgrammarBackend(StructuredOutputBackend):
     def compile_grammar(
         self, request_type: StructuredOutputOptions, grammar_spec: str
     ) -> StructuredOutputGrammar:
-        if request_type == StructuredOutputOptions.JSON:
-            ctx = self.compiler.compile_json_schema(
-                grammar_spec, any_whitespace=not self.disable_any_whitespace
-            )
-        elif request_type == StructuredOutputOptions.JSON_OBJECT:
-            ctx = self.compiler.compile_json_schema(
-                '{"type": "object"}', any_whitespace=not self.disable_any_whitespace
-            )
-        elif request_type == StructuredOutputOptions.GRAMMAR:
-            ctx = self.compiler.compile_grammar(grammar_spec)
-        elif request_type == StructuredOutputOptions.REGEX:
-            ctx = self.compiler.compile_regex(grammar_spec)
-        elif request_type == StructuredOutputOptions.STRUCTURAL_TAG:
-            s_tag = json.loads(grammar_spec)
-            if "structures" in s_tag:
-                # Falling back to deprecated method of compiling structural tag
-                tags = [
-                    xgr.StructuralTagItem(
-                        begin=s["begin"],
-                        schema=json.dumps(s["schema"]),
-                        end=s["end"],
+        with self._compiler_lock:
+            if request_type == StructuredOutputOptions.JSON:
+                ctx = self.compiler.compile_json_schema(
+                    grammar_spec, any_whitespace=not self.disable_any_whitespace
+                )
+            elif request_type == StructuredOutputOptions.JSON_OBJECT:
+                ctx = self.compiler.compile_json_schema(
+                    '{"type": "object"}',
+                    any_whitespace=not self.disable_any_whitespace,
+                )
+            elif request_type == StructuredOutputOptions.GRAMMAR:
+                ctx = self.compiler.compile_grammar(grammar_spec)
+            elif request_type == StructuredOutputOptions.REGEX:
+                ctx = self.compiler.compile_regex(grammar_spec)
+            elif request_type == StructuredOutputOptions.STRUCTURAL_TAG:
+                s_tag = json.loads(grammar_spec)
+                if "structures" in s_tag:
+                    # Falling back to deprecated method of compiling
+                    # structural tag.
+                    tags = [
+                        xgr.StructuralTagItem(
+                            begin=s["begin"],
+                            schema=json.dumps(s["schema"]),
+                            end=s["end"],
+                        )
+                        for s in s_tag["structures"]
+                    ]
+                    ctx = self.compiler.compile_structural_tag(
+                        tags, s_tag["triggers"]
                     )
-                    for s in s_tag["structures"]
-                ]
-                ctx = self.compiler.compile_structural_tag(tags, s_tag["triggers"])
+                else:
+                    ctx = self.compiler.compile_structural_tag(grammar_spec)
             else:
-                ctx = self.compiler.compile_structural_tag(grammar_spec)
-        else:
-            logger.error(
-                "Validation should have already occurred. Please file an issue."
-            )
-            raise ValueError(
-                f"grammar is not of valid supported types. ({request_type!s})"
-            )
+                logger.error(
+                    "Validation should have already occurred. Please file an issue."
+                )
+                raise ValueError(
+                    f"grammar is not of valid supported types. ({request_type!s})"
+                )
 
-        return XgrammarGrammar(
-            matcher=xgr.GrammarMatcher(
-                ctx,
-                max_rollback_tokens=self.num_speculative_tokens,
-            ),
-            vocab_size=self.vocab_size,
-            ctx=ctx,
-        )
+            return XgrammarGrammar(
+                matcher=xgr.GrammarMatcher(
+                    ctx,
+                    max_rollback_tokens=self.num_speculative_tokens,
+                ),
+                vocab_size=self.vocab_size,
+                ctx=ctx,
+            )
 
     def allocate_token_bitmask(self, max_num_seqs: int):
         return xgr.allocate_token_bitmask(max_num_seqs, self.vocab_size)


### PR DESCRIPTION
Fixes #37893.

## Purpose
Fix an inferred race in xgrammar grammar initialization when parallel sampling fans out a single structured-output request into multiple child requests.

`StructuredOutputManager.grammar_init()` can submit multiple async compilation jobs that share the same `XgrammarBackend` / `GrammarCompiler` instance. This patch serializes compiler access so each request still gets an independently-initialized `GrammarMatcher` while preserving the existing async initialization flow.

## Test Plan
Unit test:
```bash
pytest tests/v1/structured_output/test_backend_xgrammar.py -q
```

## Test Result
```text
1 passed in 0.89s
```
