### PR TITLE
Add 501 response to STT endpoint OpenAPI spec

### DIFF
--- a/vllm/entrypoints/openai/speech_to_text/api_router.py
+++ b/vllm/entrypoints/openai/speech_to_text/api_router.py
@@ -56,6 +56,7 @@ def translation(request: Request) -> OpenAIServingTranslation:
         HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
         HTTPStatus.UNPROCESSABLE_ENTITY.value: {"model": ErrorResponse},
         HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+        HTTPStatus.NOT_IMPLEMENTED.value: {"model": ErrorResponse},
     },
 )
 @with_cancellation
@@ -89,6 +90,7 @@ async def create_transcriptions(
         HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
         HTTPStatus.UNPROCESSABLE_ENTITY.value: {"model": ErrorResponse},
         HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+        HTTPStatus.NOT_IMPLEMENTED.value: {"model": ErrorResponse},
     },
 )
 @with_cancellation


### PR DESCRIPTION
## Summary

Both `/v1/audio/transcriptions` and `/v1/audio/translations` raise `NotImplementedError` when the handler is `None` (i.e., the model doesn't support the task). The global exception handler already converts this to a proper 501 JSON response, but the OpenAPI schema didn't document it — meaning auto-generated clients wouldn't expect or handle this case.

Added `HTTPStatus.NOT_IMPLEMENTED` to the `responses` dict on both routes so the 501 shows up in the spec.

Fixes #38004