### PR TITLE
[ROCm][CI] Fix spawn test decorator silently skipping tests without __main__

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1384,9 +1384,6 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
         with suppress(RuntimeError):
             mp.set_start_method("spawn")
 
-        # Get the module
-        module_name = f.__module__
-
         # Create a process with environment variable set
         env = os.environ.copy()
         env["RUNNING_IN_SUBPROCESS"] = "1"
@@ -1402,7 +1399,17 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
             env = dict(env or os.environ)
             env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
 
-            cmd = [sys.executable, "-m", f"{module_name}"]
+            # Use an inline script that reads the pickled function from
+            # stdin and calls it directly. This avoids depending on test
+            # files having an `if __name__ == "__main__":` block — without
+            # one, the old `python -m <module>` approach would exit 0
+            # without ever running the test (see issue #38097).
+            cmd = [
+                sys.executable, "-c",
+                "import sys, cloudpickle; "
+                "fn, _ = cloudpickle.loads(sys.stdin.buffer.read()); "
+                "fn()"
+            ]
 
             returned = subprocess.run(
                 cmd, input=input_bytes, capture_output=True, env=env


### PR DESCRIPTION
## Summary
- `create_new_process_for_each_test("spawn")` ran tests via `python -m <module>`, which requires test files to have `if __name__ == "__main__":` blocks
- Without that block, the subprocess exits 0 without running the test, and the decorator treats it as a pass — tests silently never execute
- This is especially impactful on ROCm since `spawn` is the default method (`use_spawn = current_platform.is_rocm()`)

## Fix
Replace `python -m <module>` with `python -c` using an inline script that reads the cloudpickle-serialized test function from stdin and calls it directly. The function was already being serialized and piped — this just ensures it's actually invoked regardless of the file's `__main__` block.

Fixes #38097

## Test plan
- [ ] Run existing spawn-based tests on ROCm CI — should still pass
- [ ] Verify that a test file without `__main__` now properly executes (instead of silently passing)
- [ ] Run on CUDA CI to ensure no regression (CUDA uses fork, not spawn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)