### PR TITLE
[MRV2][Attention] Remove `set_workspace_buffer` pattern in FlashInfer

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -560,11 +560,7 @@ def _test_backend_correctness(
 @pytest.mark.parametrize("model", ["meta-llama/Meta-Llama-3-8B"])
 @pytest.mark.parametrize("tensor_parallel_size", [1, 2, 4])
 def test_causal_backend_correctness(
-    default_vllm_config,
-    workspace_init,
-    batch_spec_name: str,
-    model: str,
-    tensor_parallel_size: int,
+    default_vllm_config, batch_spec_name: str, model: str, tensor_parallel_size: int
 ):
     """Test backend's correctness with causal attention."""
 

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -560,7 +560,11 @@ def _test_backend_correctness(
 @pytest.mark.parametrize("model", ["meta-llama/Meta-Llama-3-8B"])
 @pytest.mark.parametrize("tensor_parallel_size", [1, 2, 4])
 def test_causal_backend_correctness(
-    default_vllm_config, batch_spec_name: str, model: str, tensor_parallel_size: int
+    default_vllm_config,
+    workspace_init,
+    batch_spec_name: str,
+    model: str,
+    tensor_parallel_size: int,
 ):
     """Test backend's correctness with causal attention."""
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -75,20 +75,18 @@ FP4_DTYPE = torch.uint8
 logger = init_logger(__name__)
 
 
-_trtllm_workspace_buffer = None
+trtllm_gen_workspace_buffer = None
 
 
 # Must be zero-initialized and only used for the trtllm kernels as they properly reset
 # the workspace to zero after use; see: https://github.com/vllm-project/vllm/pull/25520
 def _get_trtllm_gen_workspace_buffer():
-    global _trtllm_workspace_buffer
-    if _trtllm_workspace_buffer is None:
-        _trtllm_workspace_buffer = torch.zeros(
-            envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE,
-            dtype=torch.uint8,
-            device="cuda",
+    global trtllm_gen_workspace_buffer
+    if trtllm_gen_workspace_buffer is None:
+        trtllm_gen_workspace_buffer = torch.zeros(
+            envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE, dtype=torch.uint8, device="cuda"
         )
-    return _trtllm_workspace_buffer
+    return trtllm_gen_workspace_buffer
 
 
 def _get_workspace_buffer():

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -85,6 +85,9 @@ def _get_trtllm_gen_workspace_buffer():
     return trtllm_gen_workspace_buffer
 
 
+_flashinfer_workspace_buffer = None
+
+
 @triton.jit
 def _trtllm_prefill_attn_kvfp8_dequant(
     kv_cache_ptr,
@@ -535,7 +538,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.cache_config = vllm_config.cache_config
         self.model_config = vllm_config.model_config
         self.attention_config = vllm_config.attention_config
-        self._workspace_buffer = None
         self._prefill_wrapper: (
             BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper | None
         ) = None  # Wrapper for prefill/append
@@ -714,17 +716,15 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
     def _get_workspace_buffer(self):
-        if self._workspace_buffer is None:
+        global _flashinfer_workspace_buffer
+        if _flashinfer_workspace_buffer is None:
             buffer_size = envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE
             if envs.VLLM_BATCH_INVARIANT:
                 buffer_size = FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT
-            self._workspace_buffer = torch.zeros(
+            _flashinfer_workspace_buffer = torch.zeros(
                 buffer_size, dtype=torch.uint8, device=self.device
             )
-        return self._workspace_buffer
-
-    def set_workspace_buffer(self, workspace_buffer: torch.Tensor):
-        self._workspace_buffer = workspace_buffer
+        return _flashinfer_workspace_buffer
 
     def _get_prefill_wrapper(
         self,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -74,7 +74,6 @@ FP4_DTYPE = torch.uint8
 
 logger = init_logger(__name__)
 
-
 trtllm_gen_workspace_buffer = None
 
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -65,6 +65,7 @@ from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import AttentionSpec, UniformTypeKVCacheSpecs
 from vllm.v1.utils import CpuGpuBuffer
+from vllm.v1.worker.workspace import current_workspace_manager
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 
@@ -73,19 +74,31 @@ FP4_DTYPE = torch.uint8
 
 logger = init_logger(__name__)
 
-trtllm_gen_workspace_buffer = None
+
+_trtllm_workspace_buffer = None
 
 
+# Must be zero-initialized and only used for the trtllm kernels as they properly reset
+# the workspace to zero after use; see: https://github.com/vllm-project/vllm/pull/25520
 def _get_trtllm_gen_workspace_buffer():
-    global trtllm_gen_workspace_buffer
-    if trtllm_gen_workspace_buffer is None:
-        trtllm_gen_workspace_buffer = torch.zeros(
-            envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE, dtype=torch.uint8, device="cuda"
+    global _trtllm_workspace_buffer
+    if _trtllm_workspace_buffer is None:
+        _trtllm_workspace_buffer = torch.zeros(
+            envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE,
+            dtype=torch.uint8,
+            device="cuda",
         )
-    return trtllm_gen_workspace_buffer
+    return _trtllm_workspace_buffer
 
 
-_flashinfer_workspace_buffer = None
+def _get_workspace_buffer():
+    buffer_size = envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE
+    if envs.VLLM_BATCH_INVARIANT:
+        buffer_size = FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT
+    (workspace,) = current_workspace_manager().get_simultaneous(
+        ((buffer_size,), torch.uint8),
+    )
+    return workspace
 
 
 @triton.jit
@@ -715,29 +728,18 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         else:
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
-    def _get_workspace_buffer(self):
-        global _flashinfer_workspace_buffer
-        if _flashinfer_workspace_buffer is None:
-            buffer_size = envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE
-            if envs.VLLM_BATCH_INVARIANT:
-                buffer_size = FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT
-            _flashinfer_workspace_buffer = torch.zeros(
-                buffer_size, dtype=torch.uint8, device=self.device
-            )
-        return _flashinfer_workspace_buffer
-
     def _get_prefill_wrapper(
         self,
     ) -> BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper:
         if self._prefill_wrapper is None:
             if self.use_dcp:
                 self._prefill_wrapper = BatchDCPPrefillWrapper(
-                    workspace_buffer=self._get_workspace_buffer(),
+                    workspace_buffer=_get_workspace_buffer(),
                     dcp_a2a=self.dcp_a2a,
                 )
             else:
                 self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
-                    self._get_workspace_buffer(), get_kv_cache_layout()
+                    _get_workspace_buffer(), get_kv_cache_layout()
                 )
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -758,7 +758,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 paged_kv_indices = None
                 paged_kv_last_page_len = None
             decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
-                self._get_workspace_buffer(),
+                _get_workspace_buffer(),
                 get_kv_cache_layout(),
                 use_cuda_graph=use_cudagraph,
                 paged_kv_indptr_buffer=paged_kv_indptr,
@@ -781,7 +781,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
     def _get_cascade_wrapper(self):
         if self._cascade_wrapper is None:
             self._cascade_wrapper = MultiLevelCascadeAttentionWrapper(
-                2, self._get_workspace_buffer(), get_kv_cache_layout()
+                2, _get_workspace_buffer(), get_kv_cache_layout()
             )
         return self._cascade_wrapper
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -65,7 +65,6 @@ from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import AttentionSpec, UniformTypeKVCacheSpecs
 from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.worker.workspace import current_workspace_manager
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 
@@ -75,6 +74,7 @@ FP4_DTYPE = torch.uint8
 logger = init_logger(__name__)
 
 trtllm_gen_workspace_buffer = None
+flashinfer_workspace_buffer = None
 
 
 # Must be zero-initialized and only used for the trtllm kernels as they properly reset
@@ -89,13 +89,16 @@ def _get_trtllm_gen_workspace_buffer():
 
 
 def _get_workspace_buffer():
-    buffer_size = envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE
-    if envs.VLLM_BATCH_INVARIANT:
-        buffer_size = FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT
-    (workspace,) = current_workspace_manager().get_simultaneous(
-        ((buffer_size,), torch.uint8),
-    )
-    return workspace
+    global flashinfer_workspace_buffer
+    if flashinfer_workspace_buffer is None:
+        buffer_size = envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE
+        if envs.VLLM_BATCH_INVARIANT:
+            buffer_size = FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT
+        flashinfer_workspace_buffer = torch.zeros(
+            buffer_size, dtype=torch.uint8, device="cuda"
+        )
+
+    return flashinfer_workspace_buffer
 
 
 @triton.jit

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -37,7 +37,6 @@ def init_attn_backend(
 ):
     attn_backends: dict[str, type[AttentionBackend]] = {}
     attn_groups: list[list[AttentionGroup]] = []
-    attn_backend_workspace: torch.Tensor | None = None
     for kv_cache_group_id, kv_cache_group_spec in enumerate(
         kv_cache_config.kv_cache_groups
     ):
@@ -79,13 +78,6 @@ def init_attn_backend(
                 kernel_block_size=None,
                 num_metadata_builders=1,
             )
-            builder = group.get_metadata_builder(0)
-            if attn_backend_workspace is None:
-                if hasattr(builder, "_get_workspace_buffer"):
-                    attn_backend_workspace = builder._get_workspace_buffer()
-            else:
-                if hasattr(builder, "set_workspace_buffer"):
-                    builder.set_workspace_buffer(attn_backend_workspace)
         attn_groups.append(groups)
     return attn_backends, attn_groups
 


### PR DESCRIPTION
Remove `set_workspace_buffer`; introduced in https://github.com/vllm-project/vllm/pull/25266, not sure why this was introduced so please feel free to close this PR if Im missing something. The get/set workspace pattern just feels messy