### PR TITLE
[CI] Fix conch kernel crash on 3D input by reshaping to 2D before GEMM

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/conch.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/conch.py
@@ -134,8 +134,11 @@ class ConchLinearKernel(MPLinearKernel):
         if group_size == -1:
             group_size = x.shape[-1]
 
+        x_2d = x.reshape(-1, x.shape[-1])
+        out_shape = x.shape[:-1] + (self.config.partition_weight_shape[1],)
+
         output = mixed_precision_gemm(
-            x=x,
+            x=x_2d,
             w_q_packed=w_q.data,
             w_s=w_s.data,
             w_zp=w_zp.data if w_zp is not None else None,
@@ -147,4 +150,4 @@ class ConchLinearKernel(MPLinearKernel):
         if bias is not None:
             output.add_(bias)  # In-place add
 
-        return output
+        return output.reshape(out_shape)


### PR DESCRIPTION
When running quantized models (e.g. AWQ) through the transformers backend, the conch kernel crashes with:

ValueError: too many values to unpack (expected 2)
at `conch/ops/quantization/gemm.py:86`:
```python
m_dim, k_dim = x.shape
```

The transformers backend passes 3D tensors (batch, seq_len, hidden_dim) through linear layers, but mixed_precision_gemm expects a 2D input (M, K).

### Fix

Reshape x to 2D before calling mixed_precision_gemm and reshape the output back to match the original batch dimensions. This matches the existing pattern used by the machete kernel.

Test

- [x] `pytest tests/models/test_transformers.py::test_quantization -v`

cc @kenroche 