### PR TITLE
[KVConnector]: Add kv_connector_class_name to resolve name conflict with built-in connectors

### DIFF
--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -64,6 +64,13 @@ class KVTransferConfig:
     """The Python module path to dynamically load the KV connector from.
     Only supported in V1."""
 
+    kv_connector_class_name: str | None = None
+    """The class name of the KV connector to load from kv_connector_module_path.
+    When set, this takes precedence over kv_connector as the class name,
+    allowing kv_connector to be used as an alias that avoids name conflicts
+    with built-in registered connectors. Only used when
+    kv_connector_module_path is also set."""
+
     enable_permute_local_kv: bool = False
     """Experiment feature flag to enable HND to NHD KV Transfer"""
 

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -114,11 +114,14 @@ class KVConnectorFactory:
             if connector_module_path is None:
                 raise ValueError(f"Unsupported connector type: {connector_name}")
             connector_module = importlib.import_module(connector_module_path)
+            class_name = (
+                kv_transfer_config.kv_connector_class_name or connector_name
+            )
             try:
-                connector_cls = getattr(connector_module, connector_name)
+                connector_cls = getattr(connector_module, class_name)
             except AttributeError as e:
                 raise AttributeError(
-                    f"Class {connector_name} not found in {connector_module_path}"
+                    "Class %s not found in %s" % (class_name, connector_module_path)
                 ) from e
             connector_cls = cast(type[KVConnectorBaseType], connector_cls)
             if not supports_kw(connector_cls, "kv_cache_config"):

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -114,9 +114,7 @@ class KVConnectorFactory:
             if connector_module_path is None:
                 raise ValueError(f"Unsupported connector type: {connector_name}")
             connector_module = importlib.import_module(connector_module_path)
-            class_name = (
-                kv_transfer_config.kv_connector_class_name or connector_name
-            )
+            class_name = kv_transfer_config.kv_connector_class_name or connector_name
             try:
                 connector_cls = getattr(connector_module, class_name)
             except AttributeError as e:

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -119,7 +119,7 @@ class KVConnectorFactory:
                 connector_cls = getattr(connector_module, class_name)
             except AttributeError as e:
                 raise AttributeError(
-                    "Class %s not found in %s" % (class_name, connector_module_path)
+                    f"Class {class_name} not found in {connector_module_path}"
                 ) from e
             connector_cls = cast(type[KVConnectorBaseType], connector_cls)
             if not supports_kw(connector_cls, "kv_cache_config"):


### PR DESCRIPTION



## Purpose

When using an external KV connector via kv_connector_module_path, the kv_connector field is also used as the class name to look up in the loaded module. This causes a conflict if the external class shares the same name as a built-in registered connector (e.g., LMCacheConnectorV1) — the factory matches the registry first and never reaches the dynamic loading path.
This PR adds an optional kv_connector_class_name field to KVTransferConfig. When set, it is used as the actual class name to load from the external module, while kv_connector acts as a logical alias.

```json
{
  "kv_connector": "MyLMCacheConnector",
  "kv_role": "kv_both",
  "kv_connector_module_path": "lmcache.integration.vllm.lmcache_connector_v1",
  "kv_connector_class_name": "LMCacheConnectorV1"
}

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

