### PR TITLE
[BugFix][Frontend]  pass kv_transfer_params through to sampling_params

### DIFF
--- a/tests/entrypoints/serve/disagg/test_serving_tokens.py
+++ b/tests/entrypoints/serve/disagg/test_serving_tokens.py
@@ -423,3 +423,34 @@ async def test_generate_with_lora_adapter(client, tokenizer, messages):
     completions_res = completions_data["choices"][0]["message"]["content"]
 
     assert generate_res == completions_res
+
+
+@pytest.mark.asyncio
+async def test_generate_with_kv_transfer_params(client):
+    payload = {
+        "model": MODEL_NAME,
+        "token_ids": [1, 2, 3],
+        "sampling_params": {"max_tokens": 5},
+        "kv_transfer_params": {
+            "do_remote_decode": True,
+            "do_remote_prefill": False,
+        },
+        "stream": False,
+    }
+    resp = await client.post(GEN_ENDPOINT, json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+    assert "choices" in data
+
+
+@pytest.mark.asyncio
+async def test_generate_without_sampling_params(client):
+    payload = {
+        "model": MODEL_NAME,
+        "token_ids": [1, 2, 3],
+        "stream": False,
+    }
+    resp = await client.post(GEN_ENDPOINT, json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+    assert "choices" in data

--- a/vllm/entrypoints/serve/disagg/protocol.py
+++ b/vllm/entrypoints/serve/disagg/protocol.py
@@ -81,7 +81,7 @@ class GenerateRequest(BaseModel):
     features: MultiModalFeatures | None = None
     """Multimodal hashes and placeholder positions (populated for MM inputs)."""
 
-    sampling_params: SamplingParams
+    sampling_params: SamplingParams = Field(default_factory=SamplingParams)
     """The sampling parameters for the model."""
 
     model: str | None = None
@@ -146,6 +146,14 @@ class GenerateRequest(BaseModel):
         if self._sampling_params_provided_keys is None:
             return True
         return name in self._sampling_params_provided_keys
+
+    def to_sampling_params(self) -> SamplingParams:
+        params = self.sampling_params
+        if self.kv_transfer_params:
+            if params.extra_args is None:
+                params.extra_args = {}
+            params.extra_args["kv_transfer_params"] = self.kv_transfer_params
+        return params
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:
         return TokenizeParams(

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -126,7 +126,7 @@ class ServingTokens(OpenAIServing):
         if raw_request:
             raw_request.state.request_metadata = request_metadata
 
-        sampling_params = request.sampling_params
+        sampling_params = request.to_sampling_params()
         max_num_seqs = self.engine_client.vllm_config.scheduler_config.max_num_seqs
         if sampling_params.n > max_num_seqs:
             return self.create_error_response(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix two issues in the disaggregated serving `GenerateRequest`:

1. **`kv_transfer_params` silently dropped**: When a client sends `kv_transfer_params` in a generate request, the field is parsed but never forwarded to the engine's `SamplingParams`. This means disaggregated prefill/decode scheduling flags (`do_remote_decode`, `do_remote_prefill`, etc.) have no effect via the token-level serving endpoint.

2. **`sampling_params` unnecessarily required**: The field has no default, forcing every caller to provide it even when default sampling is acceptable.

### Changes

- Add `GenerateRequest.to_sampling_params()` that merges `kv_transfer_params` into `SamplingParams.extra_args` before handing off to the engine.
- Default `sampling_params` to `SamplingParams()` via `Field(default_factory=...)`.
- Call `request.to_sampling_params()` in `ServingTokens` instead of accessing the raw field.

## Test Plan

```shell
curl -XPOST http://<prefillerIP>:8000/inference/v1/generate \
    -H "Content-Type: application/json" \
    -d '{
      "token_ids": [15339, 11, 1268, 527, 499, 30],
      "sampling_params": {
        "max_tokens": 20
      },
      "kv_transfer_params": {
        "do_remote_decode": true,
        "do_remote_prefill": false
      }
    }' | jq
```

```shell
curl -XPOST http://<decoderIP>:8000/inference/v1/generate \
    -H "Content-Type: application/json" \
    -d '{
      "token_ids": [15339, 11, 1268, 527, 499, 30],
      "sampling_params": {
        "max_tokens": 20
      },
      "kv_transfer_params": {
        "do_remote_prefill": true,
        "do_remote_decode": false,
        "remote_block_ids": [
          [
            1,
            2
          ]
        ],
        "remote_engine_id": "0ce78dd0-7144-4375-86ed-71dee6d9a81c_dp0",
        "remote_request_id": "generate-tokens-bcc9f408bb55b99e-9446e206",
        "remote_host": "<prefillerIP>",
        "remote_port": 5600,
        "tp_size": 1
     }
    }' | jq
```

## Test Result

```shell
{
  "request_id": "905c6d76ee0a7603",
  "choices": [
    {
      "index": 0,
      "logprobs": null,
      "finish_reason": "length",
      "token_ids": [
        29882,
        29906,
        29900,
        29906,
        29906,
        31054,
        31093,
        29871,
        237,
        181,
        131,
        239,
        134,
        140,
        240,
        152,
        163,
        29871,
        30970,
        29871
      ]
    }
  ],
  "prompt_logprobs": null,
  "kv_transfer_params": {
    "do_remote_prefill": true,
    "do_remote_decode": false,
    "remote_block_ids": [
      [
        1,
        2
      ]
    ],
    "remote_engine_id": "0ce78dd0-7144-4375-86ed-71dee6d9a81c_dp0",
    "remote_request_id": "generate-tokens-bcc9f408bb55b99e-9446e206",
    "remote_host": "<prefillerIP>",
    "remote_port": 5600,
    "tp_size": 1
  }
}
```

```shell
{
  "request_id": "b7fe3643234c27e3",
  "choices": [
    {
      "index": 0,
      "logprobs": null,
      "finish_reason": "length",
      "token_ids": [
        29871,
        239,
        161,
        139,
        31137,
        31054,
        31136,
        29871,
        237,
        181,
        194,
        239,
        188,
        30393,
        240,
        152,
        163,
        239,
        159,
        191
      ]
    }
  ],
  "prompt_logprobs": null,
  "kv_transfer_params": null
}
```
```shell
main (APIServer pid=8) INFO 03-26 14:20:00 [loggers.py:259] Engine 000: Avg prompt throughput: 0.1 tokens/s, Avg generation throughput: 2.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, External prefix cache hit rate: 100.0%
main (APIServer pid=8) INFO 03-26 14:20:00 [metrics.py:103] KV Transfer metrics: Num successful transfers=1, Avg xfer time (ms)=11.411, P90 xfer time (ms)=11.411, Avg post time (ms)=0.33, P90 post time (ms)=0.33, Avg MB per transfer=2.0, Throughput (MB/s)=175.269, Avg number of descriptors=32.0
main (APIServer pid=8) INFO 03-26 14:20:10 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, External prefix cache hit rate: 100.0%
```

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>