### PR TITLE
Fix KeyError for multimodal models with vision tower layers (fixes #3…

### DIFF
--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -129,5 +129,6 @@ __all__ = [
     "get_current_vllm_config_or_none",
     "set_current_vllm_config",
     "get_layers_from_vllm_config",
+    "get_all_layers_from_vllm_config",
     "WeightTransferConfig",
 ]

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1817,7 +1817,6 @@ def get_layers_from_vllm_config(
 
     if layer_names is None:
         layer_names = list(vllm_config.compilation_config.static_forward_context.keys())
-
     forward_context = vllm_config.compilation_config.static_forward_context
 
     return {
@@ -1825,4 +1824,26 @@ def get_layers_from_vllm_config(
         for layer_name in layer_names
         if layer_name in forward_context
         and isinstance(forward_context[layer_name], layer_type)
+    }
+
+def get_all_layers_from_vllm_config(
+    vllm_config: VllmConfig,
+    layer_type: type[T],
+) -> dict[str, T]:
+    """
+    Get all layers from the vLLM config, including multimodal submodules.
+
+    Args:
+        vllm_config: The vLLM config.
+        layer_type: The type of the layer to get.
+
+    Returns:
+        A dictionary mapping layer names to their corresponding layer instances.
+    """
+    forward_context = vllm_config.compilation_config.static_forward_context
+
+    return {
+        layer_name: forward_context[layer_name]
+        for layer_name in forward_context
+        if isinstance(forward_context[layer_name], layer_type)
     }

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6143,6 +6143,11 @@ class GPUModelRunner(
             layers = get_layers_from_vllm_config(
                 self.vllm_config, layer_type, kv_cache_group_spec.layer_names
             )
+            if not layers:
+                layer_type = cast(type[Any], nn.Module)
+                layers = get_all_layers_from_vllm_config(
+                    self.vllm_config, layer_type
+                )
             attn_backends = {}
             attn_backend_layers = defaultdict(list)
             # Dedupe based on full class name; this is a bit safer than


### PR DESCRIPTION
…7974)

When using multimodal models (e.g., Kimi-K2.5), the static_forward_context only contains language model layers, not vision tower layers. However, kv_cache_group_spec.layer_names may include vision tower layer names (e.g., language_model.model.layers.30.self_attn.attn), which causes KeyError when these layers are not found in static_forward_context.

This fix adds get_all_layers_from_vllm_config() to return all layers including multimodal submodules, and updates get_attn_backends_for_group() to fallback to get_all_layers_from_vllm_config() when layers are not found.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

