### PR TITLE
Use Inductor for More Quant Fusion 

### DIFF
--- a/benchmarks/kernels/bench_decomp_custom_ops.py
+++ b/benchmarks/kernels/bench_decomp_custom_ops.py
@@ -476,6 +476,11 @@ def main():
 
 
 if __name__ == "__main__":
+    # Disable Inductor caches to prevent stale autotuner configs from
+    # contaminating results across shapes in --sweep mode.
+    import torch._inductor.config as inductor_config
+    inductor_config.force_disable_caches = True
+
     from vllm.config import VllmConfig, set_current_vllm_config
 
     with set_current_vllm_config(VllmConfig()):

--- a/benchmarks/kernels/bench_decomp_custom_ops.py
+++ b/benchmarks/kernels/bench_decomp_custom_ops.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Benchmark vLLM CustomOp CUDA kernels vs Inductor-compiled decompositions.
+
+Section 1 — Individual ops:
+    CustomOp.forward_cuda  vs  torch.compile(CustomOp.forward_native)
+
+Section 2 — Fused patterns:
+    Single fused CUDA kernel (where available) or 2 sequential CUDA kernels
+    vs  torch.compile(composed forward_native calls)
+
+Usage:
+    python benchmarks/kernels/bench_decomp_custom_ops.py
+    python benchmarks/kernels/bench_decomp_custom_ops.py --sweep
+    python benchmarks/kernels/bench_decomp_custom_ops.py --sweep --csv results.csv
+    python benchmarks/kernels/bench_decomp_custom_ops.py --asm-ablation
+    python benchmarks/kernels/bench_decomp_custom_ops.py --verify
+"""
+
+import argparse
+import csv
+import io
+import math
+from typing import Any
+
+import torch
+import torch._dynamo
+
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.input_quant_int8 import QuantInt8
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import triton
+
+FP8_DTYPE = current_platform.fp8_dtype()
+
+SWEEP_SHAPES = [
+    (1, 4096), (4, 4096), (32, 4096), (128, 4096),
+    (512, 4096), (2048, 4096), (512, 8192), (512, 14336),
+]
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def cudagraph_wrap(fn, inputs):
+    """Capture fn(*inputs) into a CUDA graph and return a replay callable."""
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        fn(*inputs)
+    torch.cuda.current_stream().wait_stream(s)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        fn(*inputs)
+    return lambda: g.replay()
+
+
+def bench(fn, inputs, warmup=10, rep=100):
+    return triton.testing.do_bench(cudagraph_wrap(fn, inputs),
+                                   warmup=warmup, rep=rep,
+                                   return_mode="min")
+
+
+def _mark_batch_dynamic(inputs):
+    """Mark dim 0 as dynamic on all tensor inputs."""
+    for t in inputs:
+        if isinstance(t, torch.Tensor) and t.ndim >= 2:
+            torch._dynamo.mark_dynamic(t, 0)
+
+
+def compile_and_bench(fn, inputs, args):
+    """Compile fn and benchmark. Uses return_mode='min' for stable results."""
+    torch._dynamo.reset()
+    compiled = torch.compile(fn)
+    _mark_batch_dynamic(inputs)
+    for _ in range(3):
+        compiled(*inputs)
+    return bench(compiled, inputs, args.warmup, args.rep)
+
+
+def verify(name, cuda_fn, native_fn, inputs, atol=0.05, rtol=0.05):
+    a = cuda_fn(*inputs)
+    compiled = torch.compile(native_fn)
+    for _ in range(3):
+        compiled(*inputs)
+    b = compiled(*inputs)
+    if not isinstance(a, tuple):
+        a, b = (a,), (b,)
+    for i, (ra, rb) in enumerate(zip(a, b)):
+        if ra is None or rb is None:
+            continue
+        ra_f = ra.float() if ra.is_floating_point() else ra.to(torch.float32)
+        rb_f = rb.float() if rb.is_floating_point() else rb.to(torch.float32)
+        if not torch.allclose(ra_f, rb_f, atol=atol, rtol=rtol):
+            diff = (ra_f - rb_f).abs().max().item()
+            print(f"  WARN [{name}] output[{i}] max_diff={diff:.4f}")
+            return False
+    return True
+
+
+def geomean(values):
+    return math.exp(sum(math.log(v) for v in values) / len(values))
+
+
+def make_op(op, method="cuda"):
+    """Return a closure calling op.forward_cuda or op.forward_native."""
+    fn = op.forward_cuda if method == "cuda" else op.forward_native
+    return lambda *args: fn(*args)
+
+
+# ============================================================================
+# Op definitions (data-driven)
+# ============================================================================
+
+def build_individual_ops(M, N, dtype, device, scale):
+    """Return list of (name, cuda_fn, native_fn, input_fn)."""
+    ops = []
+
+    def add(name, op, input_fn):
+        ops.append((name, make_op(op, "cuda"), make_op(op, "native"), input_fn))
+
+    norm = RMSNorm(hidden_size=N, eps=1e-6, dtype=dtype).to(device)
+    add("rms_norm", norm,
+        lambda: (torch.randn(M, N, dtype=dtype, device=device),))
+
+    norm2 = RMSNorm(hidden_size=N, eps=1e-6, dtype=dtype).to(device)
+    add("fused_add_rms_norm", norm2,
+        lambda: (torch.randn(M, N, dtype=dtype, device=device),
+                 torch.randn(M, N, dtype=dtype, device=device)))
+
+    add("static_fp8_quant",
+        QuantFP8(static=True, group_shape=GroupShape.PER_TENSOR),
+        lambda: (torch.randn(M, N, dtype=dtype, device=device), scale))
+
+    add("dynamic_fp8_quant_per_tensor",
+        QuantFP8(static=False, group_shape=GroupShape.PER_TENSOR),
+        lambda: (torch.randn(M, N, dtype=dtype, device=device),))
+
+    add("dynamic_fp8_quant_per_token",
+        QuantFP8(static=False, group_shape=GroupShape.PER_TOKEN),
+        lambda: (torch.randn(M, N, dtype=dtype, device=device),))
+
+    add("silu_and_mul", SiluAndMul(),
+        lambda: (torch.randn(M, 2 * N, dtype=dtype, device=device),))
+
+    add("static_int8_quant", QuantInt8(static=True, symmetric=True),
+        lambda: (torch.randn(M, N, dtype=dtype, device=device), scale))
+
+    add("dynamic_int8_quant", QuantInt8(static=False, symmetric=True),
+        lambda: (torch.randn(M, N, dtype=dtype, device=device),))
+
+    return ops
+
+
+def build_fused_ops(M, N, dtype, device, scale):
+    """Return list of (name, cuda_fn, native_fn, input_fn)."""
+    ops = []
+
+    def add_fused(name, ops_list, fused_cuda_op=None):
+        """Build fused cuda/native fns from a list of (op, extra_args) pairs.
+
+        If fused_cuda_op is provided, use it for CUDA; otherwise chain
+        forward_cuda calls sequentially (2 kernel launches).
+        """
+        def native_fn(*args):
+            result = args
+            for op, _ in ops_list:
+                if not isinstance(result, tuple):
+                    result = (result,)
+                result = op.forward_native(*result)
+            return result
+
+        if fused_cuda_op is not None:
+            cuda_fn = fused_cuda_op
+        else:
+            def cuda_fn(*args):
+                result = args
+                for op, _ in ops_list:
+                    if not isinstance(result, tuple):
+                        result = (result,)
+                    result = op.forward_cuda(*result)
+                return result
+
+        ops.append((name, cuda_fn, native_fn))
+
+    # -- RMSNorm + static FP8 (fused CUDA kernel) --
+    norm = RMSNorm(hidden_size=N, eps=1e-6, dtype=dtype).to(device)
+
+    def rms_fp8_cuda(x, s, _n=norm):
+        out = torch.empty_like(x, dtype=FP8_DTYPE)
+        torch.ops._C.rms_norm_static_fp8_quant(
+            out, x, _n.weight, s, _n.variance_epsilon)
+        return out, s
+
+    def rms_fp8_native(x, s, _n=norm,
+                       _q=QuantFP8(static=True,
+                                   group_shape=GroupShape.PER_TENSOR)):
+        return _q.forward_native(_n.forward_native(x), s)
+
+    ops.append(("rms_norm_static_fp8_quant", rms_fp8_cuda, rms_fp8_native,
+        lambda: (torch.randn(M, N, dtype=dtype, device=device), scale)))
+
+    # -- FusedAdd+RMSNorm + static FP8 (fused CUDA kernel) --
+    norm2 = RMSNorm(hidden_size=N, eps=1e-6, dtype=dtype).to(device)
+    quant_fp8_2 = QuantFP8(static=True, group_shape=GroupShape.PER_TENSOR)
+
+    def fadd_fp8_cuda(x, res, s, _n=norm2):
+        out = torch.empty_like(x, dtype=FP8_DTYPE)
+        torch.ops._C.fused_add_rms_norm_static_fp8_quant(
+            out, x, res, _n.weight, s, _n.variance_epsilon)
+        return out, res
+
+    def fadd_fp8_native(x, res, s, _n=norm2, _q=quant_fp8_2):
+        normed, r = _n.forward_native(x, res)
+        q, _ = _q.forward_native(normed, s)
+        return q, r
+
+    ops.append(("fused_add_rms_norm_static_fp8", fadd_fp8_cuda,
+        fadd_fp8_native,
+        lambda: (torch.randn(M, N, dtype=dtype, device=device),
+                 torch.randn(M, N, dtype=dtype, device=device), scale)))
+
+    # -- RMSNorm + dynamic per-token FP8 (fused CUDA kernel) --
+    norm3 = RMSNorm(hidden_size=N, eps=1e-6, dtype=dtype).to(device)
+
+    def rms_dyn_fp8_cuda(x, _n=norm3):
+        out = torch.empty_like(x, dtype=FP8_DTYPE)
+        scales = torch.empty((x.shape[0], 1), device=x.device,
+                             dtype=torch.float32)
+        torch.ops._C.rms_norm_dynamic_per_token_quant(
+            out, x, _n.weight, scales, _n.variance_epsilon, None, None)
+        return out, scales
+
+    def rms_dyn_fp8_native(x, _n=norm3,
+                           _q=QuantFP8(static=False,
+                                       group_shape=GroupShape.PER_TOKEN)):
+        return _q.forward_native(_n.forward_native(x))
+
+    ops.append(("rms_norm_dyn_per_token_fp8", rms_dyn_fp8_cuda,
+        rms_dyn_fp8_native,
+        lambda: (torch.randn(M, N, dtype=dtype, device=device),)))
+
+
+    return ops
+
+
+# ============================================================================
+# Main benchmark loop
+# ============================================================================
+
+def run_section(section_name, ops_with_inputs, args):
+    """Benchmark a list of ops, print results, return CSV rows."""
+    print(f"\n--- {section_name} ---")
+    print(f"{'Op':<40} {'CUDA(ms)':>10} {'Decomp(ms)':>10} {'Speedup':>10}")
+    print("-" * 80)
+
+    rows = []
+    for name, cuda_fn, native_fn, input_fn in ops_with_inputs:
+        torch._dynamo.reset()
+        inputs = input_fn()
+
+        if args.verify:
+            verify(name, cuda_fn, native_fn, inputs)
+
+        cuda_ms = bench(cuda_fn, inputs, args.warmup, args.rep)
+
+        if args.no_compile:
+            native_ms = bench(native_fn, inputs, args.warmup, args.rep)
+        else:
+            native_ms = compile_and_bench(native_fn, inputs, args)
+
+        speedup = cuda_ms / native_ms
+        marker = " << decomp wins" if speedup > 1.05 else ""
+        print(f"{name:<40} {cuda_ms:>10.4f} {native_ms:>10.4f}"
+              f" {speedup:>9.2f}x{marker}")
+        rows.append({"section": section_name, "op": name,
+                      "cuda_ms": f"{cuda_ms:.4f}",
+                      "decomp_ms": f"{native_ms:.4f}",
+                      "speedup": f"{speedup:.2f}"})
+
+    speedups = [float(r["speedup"]) for r in rows]
+    if speedups:
+        print(f"{'GEOMEAN':<40} {'':>10} {'':>10}"
+              f" {geomean(speedups):>9.2f}x")
+    return rows
+
+
+
+def bench_asm_ablation(M, N, args):
+    """Compare compiled RMSNorm+INT8 with inline_asm vs round+clamp+cast.
+
+    Inlines the cast function directly so each variant gets its own compiled
+    kernel (toggling _HAS_INLINE_ASM at runtime doesn't work because
+    torch.compile captures the branch at trace time).
+    """
+    try:
+        from torch._higher_order_ops.inline_asm_elementwise import (
+            inline_asm_elementwise,
+        )
+    except ImportError:
+        print("\n--- Skipping asm ablation (inline_asm unavailable) ---")
+        return []
+
+    dtype, device = torch.bfloat16, "cuda"
+    scale = torch.tensor([0.1], dtype=torch.float32, device=device)
+
+    def asm_cast(x):
+        return inline_asm_elementwise(
+            x, asm_str="cvt.rni.sat.s8.f32 $0, $1;",
+            constraints="=r,f", dtype=torch.int8, is_pure=True, pack=1)
+
+    def no_asm_cast(x):
+        return x.round().clamp(-128, 127).to(torch.int8)
+
+    print(f"\n--- INT8 inline_asm ablation: RMSNorm+INT8 "
+          f"with vs without PTX cvt.rni.sat.s8.f32 ---")
+    print(f"{'Pattern':<40} {'asm(ms)':>10} {'no_asm(ms)':>10}"
+          f" {'asm speedup':>12}")
+    print("-" * 75)
+
+    patterns = [
+        ("RMSNorm+static_int8", True),
+        ("RMSNorm+dynamic_int8", False),
+    ]
+
+    rows = []
+    for name, is_static in patterns:
+        x = torch.randn(M, N, dtype=dtype, device=device)
+        results = {}
+        for label, cast_fn in [("asm", asm_cast), ("no_asm", no_asm_cast)]:
+            torch._dynamo.reset()
+            norm = RMSNorm(hidden_size=N, eps=1e-6, dtype=dtype).to(device)
+            if is_static:
+                def fn(x, s, _n=norm, _c=cast_fn):
+                    normed = _n.forward_native(x)
+                    return _c(normed.to(torch.float32) / s.to(torch.float32)), s
+                inputs = (x, scale)
+            else:
+                def fn(x, _n=norm, _c=cast_fn):
+                    normed = _n.forward_native(x)
+                    f32 = normed.to(torch.float32)
+                    xm = f32.abs().max(dim=-1, keepdim=True)[0]
+                    xm = torch.where(xm == 0, torch.ones_like(xm), xm)
+                    sc = xm / 127.0
+                    return _c(f32 / sc), sc
+                inputs = (x,)
+
+            results[label] = compile_and_bench(fn, inputs, args)
+
+        speedup = results["no_asm"] / results["asm"]
+        marker = " << asm wins" if speedup > 1.05 else ""
+        print(f"{name:<40} {results['asm']:>10.4f}"
+              f" {results['no_asm']:>10.4f}"
+              f" {speedup:>11.2f}x{marker}")
+        rows.append({"section": "asm_ablation", "op": name,
+                      "cuda_ms": f"{results['asm']:.4f}",
+                      "decomp_ms": f"{results['no_asm']:.4f}",
+                      "speedup": f"{speedup:.2f}",
+                      "shape": f"[{M},{N}]"})
+    return rows
+
+
+def bench_shape(M, N, args):
+    """Benchmark all ops at a single (M, N) shape."""
+    dtype, device = torch.bfloat16, "cuda"
+    scale = torch.tensor([0.1], dtype=torch.float32, device=device)
+
+    print(f"\n{'='*80}\n  Shape: [{M}, {N}]\n{'='*80}")
+
+    individual = build_individual_ops(M, N, dtype, device, scale)
+    fused = build_fused_ops(M, N, dtype, device, scale)
+
+    rows = []
+    rows += run_section("Individual Ops", individual, args)
+    rows += run_section("Fused Patterns", fused, args)
+
+    if args.asm_ablation:
+        rows += bench_asm_ablation(M, N, args)
+
+    shape_str = f"[{M},{N}]"
+    for r in rows:
+        r["shape"] = shape_str
+    return rows
+
+
+# ============================================================================
+# CSV output
+# ============================================================================
+
+def write_csv(rows, csv_path, shapes):
+    """Write pivoted CSV: one row per op, shapes as columns."""
+    if not rows:
+        return
+    shape_strs = [f"[{m},{n}]" for m, n in shapes]
+
+    from collections import OrderedDict
+    grouped: dict[tuple[str, str], dict[str, dict]] = OrderedDict()
+    for r in rows:
+        key = (r["section"], r["op"])
+        grouped.setdefault(key, {})[r.get("shape", "")] = r
+
+    buf = io.StringIO()
+    header = ["section", "op", "geomean_speedup"]
+    for s in shape_strs:
+        header.extend([f"{s}_speedup", f"{s}_cuda_ms", f"{s}_decomp_ms"])
+    writer = csv.writer(buf)
+    writer.writerow(header)
+
+    for (section, op), by_shape in grouped.items():
+        speedups = [float(by_shape[s]["speedup"])
+                    for s in shape_strs
+                    if s in by_shape and by_shape[s].get("speedup")]
+        gm = geomean(speedups) if speedups else 0.0
+        row = [section, op, f"{gm:.2f}"]
+        for s in shape_strs:
+            if s in by_shape:
+                row.extend([by_shape[s].get("speedup", ""),
+                            by_shape[s].get("cuda_ms", ""),
+                            by_shape[s].get("decomp_ms", "")])
+            else:
+                row.extend(["", "", ""])
+        writer.writerow(row)
+
+    text = buf.getvalue()
+    if csv_path:
+        with open(csv_path, "w") as f:
+            f.write(text)
+        print(f"\nCSV written to {csv_path}")
+    else:
+        print(f"\n--- CSV ---\n{text}", end="")
+
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m", type=int, default=512)
+    parser.add_argument("--n", type=int, default=4096)
+    parser.add_argument("--sweep", action="store_true",
+                        help="Sweep standard shapes")
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--no-compile", action="store_true",
+                        help="Benchmark eager (no Inductor)")
+    parser.add_argument("--asm-ablation", action="store_true",
+                        help="Compare INT8 inline_asm vs round+clamp+cast "
+                             "on RMSNorm+INT8 fused patterns")
+    parser.add_argument("--csv", type=str, default=None,
+                        help="Write CSV to file")
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--rep", type=int, default=100)
+    args = parser.parse_args()
+
+    print("vLLM CustomOp Decomposition Benchmark")
+    print(f"Device: {torch.cuda.get_device_name()}")
+    print(f"PyTorch: {torch.__version__}")
+    print(f"Mode: {'compiled' if not args.no_compile else 'eager'}")
+
+    shapes = SWEEP_SHAPES if args.sweep else [(args.m, args.n)]
+    print(f"Shapes: {shapes}")
+    print("=" * 80)
+
+    rows = []
+    for M, N in shapes:
+        rows += bench_shape(M, N, args)
+
+    write_csv(rows, args.csv, shapes)
+
+
+if __name__ == "__main__":
+    from vllm.config import VllmConfig, set_current_vllm_config
+
+    with set_current_vllm_config(VllmConfig()):
+        main()

--- a/tests/kernels/quantization/test_int8_quant.py
+++ b/tests/kernels/quantization/test_int8_quant.py
@@ -44,7 +44,7 @@ def opcheck_int8_quant_dynamic(output, input, symmetric=True):
 @pytest.mark.parametrize("seed", SEEDS)
 @torch.inference_mode()
 def test_dynamic_scaled_int8_quant(
-    num_tokens: int, hidden_size: int, dtype: torch.dtype, seed: int
+    default_vllm_config, num_tokens: int, hidden_size: int, dtype: torch.dtype, seed: int
 ) -> None:
     set_random_seed(seed)
 
@@ -68,7 +68,7 @@ def test_dynamic_scaled_int8_quant(
 @pytest.mark.parametrize("seed", SEEDS)
 @torch.inference_mode()
 def test_dynamic_scaled_int8_azp_quant(
-    num_tokens: int, hidden_size: int, dtype: torch.dtype, seed: int
+    default_vllm_config, num_tokens: int, hidden_size: int, dtype: torch.dtype, seed: int
 ) -> None:
     set_random_seed(seed)
     int8_traits = torch.iinfo(torch.int8)
@@ -80,7 +80,11 @@ def test_dynamic_scaled_int8_azp_quant(
 
     # calculate scale and azp, and adjust the range
     scales = (x_token_max - x_token_min) / torch.tensor(255.0)
-    azps = torch.round(torch.tensor(-128.0) - x_token_min / scales).to(torch.int32)
+    azps = (
+        torch.round(torch.tensor(-128.0) - x_token_min / scales)
+        .clamp(-128, 127)
+        .to(torch.int32)
+    )
 
     torch_out = (
         ((x / scales).round() + azps)
@@ -109,7 +113,7 @@ def test_dynamic_scaled_int8_azp_quant(
 @pytest.mark.parametrize("scale", SCALE)
 @torch.inference_mode()
 def test_static_scaled_int8_quant(
-    num_tokens: int, hidden_size: int, dtype: torch.dtype, seed: int, scale: float
+    default_vllm_config, num_tokens: int, hidden_size: int, dtype: torch.dtype, seed: int, scale: float
 ) -> None:
     set_random_seed(seed)
     int8_traits = torch.iinfo(torch.int8)
@@ -137,6 +141,7 @@ def test_static_scaled_int8_quant(
 @pytest.mark.parametrize("azp", [-255, 54])
 @torch.inference_mode()
 def test_static_scaled_int8_azp_quant(
+    default_vllm_config,
     num_tokens: int,
     hidden_size: int,
     dtype: torch.dtype,
@@ -169,7 +174,7 @@ def test_static_scaled_int8_azp_quant(
 
 @pytest.mark.parametrize("is_max", [True, False])
 @torch.inference_mode()
-def test_static_scaled_int8_azp_quant_saturating_cast(is_max: bool) -> None:
+def test_static_scaled_int8_azp_quant_saturating_cast(default_vllm_config, is_max: bool) -> None:
     # Test that the saturating cast works correctly for values near i32 max/min
 
     from numpy import inf, nextafter
@@ -193,3 +198,37 @@ def test_static_scaled_int8_azp_quant_saturating_cast(is_max: bool) -> None:
 
     out, _, _ = scaled_int8_quant(x, scale, azp, symmetric=False)
     torch.testing.assert_close(expected, out, atol=0, rtol=0)
+
+
+@torch.inference_mode()
+def test_compiled_static_int8_quant(default_vllm_config) -> None:
+    """Verify compiled decomposition matches CUDA for static INT8 quant."""
+    x = torch.randn(128, 4096, dtype=torch.bfloat16, device="cuda")
+    scale = torch.tensor([0.05], dtype=torch.float32, device="cuda")
+
+    out_cuda, _, _ = scaled_int8_quant(x, scale)
+
+    @torch.compile
+    def compiled(x, s):
+        return scaled_int8_quant(x, s)
+
+    out_compiled, _, _ = compiled(x, scale)
+    torch.testing.assert_close(out_cuda.float(), out_compiled.float(),
+                               atol=0, rtol=0)
+
+
+@torch.inference_mode()
+def test_compiled_dynamic_int8_quant(default_vllm_config) -> None:
+    """Verify compiled decomposition matches CUDA for dynamic INT8 quant."""
+    x = torch.randn(128, 4096, dtype=torch.bfloat16, device="cuda")
+
+    out_cuda, scale_cuda, _ = scaled_int8_quant(x)
+
+    @torch.compile
+    def compiled(x):
+        return scaled_int8_quant(x)
+
+    out_compiled, scale_compiled, _ = compiled(x)
+    torch.testing.assert_close(scale_cuda, scale_compiled, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(out_cuda.float(), out_compiled.float(),
+                               atol=1, rtol=0.01)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1962,24 +1962,12 @@ def scaled_int8_quant(
     Returns:
       tuple[torch.Tensor, torch.Tensor, torch.Tensor | None] : Output int8 tensor, scales, and optionally azp.
     """
