### PR TITLE
[MultiModal] add support for numpy array embeddings

### DIFF
--- a/tests/renderers/test_sparse_tensor_validation.py
+++ b/tests/renderers/test_sparse_tensor_validation.py
@@ -190,7 +190,38 @@ class TestImageEmbedsValidation:
         with pytest.raises((RuntimeError, ValueError)):
             io_handler.load_bytes(buffer.read())
 
+    def test_valid_numpy_tensor_accepted(self):
+        """numpy .npy format should load and return correct tensor."""
+        import numpy as np
 
+        io_handler = ImageEmbeddingMediaIO()
+
+        arr = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
+        buf = io.BytesIO()
+        np.save(buf, arr)
+        encoded = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+        result = io_handler.load_base64("", encoded)
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == torch.Size([2, 3])
+        assert result.dtype == torch.float32
+        assert torch.allclose(result, torch.from_numpy(arr))
+
+    def test_numpy_int32_tensor_accepted(self):
+        """numpy int32 arrays should round-trip correctly."""
+        import numpy as np
+
+        io_handler = ImageEmbeddingMediaIO()
+
+        arr = np.arange(280, dtype=np.int32)
+        buf = io.BytesIO()
+        np.save(buf, arr)
+        encoded = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+        result = io_handler.load_base64("", encoded)
+        assert result.dtype == torch.int32
+        assert result.shape == torch.Size([280])
+        assert (result == torch.from_numpy(arr)).all()
 class TestAudioEmbedsValidation:
     """Test sparse tensor validation in audio embeddings (Chat API)."""
 

--- a/tests/renderers/test_sparse_tensor_validation.py
+++ b/tests/renderers/test_sparse_tensor_validation.py
@@ -222,6 +222,24 @@ class TestImageEmbedsValidation:
         assert result.dtype == torch.int32
         assert result.shape == torch.Size([280])
         assert (result == torch.from_numpy(arr)).all()
+
+    def test_load_file_numpy_tensor_accepted(self, tmp_path):
+        """numpy .npy files should load correctly via load_file."""
+        import numpy as np
+
+        io_handler = ImageEmbeddingMediaIO()
+
+        arr = np.array([[1.5, 2.5], [3.5, 4.5]], dtype=np.float32)
+        npy_path = tmp_path / "image_embeds.npy"
+        np.save(npy_path, arr)
+
+        result = io_handler.load_file(npy_path)
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == torch.Size([2, 2])
+        assert result.dtype == torch.float32
+        assert torch.allclose(result, torch.from_numpy(arr))
+
+
 class TestAudioEmbedsValidation:
     """Test sparse tensor validation in audio embeddings (Chat API)."""
 

--- a/tests/renderers/test_sparse_tensor_validation.py
+++ b/tests/renderers/test_sparse_tensor_validation.py
@@ -7,6 +7,7 @@ out-of-bounds memory writes during to_dense() operations.
 
 import io
 
+import numpy as np
 import pybase64 as base64
 import pytest
 import torch
@@ -191,9 +192,6 @@ class TestImageEmbedsValidation:
             io_handler.load_bytes(buffer.read())
 
     def test_valid_numpy_tensor_accepted(self):
-        """numpy .npy format should load and return correct tensor."""
-        import numpy as np
-
         io_handler = ImageEmbeddingMediaIO()
 
         arr = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
@@ -209,7 +207,6 @@ class TestImageEmbedsValidation:
 
     def test_numpy_int32_tensor_accepted(self):
         """numpy int32 arrays should round-trip correctly."""
-        import numpy as np
 
         io_handler = ImageEmbeddingMediaIO()
 
@@ -225,7 +222,6 @@ class TestImageEmbedsValidation:
 
     def test_load_file_numpy_tensor_accepted(self, tmp_path):
         """numpy .npy files should load correctly via load_file."""
-        import numpy as np
 
         io_handler = ImageEmbeddingMediaIO()
 

--- a/tests/renderers/test_sparse_tensor_validation.py
+++ b/tests/renderers/test_sparse_tensor_validation.py
@@ -192,6 +192,7 @@ class TestImageEmbedsValidation:
             io_handler.load_bytes(buffer.read())
 
     def test_valid_numpy_tensor_accepted(self):
+        """numpy .npy format should load and return correct tensor."""
         io_handler = ImageEmbeddingMediaIO()
 
         arr = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -3,6 +3,7 @@
 
 from io import BytesIO
 from pathlib import Path
