### PR TITLE
[ZenCPU] AMD Zen CPU Backend with supported dtypes via zentorch weekly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1085,7 +1085,9 @@ setup(
     install_requires=get_requirements(),
     extras_require={
         # AMD Zen CPU optimizations via zentorch
-        "zen": ["zentorch"],
+        "zen": [
+            "zentorch-weekly"
+        ],  # Zentorch has weekly releases. This pulls the latest one
         "bench": ["pandas", "matplotlib", "seaborn", "datasets", "scipy", "plotly"],
         "tensorizer": ["tensorizer==2.10.1"],
         "fastsafetensors": ["fastsafetensors >= 0.2.2"],

--- a/setup.py
+++ b/setup.py
@@ -1086,7 +1086,7 @@ setup(
     extras_require={
         # AMD Zen CPU optimizations via zentorch
         "zen": [
-            "zentorch-weekly==5.2.1.dev20260325"
+            "zentorch-weekly==5.2.1.dev20260408"
         ],  # Zentorch has weekly releases. This pulls the known-good version.
         "bench": ["pandas", "matplotlib", "seaborn", "datasets", "scipy", "plotly"],
         "tensorizer": ["tensorizer==2.10.1"],

--- a/setup.py
+++ b/setup.py
@@ -1086,7 +1086,7 @@ setup(
     extras_require={
         # AMD Zen CPU optimizations via zentorch
         "zen": [
-            "zentorch-weekly"
+            "zentorch-weekly==5.2.1.dev20260325"
         ],  # Zentorch has weekly releases. This pulls the latest one
         "bench": ["pandas", "matplotlib", "seaborn", "datasets", "scipy", "plotly"],
         "tensorizer": ["tensorizer==2.10.1"],

--- a/setup.py
+++ b/setup.py
@@ -1087,7 +1087,7 @@ setup(
         # AMD Zen CPU optimizations via zentorch
         "zen": [
             "zentorch-weekly==5.2.1.dev20260325"
-        ],  # Zentorch has weekly releases. This pulls the latest one
+        ],  # Zentorch has weekly releases. This pulls the known-good version.
         "bench": ["pandas", "matplotlib", "seaborn", "datasets", "scipy", "plotly"],
         "tensorizer": ["tensorizer==2.10.1"],
         "fastsafetensors": ["fastsafetensors >= 0.2.2"],

--- a/vllm/platforms/zen_cpu.py
+++ b/vllm/platforms/zen_cpu.py
@@ -25,7 +25,6 @@ class ZenCpuPlatform(CpuPlatform):
         # is_cpu() also returns True for this platform (inherited from CpuPlatform).
         return True
 
-
     # Currently, AMD CPUs do not support float16 compute.
     # Hence explicitly return bfloat16 and float32.
     @property

--- a/vllm/platforms/zen_cpu.py
+++ b/vllm/platforms/zen_cpu.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import torch
+
 from vllm.logger import init_logger
 from vllm.platforms.cpu import CpuPlatform
 
@@ -22,3 +24,10 @@ class ZenCpuPlatform(CpuPlatform):
     def is_zen_cpu(self) -> bool:
         # is_cpu() also returns True for this platform (inherited from CpuPlatform).
         return True
+
+
+    # Currently, AMD CPUs do not support float16 compute.
+    # Hence explicitly return bfloat16 and float32.
+    @property
+    def supported_dtypes(self) -> list[torch.dtype]:
+        return [torch.bfloat16, torch.float32]


### PR DESCRIPTION



## Purpose
Update the AMD Zen CPU platform (`ZenCpuPlatform`) to correctly declare supported dtypes and switch the zentorch dependency to the weekly release channel.
This PR fixes the two minor issues introduced in https://github.com/vllm-project/vllm/issues/35089
1. **Declare `supported_dtypes` for Zen CPU**: AMD Zen CPUs do not support float16 compute natively. The base `CpuPlatform` includes `torch.float16` in its `supported_dtypes`, which causes vLLM to accept float16 models on Zen CPUs. This leads to dtype mismatches and the execution errors out. This PR overrides `supported_dtypes` in `ZenCpuPlatform` to return only `[torch.bfloat16, torch.float32]`, matching the actual hardware capabilities.
2. **Switch `vllm[zen]` to `zentorch-weekly`**: The `zentorch` PyPI release cadence is weekly. Using `zentorch-weekly` ensures `pip install vllm[zen]` always pulls the latest weekly build instead of release builds.
## Test Plan
- Verify that models with native float16 dtype (e.g., `bloom-560m`, `opt-125m`) are automatically resolved to bfloat16 on Zen CPU with a warning, instead of silently running in an unsupported dtype.
- Run the existing CPU generation tests on an AMD Zen machine:
  ```bash
  pytest -v -s tests/models/language/generation -m cpu_model
- Verify pip install vllm[zen] resolves to the latest zentorch-weekly package.
- Verify that the test cases added specifically for Zen CPU and zentorch can run and pass.
  ```bash
  pytest tests/test_zen_cpu_platform_detection.py -v
  pytest tests/model_executor/test_cpu_unquantized_gemm_dispatch.py -v
 
## Test Result
- Models with torch_dtype=float16 in their HF config are correctly downcast to bfloat16 with a log warning: Your device 'cpu' doesn't support torch.float16. Falling back to torch.bfloat16 for compatibility.
- Models with torch_dtype=bfloat16 or torch_dtype=float32 are unaffected.
- pip install "vllm[zen]" successfully installs zentorch-weekly.
- Test cases added specifically for Zen CPU and zentorch run and pass successfully.
```bash
tests/test_zen_cpu_platform_detection.py::test_is_amd_zen_cpu_detects_amd_with_avx512 PASSED [25%]
tests/test_zen_cpu_platform_detection.py::test_is_amd_zen_cpu_returns_false_for_amd_without_avx512 PASSED [50%]
tests/test_zen_cpu_platform_detection.py::test_is_amd_zen_cpu_returns_false_for_intel_with_avx512 PASSED [75%]
tests/test_zen_cpu_platform_detection.py::test_is_amd_zen_cpu_returns_false_when_cpuinfo_missing PASSED [100%]

tests/model_executor/test_cpu_unquantized_gemm_dispatch.py::test_dispatch_cpu_unquantized_gemm_uses_zentorch_on_zen PASSED [50%]
tests/model_executor/test_cpu_unquantized_gemm_dispatch.py::test_dispatch_cpu_unquantized_gemm_zen_remove_weight PASSED [100%]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