-    output = torch.empty_like(input, dtype=torch.int8)
-    if scale is not None:
-        # static-per-tensor quantization.
-        assert symmetric == (azp is None), (
-            "azp must only be provided for asymmetric quantization."
-        )
-        torch.ops._C.static_scaled_int8_quant(output, input, scale, azp)
-        return output, scale, azp
+    # Use CustomOp for proper decomposition support
+    from vllm.model_executor.layers.quantization.input_quant_int8 import QuantInt8
 
-    # dynamic-per-token quantization.
-    input_scales = torch.empty(
-        (input.numel() // input.shape[-1], 1), device=input.device, dtype=torch.float32
-    )
-    input_azp = None if symmetric else torch.empty_like(input_scales, dtype=torch.int32)
-    torch.ops._C.dynamic_scaled_int8_quant(
-        output, input.contiguous(), input_scales, input_azp
-    )
-    return output, input_scales, input_azp
+    static = scale is not None
+    quant_op = QuantInt8(static=static, symmetric=symmetric)
+    return quant_op.forward(input, scale, azp)
 
 
 # gguf

--- a/vllm/compilation/passes/fusion/act_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/act_quant_fusion.py
@@ -192,9 +192,9 @@ class ActivationQuantFusionPass(VllmPatternMatcherPass):
             pass_name="activation_quant_fusion_pass"
         )
 
