### PR TITLE
Improve DCP error message to suggest `VLLM_ATTENTION_BACKEND` alternative

### DIFF
--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -32,7 +32,10 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "DCP requires attention impls to return"
                     " the softmax lse for decode, but the impl "
                     f"{layer_impl.__class__.__name__} "
-                    "does not return the softmax lse for decode."
+                    "does not return the softmax lse for decode. "
+                    "Try using a different attention backend by "
+                    "setting the VLLM_ATTENTION_BACKEND environment "
+                    "variable (e.g., VLLM_ATTENTION_BACKEND=FLASH_ATTN)."
                 )
 
             if pcp_size > 1:

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -35,7 +35,8 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "does not return the softmax lse for decode. "
                     "Try using a different attention backend by "
                     "setting the VLLM_ATTENTION_BACKEND environment "
-                    "variable (e.g., VLLM_ATTENTION_BACKEND=FLASH_ATTN)."
+                    "variable (e.g., VLLM_ATTENTION_BACKEND=FLASH_ATTN) "
+                    "or using the --attention-backend CLI argument."
                 )
 
             if pcp_size > 1:


### PR DESCRIPTION
## Summary

Fixes #28407

When a backend doesn't support DCP, the assertion error message is unhelpful — it tells the user what went wrong but not how to fix it.

This PR adds a suggestion to try a different attention backend by setting the `VLLM_ATTENTION_BACKEND` environment variable (e.g., `VLLM_ATTENTION_BACKEND=FLASH_ATTN`).

## Changes

- `vllm/v1/worker/cp_utils.py`: Added actionable suggestion to the DCP assertion error message

## Testing

- No behavioral change — only error message text updated
- Existing tests unaffected
