### PR TITLE
[Misc] Switch py-cpuinfo dependency to maintained fork

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,7 +6,7 @@ numpy
 requests >= 2.26.0
 tqdm
 blake3
-py-cpuinfo
+py-cpuinfo2 ~= 10.1
 transformers >= 5.5.3
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 safetensors >= 0.6.2  # MXFP4/MXFP6 dtype support (F8_E8M0, F4) added in 0.6.0: https://github.com/huggingface/safetensors/pull/611

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -20,4 +20,4 @@ torchvision; platform_machine != "s390x"  and platform_machine != "riscv64"
 intel-openmp==2024.2.1; platform_machine == "x86_64"
 
 # Use this to gather CPU info and optimize based on ARM Neoverse cores
-py-cpuinfo; platform_machine == "aarch64"
+py-cpuinfo2 ~= 10.1; platform_machine == "aarch64"


### PR DESCRIPTION
## Purpose

This PR switches the [py-cpuinfo](https://pypi.org/project/py-cpuinfo/) (last release in 2022) dependency to to [py-cpuinfo2](https://pypi.org/project/py-cpuinfo2/), a maintained drop-in fork. 

**Full disclosure:** It's [my fork](https://github.com/akx/py-cpuinfo2/) - py-cpuinfo 10.1 is API compatible with py-cpuinfo 9, but faster (since it does less subprocess/multiprocessing calls to retrieve data...).

## Test Plan

See if CI rolls! It should (and it should be a little faster).

## Test Result

CI should pass as before.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

