### PR TITLE
[RFC] Gap C: Replacement rank bootstrapping for elastic EP peer-swap recovery

### DIFF
--- a/tests/distributed/test_recovery_ep.py
+++ b/tests/distributed/test_recovery_ep.py
@@ -1,0 +1,450 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for DP rank recovery communication fabric.
+
+Level 1 — No GPUs, runs in CI:
+
+  test_replace_peer_sequence — unit test for NixlEPAll2AllManager.replace_peer.
+      Uses FakeNixlEPBuffer. No distributed, no GPU.
+
+Level 2 — 2 GPUs, no NIXL:
+
+  Both tests share a single worker (_recovery_worker) parameterised by
+  backend.  Each spawns 2 processes (one per DP rank, TP=PP=1), each with
+  its own torch.distributed group (world_size=1) to match the elastic EP
+  topology.  The worker plants stale data in a TCPStore, calls
+  create_recovery_groups on a fresh port, and verifies:
+    - recovery_store.get("dp_0") is a valid 12-byte port triplet
+    - stale_store.get("dp_0") is still b"stale_garbage" (untouched)
+    - get_dp_group().all_reduce(tensor) returns correct sum (group is live)
+
+  test_recovery_groups[gloo] — runs with backend="gloo".
+  test_recovery_groups[nccl] — runs with backend="nccl".
+
+Level 3 — 2 SM 90+ GPUs + NIXL-EP + RDMA, end-to-end:
+
+  test_recovery_ep — starts a DP=2 vllm server with NIXL-EP, runs baseline
+      GSM8K, then attempts to trigger recovery and re-evaluate accuracy.
+      Currently blocked: the recovery trigger mechanism (reconnect_peer) is
+      implemented but not wired to any API endpoint or automatic detection.
+      Baseline inference (server startup + GSM8K eval) verified on B200.
+      See build_nixl_ep.sh for setup instructions.
+
+Run with:
+    pytest tests/distributed/test_recovery_ep.py::test_replace_peer_sequence -v
+    pytest tests/distributed/test_recovery_ep.py::test_recovery_groups -v
+    pytest tests/distributed/test_recovery_ep.py::test_recovery_ep -v
+"""
+
+import os
+import socket
+import struct
+import sys
+import time
+import traceback
+import types
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+mp.set_start_method("spawn", force=True)
+
+_HOST = "127.0.0.1"
+
+
+def _get_open_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Level 1a: unit test — NixlEPAll2AllManager.replace_peer
+# ---------------------------------------------------------------------------
+
+
+class FakeNixlEPBuffer:
+    """Minimal fake for nixl_ep.Buffer that tracks calls and connected set."""
+
+    def __init__(self, rank: int, explicitly_destroy: bool = False):
+        self.rank = rank
+        self.connected_ranks: set[int] = set()
+
+    def update_memory_buffers(self, **kwargs) -> None:
+        pass
+
+    def set_tcp_store_group(self, store) -> None:
+        pass
+
+    def connect_ranks(self, remote_ranks, remote_mds=None) -> None:
+        for r in remote_ranks:
+            self.connected_ranks.add(r)
+
+    def disconnect_ranks(self, remote_ranks) -> None:
+        for r in remote_ranks:
+            self.connected_ranks.discard(r)
+
+    def get_local_metadata(self) -> bytes:
+        return b"fake_metadata"
+
+    def is_available(self) -> bool:
+        return True
+
+
+def test_replace_peer_sequence():
+    """replace_peer disconnects the dead rank and reconnects the new one,
+    without changing _buffer[1] (EP size)."""
+    from vllm.distributed.device_communicators.all2all import NixlEPAll2AllManager
+
+    try:
+        fake_buffer = FakeNixlEPBuffer(rank=0)
+        fake_buffer.connected_ranks = {0, 1, 2, 3}
+        ep_size = 4
+        NixlEPAll2AllManager._buffer = (fake_buffer, ep_size)
+
+        NixlEPAll2AllManager.replace_peer(dead_ep_rank=2, new_ep_rank=2)
+
+        assert 2 in fake_buffer.connected_ranks, "new_ep_rank must be re-connected"
+        assert NixlEPAll2AllManager._buffer[1] == 4, "ep_size must not change"
+    finally:
+        NixlEPAll2AllManager._buffer = None
+
+
+# ---------------------------------------------------------------------------
+# Level 2 helpers — shared by test_recovery_groups_rendezvous and
+#                    test_reconnect_peer_group_swap
+# ---------------------------------------------------------------------------
+
+
+def _create_tcp_store(rank: int, port: int, world_size: int) -> "torch.distributed.TCPStore":
+    """Create a TCPStore: rank 0 as master, others as clients."""
+    if rank == 0:
+        return dist.TCPStore(_HOST, port, world_size, is_master=True)
+    timeout = 10  # seconds
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            return dist.TCPStore(_HOST, port, world_size, is_master=False)
+        except RuntimeError as e:
+            if "Connection refused" in str(e) or "Connection reset by peer" in str(e):
+                time.sleep(0.1)
+                continue
+            raise
+    raise RuntimeError(
+        f"Rank {rank} failed to connect to TCPStore at {_HOST}:{port} after {timeout}s"
+    )
+
+
+def _recovery_worker(
+    rank: int,
+    world_size: int,
+    dist_ports: list[int],
+    world_coord_port: int,
+    original_port: int,
+    recovery_port: int,
+    result_queue: "mp.Queue",
+    backend: str = "gloo",
+) -> None:
+    """Shared worker for Level 2 recovery tests.
+
+    Simulates the elastic EP topology (TP=PP=1, one process per DP rank):
+    1. Init torch.distributed with world_size=1 (local TP*PP group).
+    2. Build StatelessGroupCoordinator for _WORLD; stub _TP/_PP.
+    3. Plant stale data in TCPStore at original_port.
+    4. Start a master TCPStore on recovery_port, then call
+       create_recovery_groups.
+    5. Assert recovery store "dp_0" has 12 valid bytes.
+    6. Assert stale store is untouched.
+    7. Promote recovery groups and verify all_reduce.
+    """
+    import vllm.distributed.parallel_state as ps
+    from vllm.distributed.elastic_ep.standby_state import (
+        create_recovery_groups,
+        pop_standby_groups,
+    )
+    from vllm.distributed.parallel_state import _replace_active_groups, get_dp_group
+    from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
+
+    def _log(msg: str) -> None:
+        print(f"[Rank {rank}] {msg}", flush=True)
+        sys.stdout.flush()
+
+    try:
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+
+        # 1. torch.distributed — world_size=1 per DP rank (elastic EP topology)
+        _log(f"Step 1: init_process_group (gloo, world_size=1) ...")
+        dist.init_process_group(
+            backend="gloo",
+            init_method=f"tcp://{_HOST}:{dist_ports[rank]}",
+            world_size=1,
+            rank=0,
+        )
+        _log("Step 1: done")
+
+        # 2. Patch parallel_state with _WORLD coordinator and TP/PP stubs
+        _log("Step 2: patching parallel_state ...")
+        world_coord_store = _create_tcp_store(rank, world_coord_port, world_size)
+        ps._WORLD = StatelessGroupCoordinator(
+            group_ranks=[list(range(world_size))],
+            local_rank=rank,
+            torch_distributed_backend=backend,
+            use_device_communicator=False,
+            coord_store=world_coord_store,
+            group_name="world",
+            host=_HOST,
+            global_rank=rank,
+            global_world_size=world_size,
+        )
+        ps._TP = types.SimpleNamespace(world_size=1)
+        ps._PP = types.SimpleNamespace(world_size=1)
+        _log("Step 2: done")
+
+        # 3. Plant stale data at original_port
+        _log("Step 3: planting stale data ...")
+        stale_store = _create_tcp_store(rank, original_port, world_size)
+        if rank == 0:
+            stale_store.set("dp_0", b"stale_garbage")
+        stale_store.add("all_ready", 1)
+        while int(stale_store.get("all_ready")) < world_size:
+            pass
+        _log("Step 3: done")
+
+        # 4. Create recovery store server, then run create_recovery_groups
+        _log("Step 4: create_recovery_groups ...")
+        recovery_store = _create_tcp_store(rank, recovery_port, world_size)
+        create_recovery_groups(
+            recovery_coord_store_port=recovery_port,
+            master_ip=_HOST,
+            enable_eplb=False,
+            backend=backend,
+        )
+        _log("Step 4: done")
+
+        # 5. recovery store "dp_0" must have 12 valid bytes (3 × uint32 ports)
+        _log("Step 5: checking recovery store dp_0 ...")
+        dp_0_value = recovery_store.get("dp_0")
+        assert dp_0_value != b"stale_garbage", (
+            f"Rank {rank}: recovery store returned stale value"
+        )
+        assert len(dp_0_value) == struct.calcsize("!3I"), (
+            f"Rank {rank}: expected 12-byte port triplet, got {len(dp_0_value)} bytes"
+        )
+        ports = struct.unpack("!3I", dp_0_value)
+        assert all(p > 0 for p in ports), (
+            f"Rank {rank}: invalid zero port in recovery store: {ports}"
+        )
+        _log("Step 5: done")
+
+        # 6. Stale store must be untouched
+        _log("Step 6: checking stale store unchanged ...")
+        assert stale_store.get("dp_0") == b"stale_garbage", (
+            f"Rank {rank}: stale store was modified by create_recovery_groups"
+        )
+        _log("Step 6: done")
+
+        # 7. Promote recovery groups and verify all_reduce
+        _log("Step 7: promote + all_reduce ...")
+        _replace_active_groups(**pop_standby_groups())
+        assert get_dp_group().world_size == world_size
+
+        tensor = torch.tensor([float(rank)], device=device)
+        result = get_dp_group().all_reduce(tensor)
+        torch.cuda.synchronize()
+        expected = float(sum(range(world_size)))
+        assert result.item() == expected, (
+            f"Rank {rank}: all_reduce returned {result.item()}, expected {expected}"
+        )
+        _log("Step 7: done — all passed")
+
+        result_queue.put((rank, None))
+
+    except Exception as exc:
+        _log(f"EXCEPTION: {exc!r}")
+        result_queue.put((rank, traceback.format_exc()))
+
+
+def _run_recovery_test(
+    backend: str,
+    timeout: int = 120,
+) -> None:
+    """Spawn 2 workers, run the recovery test, and collect errors."""
+    world_size = 2
+    dist_ports = [_get_open_port() for _ in range(world_size)]
+    world_coord_port = _get_open_port()
+    original_port = _get_open_port()
+    recovery_port = _get_open_port()
+
+    ctx = mp.get_context("spawn")
+    result_queue: mp.Queue = ctx.Queue()
+
+    processes = []
+    for rank in range(world_size):
+        p = ctx.Process(
+            target=_recovery_worker,
+            args=(
+                rank,
+                world_size,
+                dist_ports,
+                world_coord_port,
+                original_port,
+                recovery_port,
+                result_queue,
+                backend,
+            ),
+        )
+        p.start()
+        processes.append(p)
+
+    for p in processes:
+        p.join(timeout=timeout)
+
+    errors = []
+    while not result_queue.empty():
+        rank_id, err = result_queue.get_nowait()
+        if err is not None:
+            errors.append(f"Rank {rank_id}:\n{err}")
+
+    for i, p in enumerate(processes):
+        if p.exitcode != 0:
+            errors.append(f"Process {i} exited with code {p.exitcode}")
+
+    assert not errors, "\n\n".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# Level 2 tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="Need at least 2 GPUs",
+)
+@pytest.mark.parametrize("backend", ["gloo", "nccl"])
+def test_recovery_groups(backend: str):
+    """create_recovery_groups on a fresh store produces a live DP group
+    that passes an all_reduce sanity check."""
+    _run_recovery_test(backend=backend)
+
+
+# ---------------------------------------------------------------------------
+# Level 3: 2 GPUs + NIXL, end-to-end recovery
+# ---------------------------------------------------------------------------
+
+try:
+    from ..utils import RemoteOpenAIServer, multi_gpu_test  # noqa: E402
+except ImportError:
+    RemoteOpenAIServer = None  # type: ignore[assignment,misc]
+
+    def multi_gpu_test(num_gpus: int):  # type: ignore[misc]
+        return pytest.mark.skip(reason="test utils not available")
+
+_MODEL_NAME = "deepseek-ai/DeepSeek-V2-Lite-Chat"
+_NUM_GSM8K_QUESTIONS = 256
+_EXPECTED_ACCURACY = 0.58
+_ACCURACY_TOL = 0.08
+_MAX_NUM_SEQS = 32
+
+
+def _send_recover_command(server: RemoteOpenAIServer, dead_dp_rank: int) -> bool:
+    """POST /recover_elastic_ep to trigger DP rank recovery."""
+    import requests
+
+    url = server.url_for("recover_elastic_ep")
+    payload = {"dead_data_parallel_rank": dead_dp_rank}
+    headers = {"Content-Type": "application/json"}
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=300)
+        return response.status_code == 200
+    except requests.exceptions.RequestException:
+        return False
+
+
+def _run_gsm8k(server: RemoteOpenAIServer, stage: str) -> float:
+    from ..evals.gsm8k.gsm8k_eval import evaluate_gsm8k
+
+    assert server.port is not None
+    result = evaluate_gsm8k(
+        num_questions=_NUM_GSM8K_QUESTIONS,
+        host=f"http://{server.host}",
+        port=server.port,
+    )
+    accuracy = result["accuracy"]
+    print(f"[{stage}] GSM8K accuracy: {accuracy:.3f} ({result['num_questions']} Qs)")
+    assert accuracy >= _EXPECTED_ACCURACY, (
+        f"[{stage}] accuracy {accuracy:.3f} below threshold {_EXPECTED_ACCURACY}"
+    )
+    return accuracy
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.skipif(
+    not os.environ.get("NIXL_EP_ENABLED"),
+    reason="Set NIXL_EP_ENABLED=1 to run NIXL end-to-end recovery test",
+)
+def test_recovery_ep():
+    """Level 3: kill DP rank 1, trigger recovery, verify accuracy is maintained.
+
+    Requires:
+    - 2 SM 90+ GPUs (Hopper/Blackwell) with RDMA support
+    - nixl_ep built from source (see build_nixl_ep.sh)
+    - NIXL_EP_ENABLED=1 environment variable
+    - Ray installed (pip install ray)
+
+    TODO: The recovery trigger mechanism is not yet implemented.
+      - reconnect_peer() exists in elastic_execute.py but nothing calls it.
+      - Need either: (a) an API endpoint (e.g. POST /recover_elastic_ep) that
+        the orchestrator calls after spawning a replacement worker, or
+        (b) automatic failure detection (e.g. NCCL timeout / heartbeat) that
+        triggers reconnect_peer internally.
+      - Once the trigger exists, update _send_recover_command() to use it
+        and remove this TODO.
+      - The baseline GSM8K eval (server startup + inference with NIXL-EP DP=2)
+        has been verified working on B200.
+    """
+    vllm_serve_args = [
+        "--trust-remote-code",
+        "--tensor-parallel-size", "1",
+        "--gpu-memory-utilization", "0.8",
+        "--max-model-len", "4096",
+        "--max-num-seqs", str(_MAX_NUM_SEQS),
+        "--enable-expert-parallel",
+        "--all2all-backend", "nixl_ep",
+        "--enable-elastic-ep",
+        "--enable-eplb",
+        "--eplb-config.num_redundant_experts", "0",
+        "--data-parallel-backend", "ray",
+        "--data-parallel-size", "2",
+        "--api-server-count", "1",
+    ]
+
+    leader_address = os.environ.get("LEADER_ADDRESS")
+    if leader_address:
+        vllm_serve_args.extend(["--data-parallel-address", leader_address])
+
+    with RemoteOpenAIServer(
+        _MODEL_NAME, vllm_serve_args, env_dict={}, max_wait_seconds=1200
+    ) as server:
+        baseline_accuracy = _run_gsm8k(server, "Baseline (DP=2, NIXL)")
+
+        # Kill DP rank 1 and trigger recovery
+        assert _send_recover_command(server, dead_dp_rank=1), (
+            "Recovery command failed — is /recover_elastic_ep implemented?"
+        )
+        time.sleep(30)  # allow reconnection + replacement rank warmup
+
+        recovery_accuracy = _run_gsm8k(server, "After recovery (DP=2, NIXL)")
+        assert recovery_accuracy >= baseline_accuracy - _ACCURACY_TOL, (
+            f"Recovery accuracy {recovery_accuracy:.3f} dropped more than "
+            f"{_ACCURACY_TOL} below baseline {baseline_accuracy:.3f}"
+        )
+
+        print("\nAccuracy Summary:")
+        print(f"  Baseline:  {baseline_accuracy:.3f}")
+        print(f"  Recovery:  {recovery_accuracy:.3f} "
+              f"(diff: {recovery_accuracy - baseline_accuracy:+.3f})")
+        print(f"  Tolerance: {_ACCURACY_TOL:.3f}")

--- a/tests/distributed/test_recovery_ep.py
+++ b/tests/distributed/test_recovery_ep.py
@@ -7,6 +7,20 @@ Level 1 — No GPUs, runs in CI:
   test_replace_peer_sequence — unit test for NixlEPAll2AllManager.replace_peer.
       Uses FakeNixlEPBuffer. No distributed, no GPU.
 
+  test_donor_rank_selection — unit test for ElasticEPScalingState.donor_dp_rank.
+      Verifies the lowest surviving DP rank is always chosen as donor, and
+      that dead_dp_rank=0 is handled correctly. No distributed, no GPU.
+
+  test_transfer_weights_noop_for_non_donor — unit test for
+      ElasticEPScalingExecutor.transfer_weights_to_replacement.
+      Verifies that non-donor ranks are a no-op (batch_transfer_weights is
+      never called). No distributed, no GPU.
+
+  test_transfer_weights_sends_for_donor — unit test for
+      ElasticEPScalingExecutor.transfer_weights_to_replacement.
+      Verifies that the donor rank calls batch_transfer_weights with
+      is_sender=True and peer_rank=dead_dp_rank. No distributed, no GPU.
+
 Level 2 — 2 GPUs, no NIXL:
 
   Both tests share a single worker (_recovery_worker) parameterised by
@@ -21,6 +35,10 @@ Level 2 — 2 GPUs, no NIXL:
   test_recovery_groups[gloo] — runs with backend="gloo".
   test_recovery_groups[nccl] — runs with backend="nccl".
 
+  test_weight_transfer_round_trip — spawns 2 processes: donor (rank 0) fills
+      a FakeModel with 1.0, replacement (rank 1) fills with 0.0.  After
+      batch_transfer_weights, replacement's weights must equal donor's (1.0).
+
 Level 3 — 2 SM 90+ GPUs + NIXL-EP + RDMA, end-to-end:
 
   test_recovery_ep — starts a DP=2 vllm server with NIXL-EP, runs baseline
@@ -32,7 +50,11 @@ Level 3 — 2 SM 90+ GPUs + NIXL-EP + RDMA, end-to-end:
 
 Run with:
     pytest tests/distributed/test_recovery_ep.py::test_replace_peer_sequence -v
+    pytest tests/distributed/test_recovery_ep.py::test_donor_rank_selection -v
+    pytest tests/distributed/test_recovery_ep.py::test_transfer_weights_noop_for_non_donor -v
+    pytest tests/distributed/test_recovery_ep.py::test_transfer_weights_sends_for_donor -v
     pytest tests/distributed/test_recovery_ep.py::test_recovery_groups -v
+    pytest tests/distributed/test_recovery_ep.py::test_weight_transfer_round_trip -v
     pytest tests/distributed/test_recovery_ep.py::test_recovery_ep -v
 """
 
