### PR TITLE
[Misc] reject batched completions requests in toy proxy

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
+++ b/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
@@ -9,7 +9,7 @@ import uuid
 from contextlib import asynccontextmanager
 
 import httpx
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 logger = logging.getLogger(__name__)
@@ -209,9 +209,34 @@ async def stream_service_response(
             yield chunk
 
 
+def _raise_if_unsupported_batched_prompt(api: str, req_data: dict) -> None:
+    if api != "/completions":
+        return
+
+    prompt = req_data.get("prompt")
+    if not isinstance(prompt, list):
+        return
+
+    if all(isinstance(token_id, int) for token_id in prompt):
+        return
+
+    if len(prompt) <= 1:
+        return
+
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            "toy_proxy_server does not support batched completions requests. "
+            "Send exactly one prompt per request. This also means tools like "
+            "lm_eval must use batch_size=1 when routing through this proxy."
+        ),
+    )
+
+
 async def _handle_completions(api: str, request: Request):
     try:
         req_data = await request.json()
+        _raise_if_unsupported_batched_prompt(api, req_data)
         request_id = str(uuid.uuid4())
 
         # Get the next prefill client in round-robin fashion
@@ -243,6 +268,8 @@ async def _handle_completions(api: str, request: Request):
 
         return StreamingResponse(generate_stream(), media_type="application/json")
 
+    except HTTPException:
+        raise
     except Exception as e:
         import sys
         import traceback


### PR DESCRIPTION



## Purpose

batched prompts in one request can make the decode side send duplicate notify ids to the prefill side, which will trigger
"Potentially invalid KV blocks for unrecognized request %s were retrieved by a decode worker. They may have expired."


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

