### PR TITLE
[CT][FP8][Marlin] refactor CompressedTensorsW8A16Fp8 to use kernel abstraction

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -478,32 +478,34 @@ def choose_mp_linear_kernel(
     )
 
 
-# TODO: add force_kernel option to choose_mp_linear_kernel and use it in
-# init_mp_linear_kernel, # similar to init_fp8_linear_kernel and
-# init_int8_linear_kernel, to allow forcing a specific kernel for testing and
-# debugging purposes.
-def choose_wfp8_a16_linear_kernel(
-    config: FP8ScaledMMLinearLayerConfig, compute_capability: int | None = None
-) -> type[FP8ScaledMMLinearKernel]:
-    if compute_capability is None:
-        if current_platform is None:
-            raise ValueError("Cannot determine compute capability")
-        _cc = current_platform.get_device_capability()
-        if _cc is not None:
-            compute_capability = _cc[0] * 10 + _cc[1]
+def init_wfp8_a16_linear_kernel(
+    weight_quant_key: QuantKey,
+    activation_quant_key: QuantKey,
+    out_dtype: torch.dtype,
+    force_kernel: type[FP8ScaledMMLinearKernel] | None = None,
+    module_name: str | None = None,
+) -> FP8ScaledMMLinearKernel:
+    config = FP8ScaledMMLinearLayerConfig(
+        weight_quant_key=weight_quant_key,
+        activation_quant_key=activation_quant_key,
+        out_dtype=out_dtype,
+    )
 