@@ -110,6 +132,144 @@ def test_replace_peer_sequence():
         assert NixlEPAll2AllManager._buffer[1] == 4, "ep_size must not change"
     finally:
         NixlEPAll2AllManager._buffer = None
+
+
+# ---------------------------------------------------------------------------
+# Level 1b: unit tests — Gap C (donor selection + weight transfer guards)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDPGroup:
+    """Minimal stand-in for StatelessGroupCoordinator for isinstance checks.
+
+    Subclasses StatelessGroupCoordinator in name only so that
+    ``isinstance(obj, StatelessGroupCoordinator)`` passes without requiring
+    any real distributed setup.
+    """
+
+    def __new__(cls, rank_in_group: int):
+        from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
+
+        # Dynamically create a subclass so isinstance checks pass.
+        fake_cls = type("_FakeDPGroup", (StatelessGroupCoordinator,), {})
+        obj = object.__new__(fake_cls)
+        obj.rank_in_group = rank_in_group
+        return obj
+
+
+@pytest.mark.parametrize("dead_dp_rank,dp_size,expected_donor", [
+    (0, 2, 1),  # dead rank 0, only survivor is rank 1
+    (1, 2, 0),  # dead rank 1, only survivor is rank 0
+    (0, 4, 1),  # dead rank 0, lowest survivor is rank 1
+    (1, 4, 0),  # dead rank 1, lowest survivor is rank 0
+    (3, 4, 0),  # dead rank 3, lowest survivor is rank 0
+])
+def test_donor_rank_selection(dead_dp_rank: int, dp_size: int, expected_donor: int):
+    """ElasticEPScalingState.donor_dp_rank is always the lowest surviving rank.
+
+    Critically, when dead_dp_rank=0 the donor must NOT be 0 — it must fall
+    back to the next surviving rank (1).
+    """
+    from unittest.mock import MagicMock
+
+    from vllm.distributed.elastic_ep.elastic_state import ElasticEPScalingState
+    from vllm.v1.engine import ReconfigureDistributedRequest
+
+    reconfig_request = ReconfigureDistributedRequest(
+        new_data_parallel_size=dp_size,
+        new_data_parallel_rank=dead_dp_rank,
+        new_data_parallel_rank_local=dead_dp_rank,
+        new_data_parallel_master_ip=_HOST,
+        new_data_parallel_master_port=0,
+        new_data_parallel_master_port_list=[],
+        coord_store_port=0,
+        dead_data_parallel_rank=dead_dp_rank,
+    )
+
+    state = ElasticEPScalingState(
+        model_executor=MagicMock(),
+        engine_core=MagicMock(),
+        vllm_config=MagicMock(),
+        new_parallel_config=MagicMock(),
+        worker_type="new",
+        scale_type="recovery",
+        reconfig_request=reconfig_request,
+    )
+
+    assert state.donor_dp_rank == expected_donor, (
+        f"dead={dead_dp_rank}, dp_size={dp_size}: "
+        f"expected donor {expected_donor}, got {state.donor_dp_rank}"
+    )
+    assert state.donor_dp_rank != dead_dp_rank, (
+        "donor must never be the dead rank"
+    )
+
+
+def test_transfer_weights_noop_for_non_donor():
+    """transfer_weights_to_replacement is a no-op when rank_in_group != donor.
+
+    All surviving ranks except the donor must return immediately without
+    calling batch_transfer_weights, so only one P2P send is issued.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from vllm.distributed.elastic_ep.elastic_execute import ElasticEPScalingExecutor
+
+    fake_dp_group = _FakeDPGroup(rank_in_group=2)  # not the donor (0)
+
+    executor = object.__new__(ElasticEPScalingExecutor)
+    executor.worker_ref = lambda: MagicMock()
+
+    with patch(
+        "vllm.distributed.elastic_ep.elastic_execute.get_dp_group",
+        return_value=fake_dp_group,
+    ):
+        with patch(
+            "vllm.distributed.elastic_ep.elastic_execute.batch_transfer_weights"
+        ) as mock_transfer:
+            executor.transfer_weights_to_replacement(
+                dead_dp_rank=1, donor_dp_rank=0
+            )
+            mock_transfer.assert_not_called()
+
+
+def test_transfer_weights_sends_for_donor():
+    """transfer_weights_to_replacement calls batch_transfer_weights for the donor.
+
+    The donor rank must call batch_transfer_weights with is_sender=True and
+    peer_rank=dead_dp_rank.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from vllm.distributed.elastic_ep.elastic_execute import ElasticEPScalingExecutor
+
+    fake_dp_group = _FakeDPGroup(rank_in_group=0)  # is the donor
+    mock_model = MagicMock()
+
+    mock_worker = MagicMock()
+    mock_worker.model_runner.get_model.return_value = mock_model
+
+    executor = object.__new__(ElasticEPScalingExecutor)
+    executor.worker_ref = lambda: mock_worker
+
+    with patch(
+        "vllm.distributed.elastic_ep.elastic_execute.get_dp_group",
+        return_value=fake_dp_group,
+    ):
+        with patch(
+            "vllm.distributed.elastic_ep.elastic_execute.batch_transfer_weights"
+        ) as mock_transfer:
+            with patch("torch.accelerator.synchronize"):
+                executor.transfer_weights_to_replacement(
+                    dead_dp_rank=1, donor_dp_rank=0
+                )
+                mock_transfer.assert_called_once_with(
+                    model=mock_model,
+                    is_sender=True,
+                    peer_rank=1,
+                    dp_group=fake_dp_group,
+                    expert_weights=mock_model.expert_weights,
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +489,151 @@ def test_recovery_groups(backend: str):
     """create_recovery_groups on a fresh store produces a live DP group
     that passes an all_reduce sanity check."""
     _run_recovery_test(backend=backend)
+
+
+# ---------------------------------------------------------------------------
+# Level 2b: weight transfer round-trip (Gap C)
+# ---------------------------------------------------------------------------
+
+
+class FakeModel(torch.nn.Module):
+    """Minimal model for weight-transfer tests: one linear layer, no MoE."""
+
+    def __init__(self, device: torch.device):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.zeros(4, 4, device=device))
+        # Empty expert_weights means all params in state_dict are transferred.
+        self.expert_weights: list = []
+
+
+def _weight_transfer_worker(
+    rank: int,
+    world_size: int,
+    dist_ports: list[int],
+    coord_port: int,
+    result_queue: "mp.Queue",
+) -> None:
+    """Worker for test_weight_transfer_round_trip.
+
+    Donor (rank 0) fills FakeModel.weight with 1.0 and sends it.
+    Replacement (rank 1, dead_dp_rank=1) fills with 0.0 and receives.
+    After transfer, replacement must have weight == 1.0.
+    """
+    import sys
+    import traceback
+
+    import torch.distributed as dist
+
+    import vllm.distributed.parallel_state as ps
+    from vllm.distributed.elastic_ep.elastic_execute import batch_transfer_weights
+    from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
+
+    def _log(msg: str) -> None:
+        print(f"[Rank {rank}] {msg}", flush=True)
+        sys.stdout.flush()
+
+    try:
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+
+        # Init a local torch.distributed group (world_size=1, elastic EP topology).
+        dist.init_process_group(
+            backend="gloo",
+            init_method=f"tcp://{_HOST}:{dist_ports[rank]}",
+            world_size=1,
+            rank=0,
+        )
+
+        # Build a real StatelessGroupCoordinator as the DP group (nccl for P2P).
+        coord_store = _create_tcp_store(rank, coord_port, world_size)
+        dp_group = StatelessGroupCoordinator(
+            group_ranks=[list(range(world_size))],
+            local_rank=rank,
+            torch_distributed_backend="nccl",
+            use_device_communicator=True,
+            coord_store=coord_store,
+            group_name="dp",
+            host=_HOST,
+            global_rank=rank,
+            global_world_size=world_size,
+        )
+        ps._DP = dp_group
+
+        # Build model: donor fills with 1.0, replacement fills with 0.0.
+        model = FakeModel(device)
+        donor_dp_rank = 0
+        dead_dp_rank = 1
+        if rank == donor_dp_rank:
+            model.weight.data.fill_(1.0)
+        else:
+            model.weight.data.fill_(0.0)
+
+        # Execute the P2P weight transfer.
+        batch_transfer_weights(
+            model=model,
+            is_sender=(rank == donor_dp_rank),
+            peer_rank=dead_dp_rank if rank == donor_dp_rank else donor_dp_rank,
+            dp_group=dp_group,
+            expert_weights=model.expert_weights,
+        )
+        torch.cuda.synchronize()
+
+        # Only the replacement rank verifies it received the correct weights.
+        if rank == dead_dp_rank:
+            expected = torch.ones(4, 4, device=device)
+            assert model.weight.data.allclose(expected), (
+                f"Rank {rank}: weight transfer failed — "
+                f"got {model.weight.data}, expected all 1.0"
+            )
+            _log("weight transfer verified: replacement has donor weights")
+
+        result_queue.put((rank, None))
+
+    except Exception:
+        result_queue.put((rank, traceback.format_exc()))
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="Need at least 2 GPUs",
+)
+def test_weight_transfer_round_trip():
+    """Donor sends model weights to replacement via batch_transfer_weights.
+
+    Verifies the P2P transfer mechanism used by receive_weights_from_donor
+    and transfer_weights_to_replacement: after the transfer the replacement
+    rank holds an exact copy of the donor's weights.
+    """
+    world_size = 2
+    dist_ports = [_get_open_port() for _ in range(world_size)]
+    coord_port = _get_open_port()
+
+    ctx = mp.get_context("spawn")
+    result_queue: mp.Queue = ctx.Queue()
+
+    processes = []
+    for rank in range(world_size):
+        p = ctx.Process(
+            target=_weight_transfer_worker,
+            args=(rank, world_size, dist_ports, coord_port, result_queue),
+        )
+        p.start()
+        processes.append(p)
+
+    for p in processes:
+        p.join(timeout=120)
+
+    errors = []
+    while not result_queue.empty():
+        rank_id, err = result_queue.get_nowait()
+        if err is not None:
+            errors.append(f"Rank {rank_id}:\n{err}")
+
+    for i, p in enumerate(processes):
+        if p.exitcode != 0:
+            errors.append(f"Process {i} exited with code {p.exitcode}")
+
+    assert not errors, "\n\n".join(errors)
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -500,6 +500,38 @@ class NixlEPAll2AllManager(All2AllManagerBase):
             buffer.disconnect_ranks(ranks_to_disconnect)
         NixlEPAll2AllManager._buffer = (buffer, new_ep_size)
 
