### PR TITLE
[Frontend][Bugfix] Fix double BOS token in Responses API for models with add_bos_token

### DIFF
--- a/tests/entrypoints/openai/responses/test_sampling_params.py
+++ b/tests/entrypoints/openai/responses/test_sampling_params.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Unit tests for ResponsesRequest.to_sampling_params() parameter mapping."""
+"""Unit tests for ResponsesRequest.to_sampling_params() and
+ResponsesRequest.build_tok_params() parameter mapping."""
+
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -154,3 +157,52 @@ class TestResponsesRequestSamplingParams:
         assert "Cannot specify both structured_outputs and text.format" in str(
             exc_info.value
         )
+
+
+class TestResponsesRequestTokParams:
+    """Test that ResponsesRequest correctly builds TokenizeParams."""
+
+    def test_add_special_tokens_false(self):
+        """add_special_tokens must be False to avoid double BOS on models
+        whose chat template already includes a BOS token."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="test input",
+        )
+        model_config = SimpleNamespace(max_model_len=4096)
+        tok_params = request.build_tok_params(model_config)
+        assert tok_params.add_special_tokens is False
+
+    def test_truncation_disabled(self):
+        """truncate_prompt_tokens should be None when truncation is disabled."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="test input",
+            truncation="disabled",
+        )
+        model_config = SimpleNamespace(max_model_len=4096)
+        tok_params = request.build_tok_params(model_config)
+        assert tok_params.truncate_prompt_tokens is None
+
+    def test_truncation_auto(self):
+        """truncate_prompt_tokens should be -1 when truncation is auto."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="test input",
+            truncation="auto",
+        )
+        model_config = SimpleNamespace(max_model_len=4096)
+        tok_params = request.build_tok_params(model_config)
+        assert tok_params.truncate_prompt_tokens == -1
+
+    def test_max_output_tokens(self):
+        """max_output_tokens is correctly passed through."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="test input",
+            max_output_tokens=512,
+        )
+        model_config = SimpleNamespace(max_model_len=4096)
+        tok_params = request.build_tok_params(model_config)
+        assert tok_params.max_total_tokens == 4096
+        assert tok_params.max_output_tokens == 512

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -291,6 +291,7 @@ class ResponsesRequest(OpenAIBaseModel):
             max_total_tokens=model_config.max_model_len,
             max_output_tokens=self.max_output_tokens or 0,
             truncate_prompt_tokens=-1 if self.truncation != "disabled" else None,
+            add_special_tokens=False,
             max_total_tokens_param="max_model_len",
             max_output_tokens_param="max_output_tokens",
         )


### PR DESCRIPTION



## Purpose

Fix double BOS token issue in the Responses API for models whose chat template
already includes a BOS token (e.g., DeepSeek).

`ChatCompletionRequest.build_tok_params()` sets `add_special_tokens=False`,
but `ResponsesRequest.build_tok_params()` did not specify this parameter,
defaulting to `TokenizeParams.add_special_tokens=True`. This caused the
tokenizer to prepend an additional BOS token on top of the one already present
in the chat template output.

## Test Plan

pytest tests/entrypoints/openai/responses/test_sampling_params.py -v -k "TokParams"

## Test Result

4 passed:
- test_add_special_tokens_false PASSED
- test_truncation_disabled PASSED
- test_truncation_auto PASSED
- test_max_output_tokens PASSED

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] (Optional) The necessary documentation update
- [ ] (Optional) Release notes update
</details>

