### PR TITLE
[Bugfix] Fix Gemma3n concurrent audio requests crashing EngineCore

### DIFF
--- a/vllm/model_executor/models/gemma3n_mm.py
+++ b/vllm/model_executor/models/gemma3n_mm.py
@@ -92,8 +92,12 @@ class Gemma3nAudioInputs(TensorSchema):
     """
 
     type: Literal["audio"] = "audio"
-    input_features_padded: Annotated[torch.Tensor, TensorShape("bn", "s", "f")]
-    input_features_mask: Annotated[torch.Tensor, TensorShape("bn", "s")]
+    input_features_padded: Annotated[
+        torch.Tensor, TensorShape("bn", "s", "f", dynamic_dims={"s"})
+    ]
+    input_features_mask: Annotated[
+        torch.Tensor, TensorShape("bn", "s", dynamic_dims={"s"})
+    ]
 
 
 Gemma3nImageInputs = Gemma3nImagePixelInputs


### PR DESCRIPTION
## Summary

`Gemma3nAudioInputs` declares `input_features_padded` and `input_features_mask` with fixed sequence-length dimensions. When two concurrent requests carry audio clips of different durations, `TensorSchema.validate()` sees mismatched shapes and kills EngineCore:

```
ValueError: input_features_padded contains inconsistent shapes:
  torch.Size([496, 128]) (index 0) vs torch.Size([449, 128]) (index 1)
```

The fix adds `dynamic_dims={"s"}` to both fields, matching the pattern established by PR #31223 for MiniCPM-o, Qwen2Audio, and AudioFlamingo3.

## Changes

- `vllm/model_executor/models/gemma3n_mm.py`: Add `dynamic_dims={"s"}` to `input_features_padded` and `input_features_mask` in `Gemma3nAudioInputs`

## Test Plan

- [ ] Verify concurrent audio requests to Gemma3n no longer crash
- [ ] Existing multimodal tests pass

Fixes #38297