### PR TITLE
Fix IndexError in streaming tool calls when max_tokens is hit

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1105,7 +1105,13 @@ class OpenAIServingChat(OpenAIServing):
                         )
                         # only check if there are any tool calls
                         # detected by partial parsing
-                        if should_check and tool_parser and auto_tools_called:
+                        if (
+                            should_check
+                            and tool_parser
+                            and auto_tools_called
+                            and index < len(tool_parser.prev_tool_call_arr)
+                            and index < len(tool_parser.streamed_args_for_tool)
+                        ):
                             latest_delta_len = 0
                             if (
                                 isinstance(


### PR DESCRIPTION
## Summary

Fixes #37937.

When streaming is enabled and the model hits `max_tokens` while generating tool call arguments, an unhandled `IndexError` crashes the stream generator:

```
args = tool_parser.prev_tool_call_arr[index].get("arguments", {})
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
IndexError: list index out of range
```

This happens because `_should_check_for_unstreamed_tool_arg_tokens` can return `True` (the delta message contains partial tool call data) even when the tool parser's `prev_tool_call_arr` is empty — the parser never completed parsing before generation was truncated.

## Fix

Added bounds checks on both `prev_tool_call_arr` and `streamed_args_for_tool` before indexing into them in the unstreamed argument recovery block. When the index is out of range, the block is skipped entirely and the response completes with the engine's original `finish_reason` (typically `"length"`), which is the correct behavior for a truncated generation.

## Test plan

- Reproduce by sending a streaming tool call request with a low `max_tokens` value that truncates mid-argument generation
- Verify the stream completes with `finish_reason: "length"` instead of crashing with a 500 error
- Verify normal (non-truncated) streaming tool calls still receive the full unstreamed argument recovery and `finish_reason: "tool_calls"`