### PR TITLE
feat(grpc): add periodic stats logging and servicer log forwarding

### DIFF
--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -20,7 +20,6 @@ Example:
 
 import argparse
 import asyncio
-import logging
 import signal
 import sys
 import time
@@ -48,14 +47,6 @@ from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
-
-# Attach the smg_grpc_servicer logger to the vllm logging hierarchy so its
-# INFO/DEBUG messages use the same handler and format as vllm loggers.
-_vllm_logger = logging.getLogger("vllm")
-_servicer_logger = logging.getLogger("smg_grpc_servicer")
-_servicer_logger.handlers = _vllm_logger.handlers
-_servicer_logger.setLevel(_vllm_logger.level)
-_servicer_logger.propagate = False
 
 
 async def serve_grpc(args: argparse.Namespace):

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -20,6 +20,7 @@ Example:
 
 import argparse
 import asyncio
+import logging
 import signal
 import sys
 import time
@@ -37,6 +38,7 @@ except ImportError:
 
 import uvloop
 
+from vllm import envs
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.utils import log_version_and_model
 from vllm.logger import init_logger
@@ -46,6 +48,14 @@ from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
+
+# Attach the smg_grpc_servicer logger to the vllm logging hierarchy so its
+# INFO/DEBUG messages use the same handler and format as vllm loggers.
+_vllm_logger = logging.getLogger("vllm")
+_servicer_logger = logging.getLogger("smg_grpc_servicer")
+_servicer_logger.handlers = _vllm_logger.handlers
+_servicer_logger.setLevel(_vllm_logger.level)
+_servicer_logger.propagate = False
 
 
 async def serve_grpc(args: argparse.Namespace):
@@ -113,6 +123,18 @@ async def serve_grpc(args: argparse.Namespace):
         logger.info("vLLM gRPC server started on %s", address)
         logger.info("Server is ready to accept requests")
 
+        # Start periodic stats logging (mirrors the HTTP server's lifespan task)
+        if not args.disable_log_stats:
+
+            async def _force_log():
+                while True:
+                    await asyncio.sleep(envs.VLLM_LOG_STATS_INTERVAL)
+                    await async_llm.do_log_stats()
+
+            stats_task = asyncio.create_task(_force_log())
+        else:
+            stats_task = None
+
         # Handle shutdown signals
         loop = asyncio.get_running_loop()
         stop_event = asyncio.Event()
@@ -130,6 +152,8 @@ async def serve_grpc(args: argparse.Namespace):
             logger.info("Interrupted by user")
     finally:
         logger.info("Shutting down vLLM gRPC server...")
+        if stats_task is not None:
+            stats_task.cancel()
         await server.stop(grace=5.0)
         logger.info("gRPC server stopped")
         async_llm.shutdown()


### PR DESCRIPTION
## Purpose

The gRPC server (`grpc_server.py`) was missing two logging features that the HTTP server provides:

1. **Periodic stats logging** — The HTTP server starts a background task in its FastAPI lifespan that calls `do_log_stats()` every `VLLM_LOG_STATS_INTERVAL` seconds, printing throughput/cache stats like:
   ```
   Avg prompt throughput: 388.7 tokens/s, Avg generation throughput: 3.0 tokens/s, ...
   ```
   The gRPC server had no equivalent, so operators had no visibility into engine performance.

2. **Servicer log forwarding** — The `smg_grpc_servicer` package uses `logging.getLogger(__name__)`, which creates loggers outside the `vllm` hierarchy. Without explicitly attaching vLLM's handlers, servicer log messages were silently dropped.

This PR adds both, mirroring the HTTP server's behavior.

## Test Plan

- Start vLLM with `--grpc` flag
- Send a few requests
- Verify stats lines appear every 10s (or `VLLM_LOG_STATS_INTERVAL`):
  ```
  INFO ... Avg prompt throughput: X tokens/s, Avg generation throughput: Y tokens/s, Running: 0 reqs, ...
  ```
- Verify servicer INFO messages (e.g. `Generate request ...`) appear with vLLM's log format
- Verify `--disable-log-stats` suppresses the stats lines

## Test Result

Before: gRPC server only shows `HealthCheck` and `Generate request` lines, no throughput stats.
After: stats lines appear every 10s, matching HTTP server behavior.