### PR TITLE
[BugFix] Fix order of compile logging

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -299,8 +299,10 @@ def _try_load_aot_compiled_fn(
             # is populated by _verify_source_unchanged.
             with maybe_use_cudagraph_partition_wrapper(model.vllm_config):
                 loaded_fn._artifacts.compiled_fn.finalize_loading(model.vllm_config)
-        compilation_counter.num_aot_artifacts_loaded += 1
-        logger.info("Directly load AOT compilation from path %s", aot_compilation_path)
+            compilation_counter.num_aot_artifacts_loaded += 1
+            logger.info(
+                "Directly load AOT compilation from path %s", aot_compilation_path
+            )
         return loaded_fn
     except Exception as e:
         if os.path.exists(aot_compilation_path):


### PR DESCRIPTION
Previously the logging went:
```
torch.compile took X s in total
Directly load AOT compilation from path ...
Initial profiling/warmup run took X s
```
This was a little weird because loading the AOT compilation is a part of "torch.compile".

This PR fixes it to
```
Directly load AOT compilation from path ...
torch.compile took X s in total
Initial profiling/warmup run took X s
```
