### PR TITLE
fix(harmony): run render_for_completion in thread pool to unblock event loop

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -1205,9 +1205,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the first turn's input
         req = ChatCompletionRequest(model=MODEL_NAME, messages=messages)
-        input_messages, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req)
-        )
+        (
+            input_messages,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req)
         verify_harmony_messages(
             input_messages,
             [
@@ -1234,9 +1235,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the second turn's input
         req_2 = ChatCompletionRequest(model=MODEL_NAME, messages=messages)
-        input_messages_2, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req_2)
-        )
+        (
+            input_messages_2,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req_2)
         verify_harmony_messages(
             input_messages_2,
             [
@@ -1257,9 +1259,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the first turn's input
         req = ChatCompletionRequest(model=MODEL_NAME, messages=messages, tools=tools)
-        input_messages, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req)
-        )
+        (
+            input_messages,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req)
         verify_harmony_messages(
             input_messages,
             [
@@ -1303,9 +1306,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the second turn's input
         req_2 = ChatCompletionRequest(model=MODEL_NAME, messages=messages, tools=tools)
-        input_messages_2, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req_2)
-        )
+        (
+            input_messages_2,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req_2)
         verify_harmony_messages(
             input_messages_2,
             [
@@ -1342,9 +1346,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the first turn's input
         req = ChatCompletionRequest(model=MODEL_NAME, messages=messages, tools=tools)
-        input_messages, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req)
-        )
+        (
+            input_messages,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req)
         verify_harmony_messages(
             input_messages,
             [
@@ -1388,9 +1393,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the second turn's input
         req_2 = ChatCompletionRequest(model=MODEL_NAME, messages=messages, tools=tools)
-        input_messages_2, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req_2)
-        )
+        (
+            input_messages_2,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req_2)
         verify_harmony_messages(
             input_messages_2,
             [
@@ -1427,9 +1433,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the first turn's input
         req = ChatCompletionRequest(model=MODEL_NAME, messages=messages, tools=tools)
-        input_messages, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req)
-        )
+        (
+            input_messages,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req)
         verify_harmony_messages(
             input_messages,
             [
@@ -1473,9 +1480,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the second turn's input
         req_2 = ChatCompletionRequest(model=MODEL_NAME, messages=messages, tools=tools)
-        input_messages_2, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req_2)
-        )
+        (
+            input_messages_2,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req_2)
         verify_harmony_messages(
             input_messages_2,
             [
@@ -1525,9 +1533,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the third turn's input
         req_3 = ChatCompletionRequest(model=MODEL_NAME, messages=messages, tools=tools)
-        input_messages_3, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req_3)
-        )
+        (
+            input_messages_3,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req_3)
         verify_harmony_messages(
             input_messages_3,
             [
@@ -1590,9 +1599,10 @@ class TestServingChatWithHarmony:
 
         # Test the Harmony messages for the fourth turn's input
         req_4 = ChatCompletionRequest(model=MODEL_NAME, messages=messages, tools=tools)
-        input_messages_4, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req_4)
-        )
+        (
+            input_messages_4,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req_4)
         verify_harmony_messages(
             input_messages_4,
             [
@@ -1641,9 +1651,10 @@ class TestServingChatWithHarmony:
             },
         ]
         req = ChatCompletionRequest(model=MODEL_NAME, messages=messages)
-        input_messages, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req)
-        )
+        (
+            input_messages,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req)
 
         verify_harmony_messages(
             input_messages,
@@ -1674,9 +1685,10 @@ class TestServingChatWithHarmony:
             },
         ]
         req = ChatCompletionRequest(model=MODEL_NAME, messages=messages)
-        input_messages, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req)
-        )
+        (
+            input_messages,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req)
 
         verify_harmony_messages(
             input_messages,
@@ -1705,9 +1717,10 @@ class TestServingChatWithHarmony:
             },
         ]
         req = ChatCompletionRequest(model=MODEL_NAME, messages=messages)
