### PR TITLE
[Bugfix] Preserve torch profiler summary output on CPU

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -21,7 +21,7 @@ To use the `torch.profiler` module, set the `profiler` entry to `'torch'` and `t
 - `torch_profiler_with_stack` to enable recording stack information, on by default
 - `torch_profiler_with_flops` to enable recording FLOPs, off by default
 - `torch_profiler_use_gzip` to control gzip-compressing profiling files, on by default
-- `torch_profiler_dump_cuda_time_total` to control dumping and printing the aggregated CUDA self time table, on by default
+- `torch_profiler_dump_cuda_time_total` to control dumping and printing the aggregated backend self time table, using CUDA self time on GPU backends and CPU self time on CPU backends, on by default
 
 When using `vllm bench serve`, you can enable profiling by passing the `--profile` flag.
 

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import pytest
+from types import SimpleNamespace
 
-from vllm.config import ProfilerConfig
+import pytest
+import torch
+
+from vllm.config import CompilationMode, ProfilerConfig
 from vllm.config.profiler import _is_uri_path
-from vllm.profiler.wrapper import WorkerProfiler
+from vllm.platforms.cpu import CpuPlatform
+from vllm.profiler.wrapper import TorchProfilerWrapper, WorkerProfiler
 
 
 class ConcreteWorkerProfiler(WorkerProfiler):
@@ -236,3 +240,67 @@ class TestIsUriPath:
     def test_is_uri_path(self, path, expected):
         """Test that _is_uri_path correctly identifies URI vs local paths."""
         assert _is_uri_path(path) == expected
+
+
+def test_cpu_torch_profiler_writes_summary_file(tmp_path):
+    profiler_config = ProfilerConfig(
+        profiler="torch",
+        torch_profiler_dir=str(tmp_path),
+        torch_profiler_dump_cuda_time_total=True,
+        delay_iterations=0,
+        warmup_iterations=0,
+        active_iterations=1,
+        wait_iterations=0,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=None,
+        cache_config=SimpleNamespace(
+            user_specified_block_size=False,
+            block_size=0,
+            enable_prefix_caching=False,
+            cache_dtype="auto",
+            cpu_kvcache_space_bytes=0,
+        ),
+        scheduler_config=SimpleNamespace(
+            async_scheduling=True,
+            enable_chunked_prefill=False,
+        ),
+        kv_transfer_config=None,
+        parallel_config=SimpleNamespace(
+            world_size=1,
+            tensor_parallel_size=1,
+            distributed_executor_backend=None,
+            worker_cls="auto",
+            enable_dbo=False,
+        ),
+        compilation_config=SimpleNamespace(
+            cudagraph_capture_sizes=[1],
+            mode=CompilationMode.NONE,
+            backend=None,
+            inductor_compile_config={},
+        ),
+        lora_config=None,
+        device_config=SimpleNamespace(device_type="cpu"),
+        profiler_config=profiler_config,
+    )
+
+    CpuPlatform.check_and_update_config(vllm_config)
+
+    assert vllm_config.profiler_config.torch_profiler_dump_cuda_time_total is True
+
+    profiler = TorchProfilerWrapper(
+        profiler_config=vllm_config.profiler_config,
+        worker_name="cpu-profiler-test",
+        local_rank=0,
+        activities=["CPU"],
+    )
+
+    profiler.start()
+    x = torch.ones(32, 32)
+    y = x @ x
+    _ = y.sum().item()
+    profiler.stop()
+
+    summary_file = tmp_path / "profiler_out_0.txt"
+    assert summary_file.exists()
+    assert "Self CPU time total" in summary_file.read_text()

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -57,7 +57,9 @@ class ProfilerConfig:
     """If `True`, saves torch profiler traces in gzip format. Enabled by default"""
 
     torch_profiler_dump_cuda_time_total: bool = True
-    """If `True`, dumps total CUDA time in torch profiler traces. Enabled by default."""
+    """If `True`, dumps a backend-specific self-time summary from torch profiler
+    traces. Uses CUDA time on GPU backends and CPU time on CPU backends.
+    Enabled by default."""
 
     torch_profiler_record_shapes: bool = False
     """If `True`, records tensor shapes in the torch profiler. Disabled by default."""

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -253,8 +253,6 @@ class CpuPlatform(Platform):
         if vllm_config.lora_config is not None:
             compilation_config.mode = CompilationMode.NONE
 
-        vllm_config.profiler_config.torch_profiler_dump_cuda_time_total = False
-
         assert vllm_config.device_config.device_type == "cpu"
 
         #

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -252,7 +252,11 @@ class TorchProfilerWrapper(WorkerProfiler):
         rank = self.local_rank
         if profiler_config.torch_profiler_dump_cuda_time_total:
             profiler_dir = profiler_config.torch_profiler_dir
-            sort_key = "self_cuda_time_total"
+            sort_key = (
+                "self_cpu_time_total"
+                if self.dump_cpu_time_total
+                else "self_cuda_time_total"
+            )
             table = self.profiler.key_averages().table(sort_by=sort_key)
 
             # Skip file write for URI paths (gs://, s3://, etc.)


### PR DESCRIPTION
## Purpose

Fixes #38131.

On the CPU backend, `torch_profiler_dump_cuda_time_total=True` was being silently overridden to `False` in `CpuPlatform.check_and_update_config`, which meant CPU torch profiling produced trace files but did not write a human-readable `profiler_out_<rank>.txt` summary even though CPU summary data was available.

This PR preserves the existing flag on CPU and, for CPU-only torch profiling, writes the summary file using `self_cpu_time_total`. GPU behavior remains unchanged.

I also updated the profiler docs to reflect that this flag now produces a backend-specific self-time summary, and added a regression test covering CPU summary file generation.

I checked the linked issue and searched open PRs referencing `#38131` and related CPU profiler summary terms before preparing this change, and did not find an overlapping open PR.

This PR includes AI-assisted code generation/editing. I reviewed all changed lines, validated the behavior locally, and ran the tests below myself.

I kept this change intentionally minimal by reusing the existing flag rather than introducing new profiler config surface; happy to follow up with a separate PR adding a CPU-specific flag if maintainers would prefer that direction.

## Test Plan

Run the profiler regression test file:

```bash
.venv/bin/python -m pytest tests/v1/worker/test_gpu_profiler.py -v
```
Run file-scoped linting/formatting/docs checks:

```bash
pre-commit run --files vllm/platforms/cpu.py vllm/profiler/wrapper.py vllm/config/profiler.py docs/contributing/profiling.md tests/v1/worker/test_gpu_profiler.py
```

## Test Result

pytest result:
```text
============================== 26 passed, 3 warnings in 4.59s ==============================
```

pre-commit result:
- ruff check passed
- ruff format passed
- typos passed
- markdownlint-cli2 passed
- mypy hook passed
- all other relevant file-scoped hooks passed or were skipped when not applicable

## Documentation

Updated:
- vllm/config/profiler.py
- docs/contributing/profiling.md

to reflect that `torch_profiler_dump_cuda_time_total` now emits a backend-specific self-time summary, using CUDA self time on GPU backends and CPU self time on CPU backends.