### PR TITLE
[Bugfix][Frontend] Return 400 for corrupt/truncated image inputs instead of 500

### DIFF
--- a/tests/multimodal/media/test_image.py
+++ b/tests/multimodal/media/test_image.py
@@ -131,3 +131,77 @@ def test_image_media_io_rgba_background_color_validation():
     ImageMediaIO(rgba_background_color=(0, 0, 0))  # Should not raise
     ImageMediaIO(rgba_background_color=[255, 255, 255])  # Should not raise
     ImageMediaIO(rgba_background_color=(128, 128, 128))  # Should not raise
+
+
+def test_image_media_io_load_bytes(tmp_path):
+    """Test load_bytes with valid and invalid image data."""
+    # Save a valid RGB image to use as source bytes
+    valid_image = Image.new("RGB", (8, 8), (100, 150, 200))
+    valid_path = tmp_path / "valid.png"
+    valid_image.save(valid_path)
+
+    valid_data = valid_path.read_bytes()
+
+    # Test 1: Valid image bytes load successfully and are fully decoded
+    image_io = ImageMediaIO()
+    result = image_io.load_bytes(valid_data)
+
+    # Check the returned media is a properly loaded image
+    assert isinstance(result.media, Image.Image)
+    assert result.media.size == (8, 8)
+    assert result.media.getpixel((0, 0)) == (100, 150, 200)
+
+    # Test 2: Garbage bytes raise ValueError
+    with pytest.raises(ValueError, match="Failed to load image"):
+        image_io.load_bytes(b"not an image")
+
+    # Test 3: Truncated PNG header raises ValueError
+    with pytest.raises(ValueError, match="Failed to load image"):
+        image_io.load_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 10)
+
+    # Test 4: Real PNG truncated mid-stream raises ValueError
+    with pytest.raises(ValueError, match="Failed to load image"):
+        image_io.load_bytes(valid_data[: len(valid_data) // 2])
+
+    # Test 5: Empty bytes raise ValueError
+    with pytest.raises(ValueError, match="Failed to load image"):
+        image_io.load_bytes(b"")
+
+
+def test_image_media_io_load_file(tmp_path):
+    """Test load_file with valid and invalid image files."""
+    # Save a valid RGB image to disk
+    valid_image = Image.new("RGB", (4, 4), (10, 20, 30))
+    valid_path = tmp_path / "valid.png"
+    valid_image.save(valid_path)
+
+    # Test 1: Valid image file loads successfully and is fully decoded
+    image_io = ImageMediaIO()
+    result = image_io.load_file(valid_path)
+
+    # Check the returned media is a properly loaded image
+    assert isinstance(result.media, Image.Image)
+    assert result.media.size == (4, 4)
+    assert result.media.getpixel((0, 0)) == (10, 20, 30)
+
+    # Test 2: File with garbage content raises ValueError
+    bad_file = tmp_path / "bad.png"
+    bad_file.write_bytes(b"this is not an image")
+
+    with pytest.raises(ValueError, match="Failed to load image"):
+        image_io.load_file(bad_file)
+
+    # Test 3: File with truncated PNG header raises ValueError
+    truncated_file = tmp_path / "truncated.png"
+    truncated_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 10)
+
+    with pytest.raises(ValueError, match="Failed to load image"):
+        image_io.load_file(truncated_file)
+
+    # Test 4: Real PNG file truncated mid-stream raises ValueError
+    valid_data = valid_path.read_bytes()
+    truncated_real_file = tmp_path / "truncated_real.png"
+    truncated_real_file.write_bytes(valid_data[: len(valid_data) // 2])
+
+    with pytest.raises(ValueError, match="Failed to load image"):
+        image_io.load_file(truncated_real_file)

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -80,15 +80,7 @@ class ImageMediaIO(MediaIO[Image.Image]):
         return self.load_bytes(pybase64.b64decode(data, validate=True))
 
     def load_file(self, filepath: Path) -> MediaWithBytes[Image.Image]:
-        with open(filepath, "rb") as f:
-            data = f.read()
-        try:
-            image = Image.open(BytesIO(data))
-            image.load()
-            image = self._convert_image_mode(image)
-        except (OSError, Image.UnidentifiedImageError) as e:
-            raise ValueError(f"Failed to load image: {e}") from e
-        return MediaWithBytes(image, data)
+        return self.load_bytes(filepath.read_bytes())
 
     def encode_base64(
         self,

--- a/vllm/multimodal/media/image.py
+++ b/vllm/multimodal/media/image.py
@@ -68,8 +68,13 @@ class ImageMediaIO(MediaIO[Image.Image]):
             return convert_image_mode(image, self.image_mode)
 
     def load_bytes(self, data: bytes) -> MediaWithBytes[Image.Image]:
-        image = Image.open(BytesIO(data))
-        return MediaWithBytes(self._convert_image_mode(image), data)
+        try:
+            image = Image.open(BytesIO(data))
+            image.load()
+            image = self._convert_image_mode(image)
+        except (OSError, Image.UnidentifiedImageError) as e:
+            raise ValueError(f"Failed to load image: {e}") from e
+        return MediaWithBytes(image, data)
 
     def load_base64(self, media_type: str, data: str) -> MediaWithBytes[Image.Image]:
         return self.load_bytes(pybase64.b64decode(data, validate=True))
@@ -77,8 +82,13 @@ class ImageMediaIO(MediaIO[Image.Image]):
     def load_file(self, filepath: Path) -> MediaWithBytes[Image.Image]:
         with open(filepath, "rb") as f:
             data = f.read()
-        image = Image.open(BytesIO(data))
-        return MediaWithBytes(self._convert_image_mode(image), data)
+        try:
+            image = Image.open(BytesIO(data))
+            image.load()
+            image = self._convert_image_mode(image)
+        except (OSError, Image.UnidentifiedImageError) as e:
+            raise ValueError(f"Failed to load image: {e}") from e
+        return MediaWithBytes(image, data)
 
     def encode_base64(
         self,


### PR DESCRIPTION




## Purpose
Fix incorrect error classification for invalid multimodal image inputs.

Currently, when a client sends a base64-encoded image that is syntactically valid but contains truncated or corrupted image data, vLLM returns an HTTP 500 Internal Server Error. This happens because PIL raises OSError during image decoding, which is not caught and falls through to the default 500 error path.

This PR ensures such cases are correctly treated as client errors by:

- catching OSError and PIL.UnidentifiedImageError during image decode/load/convert
- re-raising them as ValueError
- allowing existing error handling to return HTTP 400 Bad Request

This aligns behavior with expected API semantics:

- 4xx → client error (invalid input)
- 5xx → server error

### how to reproduce? 
Create truncated file:
```
python3 - <<'PY'
from pathlib import Path
d = Path("good.jpeg").read_bytes()
Path("truncated.jpeg").write_bytes(d[:-128])
PY
```
```
BAD_B64=$(base64 -i truncated.jpeg | tr -d '\n')

curl -s -w "\nHTTP status: %{http_code}\n" \
  -X POST http://localhost:8001/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d "{
    \"model\": \"meta-llama/Llama-4-Scout-17B-16E-Instruct\",
    \"messages\": [{
      \"role\": \"user\",
      \"content\": [
        {\"type\": \"text\", \"text\": \"What is in this image?\"},
        {\"type\": \"image_url\",\"image_url\": {\"url\": \"data:image/jpeg;base64,$BAD_B64\"}}
      ]
    }]
  }"
```
| Version | Result   |
|---------|----------|
| Before  | HTTP 500 |
| After   | HTTP 400 |

AI assistance was used (Claude Code) and all changed lines were reviewed by the human submitter.

## Test Plan
### Unit tests 

uv run --no-project pytest tests/multimodal/media/test_image.py -v

### Manual API testing
Using OpenAI-compatible endpoint. 
Test cases:
- valid JPEG/PNG/WEBP
- truncated JPEG/PNG/WEBP (real files truncated from valid images)
- malformed base64
- random non-image bytes
## Test Result
## Before / After

Test Case | Before Fix HTTP | After Fix HTTP | Change | Notes
-- | -- | -- | -- | --
✅ Valid JPEG | 200 | 200 | — | Correct behavior unchanged
✅ Valid PNG | 200 | 200 | — | Correct behavior unchanged
✅ Valid RGBA (PNG w/ alpha) | 200 | 200 | — | Correct behavior unchanged
❌ Truncated JPEG | 500 | 400 | ✅ Improved | Now correctly treated as client error (bad input)
❌ Malformed base64 | 400 | 400 | — | Already correct
❌ Truncated PNG | 500 | 400 | ✅ Improved | Decoder failure reclassified to client error
❌ Random non-image (JPEG label) | 400 | 400 | — | Already correct
❌ Missing base64 marker | 400 | 400 | — | Already correct (parsing failure)
❌ Random non-image bytes | 400 | 400 | — | Already correct
❌ Truncated WebP | 500 | 400 | ✅ Improved | Decoder error now mapped to BadRequest



### Unit tests: 
- tests/multimodal/media/test_image.py::test_image_media_io_rgba_custom_background PASSED
 - tests/multimodal/media/test_image.py::test_image_media_io_rgba_background_color_validation PASSED   
 - tests/multimodal/media/test_image.py::test_image_media_io_load_bytes PASSED                         
 - tests/multimodal/media/test_image.py::test_image_media_io_load_file PASSED 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

