### PR TITLE
[benchmark] Clarify single-image limitation in CustomMMDataset (docs + warning)

### DIFF
--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -144,6 +144,13 @@ You can skip applying chat template if your data already has it by using `--cust
 
 If the multimodal dataset you want to benchmark is not supported yet in vLLM, then you can benchmark on it using `CustomMMDataset`. Your data needs to be in `.jsonl` format and needs to have "prompt" and "image_files" field per entry, e.g., `mm_data.jsonl`:
 
+> ⚠️ **Note**
+>
+> Although `image_files` is defined as a list, **only the first image is currently used** for each request.
+> Any additional images in the list will be ignored.
+> This behavior reflects the current implementation.
+> For multi-image benchmarking, consider using `RandomMultiModalDataset`.
+
 ```json
 {"prompt": "How many animals are present in the given image?", "image_files": ["/path/to/image/folder/horsepony.jpg"]}
 {"prompt": "What colour is the bird shown in the image?", "image_files": ["/path/to/image/folder/flycatcher.jpeg"]}

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2201,8 +2201,7 @@ class CustomMMDataset(CustomDataset):
             if len(images) > 1:
                 logger.warning(
                     "Multiple image files found for sample %d. "
-                    "Only the first image will be used.",
-                    "For multi-image benchmarking, consider using RandomMultiModalDataset.",
+                    "Only the first image will be used. For multi-image benchmarking, consider using RandomMultiModalDataset.",
                     i,
                 )
             mm_content = process_image(images[0])

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2202,6 +2202,7 @@ class CustomMMDataset(CustomDataset):
                 logger.warning(
                     "Multiple image files found for sample %d. "
                     "Only the first image will be used.",
+                    "For multi-image benchmarking, consider using RandomMultiModalDataset.",
                     i,
                 )
             mm_content = process_image(images[0])


### PR DESCRIPTION

## Purpose
Clarify the current single-image limitation in `CustomMMDataset`.

When using `--dataset custom` with multimodal data, `image_files` is defined as a list, which may suggest that multiple images per request are supported. However, the current implementation only processes the first image, and additional images are silently ignored.

This PR updates the documentation to make this behavior explicit and avoid potential confusion.
## Test Plan
- Documentation renders correctly with the added note
- The behavior described (only using the first image) is consistent with the current implementation
## Test Result
- Documentation renders correctly with the added note
- The behavior described (only using the first image) is consistent with the current implementation

---

