### PR TITLE
[Security] Fix CVE-2026-4944: respect trust_remote_code in NemotronVL and KimiK25

### DIFF
--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -174,7 +174,8 @@ class KimiK25ProcessingInfo(BaseProcessingInfo):
         self.hf_config = self.get_hf_config()
         self.media_token_id = self.hf_config.media_placeholder_token_id
         media_processor = cached_get_image_processor(
-            self.ctx.model_config.model, trust_remote_code=True
+            self.ctx.model_config.model,
+            trust_remote_code=self.ctx.model_config.trust_remote_code,
         )
         self.media_processor = media_processor
         self.hf_processor = MoonshotKimiVAutoProcessor(

--- a/vllm/model_executor/models/nemotron_vl.py
+++ b/vllm/model_executor/models/nemotron_vl.py
@@ -402,6 +402,7 @@ class LlamaNemotronVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, Suppor
         multimodal_config = vllm_config.model_config.multimodal_config
 
         self.config = config
+        self.model_config = vllm_config.model_config
         self.multimodal_config = multimodal_config
         self._patch_quant_config(config, quant_config)
 
@@ -456,7 +457,10 @@ class LlamaNemotronVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, Suppor
         *,
         prefix: str,
     ):
-        return AutoModel.from_config(config.vision_config, trust_remote_code=True)
+        return AutoModel.from_config(
+            config.vision_config,
+            trust_remote_code=self.model_config.trust_remote_code,
+        )
 
     def _init_mlp1(
         self,


### PR DESCRIPTION
## Summary

Fixes **GHSA-7972-pg2x-xr59 / CVE-2026-4944** (CVSS 8.8 High).

Two model implementation files hardcoded `trust_remote_code=True` when loading sub-components, bypassing the user's explicit `--trust-remote-code=False` security opt-out. This enables remote code execution via malicious model repositories even when the user has explicitly disabled remote code trust.

**Affected files:**

- `vllm/model_executor/models/nemotron_vl.py` line 459:
  ```python
  # Before (vulnerable):
  return AutoModel.from_config(config.vision_config, trust_remote_code=True)
  
  # After (fixed):
  return AutoModel.from_config(
      config.vision_config,
      trust_remote_code=self.model_config.trust_remote_code,
  )
  ```

- `vllm/model_executor/models/kimi_k25.py` line 177:
  ```python
  # Before (vulnerable):
  cached_get_image_processor(self.ctx.model_config.model, trust_remote_code=True)
  
  # After (fixed):
  cached_get_image_processor(
      self.ctx.model_config.model,
      trust_remote_code=self.ctx.model_config.trust_remote_code,
  )
  ```

## Changes

- **`nemotron_vl.py`**: Store `vllm_config.model_config` as `self.model_config` in `__init__`, then pass `self.model_config.trust_remote_code` to `AutoModel.from_config()` in `_init_vision_model()`.
- **`kimi_k25.py`**: Pass `self.ctx.model_config.trust_remote_code` to `cached_get_image_processor()`.

## Security Impact

Without this fix, an attacker can craft a malicious model repository that executes arbitrary Python code when loaded by vLLM — even when the user has explicitly set `--trust-remote-code=False`. The hardcoded `True` overrides the user's security setting on a separate code path that survived two prior related CVE fixes (CVE-2025-66448, CVE-2026-22807).

## Test plan

- [ ] Load a NemotronVL model with `--trust-remote-code=False` and verify it raises an error rather than silently executing remote code
- [ ] Load a KimiK25 model with `--trust-remote-code=False` and verify the same
- [ ] Load both models with `--trust-remote-code=True` and verify normal operation continues

Reported by: @Wernerina (GHSA-7972-pg2x-xr59)