### PR TITLE
[CI][ROCm] Add gpt-oss w4a8 in CI

### DIFF
--- a/tests/evals/gpt_oss/configs/gpt-oss-20b-rocm-mxfp4-fp8.yaml
+++ b/tests/evals/gpt_oss/configs/gpt-oss-20b-rocm-mxfp4-fp8.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+model_name: amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8
+metric_threshold: 0.568
+reasoning_effort: low
+server_args: "--attention-backend ROCM_AITER_UNIFIED_ATTN"
+env:
+  VLLM_ROCM_USE_AITER: "1"

--- a/tests/evals/gpt_oss/configs/models-gfx950.txt
+++ b/tests/evals/gpt_oss/configs/models-gfx950.txt
@@ -1,3 +1,4 @@
 # GFX950 model configurations for GPQA evaluation
 # Tests different environment variable combinations
 gpt-oss-20b-rocm-baseline.yaml
+gpt-oss-20b-rocm-mxfp4-fp8.yaml


### PR DESCRIPTION
Enable coverage on https://github.com/vllm-project/vllm/blob/f73bcb1c51cfc764f534fcd109f8437e196be2ec/vllm/model_executor/layers/quantization/quark/quark_moe.py#L1095

Next steps:
- Enable CK backend routing in quark_moe.py. #37128 introduced mxfp4 oracle and CK backend, however it is not routed and untested for w4a4.
- Enable triton backend routing in quark_moe.py, for w4a8.
- Refactor emulation as backend.