-        pattern_silu_mul_fp8 = SiluMulFp8StaticQuantPattern()
-        pattern_silu_mul_fp8.register(self.patterns)
-
+        # Only register nvfp4 pattern. FP8 SiluMul+Quant fusion is handled
+        # by Inductor via decomposition, which outperforms the hand-fused
+        # CUDA kernel. See benchmarks/kernels/bench_decomp_custom_ops.py.
         if silu_and_mul_nvfp4_quant_supported:
             pattern_silu_mul_nvfp4 = SiluMulNvfp4QuantPattern()
             pattern_silu_mul_nvfp4.register(self.patterns)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -89,25 +89,24 @@ IS_DENSE = False
 
 
 def enable_norm_fusion(cfg: "VllmConfig") -> bool:
-    """Enable if either RMS norm or quant FP8 custom op is active;
-    otherwise Inductor handles fusion."""
+    """Disable by default - Inductor fusion outperforms hand-fused CUDA kernels.
 
-    return cfg.compilation_config.is_custom_op_enabled(
-        "rms_norm"
-    ) or cfg.compilation_config.is_custom_op_enabled("quant_fp8")
+    Benchmarks show 1.09x-1.54x speedup when Inductor handles RMSNorm+FP8Quant
+    fusion vs hand-fused CUDA kernels (rms_norm_static_fp8_quant, etc).
+    See: benchmarks/kernels/bench_decomp_custom_ops.py
+    """
+    return False
 
 
 def enable_act_fusion(cfg: "VllmConfig") -> bool:
