### PR TITLE
[ROCm][CI] Increase OpenAPI schema test timeouts

### DIFF
--- a/tests/entrypoints/openai/test_openai_schema.py
+++ b/tests/entrypoints/openai/test_openai_schema.py
@@ -14,14 +14,17 @@ from schemathesis.internal.checks import CheckContext
 from schemathesis.models import Case
 from schemathesis.transports.responses import GenericResponse
 
+from vllm.platforms import current_platform
+
 from ...utils import RemoteOpenAIServer
 
 schemathesis.experimental.OPEN_API_3_1.enable()
 
 MODEL_NAME = "HuggingFaceTB/SmolVLM-256M-Instruct"
 MAXIMUM_IMAGES = 2
-DEFAULT_TIMEOUT_SECONDS: Final[int] = 10
-LONG_TIMEOUT_SECONDS: Final[int] = 60
+_ROCM_TIMEOUT_MULTIPLIER = 3 if current_platform.is_rocm() else 1
+DEFAULT_TIMEOUT_SECONDS: Final[int] = 10 * _ROCM_TIMEOUT_MULTIPLIER
+LONG_TIMEOUT_SECONDS: Final[int] = 60 * _ROCM_TIMEOUT_MULTIPLIER
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
The `test_openapi_stateless` schemathesis test is timing out on AMD CI nightly runs:
https://buildkite.com/vllm/amd-ci/builds/6877/steps/canvas?jid=019d2394-711a-4b3f-b211-dd66372f4c08&tab=output

Multiple endpoints hit the 10s default timeout, and even endpoints with the 60s timeout fail on ROCm due to infra sluggishness. In this PR, we apply a 3x timeout multiplier when running on ROCm for both `DEFAULT_TIMEOUT_SECONDS` (10s to 30s) and `LONG_TIMEOUT_SECONDS` (60s to 180s) in `test_openai_schema.py`.

cc @kenroche 