### PR TITLE
[Metrics] Add labeled token waiting metrics for precise load balancing

### DIFF
--- a/tests/entrypoints/serve/instrumentator/test_metrics.py
+++ b/tests/entrypoints/serve/instrumentator/test_metrics.py
@@ -182,6 +182,8 @@ async def test_metrics_counts(
 EXPECTED_METRICS_V1 = [
     "vllm:num_requests_running",
     "vllm:num_requests_waiting",
+    "vllm:approximate_uncached_tokens_waiting",
+    "vllm:num_tokens_waiting",
     "vllm:kv_cache_usage_perc",
     "vllm:prefix_cache_queries",
     "vllm:prefix_cache_hits",
@@ -299,13 +301,15 @@ async def test_abort_metrics_reset(
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     prompt_ids = tokenizer.encode(_PROMPT)
 
-    running_requests, waiting_requests, kv_cache_usage = _get_running_metrics_from_api(
+    running_requests, waiting_requests, waiting_tokens, num_tokens_waiting, kv_cache_usage = _get_running_metrics_from_api(
         server,
     )
 
     # Expect no running requests or kvcache usage
     assert running_requests == 0
     assert waiting_requests == 0
+    assert waiting_tokens == 0
+    assert num_tokens_waiting == 0
     assert kv_cache_usage == 0.0
 
     # Start some long-running requests that we can abort
@@ -337,12 +341,14 @@ async def test_abort_metrics_reset(
         pytest.fail("Requests never appeared as running in metrics")
 
     # Check that we have running requests
-    running_requests, waiting_requests, kv_cache_usage = _get_running_metrics_from_api(
+    running_requests, waiting_requests, waiting_tokens, num_tokens_waiting, kv_cache_usage = _get_running_metrics_from_api(
         server,
     )
 
     # Expect running requests and kvcache usage
     assert running_requests > 0
+    assert waiting_tokens >= 0
+    assert num_tokens_waiting >= 0
     assert kv_cache_usage > 0
 
     # Cancel all tasks to abort the requests
@@ -359,7 +365,7 @@ async def test_abort_metrics_reset(
     )
 
     # Verify running and waiting requests counts and KV cache usage are zero
-    running_requests_after, waiting_requests_after, kv_cache_usage_after = (
+    running_requests_after, waiting_requests_after, waiting_tokens_after, num_tokens_waiting_after, kv_cache_usage_after = (
         _get_running_metrics_from_api(server)
     )
 
@@ -368,6 +374,12 @@ async def test_abort_metrics_reset(
     )
     assert waiting_requests_after == 0, (
         f"Expected 0 waiting requests after abort, got {waiting_requests_after}"
+    )
+    assert waiting_tokens_after == 0, (
+        f"Expected 0 waiting tokens after abort, got {waiting_tokens_after}"
+    )
+    assert num_tokens_waiting_after == 0, (
+        f"Expected 0 raw waiting tokens after abort, got {num_tokens_waiting_after}"
     )
     assert kv_cache_usage_after == 0, (
         f"Expected 0% KV cache usage after abort, got {kv_cache_usage_after}"
@@ -387,13 +399,13 @@ async def _poll_until(
 
 
 def _get_running_metrics_from_api(server: RemoteOpenAIServer):
-    """Return (running_count, waiting_count, kv_cache_usage)"""
+    """Return (running_count, waiting_count, waiting_tokens, num_tokens_waiting, kv_cache_usage)"""
 
     response = requests.get(server.url_for("metrics"))
     assert response.status_code == HTTPStatus.OK
 
     # Verify running and waiting requests counts and KV cache usage are zero
-    running_requests, waiting_requests, kv_cache_usage = None, None, None
+    running_requests, waiting_requests, waiting_tokens, num_tokens_waiting, kv_cache_usage = None, None, None, None, None
 
     kv_cache_usage_metric = "vllm:kv_cache_usage_perc"
 
@@ -408,6 +420,16 @@ def _get_running_metrics_from_api(server: RemoteOpenAIServer):
                 if sample.name == "vllm:num_requests_waiting":
                     waiting_requests = sample.value
                     break
+        elif family.name == "vllm:approximate_uncached_tokens_waiting":
+            for sample in family.samples:
+                if sample.name == "vllm:approximate_uncached_tokens_waiting":
+                    waiting_tokens = sample.value
+                    break
+        elif family.name == "vllm:num_tokens_waiting":
+            for sample in family.samples:
+                if sample.name == "vllm:num_tokens_waiting":
+                    num_tokens_waiting = sample.value
+                    break
         elif family.name == kv_cache_usage_metric:
             for sample in family.samples:
                 if sample.name == kv_cache_usage_metric:
@@ -416,9 +438,11 @@ def _get_running_metrics_from_api(server: RemoteOpenAIServer):
 
     assert running_requests is not None
     assert waiting_requests is not None
+    assert waiting_tokens is not None
+    assert num_tokens_waiting is not None
     assert kv_cache_usage is not None
 
-    return running_requests, waiting_requests, kv_cache_usage
+    return running_requests, waiting_requests, waiting_tokens, num_tokens_waiting, kv_cache_usage
 
 
 def test_metrics_exist_run_batch():

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -178,6 +178,10 @@ class Scheduler(SchedulerInterface):
         # number of unfinished requests
         self.num_waiting_for_streaming_input: int = 0
 
+        # Map to keep track of approximate uncached and raw tokens for requests in waiting state
+        # req_id -> (approximate_uncached_tokens, raw_num_prompt_tokens)
+        self.waiting_reqs_uncached_tokens_map: dict[str, tuple[int, int]] = {}
+
         # KV Connector: requests in process of async KV loading or recving
         self.finished_recving_kv_req_ids: set[str] = set()
         self.failed_recving_kv_req_ids: set[str] = set()
@@ -948,6 +952,12 @@ class Scheduler(SchedulerInterface):
         if self.log_stats:
             request.record_event(EngineCoreEventType.PREEMPTED, timestamp)
 
+        # Update approximate uncached tokens when preempted back to waiting
+        if request.request_id not in self.waiting_reqs_uncached_tokens_map:
+            _, hit_tokens = self.kv_cache_manager.get_computed_blocks(request)
+            uncached_tokens = max(0, request.num_tokens - hit_tokens)
+            self.waiting_reqs_uncached_tokens_map[request.request_id] = (uncached_tokens, request.num_prompt_tokens)
+
         # Put the request back to the waiting queue.
         self.waiting.prepend_request(request)
 
@@ -1539,6 +1549,11 @@ class Scheduler(SchedulerInterface):
         )
 
     def _enqueue_waiting_request(self, request: Request) -> None:
+        if request.request_id not in self.waiting_reqs_uncached_tokens_map:
+            _, hit_tokens = self.kv_cache_manager.get_computed_blocks(request)
+            uncached_tokens = max(0, request.num_prompt_tokens - hit_tokens)
+            self.waiting_reqs_uncached_tokens_map[request.request_id] = (uncached_tokens, request.num_prompt_tokens)
+
         if self._is_blocked_waiting_status(request.status):
             self.skipped_waiting.add_request(request)
         else:
@@ -1927,9 +1942,20 @@ class Scheduler(SchedulerInterface):
         connector_stats_payload = (
             kv_connector_stats.data if kv_connector_stats else None
         )
+
+        current_waiting = set(req.request_id for req in itertools.chain(self.waiting, self.skipped_waiting))
+        for req_id in list(self.waiting_reqs_uncached_tokens_map.keys()):
+            if req_id not in current_waiting:
+                self.waiting_reqs_uncached_tokens_map.pop(req_id)
+                
+        approximate_uncached_tokens_waiting = sum(t[0] for t in self.waiting_reqs_uncached_tokens_map.values())
+        num_tokens_waiting = sum(t[1] for t in self.waiting_reqs_uncached_tokens_map.values())
+
         return SchedulerStats(
             num_running_reqs=len(self.running),
             num_waiting_reqs=len(self.waiting) + len(self.skipped_waiting),
+            approximate_uncached_tokens_waiting=approximate_uncached_tokens_waiting,
+            num_tokens_waiting=num_tokens_waiting,
             kv_cache_usage=self.kv_cache_manager.usage,
             encoder_cache_usage=self._get_encoder_cache_usage(),
             prefix_cache_stats=prefix_cache_stats,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -325,6 +325,12 @@ class AggregatedLoggingStatLogger(LoggingStatLogger, AggregateStatLoggerBase):
             self.last_scheduler_stats.num_waiting_reqs += (
                 last_scheduler_stats.num_waiting_reqs
             )
+            self.last_scheduler_stats.approximate_uncached_tokens_waiting += (
+                last_scheduler_stats.approximate_uncached_tokens_waiting
+            )
+            self.last_scheduler_stats.num_tokens_waiting += (
+                last_scheduler_stats.num_tokens_waiting
+            )
             self.last_scheduler_stats.num_running_reqs += (
                 last_scheduler_stats.num_running_reqs
             )
@@ -451,6 +457,26 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
         self.gauge_scheduler_waiting = create_metric_per_engine(
             gauge_scheduler_waiting, per_engine_labelvalues
+        )
+
+        gauge_scheduler_waiting_tokens = self._gauge_cls(
+            name="vllm:approximate_uncached_tokens_waiting",
+            documentation="Approximate number of uncached tokens waiting to be processed.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_scheduler_waiting_tokens = create_metric_per_engine(
+            gauge_scheduler_waiting_tokens, per_engine_labelvalues
+        )
+
+        gauge_num_tokens_waiting = self._gauge_cls(
+            name="vllm:num_tokens_waiting",
+            documentation="Number of raw prompt tokens waiting to be processed.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_num_tokens_waiting = create_metric_per_engine(
+            gauge_num_tokens_waiting, per_engine_labelvalues
         )
 
         gauge_engine_sleep_state = self._gauge_cls(
@@ -1042,6 +1068,12 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             )
             self.gauge_scheduler_waiting[engine_idx].set(
                 scheduler_stats.num_waiting_reqs
+            )
+            self.gauge_scheduler_waiting_tokens[engine_idx].set(
+                scheduler_stats.approximate_uncached_tokens_waiting
+            )
+            self.gauge_num_tokens_waiting[engine_idx].set(
+                scheduler_stats.num_tokens_waiting
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
 

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -173,6 +173,8 @@ class SchedulerStats:
 
     num_running_reqs: int = 0
     num_waiting_reqs: int = 0
+    approximate_uncached_tokens_waiting: int = 0
+    num_tokens_waiting: int = 0
 
     # These are used for internal DP load-balancing.
     step_counter: int = 0


### PR DESCRIPTION

## Summary
Add Prometheus Gauges (vllm:approximate_uncached_tokens_waiting and vllm:num_tokens_waiting) to track the token-level backlog of the vLLM waiting queue.

## Purpose
Add labeled Prometheus metrics to provide detailed queue depth load visibility to external schedulers and load balancers.

Currently, vLLM exposes vllm:num_requests_waiting. However, for advanced load balancers, the number of requests is an insufficient signal for routing because requests can vary wildly in sequence length. A waiting queue of 2 requests requiring 100K tokens each represents significantly more pending computation than 10 requests requiring 100 tokens. To minimize Time To First Token (TTFT) across a cluster, routers need token-level queue depths.

This PR adds two comprehensive metrics to fill this gap:
```
vllm:num_tokens_waiting                      # The raw prompt tokens for all waiting requests
vllm:approximate_uncached_tokens_waiting     # The prompt tokens specifically requiring compute (raw - cache hits)
```
### Why the approximate uncached metric is highly effective:
When tracking prefix-cache hits for waiting requests, we evaluate the cache hits the moment a request is queued (add_request  or _preempt_request). Because external routing decisions rely on rapid, dynamic scaling, considering the high volatility in the prefill queue, this approximate_uncached_tokens_waiting evaluation is accurate enough to use in general cases. The only scenario where this approximation would drift significantly is if the queue is exceptionally long (causing large eviction shifts)—but severe queue lengths inevitably result in very high TTFTs, which is exactly the state that external load schedulers attempt to aggressively route away from anyway.

### Implementation Details and Time Complexity:
To ensure zero performance regressions to the scheduler hotpath, the metrics are tracked in O(1) time per request:

The Scheduler  maintains a lightweight tracking dictionary (waiting_reqs_uncached_tokens_map).
When a request bounds into the waiting state, we do a single O(1) prefix-cache lookahead and map its token tuple.
When Prometheus scrapes make_stats, we independently reconcile the map against the current WAITING queue using list comprehensions, dropping scheduled request IDs. This decouples the gathering phase entirely from the core schedule loop, keeping hotpath time complexity effectively O(1) relative to the items added/removed.

## Test Plan
1. Run vllm online serving engine with a model and workload that can build up the queue. We used BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic in our test on a 8xB200 node. Also make sure --enable-prefix-caching is true.
2. Run vllm bench serve against the vllm online server, with pure random input. We should observe approximate_uncached_tokens_waiting = num_tokens_waiting. By setting the random input length, we can also verify that num_tokens_waiting is about the same as num_requests_waiting*input_len
3.  Run vllm bench serve against the vllm online server, with a relative large random-prefix-len (we used random-prefix-len = 2000 and random-input-len = 6000). Validate that approximate_uncached_tokens_waiting is less than num_tokens_waiting, and the ratio is proportional to random-prefix-len/(random-prefix-len + random-input-len)

## Test Result
With pure random input:
```
bash-5.1$  curl -s localhost:8000/metrics | grep _waiting | grep -v "#"
vllm:num_requests_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 184.0
vllm:approximate_uncached_tokens_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 1.472001e+06
vllm:num_tokens_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 1.472001e+06
bash-5.1$
bash-5.1$  curl -s localhost:8000/metrics | grep _waiting | grep -v "#"
vllm:num_requests_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 107.0
vllm:approximate_uncached_tokens_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 856001.0
vllm:num_tokens_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 856001.0
```

With cache-hit input:
```
bash-5.1$  curl -s localhost:8000/metrics | grep _waiting | grep -v "#"
vllm:num_requests_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 46.0
vllm:approximate_uncached_tokens_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 271584.0
vllm:num_tokens_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 368000.0
bash-5.1$  curl -s localhost:8000/metrics | grep _waiting | grep -v "#"
vllm:num_requests_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 70.0
vllm:approximate_uncached_tokens_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 413280.0
vllm:num_tokens_waiting{engine="0",model_name="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"} 560000.0
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

