### PR TITLE
[Doc] Clarify Helm chart location in deployment guide

### DIFF
--- a/docs/deployment/frameworks/helm.md
+++ b/docs/deployment/frameworks/helm.md
@@ -17,6 +17,8 @@ Before you begin, ensure that you have the following:
 
 ## Installing the chart
 
+This guide uses the Helm chart at [examples/online_serving/chart-helm](https://github.com/vllm-project/vllm/tree/main/examples/online_serving/chart-helm).
+
 To install the chart with the release name `test-vllm`:
 
 ```bash

--- a/docs/deployment/frameworks/helm.md
+++ b/docs/deployment/frameworks/helm.md
@@ -17,7 +17,7 @@ Before you begin, ensure that you have the following:
 
 ## Installing the chart
 
-This guide uses the Helm chart at [examples/online_serving/chart-helm](https://github.com/vllm-project/vllm/tree/main/examples/online_serving/chart-helm).
+This guide uses the Helm chart at [examples/online_serving/chart-helm](../../../examples/online_serving/chart-helm).
 
 To install the chart with the release name `test-vllm`:
 


### PR DESCRIPTION
## Purpose

This clarifies which Helm chart the deployment guide uses by adding a relative link to `examples/online_serving/chart-helm`.

## Test Plan

None, since this is a docs-only change.

## Test Result

None, since this is a docs-only change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>