### PR TITLE
[Perf] Optimize mean pool cumsum by adding a small id cache, 2.8% Throughput improvement

### DIFF
--- a/vllm/model_executor/layers/pooler/seqwise/cache.py
+++ b/vllm/model_executor/layers/pooler/seqwise/cache.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import weakref
+
+import torch
+
+_hidden_states_cumsum_cache: dict[
+    int, tuple[weakref.ReferenceType[torch.Tensor], torch.Tensor]
+] = {}
+
+
+def get_hidden_states_cumsum(hidden_states: torch.Tensor) -> torch.Tensor:
+    key = id(hidden_states)
+    cached = _hidden_states_cumsum_cache.get(key)
+    if cached is not None:
+        ref, cumsum = cached
+        if ref() is hidden_states:
+            return cumsum
+
+    cumsum = torch.cumsum(hidden_states, dim=0, dtype=torch.float32)
+
+    def _cleanup(_ref: weakref.ReferenceType[torch.Tensor]) -> None:
+        _hidden_states_cumsum_cache.pop(key, None)
+
+    _hidden_states_cumsum_cache[key] = (
+        weakref.ref(hidden_states, _cleanup),
+        cumsum,
+    )
+    return cumsum

--- a/vllm/model_executor/layers/pooler/seqwise/methods.py
+++ b/vllm/model_executor/layers/pooler/seqwise/methods.py
@@ -12,6 +12,8 @@ from vllm.model_executor.layers.pooler import PoolingParamsUpdate
 from vllm.tasks import PoolingTask
 from vllm.v1.pool.metadata import PoolingMetadata
 
+from .cache import get_hidden_states_cumsum
+
 SequencePoolingMethodOutput: TypeAlias = torch.Tensor | list[torch.Tensor]
 
 
@@ -70,9 +72,7 @@ class MeanPool(SequencePoolingMethod):
             hidden_states.device, non_blocking=True
         )
 
-        # Use float32 for torch.cumsum in MeanPool,
-        # otherwise precision will be lost significantly.
-        cumsum = torch.cumsum(hidden_states, dim=0, dtype=torch.float32)
+        cumsum = get_hidden_states_cumsum(hidden_states)
 
         start_indices = pooling_cursor.first_token_indices_gpu
         end_indices = pooling_cursor.last_token_indices_gpu


### PR DESCRIPTION
## Purpose

Optimize mean pool cumsum by adding a small id cache

## Test

### Acc

Covered in unit tests

```bash
tests/models/language/pooling_mteb_test/test_jina.py
tests/models/language/pooling_mteb_test/test_nomic.py
tests/models/language/pooling_mteb_test/test_nemotron.py
tests/models/language/pooling_mteb_test/test_voyage.py
tests/models/language/pooling_mteb_test/test_st_projector.py
...
```

### Perf

```py
import asyncio
import statistics
import time

import aiohttp

URL = "http://127.0.0.1:8000/pooling"
MODEL = "BAAI/bge-m3"
TEXT = "hello world " * 1200
TASKS = ["embed", "embed&token_classify"]

WARMUP = 100
TOTAL = 2000
CONCURRENCY = 64


async def one_request(session, idx, *, include_usage=False):
    payload = {
        "model": MODEL,
        "task": TASKS[idx % 2],
        "input": [TEXT],
    }
    t0 = time.perf_counter()
    async with session.post(URL, json=payload) as resp:
        if resp.status >= 400:
            raise RuntimeError(
                f"request failed with status={resp.status}: {await resp.text()}"
            )

        if include_usage:
            body = await resp.json()
            usage = body.get("usage", {})
            prompt_tokens = int(usage.get("prompt_tokens", 0))
        else:
            await resp.read()
            prompt_tokens = None

    return time.perf_counter() - t0, prompt_tokens


async def get_prompt_tokens_per_request():
    connector = aiohttp.TCPConnector(limit=0)
    timeout = aiohttp.ClientTimeout(total=300)
    async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
        _, prompt_tokens = await one_request(session, 0, include_usage=True)
        if prompt_tokens is None:
            raise RuntimeError("response did not include usage.prompt_tokens")
        return prompt_tokens


async def run(n):
    connector = aiohttp.TCPConnector(limit=0)
    timeout = aiohttp.ClientTimeout(total=300)
    async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
        sem = asyncio.Semaphore(CONCURRENCY)

        async def wrapped(i):
            async with sem:
                latency, _ = await one_request(session, i)
                return latency

        tasks = [asyncio.create_task(wrapped(i)) for i in range(n)]
        t0 = time.perf_counter()
        latencies = await asyncio.gather(*tasks)
        elapsed = time.perf_counter() - t0
        return latencies, elapsed


async def main():
    prompt_tokens_per_request = await get_prompt_tokens_per_request()
    await run(WARMUP)
    latencies, elapsed = await run(TOTAL)

    lat_ms = [x * 1000 for x in latencies]
    total_prompt_tokens = prompt_tokens_per_request * TOTAL
    print(f"req/s: {TOTAL / elapsed:.2f}")
    print(f"prompt tokens/request: {prompt_tokens_per_request}")
    print(f"total prompt tokens: {total_prompt_tokens}")
    print(f"prompt tok/s: {total_prompt_tokens / elapsed:.2f}")
    print(f"p50: {statistics.quantiles(lat_ms, n=100)[49]:.2f} ms")
    print(f"p95: {statistics.quantiles(lat_ms, n=100)[94]:.2f} ms")
    print(f"p99: {statistics.quantiles(lat_ms, n=100)[98]:.2f} ms")


asyncio.run(main())
```

Before:

```bash
req/s: 2.74
prompt tokens/request: 3603
total prompt tokens: 7206000
prompt tok/s: 9867.03
p50: 23004.36 ms
p95: 26288.80 ms
p99: 26307.25 ms
```

Now

```bash
req/s: 2.82
prompt tokens/request: 3603
total prompt tokens: 7206000
prompt tok/s: 10143.29
p50: 22372.68 ms
p95: 25567.09 ms
p99: 25573.26 ms
```