### PR TITLE
[ROCm] Use Triton attention fallback for ViT to avoid SDPA OOM

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -536,6 +536,16 @@ class RocmPlatform(Platform):
             )
             return AttentionBackendEnum.FLASH_ATTN
 
+        # Triton prefill attention uses tiled/blocked computation, avoiding
+        # the N^2 memory allocation that TORCH_SDPA's "math" backend triggers
+        # on ROCm devices without efficient SDPA kernels (e.g. gfx906).
+        if dtype == torch.float16 or dtype == torch.bfloat16:
+            logger.info_once(
+                "No efficient SDPA backend available; using Triton attention "
+                "for ViT model to avoid N^2 memory allocation."
+            )
+            return AttentionBackendEnum.TRITON_ATTN
+
         logger.info_once("Using Torch SDPA backend for ViT model.")
         return AttentionBackendEnum.TORCH_SDPA
 


### PR DESCRIPTION
## Summary
- On ROCm devices without efficient SDPA backends (e.g. gfx906), running multimodal models (Qwen3.5, etc.) triggers PyTorch's SDPA "math" backend, which allocates the full N×N attention matrix for the vision encoder. For typical vision frames this requires ~128-192GB, causing OOM even on datacenter GPUs.
- This adds Triton prefill attention as a fallback before TORCH_SDPA in `get_vit_attn_backend()`. The Triton kernel uses tiled/blocked computation that avoids the N² memory allocation.

## Fallback chain (updated)
1. AITER Flash Attention (gfx9 with AITER)
2. Flash Attention (gfx9 with flash_attn, fp16/bf16)
3. Flash Attention Triton (gfx1x RDNA3/4, fp16/bf16)
4. **Triton Attention (fp16/bf16)** ← NEW
5. Torch SDPA (final fallback, non-fp16/bf16 only)

Fixes #36890
Related: #27706

## Test plan
- [ ] Verify Qwen3.5-0.8B starts without OOM on gfx906
- [ ] Verify existing ViT attention tests still pass on MI300X/MI325X
- [ ] Verify RDNA3/4 devices still use Flash Attention Triton (not the new fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)