### PR TITLE
[Bugfix][Tool Parser] Fix Kimi-K2 argument truncation when tool_call_…

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,22 @@
+# [Bugfix][Tool Parser] Fix Kimi-K2 argument truncation when tool_call_end + tool_call_begin in same delta
+
+## Bug
+
+When speculative decoding (or multi-step scheduling) bundles multiple tokens into a single delta, `<|tool_call_end|>` of tool N and `<|tool_call_begin|>` of tool N+1 can arrive in the same streaming delta. When this happens, the "starting a new tool call" branch (the `cur_tool_start_count > cur_tool_end_count` condition) fires and overwrites `tool_call_portion` with the new tool's data, then increments `current_tool_id` — without ever finalizing tool N's remaining argument tokens.
+
+**Result**: tool N's streamed arguments are truncated. For example, `{"city": "San Francisco", "units": "fahrenheit"}` becomes `{"city": "San Francisco", "units": "` — invalid JSON missing the final value and closing brace.
+
+## Fix
+
+Before advancing `current_tool_id` in the "starting a new tool" branch, check whether `tool_call_end_token_id` is also in `delta_token_ids`. If so, extract the closing tool's full arguments from `current_text`, compute the un-streamed diff against what was already emitted, and return that diff as a `DeltaMessage`. The new tool's name will be sent on the next streaming iteration.
+
+## Test
+
+`test_tool_end_and_next_begin_same_delta` — tokenizes a two-tool-call sequence with the real Kimi-K2 tokenizer, then merges the last 4 argument tokens of tool 0 together with `<|tool_call_end|>` and `<|tool_call_begin|>` into a single delta (simulating speculative decoding). Asserts both tools produce complete, valid JSON arguments.
+
+## Commands
+
+```bash
+pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -xvs
+# 27 passed
+```

--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -923,3 +923,146 @@ def test_streaming_multiple_tool_calls_not_leaked(kimi_k2_tool_parser):
 
     # Legitimate content preserved
     assert "compare" in full_content.lower() or len(all_content) > 0
+
+
+def test_tool_end_and_next_begin_same_delta(kimi_k2_tool_parser):
+    """
+    CRITICAL BUG REPRODUCTION: When <|tool_call_end|> of tool N and
+    <|tool_call_begin|> of tool N+1 arrive in the SAME delta (common with
+    speculative decoding or multi-step scheduling), the parser's "starting
+    a new tool" branch fires and overwrites tool_call_portion with the new
+    tool's data, skipping finalization of tool N's arguments.
+
+    Result: tool N's streamed arguments are truncated/incomplete.
+
+    This test streams two tool calls where the boundary tokens land together,
+    then verifies BOTH tools have complete, valid JSON arguments.
+    """
+    kimi_k2_tool_parser.reset_streaming_state()
+
+    tokenizer = kimi_k2_tool_parser.model_tokenizer
+
+    # Two tool calls with realistic JSON arguments
+    tool0_args = '{"city": "San Francisco", "units": "fahrenheit"}'
+    tool1_args = '{"city": "Tokyo", "units": "celsius"}'
+
+    full_text = (
+        "I'll check both cities. "
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>functions.get_weather:0"
+        f" <|tool_call_argument_begin|> {tool0_args} "
+        "<|tool_call_end|>"
+        "<|tool_call_begin|>functions.get_weather:1"
+        f" <|tool_call_argument_begin|> {tool1_args} "
+        "<|tool_call_end|>"
+        "<|tool_calls_section_end|>"
+    )
+
+    # Encode the full text to get real token IDs
+    all_ids = tokenizer.encode(full_text, add_special_tokens=False)
+
+    # Decode incrementally to get per-token text fragments
+    fragments = []
+    for i in range(len(all_ids)):
+        prefix_prev = tokenizer.decode(all_ids[:i])
+        prefix_cur = tokenizer.decode(all_ids[: i + 1])
+        fragments.append((prefix_cur[len(prefix_prev):], all_ids[i]))
+
+    # Find the token positions for tool_call_end (tool 0) and
+    # tool_call_begin (tool 1). These are the tokens we want in
+    # the same delta.
+    tool_call_end_id = kimi_k2_tool_parser.tool_call_end_token_id
+    tool_call_begin_id = kimi_k2_tool_parser.tool_call_start_token_id
+
+    # Locate first tool_call_end and the tool_call_begin that follows it
+    end0_pos = None
+    begin1_pos = None
+    for i, (_, tid) in enumerate(fragments):
+        if tid == tool_call_end_id and end0_pos is None:
+            end0_pos = i
+        elif tid == tool_call_begin_id and end0_pos is not None:
+            begin1_pos = i
+            break
+
+    assert end0_pos is not None, "Could not find tool_call_end token"
+    assert begin1_pos is not None, "Could not find tool_call_begin after end"
+
+    # Simulate speculative decoding: the last N argument tokens of tool 0
+    # are accepted together with tool_call_end + tool_call_begin in one
+    # delta. We merge 4 tokens before end0 into the same delta.
+    merge_start = max(0, end0_pos - 4)
+
+    # Build deltas: stream token-by-token EXCEPT merge the critical
+    # boundary (merge_start through begin1_pos) into a single delta.
+    deltas = []
+    i = 0
+    while i < len(fragments):
+        if i == merge_start:
+            # Merge tokens: last args of tool0 + end + begin of tool1
+            merged_text = "".join(
+                f[0] for f in fragments[merge_start:begin1_pos + 1]
+            )
+            merged_ids = [
+                f[1] for f in fragments[merge_start:begin1_pos + 1]
+            ]
+            deltas.append((merged_text, merged_ids))
+            i = begin1_pos + 1
+        else:
+            text, tid = fragments[i]
+            deltas.append((text, [tid]))
+            i += 1
+
+    results = run_streaming_sequence(kimi_k2_tool_parser, deltas)
+
+    # Collect all streamed argument fragments per tool index
+    tool_args = {}  # tool_index -> concatenated argument fragments
+    for res in results:
+        if res is None:
+            continue
+        if not hasattr(res, "tool_calls") or not res.tool_calls:
+            continue
+        for tc in res.tool_calls:
+            idx = tc.index
+            func = tc.function if hasattr(tc, "function") else tc.get("function")
+            if func is None:
+                continue
+            args = func.get("arguments", "") if isinstance(func, dict) else getattr(func, "arguments", "")
+            if args:
+                tool_args.setdefault(idx, "")
+                tool_args[idx] += args
+
+    # CRITICAL ASSERTIONS: Both tools must have complete, valid JSON
+    assert 0 in tool_args, (
+        f"Tool 0 arguments never streamed. Collected: {tool_args}"
+    )
+    assert 1 in tool_args, (
+        f"Tool 1 arguments never streamed. Collected: {tool_args}"
+    )
+
+    # Verify tool 0's arguments are complete (not truncated)
+    try:
+        parsed0 = json.loads(tool_args[0])
+    except json.JSONDecodeError:
+        pytest.fail(
+            f"Tool 0 arguments are truncated/invalid JSON: {repr(tool_args[0])}"
+        )
+    assert parsed0.get("city") == "San Francisco", (
+        f"Tool 0 'city' wrong or missing: {parsed0}"
+    )
+    assert parsed0.get("units") == "fahrenheit", (
+        f"Tool 0 'units' wrong or missing: {parsed0}"
+    )
+
+    # Verify tool 1's arguments are complete
+    try:
+        parsed1 = json.loads(tool_args[1])
+    except json.JSONDecodeError:
+        pytest.fail(
+            f"Tool 1 arguments are truncated/invalid JSON: {repr(tool_args[1])}"
+        )
+    assert parsed1.get("city") == "Tokyo", (
+        f"Tool 1 'city' wrong or missing: {parsed1}"
+    )
+    assert parsed1.get("units") == "celsius", (
+        f"Tool 1 'units' wrong or missing: {parsed1}"
+    )

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -353,6 +353,40 @@ class KimiK2ToolParser(ToolParser):
                 cur_tool_start_count > cur_tool_end_count
                 and cur_tool_start_count > prev_tool_start_count
             ):
