### PR TITLE
[Bugfix] Handle reasoning_effort="none" for Harmony models instead of crashing

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -843,6 +843,28 @@ class TestGetSystemMessage:
                     f"{channel} missing when with_custom_tools={with_tools}"
                 )
 
+    def test_none_reasoning_effort_does_not_crash(self) -> None:
+        """reasoning_effort="none" should not raise an error."""
+        sys_msg = get_system_message(reasoning_effort="none")
+        # System message should still be valid
+        assert sys_msg.author.role == Role.SYSTEM
+
+    def test_unsupported_reasoning_effort_ignored(self) -> None:
+        """Unsupported effort values (e.g. 'minimal') are silently ignored."""
+        sys_msg = get_system_message(reasoning_effort="minimal")
+        assert sys_msg.author.role == Role.SYSTEM
+
+    def test_valid_reasoning_effort_accepted(self) -> None:
+        """Valid effort values should be accepted without error."""
+        for effort in ("low", "medium", "high"):
+            sys_msg = get_system_message(reasoning_effort=effort)
+            assert sys_msg.author.role == Role.SYSTEM
+
+    def test_null_reasoning_effort_accepted(self) -> None:
+        """None reasoning_effort should be accepted without error."""
+        sys_msg = get_system_message(reasoning_effort=None)
+        assert sys_msg.author.role == Role.SYSTEM
+
 
 class TestResponseInputToHarmonyReasoningItem:
     """Tests for response_input_to_harmony handling of reasoning input items.

--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
-from openai_harmony import Message, Role
+from openai_harmony import Message, Role, SystemContent
 
 from tests.entrypoints.openai.utils import verify_harmony_messages
 from vllm.entrypoints.openai.parser.harmony_utils import (
@@ -843,27 +843,31 @@ class TestGetSystemMessage:
                     f"{channel} missing when with_custom_tools={with_tools}"
                 )
 
-    def test_none_reasoning_effort_does_not_crash(self) -> None:
-        """reasoning_effort="none" should not raise an error."""
-        sys_msg = get_system_message(reasoning_effort="none")
-        # System message should still be valid
+    @pytest.mark.parametrize(
+        "effort",
+        [
+            "none",  # Should be ignored (not a valid Harmony level)
+            "minimal",  # Unsupported, should be ignored
+            None,  # No effort specified
+            "low",
+            "medium",
+            "high",
+        ],
+    )
+    def test_reasoning_effort_handling(self, effort: str | None) -> None:
+        """Verify get_system_message handles various reasoning_effort values."""
+        from vllm.entrypoints.openai.parser.harmony_utils import REASONING_EFFORT
+
+        sys_msg = get_system_message(reasoning_effort=effort)
         assert sys_msg.author.role == Role.SYSTEM
 
-    def test_unsupported_reasoning_effort_ignored(self) -> None:
-        """Unsupported effort values (e.g. 'minimal') are silently ignored."""
-        sys_msg = get_system_message(reasoning_effort="minimal")
-        assert sys_msg.author.role == Role.SYSTEM
-
-    def test_valid_reasoning_effort_accepted(self) -> None:
-        """Valid effort values should be accepted without error."""
-        for effort in ("low", "medium", "high"):
-            sys_msg = get_system_message(reasoning_effort=effort)
-            assert sys_msg.author.role == Role.SYSTEM
-
-    def test_null_reasoning_effort_accepted(self) -> None:
-        """None reasoning_effort should be accepted without error."""
-        sys_msg = get_system_message(reasoning_effort=None)
-        assert sys_msg.author.role == Role.SYSTEM
+        system_content = sys_msg.content[0]
+        if effort in REASONING_EFFORT:
+            assert system_content.reasoning_effort == REASONING_EFFORT[effort]
+        else:
+            # Unsupported / None values leave the default unchanged
+            default_effort = SystemContent.new().reasoning_effort
+            assert system_content.reasoning_effort == default_effort
 
 
 class TestResponseInputToHarmonyReasoningItem:

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -3,7 +3,6 @@
 
 import datetime
 from collections.abc import Iterable, Sequence
-from typing import Literal
 
 from openai.types.responses.tool import Tool
 from openai_harmony import (
@@ -66,7 +65,7 @@ def get_encoding():
 
 def get_system_message(
     model_identity: str | None = None,
-    reasoning_effort: Literal["high", "medium", "low"] | None = None,
+    reasoning_effort: str | None = None,
     start_date: str | None = None,
     browser_description: str | None = None,
     python_description: str | None = None,
@@ -83,7 +82,7 @@ def get_system_message(
             f"{current_identity}\n{instructions}" if current_identity else instructions
         )
         sys_msg_content = sys_msg_content.with_model_identity(new_identity)
-    if reasoning_effort is not None:
+    if reasoning_effort is not None and reasoning_effort in REASONING_EFFORT:
         sys_msg_content = sys_msg_content.with_reasoning_effort(
             REASONING_EFFORT[reasoning_effort]
         )

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -379,8 +379,13 @@ class OpenAIServingRender:
         # if the model supports it. TODO: Support browsing.
         assert not self.supports_browsing
         assert not self.supports_code_interpreter
-        if (reasoning_effort := request.reasoning_effort) == "none":
-            raise ValueError(f"Harmony does not support {reasoning_effort=}")
+        reasoning_effort = request.reasoning_effort
+        if reasoning_effort == "none":
+            # "none" is not a valid Harmony reasoning effort level.
+            # Treat it as unset so the system message omits the directive;
+            # include_reasoning=False (set by the protocol validator) will
+            # strip reasoning from the response.
+            reasoning_effort = None
         sys_msg = get_system_message(
             reasoning_effort=reasoning_effort,
             browser_description=None,


### PR DESCRIPTION
## Purpose

Fix crash when `reasoning_effort="none"` is passed to Harmony (GPT-OSS) models.

PR #36238 added `"none"` to the `reasoning_effort` Literal type but did not update the Harmony rendering path, causing two crash scenarios:

1. **Chat Completion API** (`serving.py:382`): Explicitly raises `ValueError("Harmony does not support reasoning_effort='none'")`, returning a 500 error.
2. **Responses API** (`harmony_utils.py:88`): The `REASONING_EFFORT` dict only maps `"high"`, `"medium"`, `"low"` — any other value (including `"minimal"` from the Responses API) causes a `KeyError`.

Fixes https://github.com/vllm-project/vllm/issues/37909

**Changes:**

- `serving.py`: Replace `raise ValueError` with conversion to `None`, so the reasoning directive is simply omitted from the Harmony system message. `include_reasoning=False` (already set by the protocol validator) strips reasoning tokens from the response.
- `harmony_utils.py`: Guard the dict lookup with `if reasoning_effort is not None and reasoning_effort in REASONING_EFFORT`, preventing `KeyError` for any unsupported value.
- Relax type annotation of `get_system_message(reasoning_effort=...)` from `Literal[...]` to `str | None` since callers can now pass values outside the original Literal set.

**Scope note:** Issue #37909 also mentions that non-Harmony models still generate reasoning tokens when `reasoning_effort="none"` (they are just hidden from the response). That is a broader design question and is not addressed here — this PR only fixes the crash.

## Test Plan

```bash
pytest tests/entrypoints/openai/parser/test_harmony_utils.py -v -s
```

Added 4 new tests to `TestGetSystemMessage`:

| Test | Input | Verifies |
|------|-------|----------|
| `test_none_reasoning_effort_does_not_crash` | `"none"` | No `ValueError` |
| `test_unsupported_reasoning_effort_ignored` | `"minimal"` | No `KeyError` |
| `test_valid_reasoning_effort_accepted` | `"low"` / `"medium"` / `"high"` | Existing behavior preserved |
| `test_null_reasoning_effort_accepted` | `None` | Existing behavior preserved |

## Test Result

```
66 passed, 0 failed (62 existing + 4 new)
```

Linting:
```
ruff check: All checks passed
ruff format: All files formatted
```

No open PRs address this issue (searched `gh pr list --state open --search "37909 in:body"` and keyword variants).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>