### PR TITLE
[Kernel] Add indexer_concat_quant_fp8 kernel for DeepSeek V3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,8 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     "csrc/quantization/fp4/nvfp4_scaled_mm_entry.cu"
     "csrc/cutlass_extensions/common.cpp"
     "csrc/quantization/w8a8/fp8/per_token_group_quant.cu"
-    "csrc/quantization/w8a8/int8/per_token_group_quant.cu")
+    "csrc/quantization/w8a8/int8/per_token_group_quant.cu"
+    "csrc/quantization/w8a8/fp8/indexer_concat_quant_fp8.cu")
 
   set_gencode_flags_for_srcs(
     SRCS "${VLLM_EXT_SRC}"

--- a/benchmarks/kernels/benchmark_indexer_concat_quant_fp8.py
+++ b/benchmarks/kernels/benchmark_indexer_concat_quant_fp8.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    indexer_concat_quant_fp8,
+    per_token_group_quant_fp8,
+)
+from vllm.triton_utils import triton
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+num_tokens_range = [2**x for x in range(14)]
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_tokens"],
+        x_vals=num_tokens_range,
+        x_log=False,
+        line_arg="provider",
+        line_vals=[
+            "torch",
+            "vllm",
+        ],
+        line_names=["PyTorch", "vLLM"],
+        styles=([("blue", "-"), ("red", "-")]),
+        ylabel="us",
+        plot_name="indexer_concat_quant_fp8 latency",
+        args={},
+    )
+)
+def benchmark(num_tokens, provider):
+    num_heads = 64
+    head_dim = 128
+    rope_dim = 64
+    group_size = 128
+    nope_dim = head_dim - rope_dim
+    q_pe = torch.randn(
+        num_tokens, num_heads, rope_dim, dtype=torch.bfloat16, device="cuda"
+    )
+    q_nope = torch.randn(
+        num_tokens, num_heads, nope_dim, dtype=torch.bfloat16, device="cuda"
+    )
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if provider == "torch":
+
+        def runner():
+            q = torch.cat([q_pe, q_nope], dim=-1)
+            q = q.view(-1, head_dim)
+            per_token_group_quant_fp8(q, group_size, column_major_scales=False)
+
+    elif provider == "vllm":
+
+        def runner():
+            indexer_concat_quant_fp8(
+                q_pe, q_nope, group_size, column_major_scales=False
+            )
+
+    ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(runner, quantiles=quantiles)
+
+    return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser()
+    parser.add_argument(
+        "--save-path", type=str, default=None, help="Path to save benchmark results"
+    )
+    args = parser.parse_args()
+
+    # Run performance benchmark
+    benchmark.run(print_data=True, save_path=args.save_path)

--- a/csrc/cuda_vec_utils.cuh
+++ b/csrc/cuda_vec_utils.cuh
@@ -236,6 +236,29 @@ __forceinline__ __device__ void st32_cs(int* addr, int val) {
 #endif
 }
 