-    failure_reason_list = []
-    for kernel in _POSSIBLE_WFP8A16_KERNELS[current_platform._enum]:
-        is_supported_and_can_implement, failure_reason = (
-            is_supported_and_can_implement_kernel(kernel, config, compute_capability)
+    kernel_type = choose_scaled_mm_linear_kernel(
+        config, _POSSIBLE_WFP8A16_KERNELS, force_kernel=force_kernel
+    )
+
+    if module_name:
+        logger.info_once(
+            "Selected %s for %s",
+            kernel_type.__name__,
+            module_name,
+            scope="global",
         )
-        if is_supported_and_can_implement:
-            return kernel
-        failure_reason_list.append(failure_reason)
 
-    raise ValueError(
-        "Failed to find a kernel that can implement the "
-        "WFP8A16 linear layer. Reasons: \n" + "\n".join(failure_reason_list)
+    return kernel_type(
+        config,
+        layer_param_names=["weight", "weight_scale", "input_scale", "input_scale_ub"],
     )
 
 
@@ -632,7 +634,7 @@ __all__ = [
     "init_nvfp4_linear_kernel",
     "choose_mp_linear_kernel",
     "register_linear_kernel",
-    "choose_wfp8_a16_linear_kernel",
+    "init_wfp8_a16_linear_kernel",
     "FP8ScaledMMLinearKernel",
     "Int8ScaledMMLinearKernel",
     "ScaledMMLinearKernel",

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -478,6 +478,35 @@ def choose_mp_linear_kernel(
     )
 
 
+# TODO: add force_kernel option to choose_mp_linear_kernel and use it in
+# init_mp_linear_kernel, # similar to init_fp8_linear_kernel and
+# init_int8_linear_kernel, to allow forcing a specific kernel for testing and
+# debugging purposes.
+def choose_wfp8_a16_linear_kernel(
+    config: FP8ScaledMMLinearLayerConfig, compute_capability: int | None = None
+) -> type[FP8ScaledMMLinearKernel]:
+    if compute_capability is None:
+        if current_platform is None:
+            raise ValueError("Cannot determine compute capability")
+        _cc = current_platform.get_device_capability()
+        if _cc is not None:
+            compute_capability = _cc[0] * 10 + _cc[1]
+
+    failure_reason_list = []
+    for kernel in _POSSIBLE_WFP8A16_KERNELS[current_platform._enum]:
+        is_supported_and_can_implement, failure_reason = (
+            is_supported_and_can_implement_kernel(kernel, config, compute_capability)
+        )
+        if is_supported_and_can_implement:
+            return kernel
+        failure_reason_list.append(failure_reason)
+
+    raise ValueError(
+        "Failed to find a kernel that can implement the "
+        "WFP8A16 linear layer. Reasons: \n" + "\n".join(failure_reason_list)
+    )
+
+
 # Maps VLLM_NVFP4_GEMM_BACKEND env var values to kernel classes.
 _NVFP4_BACKEND_TO_KERNEL: dict[str, type[NvFp4LinearKernel]] = {
     "flashinfer-cutlass": FlashInferCutlassNvFp4LinearKernel,
@@ -595,38 +624,6 @@ def register_linear_kernel(
         _POSSIBLE_NVFP4_KERNELS[platform].append(kernel_class)
     else:
         raise ValueError(f"Unrecognized kernel type: {kernel_type}")
-
-
-def choose_wfp8_a16_linear_kernel(
-    config: FP8ScaledMMLinearLayerConfig, compute_capability: int | None = None
-) -> type[FP8ScaledMMLinearKernel]:
-    if compute_capability is None:
-        if current_platform is None:
-            raise ValueError("Cannot determine compute capability")
-        _cc = current_platform.get_device_capability()
-        if _cc is not None:
-            compute_capability = _cc[0] * 10 + _cc[1]
-
-    failure_reasons = []
-    for kernel in _POSSIBLE_WFP8A16_KERNELS[current_platform._enum]:
-        if kernel.__name__ in envs.VLLM_DISABLED_KERNELS:
-            failure_reasons.append(
-                f" {kernel.__name__} disabled by environment variable"
-            )
-            continue
-
-        can_implement, failure_reason = kernel.can_implement(config)
-        if can_implement:
-            return kernel
-        else:
-            failure_reasons.append(
-                f" {kernel.__name__} cannot implement due to: {failure_reason}"
-            )
-
-    raise ValueError(
-        "Failed to find a kernel that can implement the "
-        "WFP8A16 linear layer. Reasons: \n" + "\n".join(failure_reasons)
-    )
 
 
 __all__ = [

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -188,7 +188,7 @@ _POSSIBLE_WFP8A16_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]
         # To be added
     ],
     PlatformEnum.XPU: [
-        XPUFP8ScaledMMLinearKernel,
+        # To be added
     ],
 }
 

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -177,6 +177,21 @@ _POSSIBLE_FP8_BLOCK_KERNELS: dict[
     ],
 }
 
+_POSSIBLE_WFP8A16_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]]] = {
+    PlatformEnum.CUDA: [
+        MarlinFP8ScaledMMLinearKernel,
+    ],
+    PlatformEnum.ROCM: [
+        # To be added
+    ],
+    PlatformEnum.CPU: [
+        # To be added
+    ],
+    PlatformEnum.XPU: [
+        XPUFP8ScaledMMLinearKernel,
+    ],
+}
+
 # in priority/performance order (when available)
 _POSSIBLE_KERNELS: dict[PlatformEnum, list[type[MPLinearKernel]]] = {
     PlatformEnum.CUDA: [
@@ -582,12 +597,55 @@ def register_linear_kernel(
         raise ValueError(f"Unrecognized kernel type: {kernel_type}")
 
 
+def choose_wfp8_a16_linear_kernel(
+    config: FP8ScaledMMLinearLayerConfig, compute_capability: int | None = None
+) -> type[FP8ScaledMMLinearKernel]:
+    if compute_capability is None:
+        if current_platform is None:
+            raise ValueError("Cannot determine compute capability")
+        _cc = current_platform.get_device_capability()
+        if _cc is not None:
+            compute_capability = _cc[0] * 10 + _cc[1]
+
+    failure_reasons = []
+    for kernel in _POSSIBLE_WFP8A16_KERNELS[current_platform._enum]:
+        if kernel.__name__ in envs.VLLM_DISABLED_KERNELS:
+            failure_reasons.append(
+                f" {kernel.__name__} disabled by environment variable"
+            )
+            continue
+        if (
+            compute_capability is not None
+            and kernel.get_min_capability() > compute_capability
+        ):
+            failure_reasons.append(
+                f"{kernel.__name__} requires capability "
+                f"{kernel.get_min_capability()}, current compute "
+                f" capability is {compute_capability}"
+            )
+            continue
+
+        can_implement, failure_reason = kernel.can_implement(config)
+        if can_implement:
+            return kernel
+        else:
+            failure_reasons.append(
+                f" {kernel.__name__} cannot implement due to: {failure_reason}"
+            )
+
+    raise ValueError(
+        "Failed to find a kernel that can implement the "
+        "WFP8A16 linear layer. Reasons: \n" + "\n".join(failure_reasons)
+    )
+
+
 __all__ = [
     "init_fp8_linear_kernel",
     "init_int8_linear_kernel",
     "init_nvfp4_linear_kernel",
     "choose_mp_linear_kernel",
     "register_linear_kernel",
+    "choose_wfp8_a16_linear_kernel",
     "FP8ScaledMMLinearKernel",
     "Int8ScaledMMLinearKernel",
     "ScaledMMLinearKernel",

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -614,16 +614,6 @@ def choose_wfp8_a16_linear_kernel(
                 f" {kernel.__name__} disabled by environment variable"
             )
             continue
-        if (
-            compute_capability is not None
-            and kernel.get_min_capability() > compute_capability
-        ):
-            failure_reasons.append(
-                f"{kernel.__name__} requires capability "
-                f"{kernel.get_min_capability()}, current compute "
-                f" capability is {compute_capability}"
-            )
-            continue
 
         can_implement, failure_reason = kernel.can_implement(config)
         if can_implement:

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -481,6 +481,8 @@ def choose_mp_linear_kernel(
 def init_wfp8_a16_linear_kernel(
     weight_quant_key: QuantKey,
     activation_quant_key: QuantKey,
+    weight_shape: tuple[int, int],
+    input_dtype: torch.dtype,
     out_dtype: torch.dtype,
     force_kernel: type[FP8ScaledMMLinearKernel] | None = None,
     module_name: str | None = None,
@@ -488,6 +490,8 @@ def init_wfp8_a16_linear_kernel(
     config = FP8ScaledMMLinearLayerConfig(
         weight_quant_key=weight_quant_key,
         activation_quant_key=activation_quant_key,
+        weight_shape=weight_shape,
+        input_dtype=input_dtype,
         out_dtype=out_dtype,
     )
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -139,9 +139,14 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if self.strategy == QuantizationStrategy.BLOCK:
             assert self.is_static_input_scheme is False
-            # MarlinFP8ScaledMMLinearKernel expects "weight_scale_inv" for block quant.
-            # Expose weight_scale under that name so the kernel can find it.
-            replace_parameter(layer, "weight_scale_inv", layer.weight_scale.data)
+            # MarlinFP8ScaledMMLinearKernel uses "weight_scale_inv" for block
+            # quant, while CT registers the scale as "weight_scale".
+            # Rename by deleting the old parameter and adding the new one so
+            # that prepare_fp8_layer_for_marlin (which prefers "weight_scale"
+            # over "weight_scale_inv") picks up "weight_scale_inv" correctly.
+            weight_scale_data = layer.weight_scale.data
+            del layer._parameters["weight_scale"]
+            replace_parameter(layer, "weight_scale_inv", weight_scale_data)
         else:
             # Transpose weights to (K, N) layout expected by Marlin.
             replace_parameter(layer, "weight", layer.weight.data.t())

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -6,18 +6,23 @@ from collections.abc import Callable
 import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
 
+from vllm.model_executor.kernels.linear import (
+    FP8ScaledMMLinearLayerConfig,
+    choose_wfp8_a16_linear_kernel,
+)
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
 )
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     create_fp8_scale_parameter,
     create_fp8_weight_parameter,
-    process_fp8_weight_block_strategy,
     validate_fp8_block_shape,
 )
-from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
-    apply_fp8_marlin_linear,
-    prepare_fp8_layer_for_marlin,
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8DynamicTensorSym,
+    kFp8Static128BlockSym,
+    kFp8StaticChannelSym,
+    kFp8StaticTensorSym,
 )
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     convert_to_channelwise,
@@ -37,6 +42,12 @@ strategy_to_parameter_type = {
     QuantizationStrategy.TENSOR: PerTensorScaleParameter,
 }
 
+_STRATEGY_TO_WEIGHT_QUANT_KEY = {
+    QuantizationStrategy.BLOCK: kFp8Static128BlockSym,
+    QuantizationStrategy.CHANNEL: kFp8StaticChannelSym,
+    QuantizationStrategy.TENSOR: kFp8StaticTensorSym,
+}
+
 
 class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
     def __init__(self, weight_quant: QuantizationArgs, is_static_input_scheme: bool):
@@ -44,6 +55,21 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         self.strategy = weight_quant.strategy
         self.is_static_input_scheme = is_static_input_scheme
         self.weight_block_size = self.weight_quant.block_structure
+
+        weight_quant_key = _STRATEGY_TO_WEIGHT_QUANT_KEY[self.strategy]
+        activation_quant_key = (
+            kFp8StaticTensorSym if is_static_input_scheme else kFp8DynamicTensorSym
+        )
+        linear_kernel_config = FP8ScaledMMLinearLayerConfig(
+            weight_quant_key=weight_quant_key,
+            activation_quant_key=activation_quant_key,
+            out_dtype=None,
+        )
+        kernel_type = choose_wfp8_a16_linear_kernel(linear_kernel_config)
+        self.linear_kernel = kernel_type(
+            linear_kernel_config,
+            layer_param_names=["weight", "weight_scale", "input_scale", None],
+        )
 
     @classmethod
     def get_min_capability(cls) -> int:
@@ -106,31 +132,24 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
             layer.register_parameter("input_scale", input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        weight = layer.weight
-        weight_scale = layer.weight_scale
-        size_k_first = True
-        # TODO(rob): refactor block quant into separate class.
         if self.strategy == QuantizationStrategy.BLOCK:
             assert self.is_static_input_scheme is False
-            size_k_first = False
-            weight, weight_scale = process_fp8_weight_block_strategy(
-                weight, weight_scale
-            )
+            # MarlinFP8ScaledMMLinearKernel expects "weight_scale_inv" for block quant.
+            # Expose weight_scale under that name so the kernel can find it.
+            replace_parameter(layer, "weight_scale_inv", layer.weight_scale.data)
         else:
-            # Weights must be transposed for marlin
-            weight = weight.t()
+            # Transpose weights to (K, N) layout expected by Marlin.
+            replace_parameter(layer, "weight", layer.weight.data.t())
             if self.strategy == QuantizationStrategy.TENSOR:
-                # If we have a fused module (QKV, MLP) with per tensor scales,
-                # we expand each scale to its shard's channels.
-                weight_scale = convert_to_channelwise(
-                    weight_scale, layer.logical_widths
+                # For fused modules with per-tensor scales, expand each scale
+                # to its shard's channels.
+                replace_parameter(
+                    layer,
+                    "weight_scale",
+                    convert_to_channelwise(layer.weight_scale, layer.logical_widths),
                 )
 
-        # Update layer with new values
-        replace_parameter(layer, "weight", weight.data)
-        replace_parameter(layer, "weight_scale", weight_scale.data)
-
-        prepare_fp8_layer_for_marlin(layer, size_k_first=size_k_first)
+        self.linear_kernel.process_weights_after_loading(layer)
 
     def apply_weights(
         self,
@@ -138,12 +157,4 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        return apply_fp8_marlin_linear(
-            input=x,
-            weight=layer.weight,
-            weight_scale=layer.weight_scale,
-            workspace=layer.workspace,
-            size_n=layer.output_size_per_partition,
-            size_k=layer.input_size_per_partition,
-            bias=bias,
-        )
+        return self.linear_kernel.apply_weights(layer, x, bias)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -68,7 +68,12 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         kernel_type = choose_wfp8_a16_linear_kernel(linear_kernel_config)
         self.linear_kernel = kernel_type(
             linear_kernel_config,
-            layer_param_names=["weight", "weight_scale", "input_scale", None],
+            layer_param_names=[
+                "weight",
+                "weight_scale",
+                "input_scale",
+                "input_scale_ub",
+            ],
         )
 
     @classmethod

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -7,8 +7,7 @@ import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
 
 from vllm.model_executor.kernels.linear import (
-    FP8ScaledMMLinearLayerConfig,
-    choose_wfp8_a16_linear_kernel,
+    init_wfp8_a16_linear_kernel,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
@@ -60,20 +59,11 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         activation_quant_key = (
             kFp8StaticTensorSym if is_static_input_scheme else kFp8DynamicTensorSym
         )
-        linear_kernel_config = FP8ScaledMMLinearLayerConfig(
+
+        self.linear_kernel = init_wfp8_a16_linear_kernel(
             weight_quant_key=weight_quant_key,
             activation_quant_key=activation_quant_key,
             out_dtype=None,
-        )
-        kernel_type = choose_wfp8_a16_linear_kernel(linear_kernel_config)
-        self.linear_kernel = kernel_type(
-            linear_kernel_config,
-            layer_param_names=[
-                "weight",
-                "weight_scale",
-                "input_scale",
-                "input_scale_ub",
-            ],
         )
 
     @classmethod

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -12,6 +12,10 @@ from vllm.model_executor.kernels.linear import (
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    STRATEGT_TO_PARAMETER_TYPE,
+    STRATEGY_TO_WEIGHT_QUANT_KEY,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     create_fp8_scale_parameter,
     create_fp8_weight_parameter,
@@ -19,33 +23,15 @@ from vllm.model_executor.layers.quantization.utils.fp8_utils import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8DynamicTensorSym,
-    kFp8Static128BlockSym,
-    kFp8StaticChannelSym,
     kFp8StaticTensorSym,
 )
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     convert_to_channelwise,
 )
-from vllm.model_executor.parameter import (
-    BlockQuantScaleParameter,
-    ChannelQuantScaleParameter,
-    PerTensorScaleParameter,
-)
+from vllm.model_executor.parameter import PerTensorScaleParameter
 from vllm.model_executor.utils import replace_parameter
 
 __all__ = ["CompressedTensorsW8A16Fp8"]
-
-strategy_to_parameter_type = {
-    QuantizationStrategy.BLOCK: BlockQuantScaleParameter,
-    QuantizationStrategy.CHANNEL: ChannelQuantScaleParameter,
-    QuantizationStrategy.TENSOR: PerTensorScaleParameter,
-}
-
-_STRATEGY_TO_WEIGHT_QUANT_KEY = {
-    QuantizationStrategy.BLOCK: kFp8Static128BlockSym,
-    QuantizationStrategy.CHANNEL: kFp8StaticChannelSym,
-    QuantizationStrategy.TENSOR: kFp8StaticTensorSym,
-}
 
 
 class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
@@ -55,7 +41,7 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         self.is_static_input_scheme = is_static_input_scheme
         self.weight_block_size = self.weight_quant.block_structure
 
-        weight_quant_key = _STRATEGY_TO_WEIGHT_QUANT_KEY[self.strategy]
+        weight_quant_key = STRATEGY_TO_WEIGHT_QUANT_KEY[self.strategy]
         activation_quant_key = (
             kFp8StaticTensorSym if is_static_input_scheme else kFp8DynamicTensorSym
         )
@@ -110,7 +96,7 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
 
         # WEIGHT SCALE
         weight_scale = create_fp8_scale_parameter(
-            strategy_to_parameter_type[self.strategy],
+            STRATEGT_TO_PARAMETER_TYPE[self.strategy],
             output_partition_sizes,
             input_size_per_partition,
             layer.weight_block_size,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -13,7 +13,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
-    STRATEGT_TO_PARAMETER_TYPE,
+    STRATEGY_TO_PARAMETER_TYPE,
     STRATEGY_TO_WEIGHT_QUANT_KEY,
 )
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
@@ -96,7 +96,7 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
 
         # WEIGHT SCALE
         weight_scale = create_fp8_scale_parameter(
-            STRATEGT_TO_PARAMETER_TYPE[self.strategy],
+            STRATEGY_TO_PARAMETER_TYPE[self.strategy],
             output_partition_sizes,
             input_size_per_partition,
             layer.weight_block_size,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -138,8 +138,6 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
             del layer._parameters["weight_scale"]
             replace_parameter(layer, "weight_scale_inv", weight_scale_data)
         else:
-            # Transpose no longer needed after
-            # https://github.com/vllm-project/vllm/pull/38092/
             if self.strategy == QuantizationStrategy.TENSOR:
                 # For fused modules with per-tensor scales, expand each scale
                 # to its shard's channels.

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
 
+from vllm.config import get_current_vllm_config
 from vllm.model_executor.kernels.linear import (
     init_wfp8_a16_linear_kernel,
 )
@@ -38,18 +39,14 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
     def __init__(self, weight_quant: QuantizationArgs, is_static_input_scheme: bool):
         self.weight_quant = weight_quant
         self.strategy = weight_quant.strategy
+        self.out_dtype = torch.get_default_dtype()
+        self.input_dtype = get_current_vllm_config().model_config.dtype
         self.is_static_input_scheme = is_static_input_scheme
         self.weight_block_size = self.weight_quant.block_structure
 
-        weight_quant_key = STRATEGY_TO_WEIGHT_QUANT_KEY[self.strategy]
-        activation_quant_key = (
+        self.weight_quant_key = STRATEGY_TO_WEIGHT_QUANT_KEY[self.strategy]
+        self.activation_quant_key = (
             kFp8StaticTensorSym if is_static_input_scheme else kFp8DynamicTensorSym
-        )
-
-        self.linear_kernel = init_wfp8_a16_linear_kernel(
-            weight_quant_key=weight_quant_key,
-            activation_quant_key=activation_quant_key,
-            out_dtype=None,
         )
 
     @classmethod
@@ -111,6 +108,14 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
                 weight_loader=weight_loader,
             )
             layer.register_parameter("input_scale", input_scale)
+
+        self.linear_kernel = init_wfp8_a16_linear_kernel(
+            weight_quant_key=self.weight_quant_key,
+            activation_quant_key=self.activation_quant_key,
+            weight_shape=layer.weight.shape,
+            input_dtype=self.input_dtype,
+            out_dtype=self.out_dtype,
+        )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if self.strategy == QuantizationStrategy.BLOCK:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -138,8 +138,8 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
             del layer._parameters["weight_scale"]
             replace_parameter(layer, "weight_scale_inv", weight_scale_data)
         else:
-            # Transpose weights to (K, N) layout expected by Marlin.
-            replace_parameter(layer, "weight", layer.weight.data.t())
+            # Transpose no longer needed after
+            # https://github.com/vllm-project/vllm/pull/38092/
             if self.strategy == QuantizationStrategy.TENSOR:
                 # For fused modules with per-tensor scales, expand each scale
                 # to its shard's channels.

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -16,6 +16,9 @@ from vllm.model_executor.kernels.linear import (
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    STRATEGT_TO_PARAMETER_TYPE,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     create_fp8_input_scale,
     create_fp8_scale_parameter,
@@ -34,19 +37,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     cutlass_block_fp8_supported,
 )
-from vllm.model_executor.parameter import (
-    BlockQuantScaleParameter,
-    ChannelQuantScaleParameter,
-    PerTensorScaleParameter,
-)
 
 __all__ = ["CompressedTensorsW8A8Fp8"]
-
-strategy_to_parameter_type = {
-    QuantizationStrategy.BLOCK: BlockQuantScaleParameter,
-    QuantizationStrategy.CHANNEL: ChannelQuantScaleParameter,
-    QuantizationStrategy.TENSOR: PerTensorScaleParameter,
-}
 
 STATIC_QUANT = True
 DYNAMIC_QUANT = False
@@ -130,7 +122,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
 
         # WEIGHT SCALE
         weight_scale = create_fp8_scale_parameter(
-            strategy_to_parameter_type[self.strategy],
+            STRATEGT_TO_PARAMETER_TYPE[self.strategy],
             output_partition_sizes,
             input_size_per_partition,
             layer.weight_block_size,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -17,7 +17,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
-    STRATEGT_TO_PARAMETER_TYPE,
+    STRATEGY_TO_PARAMETER_TYPE,
 )
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     create_fp8_input_scale,
@@ -122,7 +122,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
 
         # WEIGHT SCALE
         weight_scale = create_fp8_scale_parameter(
-            STRATEGT_TO_PARAMETER_TYPE[self.strategy],
+            STRATEGY_TO_PARAMETER_TYPE[self.strategy],
             output_partition_sizes,
             input_size_per_partition,
             layer.weight_block_size,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -6,7 +6,35 @@ from types import MappingProxyType
 
 import regex as re
 from compressed_tensors import CompressionFormat
+from compressed_tensors.quantization import QuantizationStrategy
 from torch.nn import Module
+
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Static128BlockSym,
+    kFp8StaticChannelSym,
+    kFp8StaticTensorSym,
+)
+from vllm.model_executor.parameter import (
+    BlockQuantScaleParameter,
+    ChannelQuantScaleParameter,
+    PerTensorScaleParameter,
+)
+
+# Maps quantization strategy to the corresponding scale parameter type.
+# Shared across compressed-tensor scheme classes (w8a16_fp8, w8a8_fp8, …).
+STRATEGT_TO_PARAMETER_TYPE = {
+    QuantizationStrategy.BLOCK: BlockQuantScaleParameter,
+    QuantizationStrategy.CHANNEL: ChannelQuantScaleParameter,
+    QuantizationStrategy.TENSOR: PerTensorScaleParameter,
+}
+
+# Maps quantization strategy to the vLLM weight-quant key used for
+# kernel selection.  Shared across compressed-tensor scheme classes.
+STRATEGY_TO_WEIGHT_QUANT_KEY = {
+    QuantizationStrategy.BLOCK: kFp8Static128BlockSym,
+    QuantizationStrategy.CHANNEL: kFp8StaticChannelSym,
+    QuantizationStrategy.TENSOR: kFp8StaticTensorSym,
+}
 
 
 def is_activation_quantization_format(format: str) -> bool:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -22,7 +22,7 @@ from vllm.model_executor.parameter import (
 
 # Maps quantization strategy to the corresponding scale parameter type.
 # Shared across compressed-tensor scheme classes (w8a16_fp8, w8a8_fp8, …).
-STRATEGT_TO_PARAMETER_TYPE = {
+STRATEGY_TO_PARAMETER_TYPE = {
     QuantizationStrategy.BLOCK: BlockQuantScaleParameter,
     QuantizationStrategy.CHANNEL: ChannelQuantScaleParameter,
     QuantizationStrategy.TENSOR: PerTensorScaleParameter,

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -50,13 +50,12 @@ class BaseModelLoader(ABC):
             device_config.device if load_config.device is None else load_config.device
         )
         target_device = torch.device(load_device)
-        with set_default_torch_dtype(model_config.dtype):
-            with target_device:
-                model = initialize_model(
-                    vllm_config=vllm_config,
-                    model_config=model_config,
-                    prefix=prefix,
-                )
+        with set_default_torch_dtype(model_config.dtype), target_device:
+            model = initialize_model(
+                vllm_config=vllm_config,
+                model_config=model_config,
+                prefix=prefix,
+            )
 
             log_model_inspection(model)
 

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -50,12 +50,13 @@ class BaseModelLoader(ABC):
             device_config.device if load_config.device is None else load_config.device
         )
         target_device = torch.device(load_device)
-        with set_default_torch_dtype(model_config.dtype), target_device:
-            model = initialize_model(
-                vllm_config=vllm_config,
-                model_config=model_config,
-                prefix=prefix,
-            )
+        with set_default_torch_dtype(model_config.dtype):
+            with target_device:
+                model = initialize_model(
+                    vllm_config=vllm_config,
+                    model_config=model_config,
+                    prefix=prefix,
+                )
 
             log_model_inspection(model)
 


### PR DESCRIPTION

## Purpose
Refactors `CompressedTensorsW8A16Fp8` to select and delegate to a
`FP8ScaledMMLinearKernel` via `choose_wfp8_a16_linear_kernel` instead of
hard-coding calls to `apply_fp8_marlin_linear` / `prepare_fp8_layer_for_marlin`.
This aligns the W8A16-FP8 compressed-tensors path with the existing kernel
selection infrastructure used by other quantization schemes.

## Changes

- **Kernel selection in `__init__`**: builds a `FP8ScaledMMLinearLayerConfig`
  (mapping `QuantizationStrategy` → `QuantKey` via `_STRATEGY_TO_WEIGHT_QUANT_KEY`)
  and calls `choose_wfp8_a16_linear_kernel` to obtain a `FP8ScaledMMLinearKernel`
  instance. Future platforms only need to register a kernel in
  `_POSSIBLE_WFP8A16_KERNELS`; no changes to this class are required.
- **`process_weights_after_loading`**: CT-specific preprocessing (weight
  transpose, per-tensor → channel-wise scale expansion for fused layers,
  `weight_scale` → `weight_scale_inv` rename for block quant) is retained
  here; the call is then delegated to `self.linear_kernel.process_weights_after_loading`.
- **`apply_weights`**: fully delegated to `self.linear_kernel.apply_weights`.
- **Bug fix (block quant on pre-Ada GPUs, e.g. RTX 3090)**: previously both
  `weight_scale` and `weight_scale_inv` existed on the layer simultaneously.
  `prepare_fp8_layer_for_marlin` preferentially processes `weight_scale`
  into Marlin format but `MarlinFP8ScaledMMLinearKernel.apply_weights` reads
  `weight_scale_inv`, causing a shape mismatch at runtime
  (`b_scales dim 1 = N//block_size != size_n`). Fixed by deleting
  `weight_scale` before registering `weight_scale_inv` so only one scale
  attribute is present when the kernel processes the layer.
- Removes direct imports of `apply_fp8_marlin_linear`,
  `prepare_fp8_layer_for_marlin`, and `process_fp8_weight_block_strategy`.

## Test
```
# per channel
python3 examples/basic/offline_inference/generate.py --model RedHatAI/Qwen3-0.6B-FP8-dynamic
# per block
python3 examples/basic/offline_inference/generate.py --model RedHatAI/Qwen3-0.6B-FP8-BLOCK
```
## Test result
output make sense.

generated by Copilot + Claude 