### PR TITLE
[Core][Frontend] Add gradient computation feature with /v1/gradients API endpoint

### DIFF
--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -15,7 +15,6 @@ from vllm.gradient_params import GradientParams
 from vllm.inputs import EngineInput, PromptType
 from vllm.lora.request import LoRARequest
 from vllm.outputs import GradientRequestOutput, PoolingRequestOutput, RequestOutput
-from vllm.plugins.io_processors import IOProcessor
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import BaseRenderer
 from vllm.sampling_params import SamplingParams

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -11,9 +11,11 @@ from vllm.distributed.weight_transfer.base import (
     WeightTransferInitRequest,
     WeightTransferUpdateRequest,
 )
+from vllm.gradient_params import GradientParams
 from vllm.inputs import EngineInput, PromptType
 from vllm.lora.request import LoRARequest
-from vllm.outputs import PoolingRequestOutput, RequestOutput
+from vllm.outputs import GradientRequestOutput, PoolingRequestOutput, RequestOutput
+from vllm.plugins.io_processors import IOProcessor
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import BaseRenderer
 from vllm.sampling_params import SamplingParams
@@ -96,6 +98,20 @@ class EngineClient(ABC):
         reasoning_ended: bool | None = None,
     ) -> AsyncGenerator[PoolingRequestOutput, None]:
         """Generate outputs for a request from a pooling model."""
+        ...
+
+    @abstractmethod
+    def compute_gradients(
+        self,
+        prompt: PromptType | EngineInput,
+        gradient_params: GradientParams,
+        request_id: str,
+        lora_request: LoRARequest | None = None,
+        trace_headers: Mapping[str, str] | None = None,
+        priority: int = 0,
+        tokenization_kwargs: dict[str, Any] | None = None,
+    ) -> AsyncGenerator[GradientRequestOutput, None]:
+        """Compute gradients for a request."""
         ...
 
     @abstractmethod

--- a/vllm/entrypoints/gradient/__init__.py
+++ b/vllm/entrypoints/gradient/__init__.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+    from starlette.datastructures import State
+
+    from vllm.engine.protocol import EngineClient
+    from vllm.entrypoints.logger import RequestLogger
+    from vllm.tasks import SupportedTask
+else:
+    RequestLogger = object
+    SupportedTask = object
+
+
+def register_gradient_api_router(app: FastAPI):
+    from vllm.entrypoints.gradient.api_router import router as gradient_router
+
+    app.include_router(gradient_router)
+
+
+def init_gradient_state(
+    engine_client: "EngineClient",
+    state: "State",
+    args: "Namespace",
+    request_logger: RequestLogger | None,
+    supported_tasks: tuple["SupportedTask", ...],
+):
+    from vllm.entrypoints.gradient.serving import ServingGradient
+
+    state.serving_gradient = (
+        ServingGradient(
+            engine_client,
+            state.openai_serving_models,
+            request_logger=request_logger,
+        )
+        if "gradient" in supported_tasks
+        else None
+    )

--- a/vllm/entrypoints/gradient/__init__.py
+++ b/vllm/entrypoints/gradient/__init__.py
@@ -1,5 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Gradient computation API — POST /v1/gradients.
+
+Computes gradients of loss / per-token log-probs w.r.t. model embeddings,
+enabling token-level attribution and interpretability analysis.
+
+Architecture:
+  1. FastAPI router receives GradientRequest (prompt + target text).
+  2. ServingGradient tokenizes both, builds GradientParams.
+  3. AsyncLLM.compute_gradients() sends an EngineCoreRequest.
+  4. EngineCore bypasses the scheduler and dispatches via collective_rpc
+     to Worker.compute_gradients() (needs torch.enable_grad()).
+  5. GradientRunner runs forward + backward, returns gradients.
+  6. Results flow back through the output processor as GradientRequestOutput.
+"""
 
 from typing import TYPE_CHECKING
 

--- a/vllm/entrypoints/gradient/api_router.py
+++ b/vllm/entrypoints/gradient/api_router.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, Request
+
+from vllm.entrypoints.gradient.protocol import GradientRequest
+from vllm.entrypoints.gradient.serving import ServingGradient
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.utils import validate_json_request
+from vllm.entrypoints.utils import load_aware_call, with_cancellation
+
+router = APIRouter()
+
+
+def gradient_handler(request: Request) -> ServingGradient | None:
+    return request.app.state.serving_gradient
+
+
+@router.post(
+    "/v1/gradients",
+    dependencies=[Depends(validate_json_request)],
+    responses={
+        HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
+        HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+    },
+)
+@with_cancellation
+@load_aware_call
+async def compute_gradients(
+    request: GradientRequest,
+    raw_request: Request,
+):
+    handler = gradient_handler(raw_request)
+    if handler is None:
+        raise NotImplementedError(
+            "The model does not support the Gradients API. "
+            "Gradient computation requires a text generation model."
+        )
+
+    return await handler(request, raw_request)

--- a/vllm/entrypoints/gradient/outputs.py
+++ b/vllm/entrypoints/gradient/outputs.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Gradient computation output types and deserialization.
+
+Contains the data classes returned by the gradient API and a factory
+function that reconstructs typed outputs from the serialized dict
+produced by gpu_worker.py.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class GradientOutput:
+    """The output data of a gradient computation request.
+
+    Args:
+        token_log_probs: Per-target-token log-probabilities
+            log p(y_t | x, y_{<t}) for each target token.
+        token_attributions: Attribution matrix. Shape depends on aggregation:
+            - aggregated (l2_norm/abs_sum): [num_selected_targets, num_tokens]
+            - full (none): [num_selected_targets, num_tokens, hidden_dim]
+            where num_tokens depends on gradient_targets.
+        loss: Scalar loss value (when gradient_of is "loss" or "both").
+        loss_gradients: Gradient of loss w.r.t. each gradient target.
+            Keys are gradient target names, values are tensors.
+    """
+
+    token_log_probs: list[float] | None = None
+    token_attributions: np.ndarray | None = None
+    loss: float | None = None
+    loss_gradients: dict[str, np.ndarray] | None = None
+
+    def __repr__(self) -> str:
+        attr_shape = None
+        if self.token_attributions is not None:
+            attr_shape = self.token_attributions.shape
+        return (
+            f"GradientOutput(loss={self.loss}, "
+            f"token_log_probs_len="
+            f"{len(self.token_log_probs) if self.token_log_probs else None}, "
+            f"token_attributions_shape={attr_shape})"
+        )
+
+
+class GradientRequestOutput:
+    """The output data of a gradient computation request to the LLM.
+
+    Args:
+        request_id: A unique identifier for the gradient request.
+        outputs: The gradient computation results.
+        prompt_token_ids: The token IDs of the prompt.
+        target_token_ids: The target token IDs for gradient computation.
+        finished: Whether the gradient computation is completed.
+    """
+
+    def __init__(
+        self,
+        request_id: str,
+        outputs: GradientOutput,
+        prompt_token_ids: list[int],
+        target_token_ids: list[int],
+        finished: bool,
+    ):
+        self.request_id = request_id
+        self.outputs = outputs
+        self.prompt_token_ids = prompt_token_ids
+        self.target_token_ids = target_token_ids
+        self.finished = finished
+
+    def __repr__(self) -> str:
+        return (
+            f"GradientRequestOutput(request_id={self.request_id!r}, "
+            f"outputs={self.outputs!r}, "
+            f"prompt_token_ids=[{len(self.prompt_token_ids)} tokens], "
+            f"target_token_ids=[{len(self.target_token_ids)} tokens], "
+            f"finished={self.finished})"
+        )
+
+
+def gradient_request_output_from_engine_dict(
+    external_req_id: str,
+    gradient_output: dict[str, Any],
+    prompt_token_ids: list[int],
+    finished: bool,
+) -> GradientRequestOutput:
+    """Reconstruct a GradientRequestOutput from the serialized dict.
+
+    The engine core serializes gradient outputs as a plain dict of
+    bytes/metadata (via gpu_worker.py). This function deserializes
+    the numpy arrays and constructs the typed output.
+    """
+    token_attributions = None
+    if "token_attributions_bytes" in gradient_output:
+        token_attributions = np.frombuffer(
+            gradient_output["token_attributions_bytes"],
+            dtype=np.dtype(gradient_output["token_attributions_dtype"]),
+        ).reshape(gradient_output["token_attributions_shape"])
+
+    loss_gradients = None
+    if "loss_gradients_packed" in gradient_output:
+        loss_gradients = {}
+        for k, packed in gradient_output["loss_gradients_packed"].items():
+            loss_gradients[k] = np.frombuffer(
+                packed["bytes"],
+                dtype=np.dtype(packed["dtype"]),
+            ).reshape(packed["shape"])
+
+    return GradientRequestOutput(
+        request_id=external_req_id,
+        outputs=GradientOutput(
+            token_log_probs=gradient_output.get("token_log_probs"),
+            token_attributions=token_attributions,
+            loss=gradient_output.get("loss"),
+            loss_gradients=loss_gradients,
+        ),
+        prompt_token_ids=prompt_token_ids,
+        target_token_ids=gradient_output.get("target_token_ids", []),
+        finished=finished,
+    )

--- a/vllm/entrypoints/gradient/protocol.py
+++ b/vllm/entrypoints/gradient/protocol.py
@@ -5,6 +5,12 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+GradientTarget = Literal["input_embeddings", "output_embeddings"]
+
+
+def _default_gradient_targets() -> list[GradientTarget]:
+    return ["input_embeddings"]
+
 
 class GradientRequest(BaseModel):
     """Request body for the /v1/gradients endpoint."""
@@ -19,8 +25,8 @@ class GradientRequest(BaseModel):
         "both",
     ] = "token_log_probs"
 
-    gradient_targets: list[Literal["input_embeddings", "output_embeddings"]] = Field(
-        default_factory=lambda: ["input_embeddings"]
+    gradient_targets: list[GradientTarget] = Field(
+        default_factory=_default_gradient_targets
     )
 
     target_token_indices: list[int] | None = None

--- a/vllm/entrypoints/gradient/protocol.py
+++ b/vllm/entrypoints/gradient/protocol.py
@@ -56,6 +56,7 @@ class GradientResponse(BaseModel):
     id: str
     object: str = "gradient"
     model: str
+    encoding: Literal["json", "base64_numpy"] = "json"
 
     token_log_probs: list[GradientTokenLogProb] | None = None
 

--- a/vllm/entrypoints/gradient/protocol.py
+++ b/vllm/entrypoints/gradient/protocol.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class GradientRequest(BaseModel):
+    """Request body for the /v1/gradients endpoint."""
+
+    model: str
+    prompt: str
+    target: str
+
+    gradient_of: Literal[
+        "loss",
+        "token_log_probs",
+        "both",
+    ] = "token_log_probs"
+
+    gradient_targets: list[Literal["input_embeddings", "output_embeddings"]] = Field(
+        default_factory=lambda: ["input_embeddings"]
+    )
+
+    target_token_indices: list[int] | None = None
+
+    aggregation: Literal[
+        "none",
+        "l2_norm",
+        "abs_sum",
+    ] = "l2_norm"
+
+    loss_function: Literal[
+        "cross_entropy",
+        "log_prob_sum",
+    ] = "cross_entropy"
+
+    return_log_probs: bool = True
+
+    # Optional fields
+    encoding: Literal["json", "base64_numpy"] = "json"
+
+
+class GradientTokenLogProb(BaseModel):
+    """Per-token log-probability."""
+
+    token: str
+    token_id: int
+    log_prob: float
+
+
+class GradientResponse(BaseModel):
+    """Response body for the /v1/gradients endpoint."""
+
+    id: str
+    object: str = "gradient"
+    model: str
+
+    token_log_probs: list[GradientTokenLogProb] | None = None
+
+    token_attributions: dict | None = None
+
+    loss: float | None = None
+    loss_gradients: dict[str, dict] | None = None

--- a/vllm/entrypoints/gradient/serving.py
+++ b/vllm/entrypoints/gradient/serving.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Gradient computation serving handler.
+
+Translates HTTP GradientRequest (prompt + target text) into
+engine-level GradientParams (prompt_token_ids + target_token_ids)
+and formats the GradientOutput back into GradientResponse JSON.
+"""
 
 from typing import TYPE_CHECKING
 

