### PR TITLE
[Fix] Fix FlashInfer CUTLASS MoE for unquantized models and single-GPU, bump FlashInfer to 0.6.8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -590,7 +590,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Install FlashInfer JIT cache (requires CUDA-version-specific index URL)
 # https://docs.flashinfer.ai/installation.html
 # From versions.json: .flashinfer.version
-ARG FLASHINFER_VERSION=0.6.7
+ARG FLASHINFER_VERSION=0.6.8
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
         --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.') \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -590,7 +590,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Install FlashInfer JIT cache (requires CUDA-version-specific index URL)
 # https://docs.flashinfer.ai/installation.html
 # From versions.json: .flashinfer.version
-ARG FLASHINFER_VERSION=0.6.6
+ARG FLASHINFER_VERSION=0.6.7
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
         --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.') \

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -68,7 +68,7 @@
       "default": "true"
     },
     "FLASHINFER_VERSION": {
-      "default": "0.6.6"
+      "default": "0.6.7"
     },
     "GDRCOPY_CUDA_VERSION": {
       "default": "12.8"

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -68,7 +68,7 @@
       "default": "true"
     },
     "FLASHINFER_VERSION": {
-      "default": "0.6.7"
+      "default": "0.6.8"
     },
     "GDRCOPY_CUDA_VERSION": {
       "default": "12.8"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,8 +9,8 @@ torchaudio==2.10.0
 # These must be updated alongside torch
 torchvision==0.25.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
-flashinfer-python==0.6.7
-flashinfer-cubin==0.6.7
+flashinfer-python==0.6.8
+flashinfer-cubin==0.6.8
 # Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to
 # breaking changes in 1.19.0
 nvidia-cudnn-frontend>=1.13.0,<1.19.0

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,8 +9,8 @@ torchaudio==2.10.0
 # These must be updated alongside torch
 torchvision==0.25.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
-flashinfer-python==0.6.6
-flashinfer-cubin==0.6.6
+flashinfer-python==0.6.7
+flashinfer-cubin==0.6.7
 # Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to
 # breaking changes in 1.19.0
 nvidia-cudnn-frontend>=1.13.0,<1.19.0

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -57,7 +57,6 @@ def test_select_default_backend_by_platform(
         moe_config = make_dummy_moe_config()
         selected_backend = select_unquantized_moe_backend(
             moe_config=moe_config,
-            use_ep=False,
             use_dp=False,
         )
 
@@ -90,7 +89,6 @@ def test_select_rocm_aiter_backend(mock_aiter_enabled, mock_has_flashinfer):
         moe_config = make_dummy_moe_config()
         selected_backend = select_unquantized_moe_backend(
             moe_config=moe_config,
-            use_ep=False,
             use_dp=False,
         )
 
@@ -129,7 +127,6 @@ def test_select_cuda_flashinfer_trtllm_backend(
 
         selected_backend = select_unquantized_moe_backend(
             moe_config=moe_config,
-            use_ep=True,
             use_dp=False,
         )
 
@@ -171,7 +168,6 @@ def test_select_cuda_flashinfer_cutlass_backend(
 
         selected_backend = select_unquantized_moe_backend(
             moe_config=moe_config,
-            use_ep=True,  # CUTLASS requires EP
             use_dp=False,  # CUTLASS doesn't support DP
         )
 

--- a/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
@@ -361,7 +361,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             fc1_expert_weights = w1
             fc2_expert_weights = w2
         else:
-            quant_scales = None
+            quant_scales = []
             a1q_scale = None
             fc1_expert_weights = w1
             fc2_expert_weights = w2

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -70,7 +70,6 @@ def map_unquantized_backend(runner_backend: MoEBackend) -> UnquantizedMoeBackend
 
 def select_unquantized_moe_backend(
     moe_config: FusedMoEConfig,
-    use_ep: bool,
     use_dp: bool,
 ) -> UnquantizedMoeBackend:
     """
@@ -96,7 +95,6 @@ def select_unquantized_moe_backend(
     # FlashInfer CUTLASS MoE is only supported on Hopper and later GPUS
     flashinfer_cutlass_available = (
         has_flashinfer_cutlass_fused_moe()
-        and use_ep
         and (not use_dp)
         and current_platform.has_device_capability(90)
     )
@@ -161,7 +159,7 @@ def select_unquantized_moe_backend(
                     "to enable it for better performance.",
                     scope="local",
                 )
-            elif use_ep and (not use_dp):
+            elif (not use_dp):
                 logger.info_once(
                     "FlashInfer MoE is available for EP"
                     " but not enabled, consider setting"

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -159,9 +159,9 @@ def select_unquantized_moe_backend(
                     "to enable it for better performance.",
                     scope="local",
                 )
-            elif (not use_dp):
+            elif not use_dp and flashinfer_cutlass_available:
                 logger.info_once(
-                    "FlashInfer MoE is available for EP"
+                    "FlashInfer CUTLASS MoE is available"
                     " but not enabled, consider setting"
                     " VLLM_USE_FLASHINFER_MOE_FP16=1 to enable it.",
                     scope="local",

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -61,7 +61,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         super().__init__(moe)
         self.unquantized_backend = select_unquantized_moe_backend(
             moe_config=self.moe,
-            use_ep=self.moe.moe_parallel_config.use_ep,
             use_dp=self.moe.moe_parallel_config.dp_size > 1,
         )
 


### PR DESCRIPTION
This is a future-looking PR

### Summary

- **Fix `quant_scales` type on unquantized path** (`flashinfer_cutlass_moe.py`): Pass `quant_scales=[]` instead of `None` for the unquantized (bf16/fp16) MoE path. The C++ binding expects `List[Tensor]`; passing `None` causes a type error at runtime.

- **Remove spurious `use_ep` guard** (`oracle/unquantized.py`): The `flashinfer_cutlass_available` check was gated on `use_ep=True`, preventing the CUTLASS backend from being selected on single-GPU (EP=1) deployments. `FlashInferExperts` supports EP=1 natively (`ep_size=1, ep_rank=0`). The `use_ep` parameter is removed from `select_unquantized_moe_backend` entirely.

- **Bump FlashInfer to 0.6.7** (`Dockerfile`, `versions.json`, `requirements/cuda.txt`): Update `flashinfer-python` and `flashinfer-cubin` from 0.6.6 to 0.6.7.

### Test plan

- [x] Verify FlashInfer CUTLASS MoE activates on single-GPU with `VLLM_USE_FLASHINFER_MOE_FP16=1` (previously silently fell back to Triton)
- [x] Verify unquantized MoE models (e.g. MTP draft model) run without type errors on the CUTLASS path
- [x] Verify EP>1 deployments are unaffected
- [x] Verify FlashInfer 0.6.7 builds and runs correctly in Docker