### PR TITLE
[responsesAPI] output failed event.

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -877,3 +877,63 @@ class TestStreamingReasoningToContentTransition:
         ]
         assert len(item_done_events) == 1
         assert isinstance(item_done_events[0].item, ResponseReasoningItem)
+
+
+class TestResponseFailedEventOnStreamingError:
+    """Tests that unexpected exceptions during streaming emit a
+    response.failed event instead of silently dropping the connection."""
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_emits_response_failed(self, monkeypatch):
+        """When _process_simple_streaming_events raises an unexpected
+        exception, responses_stream_generator should catch it and yield
+        a ResponseFailedEvent with status='failed'."""
+
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_with_reasoning()
+
+        # Make _process_simple_streaming_events raise a ValueError
+        async def _exploding_processor(*args, **kwargs):
+            raise ValueError("SimpleContext only supports 5 outputs.")
+            # Make it a generator
+            yield  # pragma: no cover
+
+        monkeypatch.setattr(
+            serving,
+            "_process_simple_streaming_events",
+            _exploding_processor,
+        )
+
+        async def result_generator():
+            yield None
+
+        request = ResponsesRequest(input="hi", tools=[], stream=True)
+        sampling_params = SamplingParams(max_tokens=64)
+        metadata = RequestResponseMetadata(request_id="req")
+
+        events = []
+        async for event in serving.responses_stream_generator(
+            request=request,
+            sampling_params=sampling_params,
+            result_generator=result_generator(),
+            context=SimpleContext(),
+            model_name="test-model",
+            tokenizer=MagicMock(),
+            request_metadata=metadata,
+            created_time=0,
+        ):
+            events.append(event)
+
+        event_types = [e.type for e in events]
+
+        # Must start with created + in_progress
+        assert event_types[0] == "response.created"
+        assert event_types[1] == "response.in_progress"
+
+        # Must end with response.failed (not response.completed)
+        assert event_types[-1] == "response.failed"
+        assert events[-1].response.status == "failed"
+        assert events[-1].response.error is not None
+        assert "SimpleContext only supports 5 outputs" in (
+            events[-1].response.error.message
+        )

--- a/vllm/entrypoints/openai/responses/api_router.py
+++ b/vllm/entrypoints/openai/responses/api_router.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponseFailedEvent,
     ResponsesRequest,
     ResponsesResponse,
     StreamingResponsesResponse,
@@ -63,9 +64,11 @@ async def create_responses(request: ResponsesRequest, raw_request: Request):
 
     generator = await handler.create_responses(request, raw_request)
 
-    if isinstance(generator, ErrorResponse):
+    if isinstance(generator, ResponseFailedEvent):
         return JSONResponse(
-            content=generator.model_dump(), status_code=generator.error.code
+            # model_dump_json is more forgiving if the response does not have required fields
+            content=generator.model_dump_json(indent=None),
+            status_code=500,  # TODO
         )
     elif isinstance(generator, ResponsesResponse):
         return JSONResponse(content=generator.model_dump())
@@ -93,9 +96,11 @@ async def retrieve_responses(
         stream=stream,
     )
 
-    if isinstance(response, ErrorResponse):
+    if isinstance(response, ResponseFailedEvent):
         return JSONResponse(
-            content=response.model_dump(), status_code=response.error.code
+            # model_dump_json is more forgiving if the response
+            content=response.model_dump_json(indent=None),
+            status_code=500,  # TODO
         )
     elif isinstance(response, ResponsesResponse):
         return JSONResponse(content=response.model_dump())

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -183,9 +183,14 @@ class SimpleContext(ConversationContext):
 
         self.input_messages: list[ResponseRawMessageAndToken] = []
         self.kv_transfer_params: dict[str, Any] | None = None
+        self.lol = 0
 
     def append_output(self, output) -> None:
         self.last_output = output
+        self.lol += 1
+        if self.lol > 5:
+            raise ValueError("SimpleContext only supports 5 outputs.")
+
         if not isinstance(output, RequestOutput):
             raise ValueError("SimpleContext only supports RequestOutput.")
         self.num_prompt_tokens = len(output.prompt_token_ids or [])

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -183,14 +183,9 @@ class SimpleContext(ConversationContext):
 
         self.input_messages: list[ResponseRawMessageAndToken] = []
         self.kv_transfer_params: dict[str, Any] | None = None
-        self.lol = 0
 
     def append_output(self, output) -> None:
         self.last_output = output