--- a/vllm/entrypoints/gradient/serving.py
+++ b/vllm/entrypoints/gradient/serving.py
@@ -9,6 +9,8 @@ and formats the GradientOutput back into GradientResponse JSON.
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+import pybase64 as base64
 from fastapi import Request
 
 from vllm.entrypoints.gradient.protocol import (
@@ -27,6 +29,28 @@ if TYPE_CHECKING:
     from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 
 logger = init_logger(__name__)
+
+
+def _encode_array(arr: np.ndarray, encoding: str) -> dict:
+    """Encode a numpy array as a serializable dict.
+
+    For "json": data is nested Python lists.
+    For "base64_numpy": data is a base64-encoded string of raw bytes,
+    with shape and dtype metadata for reconstruction.
+    """
+    if encoding == "base64_numpy":
+        return {
+            "data": base64.b64encode(arr.tobytes()).decode("ascii"),
+            "shape": list(arr.shape),
+            "dtype": str(arr.dtype),
+            "encoding": "base64_numpy",
+        }
+    # Default: json
+    return {
+        "data": arr.tolist(),
+        "shape": list(arr.shape),
+        "encoding": "json",
+    }
 
 
 class ServingGradient:
@@ -106,6 +130,7 @@ class ServingGradient:
 
         # Build response.
         gradient_output = result.outputs
+        encoding = request.encoding
 
         # Format token log-probs with decoded tokens.
         token_log_probs_response = None
@@ -125,34 +150,24 @@ class ServingGradient:
         # Format token attributions.
         token_attributions_response = None
         if gradient_output.token_attributions is not None:
-            token_attributions_response = {
-                "type": request.aggregation,
-                "shape": [
-                    len(gradient_output.token_attributions),
-                    len(gradient_output.token_attributions[0])
-                    if gradient_output.token_attributions
-                    else 0,
-                ],
-                "data": gradient_output.token_attributions,
-            }
+            arr = gradient_output.token_attributions
+            encoded = _encode_array(arr, encoding)
+            encoded["type"] = request.aggregation
+            token_attributions_response = encoded
 
         # Format loss gradients.
         loss_gradients_response = None
         if gradient_output.loss_gradients is not None:
             loss_gradients_response = {}
-            for name, grad_data in gradient_output.loss_gradients.items():
-                loss_gradients_response[name] = {
-                    "type": request.aggregation,
-                    "shape": [
-                        len(grad_data),
-                        len(grad_data[0]) if grad_data else 0,
-                    ],
-                    "data": grad_data,
-                }
+            for name, grad_arr in gradient_output.loss_gradients.items():
+                encoded = _encode_array(grad_arr, encoding)
+                encoded["type"] = request.aggregation
+                loss_gradients_response[name] = encoded
 
         return GradientResponse(
             id=request_id,
             model=request.model,
+            encoding=encoding,
             token_log_probs=token_log_probs_response,
             token_attributions=token_attributions_response,
             loss=gradient_output.loss,

--- a/vllm/entrypoints/gradient/serving.py
+++ b/vllm/entrypoints/gradient/serving.py
@@ -18,8 +18,9 @@ from vllm.entrypoints.gradient.protocol import (
     GradientResponse,
     GradientTokenLogProb,
 )
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
 from vllm.gradient_params import GradientParams
+from vllm.inputs import TokensPrompt
 from vllm.logger import init_logger
 from vllm.utils import random_uuid
 
@@ -82,9 +83,11 @@ class ServingGradient:
         )
         if not target_token_ids:
             return ErrorResponse(
-                message="Target text produced no tokens after tokenization.",
-                type="invalid_request_error",
-                code=400,
+                error=ErrorInfo(
+                    message="Target text produced no tokens after tokenization.",
+                    type="invalid_request_error",
+                    code=400,
+                )
             )
 
         # Build GradientParams.
@@ -104,13 +107,15 @@ class ServingGradient:
         )
         if not prompt_token_ids:
             return ErrorResponse(
-                message="Prompt text produced no tokens after tokenization.",
-                type="invalid_request_error",
-                code=400,
+                error=ErrorInfo(
+                    message="Prompt text produced no tokens after tokenization.",
+                    type="invalid_request_error",
+                    code=400,
+                )
             )
 
         # Use TokensPrompt format (a PromptType) for the engine.
-        prompt = {"prompt_token_ids": prompt_token_ids}
+        prompt: TokensPrompt = {"prompt_token_ids": prompt_token_ids}
 
         # Call the engine.
         result = None
@@ -123,9 +128,11 @@ class ServingGradient:
 
         if result is None:
             return ErrorResponse(
-                message="Gradient computation produced no output.",
-                type="server_error",
-                code=500,
+                error=ErrorInfo(
+                    message="Gradient computation produced no output.",
+                    type="server_error",
+                    code=500,
+                )
             )
 
         # Build response.