+import numpy as np
 
 import pybase64
 import torch
@@ -117,7 +118,7 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
 
     def _load_numpy(self, data: bytes) -> torch.Tensor:
         # Path for numpy arrays
-        import numpy as np
+        
         with BytesIO(data) as buffer:
             return torch.from_numpy(np.load(buffer))  
     
@@ -134,7 +135,6 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
 
     def load_file(self, filepath: Path) -> torch.Tensor:
         if filepath.suffix == ".npy":
-            import numpy as np
             return torch.from_numpy(np.load(filepath))
         else:
             return torch.load(filepath, weights_only=True).to_dense()

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -3,8 +3,8 @@
 
 from io import BytesIO
 from pathlib import Path
-import numpy as np
 
+import numpy as np
 import pybase64
 import torch
 from PIL import Image
@@ -14,8 +14,9 @@ from vllm.utils.serial_utils import tensor2base64
 from ..image import convert_image_mode, rgba_to_rgb
 from .base import MediaIO, MediaWithBytes
 
+MAGIC_NUMPY_PREFIX = b"\x93NUMPY"  # https://numpy.org/devdocs/reference/generated/numpy.lib.format.html#format-version-1-0
 
-MAGIC_NUMPY_PREFIX = b"\x93NUMPY" # https://numpy.org/devdocs/reference/generated/numpy.lib.format.html#format-version-1-0
+
 class ImageMediaIO(MediaIO[Image.Image]):
     """Configuration values can be user-provided either by --media-io-kwargs or
     by the runtime API field "media_io_kwargs". Ensure proper validation and
@@ -106,29 +107,28 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
     def __init__(self) -> None:
         super().__init__()
 
-    
     def _load_pickled_torch(self, data: bytes) -> torch.Tensor:
         # Path for torch tensor
-        with BytesIO(data) as buffer:
-            # Enable sparse tensor integrity checks to prevent out-of-bounds
-            # writes from maliciously crafted tensors
-            with torch.sparse.check_sparse_tensor_invariants():
-                tensor = torch.load(buffer, weights_only=True)
-                return tensor.to_dense()
+        # Enable sparse tensor integrity checks to prevent out-of-bounds
+        # writes from maliciously crafted tensors.
+        with (
+            BytesIO(data) as buffer,
+            torch.sparse.check_sparse_tensor_invariants(),
+        ):
+            tensor = torch.load(buffer, weights_only=True)
+            return tensor.to_dense()
 
     def _load_numpy(self, data: bytes) -> torch.Tensor:
         # Path for numpy arrays
-        
-        with BytesIO(data) as buffer:
-            return torch.from_numpy(np.load(buffer))  
-    
-    def load_bytes(self, data: bytes) -> torch.Tensor:
 
+        with BytesIO(data) as buffer:
+            return torch.from_numpy(np.load(buffer))
+
+    def load_bytes(self, data: bytes) -> torch.Tensor:
         if data[:6] == MAGIC_NUMPY_PREFIX:
             return self._load_numpy(data)
         else:
             return self._load_pickled_torch(data)
-        
 
     def load_base64(self, media_type: str, data: str) -> torch.Tensor:
         return self.load_bytes(pybase64.b64decode(data, validate=True))
@@ -137,7 +137,8 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
         if filepath.suffix == ".npy":
             return torch.from_numpy(np.load(filepath))
         else:
-            return torch.load(filepath, weights_only=True).to_dense()
+            with torch.sparse.check_sparse_tensor_invariants():
+                return torch.load(filepath, weights_only=True).to_dense()
 
     def encode_base64(self, media: torch.Tensor) -> str:
         return tensor2base64(media)

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -109,7 +109,7 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
 
     def _load_pickled_torch(self, data: bytes) -> torch.Tensor:
         # Enable sparse tensor integrity checks to prevent out-of-bounds
-        # writes from maliciously crafted tensors.
+        # writes from maliciously crafted tensors
         with torch.sparse.check_sparse_tensor_invariants():
             buffer = BytesIO(data)
             tensor = torch.load(buffer, weights_only=True)

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -110,10 +110,8 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
     def _load_pickled_torch(self, data: bytes) -> torch.Tensor:
         # Enable sparse tensor integrity checks to prevent out-of-bounds
         # writes from maliciously crafted tensors.
-        with (
-            BytesIO(data) as buffer,
-            torch.sparse.check_sparse_tensor_invariants(),
-        ):
+        with torch.sparse.check_sparse_tensor_invariants():
+            buffer = BytesIO(data)
             tensor = torch.load(buffer, weights_only=True)
             return tensor.to_dense()
 

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -108,10 +108,10 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
         super().__init__()
 
     def _load_pickled_torch(self, data: bytes) -> torch.Tensor:
+        buffer = BytesIO(data)
         # Enable sparse tensor integrity checks to prevent out-of-bounds
         # writes from maliciously crafted tensors
         with torch.sparse.check_sparse_tensor_invariants():
-            buffer = BytesIO(data)
             tensor = torch.load(buffer, weights_only=True)
             return tensor.to_dense()
 

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -124,8 +124,8 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
     def load_bytes(self, data: bytes) -> torch.Tensor:
         if data[:6] == MAGIC_NUMPY_PREFIX:
             return self._load_numpy(data)
-        else:
-            return self._load_pickled_torch(data)
+
+        return self._load_pickled_torch(data)
 
     def load_base64(self, media_type: str, data: str) -> torch.Tensor:
         return self.load_bytes(pybase64.b64decode(data, validate=True))

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -108,7 +108,6 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
         super().__init__()
 
     def _load_pickled_torch(self, data: bytes) -> torch.Tensor:
-        # Path for torch tensor
         # Enable sparse tensor integrity checks to prevent out-of-bounds
         # writes from maliciously crafted tensors.
         with (
@@ -119,8 +118,6 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
             return tensor.to_dense()
 
     def _load_numpy(self, data: bytes) -> torch.Tensor:
-        # Path for numpy arrays
-
         with BytesIO(data) as buffer:
             return torch.from_numpy(np.load(buffer))
 

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -133,9 +133,9 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
     def load_file(self, filepath: Path) -> torch.Tensor:
         if filepath.suffix == ".npy":
             return torch.from_numpy(np.load(filepath))
-        else:
-            with torch.sparse.check_sparse_tensor_invariants():
-                return torch.load(filepath, weights_only=True).to_dense()
+
+        with torch.sparse.check_sparse_tensor_invariants():
+            return torch.load(filepath, weights_only=True).to_dense()
 
     def encode_base64(self, media: torch.Tensor) -> str:
         return tensor2base64(media)

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -14,6 +14,7 @@ from ..image import convert_image_mode, rgba_to_rgb
 from .base import MediaIO, MediaWithBytes
 
 
+MAGIC_NUMPY_PREFIX = b"\x93NUMPY" # https://numpy.org/devdocs/reference/generated/numpy.lib.format.html#format-version-1-0
 class ImageMediaIO(MediaIO[Image.Image]):
     """Configuration values can be user-provided either by --media-io-kwargs or
     by the runtime API field "media_io_kwargs". Ensure proper validation and
