### PR TITLE
[Docs] Add Granite Vision to supported multimodal models list

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -555,6 +555,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Glm4vMoeForConditionalGeneration` | GLM-4.5V | T + I<sup>E+</sup> + V<sup>E+</sup> | `zai-org/GLM-4.5V`, etc. | ✅︎ | ✅︎ |
 | `GlmOcrForConditionalGeneration` | GLM-OCR | T + I<sup>E+</sup> | `zai-org/GLM-OCR`, etc. | ✅︎ | ✅︎ |
 | `GraniteSpeechForConditionalGeneration` | Granite Speech | T + A | `ibm-granite/granite-speech-3.3-8b` | ✅︎ | ✅︎ |
+| `GraniteVision`<sup>^</sup> | Granite Vision | T + I<sup>E+</sup> | `ibm-granite/granite-vision-3.3-2b`, `ibm-granite/granite-vision-3.3-8b`, etc. | | ✅︎ |
 | `HCXVisionForCausalLM` | HyperCLOVAX-SEED-Vision-Instruct-3B | T + I<sup>+</sup> + V<sup>+</sup> | `naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B` | | |
 | `HCXVisionV2ForCausalLM` | HyperCLOVAX-SEED-Think-32B | T + I<sup>+</sup> + V<sup>+</sup> | `naver-hyperclovax/HyperCLOVAX-SEED-Think-32B` | | |
 | `H2OVLChatModel` | H2OVL | T + I<sup>E+</sup> | `h2oai/h2ovl-mississippi-800m`, `h2oai/h2ovl-mississippi-2b`, etc. | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Summary

Granite Vision models (`ibm-granite/granite-vision-3.3-2b`, `ibm-granite/granite-vision-3.3-8b`) are functional in vLLM but are **missing from the supported models documentation** (`docs/models/supported_models.md`).

### Problem

- Granite Vision is already registered in the [test registry](https://github.com/vllm-project/vllm/blob/main/tests/models/registry.py#L811) as `"GraniteVision": _HfExamplesInfo("ibm-granite/granite-vision-3.3-2b")`.
- It works through the `LlavaNextForConditionalGeneration` backend, with Granite-specific multi-layer vision feature selection in [`llava_next.py`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/llava_next.py#L258).
- Granite Speech (`GraniteSpeechForConditionalGeneration`) **is** listed in the docs (both in the multimodal and audio-only tables), but Granite Vision is completely absent.
- Users searching the docs for "granite vision" find nothing and incorrectly conclude it is not supported.

### Proposed Fix

Add a single row for `GraniteVision` to the multimodal models table in `docs/models/supported_models.md`, placed alphabetically between Granite Speech and HCXVision:

```
| `GraniteVision`<sup>^</sup> | Granite Vision | T + I<sup>E+</sup> | `ibm-granite/granite-vision-3.3-2b`, `ibm-granite/granite-vision-3.3-8b`, etc. | | ✅︎ |
```

Entry details:
- **Architecture**: `GraniteVision` with `^` superscript — consistent with other models that use custom HuggingFace model code (e.g., `GLM4VForCausalLM`, `QwenVLForConditionalGeneration`), since the architecture class is registered via the model's remote code rather than the standard `*ForConditionalGeneration` naming.
- **Modalities**: `T + I<sup>E+</sup>` — text + images, with pre-computed embedding support and multi-image input, matching its LlavaNext-based backend.
- **Pipeline Parallelism**: Marked as supported (✅︎), inherited from the LlavaNext backend.
- **LoRA**: Left blank — not explicitly validated for GraniteVision.

### Tests

This is a documentation-only change (one line added to a Markdown table). No code or test changes are needed.

The model itself is already covered by the existing test registry entry in `tests/models/registry.py:811`.

### AI Disclosure

This PR was prepared with AI assistance (Claude). All changes have been reviewed and validated by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)