+// 64-bit cache-streaming (.cs) load / store.
+// Falls back to ld64/st64 on ROCm (no .cs hint).
+__forceinline__ __device__ int2 ld64_cs(const int2* addr) {
+  int2 val;
+#ifndef USE_ROCM
+  asm volatile("ld.global.cs.v2.b32 {%0, %1}, [%2];"
+               : "=r"(val.x), "=r"(val.y)
+               : "l"(addr));
+#else
+  val = ld64(addr);
+#endif
+  return val;
+}
+
+__forceinline__ __device__ void st64_cs(int2* addr, int2 val) {
+#ifndef USE_ROCM
+  asm volatile("st.global.cs.v2.b32 [%0], {%1, %2};" ::"l"(addr), "r"(val.x),
+               "r"(val.y));
+#else
+  st64(addr, val);
+#endif
+}
+
 // 128-bit cache-streaming (.cs) load / store.
 // Falls back to ld128/st128 on ROCm (no .cs hint).
 __forceinline__ __device__ int4 ld128_cs(const int4* addr) {

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -325,6 +325,11 @@ void per_token_group_quant_8bit_packed(const torch::Tensor& input,
                                        int64_t group_size, double eps,
                                        double min_8bit, double max_8bit);
 
+void indexer_concat_quant_fp8(torch::Tensor& q_out, torch::Tensor& scale_out,
+                              const torch::Tensor& pe,
+                              const torch::Tensor& nope, int64_t group_size,
+                              double eps, double fp8_min, double fp8_max,
+                              bool scale_ue8m0);
 #endif
 
 void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,

--- a/csrc/quantization/w8a8/fp8/indexer_concat_quant_fp8.cu
+++ b/csrc/quantization/w8a8/fp8/indexer_concat_quant_fp8.cu
@@ -1,0 +1,222 @@
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <torch/all.h>
+
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+
+#include "cuda_vec_utils.cuh"
+#include "dispatch_utils.h"
+
+namespace vllm {
+
+constexpr int WARP_SIZE = 32;
+
+union BF16x4 {
+  int2 vec;
+  __nv_bfloat162 bf16x2[2];
+};
+
+union HALFx4 {
+  int2 vec;
+  __half2 half2[2];
+};
+
+union FLOATx4 {
+  int4 vec;
+  float4 f4;
+};
+
+union FP8x4 {
+  int packed;
+  __nv_fp8_e4m3 fp8[4];
+};
+
+__device__ __forceinline__ float WarpReduceMax(float val) {
+  for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+    val = fmaxf(val, __shfl_xor_sync(0xffffffff, val, offset));
+  }
+  return val;
+}
+
+template <typename InputType, int VEC_SIZE, int HEAD_DIM, bool SCALE_UE8M0>
+__global__ __launch_bounds__(256) void indexer_concat_quant_fp8_kernel(
+    __nv_fp8_e4m3* __restrict__ q_out, float* __restrict__ scale_out,
+    const InputType* __restrict__ q_pe, const InputType* __restrict__ q_nope,
+    const int num_tokens, const int num_heads, const int rope_dim,
+    const int nope_dim, const int64_t out_stride_0, const int64_t out_stride_1,
+    const int64_t nope_stride_0, const int64_t nope_stride_1,
+    const int64_t pe_stride_0, const int64_t pe_stride_1, const double eps,
+    const double min_8bit, const double max_8bit) {
+  static_assert(std::is_same_v<InputType, float> ||
+                    std::is_same_v<InputType, at::BFloat16> ||
+                    std::is_same_v<InputType, at::Half>,
+                "InputType must be float, bfloat16, or half");
+
+  const int global_warp_id =
+      (blockIdx.x * blockDim.x + threadIdx.x) / WARP_SIZE;
+  if (global_warp_id >= num_tokens * num_heads) {
+    return;
+  }
+
+  const int token_id = global_warp_id / num_heads;
+  const int head_id = global_warp_id % num_heads;
+  const int lane_id = threadIdx.x % WARP_SIZE;
+
+  int base = lane_id * VEC_SIZE;
+  const InputType* pe_row =
+      q_pe + token_id * pe_stride_0 + head_id * pe_stride_1;
+  const InputType* nope_row =
+      q_nope + token_id * nope_stride_0 + head_id * nope_stride_1;
+  const InputType* input_row =
+      (base < rope_dim) ? (pe_row + base) : (nope_row + (base - rope_dim));
+
+  float v0, v1, v2, v3;
+  if constexpr (std::is_same_v<InputType, float>) {
+    FLOATx4 src;
+    src.vec = ld128_cs(reinterpret_cast<const int4*>(input_row));
+    v0 = src.f4.x;
+    v1 = src.f4.y;
+    v2 = src.f4.z;
+    v3 = src.f4.w;
+  } else if constexpr (std::is_same_v<InputType, at::BFloat16>) {
+    BF16x4 src;
+    src.vec = ld64_cs(reinterpret_cast<const int2*>(input_row));
+    float2 f0 = __bfloat1622float2(src.bf16x2[0]);
+    float2 f1 = __bfloat1622float2(src.bf16x2[1]);
+    v0 = f0.x;
+    v1 = f0.y;
+    v2 = f1.x;
+    v3 = f1.y;
+  } else if constexpr (std::is_same_v<InputType, at::Half>) {
+    HALFx4 src;
+    src.vec = ld64_cs(reinterpret_cast<const int2*>(input_row));
+    float2 f0 = __half22float2(src.half2[0]);
+    float2 f1 = __half22float2(src.half2[1]);
+    v0 = f0.x;
+    v1 = f0.y;
+    v2 = f1.x;
+    v3 = f1.y;
+  }
+
+  // Quantization
+  float local_absmax =
+      fmaxf(fmaxf(fabsf(v0), fabsf(v1)), fmaxf(fabsf(v2), fabsf(v3)));
+  float absmax = WarpReduceMax(local_absmax);
+  absmax = fmaxf(absmax, eps);
+
+  float y_s = absmax / max_8bit;
+  if constexpr (SCALE_UE8M0) {
+    y_s = exp2f(ceilf(log2f(fmaxf(fabsf(y_s), 1e-10f))));
+  }
+
+  if (lane_id == 0) {
+    scale_out[global_warp_id] = y_s;
+  }
+
+  auto quant_op = [&](float val) -> __nv_fp8_e4m3 {
+    float q = fminf(fmaxf(val / y_s, min_8bit), max_8bit);
+    return __nv_fp8_e4m3(q);
+  };
+
+  FP8x4 dst;
+  dst.fp8[0] = quant_op(v0);
+  dst.fp8[1] = quant_op(v1);
+  dst.fp8[2] = quant_op(v2);
+  dst.fp8[3] = quant_op(v3);
+
+  int out_base =
+      token_id * out_stride_0 + head_id * out_stride_1 + lane_id * VEC_SIZE;
+  st32_cs(reinterpret_cast<int*>(q_out + out_base), dst.packed);
+}
+
+template <typename InputType, int VEC_SIZE, int HEAD_DIM>
+void invokeConcatIndexerQFp8(
+    __nv_fp8_e4m3* q_out, float* scale_out, const InputType* q_pe,
+    const InputType* q_nope, const int num_tokens, const int num_heads,
+    const int rope_dim, const int nope_dim, const int64_t out_stride_0,
+    const int64_t out_stride_1, const int64_t nope_stride_0,
+    const int64_t nope_stride_1, const int64_t pe_stride_0,
+    const int64_t pe_stride_1, const int64_t group_size, const double eps,
+    const double fp8_min, const double fp8_max, bool scale_ue8m0,
+    cudaStream_t stream) {
+  TORCH_CHECK(rope_dim % VEC_SIZE == 0,
+              "rope_dim (%d) must be a multiple of VEC_SIZE (%d)", rope_dim,
+              VEC_SIZE);
+  TORCH_CHECK(pe_stride_1 % VEC_SIZE == 0,
+              "pe_stride_1 (%d) must be multiple of VEC_SIZE (%d)", pe_stride_1,
+              VEC_SIZE);
+  TORCH_CHECK(nope_stride_1 % VEC_SIZE == 0,
+              "nope_stride_1 (%d) must be multiple of VEC_SIZE (%d)",
+              nope_stride_1, VEC_SIZE);
+
+  const int num_threads = 256;
+  const int total_warps = num_tokens * num_heads;
+  const int warps_per_block = num_threads / WARP_SIZE;
+  const int num_blocks = (total_warps + warps_per_block - 1) / warps_per_block;
+  dim3 grid(num_blocks);
+  dim3 block(num_threads);
+
+  if (scale_ue8m0) {
+    indexer_concat_quant_fp8_kernel<InputType, VEC_SIZE, HEAD_DIM, true>
+        <<<grid, block, 0, stream>>>(
+            q_out, scale_out, q_pe, q_nope, num_tokens, num_heads, rope_dim,
+            nope_dim, out_stride_0, out_stride_1, nope_stride_0, nope_stride_1,
+            pe_stride_0, pe_stride_1, eps, fp8_min, fp8_max);
+  } else {
+    indexer_concat_quant_fp8_kernel<InputType, VEC_SIZE, HEAD_DIM, false>
+        <<<grid, block, 0, stream>>>(
+            q_out, scale_out, q_pe, q_nope, num_tokens, num_heads, rope_dim,
+            nope_dim, out_stride_0, out_stride_1, nope_stride_0, nope_stride_1,
+            pe_stride_0, pe_stride_1, eps, fp8_min, fp8_max);
+  }
+}
+}  // namespace vllm
+
+// Concatenates q_pe and q_nope, then FP8 quantization.
+void indexer_concat_quant_fp8(
+    torch::Tensor& q_out,         // [num_tokens, num_heads, head_dim]
+    torch::Tensor& scale_out,     // [num_tokens, num_heads, 1]
+    torch::Tensor const& q_pe,    // [num_tokens, num_heads, rope_dim]
+    torch::Tensor const& q_nope,  // [num_tokens, num_heads, nope_dim]
+    int64_t group_size, double eps, double fp8_min, double fp8_max,
+    bool scale_ue8m0) {
+  TORCH_CHECK(scale_out.scalar_type() == at::ScalarType::Float,
+              "scale_out must be float");
+  TORCH_CHECK(q_pe.stride(-1) == 1, "q_pe must be contiguous");
+  TORCH_CHECK(q_nope.stride(-1) == 1, "q_nope must be contiguous");
+  TORCH_CHECK(q_out.stride(-1) == 1, "q_out must be contiguous");
+
+  const int num_tokens = q_nope.size(0);
+  const int num_heads = q_nope.size(1);
+  const int nope_dim = q_nope.size(-1);
+  const int rope_dim = q_pe.size(-1);
+  const int head_dim = rope_dim + nope_dim;
+
+  TORCH_CHECK(group_size == 128, "group_size must be 128");
+  TORCH_CHECK(head_dim == 128, "head_dim must be 128");
+  TORCH_CHECK(rope_dim > 0, "rope_dim must be > 0");
+  TORCH_CHECK(nope_dim > 0, "nope_dim must be > 0");
+  TORCH_CHECK(head_dim == rope_dim + nope_dim,
+              "head_dim must be equal to rope_dim + nope_dim");
+
+  if (num_tokens == 0) {
+    return;
+  }
+
+  auto stream = at::cuda::getCurrentCUDAStream(q_pe.get_device());
+
+  VLLM_DISPATCH_FLOATING_TYPES(
+      q_nope.scalar_type(), "indexer_concat_quant_fp8", [&] {
+        vllm::invokeConcatIndexerQFp8<scalar_t, 4, 128>(
+            reinterpret_cast<__nv_fp8_e4m3*>(q_out.data_ptr()),
+            scale_out.data_ptr<float>(), q_pe.data_ptr<scalar_t>(),
+            q_nope.data_ptr<scalar_t>(), num_tokens, num_heads, rope_dim,
+            nope_dim, q_out.stride(0), q_out.stride(1), q_nope.stride(0),
+            q_nope.stride(1), q_pe.stride(0), q_pe.stride(1), group_size, eps,
+            fp8_min, fp8_max, scale_ue8m0, stream);
+      });
+}

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -681,6 +681,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("per_token_group_quant_int8", torch::kCUDA,
            &per_token_group_quant_int8);
 
