### PR TITLE
[cpu] Fix chained comparisons in static_assert breaking macOS builds

### DIFF
--- a/csrc/cpu/cpu_attn_impl.hpp
+++ b/csrc/cpu/cpu_attn_impl.hpp
@@ -147,6 +147,9 @@ struct AttentionMetadata {
       case ISA::NEON:
         ss << "NEON, ";
         break;
+      case ISA::VXE:
+        ss << "VXE, ";
+        break;
     }
     ss << "workitem_group_num: " << workitem_group_num
        << ", reduction_item_num: " << reduction_item_num

--- a/csrc/cpu/cpu_attn_vec.hpp
+++ b/csrc/cpu/cpu_attn_vec.hpp
@@ -53,7 +53,7 @@ class TileGemm82 {
                          const int64_t ldb, const int64_t ldc,
                          const int32_t block_size, const int32_t dynamic_k_size,
                          const bool accum_c) {
-    static_assert(0 < M <= 8);
+    static_assert(0 < M && M <= 8);
     using load_vec_t = typename VecTypeTrait<kv_cache_t>::vec_t;
 
     kv_cache_t* __restrict__ curr_b_0 = b_tile;

--- a/csrc/cpu/cpu_attn_vec16.hpp
+++ b/csrc/cpu/cpu_attn_vec16.hpp
@@ -68,7 +68,7 @@ class TileGemm161 {
                          const int64_t ldb, const int64_t ldc,
                          const int32_t block_size, const int32_t dynamic_k_size,
                          const bool accum_c) {
-    static_assert(0 < M <= 16);
+    static_assert(0 < M && M <= 16);
     using load_vec_t = typename VecTypeTrait<kv_cache_t>::vec_t;
 
     kv_cache_t* __restrict__ curr_b_0 = b_tile;

--- a/csrc/cpu/micro_gemm/cpu_micro_gemm_vec.hpp
+++ b/csrc/cpu/micro_gemm/cpu_micro_gemm_vec.hpp
@@ -39,7 +39,7 @@ class TileGemm82 {
 
   template <int32_t M>
   static void gemm_micro(DEFINE_CPU_MICRO_GEMM_PARAMS) {
-    static_assert(0 < M <= 8);
+    static_assert(0 < M && M <= 8);
     using load_vec_t = typename cpu_utils::VecTypeTrait<scalar_t>::vec_t;
 
     scalar_t* __restrict__ curr_b_0 = b_ptr;


### PR DESCRIPTION
## Summary

- Fix C++ chained comparisons in `static_assert` that are always true and break builds on AppleClang 21+ (Xcode 26 / macOS 26 Tahoe)
- `static_assert(0 < M <= 8)` is parsed as `(0 < M) <= 8` — the left side evaluates to a `bool` (0 or 1), then `bool <= 8` is always true, so the upper bound is never validated
- Replace with `static_assert(0 < M && M <= 8)` in three files
- Add missing `ISA::VXE` enum case in switch to suppress `-Wswitch` warning

### Files changed

| File | Fix |
|---|---|
| `csrc/cpu/cpu_attn_vec.hpp:56` | `0 < M <= 8` → `0 < M && M <= 8` |
| `csrc/cpu/cpu_attn_vec16.hpp:71` | `0 < M <= 16` → `0 < M && M <= 16` |
| `csrc/cpu/micro_gemm/cpu_micro_gemm_vec.hpp:42` | `0 < M <= 8` → `0 < M && M <= 8` |
| `csrc/cpu/cpu_attn_impl.hpp:148` | Add missing `ISA::VXE` switch case |

## Test plan

- [x] Verified vllm builds successfully on macOS arm64 (Apple Silicon M5 Max) with AppleClang 21.0.0 after applying these fixes
- The fix is a straightforward correctness improvement — the old assertions were no-ops (always passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)