+    """Disable by default except for nvfp4 - Inductor fusion outperforms hand-fused CUDA.
+
+    Benchmarks show 1.47x speedup when Inductor handles SiluAndMul+FP8Quant
+    fusion vs sequential CUDA kernels. Exception: nvfp4 still needs custom fusion
+    since Inductor cannot handle nvfp4 quantization.
+    See: benchmarks/kernels/bench_decomp_custom_ops.py
     """
-    Enable if either SiLU+Mul or quant FP8 custom op is active;
-    otherwise Inductor handles fusion.
-    Also enable for FP4 models as FP4 quant is always custom so Inductor cannot fuse it.
-    """
-    return (
-        cfg.compilation_config.is_custom_op_enabled("silu_and_mul")
-        or cfg.compilation_config.is_custom_op_enabled("quant_fp8")
-        or (cfg.model_config is not None and cfg.model_config.is_nvfp4_quantized())
-    )
+    return (cfg.model_config is not None and cfg.model_config.is_nvfp4_quantized())
 
 
 def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -196,11 +196,12 @@ class QuantFP8(CustomOp):
         else:
             scale = prep_scale_for_group_broadcast(scale, x, self.group_shape)
 
-        # Even for dynamic per-token scales,
-        # reciprocal performs slightly better than division
+        # Use division instead of reciprocal to avoid Triton int32 literal
+        # codegen bug on SM100 (torch 2.11): reciprocal emits
+        # tl.full([1], 1, tl.int32) / x which causes 3x slowdown on B200.
         out = (
             x.to(torch.float32)
-            * group_broadcast(scale.to(torch.float32), x.shape[-2:]).reciprocal()
+            / group_broadcast(scale.to(torch.float32), x.shape[-2:])
         )
         out = out.clamp(_FP8_MIN, _FP8_MAX).to(_FP8_DTYPE)
 

--- a/vllm/model_executor/layers/quantization/input_quant_int8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_int8.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+INT8 quantization CustomOp with native decomposition for Inductor fusion.
+
+This follows the same pattern as QuantFP8 but provides INT8 quantization.
+When compiled, Inductor fuses this with adjacent operations. Uses
+inline_asm_elementwise when available to emit a single PTX
+cvt.rni.sat.s8.f32 instruction for a faster saturating cast vs the
+pure-torch round+clamp+cast fallback.
+"""
+
+import torch
+
+from vllm.model_executor.custom_op import CustomOp
+
+try:
+    from torch._higher_order_ops.inline_asm_elementwise import (
+        inline_asm_elementwise,
+    )
+
+    _HAS_INLINE_ASM = True
+except ImportError:
+    _HAS_INLINE_ASM = False
+
+
+def _saturating_int8_cast(x: torch.Tensor) -> torch.Tensor:
+    """Saturating float32 -> int8 cast with round-to-nearest and clamping.
+
+    Uses PTX inline asm when available (1 instruction vs 3 for the fallback).
+    Under torch.compile, Inductor fuses this into the surrounding Triton
+    kernel (e.g., with divide/scale ops), so no extra kernel launch.
+    """
+    if _HAS_INLINE_ASM:
+        return inline_asm_elementwise(
+            x,
+            asm_str="cvt.rni.sat.s8.f32 $0, $1;",
+            constraints="=r,f",
+            dtype=torch.int8,
+            is_pure=True,
+            pack=1,
+        )
+    return x.round().clamp(-128, 127).to(torch.int8)
+
+
+@CustomOp.register("quant_int8")
+class QuantInt8(CustomOp):
+    """
+    Quantize input tensor to INT8 with optional asymmetric zero point.
+    """
+
+    def __init__(
+        self,
+        static: bool,
+        symmetric: bool = True,
+        compile_native: bool = True,
+    ):
+        super().__init__(compile_native=compile_native)
+        self.static = static
+        self.symmetric = symmetric
+
+    def forward_cuda(
+        self,
+        input: torch.Tensor,
+        scale: torch.Tensor | None = None,
+        azp: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        output = torch.empty_like(input, dtype=torch.int8)
+
+        if scale is not None:
+            assert self.symmetric == (azp is None), (
+                "azp must only be provided for asymmetric quantization."
+            )
+            torch.ops._C.static_scaled_int8_quant(output, input, scale, azp)
+            return output, scale, azp
+        else:
+            input_2d = input.view(-1, input.shape[-1])
+            token_num = input_2d.shape[0]
+            input_scales = torch.empty((token_num, 1), device=input.device, dtype=torch.float32)
+            input_azp = None if self.symmetric else torch.empty_like(input_scales, dtype=torch.int32)
+            torch.ops._C.dynamic_scaled_int8_quant(output, input_2d, input_scales, input_azp)
+            return output, input_scales, input_azp
+
+    def forward_native(
+        self,
+        input: torch.Tensor,
+        scale: torch.Tensor | None = None,
+        azp: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """
+        Native PyTorch decomposition. Under torch.compile, Inductor fuses
+        this with adjacent ops into a single Triton kernel.
+        """
+        if scale is not None:
+            return self._static_quant_native(input, scale, azp)
+        else:
+            return self._dynamic_quant_native(input, azp)
+
+    def _static_quant_native(
+        self,
+        input: torch.Tensor,
+        scale: torch.Tensor,
+        azp: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        scaled = input.to(torch.float32) / scale.to(torch.float32)
+
+        if azp is not None:
+            scaled = scaled + azp.to(torch.float32)
+
+        output = _saturating_int8_cast(scaled)
+        return output, scale, azp
+
+    def _dynamic_quant_native(
+        self,
+        input: torch.Tensor,
+        azp: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        input_2d = input.view(-1, input.shape[-1])
+
+        input_f32 = input_2d.to(torch.float32)
+
+        computed_azp = None
+        if not self.symmetric:
+            x_max = input_f32.max(dim=-1, keepdim=True)[0]
+            x_min = input_f32.min(dim=-1, keepdim=True)[0]
+            scale = (x_max - x_min) / 255.0
+            scale = torch.where(scale == 0, torch.ones_like(scale), scale)
+            computed_azp = (
+                (-128.0 - x_min / scale).round().clamp(-128, 127).to(torch.int32)
+            )
+            scaled = input_f32 / scale + computed_azp.to(torch.float32)
+        else:
+            x_max = input_f32.abs().max(dim=-1, keepdim=True)[0]
+            x_max = torch.where(x_max == 0, torch.ones_like(x_max), x_max)
+            scale = x_max / 127.0
+            scaled = input_f32 / scale
+
+        output = _saturating_int8_cast(scaled)
+        return output.view(input.shape), scale, computed_azp


### PR DESCRIPTION


## Purpose

Add INT8 quantization decomposition support and disable hand-fused CUDA kernels in favor of Inductor fusion.

- Add `QuantInt8` CustomOp with native PyTorch decomposition for INT8 quantization, following the same pattern as `QuantFP8`. Uses `inline_asm_elementwise` for a single PTX `cvt.rni.sat.s8.f32` saturating cast instruction, with pure-torch fallback when unavailable.
- Disable hand-fused CUDA kernels (`enable_norm_fusion`, `enable_act_fusion`) by default. Benchmarking shows a speedup by decomposing.
Exception: nvfp4 models still use custom activation fusion since Inductor cannot handle (yet) nvfp4 quantization. I will be working on this now.
- Fix `ActivationQuantFusionPass` to only register the nvfp4 pattern when enabled for nvfp4, preventing accidental registration of the slower FP8 hand-fused path.

Decompositions show speedup here, but also, importantly, allow fusion into surrounding ops. Question for reviewers: happy to break this commit up more if it would be helpful, or take suggestions on what the split should be.

## Test Plan

```bash
pytest tests/kernels/quantization/test_int8_quant.py  # 292 pass
python benchmarks/kernels/bench_decomp_custom_ops.py --verify  # forward_cuda ≈ forward_native
python benchmarks/kernels/bench_decomp_custom_ops.py --sweep --csv results.csv  # full sweep
python benchmarks/kernels/bench_decomp_custom_ops.py --asm-ablation  # inline asm ablation
```

## Test Result

Full sweep CSVs: https://gist.github.com/eellison/c9620f0cd4a6a9d6a80caa0177516366

Individual ops — per-op geomean speedup across 8 shapes (forward_cuda vs compiled forward_native):

| Op | B200 | H100 |
|---|---|---|
| static_int8_quant | 1.16x | 1.08x |
| dynamic_int8_quant | 1.02x | 1.17x |

Fused patterns — per-op geomean across 8 shapes (fused CUDA kernel vs compiled decomposition):

| Pattern | B200 | H100 |
|---|---|---|
| rms_norm_dyn_per_token_fp8 | **1.45x** | **1.72x** |
| rms_norm_static_fp8_quant | **1.20x** | **1.34x** |
| fused_add_rms_norm_static_fp8 | **1.18x** | **1.26x** |

Inline asm ablation — per-op geomean across 8 shapes (asm vs no-asm on compiled RMSNorm+INT8):

| Pattern | B200 | H100 |
|---|---|---|
| RMSNorm+static_int8 | 1.09x | 1.07x |
| RMSNorm+dynamic_int8 | 1.08x | 1.08x |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

