### PR TITLE
[Perf] Batch KV cache swap copies via cuMemcpyBatchAsync

### DIFF
--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -10,6 +10,10 @@ void swap_blocks(torch::Tensor& src, torch::Tensor& dst,
                  int64_t block_size_in_bytes,
                  const torch::Tensor& block_mapping);
 
+void swap_blocks_batch(const torch::Tensor& src_ptrs,
+                       const torch::Tensor& dst_ptrs,
+                       const torch::Tensor& sizes);
+
 void reshape_and_cache(torch::Tensor& key, torch::Tensor& value,
                        torch::Tensor& key_cache, torch::Tensor& value_cache,
                        torch::Tensor& slot_mapping,

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -24,6 +24,8 @@
 #ifdef USE_ROCM
   #include <hip/hip_bf16.h>
 typedef __hip_bfloat16 __nv_bfloat16;
+#else
+  #include <cuda.h>
 #endif
 
 #if defined(__gfx942__)
@@ -71,6 +73,59 @@ void swap_blocks(torch::Tensor& src, torch::Tensor& dst,
     cudaMemcpyAsync(dst_ptr + dst_offset, src_ptr + src_offset,
                     block_size_in_bytes, memcpy_type, stream);
   }
+}
+
+void swap_blocks_batch(const torch::Tensor& src_ptrs,
+                       const torch::Tensor& dst_ptrs,
+                       const torch::Tensor& sizes) {
+  TORCH_CHECK(src_ptrs.device().is_cpu(), "src_ptrs must be on CPU");
+  TORCH_CHECK(dst_ptrs.device().is_cpu(), "dst_ptrs must be on CPU");
+  TORCH_CHECK(sizes.device().is_cpu(), "sizes must be on CPU");
+  TORCH_CHECK(src_ptrs.dtype() == torch::kInt64, "src_ptrs must be int64");
+  TORCH_CHECK(dst_ptrs.dtype() == torch::kInt64, "dst_ptrs must be int64");
+  TORCH_CHECK(sizes.dtype() == torch::kInt64, "sizes must be int64");
+
+  const int64_t n = src_ptrs.size(0);
+  TORCH_CHECK(dst_ptrs.size(0) == n, "dst_ptrs length must match src_ptrs");
+  TORCH_CHECK(sizes.size(0) == n, "sizes length must match src_ptrs");
+
+  if (n == 0) return;
+
+  const int64_t* src_data = src_ptrs.data_ptr<int64_t>();
+  const int64_t* dst_data = dst_ptrs.data_ptr<int64_t>();
+  const int64_t* size_data = sizes.data_ptr<int64_t>();
+
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // Use cuMemcpyBatchAsync (CUDA 12.8+) to submit all copies in a single
+  // driver call, amortizing per-copy submission overhead.
+  // int64_t and CUdeviceptr/size_t are both 8 bytes on 64-bit platforms,
+  // so we reinterpret_cast the tensor data directly to avoid copies.
+  static_assert(sizeof(CUdeviceptr) == sizeof(int64_t));
+  static_assert(sizeof(size_t) == sizeof(int64_t));
+#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+  CUmemcpyAttributes attr = {};
+  attr.srcAccessOrder = CU_MEMCPY_SRC_ACCESS_ORDER_STREAM;
+  size_t attrs_idx = 0;
+  size_t fail_idx = 0;
+  CUresult result = cuMemcpyBatchAsync(
+      reinterpret_cast<CUdeviceptr*>(const_cast<int64_t*>(dst_data)),
+      reinterpret_cast<CUdeviceptr*>(const_cast<int64_t*>(src_data)),
+      reinterpret_cast<size_t*>(const_cast<int64_t*>(size_data)),
+      static_cast<size_t>(n), &attr, &attrs_idx, 1, &fail_idx,
+      static_cast<CUstream>(stream));
+  TORCH_CHECK(result == CUDA_SUCCESS, "cuMemcpyBatchAsync failed at index ",
+              fail_idx, " with error ", result);
+#else
+  // Fallback for CUDA < 12.8 and ROCm: individual async copies.
+  // cudaMemcpyDefault lets the driver infer direction from pointer types.
+  for (int64_t i = 0; i < n; i++) {
+    cudaMemcpyAsync(reinterpret_cast<void*>(dst_data[i]),
+                    reinterpret_cast<void*>(src_data[i]),
+                    static_cast<size_t>(size_data[i]), cudaMemcpyDefault,
+                    stream);
+  }
+#endif
 }
 
 namespace vllm {

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -680,6 +680,12 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
       "            int block_size_in_bytes, Tensor block_mapping) -> ()");
   cache_ops.impl("swap_blocks", torch::kCUDA, &swap_blocks);
 
