### PR TITLE
MiniMax-M2: add Eagle3 speculative decoding support

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -805,6 +805,7 @@ class SpeculativeConfig:
             "deepseek_v3",
             "kimi_k2",
             "kimi_k25",
+            "minimax",
         ]
         if (
             self.method in ("eagle3", "extract_hidden_states")

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -24,6 +24,7 @@
 """Inference-only MiniMaxM2 model."""
 
 from collections.abc import Iterable
+from itertools import islice
 from typing import Any
 
 import torch
@@ -59,7 +60,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsLoRA, SupportsPP
+from .interfaces import SupportsEagle3, SupportsLoRA, SupportsPP
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -356,6 +357,7 @@ class MiniMaxM2Model(nn.Module):
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
         )
+        self.aux_hidden_state_layers = tuple[int, ...]()
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -378,7 +380,12 @@ class MiniMaxM2Model(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        for layer in self.layers[self.start_layer : self.end_layer]:
+        aux_hidden_states = []
+        for idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer)
+        ):
+            if idx in self.aux_hidden_state_layers:
+                aux_hidden_states.append(hidden_states + residual)
             hidden_states, residual = layer(positions, hidden_states, residual)
 
         if not get_pp_group().is_last_rank:
@@ -386,6 +393,10 @@ class MiniMaxM2Model(nn.Module):
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+
         return hidden_states
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
@@ -496,7 +507,7 @@ class MiniMaxM2Model(nn.Module):
         return loaded_params
 
 
-class MiniMaxM2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+class MiniMaxM2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -526,6 +537,13 @@ class MiniMaxM2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors
         )
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.model.aux_hidden_state_layers = layers
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        num_layers = len(self.model.layers)
+        return (2, num_layers // 2, num_layers - 3)
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -543,6 +543,7 @@ _SPECULATIVE_DECODING_MODELS = {
     "EagleLlama4ForCausalLM": ("llama4_eagle", "EagleLlama4ForCausalLM"),
     "EagleMiniCPMForCausalLM": ("minicpm_eagle", "EagleMiniCPMForCausalLM"),
     "Eagle3LlamaForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
+    "Eagle3MiniMaxM2ForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
     "LlamaForCausalLMEagle3": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
     "Eagle3Qwen2_5vlForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
     "Eagle3Qwen3vlForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),


### PR DESCRIPTION
  ---                                                                                                             
  Purpose
                                                                                                                  
  Enable Eagle3 speculative decoding for the MiniMax-M2 model.                                                  
                                                                                          
  MiniMax-M2 (230B MoE, 10B activated) currently lacks Eagle3 support in vLLM. This PR adds the necessary
  interfaces and registrations to allow Eagle3 speculative decoding on MiniMax-M2, following the same pattern as
  existing Eagle3-supported models (DeepSeek-V3, Kimi-K2, etc.).

  Changes:
  - Add minimax to the Eagle3 model type whitelist in SpeculativeConfig
  - Implement SupportsEagle3 interface on MiniMaxM2ForCausalLM with auxiliary hidden state extraction at layers
  (2, mid, n-3)
  - Collect auxiliary hidden states during MiniMaxM2Model.forward() when Eagle3 is enabled
  - Register Eagle3MiniMaxM2ForCausalLM in the speculative decoding model registry, reusing the llama_eagle3
  implementation

  Test Plan

  vllm serve MiniMaxAI/MiniMax-M2 --tensor-parallel-size 8 \
    --speculative-method eagle3 --num-speculative-tokens 3 \
    --speculative-model <eagle3-draft-model>

  Test Result

  Verified on Ascend NPU (8×910B):
  - Model loads successfully with Eagle3 enabled
  - Speculative decoding produces correct outputs with expected acceptance rate
  - No regression on standard (non-speculative) inference