### PR TITLE
[Bugfix][CI] Fix Marlin FP8 Linear Kernel for Compressed Tensors Format 

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
@@ -92,7 +92,7 @@ class MarlinFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
                 replace_parameter(
                     layer,
                     "weight",
-                    torch.nn.Parameter(w_q.t().data, requires_grad=False),
+                    w_q.t(),
                 )
 
         layer.input_scale = None

--- a/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
@@ -76,8 +76,25 @@ class MarlinFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             replace_parameter(layer, "weight", weight.data)
             replace_parameter(layer, "weight_scale_inv", weight_scale_inv.data)
         else:
-            weight = layer.weight.t()
-            replace_parameter(layer, "weight", weight.data)
+            w_q, *_ = self._get_layer_params(layer)
+            # Compressed tensors transposes the weight to (K, N)
+            # for channel and tensor quant strategies.
+            # So we can skip the transpose if the layout is
+            # already (K, N).
+            # TODO: Remove this check once the layouts have been
+            # canonicalized to a standard (N, K) dimension. See issue
+            # #33314 for more details.
+            if w_q.shape != (
+                layer.input_size_per_partition,
+                layer.output_size_per_partition,
+            ):
+                # transpose the weights to (K,N)
+                replace_parameter(
+                    layer,
+                    "weight",
+                    torch.nn.Parameter(w_q.t().data, requires_grad=False),
+                )
+
         layer.input_scale = None
         prepare_fp8_layer_for_marlin(
             layer, self.size_k_first, input_dtype=self.marlin_input_dtype

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -188,6 +188,9 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
         if self.strategy == QuantizationStrategy.BLOCK:
             maybe_post_process_fp8_weight_block(layer)
 
+        if hasattr(self, "fp8_linear"):
+            self.fp8_linear.process_weights_after_loading(layer)
+
     def apply_weights(
         self,
         layer: torch.nn.Module,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -705,6 +705,9 @@ class ModelOptFp8PbWoLinearMethod(LinearMethodBase):
 
         layer.weight_scale = Parameter(scale.contiguous(), requires_grad=False)
 
+        if hasattr(self, "fp8_linear"):
+            self.fp8_linear.process_weights_after_loading(layer)
+
     def apply(
         self,
         layer: torch.nn.Module,


### PR DESCRIPTION



## Purpose
Fix Marlin FP8 Linear Kernel when weights are loaded with compressed tensors format. 

`MarlinFP8ScaledMMLinearKernel` implements `process_weights_after_loading` but `CompressedTensorsW8A8Fp8` instances never call this method, causing failures when using this kernel. This is will also fix `tests/evals/gsm8k/test_gsm8k_correctness.py` on the CI.

## Test Plan
Run `tests/evals/gsm8k/test_gsm8k_correctness.py` on H100.

## Test Result
All tests pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

