### PR TITLE
[Cohere] Enable Cohere Transcribe

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -654,7 +654,7 @@ Speech2Text models trained specifically for Automatic Speech Recognition.
 
 | Architecture | Models | Example HF Models | [LoRA](../features/lora.md) | [PP](../serving/parallelism_scaling.md) |
 | ------------ | ------ | ----------------- | -------------------- | ------------------------- |
-| `CohereASRForConditionalGeneration` | Cohere-Transcribe | `CohereLabs/cohere-transcribe-03-2026` | | |
+| `CohereAsrForConditionalGeneration` | Cohere-Transcribe | `CohereLabs/cohere-transcribe-03-2026` | | |
 | `FireRedASR2ForConditionalGeneration` | FireRedASR2 | `allendou/FireRedASR2-LLM-vllm`, etc. | | |
 | `FunASRForConditionalGeneration` | FunASR | `allendou/Fun-ASR-Nano-2512-vllm`, etc. | | |
 | `Gemma3nForConditionalGeneration` | Gemma3n | `google/gemma-3n-E2B-it`, `google/gemma-3n-E4B-it`, etc. | | |

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -654,6 +654,7 @@ Speech2Text models trained specifically for Automatic Speech Recognition.
 
 | Architecture | Models | Example HF Models | [LoRA](../features/lora.md) | [PP](../serving/parallelism_scaling.md) |
 | ------------ | ------ | ----------------- | -------------------- | ------------------------- |
+| `CohereASRForConditionalGeneration` | Cohere-Transcribe | `CohereLabs/cohere-transcribe-03-2026` | | |
 | `FireRedASR2ForConditionalGeneration` | FireRedASR2 | `allendou/FireRedASR2-LLM-vllm`, etc. | | |
 | `FunASRForConditionalGeneration` | FunASR | `allendou/Fun-ASR-Nano-2512-vllm`, etc. | | |
 | `Gemma3nForConditionalGeneration` | Gemma3n | `google/gemma-3n-E2B-it`, `google/gemma-3n-E4B-it`, etc. | | |

--- a/examples/offline_inference/audio_language.py
+++ b/examples/offline_inference/audio_language.py
@@ -73,8 +73,7 @@ def run_audioflamingo3(question: str, audio_count: int) -> ModelRequestData:
 # CohereASR
 def run_cohere_asr(question: str, audio_count: int) -> ModelRequestData:
     assert audio_count == 1, "CohereASR only support single audio input per prompt"
