### PR TITLE
[SpecDecode] Add shortcut in rejection sampler for greedy sampling

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -68,6 +68,30 @@ def create_logits_tensor(
     return logits
 
 
+def create_logits_and_metadata_with_bonus(
+    spec_tokens: list[list[int]],
+    output_tokens: list[list[int]],
+    vocab_size: int = 100,
+) -> tuple[torch.Tensor, SpecDecodeMetadata]:
+    """Wrapper around create_logits_tensor and create_spec_decode_metadata
+    that appends bonus logit positions."""
+    logits = create_logits_tensor(output_tokens, vocab_size)
+    metadata = create_spec_decode_metadata(spec_tokens, logits)
+
+    # Append bonus rows to logits.
+    batch_size = len(output_tokens)
+    bonus_logits = torch.full((batch_size, vocab_size), -100.0, device=DEVICE_TYPE)
+    for i, tokens in enumerate(output_tokens):
+        bonus_logits[i, tokens[-1]] = 100.0
+
+    num_target = logits.shape[0]
+    logits = torch.cat([logits, bonus_logits], dim=0)
+    metadata.bonus_logits_indices = torch.arange(
+        num_target, num_target + batch_size, dtype=torch.int32, device=DEVICE_TYPE
+    )
+    return logits, metadata
+
+
 def create_sampling_metadata(
     all_greedy: bool,
     output_token_ids: list[list[int]] | None = None,
@@ -1183,3 +1207,93 @@ def test_placeholder_draft_token_rejected_random(rejection_sampler):
     assert sampled[0, 1].item() == vocab_size - 1
     recovered = sampled[0, 2].item()
     assert 0 <= recovered < vocab_size
+
+
+################### Tests for Fast Greedy Path ###################
+
+
+def test_fast_greedy_perfect_match(rejection_sampler):
+    """All draft tokens match target argmax -> all accepted + bonus."""
+    spec_tokens = [[1, 2, 3]]
+    output_tokens = [[1, 2, 3, 4]]
+
+    logits, metadata = create_logits_and_metadata_with_bonus(spec_tokens, output_tokens)
+    sampling_metadata = create_sampling_metadata(all_greedy=True)
+    output = rejection_sampler(
+        metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=sampling_metadata,
+    )
+
+    expected = torch.tensor([[1, 2, 3, 4]], dtype=torch.int, device=DEVICE_TYPE)
+    assert torch.equal(output.sampled_token_ids, expected)
+
+
+def test_fast_greedy_early_mismatch(rejection_sampler):
+    """Mismatch at position 1 -> accept corrected token, rest placeholder."""
+    spec_tokens = [[1, 2, 3]]
+    output_tokens = [[1, 5, 3, 4]]
+
+    logits, metadata = create_logits_and_metadata_with_bonus(spec_tokens, output_tokens)
+    sampling_metadata = create_sampling_metadata(all_greedy=True)
+    output = rejection_sampler(
+        metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=sampling_metadata,
+    )
+
+    expected = torch.tensor(
+        [[1, 5, PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID]],
+        dtype=torch.int,
+        device=DEVICE_TYPE,
+    )
+    assert torch.equal(output.sampled_token_ids, expected)
+
+
+def test_fast_greedy_multiple_sequences(rejection_sampler):
+    """Multiple requests with different spec lengths."""
+    spec_tokens = [[1, 2], [3]]
+    output_tokens = [[1, 2, 5], [3, 4]]
+
+    logits, metadata = create_logits_and_metadata_with_bonus(spec_tokens, output_tokens)
+    sampling_metadata = create_sampling_metadata(all_greedy=True)
+    output = rejection_sampler(
+        metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=sampling_metadata,
+    )
+
+    expected = torch.tensor(
+        [[1, 2, 5], [3, 4, PLACEHOLDER_TOKEN_ID]],
+        dtype=torch.int,
+        device=DEVICE_TYPE,
+    )
+    assert torch.equal(output.sampled_token_ids, expected)
+
+
+def test_fast_greedy_multiple_sequences_with_mismatches(rejection_sampler):
+    """Multiple requests, each with mismatches at different positions."""
+    spec_tokens = [[1, 2, 3], [4, 5, 6]]
+    output_tokens = [[1, 2, 7, 8], [4, 9, 6, 10]]
+
+    logits, metadata = create_logits_and_metadata_with_bonus(spec_tokens, output_tokens)
+    sampling_metadata = create_sampling_metadata(all_greedy=True)
+    output = rejection_sampler(
+        metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=sampling_metadata,
+    )
+
+    expected = torch.tensor(
+        [
+            [1, 2, 7, PLACEHOLDER_TOKEN_ID],
+            [4, 9, PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID],
+        ],
+        dtype=torch.int,
+        device=DEVICE_TYPE,
+    )
+    assert torch.equal(output.sampled_token_ids, expected)

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -1297,3 +1297,45 @@ def test_fast_greedy_multiple_sequences_with_mismatches(rejection_sampler):
         device=DEVICE_TYPE,
     )
     assert torch.equal(output.sampled_token_ids, expected)
+
+
+def test_fast_greedy_synthetic_all_accepted():
+    """Synthetic mode with rates=1.0 -> every draft accepted, bonus appended."""
+    sampler = _make_synthetic_sampler([1.0, 1.0])
+    spec_tokens = [[1, 2], [3, 4]]
+    # target argmax is [10, 20] / [30, 40] (irrelevant since accepted),
+    # bonus argmax is 50 / 60.
+    output_tokens = [[10, 20, 50], [30, 40, 60]]
+
+    logits, metadata = create_logits_and_metadata_with_bonus(spec_tokens, output_tokens)
+    sampling_metadata = create_sampling_metadata(all_greedy=True)
+    output = sampler(metadata, None, logits, sampling_metadata)
+
+    expected = torch.tensor(
+        [[1, 2, 50], [3, 4, 60]],
+        dtype=torch.int,
+        device=DEVICE_TYPE,
+    )
+    assert torch.equal(output.sampled_token_ids, expected)
+
+
+def test_fast_greedy_synthetic_all_rejected():
+    """Synthetic mode with rates=0.0 -> first draft rejected, replaced by
+    target argmax; remaining positions are placeholders (no bonus)."""
+    sampler = _make_synthetic_sampler([0.0, 0.0])
+    spec_tokens = [[1, 2], [3, 4]]
+    output_tokens = [[10, 20, 50], [30, 40, 60]]
+
+    logits, metadata = create_logits_and_metadata_with_bonus(spec_tokens, output_tokens)
+    sampling_metadata = create_sampling_metadata(all_greedy=True)
+    output = sampler(metadata, None, logits, sampling_metadata)
+
+    expected = torch.tensor(
+        [
+            [10, PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID],
+            [30, PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID],
+        ],
+        dtype=torch.int,
+        device=DEVICE_TYPE,
+    )
+    assert torch.equal(output.sampled_token_ids, expected)

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -119,7 +119,7 @@ class RejectionSampler(nn.Module):
         assert metadata.max_spec_len <= MAX_SPEC_LEN
 
         if self._can_use_fast_greedy_path(sampling_metadata, metadata):
-            return self._fast_greedy_path(metadata, logits)
+            return self._fast_greedy_path(metadata, logits, sampling_metadata)
 
         bonus_logits_indices = metadata.bonus_logits_indices
         target_logits_indices = metadata.target_logits_indices
@@ -212,7 +212,9 @@ class RejectionSampler(nn.Module):
         - No logprobs requested (fast path doesn't compute them)
         - No penalties/bad_words/allowed_token_ids
         - Only argmax-invariant logits processors
+        - No active thinking-budget forcing (not argmax-invariant)
         """
+        holder = sampling_metadata.thinking_budget_state_holder
         return (
             sampling_metadata.all_greedy
             and sampling_metadata.max_num_logprobs is None
@@ -220,6 +222,7 @@ class RejectionSampler(nn.Module):
             and not sampling_metadata.bad_words_token_ids
             and sampling_metadata.allowed_token_ids_mask is None
             and not sampling_metadata.logitsprocs.non_argmax_invariant
+            and not (holder is not None and holder.has_tracked_requests())
             and metadata.bonus_logits_indices.numel() > 0
         )
 
@@ -227,6 +230,7 @@ class RejectionSampler(nn.Module):
         self,
         metadata: SpecDecodeMetadata,
         logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
     ) -> SamplerOutput:
         """Fast path for greedy sampling.
 
@@ -249,6 +253,16 @@ class RejectionSampler(nn.Module):
             all_argmax[metadata.bonus_logits_indices].unsqueeze(1).to(torch.int32)
         )
 
+        # Synthetic mode
+        uniform_probs: torch.Tensor | None = None
+        if self.synthetic_mode:
+            uniform_probs = generate_uniform_probs(
+                metadata.draft_token_ids.shape[0],
+                metadata.num_draft_tokens,
+                sampling_metadata.generators,
+                device,
+            )
+
         # Create output buffer.
         output_token_ids = torch.full(
             (num_requests, metadata.max_spec_len + 1),
@@ -266,9 +280,9 @@ class RejectionSampler(nn.Module):
             bonus_token_ids,
             None,  # is_greedy=None since all are greedy
             metadata.max_spec_len,
-            None,  # uniform_probs_ptr (synthetic mode only)
-            None,  # synthetic_conditional_rates_ptr (synthetic mode only)
-            SYNTHETIC_MODE=False,
+            uniform_probs,
+            self.synthetic_conditional_rates,
+            SYNTHETIC_MODE=self.synthetic_mode,
         )
 
         return SamplerOutput(

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -118,6 +118,9 @@ class RejectionSampler(nn.Module):
         """
         assert metadata.max_spec_len <= MAX_SPEC_LEN
 
+        if self._can_use_fast_greedy_path(sampling_metadata, metadata):
+            return self._fast_greedy_path(metadata, logits)
+
         bonus_logits_indices = metadata.bonus_logits_indices
         target_logits_indices = metadata.target_logits_indices
 
@@ -194,6 +197,83 @@ class RejectionSampler(nn.Module):
         return SamplerOutput(
             sampled_token_ids=output_token_ids,
             logprobs_tensors=logprobs_tensors,
+        )
+
+    @staticmethod
+    def _can_use_fast_greedy_path(
+        sampling_metadata: SamplingMetadata,
+        metadata: SpecDecodeMetadata,
+    ) -> bool:
+        """Check if we can skip the full rejection sampling pipeline.
+
+        The fast path computes a single argmax over all logit positions
+        and runs the greedy rejection kernel directly. This is valid when:
+        - All requests use greedy decoding (argmax is the correct sampler)
+        - No logprobs requested (fast path doesn't compute them)
+        - No penalties/bad_words/allowed_token_ids
+        - Only argmax-invariant logits processors
+        """
+        return (
+            sampling_metadata.all_greedy
+            and sampling_metadata.max_num_logprobs is None
+            and sampling_metadata.no_penalties
+            and not sampling_metadata.bad_words_token_ids
+            and sampling_metadata.allowed_token_ids_mask is None
+            and not sampling_metadata.logitsprocs.non_argmax_invariant
+            and metadata.bonus_logits_indices.numel() > 0
+        )
+
+    def _fast_greedy_path(
+        self,
+        metadata: SpecDecodeMetadata,
+        logits: torch.Tensor,
+    ) -> SamplerOutput:
+        """Fast path for greedy sampling.
+
+        Computes argmax over ALL logit positions (target + bonus) in one
+        shot, avoiding:
+        - The separate bonus Sampler.forward() call
+        - Non-argmax-invariant logits processors
+        - Sampling constraints (temperature/top-k/top-p are no-ops
+          for greedy)
+        """
+        num_requests = len(metadata.num_draft_tokens)
+        device = logits.device
+
+        # Compute argmax for all positions (target + bonus) in one shot.
+        all_argmax = logits.argmax(dim=-1)
+
+        # Extract target and bonus argmax using their respective indices.
+        target_argmax = all_argmax[metadata.target_logits_indices]
+        bonus_token_ids = (
+            all_argmax[metadata.bonus_logits_indices].unsqueeze(1).to(torch.int32)
+        )
+
+        # Create output buffer.
+        output_token_ids = torch.full(
+            (num_requests, metadata.max_spec_len + 1),
+            PLACEHOLDER_TOKEN_ID,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        # Run greedy rejection kernel.
+        rejection_greedy_sample_kernel[(num_requests,)](
+            output_token_ids,
+            metadata.cu_num_draft_tokens,
+            metadata.draft_token_ids,
+            target_argmax,
+            bonus_token_ids,
+            None,  # is_greedy=None since all are greedy
+            metadata.max_spec_len,
+            None,  # uniform_probs_ptr (synthetic mode only)
+            None,  # synthetic_conditional_rates_ptr (synthetic mode only)
+            SYNTHETIC_MODE=False,
+        )
+
+        return SamplerOutput(
+            sampled_token_ids=output_token_ids,
+            logprobs_tensors=None,
         )
 
     def _get_logprobs_tensors(


### PR DESCRIPTION
## Purpose

For the **greedy sampling** with **speculative decoding proposer**, we can achieve higher performance without additional operations such as:

- logprobs (softmax operation)
- sampling restrictions (top_p, top_k, allowed_token_ids, penalties, ...)

## Test Plan

```bash
vllm serve Qwen/Qwen3-1.7B \
    --port 8000 \
    --dtype bfloat16 \
    --max-model-len 4096 \
    --max-num-seqs 128 \
    --max-num-batched-tokens 32768 \
    --gpu-memory-utilization 0.85 \
    --speculative-config '{"method":"ngram_gpu","num_speculative_tokens":3,"prompt_lookup_max":10,"prompt_lookup_min":1}'

# Optional flags used for benchmarks:                                                                        
# + --no-async-scheduling   (for sync configs)                                                               
# + --enforce-eager         (for eager configs)
```

```bash
vllm bench serve \
    --model Qwen/Qwen3-1.7B \
    --backend openai-chat \
    --base-url http://127.0.0.1:8000 \
    --endpoint /v1/chat/completions \
    --dataset-name random \
    --random-input-len 512 \
    --random-output-len 128 \
    --num-prompts 200 \
    --request-rate inf \
    --temperature 0.0
```

## Test Result

Based on the settings, the throughput increased (+1% ~ 8%)

<img width="533" height="165" alt="async+compile" src="https://github.com/user-attachments/assets/3ebad9b0-d5dc-44d0-b33f-1caf62a2d98b" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

