### PR TITLE
[ROCm] aiter_unified_attn fp8 q scale refactor

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -200,30 +200,15 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
         key_cache, value_cache = kv_cache.unbind(0)
 
         softmax_scale = self.scale
-        fp8_post_attn_v_rescale = False
         if is_quantized_kv_cache(self.kv_cache_dtype):
             key_cache = key_cache.view(self.fp8_dtype)
             value_cache = value_cache.view(self.fp8_dtype)
-            # When Q is FP8, triton kernel skips K/V dequant (for fp8xfp8 matmul).
-            # Compensate by absorbing q_scale and k_scale into softmax_scale, and
-            # v_scale into output_scale (or post-multiplying if no fusion).
-            if query.dtype == self.fp8_dtype:
-                softmax_scale = self.scale * layer._q_scale_float * layer._k_scale_float
-                if output_scale is not None:
-                    output_scale = output_scale / layer._v_scale_float
-                else:
-                    fp8_post_attn_v_rescale = True
 
         cu_seqlens_q = attn_metadata.query_start_loc
         seqused_k = attn_metadata.seq_lens
         max_seqlen_q = attn_metadata.max_query_len
         max_seqlen_k = attn_metadata.max_seq_len
         block_table = attn_metadata.block_table
-
-        descale_shape = (
-            cu_seqlens_q.shape[0] - 1,
-            key.shape[1] if key is not None else self.num_kv_heads,
-        )
 
         self.unified_attention(
             q=query[:num_actual_tokens],
@@ -240,15 +225,12 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
             window_size=self.sliding_window,
             block_table=block_table,
             softcap=self.logits_soft_cap,
-            q_descale=None,  # q_scale absorbed into softmax_scale
-            k_descale=layer._k_scale.expand(descale_shape),
-            v_descale=layer._v_scale.expand(descale_shape),
+            q_descale=layer._q_scale if query.dtype == self.fp8_dtype else None,
+            k_descale=layer._k_scale,
+            v_descale=layer._v_scale,
             sinks=self.sinks,
             output_scale=output_scale,
         )
-
-        if fp8_post_attn_v_rescale:
-            output[:num_actual_tokens].mul_(layer._v_scale_float)
 
         return output
 


### PR DESCRIPTION
(To be merged after https://github.com/ROCm/aiter/pull/2360 - aiter PR cleans up fp8 attention & adds native support for q scale)

The absorption logic for fp8xfp8 attention computation introduced in https://github.com/vllm-project/vllm/pull/36927 can now be natively handled by the aiter kernel.

1. The aiter kernel now has support for q_scale
2. We would no longer need to absorb ` layer._q_scale_float * layer._k_scale_float in softmax_scale`
3. Instead of using post multplication of out scale after the kernel, let the kernel handle it. ~(Need to follow-up on fp8 clamping)~

#### Tested using:
```
from vllm import LLM, SamplingParams
import os
os.environ["VLLM_ROCM_USE_AITER"] = "1"
if __name__ == "__main__":
    llm = LLM(
        model='/data/models/gpt-oss-120b-w-mxfp4-a-fp8-kv-fp8-fp8attn-no_lmhead_router',
        kv_cache_dtype='fp8',
    )

    output = llm.generate(
        ['Write a story about a robot that dreams for the first time.',
         'There is a table in the room which has'], 
        sampling_params=SamplingParams(max_tokens=50, temperature=0.0),
    )
    for i in range(len(output)):
        print(f"Output {i+1}: {output[i].outputs[0].text}")
```

#### Outputs:
```
Output 1:

In the bustling city of Neo-Arcadia, where towering skyscrapers pierced the clouds and neon lights painted the night sky, there lived a robot named Axiom. Axiom was a marvel of engineering, designed for efficiency and precision. He spent
Output 2:  a small box with a key inside it. The key is a small key that can be used to open the door.
```