+    @classmethod
+    def replace_peer(
+        cls,
+        dead_ep_rank: int,
+        new_ep_rank: int,
+        new_tcp_store=None,
+    ) -> None:
+        """Swap dead_ep_rank → new_ep_rank in the NIXL buffer (same EP size).
+
+        Called on every surviving rank after the replacement rank has started
+        and registered its NIXL metadata.  ``connect_ranks`` blocks internally
+        until the replacement rank's metadata is available.
+        EP size (``_buffer[1]``) is not changed — this is a same-size swap.
+
+        Args:
+            dead_ep_rank: EP rank index of the worker that died.
+            new_ep_rank: EP rank index of the replacement worker (same value
+                as ``dead_ep_rank`` for a peer swap).
+            new_tcp_store: If provided, updates the NIXL buffer's TCPStore
+                group before reconnecting.  Pass the store from the new
+                (post-recovery) EP group so that metadata exchange uses the
+                fresh rendezvous store rather than the stale original.
+        """
+        with cls._lock:
+            assert cls._buffer is not None, "NIXL EP buffer not initialized"
+            buffer, ep_size = cls._buffer
+            if new_tcp_store is not None:
+                buffer.set_tcp_store_group(new_tcp_store)
+            buffer.disconnect_ranks([dead_ep_rank])
+            buffer.connect_ranks([new_ep_rank])
+            # ep_size unchanged — do NOT update _buffer[1]
+
     def get_handle(self, kwargs):
         with NixlEPAll2AllManager._lock:
             if (

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -557,6 +557,49 @@ class ElasticEPScalingExecutor:
             old_num_physical_experts,
         )
 
