### PR TITLE
[Bugfix] Fix Helm chart Deployment using hardcoded labels

### DIFF
--- a/examples/online_serving/chart-helm/templates/deployment.yaml
+++ b/examples/online_serving/chart-helm/templates/deployment.yaml
@@ -8,16 +8,14 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- include "chart.strategy" . | nindent 2 }}
-  selector:                                                                                                                                  
+  selector:
     matchLabels:
-      environment: "test"
-      release: "test"
+    {{- include "chart.labels" . | nindent 6 }}
   progressDeadlineSeconds: 1200
   template:
     metadata:
       labels:
-        environment: "test"
-        release: "test"
+      {{- include "chart.labels" . | nindent 8 }}
     spec:
       containers:
         - name: "vllm"


### PR DESCRIPTION
Fixes selector mismatch in Deployment template when users customize `.Values.labels`.

The Deployment was using hardcoded labels instead of the `chart.labels` helper that the Service template already uses.

**Changes:**
- Deployment selector now uses `{{- include "chart.labels" . }}` (consistent with Service)
- 3 lines changed

(Supersedes #37959 — that PR accidentally included personal files)