@@ -104,23 +105,39 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
     def __init__(self) -> None:
         super().__init__()
 
+    
+    def _load_pickled_torch(self, data: bytes) -> torch.Tensor:
+        # Path for torch tensor
+        with BytesIO(data) as buffer:
+            # Enable sparse tensor integrity checks to prevent out-of-bounds
+            # writes from maliciously crafted tensors
+            with torch.sparse.check_sparse_tensor_invariants():
+                tensor = torch.load(buffer, weights_only=True)
+                return tensor.to_dense()
+
+    def _load_numpy(self, data: bytes) -> torch.Tensor:
+        # Path for numpy arrays
+        import numpy as np
+        with BytesIO(data) as buffer:
+            return torch.from_numpy(np.load(buffer))  
+    
     def load_bytes(self, data: bytes) -> torch.Tensor:
-        buffer = BytesIO(data)
-        # Enable sparse tensor integrity checks to prevent out-of-bounds
-        # writes from maliciously crafted tensors
-        with torch.sparse.check_sparse_tensor_invariants():
-            tensor = torch.load(buffer, weights_only=True)
-            return tensor.to_dense()
+
+        if data[:6] == MAGIC_NUMPY_PREFIX:
+            return self._load_numpy(data)
+        else:
+            return self._load_pickled_torch(data)
+        
 
     def load_base64(self, media_type: str, data: str) -> torch.Tensor:
         return self.load_bytes(pybase64.b64decode(data, validate=True))
 
     def load_file(self, filepath: Path) -> torch.Tensor:
