### PR TITLE
Fix offline mode test for Transformers v5

### DIFF
--- a/tests/entrypoints/offline_mode/test_offline_mode.py
+++ b/tests/entrypoints/offline_mode/test_offline_mode.py
@@ -7,6 +7,7 @@ import importlib
 import sys
 
 import pytest
+import regex as re
 import urllib3
 
 from vllm import LLM
@@ -110,11 +111,15 @@ def _re_import_modules():
     ]
 
     # These modules are aliased in Transformers v5 and so cannot be reloaded directly
-    aliased_modules = ["tokenization_utils", "tokenization_utils_fast"]
+    aliased_module_patterns = [
+        r".+\.tokenization_utils$",
+        r".+\.tokenization_utils_fast$",
+        r".+\.models\..+\.image_processing_.+_fast$",
+    ]
 
     reload_exception = None
     for module_name in hf_hub_module_names + transformers_module_names:
-        if any(module_name.endswith(f".{alias}") for alias in aliased_modules):
+        if any(re.match(pattern, module_name) for pattern in aliased_module_patterns):
             # Remove from sys.modules so they are re-aliased on next import
             del sys.modules[module_name]
             continue


### PR DESCRIPTION
The fast modules for image processing were recently removed and consolidated so there is only a single path.

Aliases for the old `image_processing_..._fast` modules were added. These need the same treatment as `tokenization_utils` in this test because they cannot be directly reloaded.