### PR TITLE
[Bugfix] Prevent IndexError on empty content in HarmonyContext tool calls

### DIFF
--- a/tests/entrypoints/openai/responses/test_context_content_empty.py
+++ b/tests/entrypoints/openai/responses/test_context_content_empty.py
@@ -1,0 +1,38 @@
+"""Test that _extract_content_text handles empty content safely."""
+import pytest
+
+from vllm.entrypoints.openai.responses.context import _extract_content_text
+
+
+class FakeContent:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class FakeMessage:
+    def __init__(self, content=None):
+        self.content = content if content is not None else []
+
+
+def test_extract_content_text_with_content():
+    msg = FakeMessage(content=[FakeContent("hello")])
+    assert _extract_content_text(msg) == "hello"
+
+
+def test_extract_content_text_empty_content():
+    msg = FakeMessage(content=[])
+    assert _extract_content_text(msg) == ""
+
+
+def test_extract_content_text_none_like():
+    """Content that is falsy should return empty string."""
+    msg = FakeMessage(content=None)
+    # content=None → not msg.content is True → returns ""
+    assert _extract_content_text(msg) == ""
+
+
+def test_original_code_would_crash():
+    """Demonstrate that direct content[0] access crashes on empty list."""
+    msg = FakeMessage(content=[])
+    with pytest.raises(IndexError):
+        _ = msg.content[0].text

--- a/tests/entrypoints/openai/responses/test_context_content_empty.py
+++ b/tests/entrypoints/openai/responses/test_context_content_empty.py
@@ -1,4 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Test that _extract_content_text handles empty content safely."""
+
 import pytest
 
 from vllm.entrypoints.openai.responses.context import _extract_content_text
@@ -29,6 +32,19 @@ def test_extract_content_text_none_like():
     msg = FakeMessage(content=None)
     # content=None → not msg.content is True → returns ""
     assert _extract_content_text(msg) == ""
+
+
+def test_extract_content_text_tool_result():
+    """Helper also works with MCP CallToolResult-like objects."""
+    # MCP CallToolResult has the same .content[0].text pattern
+    result = FakeMessage(content=[FakeContent("tool output")])
+    assert _extract_content_text(result) == "tool output"
+
+
+def test_extract_content_text_empty_tool_result():
+    """Empty tool result content should return empty string, not crash."""
+    result = FakeMessage(content=[])
+    assert _extract_content_text(result) == ""
 
 
 def test_original_code_would_crash():

--- a/tests/entrypoints/openai/responses/test_context_content_empty.py
+++ b/tests/entrypoints/openai/responses/test_context_content_empty.py
@@ -17,34 +17,24 @@ class FakeMessage:
         self.content = content if content is not None else []
 
 
-def test_extract_content_text_with_content():
-    msg = FakeMessage(content=[FakeContent("hello")])
-    assert _extract_content_text(msg) == "hello"
-
-
-def test_extract_content_text_empty_content():
-    msg = FakeMessage(content=[])
-    assert _extract_content_text(msg) == ""
-
-
-def test_extract_content_text_none_like():
-    """Content that is falsy should return empty string."""
-    msg = FakeMessage(content=None)
-    # content=None → not msg.content is True → returns ""
-    assert _extract_content_text(msg) == ""
-
-
-def test_extract_content_text_tool_result():
-    """Helper also works with MCP CallToolResult-like objects."""
-    # MCP CallToolResult has the same .content[0].text pattern
-    result = FakeMessage(content=[FakeContent("tool output")])
-    assert _extract_content_text(result) == "tool output"
-
-
-def test_extract_content_text_empty_tool_result():
-    """Empty tool result content should return empty string, not crash."""
-    result = FakeMessage(content=[])
-    assert _extract_content_text(result) == ""
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ([FakeContent("hello")], "hello"),
+        ([FakeContent("tool output")], "tool output"),
+        ([], ""),
+        (None, ""),
+    ],
+    ids=[
+        "single_text_item",
+        "tool_result_text",
+        "empty_list",
+        "none_content",
+    ],
+)
+def test_extract_content_text(content, expected):
+    msg = FakeMessage(content=content)
+    assert _extract_content_text(msg) == expected
 
 
 def test_original_code_would_crash():

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -140,6 +140,17 @@ class ConversationContext(ABC):
         raise NotImplementedError("Should not be called.")
 
 
+def _extract_content_text(msg: "Message") -> str:
+    """Safely extract text from the first content item of a Harmony message.
+
+    Returns an empty string if the content list is empty, preventing
+    IndexError crashes when the model generates a tool call with no content.
+    """
+    if not msg.content:
+        return ""
+    return msg.content[0].text
+
+
 def _create_json_parse_error_messages(
     last_msg: Message, e: json.JSONDecodeError
 ) -> list[Message]:
@@ -720,11 +731,11 @@ class HarmonyContext(ConversationContext):
         tool_name = last_msg.recipient.split(".")[1]
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
-                args = json.loads(last_msg.content[0].text)
+                args = json.loads(_extract_content_text(last_msg))
             except json.JSONDecodeError as e:
                 return _create_json_parse_error_messages(last_msg, e)
         else:
-            args = json.loads(last_msg.content[0].text)
+            args = json.loads(_extract_content_text(last_msg))
         result = await tool_session.call_tool(tool_name, args)
         result_str = result.content[0].text
         content = TextContent(text=result_str)
@@ -745,7 +756,7 @@ class HarmonyContext(ConversationContext):
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
         param = {
-            "code": last_msg.content[0].text,
+            "code": _extract_content_text(last_msg),
         }
         result = await tool_session.call_tool("python", param)
         result_str = result.content[0].text
@@ -807,11 +818,11 @@ class HarmonyContext(ConversationContext):
         tool_name = last_msg.recipient.split(".")[1].split(" ")[0]
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
-                args = json.loads(last_msg.content[0].text)
+                args = json.loads(_extract_content_text(last_msg))
             except json.JSONDecodeError as e:
                 return _create_json_parse_error_messages(last_msg, e)
         else:
-            args = json.loads(last_msg.content[0].text)
+            args = json.loads(_extract_content_text(last_msg))
         result = await tool_session.call_tool(tool_name, args)
         result_str = result.content[0].text
         content = TextContent(text=result_str)

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -140,11 +140,16 @@ class ConversationContext(ABC):
         raise NotImplementedError("Should not be called.")
 
 
-def _extract_content_text(msg: "Message") -> str:
-    """Safely extract text from the first content item of a Harmony message.
+def _extract_content_text(msg: Any) -> str:
+    """Safely extract text from the first content item.
+
+    Works with both Harmony ``Message`` objects and MCP ``CallToolResult``
+    objects — any object whose ``.content`` is a list of items with a
+    ``.text`` attribute.
 
     Returns an empty string if the content list is empty, preventing
-    IndexError crashes when the model generates a tool call with no content.
+    IndexError crashes when the model generates a tool call with no
+    content or a tool server returns an empty result.
     """
     if not msg.content:
         return ""