-        # Enable sparse tensor integrity checks to prevent out-of-bounds
-        # writes from maliciously crafted tensors
-        with torch.sparse.check_sparse_tensor_invariants():
-            tensor = torch.load(filepath, weights_only=True)
-            return tensor.to_dense()
+        if filepath.suffix == ".npy":
+            import numpy as np
+            return torch.from_numpy(np.load(filepath))
+        else:
+            return torch.load(filepath, weights_only=True).to_dense()
 
     def encode_base64(self, media: torch.Tensor) -> str:
         return tensor2base64(media)

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -133,7 +133,8 @@ class ImageEmbeddingMediaIO(MediaIO[torch.Tensor]):
             return torch.from_numpy(np.load(filepath))
 
         with torch.sparse.check_sparse_tensor_invariants():
-            return torch.load(filepath, weights_only=True).to_dense()
+            tensor = torch.load(filepath, weights_only=True)
+            return tensor.to_dense()
 
     def encode_base64(self, media: torch.Tensor) -> str:
         return tensor2base64(media)


### PR DESCRIPTION



## Purpose
Today's Image Embeddings class relies on `torch.save` and `torch.load`, which itself relies on Pickle. In our use case, we notice 3x increase in payload size due to Pickle. 

[Benchmark](https://gist.github.com/guillaumeguy/e43daa7dac3cb5a42479053171842ed9) also shows improvement in serialization/deserialization 

```
==============================================================
                Payload sizes (base64-encoded)                
==============================================================
Tensor                      raw   torch.save    np.save
--------------------------------------------------------------
  codes  (280×int32)      1496B        3556B      1664B
  grid   (3×int64)          32B        2104B       204B
  embeds (144×2560 fp32) 1966080B     1968184B   1966252B

==============================================================
      Encode latency (µs, both tensors combined, n=1000)      
==============================================================
====================================================================
                    Encode latency (µs, n=1000)                     
====================================================================
  codes+grid (per request)     torch=  246.8µs  numpy=   25.4µs  (9.7x)
  embeds (144×2560 fp32)       torch= 2874.5µs  numpy= 2483.2µs  (1.2x)

====================================================================
                    Decode latency (µs, n=1000)                     
====================================================================
  codes+grid (per request)     torch=  353.2µs  numpy=   84.6µs  (4.2x)
  embeds (144×2560 fp32)       torch= 2819.0µs  numpy= 2743.8µs  (1.0x)

====================================================================
            Round-trip latency (encode + decode, n=1000)            
====================================================================
  codes+grid (per request)     torch=  605.9µs  numpy=  148.2µs  (4.1x)
  embeds (144×2560 fp32)       torch= 5913.8µs  numpy= 5272.3µs  (1.1x)
```


Using numpy bypasses Pickle and provides much lower overhead, making it a good candidate for support. Implementation is a trivial fork and it relies on the magic numpy prefix.

Discussion:
https://vllm-dev.slack.com/archives/C07QCGVDNUF/p1774454730662799?thread_ts=1774453051.598909&cid=C07QCGVDNUF

## Test Plan

Added 3 tests to test the code path.

❯ pytest tests/renderers/test_sparse_tensor_validation.py::TestImageEmbedsValidation -vv
====================================================================== test session starts ======================================================================
platform darwin -- Python 3.12.6, pytest-9.0.2, pluggy-1.6.0 -- /Users/guillaume_guy/repos/vllm/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/guillaume_guy/repos/vllm
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 7 items                                                                                                                                               

tests/renderers/test_sparse_tensor_validation.py::TestImageEmbedsValidation::test_valid_dense_tensor_accepted PASSED                                      [ 14%]
tests/renderers/test_sparse_tensor_validation.py::TestImageEmbedsValidation::test_valid_sparse_tensor_accepted PASSED                                     [ 28%]
tests/renderers/test_sparse_tensor_validation.py::TestImageEmbedsValidation::test_malicious_sparse_tensor_rejected PASSED                                 [ 42%]
tests/renderers/test_sparse_tensor_validation.py::TestImageEmbedsValidation::test_load_bytes_validates PASSED                                             [ 57%]
tests/renderers/test_sparse_tensor_validation.py::TestImageEmbedsValidation::test_valid_numpy_tensor_accepted PASSED                                      [ 71%]
tests/renderers/test_sparse_tensor_validation.py::TestImageEmbedsValidation::test_numpy_int32_tensor_accepted PASSED                                      [ 85%]
tests/renderers/test_sparse_tensor_validation.py::TestImageEmbedsValidation::test_load_file_numpy_tensor_accepted PASSED                                  [100%]

======================================================================= warnings summary ========================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================= 7 passed, 2 warnings in 0.57s =================================================================


<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

