### PR TITLE
[Bugfix] Remove dead name-only regex fallback from DeepSeek V3.1 tool parser

### DIFF
--- a/tests/tool_parsers/test_deepseekv31_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv31_tool_parser.py
@@ -3,7 +3,11 @@
 
 import pytest
 
-from vllm.tokenizers import get_tokenizer
+from tests.tool_parsers.common_tests import (
+    ToolParserTestConfig,
+    ToolParserTests,
+)
+from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.tool_parsers.deepseekv31_tool_parser import (
     DeepSeekV31ToolParser,
 )
@@ -59,3 +63,81 @@ def test_extract_tool_calls_with_multiple_tools(parser):
 
     # prefix is content
     assert result.content == "some prefix text"
+
+
+class TestDeepSeekV31ToolParserStreaming(ToolParserTests):
+    @pytest.fixture(scope="class")
+    def tokenizer(self) -> TokenizerLike:
+        return get_tokenizer(MODEL)
+
+    @pytest.fixture
+    def streaming(self) -> bool:
+        """Only test streaming mode."""
+        return True
+
+    @pytest.fixture
+    def test_config(self) -> ToolParserTestConfig:
+        return ToolParserTestConfig(
+            parser_name="deepseek_v31",
+            no_tool_calls_output="normal text",
+            single_tool_call_output=(
+                "normal text"
+                "<｜tool▁calls▁begin｜>"
+                '<｜tool▁call▁begin｜>foo<｜tool▁sep｜>{"x":1}<｜tool▁call▁end｜>'
+                "<｜tool▁calls▁end｜>"
+            ),
+            parallel_tool_calls_output=(
+                "some prefix text"
+                "<｜tool▁calls▁begin｜>"
+                '<｜tool▁call▁begin｜>foo<｜tool▁sep｜>{"x":1}<｜tool▁call▁end｜>'
+                '<｜tool▁call▁begin｜>bar<｜tool▁sep｜>{"y":2}<｜tool▁call▁end｜>'
+                "<｜tool▁calls▁end｜>"
+                " some suffix text"
+            ),
+            various_data_types_output=(
+                "<｜tool▁calls▁begin｜>"
+                "<｜tool▁call▁begin｜>foo<｜tool▁sep｜>"
+                '{"string_field": "hello", "int_field": 42, '
+                '"float_field": 3.14, "bool_field": true, '
+                '"null_field": null, '
+                '"array_field": [1, 2], '
+                '"object_field": {"k": "v"}}'
+                "<｜tool▁call▁end｜>"
+                "<｜tool▁calls▁end｜>"
+            ),
+            empty_arguments_output=(
+                "<｜tool▁calls▁begin｜>"
+                "<｜tool▁call▁begin｜>foo<｜tool▁sep｜>{}"
+                "<｜tool▁call▁end｜>"
+                "<｜tool▁calls▁end｜>"
+            ),
+            surrounding_text_output=(
+                "some prefix text"
+                "<｜tool▁calls▁begin｜>"
+                '<｜tool▁call▁begin｜>bar<｜tool▁sep｜>{"y":2}'
+                "<｜tool▁call▁end｜>"
+                "<｜tool▁calls▁end｜>"
+                " some suffix text"
+            ),
+            escaped_strings_output=(
+                "<｜tool▁calls▁begin｜>"
+                '<｜tool▁call▁begin｜>foo<｜tool▁sep｜>{"text": "a\\"b"}'
+                "<｜tool▁call▁end｜>"
+                "<｜tool▁calls▁end｜>"
+            ),
+            malformed_input_outputs=[
+                (
+                    "<｜tool▁calls▁begin｜>"
+                    '<｜tool▁call▁begin｜>foo<｜tool▁sep｜>{"x":1'
+                    "<｜tool▁call▁end｜>"
+                    "<｜tool▁calls▁end｜>"
+                ),
+            ],
+            single_tool_call_expected_name="foo",
+            single_tool_call_expected_args={"x": 1},
+            single_tool_call_expected_content="normal text",
+            parallel_tool_calls_count=2,
+            parallel_tool_calls_names=["foo", "bar"],
+            xfail_streaming={},
+            xfail_nonstreaming={},
+        )

--- a/vllm/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv31_tool_parser.py
@@ -49,10 +49,6 @@ class DeepSeekV31ToolParser(ToolParser):
             r"(?P<function_name>.*)<｜tool▁sep｜>(?P<function_arguments>.*)"
         )
 
-        self.stream_tool_call_name_regex = re.compile(
-            r"(?P<function_name>.*)<｜tool▁sep｜>"
-        )
-
         if not self.model_tokenizer:
             raise ValueError(
                 "The model tokenizer must be passed to the ToolParser "
@@ -253,16 +249,8 @@ class DeepSeekV31ToolParser(ToolParser):
                     current_tool_call["name"] = tool_name
                     current_tool_call["arguments"] = tool_args
                 else:
-                    current_tool_call_name_matches = (
-                        self.stream_tool_call_name_regex.match(tool_call_portion)
-                    )
-                    if current_tool_call_name_matches:
-                        tool_name = current_tool_call_name_matches.groups()
-                        current_tool_call["name"] = tool_name
-                        current_tool_call["arguments"] = ""
-                    else:
-                        logger.debug("Not enough token")
-                        return None
+                    logger.debug("Not enough token")
+                    return None
 
             # case - we haven't sent the tool name yet. If it's available, send
             #   it. otherwise, wait until it's available.


### PR DESCRIPTION
## Purpose

Remove dead code from the DeepSeek V3.1 streaming tool parser.

The `stream_tool_call_name_regex` fallback branch is dead code -- probably
carried over from the DeepSeek V3 parser where it serves a real purpose.

In V3, tool calls stream in a multi-line format:

~~~
function<｜tool▁sep｜>get_weather
```json
{"city":"NYC"}
~~~

When the parser has received `function<｜tool▁sep｜>get_weather\n` but the
`` ```json `` block hasn't started yet, `stream_tool_call_portion_regex`
(which requires `` \n```json\n `` + args) fails. The
`stream_tool_call_name_regex` fallback matches the tool name only and
streams it to the client immediately rather than waiting for arguments.

In V3.1, tool calls use a flat format:

```
get_weather<｜tool▁sep｜>{"city":"NYC"}
```

`stream_tool_call_portion_regex` `(?P<function_name>.*)<｜tool▁sep｜>(?P<function_arguments>.*)`
matches with empty arguments the instant `<｜tool▁sep｜>` arrives — the
same moment the tool name becomes complete. Any regex matched by the name-only
fallback can already be matched by the portion regex.

The name-only fallback also contained a latent `.groups()` bug that would pass a
tuple as the tool name instead of the unpacked string.

This PR removes the unused regex field and the dead fallback branch.

## Test Plan

```bash
python -m pytest tests/tool_parsers/test_deepseekv31_tool_parser.py -v
```

## Test Result

```
tests/tool_parsers/test_deepseekv31_tool_parser.py::test_extract_tool_calls_with_tool PASSED
tests/tool_parsers/test_deepseekv31_tool_parser.py::test_extract_tool_calls_with_multiple_tools PASSED
======================== 2 passed in 4.18s =========================
```

Pre-commit (ruff check, ruff format, mypy, typos) all pass.

cc @sfeng33 @LopezCastroRoberto 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.
</details>