-        self.lol += 1
-        if self.lol > 5:
-            raise ValueError("SimpleContext only supports 5 outputs.")
-
         if not isinstance(output, RequestOutput):
             raise ValueError("SimpleContext only supports RequestOutput.")
         self.num_prompt_tokens = len(output.prompt_token_ids or [])

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -37,9 +37,16 @@ from openai.types.responses import (
 )
 from openai.types.responses import ResponseCreatedEvent as OpenAIResponseCreatedEvent
 from openai.types.responses import (
+    ResponseFailedEvent as OpenAIResponseFailedEvent,
+)
+from openai.types.responses import (
     ResponseInProgressEvent as OpenAIResponseInProgressEvent,
 )
-from openai.types.responses.response import IncompleteDetails, ToolChoice
+from openai.types.responses.response import (
+    IncompleteDetails,
+    ResponseError,
+    ToolChoice,
+)
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
 )
@@ -470,7 +477,7 @@ class ResponsesRequest(OpenAIBaseModel):
 class ResponsesResponse(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"resp_{random_uuid()}")
     created_at: int = Field(default_factory=lambda: int(time.time()))
-    # error: Optional[ResponseError] = None
+    error: ResponseError | None = None
     incomplete_details: IncompleteDetails | None = None
     instructions: str | None = None
     metadata: Metadata | None = None
@@ -545,6 +552,7 @@ class ResponsesResponse(OpenAIBaseModel):
         input_messages: ResponseInputOutputMessage | None = None,
         output_messages: ResponseInputOutputMessage | None = None,
         kv_transfer_params: dict[str, Any] | None = None,
+        error: ResponseError | None = None,
     ) -> "ResponsesResponse":
         incomplete_details: IncompleteDetails | None = None
         if status == "incomplete":
@@ -581,6 +589,7 @@ class ResponsesResponse(OpenAIBaseModel):
             user=request.user,
             usage=usage,
             kv_transfer_params=kv_transfer_params,
+            error=error,
         )
 
 
@@ -642,9 +651,14 @@ class ResponseInProgressEvent(OpenAIResponseInProgressEvent):
     response: ResponsesResponse  # type: ignore[override]
 
 
