### PR TITLE
[CI/Docs] Improve aarch64/DGX Spark support for dev setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ If work is duplicate/trivial busywork, **do not proceed**. Return a short explan
 
 ## 2. Development Workflow
 
+- **Never use system `python3` or bare `pip`/`pip install`.** All Python commands must go through `uv` and `.venv/bin/python`.
+
 ### Environment setup
 
 ```bash
@@ -58,7 +60,7 @@ pre-commit install
 
 ```bash
 # If you are only making Python changes:
-VLLM_USE_PRECOMPILED=1 uv pip install -e .
+VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto
 
 # If you are also making C/C++ changes:
 uv pip install -e .
@@ -66,24 +68,24 @@ uv pip install -e .
 
 ### Running tests
 
-Tests require extra dependencies.
-All versions for test dependencies should be read from `requirements/test.txt`
+> Requires [Environment setup](#environment-setup) and [Installing dependencies](#installing-dependencies).
 
 ```bash
-# Install bare minimum test dependencies:
-uv pip install pytest pytest-asyncio tblib
-
-# Install additional test dependencies as needed, or install them all as follows:
+# Install test dependencies.
+# requirements/test.txt is pinned to x86_64; on other platforms, use the
+# unpinned source file instead:
+uv pip install -r requirements/test.in    # resolves for current platform
+# OR on x86_64:
 uv pip install -r requirements/test.txt
 
-# Run specific test from specific test file
-pytest tests/path/to/test.py -v -s -k test_name
-
-# Run all tests in directory
-pytest tests/path/to/dir -v -s
+# Run a specific test file (use .venv/bin/python directly;
+# `source activate` does not persist in non-interactive shells):
+.venv/bin/python -m pytest tests/path/to/test_file.py -v
 ```
 
 ### Running linters
+
+> Requires [Environment setup](#environment-setup).
 
 ```bash
 # Run all pre-commit hooks on staged files:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ uv pip install -e . --torch-backend=auto
 # requirements/test.txt is pinned to x86_64; on other platforms, use the
 # unpinned source file instead:
 uv pip install -r requirements/test.in    # resolves for current platform
-# OR on x86_64:
+# Or on x86_64:
 uv pip install -r requirements/test.txt
 
 # Run a specific test file (use .venv/bin/python directly;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ pre-commit install
 VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto
 
 # If you are also making C/C++ changes:
-uv pip install -e .
+uv pip install -e . --torch-backend=auto
 ```
 
 ### Running tests

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -61,7 +61,7 @@ runai-model-streamer[s3,gcs,azure]==0.15.7
 fastsafetensors>=0.2.2 # 0.2.2 contains important fixes for multi-GPU mem usage
 instanttensor>=0.1.5
 pydantic>=2.12 # 2.11 leads to error on python 3.13
-decord==0.6.0
+decord==0.6.0; platform_machine == "x86_64"
 terratorch >= 1.2.2 # Required for Prithvi tests
 imagehash # Required for Prithvi tests
 segmentation-models-pytorch > 0.4.0 # Required for Prithvi tests


### PR DESCRIPTION

## Purpose

The goal here is to get a newly started container with Claude Code and vLLM source code in it to actually be able to setup a vLLM dev environment and run unit and integration tests.

- Add --torch-backend=auto to precompiled install in AGENTS.md so torch resolves correctly on non-x86 platforms
- Gate decord==0.6.0 to x86_64 only (no aarch64 wheels)
- Update AGENTS.md test instructions to recommend test.in on non-x86 platforms and use .venv/bin/python -m pytest

## Test Plan

Spin up a fresh container with Claude Code and vLLM checked out. Ask Claude Code to run a test that requires a working vLLM dev environment with GPU and proper wheels built.

I'd do this once, Claude would struggle to figure something out, I'd stop it and ask it to review what it did vs what the AGENTS.md told it to do and fix it. This also revealed the `decord` dependency doesn't ship aarch64 wheels, so we had to flag that one as x86_64 only in requirements/test.in. And, requirements/test.txt is the versions specific to x86_64, so the AGENTS.md had to clarify that for arm64 usages.

## Test Result

After these changes, Claude Code was able to successfully setup a new uv venv, install vLLM from precompiled arm64 wheels, install test dependencies, and run unit and integration tests. Here's an example session from a clean container asking it to run some integration tests:

```
❯ Run one of the integration tests in tests/entrypoints/openai/tool_parsers to verify vllm is working properly.

  Searched for 1 pattern (ctrl+o to expand)

● Let me pick one of these and run it. The Hermes parser test is a good general one.

● Bash(.venv/bin/python -m pytest tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py -v 2>&1 | tail -40)
  ⎿  /bin/bash: line 1: .venv/bin/python: No such file or directory

● Need to set up the environment first.

● Bash(which python3 && python3 -c "import vllm; print(vllm.__version__)" 2>&1)
  ⎿  Error: Exit code 1
     /usr/bin/python3
     Traceback (most recent call last):
       File "<string>", line 1, in <module>
       File "/pvc/workspace/vllm/__init__.py", line 14, in <module>
         import vllm.env_override  # noqa: F401
         ^^^^^^^^^^^^^^^^^^^^^^^^
       File "/pvc/workspace/vllm/env_override.py", line 87, in <module>
         import torch
     ModuleNotFoundError: No module named 'torch'

● Per the project instructions, I need to set up with uv. Let me do that.

● Bash(uv venv --python 3.12 2>&1 | tail -5)
  ⎿  Using CPython 3.12.12 interpreter at: /usr/bin/python3.12
     Creating virtual environment at: .venv
     Activate with: source .venv/bin/activate

● Bash(VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto 2>&1 | tail -20)
  ⎿   + tokenizers==0.22.2
      + torch==2.10.0+cu130
      + torch-c-dlpack-ext==0.1.5
     … +17 lines (ctrl+o to expand)
  ⎿  (timeout 10m)

● Bash(uv pip install -r requirements/test.in 2>&1 | tail -10)
  ⎿   + virtualenv==21.2.0
      + vocos==0.1.0
      + wandb==0.25.1
     … +7 lines (ctrl+o to expand)

● Now let's run the test.

● Bash(.venv/bin/python -m pytest tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py -v 2>&1 | tail -50)
... [ test runs from this point on ] ...
```
