### PR TITLE
[Bugfix][Core] Allow multi-dtype MambaSpec KV cache spec

### DIFF
--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -273,7 +273,7 @@ class SlidingWindowSpec(AttentionSpec):
 @dataclass(frozen=True)
 class MambaSpec(KVCacheSpec):
     shapes: tuple[tuple[int, ...], ...]
-    dtypes: tuple[torch.dtype]
+    dtypes: tuple[torch.dtype, ...]
     page_size_padded: int | None = None
     mamba_type: str = "mamba2"
     mamba_cache_mode: str = "none"


### PR DESCRIPTION


## Purpose

Fix a `msgspec` schema mismatch for `MambaSpec` KV cache specs when models use multiple state dtypes.

Several Mamba-style and hybrid models, such as `Qwen3.5` and `Mamba2`, return multiple Mamba state dtypes and shapes from `get_mamba_state_dtype_from_config` and `get_mamba_state_shape_from_config`. That flows into `MambaSpec`, but `MambaSpec.dtypes` was annotated as `tuple[torch.dtype]`, which `msgspec` interprets as a fixed-length 1-tuple.

When these specs cross the RPC boundary, for example via `collective_rpc("get_kv_cache_spec")`, decoding can fail with `ValidationError: Expected array of length 1, got 2 - at $.dtypes`. This PR updates `MambaSpec.dtypes` to `tuple[torch.dtype, ...]` so multi-dtype Mamba cache specs round-trip correctly.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [] The test plan, such as providing test command.
- [] The test results, such as pasting the results comparison before and after, or e2e results
- [] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. 
- [] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).

</details>

