### PR TITLE
[Bugfix] Fix ImportError for flash_attn < v2.1.2 missing triton rotary module

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import math
-from importlib.util import find_spec
 
 import torch
 
@@ -134,10 +133,17 @@ class ApplyRotaryEmb(CustomOp):
         self.enable_fp32_compute = enable_fp32_compute
 
         self.apply_rotary_emb_flash_attn = None
-        if find_spec("flash_attn") is not None:
+        try:
             from flash_attn.ops.triton.rotary import apply_rotary
 
             self.apply_rotary_emb_flash_attn = apply_rotary
+        except (ImportError, ModuleNotFoundError):
+            try:
+                from vllm.vllm_flash_attn.ops.triton.rotary import apply_rotary
+
+                self.apply_rotary_emb_flash_attn = apply_rotary
+            except (ImportError, ModuleNotFoundError):
+                pass
 
     @staticmethod
     def forward_static(


### PR DESCRIPTION
## Summary

Fix `ImportError` / `ModuleNotFoundError` when `flash_attn` is installed but the `flash_attn.ops.triton.rotary` submodule is not available (e.g., flash_attn < v2.1.2 or incomplete CUDA build).

**Root cause:** The old code uses `find_spec("flash_attn")` to check if the package exists, then unconditionally imports `flash_attn.ops.triton.rotary`. When flash_attn is installed but the submodule doesn't exist, this crashes with `ImportError`.

**Fix:** Replace `find_spec` + direct import with `try/except`, falling back to vLLM's internal implementation (`vllm.vllm_flash_attn.ops.triton.rotary`) which already provides an equivalent `apply_rotary` function. This follows the same pattern used elsewhere in the codebase (e.g., `vllm/v1/attention/backends/fa_utils.py`).

Fixes #38056

## Before / After

<details>
<summary>Before (old code — crashes)</summary>

```
=== Before Fix: Old code path ===

find_spec("flash_attn"): ModuleSpec(name='flash_attn', ...)
  → flash_attn IS found, so old code proceeds to import...

Attempting: from flash_attn.ops.triton.rotary import apply_rotary
Traceback (most recent call last):
  File "<string>", line 15, in <module>
  File ".../flash_attn/__init__.py", line 3, in <module>
    from flash_attn.flash_attn_interface import (
  File ".../flash_attn/flash_attn_interface.py", line 15, in <module>
    import flash_attn_2_cuda as flash_attn_gpu
ModuleNotFoundError: No module named 'flash_attn_2_cuda'
```
</details>

<details>
<summary>After (fixed code — graceful fallback)</summary>

```
=== After Fix: New code path (try/except with fallback) ===

✗ flash_attn.ops.triton.rotary not available: No module named 'flash_attn_2_cuda'
✓ Fallback to vllm.vllm_flash_attn.ops.triton.rotary

Result: apply_rotary_emb_flash_attn = <function apply_rotary at 0x7f3df7b691c0>
  → Triton-based rotary embedding will be used (fast path)
```
</details>

## Test plan

- [x] `pre-commit run ruff-check` — passed
- [x] `pre-commit run ruff-format` — passed
- [x] `pre-commit run mypy-3.10 --hook-stage manual` — passed
- [x] Verified: with flash_attn installed but submodule unavailable, old code crashes, new code falls back gracefully
- [x] Fallback chain: external flash_attn → vllm internal flash_attn → PyTorch native (forward_native)

## AI Assistance Disclosure

This PR was developed with AI assistance (Claude). All changes have been manually reviewed and tested.