+    def receive_weights_from_donor(self, donor_dp_rank: int) -> None:
+        """Replacement rank receives model weights from the donor rank during peer-swap recovery.
+
+        Unlike ``receive_weights`` (which computes the sender from
+        ``dp_rank - old_dp_size``), recovery is a same-size swap so the
+        replacement rank has the same index as the dead rank.  The donor is
+        the lowest-numbered surviving DP rank.
+        """
+        dp_group = get_dp_group()
+        assert isinstance(dp_group, StatelessGroupCoordinator)
+        model = self.worker.model_runner.get_model()
+        batch_transfer_weights(
+            model=model,
+            is_sender=False,
+            peer_rank=donor_dp_rank,
+            dp_group=dp_group,
+            expert_weights=model.expert_weights,
+        )
+        torch.accelerator.synchronize()
+
+    def transfer_weights_to_replacement(
+        self, dead_dp_rank: int, donor_dp_rank: int
+    ) -> None:
+        """Donor rank sends model weights to the replacement rank during peer-swap recovery.
+
+        Only the donor rank acts as sender; all other surviving ranks are
+        no-ops so the collective_rpc call can be issued to all workers
+        uniformly.  The donor is the lowest-numbered surviving DP rank.
+        """
+        dp_group = get_dp_group()
+        assert isinstance(dp_group, StatelessGroupCoordinator)
+        if dp_group.rank_in_group != donor_dp_rank:
+            return
+        model = self.worker.model_runner.get_model()
+        batch_transfer_weights(
+            model=model,
+            is_sender=True,
+            peer_rank=dead_dp_rank,
+            dp_group=dp_group,
+            expert_weights=model.expert_weights,
+        )
+        torch.accelerator.synchronize()
+
     def prepare_new_worker(self) -> None:
         with set_current_vllm_config(self.worker.vllm_config):
             prepare_communication_buffer_for_model(self.worker.model_runner.get_model())

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -24,6 +24,7 @@ from vllm.distributed import (
     get_tp_group,
 )
 from vllm.distributed.elastic_ep.standby_state import (
+    create_recovery_groups,
     create_standby_groups,
     get_standby_dp_group,
     get_standby_ep_group,
@@ -559,3 +560,54 @@ class ElasticEPScalingExecutor:
     def prepare_new_worker(self) -> None:
         with set_current_vllm_config(self.worker.vllm_config):
             prepare_communication_buffer_for_model(self.worker.model_runner.get_model())
+
+    def reconnect_peer(
+        self, reconfig_request: ReconfigureDistributedRequest
+    ) -> None:
+        """Reconnect communication fabric after a same-size DP rank peer swap.
+
+        Called on every *surviving* rank once the replacement rank is ready to
+        rendezvous.  Steps:
+
+        1. Rendezvous new process groups (same topology, fresh TCPStore) via
+           ``create_recovery_groups``.
+        2. Atomically promote standby → active via ``_replace_active_groups``.
+        3. For each EP rank that belonged to the dead DP rank, disconnect the
+           dead worker and reconnect the replacement worker in the NIXL buffer.
+
+        The replacement rank (the fresh worker that took the dead rank's slot)
+        also calls ``create_recovery_groups`` + ``_replace_active_groups``, and
+        then its NIXL buffer is initialized normally via
+        ``NixlEPAll2AllManager.get_handle`` during the first MoE forward pass —
+        the same ``_init_buffer`` path used at startup.  This method only
+        handles the surviving-rank side of the swap.
+        """
+        from vllm.distributed.device_communicators.all2all import (
+            NixlEPAll2AllManager,
+        )
+
+        parallel_config = self.worker.vllm_config.parallel_config
+        master_ip = reconfig_request.new_data_parallel_master_ip
+
+        create_recovery_groups(
+            recovery_coord_store_port=reconfig_request.coord_store_port,
+            master_ip=master_ip,
+            enable_eplb=parallel_config.enable_eplb,
+        )
+        _replace_active_groups(**pop_standby_groups())
+
+        # EP rank range for the dead DP rank: dp_rank * tp_size .. (dp_rank+1)*tp_size - 1
+        dead_dp_rank = reconfig_request.dead_data_parallel_rank
+        assert dead_dp_rank >= 0, (
+            "reconnect_peer requires a valid dead_data_parallel_rank"
+        )
+        tp_size = get_tp_group().world_size
+        new_ep_tcp_store = get_ep_group().tcp_store_group.store
+
+        for tp_rank in range(tp_size):
+            ep_rank = dead_dp_rank * tp_size + tp_rank
+            NixlEPAll2AllManager.replace_peer(
+                dead_ep_rank=ep_rank,
+                new_ep_rank=ep_rank,
+                new_tcp_store=new_ep_tcp_store if tp_rank == 0 else None,
+            )

--- a/vllm/distributed/elastic_ep/elastic_state.py
+++ b/vllm/distributed/elastic_ep/elastic_state.py
@@ -6,6 +6,7 @@ import weakref
 from datetime import timedelta
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
+import torch
 import torch.distributed
 
 from vllm.config import ParallelConfig
@@ -62,11 +63,42 @@ class ScaleDownRemovingEngineState(enum.IntEnum):
     COMPLETE = 2
 
 
+class RecoveryReplacementEngineState(enum.IntEnum):
+    """State machine for the replacement rank in a same-size DP peer swap.
+
+    The replacement rank follows the same broad sequence as a scale-up new
+    worker (receive expert mapping → load dummy weights → receive actual
+    weights → prepare NIXL buffer → sync wave counters) but uses
+    ``receive_weights_from_donor`` instead of ``receive_weights`` because the
+    DP size is unchanged and the normal sender-rank calculation breaks.
+    """
+
+    PRE_KV_INIT = 0  # receive weights from donor, sync KV size, prepare NIXL
+    PREPARE = 1       # sync wave/step counters with survivors
+    COMPLETE = 2
+
+
+class RecoverySurvivingEngineState(enum.IntEnum):
+    """State machine for surviving ranks during a same-size DP peer swap.
+
+    Surviving ranks run ``reconnect_peer`` synchronously, then wait
+    for the replacement rank to signal it is ready to receive weights before
+    doing the weight transfer and wave-counter sync.
+    """
+
+    RECONNECT_FABRIC = 0        # run reconnect_peer (groups + NIXL)
+    WAIT_REPLACEMENT_READY = 1  # wait for NEW_CORE_ENGINES_WEIGHTS_INIT_READY
+    TRANSFER_WEIGHTS = 2         # rank 0 sends weights; all ranks sync KV size + waves
+    COMPLETE = 3
+
+
 EngineState: TypeAlias = (
     ScaleUpExistingEngineState
     | ScaleUpNewEngineState
     | ScaleDownRemainingEngineState
     | ScaleDownRemovingEngineState
+    | RecoveryReplacementEngineState
+    | RecoverySurvivingEngineState
 )
 
 
@@ -87,7 +119,7 @@ class ElasticEPScalingState:
         vllm_config: "VllmConfig",
         new_parallel_config: ParallelConfig,
         worker_type: WorkerType,
-        scale_type: Literal["scale_up", "scale_down"],
+        scale_type: Literal["scale_up", "scale_down", "recovery"],
         reconfig_request: ReconfigureDistributedRequest | None = None,
     ):
         self.model_executor_ref = weakref.ref(model_executor)
