### PR TITLE
[Bugfix] Add dimension alignment check to Marlin MoE kernel selection

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -661,7 +661,7 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def is_supported_config(
-        cls: type["mk.FusedMoEExpertsModular"],
+        cls: type["mk.FusedMoEExperts"],
         moe_config: FusedMoEConfig,
         weight_key: QuantKey | None,
         activation_key: QuantKey | None,
@@ -676,10 +676,14 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
         # The intermediate_size appears as N in the gate/up GEMM and as K
         # in the down GEMM, so it has the same alignment requirements.
         inter = moe_config.intermediate_size_per_partition
-        if inter % GPTQ_MARLIN_MIN_THREAD_K != 0:
+        if (
+            inter % GPTQ_MARLIN_MIN_THREAD_K != 0
+            or inter % GPTQ_MARLIN_MIN_THREAD_N != 0
+        ):
             return False, (
                 f"kernel does not support intermediate_size_per_partition"
-                f"={inter} (not divisible by {GPTQ_MARLIN_MIN_THREAD_K})"
+                f"={inter} (not divisible by {GPTQ_MARLIN_MIN_THREAD_K} "
+                f"and {GPTQ_MARLIN_MIN_THREAD_N})"
             )
         return True, None
 

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -34,6 +34,8 @@ from vllm.model_executor.layers.fused_moe.utils import (
     swiglu_limit_func,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    GPTQ_MARLIN_MIN_THREAD_K,
+    GPTQ_MARLIN_MIN_THREAD_N,
     get_marlin_input_dtype,
     marlin_make_workspace_new,
     marlin_moe_intermediate_size,
@@ -645,6 +647,41 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
             moe_parallel_config.use_fi_nvl_two_sided_kernels
             or moe_parallel_config.use_fi_nvl_one_sided_kernels
         )
+
+    @staticmethod
+    def _supports_shape(hidden_dim: int) -> bool:
+        # The Marlin GEMM kernel requires K divisible by MIN_THREAD_K (128)
+        # and N divisible by MIN_THREAD_N (64).  In MoE the hidden_dim
+        # appears as K in the gate/up projection and as N in the down
+        # projection, so it must satisfy both constraints.
+        return (
+            hidden_dim % GPTQ_MARLIN_MIN_THREAD_K == 0
+            and hidden_dim % GPTQ_MARLIN_MIN_THREAD_N == 0
+        )
+
+    @staticmethod
+    def is_supported_config(
+        cls: type["mk.FusedMoEExpertsModular"],
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+        activation_format: mk.FusedMoEActivationFormat,
+    ) -> tuple[bool, str | None]:
+        supported, reason = mk.FusedMoEExpertsModular.is_supported_config(
+            cls, moe_config, weight_key, activation_key, activation_format
+        )
+        if not supported:
+            return supported, reason
+
+        # The intermediate_size appears as N in the gate/up GEMM and as K
+        # in the down GEMM, so it has the same alignment requirements.
+        inter = moe_config.intermediate_size_per_partition
+        if inter % GPTQ_MARLIN_MIN_THREAD_K != 0:
+            return False, (
+                f"kernel does not support intermediate_size_per_partition"
+                f"={inter} (not divisible by {GPTQ_MARLIN_MIN_THREAD_K})"
+            )
+        return True, None
 
     @property
     def quant_type_id(self) -> int:


### PR DESCRIPTION
## Motivation

When serving an MXFP4-quantized MoE model with non-128-aligned dimensions (e.g. GPT-OSS 20B with `hidden_size=2880`, `intermediate_size=2880`), the Marlin MoE kernel crashes at inference time with:

```
RuntimeError: Invalid thread config: thread_m_blocks = 4, thread_k = -1, thread_n = -1,
num_threads = -1 for MKN = [32768, 2880, 2880]
```

The Marlin GEMM kernel requires K to be divisible by `MIN_THREAD_K` (128) and N by `MIN_THREAD_N` (64), but 2880 % 128 = 64. The non-MoE Marlin path already has `verify_marlin_supports_shape()` that catches this at load time, but the MoE path (`MarlinExpertsBase`) had no equivalent check, so the oracle selected Marlin even though it can't handle the dimensions.

## Modifications

Override `_supports_shape()` and `is_supported_config()` in `MarlinExpertsBase` to validate both `hidden_dim` and `intermediate_size_per_partition` against the kernel's alignment requirements. When Marlin can't handle the dimensions, the oracle skips it and falls back to a compatible kernel (e.g. FlashInfer TRTLLM on Blackwell) instead of crashing.

The check mirrors the existing `verify_marlin_supports_shape()` logic in `marlin_utils.py` but operates at the oracle level so the system can fall back gracefully.

Fixes #38022