### PR TITLE
[Bugfix] Handle ImportError for flash_attn in ApplyRotaryEmb class

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -135,9 +135,17 @@ class ApplyRotaryEmb(CustomOp):
 
         self.apply_rotary_emb_flash_attn = None
         if find_spec("flash_attn") is not None:
-            from flash_attn.ops.triton.rotary import apply_rotary
+            try:
+                from flash_attn.ops.triton.rotary import apply_rotary
 
-            self.apply_rotary_emb_flash_attn = apply_rotary
+                self.apply_rotary_emb_flash_attn = apply_rotary
+            except (ImportError, ModuleNotFoundError):
+                # flash_attn exists but flash_attn.ops.triton may not be available
+                logger.debug(
+                    "flash_attn.ops.triton.rotary not available when version is less than v2.1.2, "
+                    "falling back to native implementation"
+                )
+                self.apply_rotary_emb_flash_attn = None
 
     @staticmethod
     def forward_static(

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -142,7 +142,8 @@ class ApplyRotaryEmb(CustomOp):
             except (ImportError, ModuleNotFoundError):
                 # flash_attn exists but flash_attn.ops.triton may not be available
                 logger.debug(
-                    "flash_attn.ops.triton.rotary not available when version is less than v2.1.2, "
+                    "flash_attn.ops.triton.rotary not available when "
+                    "version is less than v2.1.2, "
                     "falling back to native implementation"
                 )
                 self.apply_rotary_emb_flash_attn = None


### PR DESCRIPTION



## Decribe
Log ApplyRotaryEmb unavailability in flash_attn.ops.triton.rotary at debug level.

This is an expected compatibility fallback (e.g., flash_attn < 2.1.2), and the functionality gracefully falls back to the native implementation — not a runtime error.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

