### PR TITLE
[XPU][CT] support per-channel quantization in xpu fp8 linear method

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -204,7 +204,7 @@ _POSSIBLE_WFP8A16_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]
         # To be added
     ],
     PlatformEnum.XPU: [
-        # To be added
+        XPUFP8ScaledMMLinearKernel,
     ],
 }
 

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -9,6 +9,11 @@ from vllm.model_executor.kernels.linear import (  # noqa: E501
     FP8ScaledMMLinearKernel,
     FP8ScaledMMLinearLayerConfig,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8StaticChannelSym,
+    kFp8StaticTensorSym,
+)
+from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 
 
@@ -23,6 +28,11 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
 
     @classmethod
     def can_implement(cls, c: FP8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
+        if c.weight_quant_key not in {kFp8StaticChannelSym, kFp8StaticTensorSym}:
+            return (
+                False,
+                "XPUFP8ScaledMM only support per-channel and per-tensor quantization",
+            )
         if c.weight_quant_key.dtype not in {torch.float8_e5m2, torch.float8_e4m3fn}:
             return False, "XPUFP8ScaledMM only support FP8 weight dtype"
         return True, None
@@ -34,6 +44,9 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         assert self.is_supported()[0]
         self.config = c
         self.layer_param_names = layer_param_names
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        replace_parameter(layer, "weight", layer.weight.data.t())
 
     def apply_weights(
         self,


### PR DESCRIPTION



## Purpose
Support model like `RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic`.

## Test Plan
`VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/basic/offline_inference/generate.py --model RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic  --enforce-eager  --max-model-len=4096`

## Test Result
```
Rendering prompts: 100%|████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 27.91
Processed prompts: 100%|██████████████████| 4/4 [00:00<00:00,  4.30it/s, est. speed input: 28.00 toks/s, output: 68.91 to
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Emily and I am a 23 year old recent college graduate. I am excited'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States. The president serves'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' a city that needs no introduction, with its stunning architecture, rich history, and'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: " here, and it's all about the data\nThe future of AI is here"

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

