### PR TITLE
[Bugfix] Remove dead unicode_escape decoding from 4 tool parsers

### DIFF
--- a/vllm/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv31_tool_parser.py
@@ -210,11 +210,6 @@ class DeepSeekV31ToolParser(ToolParser):
                     return None
                 diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
                 if diff:
-                    diff = (
-                        diff.encode("utf-8").decode("unicode_escape")
-                        if diff is str
-                        else diff
-                    )
                     if '"}' not in delta_text:
                         return None
                     end_loc = delta_text.rindex('"}')

--- a/vllm/tool_parsers/deepseekv3_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv3_tool_parser.py
@@ -213,11 +213,6 @@ class DeepSeekV3ToolParser(ToolParser):
                     return None
                 diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
                 if diff:
-                    diff = (
-                        diff.encode("utf-8").decode("unicode_escape")
-                        if diff is str
-                        else diff
-                    )
                     if '"}' not in delta_text:
                         return None
                     end_loc = delta_text.rindex('"}')

--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -283,11 +283,6 @@ class Hermes2ProToolParser(ToolParser):
                     return None
                 diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
                 if diff:
-                    diff = (
-                        diff.encode("utf-8").decode("unicode_escape")
-                        if diff is str
-                        else diff
-                    )
                     if '"}' not in delta_text:
                         return None
                     end_loc = delta_text.rindex('"}')

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -391,11 +391,6 @@ class KimiK2ToolParser(ToolParser):
                     return None
                 diff = self.prev_tool_call_arr[self.current_tool_id].get("arguments")
                 if diff:
-                    diff = (
-                        diff.encode("utf-8").decode("unicode_escape")
-                        if diff is str
-                        else diff
-                    )
                     if '"}' not in delta_text:
                         # Handle deferred section exit before returning
                         if deferred_section_exit and self.in_tool_section:


### PR DESCRIPTION
## Purpose

Remove dead code in the "tool call closing" branch of 4 streaming tool parsers.
The removed lines (`diff = diff.encode("utf-8").decode("unicode_escape") if diff is str else diff`)
were dead code -- the write to `diff` is immediately overwritten
by `diff = delta_text[:end_loc] + '"}'`, so the decoded value is never used.

`diff is str` is also incorrect, it should've been `isinstance(diff, str)`.

The code was originally introduced in
[PR #10398](https://github.com/vllm-project/vllm/pull/10398) (Nov 2024) where
the decoded `diff` was passed to `json.dumps()`.
[PR #10979](https://github.com/vllm-project/vllm/pull/10979) (Dec 2024)
rewrote the closing-branch logic to extract `diff` from `delta_text` instead,
making the `unicode_escape` line dead code. It was likely copy-pasted into the
DeepSeek V3, DeepSeek V3.1, and Kimi K2 parsers.

Affected files:
- `vllm/tool_parsers/hermes_tool_parser.py`
- `vllm/tool_parsers/deepseekv3_tool_parser.py`
- `vllm/tool_parsers/deepseekv31_tool_parser.py`
- `vllm/tool_parsers/kimi_k2_tool_parser.py`

## Test Plan

- `pytest tests/tool_parsers/test_deepseekv3_tool_parser.py`
- `pytest tests/tool_parsers/test_deepseekv31_tool_parser.py`
- `pytest tests/tool_parsers/test_hermes_tool_parser.py`
- `pytest tests/tool_parsers/test_kimi_k2_tool_parser.py`

## Test Result

```
$ pytest tests/tool_parsers/test_deepseekv3_tool_parser.py \
    tests/tool_parsers/test_deepseekv31_tool_parser.py \
    tests/tool_parsers/test_hermes_tool_parser.py \
    tests/tool_parsers/test_kimi_k2_tool_parser.py -v
======= 57 passed, 1 skipped, 1 xfailed, 2 warnings in 30.83s ========
```

All 57 tests pass. The 1 skip and 1 xfail are pre-existing and unrelated
to this change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>