+class ResponseFailedEvent(OpenAIResponseFailedEvent):
+    response: ResponsesResponse  # type: ignore[override]
+
+
 StreamingResponsesResponse: TypeAlias = (
     ResponseCreatedEvent
     | ResponseInProgressEvent
+    | ResponseFailedEvent
     | ResponseCompletedEvent
     | ResponseOutputItemAddedEvent
     | ResponseOutputItemDoneEvent

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -32,6 +32,7 @@ from openai.types.responses import (
     ResponseTextDoneEvent,
     response_text_delta_event,
 )
+from openai.types.responses.response import ResponseError
 from openai.types.responses.response_output_text import Logprob, LogprobTopLogprob
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
@@ -86,6 +87,7 @@ from vllm.entrypoints.openai.responses.protocol import (
     OutputTokensDetails,
     ResponseCompletedEvent,
     ResponseCreatedEvent,
+    ResponseFailedEvent,
     ResponseInProgressEvent,
     ResponseInputOutputItem,
     ResponseInputOutputMessage,
@@ -496,6 +498,47 @@ class OpenAIServingResponses(OpenAIServing):
         if request.store:
             self.msg_store[request.request_id] = messages
 
+        try:
+            return await self._create_response_with_result_generator(
+                request,
+                result_generator,
+                sampling_params=sampling_params,
+                context=context,
+                model_name=model_name,
+                tokenizer=tokenizer,
+                request_metadata=request_metadata,
+            )
+        except Exception as e:
+            logger.exception(
+                "Failed to create response for request %s", request.request_id
+            )
+            created_time = int(time.time())
+            failed_response = ResponsesResponse.from_request(
+                request,
+                sampling_params,
+                model_name=model_name,
+                created_time=created_time,
+                output=[],
+                status="failed",
+                usage=None,
+                error=ResponseError(
+                    code="server_error",
+                    message=str(e),
+                ),
+            )
+            return failed_response
+
+    async def _create_response_with_result_generator(
+        self,
+        request: ResponsesRequest,
+        result_generator: AsyncGenerator[ConversationContext, None],
+        *,
+        sampling_params: SamplingParams,
+        context: ConversationContext,
+        model_name: str,
+        tokenizer: Any,
+        request_metadata: RequestResponseMetadata,
+    ) -> AsyncGenerator[StreamingResponsesResponse, None] | ResponsesResponse:
         if request.background:
             created_time = int(time.time())
             response = ResponsesResponse.from_request(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -548,6 +548,7 @@ class OpenAIServingResponses(OpenAIServing):
             return ResponseFailedEvent(
                 response=failed_response,
                 type="response.failed",
+                sequence_number=0,
             )
 
     async def _create_response_with_result_generator(
@@ -2076,6 +2077,29 @@ class OpenAIServingResponses(OpenAIServing):
                 error_json = self._convert_generation_error_to_streaming_response(e)
                 yield _increment_sequence_number_and_return(
                     TypeAdapter(StreamingResponsesResponse).validate_json(error_json)
+                )
+                return
+            except Exception as e:
+                logger.exception("Error in responses stream generator.")
+                failed_response = ResponsesResponse.from_request(
+                    request,
+                    sampling_params,
+                    model_name=model_name,
+                    created_time=created_time,
+                    output=[],
+                    status="failed",
+                    usage=None,
+                    error=ResponseError(
+                        code="server_error",
+                        message=str(e),
+                    ),
+                )
+                yield _increment_sequence_number_and_return(
+                    ResponseFailedEvent(
+                        type="response.failed",
+                        sequence_number=-1,
+                        response=failed_response,
+                    )
                 )
                 return
 

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -332,6 +332,7 @@ class OpenAIServingResponses(OpenAIServing):
     ) -> (
         AsyncGenerator[StreamingResponsesResponse, None]
         | ResponsesResponse
+        | ResponseFailedEvent
         | ErrorResponse
     ):
         error_check_ret = await self._check_model(request)
@@ -513,6 +514,22 @@ class OpenAIServingResponses(OpenAIServing):
                 "Failed to create response for request %s", request.request_id
             )
             created_time = int(time.time())
+
+            # Best-effort extraction of input/output messages
+            # for debugging. Context may be partially populated.
+            input_messages: ResponseInputOutputMessage | None = None
+            output_messages: ResponseInputOutputMessage | None = None
+            if request.enable_response_messages:
+                try:
+                    if isinstance(context, HarmonyContext):
+                        input_messages = context.messages[: context.num_init_messages]
+                        output_messages = context.messages[context.num_init_messages :]
+                    elif hasattr(context, "input_messages"):
+                        input_messages = context.input_messages
+                        output_messages = context.output_messages
+                except Exception:
+                    pass
+
             failed_response = ResponsesResponse.from_request(
                 request,
                 sampling_params,
@@ -525,8 +542,13 @@ class OpenAIServingResponses(OpenAIServing):
                     code="server_error",
                     message=str(e),
                 ),
+                input_messages=input_messages,
+                output_messages=output_messages,
             )
-            return failed_response
+            return ResponseFailedEvent(
+                response=failed_response,
+                type="response.failed",
+            )
 
     async def _create_response_with_result_generator(
         self,
@@ -803,6 +825,7 @@ class OpenAIServingResponses(OpenAIServing):
         # we guarantee that if the status is not "completed", it is accurate.
         # "completed" is implemented as the "catch-all" for now.
         status: ResponseStatus = "completed"
+        raise NotImplementedError("LOL")
 
         input_messages: ResponseInputOutputMessage | None = None
         output_messages: ResponseInputOutputMessage | None = None

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -555,8 +555,8 @@ class OpenAIServingResponses(OpenAIServing):
         self,
         request: ResponsesRequest,
         result_generator: AsyncGenerator[ConversationContext, None],
-        *,
         sampling_params: SamplingParams,
+        *,
         context: ConversationContext,
         model_name: str,
         tokenizer: Any,
@@ -826,7 +826,6 @@ class OpenAIServingResponses(OpenAIServing):
         # we guarantee that if the status is not "completed", it is accurate.
         # "completed" is implemented as the "catch-all" for now.
         status: ResponseStatus = "completed"
-        raise NotImplementedError("LOL")
 
         input_messages: ResponseInputOutputMessage | None = None
         output_messages: ResponseInputOutputMessage | None = None


### PR DESCRIPTION
## Purpose
If we get a failure, we should still output `ResponseFailedEvent`. This can contain raw tokens which makes debugging much easier.

## Test Plan

## Test Result
```
vllm serve Qwen/Qwen3-8B   --reasoning-parser qwen3   --tool-call-parser qwen3
```

```
[axia@devgpu011.zas1 ~]$  curl -X POST "http://localhost:8000/v1/responses"   -H "Content-Type: application/json"   -H "Authorization: Bearer dummy-api-key"
 -d '{
        "model": "Qwen/Qwen3-8B",
        "input": "Hello.", "stream": true, "enable_response_messages": true
      }'
event: response.created
data: {"response":{"id":"resp_a0b955d49500d526","created_at":1774499326,"error":null,"incomplete_details":null,"instructions":null,"metadata":null,"model":"Qw
en/Qwen3-8B","object":"response","output":[],"parallel_tool_calls":true,"temperature":0.6,"tool_choice":"auto","tools":[],"top_p":0.95,"background":false,"max
_output_tokens":40950,"max_tool_calls":null,"previous_response_id":null,"prompt":null,"reasoning":null,"service_tier":"auto","status":"in_progress","text":nul
l,"top_logprobs":null,"truncation":"disabled","usage":null,"user":null,"kv_transfer_params":null,"input_messages":null,"output_messages":null},"sequence_numbe
r":0,"type":"response.created"}

event: response.in_progress
data: {"response":{"id":"resp_a0b955d49500d526","created_at":1774499326,"error":null,"incomplete_details":null,"instructions":null,"metadata":null,"model":"Qw
en/Qwen3-8B","object":"response","output":[],"parallel_tool_calls":true,"temperature":0.6,"tool_choice":"auto","tools":[],"top_p":0.95,"background":false,"max
_output_tokens":40950,"max_tool_calls":null,"previous_response_id":null,"prompt":null,"reasoning":null,"service_tier":"auto","status":"in_progress","text":nul
l,"top_logprobs":null,"truncation":"disabled","usage":null,"user":null,"kv_transfer_params":null,"input_messages":null,"output_messages":null},"sequence_numbe
r":1,"type":"response.in_progress"}

event: response.output_item.added
data: {"item":{"id":"a7646b3f105fb76b","summary":[],"type":"reasoning","content":null,"encrypted_content":null,"status":"in_progress"},"output_index":0,"seque
nce_number":2,"type":"response.output_item.added"}

event: response.reasoning_part.added
data: {"content_index":0,"item_id":"a7646b3f105fb76b","output_index":0,"part":{"text":"","type":"reasoning_text"},"sequence_number":3,"type":"response.reasoni
ng_part.added"}

event: response.reasoning_text.delta
data: {"content_index":0,"delta":"\n","item_id":"a7646b3f105fb76b","output_index":0,"sequence_number":4,"type":"response.reasoning_text.delta"}

event: response.reasoning_text.delta
data: {"content_index":0,"delta":"Okay,","item_id":"a7646b3f105fb76b","output_index":0,"sequence_number":5,"type":"response.reasoning_text.delta"}

event: response.reasoning_text.delta
data: {"content_index":0,"delta":" the","item_id":"a7646b3f105fb76b","output_index":0,"sequence_number":6,"type":"response.reasoning_text.delta"}

event: response.reasoning_text.delta
data: {"content_index":0,"delta":" user","item_id":"a7646b3f105fb76b","output_index":0,"sequence_number":7,"type":"response.reasoning_text.delta"}

event: response.failed
data: {"response":{"id":"resp_a0b955d49500d526","created_at":1774499326,"error":{"code":"server_error","message":"SimpleContext only supports 5 outputs."},"in
complete_details":null,"instructions":null,"metadata":null,"model":"Qwen/Qwen3-8B","object":"response","output":[],"parallel_tool_calls":true,"temperature":0.
6,"tool_choice":"auto","tools":[],"top_p":0.95,"background":false,"max_output_tokens":40950,"max_tool_calls":null,"previous_response_id":null,"prompt":null,"r
easoning":null,"service_tier":"auto","status":"failed","text":null,"top_logprobs":null,"truncation":"disabled","usage":null,"user":null,"kv_transfer_params":n
ull,"input_messages":["{\"message\":\"<|im_start|>user\\nHello.<|im_end|>\\n<|im_start|>assistant\\n\",\"tokens\":[151644,872,198,9707,13,151645,198,151644,77
091,198],\"type\":\"raw_message_tokens\"}"],"output_messages":["{\"message\":\"<think>\\nOkay, the user\",\"tokens\":[151667,198,32313,11,279,1196],\"type\":\
"raw_message_tokens\"}"]},"sequence_number":8,"type":"response.failed"}
```