-        input_messages, _ = (
-            serving_chat.openai_serving_render._make_request_with_harmony(req)
-        )
+        (
+            input_messages,
+            _,
+        ) = await serving_chat.openai_serving_render._make_request_with_harmony(req)
 
         verify_harmony_messages(
             input_messages,

--- a/tests/entrypoints/openai/parser/test_render_for_completion_async.py
+++ b/tests/entrypoints/openai/parser/test_render_for_completion_async.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests verifying that render_for_completion is run off the event loop.
+
+Issue #38266: render_for_completion() is a synchronous Harmony tokenizer call
+that can take up to 10 minutes for 1M-character inputs. Calling it directly
+inside async request handlers freezes the event loop for all concurrent
+requests. The fix wraps it with make_async() so it runs in a thread-pool
+executor, keeping the event loop free.
+
+These tests require no GPU and no real model.
+"""
+
+import asyncio
+import inspect
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.utils.async_utils import make_async
+
+
+class TestMakeAsyncReleasesEventLoop:
+    """
+    Verify the make_async() wrapper used by render_for_completion_async
+    actually releases the event loop during synchronous execution.
+    """
+
+    @pytest.mark.asyncio
+    async def test_blocking_call_in_executor_allows_other_coroutines(self):
+        """
+        A sync function wrapped with make_async() must not block other
+        coroutines from running while the sync work is in progress.
+        """
+        events: list = []
+
+        def slow_sync(messages: list) -> list:
+            time.sleep(0.05)  # simulate slow tokenization (~50 ms)
+            events.append("tokenize_done")
+            return [1, 2, 3]
+
+        slow_async = make_async(slow_sync)
+
+        async def event_loop_checker() -> None:
+            # Yield once so slow_async can be dispatched to the thread pool,
+            # then record that the loop is responsive.
+            await asyncio.sleep(0.01)
+            events.append("loop_free")
+
+        await asyncio.gather(slow_async([]), event_loop_checker())
+
+        assert "loop_free" in events, "event_loop_checker never ran"
+        assert "tokenize_done" in events, "slow_sync never completed"
+        # The event-loop check should finish before the slow sync call
+        assert events.index("loop_free") < events.index("tokenize_done"), (
+            "event loop was blocked: loop_free happened after tokenize_done"
+        )
+
+    @pytest.mark.asyncio
+    async def test_make_async_returns_awaitable(self):
+        """make_async() must return a callable that produces an awaitable."""
+
+        def identity(x: int) -> int:
+            return x
+
+        async_identity = make_async(identity)
+        result = async_identity(42)
+        # The return value should be a Future / awaitable
+        assert asyncio.isfuture(result) or inspect.isawaitable(result)
+        value = await result
+        assert value == 42
+
+
+class TestRenderForCompletionAsyncIsAwaitable:
+    """
+    Structural tests: verify the async wrapper is correctly exported and
+    that the context methods were changed to async def.
+    """
+
+    def test_render_for_completion_async_exported(self):
+        """render_for_completion_async must be importable from harmony_utils."""
+        from vllm.entrypoints.openai.parser.harmony_utils import (
+            render_for_completion_async,
+        )
+
+        assert callable(render_for_completion_async)
+
+    def test_harmony_context_render_for_completion_is_coroutine(self):
+        """HarmonyContext.render_for_completion must be an async def."""
+        from vllm.entrypoints.openai.responses.context import HarmonyContext
+
+        assert inspect.iscoroutinefunction(HarmonyContext.render_for_completion), (
+            "HarmonyContext.render_for_completion must be async to avoid "
+            "blocking the event loop"
+        )
+
+    def test_streaming_harmony_context_render_for_completion_is_coroutine(self):
+        """StreamingHarmonyContext.render_for_completion must be an async def."""
+        from vllm.entrypoints.openai.responses.context import StreamingHarmonyContext
+
+        assert inspect.iscoroutinefunction(
+            StreamingHarmonyContext.render_for_completion
+        ), (
+            "StreamingHarmonyContext.render_for_completion must be async to "
+            "avoid blocking the event loop"
+        )
+
+    def test_make_request_with_harmony_is_coroutine_in_render_serving(self):
+        """OpenAIServingRender._make_request_with_harmony must be async def."""
+        from vllm.entrypoints.serve.render.serving import OpenAIServingRender
+
+        assert inspect.iscoroutinefunction(
+            OpenAIServingRender._make_request_with_harmony
+        ), (
+            "OpenAIServingRender._make_request_with_harmony must be async to "
+            "avoid blocking the event loop"
+        )
+
+    def test_make_request_with_harmony_is_coroutine_in_responses_serving(self):
+        """OpenAIServingResponses._make_request_with_harmony must be async def."""
+        from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+        assert inspect.iscoroutinefunction(
+            OpenAIServingResponses._make_request_with_harmony
+        ), (
+            "OpenAIServingResponses._make_request_with_harmony must be async to "
+            "avoid blocking the event loop"
+        )
+
+
+class TestGetEncodingThreadSafety:
+    """
+    Verify that get_encoding() initializes the singleton exactly once even when
+    called concurrently from many threads (the scenario introduced by wrapping
+    render_for_completion with make_async).
+    """
+
+    def test_get_encoding_initialized_exactly_once_under_concurrency(self):
+        """
+        Simulate many threads racing to call get_encoding() while the singleton
+        is unset. load_harmony_encoding() must be called exactly once.
+        """
+        import vllm.entrypoints.openai.parser.harmony_utils as hu
+
+        call_count = 0
+        call_count_lock = threading.Lock()
+
+        def slow_load_harmony_encoding(_name):
+            nonlocal call_count
+            # Widen the race window so threads are more likely to overlap.
+            time.sleep(0.05)
+            with call_count_lock:
+                call_count += 1
+            return MagicMock()
+
+        original_encoding = hu._harmony_encoding
+        try:
+            hu._harmony_encoding = None
+            with patch(
+                "vllm.entrypoints.openai.parser.harmony_utils.load_harmony_encoding",
+                side_effect=slow_load_harmony_encoding,
+            ):
+                threads = [threading.Thread(target=hu.get_encoding) for _ in range(20)]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+
+            assert call_count == 1, (
+                f"load_harmony_encoding was called {call_count} times; "
+                "expected exactly 1 (race condition in get_encoding)"
+            )
+        finally:
+            hu._harmony_encoding = original_encoding
+
+
+class TestRenderForCompletionAsyncResult:
+    """
+    Functional test: render_for_completion_async must return the same value
+    as the synchronous render_for_completion when given the same input.
+    The underlying sync function is mocked to avoid needing openai_harmony.
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_wrapper_preserves_return_value(self):
+        """render_for_completion_async must propagate the return value."""
+        import vllm.entrypoints.openai.parser.harmony_utils as hu
+
+        expected = [10, 20, 30]
+
+        original = hu.render_for_completion_async
+        try:
+            hu.render_for_completion_async = make_async(lambda msgs: expected)
+            result = await hu.render_for_completion_async([])
+            assert result == expected
+        finally:
+            hu.render_for_completion_async = original

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -62,7 +62,7 @@ class MockConversationContext(ConversationContext):
     def need_builtin_tool_call(self) -> bool:
         return False
 
-    def render_for_completion(self):
+    async def render_for_completion(self):
         return []
 
     async def init_tool_sessions(self, tool_server, exit_stack, request_id, mcp_tools):

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -83,7 +83,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
         for messages in request.messages:
             single_request = request.to_chat_completion_request(messages)
             if render.use_harmony:
-                conversation, engine_prompts = render._make_request_with_harmony(
+                conversation, engine_prompts = await render._make_request_with_harmony(
                     single_request, should_include_tools=tool_dicts is not None
                 )
             else:

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import datetime
+import threading
 from collections.abc import Iterable, Sequence
 from typing import Literal
 
@@ -24,6 +25,7 @@ from openai_harmony import (
 from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
 from vllm.logger import init_logger
+from vllm.utils.async_utils import make_async
 
 logger = init_logger(__name__)
 
@@ -34,6 +36,7 @@ REASONING_EFFORT = {
 }
 
 _harmony_encoding = None
+_harmony_encoding_lock = threading.Lock()
 
 # Builtin tools that should be included in the system message when
 # they are available and requested by the user.
@@ -60,7 +63,11 @@ def has_custom_tools(tool_types: set[str]) -> bool:
 def get_encoding():
     global _harmony_encoding
     if _harmony_encoding is None:
-        _harmony_encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+        with _harmony_encoding_lock:
+            if _harmony_encoding is None:
+                _harmony_encoding = load_harmony_encoding(
+                    HarmonyEncodingName.HARMONY_GPT_OSS
+                )
     return _harmony_encoding
 
 
@@ -322,6 +329,9 @@ def render_for_completion(messages: list[Message]) -> list[int]:
         conversation, Role.ASSISTANT
     )
     return token_ids
+
+
+render_for_completion_async = make_async(render_for_completion)
 
 
 def get_stop_tokens_for_assistant_actions() -> list[int]:

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -30,7 +30,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.entrypoints.openai.parser.harmony_utils import (
     get_encoding,
     get_streamable_parser_for_assistant,
-    render_for_completion,
+    render_for_completion_async,
 )
 from vllm.entrypoints.openai.parser.responses_parser import (
     get_responses_parser_for_simple_context,
@@ -122,7 +122,7 @@ class ConversationContext(ABC):
         pass
 
     @abstractmethod
-    def render_for_completion(self) -> list[int]:
+    async def render_for_completion(self) -> list[int]:
         pass
 
     @abstractmethod
@@ -251,7 +251,7 @@ class SimpleContext(ConversationContext):
     async def call_tool(self) -> list[Message]:
         raise NotImplementedError("Should not be called.")
 
-    def render_for_completion(self) -> list[int]:
+    async def render_for_completion(self) -> list[int]:
         raise NotImplementedError("Should not be called.")
 
     async def init_tool_sessions(
@@ -474,7 +474,7 @@ class ParsableContext(ConversationContext):
             )
         return []
 
-    def render_for_completion(self):
+    async def render_for_completion(self):
         raise NotImplementedError("Should not be called.")
 
     async def init_tool_sessions(
@@ -708,8 +708,8 @@ class HarmonyContext(ConversationContext):
                 )
         raise ValueError("No tool call found")
 
-    def render_for_completion(self) -> list[int]:
-        return render_for_completion(self.messages)
+    async def render_for_completion(self) -> list[int]:
+        return await render_for_completion_async(self.messages)
 
     async def call_search_tool(
         self, tool_session: Union["ClientSession", Tool], last_msg: Message
@@ -912,11 +912,11 @@ class StreamingHarmonyContext(HarmonyContext):
     def is_assistant_action_turn(self) -> bool:
         return self.last_tok in self.encoding.stop_tokens_for_assistant_actions()
 
-    def render_for_completion(self) -> list[int]:
+    async def render_for_completion(self) -> list[int]:
         # now this list of tokens as next turn's starting tokens
         # `<|start|>assistant`,
         # we need to process them in parser.
-        rendered_tokens = super().render_for_completion()
+        rendered_tokens = await super().render_for_completion()
 
         last_n = -1
         to_process = []

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -66,7 +66,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     get_system_message,
     get_user_message,
     has_custom_tools,
-    render_for_completion,
+    render_for_completion_async,
 )
 from vllm.entrypoints.openai.responses.context import (
     ConversationContext,
@@ -369,7 +369,7 @@ class OpenAIServingResponses(OpenAIServing):
         model_name = self.models.model_name(lora_request)
 
         if self.use_harmony:
-            messages, engine_inputs = self._make_request_with_harmony(
+            messages, engine_inputs = await self._make_request_with_harmony(
                 request, prev_response
             )
         else:
@@ -674,7 +674,7 @@ class OpenAIServingResponses(OpenAIServing):
             # Create inputs for the next turn.
             # Render the next prompt token ids and update sampling_params.
             if isinstance(context, (HarmonyContext, StreamingHarmonyContext)):
-                token_ids = context.render_for_completion()
+                token_ids = await context.render_for_completion()
                 engine_input = tokens_input(token_ids)
 
                 sampling_params.max_tokens = max_model_len - len(token_ids)
@@ -700,7 +700,7 @@ class OpenAIServingResponses(OpenAIServing):
             priority = orig_priority - 1
             sub_request += 1
 
-    def _make_request_with_harmony(
+    async def _make_request_with_harmony(
         self,
         request: ResponsesRequest,
         prev_response: ResponsesResponse | None,
@@ -712,7 +712,7 @@ class OpenAIServingResponses(OpenAIServing):
 
         arrival_time = time.time()
         messages = self._construct_input_messages_with_harmony(request, prev_response)
-        prompt_token_ids = render_for_completion(messages)
+        prompt_token_ids = await render_for_completion_async(messages)
         engine_input = tokens_input(prompt_token_ids, cache_salt=request.cache_salt)
         engine_input["arrival_time"] = arrival_time
 

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -22,7 +22,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     get_developer_message,
     get_system_message,
     parse_chat_inputs_to_harmony_messages,
-    render_for_completion,
+    render_for_completion_async,
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.entrypoints.serve.disagg.protocol import (
@@ -249,7 +249,7 @@ class OpenAIServingRender:
         else:
             # For GPT-OSS.
             should_include_tools = tool_dicts is not None
-            conversation, engine_inputs = self._make_request_with_harmony(
+            conversation, engine_inputs = await self._make_request_with_harmony(
                 request, should_include_tools
             )
 
@@ -366,7 +366,7 @@ class OpenAIServingRender:
             mm_placeholders=mm_placeholders,
         )
 
-    def _make_request_with_harmony(
+    async def _make_request_with_harmony(
         self,
         request: ChatCompletionRequest,
         should_include_tools: bool = True,
@@ -405,7 +405,7 @@ class OpenAIServingRender:
         messages.extend(parse_chat_inputs_to_harmony_messages(request.messages))
 
         # Render prompt token ids.
-        prompt_token_ids = render_for_completion(messages)
+        prompt_token_ids = await render_for_completion_async(messages)
         engine_input = tokens_input(prompt_token_ids, cache_salt=request.cache_salt)
 
         return messages, [engine_input]


### PR DESCRIPTION

## Purpose
Resolves #38266. When a request contains a very long repetitive sequence, the synchronous Harmony tokenizer call (`render_for_completion`) could block the asyncio event loop for minutes, making the server unresponsive to all
other requests.

Fix: wrap `render_for_completion` with `make_async()` (`run_in_executor`) and propagate `async`/`await` through the entire call chain (`_make_request_with_harmony`, `HarmonyContext.render_for_completion`,
`StreamingHarmonyContext.render_for_completion`) so the event loop is free to serve concurrent requests while tokenization runs in a thread. The same fix is applied to `OpenAIServingRender._make_request_with_harmony` in the Chat
Completions path.

Checked for existing PRs addressing #38266 — none found as of March 26, 2026.


## Test Plan
Add a unit test, `test_render_for_completion_async.py`, to ensure all callers of the function are async and that the function itself releases the event loop. 

Also run existing tests that call _make_request_with_harmony, since those call sites were updated to add await.

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/parser/test_render_for_completion_async.py -v
.venv/bin/python -m pytest tests/entrypoints/openai/responses/test_serving_responses.py -v
```

Chat Completion test (requires model artifacts)
```bash
.venv/bin/python -m pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py -v
```

## Test Result

This fix was developed with AI assistance (Claude). I have reviewed every changed line and personally ran the first two test commands above.

Note: test_serving_chat.py::TestGPTOSSChat requires the Harmony vocab file (not available in a standard dev environment) and was not run locally. The await fixes to that file are mechanical call-site corrections that follow directly from the async signature change.

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/parser/test_render_for_completion_async.py -v
====================================== test session starts ======================================
platform darwin -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /Users/tzhou/Documents/GitHub/vllm/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/tzhou/Documents/GitHub/vllm
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 9 items                                                                               

tests/entrypoints/openai/parser/test_render_for_completion_async.py::TestMakeAsyncReleasesEventLoop::test_blocking_call_in_executor_allows_other_coroutines PASSED [ 11%]
tests/entrypoints/openai/parser/test_render_for_completion_async.py::TestMakeAsyncReleasesEventLoop::test_make_async_returns_awaitable PASSED [ 22%]
tests/entrypoints/openai/parser/test_render_for_completion_async.py::TestRenderForCompletionAsyncIsAwaitable::test_render_for_completion_async_exported PASSED [ 33%]
tests/entrypoints/openai/parser/test_render_for_completion_async.py::TestRenderForCompletionAsyncIsAwaitable::test_harmony_context_render_for_completion_is_coroutine PASSED [ 44%]
tests/entrypoints/openai/parser/test_render_for_completion_async.py::TestRenderForCompletionAsyncIsAwaitable::test_streaming_harmony_context_render_for_completion_is_coroutine PASSED [ 55%]
tests/entrypoints/openai/parser/test_render_for_completion_async.py::TestRenderForCompletionAsyncIsAwaitable::test_make_request_with_harmony_is_coroutine_in_render_serving PASSED [ 66%]
tests/entrypoints/openai/parser/test_render_for_completion_async.py::TestRenderForCompletionAsyncIsAwaitable::test_make_request_with_harmony_is_coroutine_in_responses_serving PASSED [ 77%]
tests/entrypoints/openai/parser/test_render_for_completion_async.py::TestGetEncodingThreadSafety::test_get_encoding_initialized_exactly_once_under_concurrency PASSED [ 88%]
tests/entrypoints/openai/parser/test_render_for_completion_async.py::TestRenderForCompletionAsyncResult::test_async_wrapper_preserves_return_value PASSED [100%]
```

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/responses/test_serving_responses.py -v
====================================== test session starts ======================================
platform darwin -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /Users/tzhou/Documents/GitHub/vllm/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/tzhou/Documents/GitHub/vllm
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 16 items                                                                              

tests/entrypoints/openai/responses/test_serving_responses.py::test_extract_tool_types PASSED [  6%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestInitializeToolSessions::test_initialize_tool_sessions PASSED [ 12%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestInitializeToolSessions::test_validate_create_responses_input PASSED [ 18%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestValidateGeneratorInput::test_validate_generator_input PASSED [ 25%]
tests/entrypoints/openai/responses/test_serving_responses.py::test_reasoning_tokens_counted_for_text_reasoning_model PASSED [ 31%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestExtractAllowedToolsFromMcpRequests::test_extract_allowed_tools_basic_formats PASSED [ 37%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestExtractAllowedToolsFromMcpRequests::test_extract_allowed_tools_star_normalization PASSED [ 43%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestExtractAllowedToolsFromMcpRequests::test_extract_allowed_tools_filters_non_mcp PASSED [ 50%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_preamble_delta_emits_text_events PASSED [ 56%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_preamble_delta_second_token_no_added PASSED [ 62%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_commentary_with_function_recipient_not_preamble PASSED [ 68%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_preamble_done_emits_text_done_events PASSED [ 75%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_commentary_with_recipient_no_preamble_done PASSED [ 81%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestStreamingReasoningToContentTransition::test_mixed_delta_reasoning_and_content_emits_reasoning_delta PASSED [ 87%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestStreamingReasoningToContentTransition::test_transition_without_mixed_delta_no_extra_reasoning_event PASSED [ 93%]
tests/entrypoints/openai/responses/test_serving_responses.py::TestStreamingReasoningToContentTransition::test_reasoning_only_stream_no_content PASSED [100%]
```
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