+  // Concat q_pe and q_nope, and FP8 quantization.
+  ops.def(
+      "indexer_concat_quant_fp8(Tensor! q_out, Tensor! scale_out, Tensor pe, "
+      "Tensor nope, int group_size, float eps, float fp8_min, float fp8_max, "
+      "bool use_ue8m0) -> ()");
+  ops.impl("indexer_concat_quant_fp8", torch::kCUDA, &indexer_concat_quant_fp8);
+
   // reorder weight for AllSpark Ampere W8A16 Fused Gemm kernel
   ops.def(
       "rearrange_kn_weight_as_n32k16_order(Tensor b_qweight, Tensor b_scales, "

--- a/tests/kernels/test_indexer_concat_quant_fp8.py
+++ b/tests/kernels/test_indexer_concat_quant_fp8.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    indexer_concat_quant_fp8,
+    per_token_group_quant_fp8,
+)
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
+)
+@pytest.mark.parametrize("num_tokens", [1, 4, 16, 64, 128])
+@pytest.mark.parametrize("num_heads", [64])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("rope_dim", [64])
+@pytest.mark.parametrize("group_size", [128])
+@pytest.mark.parametrize("use_ue8m0", [True, False])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_indexer_concat_quant_fp8(
+    num_tokens: int,
+    num_heads: int,
+    head_dim: int,
+    rope_dim: int,
+    group_size: int,
+    use_ue8m0: bool,
+    dtype: torch.dtype,
+):
+    set_random_seed(0)
+    nope_dim = head_dim - rope_dim
+    q_pe = torch.randn(num_tokens, num_heads, rope_dim, dtype=dtype, device="cuda")
+    q_nope = torch.randn(num_tokens, num_heads, nope_dim, dtype=dtype, device="cuda")
+
+    q_ref = torch.cat([q_pe, q_nope], dim=-1)
+    q_ref = q_ref.view(-1, head_dim)
+    q_fp8_ref, q_scale_ref = per_token_group_quant_fp8(
+        q_ref, group_size, column_major_scales=False, use_ue8m0=use_ue8m0
+    )
+    q_fp8_ref = q_fp8_ref.view(-1, num_heads, head_dim)
+    q_scale_ref = q_scale_ref.view(-1, num_heads, 1)
+
+    q_fp8, q_scale = indexer_concat_quant_fp8(
+        q_pe, q_nope, group_size, column_major_scales=False, use_ue8m0=use_ue8m0
+    )
+
+    torch.testing.assert_close(q_fp8.float(), q_fp8_ref.float(), atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(q_scale, q_scale_ref, atol=2e-3, rtol=2e-3)

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -1679,3 +1679,54 @@ def process_fp8_input_tensor_strategy_moe(
         )
 
     return w13_input_scale.max(), w2_input_scale.max()
+
+
+def indexer_concat_quant_fp8(
+    q_pe: torch.Tensor,  # [num_tokens, n_head, rope_dim].
+    q_nope: torch.Tensor,  # [num_tokens, n_head, nope_dim].
+    group_size: int,
+    eps: float = 1e-10,
+    column_major_scales: bool = False,
+    use_ue8m0: bool | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Function that fuses concat and fp8 quantization."""
+    if use_ue8m0 is None:
+        use_ue8m0 = is_deep_gemm_e8m0_used()
+
+    if current_platform.is_cuda() and q_pe.is_contiguous() and q_nope.is_contiguous():
+        fp8_min, fp8_max = get_fp8_min_max()
+        rope_dim = q_pe.shape[-1]
+        nope_dim = q_nope.shape[-1]
+        x_q = torch.empty(
+            (*q_pe.shape[:-1], rope_dim + nope_dim),
+            dtype=current_platform.fp8_dtype(),
+            device=q_pe.device,
+        )
+        x_s = torch.empty(
+            (*q_pe.shape[:-1], 1), device=q_pe.device, dtype=torch.float32
+        )
+        torch.ops._C.indexer_concat_quant_fp8(
+            x_q,
+            x_s,
+            q_pe,
+            q_nope,
+            group_size,
+            eps,
+            fp8_min,
+            fp8_max,
+            use_ue8m0,
+        )
+        return x_q, x_s
+
+    # Fallback
+    rope_dim = q_pe.shape[-1]
+    nope_dim = q_nope.shape[-1]
+    q = torch.cat([q_pe, q_nope], dim=-1)
+    q = q.view(-1, rope_dim + nope_dim)
+    x_q, x_s = per_token_group_quant_fp8(
+        q,
+        group_size,
+        column_major_scales=column_major_scales,
+        use_ue8m0=use_ue8m0,
+    )
+    return x_q, x_s

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -64,7 +64,7 @@ from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mla import MLAModules, MultiHeadLatentAttentionWrapper
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-    per_token_group_quant_fp8,
+    indexer_concat_quant_fp8,
 )
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
@@ -706,16 +706,15 @@ class Indexer(nn.Module):
         q_pe = q_pe.reshape(-1, self.n_head, self.rope_dim)
         k_pe = k_pe.reshape(-1, 1, self.rope_dim)
 
-        # `rotary_emb` is shape-preserving; `q_pe` is already
-        # [num_tokens, n_head, rope_dim].
-        q = torch.cat([q_pe, q_nope], dim=-1)
         # `k_pe` is [num_tokens, 1, rope_dim] (MQA).
         k = torch.cat([k_pe.squeeze(-2), k_nope], dim=-1)
 
+        # `rotary_emb` is shape-preserving; `q_pe` is already
+        # [num_tokens, n_head, rope_dim].
         # we only quant q here since k quant is fused with cache insertion
-        q = q.view(-1, self.head_dim)
-        q_fp8, q_scale = per_token_group_quant_fp8(
-            q,
+        q_fp8, q_scale = indexer_concat_quant_fp8(
+            q_pe,
+            q_nope,
             self.quant_block_size,
             column_major_scales=False,
             use_ue8m0=self.scale_fmt is not None,


### PR DESCRIPTION



## Purpose

This PR add `indexer_concat_quant_fp8` kernel that fuses concat and fp8 quantization in DeepSeek V3.2 Indexer. Currently only support head_dim=128 for DeepSeek V3.2. I have reused some of the code from [concat_mla_q](https://github.com/vllm-project/vllm/blob/v0.18.0/csrc/concat_mla_q.cuh#L17)

* Since DeepSeek V3.2 indexer head_dim=128, all 128 elements can fit into a single warp. Each thread in a warp load 128 / 32 = 4 elements.
* Do max reduction within warp, so no synchronization and shared memory needed.
* Added test in test_indexer_concat_quant_fp8.py
* Added micro bench script benchmark_concat_indexer_q.py

## Test Plan

```
pytest -s -v tests/kernels/test_indexer_concat_quant_fp8.py
```

## Test Result

Unit test passed.

## Micro bench

```
python3 benchmarks/kernels/benchmark_indexer_concat_quant_fp8.py
```

```
indexer_concat_quant_fp8 latency:
    num_tokens  PyTorch (us)   vLLM (us)
0          1.0      2.810146    1.657154
1          2.0      3.299750    1.666530
2          4.0      3.345727    1.702395
3          8.0      3.382541    1.715597
4         16.0      3.511889    1.756828
5         32.0      3.597086    1.885549
6         64.0      3.884780    2.249035
7        128.0      4.849041    3.222031
8        256.0      6.924584    5.155195
9        512.0     10.912246    8.805989
10      1024.0     21.179043   16.196680
11      2048.0     44.994000   31.824892
12      4096.0     85.880730   62.038422
13      8192.0    170.178787  122.532600
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

