### PR TITLE
Removed GPU state confirmation and cleanup steps.

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -35,23 +35,6 @@ export PYTHONPATH=".."
 # Helper Functions
 ###############################################################################
 
-wait_for_clean_gpus() {
-  local timeout=${1:-300}
-  local start=$SECONDS
-  echo "--- Waiting for clean GPU state (timeout: ${timeout}s)"
-  while true; do
-    if grep -q clean /opt/amdgpu/etc/gpu_state; then
-      echo "GPUs state is \"clean\""
-      return
-    fi
-    if (( SECONDS - start >= timeout )); then
-      echo "Error: GPUs did not reach clean state within ${timeout}s" >&2
-      exit 1
-    fi
-    sleep 3
-  done
-}
-
 cleanup_docker() {
   # Get Docker's root directory
   docker_root=$(docker info -f '{{.DockerRootDir}}')
@@ -365,18 +348,11 @@ apply_rocm_test_overrides() {
 ###############################################################################
 
 # --- GPU initialization ---
-echo "--- Confirming Clean Initial State"
-wait_for_clean_gpus
-
 echo "--- ROCm info"
 rocminfo
 
 # --- Docker housekeeping ---
 cleanup_docker
-
-echo "--- Resetting GPUs"
-echo "reset" > /opt/amdgpu/etc/gpu_state
-wait_for_clean_gpus
 
 # --- Pull test image ---
 echo "--- Pulling container"


### PR DESCRIPTION



## Purpose
Remove GPU reset functionality from the AMD hardware CI test script (.buildkite/scripts/hardware_ci/run-amd-test.sh) as it is no longer applicable for Kubernetes pods.
The removed code interacted with /opt/amdgpu/etc/gpu_state to:
Wait for GPUs to reach a "clean" state before tests (wait_for_clean_gpus())
Confirm clean initial GPU state at startup
Trigger a GPU reset by writing "reset" to /opt/amdgpu/etc/gpu_state and waiting for completion
In a Kubernetes environment, pods do not have access to the host-level /opt/amdgpu/etc/gpu_state file. GPU device lifecycle is managed by the AMD GPU device plugin and the kubelet -- resetting from within a pod is unsupported.