@@ -737,7 +742,7 @@ class HarmonyContext(ConversationContext):
         else:
             args = json.loads(_extract_content_text(last_msg))
         result = await tool_session.call_tool(tool_name, args)
-        result_str = result.content[0].text
+        result_str = _extract_content_text(result)
         content = TextContent(text=result_str)
         author = Author(role=Role.TOOL, name=last_msg.recipient)
         return [
@@ -759,7 +764,7 @@ class HarmonyContext(ConversationContext):
             "code": _extract_content_text(last_msg),
         }
         result = await tool_session.call_tool("python", param)
-        result_str = result.content[0].text
+        result_str = _extract_content_text(result)
 
         content = TextContent(text=result_str)
         author = Author(role=Role.TOOL, name="python")
@@ -824,7 +829,7 @@ class HarmonyContext(ConversationContext):
         else:
             args = json.loads(_extract_content_text(last_msg))
         result = await tool_session.call_tool(tool_name, args)
-        result_str = result.content[0].text
+        result_str = _extract_content_text(result)
         content = TextContent(text=result_str)
         author = Author(role=Role.TOOL, name=last_msg.recipient)
         return [


### PR DESCRIPTION
## Purpose

Fix 5 unchecked `last_msg.content[0].text` accesses in `HarmonyContext` tool call methods (`call_search_tool`, `call_python_tool`, `call_container_tool`) that crash with `IndexError` when the model generates a tool call with empty content.

This is the same class of bug as the empty-content checks already present in `utils.py` and `streaming_events.py`, but in the `context.py` Harmony tool dispatch path.

## Test Plan

```bash
python -m pytest tests/entrypoints/openai/responses/test_context_content_empty.py -v
```

## Test Result

All 4 new tests pass. 

The fix introduces a `_extract_content_text(msg)` helper that returns `""` when `msg.content` is empty, replacing the 5 direct `content[0].text` accesses.