### PR TITLE
[ROCm] Fix ROCM_ATTN cross-attention for beam search encoder-decoder models

### DIFF
--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -414,6 +414,15 @@ class RocmAttentionImpl(AttentionImpl):
         max_seqlen_k = attn_metadata.max_seq_len
         block_table = attn_metadata.block_table
 
+        # For cross-attention (encoder-decoder), the encoder K/V have already
+        # been written to the paged cache by CrossAttentionImpl before this
+        # forward call. Pass key=None so chunked_prefill_paged_decode reads
+        # exclusively from the cache instead of mixing cached and raw K/V
+        # (which would double-count some encoder tokens and miss others).
+        if self.attn_type == AttentionType.ENCODER_DECODER:
+            key = None
+            value = None
+
         # Compute attention and update output up to `num_actual_tokens`.
         chunked_prefill_paged_decode(
             query=query[:num_actual_tokens],

--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -278,7 +278,12 @@ def chunked_prefill_paged_decode(
     if sliding_window is None or sliding_window <= 0:
         sliding_window = 0
 
-    if max_query_len > 1:
+    # Cross-attention: key is None means all K/V are already in the paged
+    # cache (populated by CrossAttentionImpl.do_kv_cache_update). Skip the
+    # prefill kernel which would incorrectly mix cached and "new" K/V.
+    is_cross_attn = key is None
+
+    if max_query_len > 1 and not is_cross_attn:
         context_attention_fwd(
             q=query,
             k=key,
@@ -331,6 +336,19 @@ def chunked_prefill_paged_decode(
 
     num_queries_per_kv_padded = max(triton.next_power_of_2(num_queries_per_kv), 16)
 
+    # The decode kernel (kernel_paged_attention_2d) skips sequences with
+    # query_len > 1 when filter_by_query_len=True, expecting the prefill
+    # kernel to handle them. Since we skipped the prefill kernel for
+    # cross-attention above, we need to make those multi-token sequences
+    # visible to the decode kernel. We do this by expanding metadata so
+    # each query token appears as its own single-token "sequence",
+    # duplicating the corresponding seq_lens and block_table entries.
+    if is_cross_attn and max_query_len > 1:
+        query_lens = query_start_loc[1:] - query_start_loc[:-1]
+        seq_lens = seq_lens.repeat_interleave(query_lens)
+        block_table = block_table.repeat_interleave(query_lens, dim=0)
+        num_seqs = seq_lens.shape[0]  # now equals num_actual_tokens
+
     from vllm.platforms.rocm import use_rocm_custom_paged_attention
 
     use_custom = use_rocm_custom_paged_attention(
@@ -352,6 +370,11 @@ def chunked_prefill_paged_decode(
     # then our Triton path is forced.
     is_pow2 = block_size > 0 and (block_size & (block_size - 1) == 0)
     if not is_pow2:
+        use_custom = False
+    # Force Triton for cross-attention multi-token: the HIP C++ kernel uses
+    # query_start_loc to skip prefill tokens, but here we skipped the prefill
+    # kernel and expanded metadata to per-token instead.
+    if is_cross_attn and max_query_len > 1:
         use_custom = False
 
     if use_custom:
@@ -418,6 +441,11 @@ def chunked_prefill_paged_decode(
         else:
             processed_block_table = block_table.to(torch.int32)
 
+        # For cross-attention multi-token: metadata was expanded to per-token
+        # above, so each "seq" is one token. Use filter_by_query_len=False
+        # so the kernel treats seq_idx as a flat token index.
+        use_filter = not (is_cross_attn and max_query_len > 1)
+
         kernel_paged_attention_2d[
             (
                 num_seqs,
@@ -460,7 +488,7 @@ def chunked_prefill_paged_decode(
             stride_v_cache_1=value_cache.stride(1),
             stride_v_cache_2=value_cache.stride(2),
             stride_v_cache_3=value_cache.stride(3),
-            filter_by_query_len=True,
+            filter_by_query_len=use_filter,
             query_start_len_ptr=query_start_loc,
             USE_SINKS=sinks is not None,
             USE_FP8=output_scale is not None,


### PR DESCRIPTION
Cross-attention for encoder-decoder models on ROCM_ATTN was broken. The `context_attention_fwd` prefill kernel assumed self-attention semantics (new K/V correspond to query tokens), which is wrong for cross-attention where K/V are encoder outputs and Q is decoder tokens. It appeared to work for greedy decode only because `max_query_len=1` skipped the buggy prefill kernel. Beam search exposed the bug because every step has `max_query_len > 1`.

Fixes cross-attention bug in ROCM_ATTN backend that produced incorrect beam search results for encoder-decoder models (e.g., Whisper). The `context_attention_fwd` prefill kernel assumed self-attention semantics, double-counting some encoder tokens and missing others when `max_query_len > 1`. Skip the prefill kernel for cross-attention (all encoder K/V are already cached) and use a CROSS_ATTN mode in the Triton decode kernel with a 3D grid for multi-token queries 

This does not affect non-cross-attention architectures in terms of performance. The only changes are: (1) rocm_attn.py: the if self.attn_type == ENCODER_DECODER guard only fires for cross-attention layers and regular decoder self-attention is untouched. (2) chunked_prefill_paged_decode.py: is_cross_attn = key is None is False for self-attention, so all code paths are identical. The CROSS_ATTN constexpr in the Triton kernel compiles away entirely when False.

Test plan
- [x] `pytest -s -v tests/entrypoints/openai/speech_to_text/test_transcription_validation_whisper.py::test_whisper_beam_search_single_beam`

cc @kenroche 