### PR TITLE
[Bugfix] Detect missing shard files in quantized checkpoints

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -646,6 +646,22 @@ def filter_duplicate_safetensors_files(
     weight_files_in_index = set()
     for weight_name in weight_map:
         weight_files_in_index.add(os.path.join(hf_folder, weight_map[weight_name]))
+    # Check that all files referenced in the index actually exist on disk.
+    # This catches cases where shard files are missing from a downloaded
+    # or quantized checkpoint, which would otherwise silently produce a
+    # model with uninitialized weights.
+    missing_files = {
+        f for f in weight_files_in_index if not os.path.isfile(f)
+    }
+    if missing_files:
+        raise RuntimeError(
+            "The following weight files are referenced in "
+            f"{index_file} but are missing on disk: "
+            f"{sorted(missing_files)}. This usually means the "
+            "model checkpoint is incomplete or was not fully "
+            "downloaded. Please re-download the model."
+        )
+
     # Filter out any fields that are not found in the index file.
     hf_weights_files = [f for f in hf_weights_files if f in weight_files_in_index]
     return hf_weights_files


### PR DESCRIPTION
## Summary
- When loading a quantized model from a sharded safetensors checkpoint with missing shard files, vLLM silently succeeds with uninitialized weights
- This happens because the strict weight check in `default_loader.py` is skipped for quantized models, and `filter_duplicate_safetensors_files` never validates that index-referenced files exist on disk
- Adds a missing-file check in `filter_duplicate_safetensors_files()` that raises `RuntimeError` if any shard files referenced in the index are missing

Fixes #34859

## Test plan
- [ ] Load a quantized model with a missing shard file — should now raise `RuntimeError` instead of silently loading
- [ ] Load a complete quantized model — should work as before (no false positives)
- [ ] Load a non-quantized model with missing shards — should also be caught (defense in depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)