### PR TITLE
[Bugfix][Backport][Hardware][AMD] Backport PR #31282 to v0.13.0: Fix last_page_len calculation in AITER MLA decode

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -93,7 +93,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             self.paged_kv_indices = torch.zeros(
                 max_num_pages, dtype=torch.int32, device=device
             )
-            self.paged_kv_last_page_len = torch.zeros(
+            self.paged_kv_last_page_len = torch.ones(
                 max_num_reqs, dtype=torch.int32, device=device
             )
 
@@ -147,7 +147,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             self.paged_kv_last_page_len[:num_reqs].copy_(
                 paged_kv_last_page_len, non_blocking=True
             )
-            self.paged_kv_last_page_len[num_reqs:].fill_(1)
+            # No need to fill with 1 - buffer is already initialized to 1s
             paged_kv_last_page_len = self.paged_kv_last_page_len[:num_reqs]
 
             qo_indptr = self.qo_indptr[: 1 + num_reqs]

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -86,15 +86,19 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # TODO: we can disambiguate between decode and mixed-prefill decode here
         # so we can only use the persistent buffer if a cudagraph is actually
         # being used.
+
+        # paged_kv_last_page_len is always 1s (kernel block size is always 1),
+        # so we create it once and reuse slices in both eager and cudagraph modes.
+        self.paged_kv_last_page_len = torch.ones(
+            max_num_reqs, dtype=torch.int32, device=device
+        )
+
         if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
             self.paged_kv_indptr = torch.zeros(
                 max_num_reqs + 1, dtype=torch.int32, device=device
             )
             self.paged_kv_indices = torch.zeros(
                 max_num_pages, dtype=torch.int32, device=device
-            )
-            self.paged_kv_last_page_len = torch.ones(
-                max_num_reqs, dtype=torch.int32, device=device
             )
 
             self.qo_indptr = torch.arange(
@@ -120,7 +124,9 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         ).unsqueeze(0) < seq_lens_device.unsqueeze(1)
         paged_kv_indices = block_table_tensor[mask]
 
-        paged_kv_last_page_len = torch.where(seq_lens_device == 0, 1, seq_lens_device)
+        # kernel block size is always 1, so each page has exactly 1 token.
+        # last_page_len is always 1 - just slice the pre-initialized buffer.
+        paged_kv_last_page_len = self.paged_kv_last_page_len[:num_reqs]
 
         paged_kv_indptr = torch.cat(
             [
@@ -144,11 +150,8 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             self.paged_kv_indptr[1 + num_reqs :].fill_(paged_kv_indptr[-1])
             paged_kv_indptr = self.paged_kv_indptr[: 1 + num_reqs]
 
-            self.paged_kv_last_page_len[:num_reqs].copy_(
-                paged_kv_last_page_len, non_blocking=True
-            )
-            # No need to fill with 1 - buffer is already initialized to 1s
-            paged_kv_last_page_len = self.paged_kv_last_page_len[:num_reqs]
+            # paged_kv_last_page_len already uses the pre-initialized buffer slice
+            # (set above), so no copy needed - buffer is always 1s.
 
             qo_indptr = self.qo_indptr[: 1 + num_reqs]
 


### PR DESCRIPTION
## Summary

Backport of #31282 to v0.13.0: Fixes incorrect `paged_kv_last_page_len` calculation in the ROCm AITER MLA decode path.

### The Bug

The AITER MLA kernel uses a block size of 1 (each page contains exactly 1 token). However, the `paged_kv_last_page_len` was incorrectly set to the full sequence length:

```python
# BEFORE (buggy):
paged_kv_last_page_len = torch.where(seq_lens_device == 0, 1, seq_lens_device)
```

For a sequence of 127 tokens, this would set `last_page_len=127`, telling the kernel the last page has 127 tokens when it only has 1.

### Impact

This bug could cause:
- Incorrect attention score calculations for sequences with non-standard lengths
- Potential out-of-bounds memory access in the MLA decode kernel
- Unpredictable behavior for sequences with prime-number lengths

### The Fix

Per @ganyi1996ppo's suggestion, the persistent buffer is now pre-initialized to 1s for efficiency:

```python
# In __init__:
self.paged_kv_last_page_len = torch.ones(
    max_num_reqs, dtype=torch.int32, device=device
)

# In _build_decode (cudagraph path):
# Just slice the pre-initialized buffer - no fill needed
paged_kv_last_page_len = self.paged_kv_last_page_len[:num_reqs]
```

### Comparison with Other Backends

The FlashInfer backend correctly computes `last_page_len` using modulo:
```python
paged_kv_last_page_len_np = seq_lens_np % page_size
```

For AITER MLA with `page_size=1`, this would always yield 0, which then becomes 1. Our fix directly initializes to 1, which is equivalent and more efficient.

## Test Plan
### MLA-Specific Validation (DeepSeek-V2-Lite)                                                                                                                                                                                
                                                                                                                                                                                                                                
  ```bash                                                                                                                                                                                                                       
  VLLM_USE_V1=1 python -c "                                                                                                                                                                                                   
  from vllm import LLM, SamplingParams                                                                                                                                                                                          
                                                                                                                                                                                                                                
  # DeepSeek-V2-Lite uses MLA architecture                                                                                                                                                                                      
  llm = LLM(                                                                                                                                                                                                                    
      model='deepseek-ai/DeepSeek-V2-Lite',                                                                                                                                                                                     
      max_model_len=512,                                                                                                                                                                                                        
      trust_remote_code=True                                                                                                                                                                                                    
  )                                                                                                                                                                                                                             
                                                                                                                                                                                                                                
  # Test with prime-number token counts (most likely to expose the bug)                                                                                                                                                         
  params = SamplingParams(max_tokens=127, temperature=0.0)                                                                                                                                                                    
  outputs = llm.generate(['Explain quantum computing.'], params)                                                                                                                                                                
  print(f'Generated {len(outputs[0].outputs[0].token_ids)} tokens')                                                                                                                                                             
  "        
```

### Test Criteria

No crash or hang during MLA decode
 Output is coherent (not garbage)
 Works with prime-number token counts (127, 131)
 Pre-commit CI passes
 DCO check passes

## Impact

- Fixes potential correctness issues in AITER MLA decode on v0.13.0
- Required for DeepSeek-V2/V3 models using MLA architecture on ROCm
- More efficient: pre-initialized buffer eliminates redundant fills
- 1 file changed, 12 insertions(+), 9 deletions(-)

## Related

- Original PR: #31282
- Target branch: `releases/v0.13.0`