### PR TITLE
[frontend] dump openai responses type by alias

### DIFF
--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -105,8 +105,8 @@ def serialize_message(msg):
     elif hasattr(msg, "to_dict"):
         return msg.to_dict()
     else:
-        # fallback to pyandic dump
-        return msg.model_dump_json()
+        # fallback to pydantic dump
+        return msg.model_dump_json(by_alias=True)
 
 
 def serialize_messages(msgs):


### PR DESCRIPTION



## Purpose

Some openai types (e.g. [`openai.types.responses.response_format_text_json_schema_config.ResponseFormatTextJSONSchemaConfig`](https://github.com/openai/openai-python/blob/5ae2cc10e4140d36aa236fa7c0bc5ce5ff190a01/src/openai/types/responses/response_format_text_json_schema_config.py#L26-L32)) uses aliases for their fields. As openai [dumps these types by alias](https://github.com/openai/openai-python/blob/5ae2cc10e4140d36aa236fa7c0bc5ce5ff190a01/src/openai/_models.py#L143), we do the same in responses endpoint.

Fix #38245.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