--- a/vllm/entrypoints/gradient/serving.py
+++ b/vllm/entrypoints/gradient/serving.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import TYPE_CHECKING
+
+from fastapi import Request
+
+from vllm.entrypoints.gradient.protocol import (
+    GradientRequest,
+    GradientResponse,
+    GradientTokenLogProb,
+)
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.gradient_params import GradientParams
+from vllm.logger import init_logger
+from vllm.utils import random_uuid
+
+if TYPE_CHECKING:
+    from vllm.engine.protocol import EngineClient
+    from vllm.entrypoints.logger import RequestLogger
+    from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+
+logger = init_logger(__name__)
+
+
+class ServingGradient:
+    """Handles gradient computation requests."""
+
+    def __init__(
+        self,
+        engine_client: "EngineClient",
+        model_serving: "OpenAIServingModels",
+        request_logger: "RequestLogger | None" = None,
+    ):
+        self.engine_client = engine_client
+        self.model_serving = model_serving
+        self.request_logger = request_logger
+        self.tokenizer = engine_client.renderer.get_tokenizer()
+
+    async def __call__(
+        self,
+        request: GradientRequest,
+        raw_request: Request,
+    ) -> GradientResponse | ErrorResponse:
+        """Handle a gradient computation request."""
+
+        request_id = f"grad-{random_uuid()}"
+
+        # Tokenize the target to get target_token_ids.
+        target_token_ids = self.tokenizer.encode(
+            request.target, add_special_tokens=False
+        )
+        if not target_token_ids:
+            return ErrorResponse(
+                message="Target text produced no tokens after tokenization.",
+                type="invalid_request_error",
+                code=400,
+            )
+
+        # Build GradientParams.
+        gradient_params = GradientParams(
+            target_token_ids=target_token_ids,
+            gradient_of=request.gradient_of,
+            gradient_targets=request.gradient_targets,
+            target_token_indices=request.target_token_indices,
+            aggregation=request.aggregation,
+            loss_function=request.loss_function,
+            return_log_probs=request.return_log_probs,
+        )
+
+        # Tokenize prompt.
+        prompt_token_ids = self.tokenizer.encode(
+            request.prompt, add_special_tokens=True
+        )
+        if not prompt_token_ids:
+            return ErrorResponse(
+                message="Prompt text produced no tokens after tokenization.",
+                type="invalid_request_error",
+                code=400,
+            )
+
+        # Use TokensPrompt format (a PromptType) for the engine.
+        prompt = {"prompt_token_ids": prompt_token_ids}
+
+        # Call the engine.
+        result = None
+        async for output in self.engine_client.compute_gradients(
+            prompt=prompt,
+            gradient_params=gradient_params,
+            request_id=request_id,
+        ):
+            result = output
+
+        if result is None:
+            return ErrorResponse(
+                message="Gradient computation produced no output.",
+                type="server_error",
+                code=500,
+            )
+
+        # Build response.
+        gradient_output = result.outputs
+
+        # Format token log-probs with decoded tokens.
+        token_log_probs_response = None
+        if gradient_output.token_log_probs is not None:
+            token_log_probs_response = []
+            for i, lp in enumerate(gradient_output.token_log_probs):
+                tid = target_token_ids[i]
+                token_str = self.tokenizer.decode([tid])
+                token_log_probs_response.append(
+                    GradientTokenLogProb(
+                        token=token_str,
+                        token_id=tid,
+                        log_prob=lp,
+                    )
+                )
+
+        # Format token attributions.
+        token_attributions_response = None
+        if gradient_output.token_attributions is not None:
+            token_attributions_response = {
+                "type": request.aggregation,
+                "shape": [
+                    len(gradient_output.token_attributions),
+                    len(gradient_output.token_attributions[0])
+                    if gradient_output.token_attributions
+                    else 0,
+                ],
+                "data": gradient_output.token_attributions,
+            }
+
+        # Format loss gradients.
+        loss_gradients_response = None
+        if gradient_output.loss_gradients is not None:
+            loss_gradients_response = {}
+            for name, grad_data in gradient_output.loss_gradients.items():
+                loss_gradients_response[name] = {
+                    "type": request.aggregation,
+                    "shape": [
+                        len(grad_data),
+                        len(grad_data[0]) if grad_data else 0,
+                    ],
+                    "data": grad_data,
+                }
+
+        return GradientResponse(
+            id=request_id,
+            model=request.model,
+            token_log_probs=token_log_probs_response,
+            token_attributions=token_attributions_response,
+            loss=gradient_output.loss,
+            loss_gradients=loss_gradients_response,
+        )

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -245,6 +245,11 @@ def build_app(
 
         register_pooling_api_routers(app, supported_tasks, model_config)
 
+    if "gradient" in supported_tasks:
+        from vllm.entrypoints.gradient import register_gradient_api_router
+
+        register_gradient_api_router(app)
+
     app.root_path = args.root_path
     app.add_middleware(
         CORSMiddleware,
@@ -425,6 +430,11 @@ async def init_app_state(
         from vllm.entrypoints.pooling.factories import init_pooling_state
 
         init_pooling_state(engine_client, state, args, request_logger, supported_tasks)
+
+    if "gradient" in supported_tasks:
+        from vllm.entrypoints.gradient import init_gradient_state
+
+        init_gradient_state(engine_client, state, args, request_logger, supported_tasks)
 
     state.enable_server_load_tracking = args.enable_server_load_tracking
     state.server_load_metrics = 0

--- a/vllm/gradient_params.py
+++ b/vllm/gradient_params.py
@@ -1,5 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Parameters for gradient computation requests.
+
+Gradient computation enables token-level attribution and interpretability
+by differentiating log p(y_t | x, y_{<t}) w.r.t. model embeddings.
+
+Data flow:
+  API request (GradientRequest)
+    → ServingGradient tokenizes prompt/target
+    → GradientParams created and sent through engine
+    → EngineCore dispatches via collective_rpc (bypasses scheduler)
+    → GradientRunner performs forward + backward passes
+    → Results returned as GradientOutput
+"""
 
 from copy import deepcopy
 from typing import Literal
@@ -14,37 +27,22 @@ class GradientParams(
     omit_defaults=True,  # type: ignore[call-arg]
     array_like=True,
 ):  # type: ignore[call-arg]
-    """API parameters for gradient computation.
-
-    Given a prompt and target continuation tokens, computes gradients of
-    a loss and/or per-token log-probabilities with respect to specified
-    model components (e.g. input embeddings). This enables token-level
-    attribution and interpretability analysis.
+    """Parameters controlling what and how to compute gradients.
 
     Attributes:
-        target_token_ids: The output token IDs to compute gradients for.
-            These represent the continuation after the prompt.
-        gradient_of: What quantity to differentiate:
-            - "loss": scalar cross-entropy loss (single backward pass).
-            - "token_log_probs": per-token log p(y_t | x, y_{<t})
-              (one backward pass per selected target token).
-            - "both": return both loss and per-token gradients.
-        gradient_targets: What to differentiate with respect to:
-            - "input_embeddings": gradients w.r.t. prompt token embeddings.
-            - "output_embeddings": gradients w.r.t. target token embeddings.
-        target_token_indices: If set, only compute per-token gradients for
-            these target positions (0-indexed). None = all target tokens.
-            Reduces compute when only a subset of tokens is of interest.
-        aggregation: How to reduce the hidden_dim of gradient tensors:
-            - "none": return full [num_tokens, hidden_dim] gradients.
-            - "l2_norm": ||grad||_2 per token position (most common for
-              attribution heatmaps).
-            - "abs_sum": sum(|grad|) per token position.
-        loss_function: Loss to use when gradient_of is "loss" or "both":
-            - "cross_entropy": standard cross-entropy loss over targets.
-            - "log_prob_sum": sum of log-probabilities of target tokens.
-        return_log_probs: Whether to also return the log-probability values
-            for each target token.
+        target_token_ids: Output token IDs (the continuation after the prompt).
+        gradient_of: What to differentiate:
+            "loss" — scalar cross-entropy (one backward pass),
+            "token_log_probs" — per-token log-probs (one backward per token),
+            "both" — both of the above.
+        gradient_targets: What to differentiate *with respect to*:
+            "input_embeddings" and/or "output_embeddings".
+        target_token_indices: Subset of target positions for per-token
+            gradients (0-indexed). None means all targets.
+        aggregation: Reduction over hidden_dim:
+            "none" — full gradients, "l2_norm", or "abs_sum".
+        loss_function: "cross_entropy" or "log_prob_sum".
+        return_log_probs: Also return log p(y_t | x, y_{<t}) values.
     """
 
     target_token_ids: list[int]
@@ -102,27 +100,11 @@ class GradientParams(
         if not self.gradient_targets:
             raise ValueError("gradient_targets must contain at least one target")
 
-        valid_targets = {"input_embeddings", "output_embeddings"}
-        for target in self.gradient_targets:
-            if target not in valid_targets:
-                raise ValueError(
-                    f"Unknown gradient target: {target!r}. "
-                    f"Valid targets: {valid_targets}"
-                )
-
     def __repr__(self) -> str:
         return (
             f"GradientParams("
             f"gradient_of={self.gradient_of!r}, "
-            f"gradient_targets={self.gradient_targets}, "
-            f"target_token_ids=[{len(self.target_token_ids)} tokens], "
-            f"target_token_indices={self.target_token_indices}, "
-            f"aggregation={self.aggregation!r}, "
-            f"loss_function={self.loss_function!r}, "
-            f"return_log_probs={self.return_log_probs})"
-        )
-
-    def __post_init__(self) -> None:
-        assert self.output_kind == RequestOutputKind.FINAL_ONLY, (
-            "For gradient computation output_kind has to be FINAL_ONLY"
+            f"targets={self.gradient_targets}, "
+            f"num_target_tokens={len(self.target_token_ids)}, "
+            f"aggregation={self.aggregation!r})"
         )

--- a/vllm/gradient_params.py
+++ b/vllm/gradient_params.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from copy import deepcopy
+from typing import Literal
+
+import msgspec
+
+from vllm.sampling_params import RequestOutputKind
+
+
+class GradientParams(
+    msgspec.Struct,
+    omit_defaults=True,  # type: ignore[call-arg]
+    array_like=True,
+):  # type: ignore[call-arg]
+    """API parameters for gradient computation.
+
+    Given a prompt and target continuation tokens, computes gradients of
+    a loss and/or per-token log-probabilities with respect to specified
+    model components (e.g. input embeddings). This enables token-level
+    attribution and interpretability analysis.
+
+    Attributes:
+        target_token_ids: The output token IDs to compute gradients for.
+            These represent the continuation after the prompt.
+        gradient_of: What quantity to differentiate:
+            - "loss": scalar cross-entropy loss (single backward pass).
+            - "token_log_probs": per-token log p(y_t | x, y_{<t})
+              (one backward pass per selected target token).
+            - "both": return both loss and per-token gradients.
+        gradient_targets: What to differentiate with respect to:
+            - "input_embeddings": gradients w.r.t. prompt token embeddings.
+            - "output_embeddings": gradients w.r.t. target token embeddings.
+        target_token_indices: If set, only compute per-token gradients for
+            these target positions (0-indexed). None = all target tokens.
+            Reduces compute when only a subset of tokens is of interest.
+        aggregation: How to reduce the hidden_dim of gradient tensors:
+            - "none": return full [num_tokens, hidden_dim] gradients.
+            - "l2_norm": ||grad||_2 per token position (most common for
+              attribution heatmaps).
+            - "abs_sum": sum(|grad|) per token position.
+        loss_function: Loss to use when gradient_of is "loss" or "both":
+            - "cross_entropy": standard cross-entropy loss over targets.
+            - "log_prob_sum": sum of log-probabilities of target tokens.
+        return_log_probs: Whether to also return the log-probability values
+            for each target token.
+    """
+
+    target_token_ids: list[int]
+
+    gradient_of: Literal[
+        "loss",
+        "token_log_probs",
+        "both",
+    ] = "token_log_probs"
+
+    gradient_targets: list[
+        Literal[
+            "input_embeddings",
+            "output_embeddings",
+        ]
+    ] = msgspec.field(default_factory=lambda: ["input_embeddings"])
+
+    target_token_indices: list[int] | None = None
+
+    aggregation: Literal[
+        "none",
+        "l2_norm",
+        "abs_sum",
+    ] = "l2_norm"
+
+    loss_function: Literal[
+        "cross_entropy",
+        "log_prob_sum",
+    ] = "cross_entropy"
+
+    return_log_probs: bool = True
+
+    ## Internal use only
+    output_kind: RequestOutputKind = RequestOutputKind.FINAL_ONLY
+
+    def clone(self) -> "GradientParams":
+        """Returns a deep copy of the GradientParams instance."""
+        return deepcopy(self)
+
+    def verify(self) -> None:
+        """Validate gradient parameters."""
+        if not self.target_token_ids:
+            raise ValueError("target_token_ids must be non-empty")
+
+        if self.target_token_indices is not None:
+            num_targets = len(self.target_token_ids)
+            for idx in self.target_token_indices:
+                if idx < 0 or idx >= num_targets:
+                    raise ValueError(
+                        f"target_token_indices contains {idx}, but "
+                        f"target_token_ids has only {num_targets} tokens "
+                        f"(valid range: 0 to {num_targets - 1})"
+                    )
+
+        if not self.gradient_targets:
+            raise ValueError("gradient_targets must contain at least one target")
+
+        valid_targets = {"input_embeddings", "output_embeddings"}
+        for target in self.gradient_targets:
+            if target not in valid_targets:
+                raise ValueError(
+                    f"Unknown gradient target: {target!r}. "
+                    f"Valid targets: {valid_targets}"
+                )
+
+    def __repr__(self) -> str:
+        return (
+            f"GradientParams("
+            f"gradient_of={self.gradient_of!r}, "
+            f"gradient_targets={self.gradient_targets}, "
+            f"target_token_ids=[{len(self.target_token_ids)} tokens], "
+            f"target_token_indices={self.target_token_indices}, "
+            f"aggregation={self.aggregation!r}, "
+            f"loss_function={self.loss_function!r}, "
+            f"return_log_probs={self.return_log_probs})"
+        )
+
+    def __post_init__(self) -> None:
+        assert self.output_kind == RequestOutputKind.FINAL_ONLY, (
+            "For gradient computation output_kind has to be FINAL_ONLY"
+        )

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -10,6 +10,10 @@ import numpy as np
 import torch
 from typing_extensions import TypeVar
 
+from vllm.entrypoints.gradient.outputs import (  # noqa: F401
+    GradientOutput,
+    GradientRequestOutput,
+)
 from vllm.logger import init_logger
 from vllm.logprobs import PromptLogprobs, SampleLogprobs
 from vllm.lora.request import LoRARequest
@@ -354,72 +358,4 @@ class ScoringRequestOutput(PoolingRequestOutput[ScoringOutput]):
             prompt_token_ids=request_output.prompt_token_ids,
             num_cached_tokens=request_output.num_cached_tokens,
             finished=request_output.finished,
-        )
-
-
-@dataclass
-class GradientOutput:
-    """The output data of a gradient computation request.
-
-    Args:
-        token_log_probs: Per-target-token log-probabilities
-            log p(y_t | x, y_{<t}) for each target token.
-        token_attributions: Attribution matrix. Shape depends on aggregation:
-            - aggregated (l2_norm/abs_sum): [num_selected_targets, num_tokens]
-            - full (none): [num_selected_targets, num_tokens, hidden_dim]
-            where num_tokens depends on gradient_targets.
-        loss: Scalar loss value (when gradient_of is "loss" or "both").
-        loss_gradients: Gradient of loss w.r.t. each gradient target.
-            Keys are gradient target names, values are tensors.
-    """
-
-    token_log_probs: list[float] | None = None
-    token_attributions: np.ndarray | None = None
-    loss: float | None = None
-    loss_gradients: dict[str, np.ndarray] | None = None
-
-    def __repr__(self) -> str:
-        attr_shape = None
-        if self.token_attributions is not None:
-            attr_shape = self.token_attributions.shape
-        return (
-            f"GradientOutput(loss={self.loss}, "
-            f"token_log_probs_len="
-            f"{len(self.token_log_probs) if self.token_log_probs else None}, "
-            f"token_attributions_shape={attr_shape})"
-        )
-
-
-class GradientRequestOutput:
-    """The output data of a gradient computation request to the LLM.
-
-    Args:
-        request_id: A unique identifier for the gradient request.
-        outputs: The gradient computation results.
-        prompt_token_ids: The token IDs of the prompt.
-        target_token_ids: The target token IDs for gradient computation.
-        finished: Whether the gradient computation is completed.
-    """
-
-    def __init__(
-        self,
-        request_id: str,
-        outputs: GradientOutput,
-        prompt_token_ids: list[int],
-        target_token_ids: list[int],
-        finished: bool,
-    ):
-        self.request_id = request_id
-        self.outputs = outputs
-        self.prompt_token_ids = prompt_token_ids
-        self.target_token_ids = target_token_ids
-        self.finished = finished
-
-    def __repr__(self) -> str:
-        return (
-            f"GradientRequestOutput(request_id={self.request_id!r}, "
-            f"outputs={self.outputs!r}, "
-            f"prompt_token_ids=[{len(self.prompt_token_ids)} tokens], "
-            f"target_token_ids=[{len(self.target_token_ids)} tokens], "
-            f"finished={self.finished})"
         )

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -355,3 +355,74 @@ class ScoringRequestOutput(PoolingRequestOutput[ScoringOutput]):
             num_cached_tokens=request_output.num_cached_tokens,
             finished=request_output.finished,
         )
+
+
+@dataclass
+class GradientOutput:
+    """The output data of a gradient computation request.
+
+    Args:
+        token_log_probs: Per-target-token log-probabilities
+            log p(y_t | x, y_{<t}) for each target token.
+        token_attributions: Attribution matrix. Shape depends on aggregation:
+            - aggregated (l2_norm/abs_sum): [num_selected_targets, num_tokens]
+            - full (none): [num_selected_targets, num_tokens, hidden_dim]
+            where num_tokens depends on gradient_targets.
+        loss: Scalar loss value (when gradient_of is "loss" or "both").
+        loss_gradients: Gradient of loss w.r.t. each gradient target.
+            Keys are gradient target names, values are tensors.
+    """
+
+    token_log_probs: list[float] | None = None
+    token_attributions: list[list[float]] | None = None
+    loss: float | None = None
+    loss_gradients: dict[str, list[list[float]]] | None = None
+
+    def __repr__(self) -> str:
+        attr_shape = None
+        if self.token_attributions is not None:
+            attr_shape = (
+                len(self.token_attributions),
+                len(self.token_attributions[0]) if self.token_attributions else 0,
+            )
+        return (
+            f"GradientOutput(loss={self.loss}, "
+            f"token_log_probs_len="
+            f"{len(self.token_log_probs) if self.token_log_probs else None}, "
+            f"token_attributions_shape={attr_shape})"
+        )
+
+
+class GradientRequestOutput:
+    """The output data of a gradient computation request to the LLM.
+
+    Args:
+        request_id: A unique identifier for the gradient request.
+        outputs: The gradient computation results.
+        prompt_token_ids: The token IDs of the prompt.
+        target_token_ids: The target token IDs for gradient computation.
+        finished: Whether the gradient computation is completed.
+    """
+
+    def __init__(
+        self,
+        request_id: str,
+        outputs: GradientOutput,
+        prompt_token_ids: list[int],
+        target_token_ids: list[int],
+        finished: bool,
+    ):
+        self.request_id = request_id
+        self.outputs = outputs
+        self.prompt_token_ids = prompt_token_ids
+        self.target_token_ids = target_token_ids
+        self.finished = finished
+
+    def __repr__(self) -> str:
+        return (
+            f"GradientRequestOutput(request_id={self.request_id!r}, "
+            f"outputs={self.outputs!r}, "
+            f"prompt_token_ids=[{len(self.prompt_token_ids)} tokens], "
+            f"target_token_ids=[{len(self.target_token_ids)} tokens], "
+            f"finished={self.finished})"
+        )

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -374,17 +374,14 @@ class GradientOutput:
     """
 
     token_log_probs: list[float] | None = None
-    token_attributions: list[list[float]] | None = None
+    token_attributions: np.ndarray | None = None
     loss: float | None = None
-    loss_gradients: dict[str, list[list[float]]] | None = None
+    loss_gradients: dict[str, np.ndarray] | None = None
 
     def __repr__(self) -> str:
         attr_shape = None
         if self.token_attributions is not None:
-            attr_shape = (
-                len(self.token_attributions),
-                len(self.token_attributions[0]) if self.token_attributions else 0,
-            )
+            attr_shape = self.token_attributions.shape
         return (
             f"GradientOutput(loss={self.loss}, "
             f"token_log_probs_len="

--- a/vllm/tasks.py
+++ b/vllm/tasks.py
@@ -15,6 +15,9 @@ PoolingTask = Literal[
 ]
 POOLING_TASKS: tuple[PoolingTask, ...] = get_args(PoolingTask)
 
+GradientTask = Literal["gradient"]
+GRADIENT_TASKS: tuple[GradientTask, ...] = get_args(GradientTask)
+
 ScoreType = Literal["bi-encoder", "cross-encoder", "late-interaction"]
 SCORE_TYPE_MAP: dict[PoolingTask, ScoreType] = {
     "embed": "bi-encoder",
@@ -25,4 +28,4 @@ SCORE_TYPE_MAP: dict[PoolingTask, ScoreType] = {
 FrontendTask = Literal["render"]
 FRONTEND_TASKS: tuple[FrontendTask, ...] = get_args(FrontendTask)
 
-SupportedTask = Literal[GenerationTask, PoolingTask, FrontendTask]
+SupportedTask = Literal[GenerationTask, PoolingTask, GradientTask, FrontendTask]

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -11,6 +11,7 @@ import msgspec
 import numpy as np
 import torch
 
+from vllm.gradient_params import GradientParams
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
@@ -100,6 +101,9 @@ class EngineCoreRequest(
     # `prompt_embeds`. `None` for pure-tokens and pure-embeds requests.
     prompt_is_token_ids: list[bool] | None = None
 
+    # Gradient computation params (default None for backward compat).
+    gradient_params: GradientParams | None = None
+
     # Index of the client, used to ensure outputs are sent back to the same
     # client for this request when scaling out the front-end.
     client_index: int = 0
@@ -129,12 +133,14 @@ class EngineCoreRequest(
     abort_immediately: bool = False
 
     @property
-    def params(self) -> SamplingParams | PoolingParams:
-        """Return the processed params (sampling or pooling)."""
+    def params(self) -> SamplingParams | PoolingParams | GradientParams:
+        """Return the processed params (sampling, pooling, or gradient)."""
         if self.sampling_params is not None:
             return self.sampling_params
-        assert self.pooling_params is not None
-        return self.pooling_params
+        if self.pooling_params is not None:
+            return self.pooling_params
+        assert self.gradient_params is not None
+        return self.gradient_params
 
 
 class EngineCoreEventType(enum.IntEnum):
@@ -177,6 +183,7 @@ class EngineCoreOutput(
     new_prompt_logprobs_tensors: LogprobsTensors | None = None
 
     pooling_output: torch.Tensor | None = None
+    gradient_output: dict[str, Any] | None = None
 
     finish_reason: FinishReason | None = None
     stop_reason: int | str | None = None

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -902,8 +902,8 @@ class AsyncLLM(EngineClient):
     ) -> AsyncGenerator[GradientRequestOutput, None]:
         """Compute gradients for a prompt + target pair.
 
-        Follows the same async pattern as encode() — the request goes
-        through the engine core and results are yielded via an async queue.
+        Same async queue pattern as encode() — single-shot request
+        that yields one GradientRequestOutput with finished=True.
         """
         q: RequestOutputCollector | None = None
         try:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -32,7 +32,6 @@ from vllm.outputs import (
     PoolingRequestOutput,
     RequestOutput,
 )
-from vllm.plugins.io_processors import get_io_processor
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import renderer_from_config
 from vllm.renderers.inputs.preprocess import extract_prompt_components

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -21,11 +21,18 @@ from vllm.distributed.weight_transfer.base import (
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.protocol import EngineClient, StreamingInput
 from vllm.entrypoints.serve.elastic_ep.middleware import set_scaling_elastic_ep
+from vllm.gradient_params import GradientParams
 from vllm.inputs import EngineInput, PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
-from vllm.outputs import STREAM_FINISHED, PoolingRequestOutput, RequestOutput
+from vllm.outputs import (
+    STREAM_FINISHED,
+    GradientRequestOutput,
+    PoolingRequestOutput,
+    RequestOutput,
+)
+from vllm.plugins.io_processors import get_io_processor
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import renderer_from_config
 from vllm.renderers.inputs.preprocess import extract_prompt_components
@@ -284,7 +291,7 @@ class AsyncLLM(EngineClient):
         | PromptType
         | EngineInput
         | AsyncGenerator[StreamingInput, None],
-        params: SamplingParams | PoolingParams,
+        params: SamplingParams | PoolingParams | GradientParams,
         arrival_time: float | None = None,
         lora_request: LoRARequest | None = None,
         tokenization_kwargs: dict[str, Any] | None = None,
@@ -301,10 +308,12 @@ class AsyncLLM(EngineClient):
             raise EngineDeadError()
 
         is_pooling = isinstance(params, PoolingParams)
+        is_gradient = isinstance(params, GradientParams)
 
         if (
             self.vllm_config.cache_config.kv_sharing_fast_prefill
             and not is_pooling
+            and not is_gradient
             and params.prompt_logprobs
         ):
             raise ValueError(
@@ -378,7 +387,7 @@ class AsyncLLM(EngineClient):
         # Use cloned params that may have been updated in process_inputs()
         params = request.params
 
-        if is_pooling or params.n == 1:
+        if is_pooling or is_gradient or params.n == 1:
             await self._add_request(request, prompt_text, None, 0, queue)
             return queue
 
@@ -871,6 +880,64 @@ class AsyncLLM(EngineClient):
             raise
 
         # Unexpected error in the generate() task (possibly recoverable).
+        except Exception as e:
+            if q is not None:
+                await self.abort(q.request_id, internal=True)
+            if self.log_requests:
+                logger.info("Request %s failed.", request_id)
+            raise EngineGenerateError() from e
+        finally:
+            if q is not None:
+                q.close()
+
+    async def compute_gradients(
+        self,
+        prompt: PromptType | EngineInput,
+        gradient_params: GradientParams,
+        request_id: str,
+        lora_request: LoRARequest | None = None,
+        trace_headers: Mapping[str, str] | None = None,
+        priority: int = 0,
+        tokenization_kwargs: dict[str, Any] | None = None,
+    ) -> AsyncGenerator[GradientRequestOutput, None]:
+        """Compute gradients for a prompt + target pair.
+
+        Follows the same async pattern as encode() — the request goes
+        through the engine core and results are yielded via an async queue.
+        """
+        q: RequestOutputCollector | None = None
+        try:
+            q = await self.add_request(
+                request_id,
+                prompt,
+                gradient_params,
+                lora_request=lora_request,
+                tokenization_kwargs=tokenization_kwargs,
+                trace_headers=trace_headers,
+                priority=priority,
+            )
+
+            finished = False
+            while not finished:
+                out = q.get_nowait() or await q.get()
+                assert isinstance(out, GradientRequestOutput)
+                finished = out.finished
+                yield out
+
+        except asyncio.CancelledError:
+            if q is not None:
+                await self.abort(q.request_id, internal=True)
+            if self.log_requests:
+                logger.info("Request %s aborted.", request_id)
+            raise
+        except EngineDeadError:
+            if self.log_requests:
+                logger.info("Request %s failed (engine dead).", request_id)
+            raise
+        except ValueError:
+            if self.log_requests:
+                logger.info("Request %s failed (bad request).", request_id)
+            raise
         except Exception as e:
             if q is not None:
                 await self.abort(q.request_id, internal=True)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -153,11 +153,10 @@ class EngineCore:
         )
         self.use_spec_decode = vllm_config.speculative_config is not None
 
-        # Gradient requests are queued here during add_request() and
-        # executed during step() so that request processing is not blocked.
-        self._queued_gradient_requests: deque[Request] = deque()
-        # Completed gradient outputs awaiting delivery in the next step().
-        self._pending_gradient_outputs: list[tuple[int, EngineCoreOutputs]] = []
+        # Gradient requests bypass the scheduler and are handled out-of-band.
+        from vllm.v1.engine.gradient_handler import GradientHandler
+
+        self._gradient_handler = GradientHandler(self.model_executor)
         if self.scheduler.connector is not None:  # type: ignore
             self.model_executor.init_kv_output_aggregator(self.scheduler.connector)  # type: ignore
 
@@ -349,10 +348,9 @@ class EngineCore:
                 f"request_id must be a string, got {type(request.request_id)}"
             )
 
-        # Gradient requests are queued and executed during step() so
-        # that request processing is not blocked by GPU computation.
+        # Gradient requests bypass the scheduler; queue for step().
         if request.gradient_params is not None:
-            self._queued_gradient_requests.append(request)
+            self._gradient_handler.enqueue(request)
             return
 
         if pooling_params := request.pooling_params:
@@ -379,45 +377,6 @@ class EngineCore:
             # Immediately abort so the connector's request_finished hook runs
             # to free any pre-admission KV-transfer resources.
             self.abort_requests([request.request_id])
-
-    def _handle_gradient_request(self, request: Request) -> None:
-        """Handle gradient computation via collective_rpc.
-
-        Gradient requests bypass the scheduler because they need
-        torch.enable_grad() and cannot be batched with inference.
-        """
-        gradient_params = request.gradient_params
-        assert gradient_params is not None
-        assert request.prompt_token_ids is not None, (
-            "Gradient requests require prompt_token_ids"
-        )
-
-        gradient_result = None
-        finish_reason = FinishReason.STOP
-        try:
-            # collective_rpc returns [result_per_worker]; take first.
-            results = self.model_executor.collective_rpc(
-                "compute_gradients",
-                args=(request.prompt_token_ids, gradient_params),
-            )
-            gradient_result = results[0]
-            gradient_result["target_token_ids"] = gradient_params.target_token_ids
-        except Exception:
-            logger.exception(
-                "Gradient computation failed for request %s",
-                request.request_id,
-            )
-            finish_reason = FinishReason.ERROR
-
-        output = EngineCoreOutput(
-            request_id=request.request_id,
-            new_token_ids=[],
-            gradient_output=gradient_result or {},
-            finish_reason=finish_reason,
-        )
-        self._pending_gradient_outputs.append(
-            (request.client_index, EngineCoreOutputs(outputs=[output]))
-        )
 
     def abort_requests(self, request_ids: list[str]):
         """Abort requests from the scheduler."""
@@ -473,18 +432,6 @@ class EngineCore:
         )
         self._iteration_index += 1
 
-    def _flush_gradient_outputs(
-        self,
-        engine_core_outputs: dict[int, EngineCoreOutputs],
-    ) -> None:
-        """Merge pending gradient outputs into the step's output dict."""
-        for client_index, grad_outputs in self._pending_gradient_outputs:
-            if client_index in engine_core_outputs:
-                engine_core_outputs[client_index].outputs.extend(grad_outputs.outputs)
-            else:
-                engine_core_outputs[client_index] = grad_outputs
-        self._pending_gradient_outputs.clear()
-
     def step(self) -> tuple[dict[int, EngineCoreOutputs], bool]:
         """Schedule, execute, and make output.
 
@@ -492,18 +439,14 @@ class EngineCore:
         was executed.
         """
 
-        # Process any queued gradient requests. These are executed here
-        # rather than in add_request() so the request processing loop
-        # is not blocked by GPU computation.
-        self._process_gradient_queue()
+        self._gradient_handler.process_queue()
 
         # Check for any requests remaining in the scheduler - unfinished,
         # or finished and not yet removed from the batch.
         if not self.scheduler.has_requests():
-            # Even if scheduler is idle, flush pending gradient outputs.
-            if self._pending_gradient_outputs:
+            if self._gradient_handler.has_pending:
                 outputs: dict[int, EngineCoreOutputs] = {}
-                self._flush_gradient_outputs(outputs)
+                self._gradient_handler.flush_outputs(outputs)
                 return outputs, False
             return {}, False
         scheduler_output = self.scheduler.schedule()
@@ -524,16 +467,9 @@ class EngineCore:
             scheduler_output, model_output
         )
 
-        # Flush any pending gradient outputs into the result.
-        self._flush_gradient_outputs(engine_core_outputs)
+        self._gradient_handler.flush_outputs(engine_core_outputs)
 
         return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
-
-    def _process_gradient_queue(self) -> None:
-        """Execute all queued gradient requests."""
-        while self._queued_gradient_requests:
-            request = self._queued_gradient_requests.popleft()
-            self._handle_gradient_request(request)
 
     def post_step(self, model_executed: bool) -> None:
         # When using async scheduling we can't get draft token ids in advance,
@@ -562,8 +498,7 @@ class EngineCore:
         3. Update the scheduler from the output.
         """
 
-        # Process any queued gradient requests.
-        self._process_gradient_queue()
+        self._gradient_handler.process_queue()
 
         batch_queue = self.batch_queue
         assert batch_queue is not None
@@ -664,8 +599,7 @@ class EngineCore:
             future = self.model_executor.sample_tokens(grammar_output, non_block=True)
             batch_queue.appendleft((future, deferred_scheduler_output, exec_future))
 
-        # Flush any pending gradient outputs into the result.
-        self._flush_gradient_outputs(engine_core_outputs)
+        self._gradient_handler.flush_outputs(engine_core_outputs)
 
         return engine_core_outputs, model_executed
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -380,71 +380,43 @@ class EngineCore:
             self.abort_requests([request.request_id])
 
     def _handle_gradient_request(self, request: Request) -> None:
-        """Handle gradient computation request via collective_rpc.
+        """Handle gradient computation via collective_rpc.
 
-        Gradient requests bypass the scheduler and execute directly
-        on the worker because they need torch.enable_grad() and cannot
-        be batched with normal inference.
+        Gradient requests bypass the scheduler because they need
+        torch.enable_grad() and cannot be batched with inference.
         """
         gradient_params = request.gradient_params
         assert gradient_params is not None
-
-        # Serialize GradientParams to dict for RPC transport.
-        gp_dict = {
-            "target_token_ids": gradient_params.target_token_ids,
-            "gradient_of": gradient_params.gradient_of,
-            "gradient_targets": gradient_params.gradient_targets,
-            "target_token_indices": gradient_params.target_token_indices,
-            "aggregation": gradient_params.aggregation,
-            "loss_function": gradient_params.loss_function,
-            "return_log_probs": gradient_params.return_log_probs,
-        }
-
-        prompt_token_ids = request.prompt_token_ids
-        assert prompt_token_ids is not None, (
+        assert request.prompt_token_ids is not None, (
             "Gradient requests require prompt_token_ids"
         )
 
+        gradient_result = None
+        finish_reason = FinishReason.STOP
         try:
-            # Call worker.compute_gradients via RPC.
-            result = self.model_executor.collective_rpc(
+            # collective_rpc returns [result_per_worker]; take first.
+            results = self.model_executor.collective_rpc(
                 "compute_gradients",
-                args=(prompt_token_ids, gp_dict),
+                args=(request.prompt_token_ids, gradient_params),
             )
-            # collective_rpc returns a list of results (one per worker).
-            # We only need the first one.
-            gradient_result = result[0] if isinstance(result, list) else result
+            gradient_result = results[0]
             gradient_result["target_token_ids"] = gradient_params.target_token_ids
-
-            # Build EngineCoreOutput with gradient_output.
-            output = EngineCoreOutput(
-                request_id=request.request_id,
-                new_token_ids=[],
-                gradient_output=gradient_result,
-                finish_reason=FinishReason.STOP,
-            )
-            engine_core_outputs = EngineCoreOutputs(
-                outputs=[output],
-            )
-            self._pending_gradient_outputs.append(
-                (request.client_index, engine_core_outputs)
-            )
         except Exception:
             logger.exception(
                 "Gradient computation failed for request %s",
                 request.request_id,
             )
-            output = EngineCoreOutput(
-                request_id=request.request_id,
-                new_token_ids=[],
-                finish_reason=FinishReason.ERROR,
-            )
-            engine_core_outputs = EngineCoreOutputs(
-                outputs=[output],
-            )
-            self._pending_gradient_outputs.append(
-                (request.client_index, engine_core_outputs)
-            )
+            finish_reason = FinishReason.ERROR
+
+        output = EngineCoreOutput(
+            request_id=request.request_id,
+            new_token_ids=[],
+            gradient_output=gradient_result,
+            finish_reason=finish_reason,
+        )
+        self._pending_gradient_outputs.append(
+            (request.client_index, EngineCoreOutputs(outputs=[output]))
+        )
 
     def abort_requests(self, request_ids: list[str]):
         """Abort requests from the scheduler."""

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -152,6 +152,10 @@ class EngineCore:
             hash_block_size=hash_block_size,
         )
         self.use_spec_decode = vllm_config.speculative_config is not None
+
+        # Gradient results bypass the scheduler and are collected here
+        # for delivery during the next step() call.
+        self._pending_gradient_outputs: list[tuple[int, EngineCoreOutputs]] = []
         if self.scheduler.connector is not None:  # type: ignore
             self.model_executor.init_kv_output_aggregator(self.scheduler.connector)  # type: ignore
 
@@ -343,6 +347,13 @@ class EngineCore:
                 f"request_id must be a string, got {type(request.request_id)}"
             )
 
+        # Gradient requests are handled separately via collective_rpc
+        # because they need torch.enable_grad() and can't be batched
+        # with normal inference requests.
+        if request.gradient_params is not None:
+            self._handle_gradient_request(request)
+            return
+
         if pooling_params := request.pooling_params:
             supported_pooling_tasks = [
                 task for task in self.get_supported_tasks() if task in POOLING_TASKS
@@ -367,6 +378,73 @@ class EngineCore:
             # Immediately abort so the connector's request_finished hook runs
             # to free any pre-admission KV-transfer resources.
             self.abort_requests([request.request_id])
+
+    def _handle_gradient_request(self, request: Request) -> None:
+        """Handle gradient computation request via collective_rpc.
+
+        Gradient requests bypass the scheduler and execute directly
+        on the worker because they need torch.enable_grad() and cannot
+        be batched with normal inference.
+        """
+        gradient_params = request.gradient_params
+        assert gradient_params is not None
+
+        # Serialize GradientParams to dict for RPC transport.
+        gp_dict = {
+            "target_token_ids": gradient_params.target_token_ids,
+            "gradient_of": gradient_params.gradient_of,
+            "gradient_targets": gradient_params.gradient_targets,
+            "target_token_indices": gradient_params.target_token_indices,
+            "aggregation": gradient_params.aggregation,
+            "loss_function": gradient_params.loss_function,
+            "return_log_probs": gradient_params.return_log_probs,
+        }
+
+        prompt_token_ids = request.prompt_token_ids
+        assert prompt_token_ids is not None, (
+            "Gradient requests require prompt_token_ids"
+        )
+
+        try:
+            # Call worker.compute_gradients via RPC.
+            result = self.model_executor.collective_rpc(
+                "compute_gradients",
+                args=(prompt_token_ids, gp_dict),
+            )
+            # collective_rpc returns a list of results (one per worker).
+            # We only need the first one.
+            gradient_result = result[0] if isinstance(result, list) else result
+            gradient_result["target_token_ids"] = gradient_params.target_token_ids
+
+            # Build EngineCoreOutput with gradient_output.
+            output = EngineCoreOutput(
+                request_id=request.request_id,
+                new_token_ids=[],
+                gradient_output=gradient_result,
+                finish_reason=FinishReason.STOP,
+            )
+            engine_core_outputs = EngineCoreOutputs(
+                outputs=[output],
+            )
+            self._pending_gradient_outputs.append(
+                (request.client_index, engine_core_outputs)
+            )
+        except Exception:
+            logger.exception(
+                "Gradient computation failed for request %s",
+                request.request_id,
+            )
+            output = EngineCoreOutput(
+                request_id=request.request_id,
+                new_token_ids=[],
+                finish_reason=FinishReason.ERROR,
+            )
+            engine_core_outputs = EngineCoreOutputs(
+                outputs=[output],
+            )
+            self._pending_gradient_outputs.append(
+                (request.client_index, engine_core_outputs)
+            )
 
     def abort_requests(self, request_ids: list[str]):
         """Abort requests from the scheduler."""
@@ -422,6 +500,18 @@ class EngineCore:
         )
         self._iteration_index += 1
 
+    def _flush_gradient_outputs(
+        self,
+        engine_core_outputs: dict[int, EngineCoreOutputs],
+    ) -> None:
+        """Merge pending gradient outputs into the step's output dict."""
+        for client_index, grad_outputs in self._pending_gradient_outputs:
+            if client_index in engine_core_outputs:
+                engine_core_outputs[client_index].outputs.extend(grad_outputs.outputs)
+            else:
+                engine_core_outputs[client_index] = grad_outputs
+        self._pending_gradient_outputs.clear()
+
     def step(self) -> tuple[dict[int, EngineCoreOutputs], bool]:
         """Schedule, execute, and make output.
 
@@ -432,6 +522,11 @@ class EngineCore:
         # Check for any requests remaining in the scheduler - unfinished,
         # or finished and not yet removed from the batch.
         if not self.scheduler.has_requests():
+            # Even if scheduler is idle, flush pending gradient outputs.
+            if self._pending_gradient_outputs:
+                outputs: dict[int, EngineCoreOutputs] = {}
+                self._flush_gradient_outputs(outputs)
+                return outputs, False
             return {}, False
         scheduler_output = self.scheduler.schedule()
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
@@ -450,6 +545,9 @@ class EngineCore:
         engine_core_outputs = self.scheduler.update_from_output(
             scheduler_output, model_output
         )
+
+        # Flush any pending gradient outputs into the result.
+        self._flush_gradient_outputs(engine_core_outputs)
 
         return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -411,7 +411,7 @@ class EngineCore:
         output = EngineCoreOutput(
             request_id=request.request_id,
             new_token_ids=[],
-            gradient_output=gradient_result,
+            gradient_output=gradient_result or {},
             finish_reason=finish_reason,
         )
         self._pending_gradient_outputs.append(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -153,8 +153,10 @@ class EngineCore:
         )
         self.use_spec_decode = vllm_config.speculative_config is not None
 
-        # Gradient results bypass the scheduler and are collected here
-        # for delivery during the next step() call.
+        # Gradient requests are queued here during add_request() and
+        # executed during step() so that request processing is not blocked.
+        self._queued_gradient_requests: deque[Request] = deque()
+        # Completed gradient outputs awaiting delivery in the next step().
         self._pending_gradient_outputs: list[tuple[int, EngineCoreOutputs]] = []
         if self.scheduler.connector is not None:  # type: ignore
             self.model_executor.init_kv_output_aggregator(self.scheduler.connector)  # type: ignore
@@ -347,11 +349,10 @@ class EngineCore:
                 f"request_id must be a string, got {type(request.request_id)}"
             )
 
-        # Gradient requests are handled separately via collective_rpc
-        # because they need torch.enable_grad() and can't be batched
-        # with normal inference requests.
+        # Gradient requests are queued and executed during step() so
+        # that request processing is not blocked by GPU computation.
         if request.gradient_params is not None:
-            self._handle_gradient_request(request)
+            self._queued_gradient_requests.append(request)
             return
 
         if pooling_params := request.pooling_params:
@@ -491,6 +492,11 @@ class EngineCore:
         was executed.
         """
 
+        # Process any queued gradient requests. These are executed here
+        # rather than in add_request() so the request processing loop
+        # is not blocked by GPU computation.
+        self._process_gradient_queue()
+
         # Check for any requests remaining in the scheduler - unfinished,
         # or finished and not yet removed from the batch.
         if not self.scheduler.has_requests():
@@ -523,6 +529,12 @@ class EngineCore:
 
         return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
 
+    def _process_gradient_queue(self) -> None:
+        """Execute all queued gradient requests."""
+        while self._queued_gradient_requests:
+            request = self._queued_gradient_requests.popleft()
+            self._handle_gradient_request(request)
+
     def post_step(self, model_executed: bool) -> None:
         # When using async scheduling we can't get draft token ids in advance,
         # so we update draft token ids in the worker process and don't
@@ -549,6 +561,9 @@ class EngineCore:
         batch in the job queue is finished.
         3. Update the scheduler from the output.
         """
+
+        # Process any queued gradient requests.
+        self._process_gradient_queue()
 
         batch_queue = self.batch_queue
         assert batch_queue is not None
@@ -648,6 +663,9 @@ class EngineCore:
             )
             future = self.model_executor.sample_tokens(grammar_output, non_block=True)
             batch_queue.appendleft((future, deferred_scheduler_output, exec_future))
+
+        # Flush any pending gradient outputs into the result.
+        self._flush_gradient_outputs(engine_core_outputs)
 
         return engine_core_outputs, model_executed
 

--- a/vllm/v1/engine/gradient_handler.py
+++ b/vllm/v1/engine/gradient_handler.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Gradient request handler for EngineCore.
+
+Encapsulates the queueing and execution of gradient computation requests,
+which bypass the scheduler because they need torch.enable_grad() and
+cannot be batched with normal inference.
+
+Gradient requests are queued during add_request() and executed during
+step() via collective_rpc to avoid blocking the engine's request
+processing loop.
+"""
+
+from collections import deque
+
+from vllm.logger import init_logger
+from vllm.v1.engine import (
+    EngineCoreOutput,
+    EngineCoreOutputs,
+    FinishReason,
+)
+from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+class GradientHandler:
+    """Manages gradient request queuing and execution in EngineCore.
+
+    Gradient requests bypass the scheduler (they need torch.enable_grad())
+    and are executed synchronously via collective_rpc during step().
+
+    Usage in EngineCore:
+        self._gradient_handler = GradientHandler(self.model_executor)
+
+        # In add_request():
+        if request.gradient_params is not None:
+            self._gradient_handler.enqueue(request)
+            return
+
+        # In step():
+        self._gradient_handler.process_queue()
+        ...
+        self._gradient_handler.flush_outputs(engine_core_outputs)
+    """
+
+    def __init__(self, model_executor):
+        self._executor = model_executor
+        self._queued: deque[Request] = deque()
+        self._pending: list[tuple[int, EngineCoreOutputs]] = []
+
+    def enqueue(self, request: Request) -> None:
+        """Queue a gradient request for execution during step()."""
+        self._queued.append(request)
+
+    def process_queue(self) -> None:
+        """Execute all queued gradient requests."""
+        while self._queued:
+            request = self._queued.popleft()
+            self._handle(request)
+
+    def flush_outputs(
+        self,
+        engine_core_outputs: dict[int, EngineCoreOutputs],
+    ) -> None:
+        """Merge pending gradient outputs into the step's output dict."""
+        for client_index, grad_outputs in self._pending:
+            if client_index in engine_core_outputs:
+                engine_core_outputs[client_index].outputs.extend(grad_outputs.outputs)
+            else:
+                engine_core_outputs[client_index] = grad_outputs
+        self._pending.clear()
+
+    @property
+    def has_pending(self) -> bool:
+        """Whether there are completed gradient outputs awaiting delivery."""
+        return bool(self._pending)
+
+    def _handle(self, request: Request) -> None:
+        """Execute a single gradient request via collective_rpc."""
+        gradient_params = request.gradient_params
+        assert gradient_params is not None
+        assert request.prompt_token_ids is not None, (
+            "Gradient requests require prompt_token_ids"
+        )
+
+        gradient_result = None
+        finish_reason = FinishReason.STOP
+        try:
+            # collective_rpc returns [result_per_worker]; take first.
+            results = self._executor.collective_rpc(
+                "compute_gradients",
+                args=(request.prompt_token_ids, gradient_params),
+            )
+            gradient_result = results[0]
+            gradient_result["target_token_ids"] = gradient_params.target_token_ids
+        except Exception:
+            logger.exception(
+                "Gradient computation failed for request %s",
+                request.request_id,
+            )
+            finish_reason = FinishReason.ERROR
+
+        output = EngineCoreOutput(
+            request_id=request.request_id,
+            new_token_ids=[],
+            gradient_output=gradient_result or {},
+            finish_reason=finish_reason,
+        )
+        self._pending.append(
+            (request.client_index, EngineCoreOutputs(outputs=[output]))
+        )

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 import vllm.envs as envs
 from vllm.config import VllmConfig
+from vllm.gradient_params import GradientParams
 from vllm.inputs import (
     EngineInput,
     PromptType,
@@ -24,7 +25,12 @@ from vllm.platforms import current_platform
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import BaseRenderer, renderer_from_config
 from vllm.sampling_params import SamplingParams
-from vllm.tasks import GENERATION_TASKS, POOLING_TASKS, SupportedTask
+from vllm.tasks import (
+    GENERATION_TASKS,
+    GRADIENT_TASKS,
+    POOLING_TASKS,
+    SupportedTask,
+)
 from vllm.tokenizers import TokenizerLike
 from vllm.utils import length_from_prompt_token_ids_or_embeds, random_uuid
 from vllm.utils.jsontree import json_iter_leaves
@@ -80,10 +86,10 @@ class InputProcessor:
 
     def _validate_params(
         self,
-        params: SamplingParams | PoolingParams,
+        params: SamplingParams | PoolingParams | GradientParams,
         supported_tasks: tuple[SupportedTask, ...],
     ) -> None:
-        """Raise `ValueError` if SamplingParams or PoolingParams is not valid."""
+        """Raise `ValueError` if params are not valid."""
         if isinstance(params, SamplingParams):
             supported_generation_tasks = [
                 task for task in supported_tasks if task in GENERATION_TASKS
@@ -129,10 +135,20 @@ class InputProcessor:
                 )
 
             params.verify(self.model_config)
+        elif isinstance(params, GradientParams):
+            supported_gradient_tasks = [
+                task for task in supported_tasks if task in GRADIENT_TASKS
+            ]
+            if not supported_gradient_tasks:
+                raise ValueError(
+                    "This model does not support gradient computation. "
+                    "Gradient computation requires a text generation model."
+                )
+            params.verify()
         else:
             raise TypeError(
-                f"params must be either SamplingParams or PoolingParams, "
-                f"but got {type(params).__name__}"
+                f"params must be SamplingParams, PoolingParams, or "
+                f"GradientParams, but got {type(params).__name__}"
             )
 
     def _validate_lora(self, lora_request: LoRARequest | None) -> None:
@@ -235,7 +251,7 @@ class InputProcessor:
         self,
         request_id: str,
         prompt: PromptType | EngineInput,
-        params: SamplingParams | PoolingParams,
+        params: SamplingParams | PoolingParams | GradientParams,
         supported_tasks: tuple[SupportedTask, ...],
         arrival_time: float | None = None,
         lora_request: LoRARequest | None = None,
@@ -302,6 +318,7 @@ class InputProcessor:
 
         sampling_params = None
         pooling_params = None
+        gradient_params = None
         if isinstance(params, SamplingParams):
             # TODO: can we avoid cloning here in multiproc case?
             sampling_params = params.clone()
@@ -318,6 +335,8 @@ class InputProcessor:
             )
             if self.tokenizer is not None:
                 sampling_params.update_from_tokenizer(self.tokenizer)
+        elif isinstance(params, GradientParams):
+            gradient_params = params.clone()
         else:
             pooling_params = params.clone()
 
@@ -367,6 +386,7 @@ class InputProcessor:
             mm_features=mm_features,
             sampling_params=sampling_params,
             pooling_params=pooling_params,
+            gradient_params=gradient_params,
             arrival_time=arrival_time,
             lora_request=lora_request,
             cache_salt=decoder_inputs.get("cache_salt"),

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -17,7 +17,6 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 from vllm.outputs import (
     STREAM_FINISHED,
     CompletionOutput,
-    GradientOutput,
     GradientRequestOutput,
     PoolingOutput,
     PoolingRequestOutput,
@@ -477,38 +476,16 @@ class RequestState:
         gradient_output: dict[str, Any],
         finished: bool,
     ) -> GradientRequestOutput:
+        from vllm.entrypoints.gradient.outputs import (
+            gradient_request_output_from_engine_dict,
+        )
+
         prompt_token_ids = self.prompt_token_ids
         if prompt_token_ids is None:
             prompt_token_ids = list(range(self.prompt_len))
 
-        # Reconstruct numpy arrays from packed bytes format.
-        token_attributions = None
-        if "token_attributions_bytes" in gradient_output:
-            token_attributions = np.frombuffer(
-                gradient_output["token_attributions_bytes"],
-                dtype=np.dtype(gradient_output["token_attributions_dtype"]),
-            ).reshape(gradient_output["token_attributions_shape"])
-
-        loss_gradients = None
-        if "loss_gradients_packed" in gradient_output:
-            loss_gradients = {}
-            for k, packed in gradient_output["loss_gradients_packed"].items():
-                loss_gradients[k] = np.frombuffer(
-                    packed["bytes"],
-                    dtype=np.dtype(packed["dtype"]),
-                ).reshape(packed["shape"])
-
-        return GradientRequestOutput(
-            request_id=external_req_id,
-            outputs=GradientOutput(
-                token_log_probs=gradient_output.get("token_log_probs"),
-                token_attributions=token_attributions,
-                loss=gradient_output.get("loss"),
-                loss_gradients=loss_gradients,
-            ),
-            prompt_token_ids=prompt_token_ids,
-            target_token_ids=gradient_output.get("target_token_ids", []),
-            finished=finished,
+        return gradient_request_output_from_engine_dict(
+            external_req_id, gradient_output, prompt_token_ids, finished
         )
 
 

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -17,6 +17,8 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 from vllm.outputs import (
     STREAM_FINISHED,
     CompletionOutput,
+    GradientOutput,
+    GradientRequestOutput,
     PoolingOutput,
     PoolingRequestOutput,
     RequestOutput,
@@ -57,12 +59,23 @@ class RequestOutputCollector:
     def __init__(self, output_kind: RequestOutputKind, request_id: str):
         self.aggregate = output_kind == RequestOutputKind.DELTA
         self.request_id = request_id
-        self.output: RequestOutput | PoolingRequestOutput | Exception | None = None
+        self.output: (
+            RequestOutput
+            | PoolingRequestOutput
+            | GradientRequestOutput
+            | Exception
+            | None
+        ) = None
         self.ready = asyncio.Event()
 
         self._input_stream_task: asyncio.Task | None = None
 
-    def put(self, output: RequestOutput | PoolingRequestOutput | Exception) -> None:
+    def put(
+        self,
+        output: (
+            RequestOutput | PoolingRequestOutput | GradientRequestOutput | Exception
+        ),
+    ) -> None:
         """Non-blocking put operation."""
         if self.output is None or isinstance(output, Exception):
             self.output = output
@@ -73,12 +86,17 @@ class RequestOutputCollector:
             # This ensures that request outputs with different request indexes
             # (if n > 1) do not override each other.
             self.output.add(output, aggregate=self.aggregate)
-        elif isinstance(self.output, PoolingRequestOutput) and isinstance(
-            output, PoolingRequestOutput
+        elif (
+            isinstance(self.output, PoolingRequestOutput)
+            and isinstance(output, PoolingRequestOutput)
+            or isinstance(self.output, GradientRequestOutput)
+            and isinstance(output, GradientRequestOutput)
         ):
             self.output = output
 
-    async def get(self) -> RequestOutput | PoolingRequestOutput:
+    async def get(
+        self,
+    ) -> RequestOutput | PoolingRequestOutput | GradientRequestOutput:
         """Get operation blocks on put event."""
         while (output := self.output) is None:
             await self.ready.wait()
@@ -88,7 +106,9 @@ class RequestOutputCollector:
             raise output
         return output
 
-    def get_nowait(self) -> RequestOutput | PoolingRequestOutput | None:
+    def get_nowait(
+        self,
+    ) -> RequestOutput | PoolingRequestOutput | GradientRequestOutput | None:
         """Non-blocking get operation."""
         output = self.output
         if output is not None:
@@ -111,7 +131,7 @@ class RequestOutputCollector:
 
 @dataclass
 class OutputProcessorOutput:
-    request_outputs: list[RequestOutput | PoolingRequestOutput]
+    request_outputs: list[RequestOutput | PoolingRequestOutput | GradientRequestOutput]
     reqs_to_abort: list[str]
 
 
@@ -235,15 +255,26 @@ class RequestState:
             top_p = sampling_params.top_p
             n = sampling_params.n
             temperature = sampling_params.temperature
-        else:
+        elif request.pooling_params is not None:
             logprobs_processor = None
             detokenizer = None
             max_tokens_param = None
             top_p = None
             n = None
             temperature = None
-            assert request.pooling_params is not None
             output_kind = request.pooling_params.output_kind
+        elif request.gradient_params is not None:
+            logprobs_processor = None
+            detokenizer = None
+            max_tokens_param = None
+            top_p = None
+            n = None
+            temperature = None
+            output_kind = request.gradient_params.output_kind
+        else:
+            raise ValueError(
+                "Request must have sampling_params, pooling_params, or gradient_params"
+            )
 
         assert request.external_req_id is not None
         return cls(
@@ -277,7 +308,8 @@ class RequestState:
         stop_reason: int | str | None,
         kv_transfer_params: dict[str, Any] | None = None,
         routed_experts: np.ndarray | None = None,
-    ) -> RequestOutput | PoolingRequestOutput | None:
+        gradient_output: dict[str, Any] | None = None,
+    ) -> RequestOutput | PoolingRequestOutput | GradientRequestOutput | None:
         finished = finish_reason is not None
         final_only = self.output_kind == RequestOutputKind.FINAL_ONLY
 
@@ -309,6 +341,11 @@ class RequestState:
                 self.sent_tokens_offset = self.detokenizer.num_output_tokens()
 
         external_req_id = self.external_req_id
+
+        if gradient_output is not None:
+            return self._new_gradient_request_output(
+                external_req_id, gradient_output, finished
+            )
 
         if pooling_output is not None:
             return self._new_request_output(
@@ -433,6 +470,28 @@ class RequestState:
 
     def _new_pooling_output(self, pooling_output: torch.Tensor) -> PoolingOutput:
         return PoolingOutput(data=pooling_output)
+
+    def _new_gradient_request_output(
+        self,
+        external_req_id: str,
+        gradient_output: dict[str, Any],
+        finished: bool,
+    ) -> GradientRequestOutput:
+        prompt_token_ids = self.prompt_token_ids
+        if prompt_token_ids is None:
+            prompt_token_ids = list(range(self.prompt_len))
+        return GradientRequestOutput(
+            request_id=external_req_id,
+            outputs=GradientOutput(
+                token_log_probs=gradient_output.get("token_log_probs"),
+                token_attributions=gradient_output.get("token_attributions"),
+                loss=gradient_output.get("loss"),
+                loss_gradients=gradient_output.get("loss_gradients"),
+            ),
+            prompt_token_ids=prompt_token_ids,
+            target_token_ids=gradient_output.get("target_token_ids", []),
+            finished=finished,
+        )
 
 
 class OutputProcessor:
@@ -622,7 +681,9 @@ class OutputProcessor:
         within the loop below.
         """
 
-        request_outputs: list[RequestOutput | PoolingRequestOutput] = []
+        request_outputs: list[
+            RequestOutput | PoolingRequestOutput | GradientRequestOutput
+        ] = []
         reqs_to_abort: list[str] = []
         for engine_core_output in engine_core_outputs:
             req_id = engine_core_output.request_id
@@ -638,6 +699,7 @@ class OutputProcessor:
 
             new_token_ids = engine_core_output.new_token_ids
             pooling_output = engine_core_output.pooling_output
+            gradient_output = engine_core_output.gradient_output
             finish_reason = engine_core_output.finish_reason
             stop_reason = engine_core_output.stop_reason
             kv_transfer_params = engine_core_output.kv_transfer_params
@@ -650,7 +712,7 @@ class OutputProcessor:
                     )
                 req_state.is_prefilling = False
 
-            if pooling_output is None:
+            if pooling_output is None and gradient_output is None:
                 assert req_state.detokenizer is not None
                 assert req_state.logprobs_processor is not None
                 # 2) Detokenize the token ids into text and perform stop checks.
@@ -673,6 +735,7 @@ class OutputProcessor:
                 stop_reason,
                 kv_transfer_params,
                 routed_experts,
+                gradient_output=gradient_output,
             ):
                 if req_state.streaming_input:
                     request_output.finished = False

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -480,13 +480,31 @@ class RequestState:
         prompt_token_ids = self.prompt_token_ids
         if prompt_token_ids is None:
             prompt_token_ids = list(range(self.prompt_len))
+
+        # Reconstruct numpy arrays from packed bytes format.
+        token_attributions = None
+        if "token_attributions_bytes" in gradient_output:
+            token_attributions = np.frombuffer(
+                gradient_output["token_attributions_bytes"],
+                dtype=np.dtype(gradient_output["token_attributions_dtype"]),
+            ).reshape(gradient_output["token_attributions_shape"])
+
+        loss_gradients = None
+        if "loss_gradients_packed" in gradient_output:
+            loss_gradients = {}
+            for k, packed in gradient_output["loss_gradients_packed"].items():
+                loss_gradients[k] = np.frombuffer(
+                    packed["bytes"],
+                    dtype=np.dtype(packed["dtype"]),
+                ).reshape(packed["shape"])
+
         return GradientRequestOutput(
             request_id=external_req_id,
             outputs=GradientOutput(
                 token_log_probs=gradient_output.get("token_log_probs"),
-                token_attributions=gradient_output.get("token_attributions"),
+                token_attributions=token_attributions,
                 loss=gradient_output.get("loss"),
-                loss_gradients=gradient_output.get("loss_gradients"),
+                loss_gradients=loss_gradients,
             ),
             prompt_token_ids=prompt_token_ids,
             target_token_ids=gradient_output.get("target_token_ids", []),

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from vllm.gradient_params import GradientParams
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
@@ -63,6 +64,7 @@ class Request:
         prompt_token_ids: list[int] | None,
         sampling_params: SamplingParams | None,
         pooling_params: PoolingParams | None,
+        gradient_params: GradientParams | None = None,
         client_index: int = 0,
         arrival_time: float | None = None,
         prompt_embeds: torch.Tensor | None = None,
@@ -83,6 +85,7 @@ class Request:
         self.priority = priority
         self.sampling_params = sampling_params
         self.pooling_params = pooling_params
+        self.gradient_params = gradient_params
         self.lora_request = lora_request
         self.structured_output_request = StructuredOutputRequest.from_sampling_params(
             sampling_params
@@ -101,7 +104,10 @@ class Request:
         # P/D: Connector-specific KV transfer parameters.
         self.kv_transfer_params: dict[str, Any] | None = None
 
-        if pooling_params is not None:
+        if gradient_params is not None:
+            # Gradient computation: single-shot like pooling.
+            self.max_tokens = 1
+        elif pooling_params is not None:
             # Pooling models.
             self.max_tokens = 1
         elif sampling_params is not None:
@@ -116,7 +122,10 @@ class Request:
                     "kv_transfer_params"
                 )
         else:
-            raise ValueError("sampling_params and pooling_params can't both be unset")
+            raise ValueError(
+                "sampling_params, pooling_params, and gradient_params "
+                "can't all be unset"
+            )
 
         self.prompt_token_ids = prompt_token_ids
         self.prompt_embeds = prompt_embeds
@@ -202,6 +211,7 @@ class Request:
             mm_features=request.mm_features,
             sampling_params=request.sampling_params,
             pooling_params=request.pooling_params,
+            gradient_params=request.gradient_params,
             arrival_time=request.arrival_time,
             lora_request=request.lora_request,
             cache_salt=request.cache_salt,

--- a/vllm/v1/worker/gpu/gradient/gradient_runner.py
+++ b/vllm/v1/worker/gpu/gradient/gradient_runner.py
@@ -1,10 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""GradientRunner: computes gradients of loss and/or per-token log-probs
-with respect to input/output embeddings for a given prompt + target pair.
+"""GradientRunner — core gradient computation for attribution.
 
-This enables token-level attribution (e.g. "how much did each input token
-influence the log-probability of each output token?").
+Computes d/d(embeddings) of loss and/or per-token log-probs for a
+prompt + target pair. Enables token-level attribution ("how much did
+each input token influence each output token's log-probability?").
+
+Key design decisions:
+  - Uses @torch.enable_grad() to override the outer inference_mode
+    context that wraps normal vLLM inference.
+  - Embeddings are detached and cloned so they become leaf tensors
+    that accumulate .grad without affecting the model's own parameters.
+  - Per-token gradients require one backward pass per selected target
+    token; retain_graph is used only when more passes follow.
 """
 
 from dataclasses import dataclass, field

--- a/vllm/v1/worker/gpu/gradient/gradient_runner.py
+++ b/vllm/v1/worker/gpu/gradient/gradient_runner.py
@@ -13,6 +13,8 @@ Key design decisions:
     that accumulate .grad without affecting the model's own parameters.
   - Per-token gradients require one backward pass per selected target
     token; retain_graph is used only when more passes follow.
+  - Uses torch.autograd.grad instead of .backward() to avoid manual
+    gradient zeroing and cloning overhead.
 """
 
 from dataclasses import dataclass, field
@@ -120,6 +122,16 @@ class GradientRunner:
 
         inputs_embeds = torch.cat([input_embeds, output_embeds], dim=0)
 
+        # Build list of tensors we need gradients for.
+        grad_targets = []
+        grad_target_names = []
+        if want_input_grad:
+            grad_targets.append(input_embeds)
+            grad_target_names.append("input_embeddings")
+        if want_output_grad:
+            grad_targets.append(output_embeds)
+            grad_target_names.append("output_embeddings")
+
         # --- Forward pass (builds computation graph) ---
         hidden_states = self.model.forward(
             input_ids=None,
@@ -170,19 +182,18 @@ class GradientRunner:
                 # (more token indices, or a loss backward to follow).
                 need_graph = not is_last or (gradient_params.gradient_of == "both")
 
-                # Zero existing gradients
-                if input_embeds.grad is not None:
-                    input_embeds.grad.zero_()
-                if output_embeds.grad is not None:
-                    output_embeds.grad.zero_()
+                # torch.autograd.grad returns gradients directly, avoiding
+                # the overhead of .backward() + manual .grad zeroing/cloning.
+                grads = torch.autograd.grad(
+                    token_log_probs[t],
+                    grad_targets,
+                    retain_graph=need_graph,
+                )
 
-                token_log_probs[t].backward(retain_graph=need_graph)
-
-                # Collect gradients from requested targets
-                token_grad = self._collect_and_aggregate(
-                    input_embeds,
-                    output_embeds,
-                    gradient_params,
+                # Collect and aggregate gradients from all targets.
+                token_grad = self._aggregate_grad_targets(
+                    grads,
+                    gradient_params.aggregation,
                 )
                 per_token_grads.append(token_grad)
 
@@ -191,59 +202,30 @@ class GradientRunner:
 
         # --- Loss gradients (single backward) ---
         if gradient_params.gradient_of in ("loss", "both"):
-            # Zero existing gradients
-            if input_embeds.grad is not None:
-                input_embeds.grad.zero_()
-            if output_embeds.grad is not None:
-                output_embeds.grad.zero_()
-
             if gradient_params.loss_function == "cross_entropy":
                 loss = F.cross_entropy(target_logits, target_ids)
             else:
                 # log_prob_sum: negative log-likelihood
                 loss = -token_log_probs.sum()
 
-            loss.backward()
+            grads = torch.autograd.grad(loss, grad_targets)
             result.loss = loss.item()
 
-            if want_input_grad:
-                assert input_embeds.grad is not None
-                grad = input_embeds.grad.clone()
-                result.loss_gradients["input_embeddings"] = self._aggregate(
-                    grad, gradient_params.aggregation
-                )
-            if want_output_grad:
-                assert output_embeds.grad is not None
-                grad = output_embeds.grad.clone()
-                result.loss_gradients["output_embeddings"] = self._aggregate(
+            for name, grad in zip(grad_target_names, grads):
+                result.loss_gradients[name] = self._aggregate(
                     grad, gradient_params.aggregation
                 )
 
         return result
 
-    def _collect_and_aggregate(
-        self,
-        input_embeds: torch.Tensor,
-        output_embeds: torch.Tensor,
-        gradient_params: GradientParams,
+    @staticmethod
+    def _aggregate_grad_targets(
+        grads: tuple[torch.Tensor, ...],
+        aggregation: str,
     ) -> torch.Tensor:
-        """Collect gradients from the requested targets and aggregate."""
-        parts = []
-        if "input_embeddings" in gradient_params.gradient_targets:
-            assert input_embeds.grad is not None
-            parts.append(input_embeds.grad.clone())
-        if "output_embeddings" in gradient_params.gradient_targets:
-            assert output_embeds.grad is not None
-            parts.append(output_embeds.grad.clone())
-
-        if not parts:
-            raise RuntimeError(
-                "No gradient targets produced gradients. "
-                "Ensure gradient_targets is non-empty."
-            )
-
-        grad = torch.cat(parts, dim=0) if len(parts) > 1 else parts[0]
-        return self._aggregate(grad, gradient_params.aggregation)
+        """Concatenate gradients from multiple targets and aggregate."""
+        grad = torch.cat(grads, dim=0) if len(grads) > 1 else grads[0]
+        return GradientRunner._aggregate(grad, aggregation)
 
     @staticmethod
     def _aggregate(

--- a/vllm/v1/worker/gpu/gradient/gradient_runner.py
+++ b/vllm/v1/worker/gpu/gradient/gradient_runner.py
@@ -133,7 +133,9 @@ class GradientRunner:
             grad_target_names.append("output_embeddings")
 
         # --- Forward pass (builds computation graph) ---
-        hidden_states = self.model.forward(
+        # Concrete model classes accept intermediate_tensors and inputs_embeds
+        # but the VllmModel Protocol only declares (input_ids, positions).
+        hidden_states = self.model.forward(  # type: ignore[call-arg]
             input_ids=None,
             positions=positions,
             intermediate_tensors=None,

--- a/vllm/v1/worker/gpu/gradient/gradient_runner.py
+++ b/vllm/v1/worker/gpu/gradient/gradient_runner.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GradientRunner: computes gradients of loss and/or per-token log-probs
+with respect to input/output embeddings for a given prompt + target pair.
+
+This enables token-level attribution (e.g. "how much did each input token
+influence the log-probability of each output token?").
+"""
+
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from vllm.gradient_params import GradientParams
+from vllm.model_executor.models.interfaces_base import (
+    VllmModelForTextGeneration,
+    is_text_generation_model,
+)
+
+
+@dataclass
+class GradientRunnerOutput:
+    """Raw output from the gradient runner (GPU tensors / Python scalars).
+
+    This is converted to GradientOutput (CPU lists) by the caller before
+    being sent over the wire.
+
+    Attributes:
+        token_log_probs: Per-target-token log p(y_t | x, y_{<t}).
+        token_attributions: Attribution matrix.
+            If aggregated: [num_selected_targets, num_grad_tokens]
+            If full: [num_selected_targets, num_grad_tokens, hidden_dim]
+        loss: Scalar loss value.
+        loss_gradients: dict mapping gradient target name to gradient tensor.
+    """
+
+    token_log_probs: list[float] | None = None
+    token_attributions: torch.Tensor | None = None
+    loss: float | None = None
+    loss_gradients: dict[str, torch.Tensor] = field(default_factory=dict)
+
+
+class GradientRunner:
+    """Computes gradients for a causal LM given prompt + target tokens.
+
+    Runs a forward pass with gradient tracking enabled (overriding
+    the outer torch.inference_mode context), computes a loss or per-token
+    log-probs, calls backward, and extracts gradients w.r.t. the
+    requested targets.
+    """
+
+    def __init__(self, model: nn.Module):
+        if not is_text_generation_model(model):
+            raise TypeError(
+                "GradientRunner requires a text generation model that "
+                "implements embed_input_ids() and compute_logits(). "
+                f"Got: {type(model).__name__}"
+            )
+        self.model: VllmModelForTextGeneration = model  # type: ignore[assignment]
+
+    @torch.enable_grad()
+    def compute_gradients(
+        self,
+        input_ids: torch.Tensor,
+        target_ids: torch.Tensor,
+        gradient_params: GradientParams,
+    ) -> GradientRunnerOutput:
+        """Compute gradients for the given input/target pair.
+
+        Args:
+            input_ids: Prompt token IDs, shape [num_input_tokens].
+            target_ids: Target continuation token IDs, shape [num_target_tokens].
+            gradient_params: Configuration for what/how to compute.
+
+        Returns:
+            GradientRunnerOutput with requested gradient information.
+        """
+        device = input_ids.device
+        num_input = input_ids.shape[0]
+        num_target = target_ids.shape[0]
+
+        if num_input < 1:
+            raise ValueError(
+                "input_ids must have at least 1 token for gradient computation"
+            )
+
+        num_total = num_input + num_target
+
+        want_input_grad = "input_embeddings" in gradient_params.gradient_targets
+        want_output_grad = "output_embeddings" in gradient_params.gradient_targets
+
+        # --- Build the full sequence: [input | target] ---
+        full_ids = torch.cat([input_ids, target_ids])
+        positions = torch.arange(num_total, device=device)
+
+        # --- Embed with gradient tracking ---
+        # We detach and re-enable grad so the embedding lookup itself
+        # is not part of the graph, but the embeddings tensor IS a leaf
+        # that accumulates gradients.
+        with torch.no_grad():
+            all_embeds = self.model.embed_input_ids(full_ids)
+
+        input_embeds = (
+            all_embeds[:num_input].detach().clone().requires_grad_(want_input_grad)
+        )
+        output_embeds = (
+            all_embeds[num_input:].detach().clone().requires_grad_(want_output_grad)
+        )
+        del all_embeds  # Free original embeddings
+
+        inputs_embeds = torch.cat([input_embeds, output_embeds], dim=0)
+
+        # --- Forward pass (builds computation graph) ---
+        hidden_states = self.model.forward(
+            input_ids=None,
+            positions=positions,
+            intermediate_tensors=None,
+            inputs_embeds=inputs_embeds,
+        )
+        logits = self.model.compute_logits(hidden_states)
+        del hidden_states  # Free intermediate activations
+
+        assert logits is not None, (
+            "compute_logits returned None (likely not last PP rank)"
+        )
+        # logits: [num_total, vocab_size]
+
+        # --- Compute per-token log-probs for target positions ---
+        # Position i predicts token at position i+1.
+        # So target token 0 (at position num_input) is predicted by
+        # logits at position num_input - 1.
+        predict_start = num_input - 1
+        predict_end = num_input + num_target - 1
+        target_logits = logits[predict_start:predict_end]  # [num_target, V]
+        del logits  # Free full logits
+
+        log_probs = target_logits.log_softmax(dim=-1)
+
+        # Gather log-prob of each actual target token
+        token_log_probs = log_probs.gather(
+            dim=-1, index=target_ids.unsqueeze(-1)
+        ).squeeze(-1)  # [num_target]
+        del log_probs
+
+        result = GradientRunnerOutput()
+
+        if gradient_params.return_log_probs:
+            result.token_log_probs = token_log_probs.detach().tolist()
+
+        # --- Per-token log-prob gradients (token-level attribution) ---
+        if gradient_params.gradient_of in ("token_log_probs", "both"):
+            indices = gradient_params.target_token_indices
+            if indices is None:
+                indices = list(range(num_target))
+
+            per_token_grads = []
+            for i, t in enumerate(indices):
+                is_last = i == len(indices) - 1
+                # Only retain the graph if we need more backward passes
+                # (more token indices, or a loss backward to follow).
+                need_graph = not is_last or (gradient_params.gradient_of == "both")
+
+                # Zero existing gradients
+                if input_embeds.grad is not None:
+                    input_embeds.grad.zero_()
+                if output_embeds.grad is not None:
+                    output_embeds.grad.zero_()
+
+                token_log_probs[t].backward(retain_graph=need_graph)
+
+                # Collect gradients from requested targets
+                token_grad = self._collect_and_aggregate(
+                    input_embeds,
+                    output_embeds,
+                    gradient_params,
+                )
+                per_token_grads.append(token_grad)
+
+            # Stack: [num_selected_targets, num_grad_tokens, ...]
+            result.token_attributions = torch.stack(per_token_grads, dim=0)
+
+        # --- Loss gradients (single backward) ---
+        if gradient_params.gradient_of in ("loss", "both"):
+            # Zero existing gradients
+            if input_embeds.grad is not None:
+                input_embeds.grad.zero_()
+            if output_embeds.grad is not None:
+                output_embeds.grad.zero_()
+
+            if gradient_params.loss_function == "cross_entropy":
+                loss = F.cross_entropy(target_logits, target_ids)
+            else:
+                # log_prob_sum: negative log-likelihood
+                loss = -token_log_probs.sum()
+
+            loss.backward()
+            result.loss = loss.item()
+
+            if want_input_grad:
+                assert input_embeds.grad is not None
+                grad = input_embeds.grad.clone()
+                result.loss_gradients["input_embeddings"] = self._aggregate(
+                    grad, gradient_params.aggregation
+                )
+            if want_output_grad:
+                assert output_embeds.grad is not None
+                grad = output_embeds.grad.clone()
+                result.loss_gradients["output_embeddings"] = self._aggregate(
+                    grad, gradient_params.aggregation
+                )
+
+        return result
+
+    def _collect_and_aggregate(
+        self,
+        input_embeds: torch.Tensor,
+        output_embeds: torch.Tensor,
+        gradient_params: GradientParams,
+    ) -> torch.Tensor:
+        """Collect gradients from the requested targets and aggregate."""
+        parts = []
+        if "input_embeddings" in gradient_params.gradient_targets:
+            assert input_embeds.grad is not None
+            parts.append(input_embeds.grad.clone())
+        if "output_embeddings" in gradient_params.gradient_targets:
+            assert output_embeds.grad is not None
+            parts.append(output_embeds.grad.clone())
+
+        if not parts:
+            raise RuntimeError(
+                "No gradient targets produced gradients. "
+                "Ensure gradient_targets is non-empty."
+            )
+
+        grad = torch.cat(parts, dim=0) if len(parts) > 1 else parts[0]
+        return self._aggregate(grad, gradient_params.aggregation)
+
+    @staticmethod
+    def _aggregate(
+        grad: torch.Tensor,
+        aggregation: str,
+    ) -> torch.Tensor:
+        """Reduce [num_tokens, hidden_dim] → [num_tokens] or keep full.
+
+        Args:
+            grad: Gradient tensor of shape [num_tokens, hidden_dim].
+            aggregation: "none", "l2_norm", or "abs_sum".
+
+        Returns:
+            If aggregation is "none": [num_tokens, hidden_dim]
+            Otherwise: [num_tokens]
+        """
+        if aggregation == "l2_norm":
+            return grad.norm(dim=-1)
+        elif aggregation == "abs_sum":
+            return grad.abs().sum(dim=-1)
+        elif aggregation == "none":
+            return grad
+        else:
+            raise ValueError(f"Unknown aggregation mode: {aggregation!r}")

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -21,7 +21,7 @@ import functools
 import gc
 import time
 from copy import deepcopy
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 import torch
@@ -68,7 +68,10 @@ from vllm.v1.worker.gpu.cudagraph_utils import (
 )
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.eplb_utils import EPLBController, step_eplb_after
-from vllm.v1.worker.gpu.gradient.gradient_runner import GradientRunner
+from vllm.v1.worker.gpu.gradient.gradient_runner import (
+    GradientRunner,
+    GradientRunnerOutput,
+)
 from vllm.v1.worker.gpu.input_batch import (
     InputBatch,
     InputBuffers,
@@ -103,6 +106,9 @@ from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+
+if TYPE_CHECKING:
+    from vllm.gradient_params import GradientParams
 
 logger = init_logger(__name__)
 
@@ -1368,27 +1374,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def compute_gradients(
         self,
         input_ids: torch.Tensor,
-        gradient_params: Any,
-    ) -> Any:
+        gradient_params: "GradientParams",
+    ) -> GradientRunnerOutput:
         """Compute gradients for a single prompt + target pair.
 
-        This runs outside the normal execute_model / sample_tokens path
-        because it needs torch.enable_grad() and operates on a single
-        request at a time (no batching with generation requests).
-
-        Args:
-            input_ids: Prompt token IDs (already on device).
-            gradient_params: Configuration specifying what to compute.
-
-        Returns:
-            GradientRunnerOutput with the requested gradient information.
+        Runs outside the normal execute_model path because it needs
+        torch.enable_grad() and processes one request at a time.
         """
-        from vllm.gradient_params import GradientParams as _GradientParams
-
-        assert isinstance(gradient_params, _GradientParams)
         assert self.gradient_runner is not None, (
-            "GradientRunner not initialized. This model may not support "
-            "gradient computation."
+            "GradientRunner not initialized — model may not support gradients"
         )
         target_ids = torch.tensor(
             gradient_params.target_token_ids,
@@ -1396,9 +1390,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             device=self.device,
         )
         return self.gradient_runner.compute_gradients(
-            input_ids=input_ids,
-            target_ids=target_ids,
-            gradient_params=gradient_params,
+            input_ids, target_ids, gradient_params
         )
 
     def postprocess_pool(self, input_batch: InputBatch) -> None:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -68,6 +68,7 @@ from vllm.v1.worker.gpu.cudagraph_utils import (
 )
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.eplb_utils import EPLBController, step_eplb_after
+from vllm.v1.worker.gpu.gradient.gradient_runner import GradientRunner
 from vllm.v1.worker.gpu.input_batch import (
     InputBatch,
     InputBuffers,
@@ -188,6 +189,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.is_pooling_model = self.model_config.runner_type == "pooling"
         self.pooling_runner: PoolingRunner | None = None
 
+        # Gradient computation (available for generative models).
+        self.gradient_runner: GradientRunner | None = None
+
         # General request states.
         self.req_states = RequestState(
             max_num_reqs=self.max_num_reqs,
@@ -251,9 +255,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.req_states.max_model_len = max_model_len
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
+        from vllm.model_executor.models.interfaces_base import (
+            is_text_generation_model,
+        )
+
         tasks: list[SupportedTask] = []
         if self.model_config.runner_type == "generate":
             tasks.extend(self.model_state.get_supported_generation_tasks())
+            # Gradient computation is available for all text generation models.
+            if is_text_generation_model(self.model):
+                tasks.append("gradient")
         if self.is_pooling_model:
             # Do not rely on pooling_runner here, since this information is needed
             # on the first PP rank, while pooling_runner is only initialized
@@ -313,6 +324,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             load_dummy_weights,
         )
         self.eplb.maybe_start_async_loop(eplb_models_added)
+
+        # Initialize gradient runner for text generation models.
+        if not self.is_pooling_model and self.is_last_pp_rank:
+            from vllm.model_executor.models.interfaces_base import (
+                is_text_generation_model,
+            )
+
+            if is_text_generation_model(self.model):
+                self.gradient_runner = GradientRunner(self.model)
 
         if not self.is_first_pp_rank:
             # For non-first PP ranks, create intermediate tensors sized
@@ -1344,6 +1364,42 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.use_async_scheduling:
             return async_output
         return async_output.get_output()
+
+    def compute_gradients(
+        self,
+        input_ids: torch.Tensor,
+        gradient_params: Any,
+    ) -> Any:
+        """Compute gradients for a single prompt + target pair.
+
+        This runs outside the normal execute_model / sample_tokens path
+        because it needs torch.enable_grad() and operates on a single
+        request at a time (no batching with generation requests).
+
+        Args:
+            input_ids: Prompt token IDs (already on device).
+            gradient_params: Configuration specifying what to compute.
+
+        Returns:
+            GradientRunnerOutput with the requested gradient information.
+        """
+        from vllm.gradient_params import GradientParams as _GradientParams
+
+        assert isinstance(gradient_params, _GradientParams)
+        assert self.gradient_runner is not None, (
+            "GradientRunner not initialized. This model may not support "
+            "gradient computation."
+        )
+        target_ids = torch.tensor(
+            gradient_params.target_token_ids,
+            dtype=torch.long,
+            device=self.device,
+        )
+        return self.gradient_runner.compute_gradients(
+            input_ids=input_ids,
+            target_ids=target_ids,
+            gradient_params=gradient_params,
+        )
 
     def postprocess_pool(self, input_batch: InputBatch) -> None:
         # Update the number of computed tokens.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -67,6 +67,7 @@ from .utils import request_memory
 logger = init_logger(__name__)
 
 if TYPE_CHECKING:
+    from vllm.gradient_params import GradientParams
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
@@ -782,42 +783,32 @@ class Worker(WorkerBase):
     def compute_gradients(
         self,
         prompt_token_ids: list[int],
-        gradient_params_dict: dict,
+        gradient_params: "GradientParams",
     ) -> dict:
         """Compute gradients for a prompt + target pair.
 
-        This method is called via collective_rpc from the EngineCore.
-        It does NOT use @torch.inference_mode() because GradientRunner
-        needs gradient tracking enabled.
+        Called via collective_rpc from EngineCore. Not decorated with
+        @torch.inference_mode() because GradientRunner needs gradients.
 
-        Args:
-            prompt_token_ids: The prompt token IDs.
-            gradient_params_dict: Serialized GradientParams fields.
-
-        Returns:
-            A dict with gradient results (CPU tensors converted to lists).
+        Returns a plain dict so the result is serializable across
+        process boundaries (multiproc executor).
         """
-        from vllm.gradient_params import GradientParams
+        from vllm.gradient_params import GradientParams as _GradientParams
 
-        gradient_params = GradientParams(**gradient_params_dict)
+        assert isinstance(gradient_params, _GradientParams)
         input_ids = torch.tensor(prompt_token_ids, dtype=torch.long, device=self.device)
-        runner_output = self.model_runner.compute_gradients(
-            input_ids=input_ids,
-            gradient_params=gradient_params,
-        )
-        # Convert to serializable dict for RPC transport.
+        out = self.model_runner.compute_gradients(input_ids, gradient_params)
+
         result: dict = {}
-        if runner_output.token_log_probs is not None:
-            result["token_log_probs"] = runner_output.token_log_probs
-        if runner_output.token_attributions is not None:
-            result["token_attributions"] = (
-                runner_output.token_attributions.cpu().tolist()
-            )
-        if runner_output.loss is not None:
-            result["loss"] = runner_output.loss
-        if runner_output.loss_gradients:
+        if out.token_log_probs is not None:
+            result["token_log_probs"] = out.token_log_probs
+        if out.token_attributions is not None:
+            result["token_attributions"] = out.token_attributions.cpu().tolist()
+        if out.loss is not None:
+            result["loss"] = out.loss
+        if out.loss_gradients:
             result["loss_gradients"] = {
-                k: v.cpu().tolist() for k, v in runner_output.loss_gradients.items()
+                k: v.cpu().tolist() for k, v in out.loss_gradients.items()
             }
         return result
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -797,7 +797,7 @@ class Worker(WorkerBase):
 
         assert isinstance(gradient_params, _GradientParams)
         input_ids = torch.tensor(prompt_token_ids, dtype=torch.long, device=self.device)
-        out = self.model_runner.compute_gradients(input_ids, gradient_params)
+        out = self.model_runner.compute_gradients(input_ids, gradient_params)  # type: ignore[attr-defined]
 
         result: dict = {}
         if out.token_log_probs is not None:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -803,13 +803,21 @@ class Worker(WorkerBase):
         if out.token_log_probs is not None:
             result["token_log_probs"] = out.token_log_probs
         if out.token_attributions is not None:
-            result["token_attributions"] = out.token_attributions.cpu().tolist()
+            arr = out.token_attributions.cpu().numpy()
+            result["token_attributions_bytes"] = arr.tobytes()
+            result["token_attributions_shape"] = list(arr.shape)
+            result["token_attributions_dtype"] = str(arr.dtype)
         if out.loss is not None:
             result["loss"] = out.loss
         if out.loss_gradients:
-            result["loss_gradients"] = {
-                k: v.cpu().tolist() for k, v in out.loss_gradients.items()
-            }
+            result["loss_gradients_packed"] = {}
+            for k, v in out.loss_gradients.items():
+                arr = v.cpu().numpy()
+                result["loss_gradients_packed"][k] = {
+                    "bytes": arr.tobytes(),
+                    "shape": list(arr.shape),
+                    "dtype": str(arr.dtype),
+                }
         return result
 
     @torch.inference_mode()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -779,6 +779,48 @@ class Worker(WorkerBase):
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
         return self.model_runner.sample_tokens(grammar_output)
 
+    def compute_gradients(
+        self,
+        prompt_token_ids: list[int],
+        gradient_params_dict: dict,
+    ) -> dict:
+        """Compute gradients for a prompt + target pair.
+
+        This method is called via collective_rpc from the EngineCore.
+        It does NOT use @torch.inference_mode() because GradientRunner
+        needs gradient tracking enabled.
+
+        Args:
+            prompt_token_ids: The prompt token IDs.
+            gradient_params_dict: Serialized GradientParams fields.
+
+        Returns:
+            A dict with gradient results (CPU tensors converted to lists).
+        """
+        from vllm.gradient_params import GradientParams
+
+        gradient_params = GradientParams(**gradient_params_dict)
+        input_ids = torch.tensor(prompt_token_ids, dtype=torch.long, device=self.device)
+        runner_output = self.model_runner.compute_gradients(
+            input_ids=input_ids,
+            gradient_params=gradient_params,
+        )
+        # Convert to serializable dict for RPC transport.
+        result: dict = {}
+        if runner_output.token_log_probs is not None:
+            result["token_log_probs"] = runner_output.token_log_probs
+        if runner_output.token_attributions is not None:
+            result["token_attributions"] = (
+                runner_output.token_attributions.cpu().tolist()
+            )
+        if runner_output.loss is not None:
+            result["loss"] = runner_output.loss
+        if runner_output.loss_gradients:
+            result["loss_gradients"] = {
+                k: v.cpu().tolist() for k, v in runner_output.loss_gradients.items()
+            }
+        return result
+
     @torch.inference_mode()
     def execute_model(
         self, scheduler_output: "SchedulerOutput"


### PR DESCRIPTION
## Summary
- Adds a `/v1/gradients` API endpoint that computes gradients of loss and/or per-token log-probabilities w.r.t. input/output embeddings for a given prompt + target pair, enabling token-level attribution and interpretability analysis.
- Introduces `GradientParams`, `GradientRunner`, and full engine wiring (`EngineCoreRequest`, `AsyncLLM`, `EngineCore`, `InputProcessor`, `OutputProcessor`) so gradient requests flow through the standard vLLM serving stack.
- Gradient requests bypass the scheduler and execute via `collective_rpc` to avoid conflicts with the batched `@torch.inference_mode()` inference path.

## Architecture

```
POST /v1/gradients (GradientRequest: prompt + target text)
  → ServingGradient tokenizes both, builds GradientParams
  → AsyncLLM.compute_gradients() sends EngineCoreRequest
  → EngineCore bypasses scheduler, dispatches via collective_rpc
  → Worker.compute_gradients() → GradientRunner (torch.enable_grad())
  → Results flow back as GradientRequestOutput → GradientResponse JSON
```

## Key components
- **`vllm/gradient_params.py`** — `GradientParams` msgspec struct controlling what/how to compute
- **`vllm/entrypoints/gradient/`** — FastAPI router, Pydantic request/response protocol, serving handler
- **`vllm/v1/worker/gpu/gradient/gradient_runner.py`** — Core computation: forward pass with gradient tracking, per-token backward passes, GPU-side aggregation
- **`vllm/v1/engine/core.py`** — Scheduler bypass via `_handle_gradient_request` + `collective_rpc`
- **`vllm/outputs.py`** — `GradientOutput` and `GradientRequestOutput` data classes

## Test plan
- [ ] Unit test `GradientRunner` with a small model (forward + backward correctness)
- [ ] Integration test `/v1/gradients` endpoint with `pytest` against a running server
- [ ] Verify `gradient_of="loss"`, `"token_log_probs"`, and `"both"` modes
- [ ] Verify `aggregation="l2_norm"`, `"abs_sum"`, and `"none"` modes
- [ ] Verify `target_token_indices` subset selection
- [ ] Confirm normal inference is unaffected (gradient requests don't interfere with batched generation)

## Notes
- AI assistance was used (Claude). All changes were reviewed line-by-line.
- No existing PR addresses this feature (checked via `gh pr list --search`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)