### PR TITLE
[Bugfix] Suggest upgrading Transformers for tokenizer class errors

### DIFF
--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -103,7 +103,10 @@ class CachedHfTokenizer(TokenizerLike):
                     "is a custom tokenizer not yet available in the "
                     "HuggingFace transformers library, consider "
                     "setting `trust_remote_code=True` in LLM or using "
-                    "the `--trust-remote-code` flag in the CLI."
+                    "the `--trust-remote-code` flag in the CLI. If the "
+                    "model was created with a newer version of "
+                    "transformers, consider upgrading: "
+                    "`uv pip install --upgrade transformers`"
                 )
                 raise RuntimeError(err_msg) from e
             else:


### PR DESCRIPTION
## Summary

Fixes https://github.com/vllm-project/vllm/issues/38024

When `AutoTokenizer.from_pretrained()` fails because the installed Transformers version does not recognize a tokenizer class, vLLM currently tells users to try `trust_remote_code`. For models produced with newer Transformers versions, such as tokenizer configs containing `"tokenizer_class": "TokenizersBackend"`, `trust_remote_code` does not resolve the issue because the missing class is from Transformers itself.

This PR keeps the existing tokenizer loading behavior unchanged and only improves the error message. It now also suggests upgrading Transformers with:

```bash
uv pip install --upgrade transformers
```

No fallback logic is added in this final version; this keeps the change narrow and avoids masking real tokenizer incompatibilities.

## Before / After

<details>
<summary>Before fix</summary>

```bash
$ python - <<'PY'
from unittest.mock import patch

from vllm.tokenizers.hf import CachedHfTokenizer

error = ValueError("Tokenizer class TokenizersBackend does not exist or is not currently imported.")
with patch("vllm.tokenizers.hf.AutoTokenizer.from_pretrained", side_effect=error):
    try:
        CachedHfTokenizer.from_pretrained("dummy-tokenizer")
    except Exception as exc:
        print(f"{type(exc).__name__}: {exc}")
        print("contains upgrade hint:", "uv pip install --upgrade transformers" in str(exc))
PY
WARNING 05-05 20:26:11 [config.py:70] Support for Transformers v4 is deprecated. The Transformers v4 codepath will become unmaintained in vLLM v0.22.0 and will be removed in vLLM v0.24.0. Please upgrade to Transformers v5: pip install --upgrade transformers
RuntimeError: Failed to load the tokenizer. If the tokenizer is a custom tokenizer not yet available in the HuggingFace transformers library, consider setting `trust_remote_code=True` in LLM or using the `--trust-remote-code` flag in the CLI.
contains upgrade hint: False
```

</details>

<details>
<summary>After fix</summary>

```bash
$ python - <<'PY'
from unittest.mock import patch

from vllm.tokenizers.hf import CachedHfTokenizer

error = ValueError("Tokenizer class TokenizersBackend does not exist or is not currently imported.")
with patch("vllm.tokenizers.hf.AutoTokenizer.from_pretrained", side_effect=error):
    try:
        CachedHfTokenizer.from_pretrained("dummy-tokenizer")
    except Exception as exc:
        print(f"{type(exc).__name__}: {exc}")
        print("contains upgrade hint:", "uv pip install --upgrade transformers" in str(exc))
PY
WARNING 05-05 20:26:34 [config.py:70] Support for Transformers v4 is deprecated. The Transformers v4 codepath will become unmaintained in vLLM v0.22.0 and will be removed in vLLM v0.24.0. Please upgrade to Transformers v5: pip install --upgrade transformers
RuntimeError: Failed to load the tokenizer. If the tokenizer is a custom tokenizer not yet available in the HuggingFace transformers library, consider setting `trust_remote_code=True` in LLM or using the `--trust-remote-code` flag in the CLI. If the model was created with a newer version of transformers, consider upgrading: `uv pip install --upgrade transformers`
contains upgrade hint: True
```

</details>

## Test plan

```bash
python -m compileall -q vllm/tokenizers/hf.py
pre-commit run --files vllm/tokenizers/hf.py
```

`pre-commit run --files vllm/tokenizers/hf.py` passed all applicable hooks, including ruff, typos, mypy, SPDX headers, lazy imports, forbidden imports, default-value validation, attention backend docs, and suggestion checks.

No unit test is added here because the earlier message-content tests were reverted per reviewer feedback as brittle; this PR is intentionally limited to the user-facing error text.
