### PR TITLE
[Docs] Fix build

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -105,7 +105,6 @@ plugins:
           - https://pillow.readthedocs.io/en/stable/objects.inv
           - https://numpy.org/doc/stable/objects.inv
           - https://pytorch.org/docs/stable/objects.inv
-          - https://psutil.readthedocs.io/en/stable/objects.inv
   - redirects:
       redirect_maps:
         features/spec_decode/README.md: features/speculative_decoding/README.md


### PR DESCRIPTION
`psutil` has recently created transient issues for those consuming their docs by removing all versions. Therefore, `stable` doesn't exist right now.

Let's simply remove this inventory as we do not directly reference anything in it and it is causing problems right now.