### PR TITLE
fix(reasoning): MiniMaxM2ReasoningParser broken for M2.5

### DIFF
--- a/vllm/reasoning/minimax_m2_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_reasoning_parser.py
@@ -22,11 +22,11 @@ logger = init_logger(__name__)
 
 class MiniMaxM2ReasoningParser(BaseThinkingReasoningParser):
     """
-    Reasoning parser for MiniMax M2 model.
+    Reasoning parser for MiniMax M2 and M2.5 models.
 
-    MiniMax M2 models don't generate <think> start token, only </think> end
-    token. All content before </think> is reasoning, content after is the
-    actual response.
+    The original M2 only generates </think> (no start tag), but M2.5
+    generates both <think> and </think>.  The base class handles both
+    cases correctly, so no override is needed.
     """
 
     @property
@@ -38,45 +38,6 @@ class MiniMaxM2ReasoningParser(BaseThinkingReasoningParser):
     def end_token(self) -> str:
         """The token that ends reasoning content."""
         return "</think>"
-
-    def extract_reasoning_streaming(
-        self,
-        previous_text: str,
-        current_text: str,
-        delta_text: str,
-        previous_token_ids: Sequence[int],
-        current_token_ids: Sequence[int],
-        delta_token_ids: Sequence[int],
-    ) -> DeltaMessage | None:
-        """
-        Extract reasoning content from a delta message for streaming.
-
-        MiniMax M2 models don't generate <think> start token, so we assume
-        all content is reasoning until we encounter the </think> end token.
-        """
-        # Skip single end token
-        if len(delta_token_ids) == 1 and delta_token_ids[0] == self.end_token_id:
-            return None
-
-        # Check if end token has already appeared in previous tokens
-        # meaning we're past the reasoning phase
-        if self.end_token_id in previous_token_ids:
-            # We're past the reasoning phase, this is content
-            return DeltaMessage(content=delta_text)
-
-        # Check if end token is in delta tokens
-        if self.end_token_id in delta_token_ids:
-            # End token in delta, split reasoning and content
-            end_index = delta_text.find(self.end_token)
-            reasoning = delta_text[:end_index]
-            content = delta_text[end_index + len(self.end_token) :]
-            return DeltaMessage(
-                reasoning=reasoning if reasoning else None,
-                content=content if content else None,
-            )
-
-        # No end token yet, all content is reasoning
-        return DeltaMessage(reasoning=delta_text)
 
 
 class MiniMaxM2AppendThinkReasoningParser(ReasoningParser):


### PR DESCRIPTION
## Summary

- Remove broken `extract_reasoning_streaming` override from `MiniMaxM2ReasoningParser`
- M2.5 generates both `<think>` and `</think>`, but the override assumed only `</think>` (M2 behavior)
- The base class `BaseThinkingReasoningParser` already handles both tags correctly

## Problem

With `--reasoning-parser minimax_m2`, reasoning content (including raw `<think>...</think>` tags) leaks into the `content` field. The `reasoning` field is always `null`, even with `include_reasoning: true`.

Root cause: `MiniMaxM2ReasoningParser.extract_reasoning_streaming` treats everything as reasoning until `</think>`, never checking for or stripping `<think>`. The `<think>` tag gets included in the reasoning text, and downstream the entire block ends up in `content`.

## Fix

Delete the override. `BaseThinkingReasoningParser.extract_reasoning_streaming` checks for `start_token_id` in previous/delta tokens, handles both tags, and correctly splits reasoning from content. This also maintains backward compatibility with M2 (which only generates `</think>`) since the base class handles that case too.

## Test plan

- [x] Verified `extract_reasoning` correctly returns `reasoning='thinking'`, `content='\n\nanswer'` for input `<think>thinking</think>\n\nanswer`
- [x] Verified end-to-end with vLLM v0.17.1rc1.dev150 serving MiniMax-M2.5-REAP-172B: `reasoning` field populated, `content` clean
- [ ] Existing tests continue to pass

Fixes #38212

🤖 Generated with [Claude Code](https://claude.com/claude-code)