### PR TITLE
[CI] Add xpu auto-label rule for Intel GPU/XPU PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -235,7 +235,7 @@ pull_request_rules:
         - rocm
 
 - name: label-xpu
-  description: Automatically apply xpu label
+  description: Automatically apply intel-gpu label
   conditions:
     - label != stale
     - or:
@@ -259,7 +259,7 @@ pull_request_rules:
   actions:
     label:
       add:
-        - xpu
+        - intel-gpu
 
 - name: label-cpu
   description: Automatically apply cpu label

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -239,6 +239,9 @@ pull_request_rules:
   conditions:
     - label != stale
     - or:
+      - files~=^docker/Dockerfile.xpu
+      - files~=^\\.buildkite/intel_jobs/
+      - files=\.buildkite/ci_config_intel.yaml
       - files=vllm/model_executor/layers/fused_moe/xpu_fused_moe.py
       - files=vllm/model_executor/kernels/linear/mixed_precision/xpu.py
       - files=vllm/model_executor/kernels/linear/scaled_mm/xpu.py

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -234,6 +234,33 @@ pull_request_rules:
       add:
         - rocm
 
+- name: label-xpu
+  description: Automatically apply xpu label
+  conditions:
+    - label != stale
+    - or:
+      - files=vllm/model_executor/layers/fused_moe/xpu_fused_moe.py
+      - files=vllm/model_executor/kernels/linear/mixed_precision/xpu.py
+      - files=vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+      - files=vllm/distributed/device_communicators/xpu_communicator.py
+      - files=vllm/v1/attention/backends/mla/xpu_mla_sparse.py
+      - files=vllm/v1/attention/ops/xpu_mla_sparse.py
+      - files=vllm/v1/worker/xpu_worker.py
+      - files=vllm/v1/worker/xpu_model_runner.py
+      - files=vllm/_xpu_ops.py
+      - files~=^vllm/lora/ops/xpu_ops
+      - files=vllm/lora/punica_wrapper/punica_xpu.py
+      - files=vllm/platforms/xpu.py
+      - title~=(?i)Intel gpu
+      - title~=(?i)XPU
+      - title~=(?i)Intel
+      - title~=(?i)BMG
+      - title~=(?i)Arc
+  actions:
+    label:
+      add:
+        - xpu
+
 - name: label-cpu
   description: Automatically apply cpu label
   conditions:


### PR DESCRIPTION



## Purpose
Add a new `xpu` Mergify auto-label rule for PRs that touch Intel XPU-related files or include Intel GPU/XPU keywords in the title.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

Add a new `xpu` Mergify auto-label rule for PRs that touch Intel XPU-related files or include Intel GPU/XPU keywords in the title.

## Changes

- add `label-xpu` rule in `.github/mergify.yml`
- match Intel XPU-related file paths
- match title keywords:
  - `Intel gpu`
  - `XPU`
  - `Intel`
  - `BMG`
  - `Arc`

## Validation

- verified `.github/mergify.yml` parses successfully
- verified the new `label-xpu` rule is present and adds the `xpu` label
- checked formatting with `git diff --check`


