### PR TITLE
[Feature]: fused RMSNorm + fp8 block quantized kernel in Helion

### DIFF
--- a/tests/kernels/helion/test_rms_norm_fp8_block_quant.py
+++ b/tests/kernels/helion/test_rms_norm_fp8_block_quant.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    pytest.skip(
+        "Helion is not installed. Install with: pip install vllm[helion]",
+        allow_module_level=True,
+    )
+
+from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.ops.rms_norm_fp8_block_quant import (
+    pick_rms_norm_fp8_block_quant_config,
+    rms_norm_fp8_block_quant,
+    rms_norm_fp8_block_quant_baseline,
+)
+
+
+def skip_if_platform_unsupported():
+    try:
+        from vllm.kernels.helion.utils import get_canonical_gpu_name
+
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        platform = get_canonical_gpu_name()
+
+        try:
+            config_manager = ConfigManager.get_instance()
+        except RuntimeError:
+            config_manager = ConfigManager()
+
+        configs = config_manager.get_platform_configs(
+            "rms_norm_fp8_block_quant", platform
+        )
+        if len(configs) == 0:
+            pytest.skip(
+                "Current GPU platform not supported for "
+                "rms_norm_fp8_block_quant kernel"
+            )
+
+    except (ImportError, RuntimeError, KeyError):
+        pytest.skip(
+            "Error detecting platform support for rms_norm_fp8_block_quant kernel"
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_config_manager_singleton():
+    ConfigManager.reset_instance()
+    ConfigManager()
+    yield
+    ConfigManager.reset_instance()
+
+
+class TestRmsNormFp8BlockQuantConfigPicker:
+    def test_config_picker_exact_match(self):
+        config_keys = [
+            "hidden_4096_numtokens_32_groupsize_128",
+            "hidden_8192_numtokens_32_groupsize_128",
+        ]
+        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cpu")
+        weight = torch.ones(4096, dtype=torch.bfloat16, device="cpu")
+        args = (input_tensor, weight, 128, 1e-6)
+
+        selected = pick_rms_norm_fp8_block_quant_config(args, config_keys)
+        assert selected == "hidden_4096_numtokens_32_groupsize_128"
+
+    def test_config_picker_closest_hidden_size(self):
+        config_keys = [
+            "hidden_4096_numtokens_32_groupsize_128",
+            "hidden_8192_numtokens_32_groupsize_128",
+        ]
+        # hidden_size=7000, closer to 8192 (diff=1192) than 4096 (diff=2904)
+        input_tensor = torch.randn(32, 7000, dtype=torch.bfloat16, device="cpu")
+        weight = torch.ones(7000, dtype=torch.bfloat16, device="cpu")
+        args = (input_tensor, weight, 128, 1e-6)
+
+        selected = pick_rms_norm_fp8_block_quant_config(args, config_keys)
+        assert selected == "hidden_8192_numtokens_32_groupsize_128"
+
+    def test_config_picker_numtokens_ceiling(self):
+        config_keys = [
+            "hidden_4096_numtokens_8_groupsize_128",
+            "hidden_4096_numtokens_32_groupsize_128",
+            "hidden_4096_numtokens_128_groupsize_128",
+        ]
+        # 20 tokens -> should pick 32 (smallest >= 20)
+        input_tensor = torch.randn(20, 4096, dtype=torch.bfloat16, device="cpu")
+        weight = torch.ones(4096, dtype=torch.bfloat16, device="cpu")
+        args = (input_tensor, weight, 128, 1e-6)
+
+        selected = pick_rms_norm_fp8_block_quant_config(args, config_keys)
+        assert selected == "hidden_4096_numtokens_32_groupsize_128"
+
+    def test_config_picker_numtokens_fallback_to_largest(self):
+        config_keys = [
+            "hidden_4096_numtokens_8_groupsize_128",
+            "hidden_4096_numtokens_32_groupsize_128",
+            "hidden_4096_numtokens_128_groupsize_128",
+        ]
+        # 512 tokens -> exceeds all, pick largest (128)
+        input_tensor = torch.randn(512, 4096, dtype=torch.bfloat16, device="cpu")
+        weight = torch.ones(4096, dtype=torch.bfloat16, device="cpu")
+        args = (input_tensor, weight, 128, 1e-6)
+
+        selected = pick_rms_norm_fp8_block_quant_config(args, config_keys)
+        assert selected == "hidden_4096_numtokens_128_groupsize_128"
+
+    def test_config_picker_fallback_to_default(self):
+        config_keys = ["default"]
+        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cpu")
+        weight = torch.ones(4096, dtype=torch.bfloat16, device="cpu")
+        args = (input_tensor, weight, 128, 1e-6)
+
+        selected = pick_rms_norm_fp8_block_quant_config(args, config_keys)
+        assert selected == "default"
+
+    def test_config_picker_no_configs(self):
+        config_keys: list[str] = []
+        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cpu")
+        weight = torch.ones(4096, dtype=torch.bfloat16, device="cpu")
+        args = (input_tensor, weight, 128, 1e-6)
+
+        selected = pick_rms_norm_fp8_block_quant_config(args, config_keys)
+        assert selected is None
+
+    def test_config_picker_malformed_key_raises(self):
+        config_keys = ["hidden_4096_badformat_128"]
+        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cpu")
+        weight = torch.ones(4096, dtype=torch.bfloat16, device="cpu")
+        args = (input_tensor, weight, 128, 1e-6)
+
+        with pytest.raises(ValueError, match="Malformed config key"):
+            pick_rms_norm_fp8_block_quant_config(args, config_keys)
+
+
+class TestRmsNormFp8BlockQuantCorrectness:
+    @pytest.mark.parametrize("num_tokens", [1, 8, 32, 128])
+    @pytest.mark.parametrize("hidden_size", [2048, 4096, 8192])
+    @pytest.mark.parametrize("group_size", [128])
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_correctness(self, num_tokens, hidden_size, group_size, dtype):
+        skip_if_platform_unsupported()
+
+        input_tensor = torch.randn(
+            num_tokens, hidden_size, dtype=dtype, device="cuda"
+        )
+        weight = torch.ones(hidden_size, dtype=dtype, device="cuda")
+
+        ref_out, ref_scales = rms_norm_fp8_block_quant_baseline(
+            input_tensor, weight, group_size, 1e-6
+        )
+        helion_out, helion_scales = rms_norm_fp8_block_quant(
+            input_tensor, weight, group_size, 1e-6
+        )
+
+        assert helion_out.shape == ref_out.shape
+        assert helion_out.dtype == torch.float8_e4m3fn
+        assert helion_scales.shape == ref_scales.shape
+
+        torch.testing.assert_close(
+            helion_scales, ref_scales, atol=1e-4, rtol=1e-4,
+            msg=f"Scale mismatch at tokens={num_tokens}, hidden={hidden_size}",
+        )
+        torch.testing.assert_close(
+            helion_out.to(torch.float32),
+            ref_out.to(torch.float32),
+            atol=0.05, rtol=0.05,
+            msg=f"Output mismatch at tokens={num_tokens}, hidden={hidden_size}",
+        )
+
+    def test_output_shape(self):
+        skip_if_platform_unsupported()
+
+        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cuda")
+        weight = torch.ones(4096, dtype=torch.bfloat16, device="cuda")
+
+        out, scales = rms_norm_fp8_block_quant(input_tensor, weight, 128, 1e-6)
+
+        assert out.shape == (32, 4096)
+        assert scales.shape == (32, 32)  # 4096 // 128 = 32 groups
+        assert out.dtype == torch.float8_e4m3fn
+        assert scales.dtype == torch.float32
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (1, 4096),
+            (16, 4096),
+            (128, 4096),
+            (1, 8192),
+            (16, 8192),
+        ],
+    )
+    def test_various_shapes(self, shape):
+        skip_if_platform_unsupported()
+
+        input_tensor = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
+        weight = torch.ones(shape[-1], dtype=torch.bfloat16, device="cuda")
+
+        out, scales = rms_norm_fp8_block_quant(input_tensor, weight, 128, 1e-6)
+
+        assert out.shape == shape
+        assert scales.shape == (shape[0], shape[1] // 128)
+
+
+class TestRmsNormFp8BlockQuantIntegration:
+    def test_kernel_registration(self):
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered = get_registered_kernels()
+        assert "rms_norm_fp8_block_quant" in registered
+
+        wrapper = registered["rms_norm_fp8_block_quant"]
+        assert wrapper.op_name == "rms_norm_fp8_block_quant"
+        assert wrapper._config_picker is not None
+
+    def test_input_generator(self):
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered = get_registered_kernels()
+        wrapper = registered["rms_norm_fp8_block_quant"]
+        inputs = wrapper.get_inputs()
+
+        assert len(inputs) > 0
+        for key, args in inputs.items():
+            assert len(args) == 4  # input, weight, group_size, epsilon

--- a/vllm/kernels/helion/ops/rms_norm_fp8_block_quant.py
+++ b/vllm/kernels/helion/ops/rms_norm_fp8_block_quant.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import regex as re
+import torch
+
+from vllm.logger import init_logger
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    raise ImportError(
+        "rms_norm_fp8_block_quant Helion kernel requires helion to be installed. "
+        "Install it with: pip install helion"
+    )
+
+import helion.language as hl
+
+from vllm.kernels.helion.register import register_kernel
+
+logger = init_logger(__name__)
+
+
+def generate_rms_norm_fp8_block_quant_inputs() -> dict[str, tuple[Any, ...]]:
+    hidden_sizes = [2048, 4096, 8192, 14336]
+    num_tokens_list = [1, 2, 4] + list(range(8, 256, 8)) + list(range(256, 513, 16))
+    group_sizes = [128]
+
+    inputs = {}
+    for num_tokens in num_tokens_list:
+        for hidden_size in hidden_sizes:
+            for group_size in group_sizes:
+                input_tensor = torch.randn(
+                    num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16
+                )
+                weight = torch.ones(
+                    hidden_size, device="cuda", dtype=torch.bfloat16
+                )
+                config_key = (
+                    f"hidden_{hidden_size}_numtokens_{num_tokens}"
+                    f"_groupsize_{group_size}"
+                )
+                inputs[config_key] = (input_tensor, weight, group_size, 1e-6)
+
+    return inputs
+
+
+def pick_rms_norm_fp8_block_quant_config(
+    args: tuple[Any, ...], config_keys: list[str]
+) -> str | None:
+    """Pick the best pre-tuned config for the given input shape.
+
+    Selection strategy:
+      1. Find the closest hidden_size + group_size combination.
+      2. Among available num_tokens, pick the smallest >= input num_tokens.
+         Fall back to the largest if input exceeds all available.
+
+    Config keys must be "default" or follow the format
+    "hidden_{int}_numtokens_{int}_groupsize_{int}".
+    """
+    if not config_keys:
+        return None
+
+    input_tensor, _weight, group_size, _eps = args
+    input_2d = input_tensor.view(-1, input_tensor.shape[-1])
+    num_tokens = input_2d.shape[0]
+    hidden_size = input_2d.shape[1]
+
+    configs: dict[tuple[int, int], list[int]] = {}
+    for key in config_keys:
+        if key == "default":
+            continue
+        match = re.fullmatch(
+            r"hidden_(\d+)_numtokens_(\d+)_groupsize_(\d+)", key
+        )
+        if not match:
+            raise ValueError(
+                f"Malformed config key '{key}', "
+                f"expected format "
+                f"'hidden_{{int}}_numtokens_{{int}}_groupsize_{{int}}'"
+            )
+        h, nt, gs = int(match.group(1)), int(match.group(2)), int(match.group(3))
+        configs.setdefault((h, gs), []).append(nt)
+
+    if not configs:
+        return "default" if "default" in config_keys else None
+
+    best_key = min(
+        configs,
+        key=lambda k: (abs(k[0] - hidden_size), abs(k[1] - group_size)),
+    )
+    available_ntokens = sorted(configs[best_key])
+    best_ntokens = next(
+        (n for n in available_ntokens if n >= num_tokens), available_ntokens[-1]
+    )
+
+    return (
+        f"hidden_{best_key[0]}_numtokens_{best_ntokens}_groupsize_{best_key[1]}"
+    )
+
+
+@register_kernel(
+    config_picker=pick_rms_norm_fp8_block_quant_config,
+    input_generator=generate_rms_norm_fp8_block_quant_inputs,
+)
+def rms_norm_fp8_block_quant(
+    input: torch.Tensor,   # [..., hidden_size]
+    weight: torch.Tensor,  # [hidden_size]
+    group_size: int,
+    epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused RMSNorm + fp8 block (group) quantization Helion kernel.
+
+    Computes RMSNorm then dynamically quantizes the output into fp8 using
+    per-group (block) scaling. Scales are computed dynamically inside the
+    kernel — no pre-computed scale is needed.
+
+    Args:
+        input:      Input tensor of shape [..., hidden_size]
+        weight:     RMSNorm weight of shape [hidden_size]
+        group_size: Number of elements per quantization group (e.g. 128)
+        epsilon:    Variance epsilon for numerical stability
+
+    Returns:
+        out:    fp8-quantized output, same shape as input
+        scales: Per-group scales, shape [num_tokens, hidden_size // group_size]
+    """
+    input_2d = input.view(-1, input.shape[-1])
+    num_tokens = input_2d.shape[0]
+    hidden_size = hl.specialize(input_2d.shape[1])
+    num_groups = hidden_size // group_size
+
+    out = torch.empty(
+        (num_tokens, hidden_size),
+        device=input.device,
+        dtype=torch.float8_e4m3fn,
+    )
+    scales = torch.empty(
+        (num_tokens, num_groups),
+        device=input.device,
+        dtype=torch.float32,
+    )
+
+    fp8_max: float = 448.0
+
+    for tile_m in hl.tile([num_tokens]):
+        # Step 1: RMSNorm
+        row_f32 = input_2d[tile_m, :].to(torch.float32)
+        variance = (row_f32 * row_f32).mean(dim=-1, keepdim=True)
+        rms = torch.rsqrt(variance + epsilon)
+        normed = row_f32 * rms * weight.to(torch.float32)  # [tile_m, hidden_size]
+
+        # Step 2: dynamic per-group fp8 quantization
+        normed_groups = normed.reshape(-1, num_groups, group_size)
+
+        amax = normed_groups.abs().amax(dim=-1)             # [tile_m, num_groups]
+        group_scale = torch.clamp(amax / fp8_max, min=1e-12)
+
+        scales[tile_m, :] = group_scale
+
+        inv_scale = (1.0 / group_scale).unsqueeze(-1)       # [tile_m, num_groups, 1]
+        quantized = (normed_groups * inv_scale).clamp(-fp8_max, fp8_max)
+        out[tile_m, :] = quantized.reshape(-1, hidden_size).to(torch.float8_e4m3fn)
+
+    return out.view(input.shape), scales
+
+
+def rms_norm_fp8_block_quant_baseline(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    group_size: int,
+    epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Baseline using the existing vLLM CUDA kernel for correctness comparison."""
+    from vllm import _custom_ops as ops
+
+    hidden_size = input.shape[-1]
+    num_tokens = input.numel() // hidden_size
+    num_groups = hidden_size // group_size
+
+    out = torch.empty(input.shape, device=input.device, dtype=torch.float8_e4m3fn)
+    scales = torch.empty(
+        (num_tokens, num_groups), device=input.device, dtype=torch.float32
+    )
+    ops.rms_norm_per_block_quant(
+        out, input, weight, scales, epsilon, None, None, group_size, False
+    )
+    return out, scales


### PR DESCRIPTION



## Purpose
add a fused RMSNorm + fp8 block (group) quantization kernel in Helion as a portable alternative to the existing CUDA kernel (`rms_norm_per_block_quant`)

this is a sub-task of #25179 and closes #38071 

unlike the existing CUDA kernel, this Helion kernel improves portability across hardware (Hopper, AMD, etc.) and avoids combinatorial explosion of platform-specific kernels. Scales are computed **dynamically** inside the kernel, no pre-computed scale is needed.

## Test Plan
```bash
pytest tests/kernels/helion/test_rms_norm_fp8_block_quant.py -v
```

## Test Result
- config picker tests: verify correct config selection for exact match, closest hidden size, num_tokens ceiling, fallback to largest, fallback to default, no configs, and malformed key error
- correctness tests: Helion output compared against existing CUDA baseline (`rms_norm_per_block_quant`) across batch sizes [1, 8, 32, 128], hidden sizes [2048, 4096, 8192], group_size=128, dtypes [float16, bfloat16]
- shape tests: verify output and scale shapes across various input shapes
- integration tests: verify kernel registration and input generator

cc @ProExpertProg

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