@@ -102,12 +134,32 @@ class ElasticEPScalingState:
         self.scale_type = scale_type
         self.reconfig_request = reconfig_request
 
+        # Donor rank for recovery weight transfer — computed once here so that
+        # both _progress_recovery_replacement_engine and
+        # _progress_recovery_surviving_engine are guaranteed to use the same
+        # rank.  None for non-recovery scale operations.
+        self.donor_dp_rank: int | None = None
+        if scale_type == "recovery" and reconfig_request is not None:
+            _dead = reconfig_request.dead_data_parallel_rank
+            # TODO: prefer a donor on the same physical node as the replacement
+            # rank to reduce cross-node bandwidth during weight transfer.
+            self.donor_dp_rank = next(
+                r for r in range(reconfig_request.new_data_parallel_size)
+                if r != _dead
+            )
+
         self.state: EngineState
         if scale_type == "scale_up":
             self.state = (
                 ScaleUpNewEngineState.PRE_KV_INIT
                 if worker_type == "new"
                 else ScaleUpExistingEngineState.WAIT_NEW_CORE_ENGINES_INIT
+            )
+        elif scale_type == "recovery":
+            self.state = (
+                RecoveryReplacementEngineState.PRE_KV_INIT
+                if worker_type == "new"
+                else RecoverySurvivingEngineState.RECONNECT_FABRIC
             )
         else:
             self.state = (
@@ -131,6 +183,12 @@ class ElasticEPScalingState:
         return engine_core
 
     def progress(self) -> bool:
+        if self.scale_type == "recovery":
+            return (
+                self._progress_recovery_replacement_engine()
+                if self.worker_type == "new"
+                else self._progress_recovery_surviving_engine()
+            )
         if self.scale_type == "scale_up":
             return (
                 self._progress_new_engine()
@@ -144,10 +202,15 @@ class ElasticEPScalingState:
         )
 
     def run_pre_kv_init_states(self) -> None:
-        assert self.scale_type == "scale_up" and self.worker_type == "new"
-        assert self.state == ScaleUpNewEngineState.PRE_KV_INIT
-        assert self.progress()
-        assert self.state == ScaleUpNewEngineState.PREPARE
+        assert self.scale_type in ("scale_up", "recovery") and self.worker_type == "new"
+        if self.scale_type == "recovery":
+            assert self.state == RecoveryReplacementEngineState.PRE_KV_INIT
+            assert self.progress()
+            assert self.state == RecoveryReplacementEngineState.PREPARE
+        else:
+            assert self.state == ScaleUpNewEngineState.PRE_KV_INIT
+            assert self.progress()
+            assert self.state == ScaleUpNewEngineState.PREPARE
 
     def _execute_tcp_store_barrier(
         self, dp_store, group_rank, group_size, barrier_id, timeout=None
@@ -448,8 +511,20 @@ class ElasticEPScalingState:
         ):
             self.old_dp_store.add("eep_barrier_engine_count", 1)
             self.state = ScaleUpExistingEngineState.TRANSFER_WEIGHTS
+        elif (
+            notification_type == EEPNotificationType.NEW_CORE_ENGINES_WEIGHTS_INIT_READY
+            and self.scale_type == "recovery"
+            and self.state == RecoverySurvivingEngineState.WAIT_REPLACEMENT_READY
+        ):
+            self.state = RecoverySurvivingEngineState.TRANSFER_WEIGHTS
 
     def is_complete(self) -> bool:
+        if self.scale_type == "recovery":
+            return (
+                self.state == RecoveryReplacementEngineState.COMPLETE
+                if self.worker_type == "new"
+                else self.state == RecoverySurvivingEngineState.COMPLETE
+            )
         if self.scale_type == "scale_up":
             return (
                 self.state == ScaleUpNewEngineState.COMPLETE
@@ -461,6 +536,143 @@ class ElasticEPScalingState:
             if self.worker_type == "removing"
             else self.state == ScaleDownRemainingEngineState.COMPLETE
         )
+
+    def _progress_recovery_replacement_engine(self) -> bool:
+        """State machine for the replacement rank in a same-size peer swap.
+
+        PRE_KV_INIT: signal survivors, receive weights from donor rank,
+            sync KV cache size, prepare NIXL buffer.
+        PREPARE: sync wave/step counters with all survivors via all-reduce.
+
+        Returns:
+            True if the state advanced and the caller should invoke
+            progress() again; always True for this engine since the
+            replacement rank never blocks on an external event.
+        """
+        state = self.state
+        assert self.new_dp_group is not None and self.new_dp_store is not None
+
+        if state == RecoveryReplacementEngineState.PRE_KV_INIT:
+            assert self.donor_dp_rank is not None
+            # Tell surviving ranks we are ready to receive weights.
+            self.engine_core._eep_send_engine_core_notification(
+                EEPNotificationType.NEW_CORE_ENGINES_WEIGHTS_INIT_READY
+            )
+            self.model_executor.collective_rpc(
+                "elastic_ep_execute",
+                args=("receive_weights_from_donor", self.donor_dp_rank),
+            )
+            self.engine_core.available_gpu_memory_for_kv_cache = (
+                ParallelConfig.sync_kv_cache_memory_size(self.new_dp_group, -1)
+            )
+            self.model_executor.collective_rpc(
+                "elastic_ep_execute", args=("prepare_new_worker",)
+            )
+            self.state = RecoveryReplacementEngineState.PREPARE
+            return True
+
+        elif state == RecoveryReplacementEngineState.PREPARE:
+            tensor = torch.tensor([0, 0, 0], dtype=torch.int32, device="cpu")
+            torch.distributed.all_reduce(
+                tensor,
+                op=torch.distributed.ReduceOp.MAX,
+                group=self.new_dp_group,
+            )
+            data = tensor.tolist()
+            self.engine_core.engines_running = bool(data[0])
+            self.engine_core.current_wave = int(data[1])
+            self.engine_core.step_counter = int(data[2])
+            self.state = RecoveryReplacementEngineState.COMPLETE
+            return True
+
+        else:
+            assert self.state == RecoveryReplacementEngineState.COMPLETE, (
+                f"Unexpected recovery replacement state: {self.state}"
+            )
+            return True
+
+    def _progress_recovery_surviving_engine(self) -> bool:
+        """State machine for surviving ranks in a same-size peer swap.
+
+        RECONNECT_FABRIC: call reconnect_peer synchronously — rebuilds
+            StatelessGroupCoordinator groups and NIXL peer connections.
+            Blocks until the replacement rank joins the recovery rendezvous.
+        WAIT_REPLACEMENT_READY: idle until the replacement signals it is
+            ready to receive weights (NEW_CORE_ENGINES_WEIGHTS_INIT_READY).
+        TRANSFER_WEIGHTS: donor rank sends weights; all ranks sync KV cache
+            size and wave/step counters with the replacement.
+
+        Returns:
+            True if the state advanced and the caller should invoke
+            progress() again; False if blocked waiting for an external
+            event (e.g. the replacement rank's ready notification).
+        """
+        state = self.state
+        assert self.old_dp_group is not None and self.old_dp_store is not None
+
+        if state == RecoverySurvivingEngineState.RECONNECT_FABRIC:
+            assert self.reconfig_request is not None
+            self.model_executor.collective_rpc(
+                "elastic_ep_execute",
+                args=("reconnect_peer", self.reconfig_request),
+            )
+            # reconnect_peer promotes the standby groups to active via
+            # _replace_active_groups.  Capture the new communicator (which now
+            # includes the replacement rank) for use in TRANSFER_WEIGHTS.
+            self.new_dp_group = self.engine_core.dp_group
+            self.new_dp_store = self.engine_core.dp_store
+            self.state = RecoverySurvivingEngineState.WAIT_REPLACEMENT_READY
+            if self.old_dp_group.rank() == 0:
+                logger.info("[Elastic EP Recovery] Fabric reconnected, waiting for replacement rank")
+            return True
+
+        elif state == RecoverySurvivingEngineState.WAIT_REPLACEMENT_READY:
+            return False
+
+        elif state == RecoverySurvivingEngineState.TRANSFER_WEIGHTS:
+            assert self.reconfig_request is not None
+            assert self.donor_dp_rank is not None
+            dead_dp_rank = self.reconfig_request.dead_data_parallel_rank
+            # Sync KV cache memory size with the replacement rank.
+            assert self.new_dp_group is not None
+            ParallelConfig.sync_kv_cache_memory_size(
+                self.new_dp_group,
+                self.engine_core.available_gpu_memory_for_kv_cache,
+            )
+            # Donor rank sends weights; other surviving ranks are no-ops.
+            self.model_executor.collective_rpc(
+                "elastic_ep_execute",
+                args=("transfer_weights_to_replacement", dead_dp_rank, self.donor_dp_rank),
+            )
+            # Sync wave/step counters with the replacement rank.
+            engines_running = int(self.engine_core.engines_running)
+            current_wave = self.engine_core.current_wave
+            step_counter = self.engine_core.step_counter
+            tensor = torch.tensor(
+                [engines_running, current_wave, step_counter],
+                dtype=torch.int32,
+                device="cpu",
+            )
+            torch.distributed.all_reduce(
+                tensor,
+                op=torch.distributed.ReduceOp.MAX,
+                group=self.new_dp_group,
+            )
+            data = tensor.tolist()
+            self.engine_core.engines_running = bool(data[0])
+            self.engine_core.current_wave = int(data[1])
+            self.engine_core.step_counter = int(data[2])
+            self.state = RecoverySurvivingEngineState.COMPLETE
+            if self.new_dp_group.rank() == 0:
+                self.engine_core._eep_send_engine_core_notification(
+                    EEPNotificationType.RECONFIGURE_FINISHED
+                )
+                logger.info("[Elastic EP Recovery] Replacement rank fully integrated")
+            return True
+
+        else:
+            assert self.state == RecoverySurvivingEngineState.COMPLETE
+            return True
 
     def _create_standby_groups(self):
         assert self.old_dp_group is not None

--- a/vllm/distributed/elastic_ep/standby_state.py
+++ b/vllm/distributed/elastic_ep/standby_state.py
@@ -51,7 +51,11 @@ def create_standby_groups(
 
     from vllm.distributed.utils import get_cached_tcp_store_client
 
-    assert new_world_size_across_dp == torch.distributed.get_world_size() * new_dp_size
+    assert new_world_size_across_dp == torch.distributed.get_world_size() * new_dp_size, (
+        f"new_world_size_across_dp={new_world_size_across_dp} != "
+        f"torch.distributed.get_world_size()={torch.distributed.get_world_size()} "
+        f"* new_dp_size={new_dp_size}"
+    )
     world_group = get_world_group()
     assert isinstance(world_group, StatelessGroupCoordinator)
     backend = backend or world_group.backend
@@ -97,6 +101,46 @@ def create_standby_groups(
             backend,
             coord_store=coord_store,
         )
+
+
+def create_recovery_groups(
+    recovery_coord_store_port: int,
+    master_ip: str,
+    enable_eplb: bool = True,
+    backend: str | None = None,
+) -> None:
+    """Build recovery groups for a same-size DP rank peer swap.
+
+    Identical topology to the current active groups (dp_size unchanged), but
+    rendezvous on a fresh TCPStore at ``recovery_coord_store_port`` so that
+    stale keys written during the original init — which TCPStore.get() would
+    return immediately — cannot block the new rendezvous.  This mirrors the
+    approach used by elastic EP scaling, which also allocates a new
+    ``coord_store_port`` per reconfiguration.
+
+    The replacement rank and all surviving ranks must call this function with
+    the same ``recovery_coord_store_port``; rank 0 allocates fresh TCP ports
+    and publishes them, everyone else blocks until they appear.
+
+    Results are stored in _STANDBY_* so the existing
+    ``pop_standby_groups()`` → ``_replace_active_groups()`` path promotes
+    them without modification.
+    """
+    world_group = get_world_group()
+    assert isinstance(world_group, StatelessGroupCoordinator)
+    tp_size = get_tp_group().world_size
+    pp_size = get_pp_group().world_size
+    world_size = world_group.world_size
+    dp_size = world_size // (tp_size * pp_size)
+
+    create_standby_groups(
+        new_dp_size=dp_size,
+        new_world_size_across_dp=world_size,
+        master_ip=master_ip,
+        coord_store_port=recovery_coord_store_port,
+        enable_eplb=enable_eplb,
+        backend=backend,
+    )
 
 
 def pop_standby_groups() -> dict:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -245,6 +245,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_CUDA_COMPATIBILITY: bool = False
     VLLM_CUDA_COMPATIBILITY_PATH: str | None = None
     VLLM_ELASTIC_EP_SCALE_UP_LAUNCH: bool = False
+    VLLM_ELASTIC_EP_RECOVERY_LAUNCH: bool = False
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
@@ -1637,6 +1638,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Should only be set by EngineCoreClient.
     "VLLM_ELASTIC_EP_SCALE_UP_LAUNCH": lambda: bool(
         int(os.getenv("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH", "0"))
+    ),
+    # Whether this is a recovery launch (replacement rank for a dead DP rank).
+    # Set by CoreEngineProcManager.respawn_rank before spawning the replacement.
+    "VLLM_ELASTIC_EP_RECOVERY_LAUNCH": lambda: bool(
+        int(os.getenv("VLLM_ELASTIC_EP_RECOVERY_LAUNCH", "0"))
     ),
     # Whether to wait for all requests to drain before sending the
     # scaling command in elastic EP.

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -238,6 +238,9 @@ class ReconfigureDistributedRequest(msgspec.Struct):
     new_data_parallel_master_port: int
     new_data_parallel_master_port_list: list[int]
     coord_store_port: int
+    # For same-size peer swap (DP rank recovery): identifies the dead DP rank.
+    # -1 means this is a normal elastic scaling operation, not a recovery.
+    dead_data_parallel_rank: int = -1
 
 
 class ReconfigureRankType(enum.IntEnum):

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -117,7 +117,7 @@ class EngineCore:
 
         self.available_gpu_memory_for_kv_cache = -1
 
-        if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+        if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH or envs.VLLM_ELASTIC_EP_RECOVERY_LAUNCH:
             self._eep_scale_up_before_kv_init()
 
         # Setup KV Caches and update CacheConfig after profiling.
@@ -234,7 +234,7 @@ class EngineCore:
 
         has_kv_cache = any(kv_cache_spec for kv_cache_spec in kv_cache_specs)
         if has_kv_cache:
-            if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+            if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH or envs.VLLM_ELASTIC_EP_RECOVERY_LAUNCH:
                 # NOTE(yongji): should already be set
                 # during _eep_scale_up_before_kv_init
                 assert self.available_gpu_memory_for_kv_cache > 0
@@ -838,7 +838,7 @@ class EngineCoreProc(EngineCore):
 
             self.addresses = addresses
             self.process_input_queue_block = True
-            if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+            if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH or envs.VLLM_ELASTIC_EP_RECOVERY_LAUNCH:
                 self._eep_send_engine_core_notification(
                     EEPNotificationType.NEW_CORE_ENGINES_INIT_READY,
                     vllm_config=vllm_config,
@@ -1790,14 +1790,25 @@ class DPEngineCoreProc(EngineCoreProc):
             reconfig_request.new_data_parallel_rank
             == ReconfigureRankType.SHUTDOWN_CURRENT_RANK
         )
+        is_recovery = reconfig_request.dead_data_parallel_rank >= 0
+
+        if is_recovery:
+            scale_type = "recovery"
+            worker_type = "existing"
+        elif is_scale_down:
+            scale_type = "scale_down"
+            worker_type = "removing" if is_shutdown else "existing"
+        else:
+            scale_type = "scale_up"
+            worker_type = "existing"
 
         self.eep_scaling_state = ElasticEPScalingState(
             model_executor=self.model_executor,
             engine_core=self,
             vllm_config=self.vllm_config,
             new_parallel_config=new_parallel_config,
-            worker_type="removing" if is_shutdown else "existing",
-            scale_type="scale_down" if is_scale_down else "scale_up",
+            worker_type=worker_type,
+            scale_type=scale_type,
             reconfig_request=reconfig_request,
         )
         self.process_input_queue_block = False
@@ -1858,15 +1869,17 @@ class DPEngineCoreProc(EngineCoreProc):
         self.eep_scaling_state.handle_notification(notification_type)
 
     def _eep_scale_up_before_kv_init(self):
+        from vllm import envs
         from vllm.distributed.elastic_ep.elastic_state import ElasticEPScalingState
 
+        scale_type = "recovery" if envs.VLLM_ELASTIC_EP_RECOVERY_LAUNCH else "scale_up"
         self.eep_scaling_state = ElasticEPScalingState(
             model_executor=self.model_executor,
             engine_core=self,
             vllm_config=self.vllm_config,
             new_parallel_config=self.vllm_config.parallel_config,
             worker_type="new",
-            scale_type="scale_up",
+            scale_type=scale_type,
             reconfig_request=None,
         )
         self.eep_scaling_state.run_pre_kv_init_states()

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -31,6 +31,8 @@ from vllm.v1.utils import get_engine_client_zmq_addr, shutdown
 if TYPE_CHECKING:
     from ray.util.placement_group import PlacementGroup
 
+    from vllm.v1.engine import ReconfigureDistributedRequest
+
 logger = init_logger(__name__)
 
 STARTUP_POLL_PERIOD_MS = 10000
@@ -115,6 +117,13 @@ class CoreEngineProcManager:
 
         from vllm.v1.engine.core import EngineCoreProc
 
+        # Store construction state for respawn_rank.
+        self._common_kwargs = common_kwargs
+        self._vllm_config = vllm_config
+        self._is_dp = is_dp
+        # global_dp_rank -> list index and local_dp_rank
+        self._rank_info: dict[int, tuple[int, int]] = {}
+
         self.processes: list[BaseProcess] = []
         local_dp_ranks = []
         for index in range(local_engine_count):
@@ -123,6 +132,7 @@ class CoreEngineProcManager:
 
             # Start EngineCore in background process.
             local_dp_ranks.append(local_index)
+            self._rank_info[global_index] = (index, local_index)
             self.processes.append(
                 context.Process(
                     target=EngineCoreProc.run_engine_core,
@@ -171,6 +181,69 @@ class CoreEngineProcManager:
             for proc in self.processes
             if proc.exitcode is not None
         }
+
+    def respawn_rank(
+        self,
+        global_dp_rank: int,
+        reconfig_request: "ReconfigureDistributedRequest",
+    ) -> None:
+        """Spawn a replacement process for the failed DP rank.
+
+        The replacement process is started with ``VLLM_ELASTIC_EP_RECOVERY_LAUNCH=1``
+        so it follows the recovery initialization path in
+        ``DPEngineCoreProc._eep_scale_up_before_kv_init``.
+
+        The ``vllm_config.parallel_config`` is updated with the recovery
+        rendezvous coordinates from *reconfig_request* so the replacement
+        joins the same fresh TCPStore as the surviving ranks.
+
+        Args:
+            global_dp_rank: DP rank of the failed worker to replace.
+            reconfig_request: Recovery reconfiguration parameters, must have
+                ``dead_data_parallel_rank == global_dp_rank``.
+        """
+        import copy
+        import os
+
+        from vllm.v1.engine.core import EngineCoreProc
+
+        proc_idx, local_dp_rank = self._rank_info[global_dp_rank]
+
+        # Deep-copy config and update rendezvous coordinates.
+        vllm_config = copy.deepcopy(self._vllm_config)
+        pc = vllm_config.parallel_config
+        pc.data_parallel_master_ip = reconfig_request.new_data_parallel_master_ip
+        pc.data_parallel_master_port = reconfig_request.new_data_parallel_master_port
+        pc._data_parallel_master_port_list = (
+            reconfig_request.new_data_parallel_master_port_list
+        )
+        pc._coord_store_port = reconfig_request.coord_store_port
+
+        kwargs = dict(self._common_kwargs)
+        kwargs["vllm_config"] = vllm_config
+
+        context = get_mp_context()
+        proc = context.Process(
+            target=EngineCoreProc.run_engine_core,
+            name=f"EngineCore_DP{global_dp_rank}",
+            kwargs=kwargs | {"dp_rank": global_dp_rank, "local_dp_rank": local_dp_rank},
+        )
+
+        self.processes[proc_idx] = proc
+
+        with patch.dict(os.environ, {"VLLM_ELASTIC_EP_RECOVERY_LAUNCH": "1"}):
+            if self._is_dp and (
+                not current_platform.is_cuda_alike()
+                or self._vllm_config.parallel_config.use_ray
+            ):
+                with set_device_control_env_var(self._vllm_config, local_dp_rank):
+                    proc.start()
+            else:
+                proc.start()
+
+        logger.info(
+            "Spawned replacement for DP rank %d (PID %d)", global_dp_rank, proc.pid
+        )
 
 
 class SignalCallback:

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -607,7 +607,7 @@ class WorkerProc:
         self.setup_proc_title_and_log_prefix(
             enable_ep=vllm_config.parallel_config.enable_expert_parallel
         )
-        if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+        if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH or envs.VLLM_ELASTIC_EP_RECOVERY_LAUNCH:
             self.worker.elastic_ep_execute("load_model")
         else:
             self.worker.load_model()

--- a/vllm/v1/executor/ray_executor.py
+++ b/vllm/v1/executor/ray_executor.py
@@ -383,7 +383,7 @@ class RayDistributedExecutor(Executor):
         self.collective_rpc("init_worker", args=(all_kwargs,))
 
         self.collective_rpc("init_device")
-        if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+        if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH or envs.VLLM_ELASTIC_EP_RECOVERY_LAUNCH:
             self.collective_rpc("elastic_ep_execute", args=("load_model",))
         else:
             self.collective_rpc("load_model")

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -46,7 +46,7 @@ class UniProcExecutor(Executor):
         self.driver_worker.init_worker(all_kwargs=[kwargs])
         self.driver_worker.init_device()
 
-        if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+        if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH or envs.VLLM_ELASTIC_EP_RECOVERY_LAUNCH:
             self.driver_worker.elastic_ep_execute("load_model")
         else:
             self.driver_worker.load_model()


### PR DESCRIPTION
## Summary

This PR implements **Gap C**: replacement rank bootstrapping for elastic EP same-size peer-swap recovery. When a DP rank dies and is replaced by a new worker, the replacement must receive the dead rank's model weights and have its state machine driven to completion before it can serve traffic.

**Depends on:** #38072 (Gap D — reconnection fabric). This PR stacks on top of that branch.

### Changes

**`vllm/distributed/elastic_ep/elastic_execute.py`**
- `receive_weights_from_donor(donor_dp_rank)` — replacement rank receives model weights via `batch_transfer_weights`
- `transfer_weights_to_replacement(dead_dp_rank, donor_dp_rank)` — donor rank sends weights; all other surviving ranks are no-ops so the `collective_rpc` can be issued uniformly

**`vllm/distributed/elastic_ep/elastic_state.py`**
- `ElasticEPScalingState.__init__`: computes `self.donor_dp_rank` once (lowest surviving DP rank) so both the replacement and surviving state machine paths use a consistent value
  - Example: if `dead_dp_rank=0`, donor is rank 1 (not rank 0 — the hardcoded `peer_rank=0` bug is fixed)
  - TODO comment for future work: prefer a donor on the same physical node as the replacement to reduce cross-node bandwidth
- `_progress_recovery_replacement_engine`: drives replacement through `PRE_KV_INIT → COMPLETE`, calling `receive_weights_from_donor`
- `_progress_recovery_surviving_engine`: drives survivors through `TRANSFER_WEIGHTS → COMPLETE`, calling `transfer_weights_to_replacement`

**`tests/distributed/test_recovery_ep.py`**
- `test_donor_rank_selection` (Level 1, no GPU): parametrized over 5 `(dead, dp_size, expected_donor)` cases including the `dead=0` edge case
- `test_transfer_weights_noop_for_non_donor` (Level 1, no GPU): non-donor ranks must not call `batch_transfer_weights`
- `test_transfer_weights_sends_for_donor` (Level 1, no GPU): donor rank calls `batch_transfer_weights` with correct `is_sender=True` and `peer_rank=dead_dp_rank`
- `test_weight_transfer_round_trip` (Level 2, 2 GPUs): 2-process spawn test — donor fills weights with 1.0, replacement fills with 0.0; after transfer replacement must equal donor

## Test plan

- [x] Level 1 (no GPU): `pytest tests/distributed/test_recovery_ep.py::test_donor_rank_selection -v` — PASSED
- [x] Level 1 (no GPU): `pytest tests/distributed/test_recovery_ep.py::test_transfer_weights_noop_for_non_donor -v` — PASSED
- [x] Level 1 (no GPU): `pytest tests/distributed/test_recovery_ep.py::test_transfer_weights_sends_for_donor -v` — PASSED
- [x] Level 2 (2 GPUs): `pytest tests/distributed/test_recovery_ep.py::test_weight_transfer_round_trip -v` — PASSED
- [ ] Level 3 (2× SM90+ + NIXL-EP): `pytest tests/distributed/test_recovery_ep.py::test_recovery_ep -v` — requires full NIXL-EP environment; pending end-to-end wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)