-    # TODO (ekagra): add HF ckpt after asr release
-    model_name = "/host/engines/vllm/audio/2b-release"
+    model_name = "CohereLabs/cohere-transcribe-03-2026"
 
     prompt = (
         "<|startofcontext|><|startoftranscript|>"

--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -33,6 +33,7 @@ def to_bytes(y, sr):
     buffer.seek(0)
     return buffer
 
+# not all models have a normalizer so use the one from whisper as a standard option
 normalizer_model_info = HF_EXAMPLE_MODELS.find_hf_info("openai/whisper-large-v3")
 normalizer_tokenizer = get_tokenizer(
     "openai/whisper-large-v3",

--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -167,7 +167,7 @@ def run_evaluation(
         ("openai/whisper-large-v3", 12.744980),
         # TODO (ekagra): turn on after asr release
         # CohereASR is used to test the variable encoder length code paths
-        # ("CohereLabs/cohere-transcribe-03-2026", 11.73),
+        # ("CohereLabs/cohere-transcribe-03-2026", 11.92),
     ],
 )
 # Original dataset is 20GB+ in size, hence we use a pre-filtered slice.

--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -17,6 +17,7 @@ import librosa
 import pytest
 import soundfile
 import torch
+from transformers.models.whisper.english_normalizer import EnglishTextNormalizer
 from datasets import load_dataset
 from evaluate import load
 
@@ -31,6 +32,14 @@ def to_bytes(y, sr):
     soundfile.write(buffer, y, sr, format="WAV")
     buffer.seek(0)
     return buffer
+
+normalizer_model_info = HF_EXAMPLE_MODELS.find_hf_info("openai/whisper-large-v3")
+normalizer_tokenizer = get_tokenizer(
+    "openai/whisper-large-v3",
+    tokenizer_mode=normalizer_model_info.tokenizer_mode,
+    trust_remote_code=normalizer_model_info.trust_remote_code,
+)
+normalizer = EnglishTextNormalizer(normalizer_tokenizer.english_spelling_normalizer)
 
 
 async def transcribe_audio(client, tokenizer, y, sr):
@@ -58,8 +67,8 @@ async def bound_transcribe(sem, client, tokenizer, audio, reference):
     async with sem:
         result = await transcribe_audio(client, tokenizer, *audio)
         # Normalize *english* output/reference for evaluation.
-        out = tokenizer.normalize(result[2])
-        ref = tokenizer.normalize(reference)
+        out = normalizer(result[2])
+        ref = normalizer(reference)
         return result[:2] + (out, ref)
 
 
@@ -156,8 +165,9 @@ def run_evaluation(
     "model_config",
     [
         ("openai/whisper-large-v3", 12.744980),
-        # TODO (ekagra): add HF ckpt after asr release
-        # ("/host/engines/vllm/audio/2b-release", 11.73),
+        # TODO (ekagra): turn on after asr release
+        # CohereASR is used to test the variable encoder length code paths
+        # ("CohereLabs/cohere-transcribe-03-2026", 11.73),
     ],
 )
 # Original dataset is 20GB+ in size, hence we use a pre-filtered slice.

--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -17,9 +17,9 @@ import librosa
 import pytest
 import soundfile
 import torch
-from transformers.models.whisper.english_normalizer import EnglishTextNormalizer
 from datasets import load_dataset
 from evaluate import load
+from transformers.models.whisper.english_normalizer import EnglishTextNormalizer
 
 from vllm.tokenizers import get_tokenizer
 
@@ -32,6 +32,7 @@ def to_bytes(y, sr):
     soundfile.write(buffer, y, sr, format="WAV")
     buffer.seek(0)
     return buffer
+
 
 # not all models have a normalizer so use the one from whisper as a standard option
 normalizer_model_info = HF_EXAMPLE_MODELS.find_hf_info("openai/whisper-large-v3")

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1131,7 +1131,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "CohereASRForConditionalGeneration": _HfExamplesInfo(
         "CohereLabs/cohere-transcribe-03-2026",
         trust_remote_code=True,
-        is_available_online=True,
+        is_available_online=False,  # TODO (ekagra): revert after asr release
     ),
     "NemotronParseForConditionalGeneration": _HfExamplesInfo(
         "nvidia/NVIDIA-Nemotron-Parse-v1.1", trust_remote_code=True

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1129,9 +1129,9 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     ),
     # [Encoder-decoder]
     "CohereASRForConditionalGeneration": _HfExamplesInfo(
-        "/host/engines/vllm/audio/2b-release",
+        "CohereLabs/cohere-transcribe-03-2026",
         trust_remote_code=True,
-        is_available_online=False,  # TODO (ekagra): revert after asr release
+        is_available_online=True,
     ),
     "NemotronParseForConditionalGeneration": _HfExamplesInfo(
         "nvidia/NVIDIA-Nemotron-Parse-v1.1", trust_remote_code=True

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1128,7 +1128,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         tokenizer_mode="mistral",
     ),
     # [Encoder-decoder]
-    "CohereASRForConditionalGeneration": _HfExamplesInfo(
+    "CohereAsrForConditionalGeneration": _HfExamplesInfo(
         "CohereLabs/cohere-transcribe-03-2026",
         trust_remote_code=True,
         is_available_online=False,  # TODO (ekagra): revert after asr release

--- a/vllm/model_executor/models/cohere_asr.py
+++ b/vllm/model_executor/models/cohere_asr.py
@@ -1989,7 +1989,7 @@ class CohereASRMultiModalProcessor(EncDecMultiModalProcessor[CohereASRProcessing
     info=CohereASRProcessingInfo,
     dummy_inputs=CohereASRDummyInputsBuilder,
 )
-class CohereASRForConditionalGeneration(
+class CohereAsrForConditionalGeneration(
     nn.Module, SupportsTranscription, SupportsMultiModal
 ):
     packed_modules_mapping = {

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -529,6 +529,10 @@ _MULTIMODAL_MODELS = {
         "cohere_asr",
         "CohereASRForConditionalGeneration",
     ),
+    "CohereAsrForConditionalGeneration": (
+        "cohere_asr",
+        "CohereASRForConditionalGeneration",
+    ),
     "NemotronParseForConditionalGeneration": (
         "nemotron_parse",
         "NemotronParseForConditionalGeneration",

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -525,13 +525,9 @@ _MULTIMODAL_MODELS = {
     "VoxtralForConditionalGeneration": ("voxtral", "VoxtralForConditionalGeneration"),
     "VoxtralRealtimeGeneration": ("voxtral_realtime", "VoxtralRealtimeGeneration"),
     # [Encoder-decoder]
-    "CohereASRForConditionalGeneration": (
-        "cohere_asr",
-        "CohereASRForConditionalGeneration",
-    ),
     "CohereAsrForConditionalGeneration": (
         "cohere_asr",
-        "CohereASRForConditionalGeneration",
+        "CohereAsrForConditionalGeneration",
     ),
     "NemotronParseForConditionalGeneration": (
         "nemotron_parse",


### PR DESCRIPTION
Followup to https://github.com/vllm-project/vllm/pull/35809
Turns on `Cohere Transcribe` model (official name) refered as `CohereAsrForConditionalGeneration` withing vLLM code. The official HF repo will be `CohereLabs/cohere-transcribe-03-2026`. 

The PR also adds the model to test_transcription_api_correctness.py but doesnt enable it yet. Its adds additional value to this test because this model touches all the recent changes that was done to the variable length encoder inputs. Earlier, vLLM only had padded length encoder inputs which was suited for whisper but not for Cohere-Transcribe. 

That test calls a normalizer from the tokenizer but not all the models have a normalizer so we use the standard normalizer in the test for all the models in that test.

Cmd to run the model:
Install vLLM nightly and dependencies
```
uv pip install -U vllm --torch-backend=auto --extra-index-url https://wheels.vllm.ai/nightly
uv pip install vllm[audio]
uv pip install librosa
```

Start server
```
vllm serve CohereLabs/cohere-transcribe-03-2026 --trust-remote-code
```

Send request
```
AUDIO_PATH=<your-audio-path>

curl -v -X POST http://localhost:8000/v1/audio/transcriptions \
-H "Authorization: Bearer $VLLM_API_KEY" \
-F "file=@$(realpath ${AUDIO_PATH})" \
-F "model=CohereLabs/cohere-transcribe-03-2026"
```
