### PR TITLE
[Bugfix] Respect max_output_tokens in Harmony tool-call loop

### DIFF
--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -523,10 +523,12 @@ class HarmonyContext(ConversationContext):
         self,
         messages: list,
         available_tools: list[str],
+        request: ResponsesRequest | None = None,
     ):
         self._messages = messages
         self.finish_reason: str | None = None
         self.available_tools = available_tools
+        self.request = request
         self._tool_sessions: dict[str, ClientSession | Tool] = {}
         self.called_tools: set[str] = set()
 

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -439,9 +439,11 @@ class OpenAIServingResponses(OpenAIServing):
             context: ConversationContext
             if self.use_harmony:
                 if request.stream:
-                    context = StreamingHarmonyContext(messages, available_tools)
+                    context = StreamingHarmonyContext(
+                        messages, available_tools, request=request)
                 else:
-                    context = HarmonyContext(messages, available_tools)
+                    context = HarmonyContext(
+                        messages, available_tools, request=request)
             else:
                 if envs.VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT:
                     # This is a feature in development for parsing
@@ -677,7 +679,14 @@ class OpenAIServingResponses(OpenAIServing):
                 token_ids = context.render_for_completion()
                 engine_input = tokens_input(token_ids)
 
-                sampling_params.max_tokens = max_model_len - len(token_ids)
+                sampling_params.max_tokens = get_max_tokens(
+                    max_model_len,
+                    context.request.max_output_tokens
+                    if context.request else None,
+                    len(token_ids),
+                    self.default_sampling_params,  # type: ignore
+                    self.override_max_tokens,  # type: ignore
+                )
             elif isinstance(context, ParsableContext):
                 (engine_input,) = await self._render_next_turn(
                     context.request,


### PR DESCRIPTION
## Purpose

Fix the Harmony tool-call loop in `serving.py` to respect `max_output_tokens`. Currently the loop uses `max_model_len - len(token_ids)` to set `sampling_params.max_tokens`, completely ignoring the user's `max_output_tokens` constraint. This allows subsequent tool-call turns to generate far more tokens than intended (e.g., 130K instead of 100).

The `ParsableContext` path on line 697 already correctly calls `get_max_tokens()` — the `HarmonyContext` path was simply missed.

## Test Plan

```bash
python -m pytest tests/entrypoints/openai/responses/test_harmony_max_tokens_tool_loop.py -v
```

## Test Result

All 3 tests pass, verifying that:
1. `max_output_tokens=100` is respected (not 130K)
2. Without explicit limit, falls back to context window
3. `max_output_tokens` exceeding context window is capped correctly