### PR TITLE
[Bugfix][Backport] Backport PR #31816 to v0.13.0: Fix ROCM_AITER_TRITON_MLA accuracy for DeepSeek-V3

### DIFF
--- a/vllm/v1/attention/backends/mla/aiter_triton_mla.py
+++ b/vllm/v1/attention/backends/mla/aiter_triton_mla.py
@@ -1,13 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from vllm.v1.attention.backends.mla.common import MLACommonBackend
-from vllm.v1.attention.backends.mla.rocm_aiter_mla import (
-    AiterMLAImpl,
-    AiterMLAMetadataBuilder,
-)
+from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLABackend, AiterMLAImpl
 
 
-class AiterTritonMLABackend(MLACommonBackend):
+class AiterTritonMLABackend(AiterMLABackend):
     @staticmethod
     def get_name() -> str:
         return "AITER_TRITON_MLA"
@@ -15,10 +11,6 @@ class AiterTritonMLABackend(MLACommonBackend):
     @staticmethod
     def get_impl_cls() -> type["AiterTritonMLAImpl"]:
         return AiterTritonMLAImpl
-
-    @staticmethod
-    def get_builder_cls() -> type["AiterMLAMetadataBuilder"]:
-        return AiterMLAMetadataBuilder
 
 
 class AiterTritonMLAImpl(AiterMLAImpl):


### PR DESCRIPTION
## Summary

Backport of #31816 to v0.13.0: Fix accuracy regression in ROCM_AITER_TRITON_MLA backend for DeepSeek-V3.

### The Bug

`AiterTritonMLABackend` was incorrectly inheriting from `MLACommonBackend` instead of `AiterMLABackend`, causing it to use the wrong metadata builder and resulting in extremely low accuracy (0.67% on gsm8k).

### The Fix

Changed `AiterTritonMLABackend` to inherit from `AiterMLABackend`, which provides the correct AITER-specific metadata builder and shared functionality.

## Test Plan

Validated with DeepSeek-V3 on ROCm using AITER_TRITON_MLA backend:

```bash
export VLLM_USE_V1=1
export SAFETENSORS_FAST_GPU=1
export VLLM_ROCM_USE_AITER=1
export VLLM_ATTENTION_BACKEND=ROCM_AITER_TRITON_MLA
vllm serve deepseek-ai/DeepSeek-V3 -tp 8
```

### Test Results

**lm-eval gsm8k (n=300, 5-shot):**

| Filter | Metric | Value | Stderr |
|--------|--------|-------|--------|
| flexible-extract | exact_match | **96.33%** | ±0.0109 |
| strict-match | exact_match | **96.00%** | ±0.0113 |

**Before fix:** 0.67% accuracy  
**After fix:** 96.33% accuracy ✅

## Impact

- Enables DeepSeek-V3 inference on v0.13.0 with ROCM_AITER_TRITON_MLA backend
- No regression for other models or backends
- Minimal code change (inheritance fix only, 1 file changed, 2 insertions, 10 deletions)

## Related

- Original PR: #31816
- Target branch: `releases/v0.13.0`