### PR TITLE
[Bugfix] Fix benchmark_fused_collective.py

### DIFF
--- a/benchmarks/kernels/benchmark_fused_collective.py
+++ b/benchmarks/kernels/benchmark_fused_collective.py
@@ -25,6 +25,7 @@ import pandas as pd
 import torch  # type: ignore
 import torch.distributed as dist  # type: ignore
 
+from vllm._custom_ops import create_fp4_output_tensors
 from vllm.config.vllm import CompilationConfig, VllmConfig, set_current_vllm_config
 from vllm.distributed import (
     tensor_model_parallel_all_reduce,
@@ -46,7 +47,7 @@ RMS_NORM_STATIC_FP8_QUANT_OP = torch.ops._C.rms_norm_static_fp8_quant
 FUSED_ADD_RMS_NORM_STATIC_FP8_QUANT_OP = (
     torch.ops._C.fused_add_rms_norm_static_fp8_quant
 )
-SCALED_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant
+SCALED_FP4_QUANT_OUT_OP = torch.ops._C.scaled_fp4_quant.out
 
 logger = init_logger(__name__)
 
@@ -336,11 +337,23 @@ class VllmFusedAllreduce:
         allreduce_out = tensor_model_parallel_all_reduce(input_tensor)
         rms_out = self.rms_norm(allreduce_out, residual)
         if residual is None:
-            SCALED_FP4_QUANT_OP(quant_out, rms_out, output_scale, input_global_scale)
+            SCALED_FP4_QUANT_OUT_OP(
+                rms_out,
+                input_global_scale,
+                True,
+                output=quant_out,
+                output_scale=output_scale,
+            )
             return quant_out, output_scale
         else:
             rms_out, residual_out = rms_out
-            SCALED_FP4_QUANT_OP(quant_out, rms_out, output_scale, input_global_scale)
+            SCALED_FP4_QUANT_OUT_OP(
+                rms_out,
+                input_global_scale,
+                True,
+                output=quant_out,
+                output_scale=output_scale,
+            )
             return quant_out, residual_out, output_scale
 
 
@@ -362,8 +375,9 @@ def create_test_tensors(
     scale_fp4 = torch.tensor(1.0, dtype=torch.float32)
     quant_out_fp8 = torch.empty_like(input_tensor, dtype=FP8_DTYPE)
     # Pre-allocate FP4 output tensors (to avoid allocation overhead in benchmarks)
-    fp4_quant_out = torch.empty((num_tokens, hidden_dim // 2), dtype=torch.uint8)
-    fp4_output_scale = torch.empty((128, 4), dtype=torch.int32)
+    fp4_quant_out, fp4_output_scale = create_fp4_output_tensors(
+        num_tokens, hidden_dim, input_tensor.device, True
+    )
 
     return (
         input_tensor,

--- a/benchmarks/kernels/benchmark_fused_collective.py
+++ b/benchmarks/kernels/benchmark_fused_collective.py
@@ -335,25 +335,23 @@ class VllmFusedAllreduce:
         output_scale: torch.Tensor,
     ):
         allreduce_out = tensor_model_parallel_all_reduce(input_tensor)
-        rms_out = self.rms_norm(allreduce_out, residual)
+        rms_output = self.rms_norm(allreduce_out, residual)
         if residual is None:
-            SCALED_FP4_QUANT_OUT_OP(
-                rms_out,
-                input_global_scale,
-                True,
-                output=quant_out,
-                output_scale=output_scale,
-            )
+            rms_out = rms_output
+        else:
+            rms_out, residual_out = rms_output
+
+        SCALED_FP4_QUANT_OUT_OP(
+            rms_out,
+            input_global_scale,
+            True,
+            output=quant_out,
+            output_scale=output_scale,
+        )
+
+        if residual is None:
             return quant_out, output_scale
         else:
-            rms_out, residual_out = rms_out
-            SCALED_FP4_QUANT_OUT_OP(
-                rms_out,
-                input_global_scale,
-                True,
-                output=quant_out,
-                output_scale=output_scale,
-            )
             return quant_out, residual_out, output_scale
 
 


### PR DESCRIPTION



## Purpose

Fix the following error

```bash

  Developer debug context: 

 For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0049.html

from user code:
   File "/vllm/benchmarks/kernels/benchmark_fused_collective.py", line 343, in allreduce_rmsnorm_fp4_quant
    SCALED_FP4_QUANT_OP(quant_out, rms_out, output_scale, input_global_scale)
  File "/vllm/.venv/lib/python3.12/site-packages/torch/utils/_device.py", line 109, in __torch_function__
    return func(*args, **kwargs)

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"

ERROR:__main__:Standard AllReduce+RMSNorm+FP4 Native Compiled failed: Error when attempting to resolve op packet
  Explanation: Overloaded torch operator invoked from Python failed to match any schema:
    _C::scaled_fp4_quant() expected at most 3 argument(s) but received 4 argument(s). Declaration: _C::scaled_fp4_quant(Tensor input, Tensor input_scale, bool is_sf_swizzled_layout) -> (Tensor, Tensor)

    _C::scaled_fp4_quant() Expected a value of type 'bool' for argument 'is_sf_swizzled_layout' but instead found type 'FakeTensor'.
    Position: 2
    Value: FakeTensor(..., device='cuda:0', size=(128, 4), dtype=torch.int32)
    Declaration: _C::scaled_fp4_quant.out(Tensor input, Tensor input_scale, bool is_sf_swizzled_layout, *, Tensor(a!) output, Tensor(b!) output_scale) -> ()
    Cast error details: cannot extract bool from tensor with meta storage
```

## Test Plan

```bash
torchrun --nproc_per_node=2 benchmark_fused_collective.py
```

## Test Result

The above error should be fixed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