+  // Batch swap: submit all block copies in a single driver call.
+  cache_ops.def(
+      "swap_blocks_batch(Tensor src_ptrs, Tensor dst_ptrs,"
+      "                  Tensor sizes) -> ()");
+  cache_ops.impl("swap_blocks_batch", torch::kCPU, &swap_blocks_batch);
+
   // Reshape the key and value tensors and cache them.
   cache_ops.def(
       "reshape_and_cache(Tensor key, Tensor value,"

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2595,6 +2595,22 @@ def swap_blocks(
     torch.ops._C_cache_ops.swap_blocks(src, dst, block_size_in_bytes, block_mapping)
 
 
+def swap_blocks_batch(
+    src_ptrs: torch.Tensor,
+    dst_ptrs: torch.Tensor,
+    sizes: torch.Tensor,
+) -> None:
+    """
+    Batch version of swap_blocks: submit all copies in a single driver call.
+
+    Each entry specifies a raw pointer copy: src_ptrs[i] -> dst_ptrs[i]
+    of sizes[i] bytes. All three tensors must be int64 CPU tensors.
+    On CUDA 12.8+ this uses cuMemcpyBatchAsync for minimal submission
+    overhead; on older CUDA it falls back to a loop of cudaMemcpyAsync.
+    """
+    torch.ops._C_cache_ops.swap_blocks_batch(src_ptrs, dst_ptrs, sizes)
+
+
 def convert_fp8(
     output: torch.Tensor, input: torch.Tensor, scale: float = 1.0, kv_dtype: str = "fp8"
 ) -> None:

--- a/vllm/v1/kv_offload/worker/cpu_gpu.py
+++ b/vllm/v1/kv_offload/worker/cpu_gpu.py
@@ -149,6 +149,17 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
         # list of CUDA events available for re-use
         self._event_pool: list[torch.Event] = []
 
+        # Pre-compute base pointers and block sizes for batch copies.
+        self._src_base_ptrs = np.array(
+            [t.data_ptr() for t in self.src_tensors], dtype=np.int64
+        )
+        self._dst_base_ptrs = np.array(
+            [t.data_ptr() for t in self.dst_tensors], dtype=np.int64
+        )
+        self._block_size_in_bytes_arr = np.array(
+            self.tensor_block_size_in_bytes, dtype=np.int64
+        )
+
     def transfer_async(self, job_id: int, transfer_spec: TransferSpec) -> bool:
         src_spec, dst_spec = transfer_spec
         assert isinstance(src_spec, BlockIDsLoadStoreSpec)
@@ -165,15 +176,35 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
 
         assert dst_sub_block_count == src_sub_block_count - src_sub_blocks_to_skip
 
-        src_to_dst = np.empty((dst_sub_block_count, 2), dtype=np.int64)
+        src_block_ids = np.empty(dst_sub_block_count, dtype=np.int64)
+        dst_block_ids = np.empty(dst_sub_block_count, dtype=np.int64)
         expand_block_ids(
             src_blocks,
             self.src_block_size_factor,
-            src_to_dst[:, 0],
+            src_block_ids,
             skip_count=src_sub_blocks_to_skip,
         )
-        expand_block_ids(dst_blocks, self.dst_block_size_factor, src_to_dst[:, 1])
-        src_to_dst_tensor = torch.from_numpy(src_to_dst)
+        expand_block_ids(dst_blocks, self.dst_block_size_factor, dst_block_ids)
+
+        # Build flat pointer arrays for all tensors × all block pairs.
+        num_pairs = dst_sub_block_count
+        num_tensors = len(self.src_tensors)
+        total = num_pairs * num_tensors
+
+        all_src = np.empty(total, dtype=np.int64)
+        all_dst = np.empty(total, dtype=np.int64)
+        all_sizes = np.empty(total, dtype=np.int64)
+
+        for t_idx, bsz in enumerate(self._block_size_in_bytes_arr):
+            start = t_idx * num_pairs
+            end = start + num_pairs
+            all_src[start:end] = self._src_base_ptrs[t_idx] + src_block_ids * bsz
+            all_dst[start:end] = self._dst_base_ptrs[t_idx] + dst_block_ids * bsz
+            all_sizes[start:end] = bsz
+
+        batch_src = torch.from_numpy(all_src)
+        batch_dst = torch.from_numpy(all_dst)
+        batch_sizes = torch.from_numpy(all_sizes)
 
         stream = self._stream_pool.pop() if self._stream_pool else torch.cuda.Stream()
         start_event = (
@@ -197,17 +228,8 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
             stream.wait_event(last_event)
         with torch.cuda.stream(stream):
             start_event.record(stream)
-            for src_tensor, dst_tensor, block_size_in_bytes in zip(
-                self.src_tensors,
-                self.dst_tensors,
-                self.tensor_block_size_in_bytes,
-            ):
-                ops.swap_blocks(
-                    src_tensor,
-                    dst_tensor,
-                    block_size_in_bytes,
-                    src_to_dst_tensor,
-                )
+            if total > 0:
+                ops.swap_blocks_batch(batch_src, batch_dst, batch_sizes)
             end_event.record(stream)
 
         self._transfer_events[job_id] = end_event


### PR DESCRIPTION
Replace per-layer per-block `swap_blocks` calls in the KV cache offloading
handler with a single `swap_blocks_batch` call that submits all copies in
one driver invocation.

On CUDA 12.8+ this uses `cuMemcpyBatchAsync`; on older CUDA/ROCm it falls
back to a flat `cudaMemcpyAsync` loop with `cudaMemcpyDefault`. Zero extra
GPU memory. No behavior change.

## Benchmark Results

**Hardware:** 8xH100 80GB HBM3, CUDA 12.8/12.9.

Baseline runs the original files via
`pip install vllm==0.18.0 --force-reinstall --no-deps`. Each mode ran in a
fresh Python process to avoid stale module state.

### Handler-level benchmark

Directly measures the transfer path in isolation — no model inference.

**Setup:** Instantiate `CpuGpuOffloadingHandlers` with BF16 GPU tensors shaped
by `FlashAttentionBackend.get_kv_cache_shape()` using each model's real
architecture.
Call `handler.transfer_async()`, poll `get_finished()` until complete. Measure
with `time.perf_counter()` (includes CUDA sync). 5 warmup + 100 measured
iterations. Baseline and batched ran as separate processes.

| Config | Layers | KV Heads | Head Dim | Tensors | Per-tensor block size |
|--------|--------|----------|----------|---------|----------------------|
| LLaMA-8B | 32 | 8 | 128 | 64 | 32 KB |
| LLaMA-70B | 80 | 8 | 128 | 160 | 32 KB |
| LLaMA-70B TP=4 | 80 | 2 | 128 | 160 | 8 KB |
| Qwen2.5-0.5B | 24 | 2 | 64 | 48 | 4 KB |
| Qwen2.5-1.5B | 28 | 2 | 128 | 56 | 8 KB |
| Qwen2.5-3B | 36 | 2 | 128 | 72 | 8 KB |
| Phi-3-mini | 32 | 8 | 96 | 64 | 24 KB |

**Per-layer tensors** (FlashAttn K/V split, no cross-layer allocation):

| Config | Tensors | Baseline | Batched | Speedup |
|--------|---------|----------|---------|---------|
| LLaMA-8B, 64 blocks | 64 | 16,358 us | 4,519 us | **3.6x** |
| LLaMA-70B, 64 blocks | 160 | 41,124 us | 10,239 us | **4.0x** |
| LLaMA-70B TP=4, 32 blocks | 160 | 20,427 us | 3,299 us | **6.2x** |
| Qwen2.5-0.5B, 128 blocks | 48 | 23,484 us | 3,184 us | **7.4x** |
| Qwen2.5-1.5B, 64 blocks | 56 | 14,042 us | 2,272 us | **6.2x** |
| Qwen2.5-3B, 64 blocks | 72 | 18,045 us | 2,935 us | **6.2x** |
| Phi-3-mini, 64 blocks | 64 | 15,963 us | 3,888 us | **4.1x** |

### E2E vLLM serve — KV transfer bandwidth

**Setup:**
1. Start `vllm serve` with each real model, offloading enabled:
   ```bash
   python -m vllm.entrypoints.openai.api_server \
       --model <model> --gpu-memory-utilization <0.4-0.5> \
       --kv-transfer-config '{"kv_connector":"OffloadingConnector",
           "kv_role":"kv_both",
           "kv_connector_extra_config":{"cpu_bytes_to_use":2147483648,
           "block_size":48}}' \
       --max-model-len 4096 --enforce-eager
   ```
2. Send sustained load: 8 concurrent Python threads, each sending prompts in a loop for 45 seconds.
3. Read the KV transfer bandwidth from vLLM's server log
   `total_time` is measured by CUDA events (`start_event.elapsed_time(end_event)`)
   inside `SingleDirectionOffloadingHandler.get_finished()` Bandwidth = `total_bytes / total_time`.

| Model | KV Heads | Baseline BW | Batched BW | Improvement |
|-------|----------|------------|-----------|-------------|
| LLaMA-3.2-1B | 8 | 27.9 GB/s | 32.4 GB/s | **+16%** |
| Qwen2.5-1.5B | 2 | 25.8 GB/s | 31.8 GB/s | **+23%** |
| Qwen2.5-3B | 2 | 29.5 GB/s | 34.3 GB/s | **+16%** |
| Gemma-2-2B | 4 | 40.2 GB/s | 43.3 GB/s | +8% |
| Phi-3.5-mini | 8 | 51.6 GB/s | 53.3 GB/s | +3% |
| Qwen2.5-7B | 4 | 34.2 GB/s | 40.7 GB/s | **+19%** |
| LLaMA-3.1-8B | 8 | 44.0 GB/s | 47.0 GB/s | +7% |
| Mistral-7B | 8 | 45.1 GB/s | 48.6 GB/s | +8% |

### 3. E2E serving throughput

| Model | Baseline req/s | Batched req/s | Baseline p99 TTFT | Batched p99 TTFT |
|-------|---------------|--------------|-------------------|------------------|
| **Qwen2.5-7B** | **6.0** | **7.1 (+18%)** | **6,077 ms** | **117 ms** |
| LLaMA-3.1-8B | 6.7 | 6.7 | 100.7 ms | 105.7 ms |
| Mistral-7B | 6.7 | 6.6 | 91.4 ms | 82.5 ms |

Qwen2.5-7B shows 18% throughput improvement and p99 TTFT reduction from
6 seconds to 117ms under concurrent load. This I guess it because the model has 4 KV heads
(vs 8 for LLaMA/Mistral), producing smaller per-block copies where
submission overhead dominates.