### PR TITLE
[MoE] Add RoutingMethodType.Simulated to TRT-LLM FP8/NVFP4 kernel allowlists

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -256,13 +256,18 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
     ) -> bool:
         """
         The FlashInfer TRTLLM FP8 kernel expects bfloat16 router_logits by default.
-        Only DeepSeekV3 routing supports float32 router_logits (which is converted
-        internally in the kernel).
+        DeepSeekV3 routing supports float32 router_logits (converted internally).
+        Simulated routing generates synthetic decisions and is agnostic to dtype.
         """
         if router_logits_dtype == torch.float32:
-            # Only DeepSeekV3 routing handles float32 logits
+            # DeepSeekV3 routing handles float32 logits internally.
+            # Simulated routing generates synthetic decisions, so the
+            # kernel doesn't care about the actual logits dtype.
             # https://github.com/flashinfer-ai/flashinfer/issues/2469
-            return routing_method == RoutingMethodType.DeepSeekV3
+            return routing_method in (
+                RoutingMethodType.DeepSeekV3,
+                RoutingMethodType.Simulated,
+            )
         return True
 
     @staticmethod
@@ -288,12 +293,14 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
             # NOTE(rob): potentially allow others here. This is a conservative list.
             return routing_method in [
                 RoutingMethodType.DeepSeekV3,
+                RoutingMethodType.Simulated,
             ]
         elif (weight_key, activation_key) == (kFp8StaticTensorSym, kFp8StaticTensorSym):
             # NOTE(dbari): as above, potentially allow others here.
             return routing_method in [
                 RoutingMethodType.DeepSeekV3,
                 RoutingMethodType.Llama4,
+                RoutingMethodType.Simulated,
             ]
         else:
             raise ValueError("Unsupported quantization scheme.")

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -255,6 +255,7 @@ class TrtLlmNvFp4ExpertsMonolithic(
             RoutingMethodType.Renormalize,
             RoutingMethodType.RenormalizeNaive,
             RoutingMethodType.Llama4,
+            RoutingMethodType.Simulated,
         ]
 
     @staticmethod
@@ -264,13 +265,18 @@ class TrtLlmNvFp4ExpertsMonolithic(
     ) -> bool:
         """
         The FlashInfer TRTLLM NvFp4 kernel expects bfloat16 router_logits by default.
-        Only DeepSeekV3 routing supports float32 router_logits (which is converted
-        internally in the kernel).
+        DeepSeekV3 routing supports float32 router_logits (converted internally).
+        Simulated routing generates synthetic decisions and is agnostic to dtype.
         """
         if router_logits_dtype == torch.float32:
-            # Only DeepSeekV3 routing handles float32 logits
+            # DeepSeekV3 routing handles float32 logits internally.
+            # Simulated routing generates synthetic decisions, so the
+            # kernel doesn't care about the actual logits dtype.
             # https://github.com/flashinfer-ai/flashinfer/issues/2469
-            return routing_method == RoutingMethodType.DeepSeekV3
+            return routing_method in (
+                RoutingMethodType.DeepSeekV3,
+                RoutingMethodType.Simulated,
+            )
         return True
 
     def apply(


### PR DESCRIPTION
## Summary

The `RoutingMethodType.Simulated` routing method is used by the routing simulator (`RoutingSimulatorRouter`) when `VLLM_MOE_ROUTING_SIMULATION_STRATEGY` is set (e.g., `uniform_random`). This is a **benchmarking-only feature** — production deployments do not use simulated routing.

Two issues fixed:

### 1. Missing `Simulated` in `_supports_routing_method` allowlists

The TRT-LLM FP8 and NVFP4 fused MoE kernels maintain explicit allowlists of supported routing methods. `Simulated` was missing, causing any benchmark run combining these backends with routing simulation to fail:

```
FP8 MoE backend FLASHINFER_TRTLLM does not support the deployment
configuration since kernel does not support routing method 7
```

### 2. Missing `Simulated` in `_supports_router_logits_dtype`

The `_supports_router_logits_dtype` methods only allowed `DeepSeekV3` for float32 router logits. `Simulated` routing generates synthetic decisions and is agnostic to the actual logits dtype, so it should also be allowed when float32 logits are present.

---

`Simulated` is functionally transparent to kernels — it produces synthetic routing decisions with the same tensor shape/format as real routing methods. The kernel is agnostic to how routes were computed.

**No production behavior changes.** This only unblocks benchmark configurations that opt into routing simulation via environment variable.

### Changes

- `trtllm_fp8_moe.py`: Added `RoutingMethodType.Simulated` to routing method allowlists and `_supports_router_logits_dtype`
- `trtllm_nvfp4_moe.py`: Added `RoutingMethodType.Simulated` to routing method allowlist and `_supports_router_logits_dtype`

## Test plan

Ran MoE benchmarks with `VLLM_MOE_ROUTING_SIMULATION_STRATEGY=uniform_random` on both FP8 and NVFP4 TRT-LLM backends:
- `flashinfer_trtllm_fp8` backend + routing simulation: previously failed, now passes
- `nvfp4_trtllm` backend + routing simulation: previously failed, now passes