### PR TITLE
[Bugfix] Add minimax_m2 to eagle3 supported models list

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -792,6 +792,7 @@ class SpeculativeConfig:
             "deepseek_v3",
             "kimi_k2",
             "kimi_k25",
+            "minimax_m2",
         ]
         if (
             self.method in ("eagle3", "extract_hidden_states")

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -390,8 +390,7 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             hidden_states, residual = layer(positions, hidden_states, residual)
             if use_aux_hidden_states:
                 self._maybe_add_hidden_state(
-                    aux_hidden_states, self.start_layer + idx, hidden_states,
-                    residual
+                    aux_hidden_states, idx + 1, hidden_states, residual
                 )
 
         if not get_pp_group().is_last_rank:

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -59,7 +59,8 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsLoRA, SupportsPP
+from .interfaces import (EagleModelMixin, SupportsEagle, SupportsEagle3, SupportsLoRA,
+                         SupportsPP)
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -313,7 +314,7 @@ class MiniMaxM2DecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class MiniMaxM2Model(nn.Module):
+class MiniMaxM2Model(nn.Module, EagleModelMixin):
     fall_back_to_pt_during_load = False
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -366,7 +367,8 @@ class MiniMaxM2Model(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor,
+                                                   list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -378,14 +380,23 @@ class MiniMaxM2Model(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        for layer in self.layers[self.start_layer : self.end_layer]:
+        aux_hidden_states = self._maybe_add_hidden_state(
+            [], 0, hidden_states, residual
+        )
+        for idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
             hidden_states, residual = layer(positions, hidden_states, residual)
+            self._maybe_add_hidden_state(
+                aux_hidden_states, self.start_layer + idx, hidden_states, residual
+            )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
         return hidden_states
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
@@ -485,7 +496,8 @@ class MiniMaxM2Model(nn.Module):
         return loaded_params
 
 
-class MiniMaxM2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+class MiniMaxM2ForCausalLM(nn.Module, SupportsEagle, SupportsEagle3, SupportsLoRA,
+                           SupportsPP):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -526,11 +538,11 @@ class MiniMaxM2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
         **kwargs,
-    ) -> torch.Tensor | IntermediateTensors:
-        hidden_states = self.model(
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor,
+                                                     list[torch.Tensor]]:
+        return self.model(
             input_ids, positions, intermediate_tensors, inputs_embeds
         )
-        return hidden_states
 
     def compute_logits(
         self,

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -380,14 +380,19 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        aux_hidden_states = self._maybe_add_hidden_state(
-            [], 0, hidden_states, residual
-        )
+        use_aux_hidden_states = len(self.aux_hidden_state_layers) > 0
+        aux_hidden_states: list[torch.Tensor] = []
+        if use_aux_hidden_states:
+            aux_hidden_states = self._maybe_add_hidden_state(
+                [], 0, hidden_states, residual
+            )
         for idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
             hidden_states, residual = layer(positions, hidden_states, residual)
-            self._maybe_add_hidden_state(
-                aux_hidden_states, self.start_layer + idx, hidden_states, residual
-            )
+            if use_aux_hidden_states:
+                self._maybe_add_hidden_state(
+                    aux_hidden_states, self.start_layer + idx, hidden_states,
+                    residual
+                )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
@@ -395,7 +400,7 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             )
         hidden_states, _ = self.norm(hidden_states, residual)
 
-        if len(aux_hidden_states) > 0:
+        if use_aux_hidden_states and len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states
         return hidden_states
 


### PR DESCRIPTION
eagle3 speculative decoding method requires aux_hidden_states_support for target model. Currently minimax_m2 model type is missing from the supported list, causing ValueError when using eagle3 with minimax_m2 models.

Fixes #37868

Co-authored-by: Claude




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

