### PR TITLE
[ROCm][Build] Fix pip install detection when build isolation installs CUDA PyTorch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,18 @@ elif sys.platform.startswith("linux") and os.getenv("VLLM_TARGET_DEVICE") is Non
     if torch.version.hip is not None:
         VLLM_TARGET_DEVICE = "rocm"
         logger.info("Auto-detected ROCm")
+    elif ROCM_HOME is not None and CUDA_HOME is None:
+        # When pip build isolation installs the CUDA variant of PyTorch from
+        # PyPI, torch.version.hip will be None even on a ROCm system.  Fall
+        # back to the environment: if ROCM_HOME is set and CUDA_HOME is not,
+        # this is clearly a ROCm build.  (Fixes #20639)
+        VLLM_TARGET_DEVICE = "rocm"
+        logger.warning(
+            "PyTorch reports CUDA, but ROCM_HOME is set (%s) and "
+            "CUDA_HOME is not.  Treating this as a ROCm build.  "
+            "Install the ROCm PyTorch wheel to avoid this fallback.",
+            ROCM_HOME,
+        )
     elif torch.version.xpu is not None:
         VLLM_TARGET_DEVICE = "xpu"
         logger.info("Auto-detected XPU")
@@ -796,6 +808,12 @@ def _is_cuda() -> bool:
 
 
 def _is_hip() -> bool:
+    if VLLM_TARGET_DEVICE == "rocm":
+        # When VLLM_TARGET_DEVICE is explicitly "rocm" (either user-set or
+        # auto-detected via ROCM_HOME fallback), trust it even if
+        # torch.version.hip is None (pip build-isolation can install the
+        # wrong PyTorch variant).
+        return True
     return (
         VLLM_TARGET_DEVICE == "cuda" or VLLM_TARGET_DEVICE == "rocm"
     ) and torch.version.hip is not None


### PR DESCRIPTION
## Summary
- Running `pip install -e .` on a ROCm system fails with `AssertionError: CUDA_HOME is not set`
- Root cause: pip's build isolation installs the CUDA variant of PyTorch from PyPI, so `torch.version.hip` is `None` even though the system has ROCm
- The auto-detection logic in `setup.py` then misidentifies the build as CUDA

## Fix
1. Add a fallback in the auto-detection: when `ROCM_HOME` is set and `CUDA_HOME` is not, treat the build as ROCm (with a warning to install the correct PyTorch wheel)
2. Update `_is_hip()` to trust `VLLM_TARGET_DEVICE == "rocm"` even when `torch.version.hip is None`

This preserves backward compatibility — existing CUDA builds, manual `VLLM_TARGET_DEVICE` overrides, and normal ROCm builds with correct PyTorch are all unaffected.

Fixes #20639

## Test plan
- [ ] `pip install -e .` on a ROCm system without ROCm PyTorch — should detect ROCm via ROCM_HOME fallback
- [ ] `pip install -e .` on a ROCm system with ROCm PyTorch — should detect via `torch.version.hip` (existing path)
- [ ] `pip install -e .` on a CUDA system — should detect CUDA as before (CUDA_HOME set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)