### PR TITLE
[ROCm][CI] Fix wvSplitKrc mock argument order in test_rocm_unquantized_gemm

### DIFF
--- a/tests/model_executor/layers/test_rocm_unquantized_gemm.py
+++ b/tests/model_executor/layers/test_rocm_unquantized_gemm.py
@@ -76,7 +76,7 @@ def test_rocm_unquantized_gemm_gfx950_wvsplitkrc_path(monkeypatch):
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx950", lambda: True)
     monkeypatch.setattr(utils, "num_compute_units", lambda: 120)
 
-    wvsplitkrc_mock = MagicMock(side_effect=lambda w, x_view, _, __: x_view @ w.t())
+    wvsplitkrc_mock = MagicMock(side_effect=lambda x_view, w, _, __: x_view @ w.t())
     monkeypatch.setattr(utils.ops, "wvSplitKrc", wvsplitkrc_mock)
     wvsplitk_mock = MagicMock(side_effect=lambda w, x_view, _, __: x_view @ w.t())
     monkeypatch.setattr(utils.ops, "wvSplitK", wvsplitk_mock)


### PR DESCRIPTION
Fixes `test_rocm_unquantized_gemm_gfx950_wvsplitkrc_path` which was failing due to a copy-paste error in the mock setup.

`wvSplitK` and `wvSplitKrc` have reversed argument conventions in their C++ implementations:
- `wvSplitK(in_a=weight, in_b=x, ...)` is weight first
- `wvSplitKrc(in_a=x, in_b=weight, ...)` is activations first

The mock for `wvSplitKrc` was copied from the `wvSplitK` mock with the same `lambda w, x_view, ...` parameter order. Since `utils.py` calls `ops.wvSplitKrc(x, weight, cu_count, bias)` (activations first), the mock was receiving arguments in the wrong order and returning `weight @ x.T` (shape `256×16`) instead of `x @ weight.T` (shape `16x256`), causing `torch.allclose` to fail.

## Fix

- `tests/model_executor/layers/test_rocm_unquantized_gemm.py`: swap lambda parameter order in `wvsplitkrc_mock` from
  `lambda w, x_view, _, __` to `lambda x_view, w, _, __`

## Test

- [x] `pytest -s -v model_executor/layers/test_rocm_unquantized_gemm.py::test_rocm_unquantized_gemm_gfx950_wvsplitkrc_path`

cc @kenroche 