### PR TITLE
[specdec][v1] Fix sampler peak memory utilization when using specdec

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5599,7 +5599,8 @@ class GPUModelRunner(
             else:
                 raise e
         if self.speculative_config:
-            draft_token_ids = [[0] for _ in range(num_reqs)]
+            num_spec_tokens = self.speculative_config.num_speculative_tokens
+            draft_token_ids = [[0] * num_spec_tokens for _ in range(num_reqs)]
             dummy_spec_decode_metadata = SpecDecodeMetadata.make_dummy(
                 draft_token_ids, self.device
             )


### PR DESCRIPTION
When capturing peak memory utilization of the rejection sampler, vLLM v1 assumes a single drafted token. This doesn't match the worst case where all requests draft k>1 tokens, which can lead to OOM.

With `max_num_seq = 200`, num drafted tokens = 5:
- the previous code has logits shape (200+200, vocab_size:=131072) so 400*131072*4 bytes = 209MiB.
- the new code has logits shape (200*5+200, 131072) = 629MiB