+                # If tool_call_end is also in this delta, finalize the
+                # previous tool's args before switching (speculative
+                # decoding can bundle end+begin in one delta).
+                if (self.tool_call_end_token_id in delta_token_ids
+                        and self.current_tool_id >= 0
+                        and self.prev_tool_call_arr):
+                    parts = current_text.split(self.tool_call_start_token)
+                    cidx = self.current_tool_id + 1
+                    if cidx < len(parts):
+                        raw = parts[cidx].split(
+                            self.tool_call_end_token)[0].rstrip()
+                        m = self.stream_tool_call_portion_regex.match(raw)
+                        if m:
+                            args = m.group("function_arguments")
+                            prev = self.prev_tool_call_arr[
+                                self.current_tool_id].get("arguments", "")
+                            if (args and prev
+                                    and args.startswith(prev)
+                                    and len(args) > len(prev)):
+                                diff = args[len(prev):]
+                                self.streamed_args_for_tool[
+                                    self.current_tool_id] += diff
+                                self.current_tool_id += 1
+                                self.current_tool_name_sent = False
+                                self.streamed_args_for_tool.append("")
+                                return DeltaMessage(tool_calls=[
+                                    DeltaToolCall(
+                                        index=self.current_tool_id - 1,
+                                        function=DeltaFunctionCall(
+                                            arguments=diff,
+                                        ).model_dump(exclude_none=True),
+                                    )
+                                ])
+
                 if len(delta_token_ids) > 1:
                     tool_call_portion = current_text.split(self.tool_call_start_token)[
                         -1


### PR DESCRIPTION


## Purpose

When speculative decoding bundles `tool_call_end` and `tool_call_begin` into a single streaming delta, the "starting new tool" branch overwrites `tool_call_portion` without finalizing the previous tool's arguments, causing truncated JSON (e.g. missing closing values and braces).

Fix: before advancing `current_tool_id`, detect when `tool_call_end` is in the same delta, extract the closing tool's remaining arg diff from `current_text`, and emit it. The new tool's name is sent on the next iteration.

## Test Plan

- Replay streaming traces that contain merged `tool_call_end + tool_call_begin` deltas and verify the previous tool's arguments are fully emitted before the next tool starts.
- Run existing agent integration tests to confirm no regression in standard (non-speculative) tool-call streaming.

## Test Result

- Tool argument JSON is no longer truncated when speculative decoding merges end/begin deltas.
- Existing tests pass without modification.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

