### PR TITLE
[Hybrid] Introduce MambaProcessContext to simplify function signatures

### DIFF
--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -15,7 +15,6 @@ from tests.utils import create_new_process_for_each_test
 from vllm import LLM, SamplingParams, TokensPrompt
 from vllm.config import CacheConfig
 from vllm.distributed import cleanup_dist_env_and_memory
-from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
@@ -27,7 +26,6 @@ from vllm.v1.request import Request
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.worker import mamba_utils
-from vllm.v1.worker.gpu_input_batch import CachedRequestState
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
 from vllm.v1.worker.mamba_utils import get_mamba_groups
@@ -318,65 +316,34 @@ def get_fake_process_mamba_fn(
 
     def fake_preprocess_mamba_fn(
         scheduler_output: SchedulerOutput,
-        kv_cache_config: KVCacheConfig,
         cache_config: CacheConfig,
-        mamba_state_idx: dict[str, int],
-        input_batch: GPUInputBatch,
-        requests: dict[str, CachedRequestState],
-        forward_context: dict[str, Any],
-        mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
-        copy_bufs: mamba_utils.MambaCopyBuffers,
+        ctx: mamba_utils.MambaProcessContext,
     ):
         nonlocal copy_info
         copy_info = None
-        ret = original_preprocess_mamba_fn(
-            scheduler_output,
-            kv_cache_config,
-            cache_config,
-            mamba_state_idx,
-            input_batch,
-            requests,
-            forward_context,
-            mamba_state_copy_funcs,
-            copy_bufs,
-        )
+        ret = original_preprocess_mamba_fn(scheduler_output, cache_config, ctx)
         if cur_step_action is not None:
             check_copy_info(
                 cur_step_action.preprocess_copy_idx,
-                kv_cache_config,
-                forward_context,
-                input_batch,
+                ctx.kv_cache_config,
+                ctx.forward_context,
+                ctx.input_batch,
             )
         return ret
 
     def fake_post_process_mamba_fn(
         scheduler_output: SchedulerOutput,
-        kv_cache_config: KVCacheConfig,
-        input_batch: GPUInputBatch,
-        requests: dict[str, CachedRequestState],
-        mamba_state_idx: dict[str, int],
-        forward_context: dict[str, Any],
-        mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
-        copy_bufs: mamba_utils.MambaCopyBuffers,
+        ctx: mamba_utils.MambaProcessContext,
     ):
         nonlocal copy_info
         copy_info = None
-        ret = original_post_process_mamba_fn(
-            scheduler_output,
-            kv_cache_config,
-            input_batch,
-            requests,
-            mamba_state_idx,
-            forward_context,
-            mamba_state_copy_funcs,
-            copy_bufs,
-        )
+        ret = original_post_process_mamba_fn(scheduler_output, ctx)
         if cur_step_action is not None:
             check_copy_info(
                 cur_step_action.postprocess_copy_idx,
-                kv_cache_config,
-                forward_context,
-                input_batch,
+                ctx.kv_cache_config,
+                ctx.forward_context,
+                ctx.input_batch,
             )
         return ret
 

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
-from vllm.v1.worker.mamba_utils import preprocess_mamba
+from vllm.v1.worker.mamba_utils import MambaProcessContext, preprocess_mamba
 
 
 def _make_scheduler_output(
@@ -50,20 +50,20 @@ def test_resumed_req_ids_cleared_from_mamba_state_idx():
         resumed_req_ids={"resumed"},
     )
 
+    ctx = MambaProcessContext(
+        kv_cache_config=MagicMock(),
+        mamba_state_idx=mamba_state_idx,
+        input_batch=input_batch,
+        requests={},
+        forward_context={},
+        mamba_state_copy_funcs=(),
+        copy_bufs=copy_bufs,
+    )
+
     with patch(
         "vllm.v1.worker.mamba_utils.get_mamba_groups",
         return_value=([0], spec),
     ):
-        preprocess_mamba(
-            sched,
-            MagicMock(),
-            cache_config,
-            mamba_state_idx,
-            input_batch,
-            {},
-            {},
-            (),
-            copy_bufs,
-        )
+        preprocess_mamba(sched, cache_config, ctx)
 
     assert mamba_state_idx == {"keep": 99}

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1446,16 +1446,16 @@ class GPUModelRunner(
                 self.num_accepted_tokens.gpu[:num_reqs].cpu().numpy()
             ):
                 self.input_batch.num_accepted_tokens_cpu[i] = num_tokens
-            mamba_utils.postprocess_mamba(
-                scheduler_output,
-                self.kv_cache_config,
-                self.input_batch,
-                self.requests,
-                self.mamba_state_idx,
-                self.compilation_config.static_forward_context,
-                self.model.get_mamba_state_copy_func(),
-                self._get_mamba_copy_bufs(),
+            mamba_ctx = mamba_utils.MambaProcessContext(
+                kv_cache_config=self.kv_cache_config,
+                mamba_state_idx=self.mamba_state_idx,
+                input_batch=self.input_batch,
+                requests=self.requests,
+                forward_context=self.compilation_config.static_forward_context,
+                mamba_state_copy_funcs=self.model.get_mamba_state_copy_func(),
+                copy_bufs=self._get_mamba_copy_bufs(),
             )
+            mamba_utils.postprocess_mamba(scheduler_output, mamba_ctx)
         else:
             self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
                 self.num_accepted_tokens.gpu[:num_reqs], non_blocking=True
@@ -3914,16 +3914,17 @@ class GPUModelRunner(
                 if deferred_state_corrections_fn:
                     deferred_state_corrections_fn()
                     deferred_state_corrections_fn = None
+                mamba_ctx = mamba_utils.MambaProcessContext(
+                    kv_cache_config=self.kv_cache_config,
+                    mamba_state_idx=self.mamba_state_idx,
+                    input_batch=self.input_batch,
+                    requests=self.requests,
+                    forward_context=self.compilation_config.static_forward_context,
+                    mamba_state_copy_funcs=self.model.get_mamba_state_copy_func(),
+                    copy_bufs=self._get_mamba_copy_bufs(),
+                )
                 mamba_utils.preprocess_mamba(
-                    scheduler_output,
-                    self.kv_cache_config,
-                    self.cache_config,
-                    self.mamba_state_idx,
-                    self.input_batch,
-                    self.requests,
-                    self.compilation_config.static_forward_context,
-                    self.model.get_mamba_state_copy_func(),
-                    self._get_mamba_copy_bufs(),
+                    scheduler_output, self.cache_config, mamba_ctx
                 )
                 # preprocess_mamba resets num_accepted_tokens_cpu to 1
                 # for requests whose state was copied to a new block.

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -94,19 +94,30 @@ class MambaCopyBuffers:
         )
 
 
+@dataclasses.dataclass
+class MambaProcessContext:
+    """Bundles common parameters for mamba pre/post processing."""
+
+    kv_cache_config: KVCacheConfig
+    mamba_state_idx: dict[str, int]
+    input_batch: GPUInputBatch
+    requests: dict[str, CachedRequestState]
+    forward_context: dict[str, Any]
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...]
+    copy_bufs: MambaCopyBuffers
+
+
 def collect_mamba_copy_meta(
-    copy_bufs: MambaCopyBuffers,
-    kv_cache_config: KVCacheConfig,
-    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+    ctx: MambaProcessContext,
     src_block_idx: int,
     dest_block_idx: int,
     accept_token_bias: int,
     req_state: CachedRequestState,
-    forward_context: dict[str, Any],
 ) -> None:
     if src_block_idx == dest_block_idx and accept_token_bias == 0:
         return
 
+    copy_bufs = ctx.copy_bufs
     mamba_group_ids = copy_bufs.mamba_group_ids
     src_ptrs_np = copy_bufs.src_ptrs.np
     dst_ptrs_np = copy_bufs.dst_ptrs.np
@@ -116,11 +127,11 @@ def collect_mamba_copy_meta(
     for mamba_group_id in mamba_group_ids:
         block_ids = req_state.block_ids[mamba_group_id]
         dest_block_id = block_ids[dest_block_idx]
-        layer_names = kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
+        layer_names = ctx.kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
         for layer_name in layer_names:
-            attention = forward_context[layer_name]
+            attention = ctx.forward_context[layer_name]
             kv_caches: list[torch.Tensor] = attention.kv_cache
-            for state, state_copy_func in zip(kv_caches, mamba_state_copy_funcs):
+            for state, state_copy_func in zip(kv_caches, ctx.mamba_state_copy_funcs):
                 copy_spec = state_copy_func(
                     state, block_ids, src_block_idx, accept_token_bias + 1
                 )
@@ -146,20 +157,14 @@ def do_mamba_copy_block(copy_bufs: MambaCopyBuffers):
 
 def preprocess_mamba(
     scheduler_output: SchedulerOutput,
-    kv_cache_config: KVCacheConfig,
     cache_config: CacheConfig,
-    mamba_state_idx: dict[str, int],
-    input_batch: GPUInputBatch,
-    requests: dict[str, CachedRequestState],
-    forward_context: dict[str, Any],
-    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
-    copy_bufs: MambaCopyBuffers,
+    ctx: MambaProcessContext,
 ):
     """
     Copy the mamba state of previous step to the last
     (1 + num_speculative_blocks) block.
     """
-    mamba_spec = copy_bufs.mamba_spec
+    mamba_spec = ctx.copy_bufs.mamba_spec
     num_speculative_blocks = mamba_spec.num_speculative_blocks
     # TODO(Chen): we need to optimize this function a lot
     assert cache_config.enable_prefix_caching
@@ -173,12 +178,13 @@ def preprocess_mamba(
     # point to block indices beyond the new (smaller) block allocation.
     resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
     for req_id in itertools.chain(finished_req_ids, preempted_req_ids, resumed_req_ids):
-        mamba_state_idx.pop(req_id, None)
+        ctx.mamba_state_idx.pop(req_id, None)
 
-    copy_bufs.offset = 0
+    input_batch = ctx.input_batch
+    ctx.copy_bufs.offset = 0
     for i, req_id in enumerate(input_batch.req_ids):
-        req_state = requests[req_id]
-        prev_state_idx = mamba_state_idx.get(req_id)
+        req_state = ctx.requests[req_id]
+        prev_state_idx = ctx.mamba_state_idx.get(req_id)
         if prev_state_idx is None:
             # new / resumed request, no previous state
             # if num_computed_tokens is 0, prev_state_idx will be -1
@@ -201,31 +207,22 @@ def preprocess_mamba(
         # Block 3: speculative block
         # And use block 1 to save the running state.
         curr_state_idx = num_blocks - 1 - num_speculative_blocks
-        mamba_state_idx[req_id] = curr_state_idx
+        ctx.mamba_state_idx[req_id] = curr_state_idx
         if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
             collect_mamba_copy_meta(
-                copy_bufs,
-                kv_cache_config,
-                mamba_state_copy_funcs,
+                ctx,
                 prev_state_idx,
                 curr_state_idx,
                 input_batch.num_accepted_tokens_cpu[i] - 1,
                 req_state,
-                forward_context,
             )
             input_batch.num_accepted_tokens_cpu[i] = 1
-    do_mamba_copy_block(copy_bufs)
+    do_mamba_copy_block(ctx.copy_bufs)
 
 
 def postprocess_mamba(
     scheduler_output: SchedulerOutput,
-    kv_cache_config: KVCacheConfig,
-    input_batch: GPUInputBatch,
-    requests: dict[str, CachedRequestState],
-    mamba_state_idx: dict[str, int],
-    forward_context: dict[str, Any],
-    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
-    copy_bufs: MambaCopyBuffers,
+    ctx: MambaProcessContext,
 ):
     """
     If a blocks is converted from partial block to full block in this step, copy the
@@ -233,9 +230,12 @@ def postprocess_mamba(
     """
     num_scheduled_tokens_dict = scheduler_output.num_scheduled_tokens
     scheduled_spec_decode_tokens_dict = scheduler_output.scheduled_spec_decode_tokens
+    input_batch = ctx.input_batch
     num_accepted_tokens_cpu = input_batch.num_accepted_tokens_cpu
-    mamba_spec = copy_bufs.mamba_spec
-    copy_bufs.offset = 0
+    mamba_spec = ctx.copy_bufs.mamba_spec
+    mamba_state_idx = ctx.mamba_state_idx
+    requests = ctx.requests
+    ctx.copy_bufs.offset = 0
     for i, req_id in enumerate(input_batch.req_ids):
         req_state = requests[req_id]
         num_computed_tokens = req_state.num_computed_tokens
@@ -255,15 +255,12 @@ def postprocess_mamba(
             src_block_idx = mamba_state_idx[req_id]
             dest_block_idx = aligned_new_computed_tokens // mamba_spec.block_size - 1
             collect_mamba_copy_meta(
-                copy_bufs,
-                kv_cache_config,
-                mamba_state_copy_funcs,
+                ctx,
                 src_block_idx,
                 dest_block_idx,
                 accept_token_bias,
                 req_state,
-                forward_context,
             )
             if src_block_idx == dest_block_idx:
                 num_accepted_tokens_cpu[i] = 1
-    do_mamba_copy_block(copy_bufs)
+    do_mamba_copy_block(ctx.copy_bufs)

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -98,7 +98,6 @@ def collect_mamba_copy_meta(
     copy_bufs: MambaCopyBuffers,
     kv_cache_config: KVCacheConfig,
     mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
-    mamba_group_ids: list[int],
     src_block_idx: int,
     dest_block_idx: int,
     accept_token_bias: int,
@@ -108,6 +107,7 @@ def collect_mamba_copy_meta(
     if src_block_idx == dest_block_idx and accept_token_bias == 0:
         return
 
+    mamba_group_ids = copy_bufs.mamba_group_ids
     src_ptrs_np = copy_bufs.src_ptrs.np
     dst_ptrs_np = copy_bufs.dst_ptrs.np
     sizes_np = copy_bufs.sizes.np
@@ -159,7 +159,6 @@ def preprocess_mamba(
     Copy the mamba state of previous step to the last
     (1 + num_speculative_blocks) block.
     """
-    mamba_group_ids = copy_bufs.mamba_group_ids
     mamba_spec = copy_bufs.mamba_spec
     num_speculative_blocks = mamba_spec.num_speculative_blocks
     # TODO(Chen): we need to optimize this function a lot
@@ -208,7 +207,6 @@ def preprocess_mamba(
                 copy_bufs,
                 kv_cache_config,
                 mamba_state_copy_funcs,
-                mamba_group_ids,
                 prev_state_idx,
                 curr_state_idx,
                 input_batch.num_accepted_tokens_cpu[i] - 1,
@@ -236,7 +234,6 @@ def postprocess_mamba(
     num_scheduled_tokens_dict = scheduler_output.num_scheduled_tokens
     scheduled_spec_decode_tokens_dict = scheduler_output.scheduled_spec_decode_tokens
     num_accepted_tokens_cpu = input_batch.num_accepted_tokens_cpu
-    mamba_group_ids = copy_bufs.mamba_group_ids
     mamba_spec = copy_bufs.mamba_spec
     copy_bufs.offset = 0
     for i, req_id in enumerate(input_batch.req_ids):
@@ -261,7 +258,6 @@ def postprocess_mamba(
                 copy_bufs,
                 kv_cache_config,
                 mamba_state_copy_funcs,
-                mamba_group_ids,
                 src_block_idx,
                 dest_block_idx,
                 accept_token_bias,


### PR DESCRIPTION
## Purpose

This PR Refactor mamba preprocessing and postprocessing functions in `mamba_utils.py` to improve code readability and maintainability. In particular, the `preprocess_mamba` and `postprocess_mamba` had almost the same parameters but in a different order. This PR introduces a  `MambaProcessContext` dataclass to bundle parameters that are common to both pre and post process.

## Test Plan

```
vllm serve ibm-granite/granite-4.0-tiny-preview --enforce-eager
```

```
lm_eval --model local-completions --tasks gsm8k --num_fewshot 5 --batch_size auto --limit 500     \
    --model_args model=ibm-granite/granite-4.0-tiny-preview,base_url=http://0.0.0.0:8000/v1/completions,num_concurrent=50,max_retries=3,tokenized_requests=False
```

## Test Result

Branch `preprocess_refactor`:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.616|±  |0.0218|
|     |       |strict-match    |     5|exact_match|↑  |0.586|±  |0.0220|
```

Branch `main`:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.638|±  |0.0215|
|     |       |strict-match    |     5|exact_match|↑  |0.604|±  |0.0219|
```