### PR TITLE
[Kernel] Add Triton reference implementation of NVFP4 GEMM

### DIFF
--- a/benchmarks/kernels/benchmark_nvfp4_gemm.py
+++ b/benchmarks/kernels/benchmark_nvfp4_gemm.py
@@ -76,10 +76,8 @@ def _quant_nvfp4_linear_scales(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Quantize to NVFP4 with linear (non-swizzled) block scales for Triton."""
     x_amax = torch.abs(x).max().to(torch.float32)
-    global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / x_amax
-    fp4, scale = ops.scaled_fp4_quant(
-        x, global_scale, is_sf_swizzled_layout=False
-    )
+    global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / (x_amax + 1e-12)
+    fp4, scale = ops.scaled_fp4_quant(x, global_scale, is_sf_swizzled_layout=False)
     return fp4, scale, global_scale
 
 
@@ -87,16 +85,14 @@ def build_triton_nvfp4_runner(cfg, a, b, dtype, device):
     """Build a runner for the Triton NVFP4 GEMM kernel."""
     b_fp4, scale_b, b_global_scale = _quant_nvfp4_linear_scales(b, device)
     a_amax = torch.abs(a).max().to(torch.float32)
-    a_global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / a_amax
+    a_global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / (a_amax + 1e-12)
     alpha = 1.0 / (a_global_scale * b_global_scale)
 
     if cfg["no_a_quant"]:
         a_fp4, scale_a, _ = _quant_nvfp4_linear_scales(a, device)
 
         def run():
-            return triton_scaled_fp4_mm(
-                a_fp4, b_fp4, scale_a, scale_b, alpha, dtype
-            )
+            return triton_scaled_fp4_mm(a_fp4, b_fp4, scale_a, scale_b, alpha, dtype)
 
         return run
 

--- a/benchmarks/kernels/benchmark_nvfp4_gemm.py
+++ b/benchmarks/kernels/benchmark_nvfp4_gemm.py
@@ -24,6 +24,8 @@ PROVIDER_CFGS = {
     "torch-bf16": dict(enabled=True),
     "nvfp4": dict(no_a_quant=False, enabled=True),
     "nvfp4-noquant": dict(no_a_quant=True, enabled=True),
+    "triton-nvfp4": dict(triton=True, no_a_quant=False, enabled=True),
+    "triton-nvfp4-noquant": dict(triton=True, no_a_quant=True, enabled=True),
     "fbgemm-nvfp4": dict(fbgemm=True, no_a_quant=False, enabled=True),
     "fbgemm-nvfp4-noquant": dict(fbgemm=True, no_a_quant=True, enabled=True),
 }
@@ -47,6 +49,14 @@ if _needs_fbgemm:
             if cfg.get("fbgemm"):
                 cfg["enabled"] = False
 
+try:
+    from triton_nvfp4_gemm import triton_scaled_fp4_mm
+except ImportError:
+    # Disable Triton providers if kernel is not available
+    for cfg in PROVIDER_CFGS.values():
+        if cfg.get("triton"):
+            cfg["enabled"] = False
+
 _enabled = [k for k, v in PROVIDER_CFGS.items() if v["enabled"]]
 
 
@@ -59,6 +69,44 @@ def _quant_weight_nvfp4(b: torch.Tensor, device: str, cfg):
     else:
         b_fp4, scale_b_fp4 = ops.scaled_fp4_quant(b, b_global_scale)
     return b_fp4, scale_b_fp4, b_global_scale
+
+
+def _quant_nvfp4_linear_scales(
+    x: torch.Tensor, device: str
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize to NVFP4 with linear (non-swizzled) block scales for Triton."""
+    x_amax = torch.abs(x).max().to(torch.float32)
+    global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / x_amax
+    fp4, scale = ops.scaled_fp4_quant(
+        x, global_scale, is_sf_swizzled_layout=False
+    )
+    return fp4, scale, global_scale
+
+
+def build_triton_nvfp4_runner(cfg, a, b, dtype, device):
+    """Build a runner for the Triton NVFP4 GEMM kernel."""
+    b_fp4, scale_b, b_global_scale = _quant_nvfp4_linear_scales(b, device)
+    a_amax = torch.abs(a).max().to(torch.float32)
+    a_global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / a_amax
+    alpha = 1.0 / (a_global_scale * b_global_scale)
+
+    if cfg["no_a_quant"]:
+        a_fp4, scale_a, _ = _quant_nvfp4_linear_scales(a, device)
+
+        def run():
+            return triton_scaled_fp4_mm(
+                a_fp4, b_fp4, scale_a, scale_b, alpha, dtype
+            )
+
+        return run
+
+    def run():
+        a_fp4, scale_a = ops.scaled_fp4_quant(
+            a, a_global_scale, is_sf_swizzled_layout=False
+        )
+        return triton_scaled_fp4_mm(a_fp4, b_fp4, scale_a, scale_b, alpha, dtype)
+
+    return run
 
 
 def build_nvfp4_runner(cfg, a, b, dtype, device):
@@ -151,7 +199,10 @@ def benchmark(batch_size, provider, N, K):
         )
     else:
         cfg = PROVIDER_CFGS[provider]
-        run_quant = build_nvfp4_runner(cfg, a, b, dtype, device)
+        if cfg.get("triton"):
+            run_quant = build_triton_nvfp4_runner(cfg, a, b, dtype, device)
+        else:
+            run_quant = build_nvfp4_runner(cfg, a, b, dtype, device)
         ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
             lambda: run_quant(), quantiles=quantiles
         )

--- a/benchmarks/kernels/triton_nvfp4_gemm.py
+++ b/benchmarks/kernels/triton_nvfp4_gemm.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Triton implementation of NVFP4 GEMM (FP4 x FP4 -> BF16/FP16).
+
+Uses tl.dot_scaled for block-scaled FP4 matrix multiplication on SM100+.
+This serves as a portable reference/fallback when CUTLASS kernels are
+not available (e.g., SM120 without CUTLASS support).
+
+Data format (NVFP4):
+  - FP4 values: E2M1 format, 2 packed per uint8 byte along K dimension
+  - Block scales: float8_e4m3fn, 1 scale per 16 FP4 elements
+  - Global scale: float32 scalar
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _triton_nvfp4_gemm_kernel(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    # Pointers to block scales
+    a_scale_ptr,
+    b_scale_ptr,
+    # Global alpha = 1/(global_scale_a * global_scale_b)
+    alpha,
+    # Matrix dimensions
+    M,
+    N,
+    K,  # logical K (unpacked)
+    # Strides (in elements, accounting for packing)
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    # Scale strides
+    stride_a_scale_m,
+    stride_b_scale_n,
+    # Tile sizes
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    # NVFP4 block scale group size (elements per scale)
+    VEC_SIZE: tl.constexpr,
+):
+    """Triton kernel for NVFP4 GEMM: C = alpha * (A @ B^T).
+
+    A is [M, K//2] uint8 (packed FP4, row-major)
+    B is [N, K//2] uint8 (packed FP4, row-major, weight format)
+    C is [M, N] output (bf16/fp16)
+    a_scale is [M, K//VEC_SIZE] float8_e4m3fn (linear layout)
+    b_scale is [N, K//VEC_SIZE] float8_e4m3fn (linear layout)
+
+    Computes C = alpha * dot_scaled(A, B^T) where dot_scaled handles
+    block-scale dequantization internally via tensor core instructions.
+    """
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+
+    # Offsets for the M and N tile
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    # K is packed: 2 FP4 values per uint8 byte
+    BLOCK_K_PACKED: tl.constexpr = BLOCK_K // 2
+    offs_k = tl.arange(0, BLOCK_K_PACKED)
+
+    # Scale offsets: one scale per VEC_SIZE elements along K
+    SCALE_K: tl.constexpr = BLOCK_K // VEC_SIZE
+    offs_scale_k = tl.arange(0, SCALE_K)
+
+    # Initialize pointers for A [M, K//2] and B^T [K//2, N]
+    # A is row-major: a[m, k] = a_ptr + m * stride_am + k * stride_ak
+    a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    # B is [N, K//2] row-major, but we want B^T [K//2, N]
+    # b^T[k, n] = b[n, k] = b_ptr + n * stride_bn + k * stride_bk
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)
+
+    # Scale pointers
+    # a_scale [M, K//VEC_SIZE]: a_scale[m, g] = a_scale_ptr + m * stride + g
+    a_scale_ptrs = (a_scale_ptr + offs_m[:, None] * stride_a_scale_m +
+                    offs_scale_k[None, :])
+    # b_scale [N, K//VEC_SIZE]: b_scale[n, g] = b_scale_ptr + n * stride + g
+    b_scale_ptrs = (b_scale_ptr + offs_n[:, None] * stride_b_scale_n +
+                    offs_scale_k[None, :])
+
+    # Accumulator in float32
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # Main loop over K dimension
+    for _ in tl.range(0, tl.cdiv(K, BLOCK_K)):
+        # Load A tile [BLOCK_M, BLOCK_K_PACKED] and B^T tile [BLOCK_K_PACKED, BLOCK_N]
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+
+        # Load block scales
+        scale_a = tl.load(a_scale_ptrs)
+        scale_b = tl.load(b_scale_ptrs)
+
+        # Block-scaled FP4 dot product
+        # tl.dot_scaled handles: dequant(a, scale_a) @ dequant(b, scale_b)
+        accumulator = tl.dot_scaled(
+            a,
+            scale_a,
+            "e2m1",
+            b,
+            scale_b,
+            "e2m1",
+            accumulator,
+            lhs_k_pack=True,
+            rhs_k_pack=True,
+        )
+
+        # Advance pointers
+        a_ptrs += BLOCK_K_PACKED * stride_ak
+        b_ptrs += BLOCK_K_PACKED * stride_bk
+        a_scale_ptrs += SCALE_K
+        b_scale_ptrs += SCALE_K
+
+    # Apply global scale: C = alpha * accumulator
+    c = (accumulator * alpha).to(c_ptr.dtype.element_ty)
+
+    # Store output with bounds checking
+    offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=mask)
+
+
+def triton_scaled_fp4_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scale: torch.Tensor,
+    b_scale: torch.Tensor,
+    alpha: float | torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Triton-based NVFP4 GEMM: C = alpha * dequant(A) @ dequant(B)^T.
+
+    Args:
+        a:       Packed FP4 activations [M, K//2] uint8
+        b:       Packed FP4 weights    [N, K//2] uint8
+        a_scale: Block scales for A    [M, K//16] float8_e4m3fn (linear layout)
+        b_scale: Block scales for B    [N, K//16] float8_e4m3fn (linear layout)
+        alpha:   Global scale = 1 / (global_scale_a * global_scale_b)
+        out_dtype: Output dtype (torch.bfloat16 or torch.float16)
+
+    Returns:
+        C: [M, N] tensor in out_dtype
+    """
+    assert a.ndim == 2 and b.ndim == 2
+    assert a.dtype == torch.uint8 and b.dtype == torch.uint8
+
+    M, K_packed = a.shape
+    N, K_packed_b = b.shape
+    assert K_packed == K_packed_b, (
+        f"K dimension mismatch: A has {K_packed}, B has {K_packed_b}"
+    )
+    K = K_packed * 2  # Logical K (unpacked)
+
+    # Validate scale shapes
+    VEC_SIZE = 16  # NVFP4 block scale group size
+    assert a_scale.shape == (M, K // VEC_SIZE), (
+        f"a_scale shape {a_scale.shape} != expected ({M}, {K // VEC_SIZE})"
+    )
+    assert b_scale.shape == (N, K // VEC_SIZE), (
+        f"b_scale shape {b_scale.shape} != expected ({N}, {K // VEC_SIZE})"
+    )
+
+    # Convert alpha to float
+    if isinstance(alpha, torch.Tensor):
+        alpha_val = alpha.item()
+    else:
+        alpha_val = float(alpha)
+
+    # Allocate output
+    c = torch.empty((M, N), device=a.device, dtype=out_dtype)
+
+    # Tile sizes — tuned for SM100+ tensor cores
+    BLOCK_M = 128
+    BLOCK_N = 128
+    BLOCK_K = 128  # Must be multiple of VEC_SIZE (16)
+
+    # Adjust block sizes for small matrices
+    if M < BLOCK_M:
+        BLOCK_M = max(16, triton.next_power_of_2(M))
+    if N < BLOCK_N:
+        BLOCK_N = max(16, triton.next_power_of_2(N))
+
+    grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),)
+
+    # Strides for A [M, K//2] — row-major
+    stride_am = a.stride(0)
+    stride_ak = a.stride(1)
+
+    # Strides for B [N, K//2] — row-major
+    # For B^T access: b^T[k, n] = b[n, k]
+    stride_bn = b.stride(0)  # stride to move along N (rows of B)
+    stride_bk = b.stride(1)  # stride to move along K (cols of B)
+
+    # Scale strides
+    stride_a_scale_m = a_scale.stride(0)
+    stride_b_scale_n = b_scale.stride(0)
+
+    _triton_nvfp4_gemm_kernel[grid](
+        a,
+        b,
+        c,
+        a_scale,
+        b_scale,
+        alpha_val,
+        M,
+        N,
+        K,
+        stride_am,
+        stride_ak,
+        stride_bk,
+        stride_bn,
+        c.stride(0),
+        c.stride(1),
+        stride_a_scale_m,
+        stride_b_scale_n,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        VEC_SIZE=VEC_SIZE,
+    )
+
+    return c

--- a/tests/kernels/quantization/test_triton_nvfp4_gemm.py
+++ b/tests/kernels/quantization/test_triton_nvfp4_gemm.py
@@ -24,9 +24,7 @@ if not current_platform.has_device_capability(100):
     )
 
 # Add the benchmarks/kernels directory so we can import the Triton kernel
-sys.path.insert(
-    0, str(Path(__file__).resolve().parents[3] / "benchmarks" / "kernels")
-)
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "benchmarks" / "kernels"))
 from nvfp4_utils import FLOAT4_E2M1_MAX, FLOAT8_E4M3_MAX, break_fp4_bytes
 from triton_nvfp4_gemm import triton_scaled_fp4_mm
 
@@ -55,8 +53,7 @@ def dequantize_linear_scales(
     block_size = 16
 
     # Unpack FP4 nibbles to float values
-    values = break_fp4_bytes(fp4, torch.float32).reshape(m, k // block_size,
-                                                         block_size)
+    values = break_fp4_bytes(fp4, torch.float32).reshape(m, k // block_size, block_size)
     # Apply block scales: dequant = fp4_val * (block_scale / global_scale)
     scale_f32 = scale.to(torch.float32) / global_scale
     out = (values * scale_f32.unsqueeze(-1)).reshape(m, k)
@@ -97,10 +94,10 @@ def test_triton_nvfp4_gemm_correctness(
 
     # Compute global scales
     a_global_scale = (
-        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(a_bf16).max().float()
+        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / (torch.abs(a_bf16).max().float() + 1e-12)
     )
     b_global_scale = (
-        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(b_bf16).max().float()
+        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / (torch.abs(b_bf16).max().float() + 1e-12)
     )
     alpha = 1.0 / (a_global_scale * b_global_scale)
 
@@ -117,8 +114,13 @@ def test_triton_nvfp4_gemm_correctness(
 
     # Reference
     expected = get_ref_results(
-        a_fp4, b_fp4, a_scale, b_scale,
-        a_global_scale, b_global_scale, dtype,
+        a_fp4,
+        b_fp4,
+        a_scale,
+        b_scale,
+        a_global_scale,
+        b_global_scale,
+        dtype,
     )
 
     assert out.shape == expected.shape
@@ -144,16 +146,12 @@ def test_triton_nvfp4_gemm_output_shape(dtype: torch.dtype) -> None:
     a_bf16 = torch.randn((m, k), dtype=dtype, device=device)
     b_bf16 = torch.randn((n, k), dtype=dtype, device=device)
 
-    a_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(a_bf16).max().float()
-    b_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(b_bf16).max().float()
+    a_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / (torch.abs(a_bf16).max().float() + 1e-12)
+    b_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / (torch.abs(b_bf16).max().float() + 1e-12)
     alpha = 1.0 / (a_gs * b_gs)
 
-    a_fp4, a_scale = ops.scaled_fp4_quant(
-        a_bf16, a_gs, is_sf_swizzled_layout=False
-    )
-    b_fp4, b_scale = ops.scaled_fp4_quant(
-        b_bf16, b_gs, is_sf_swizzled_layout=False
-    )
+    a_fp4, a_scale = ops.scaled_fp4_quant(a_bf16, a_gs, is_sf_swizzled_layout=False)
+    b_fp4, b_scale = ops.scaled_fp4_quant(b_bf16, b_gs, is_sf_swizzled_layout=False)
 
     out = triton_scaled_fp4_mm(a_fp4, b_fp4, a_scale, b_scale, alpha, dtype)
 
@@ -179,8 +177,8 @@ def test_triton_vs_cutlass_nvfp4(m: int, n: int, k: int) -> None:
     a_bf16 = torch.randn((m, k), dtype=dtype, device=device)
     b_bf16 = torch.randn((n, k), dtype=dtype, device=device)
 
-    a_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(a_bf16).max().float()
-    b_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(b_bf16).max().float()
+    a_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / (torch.abs(a_bf16).max().float() + 1e-12)
+    b_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / (torch.abs(b_bf16).max().float() + 1e-12)
     alpha = 1.0 / (a_gs * b_gs)
 
     # CUTLASS: swizzled scales

--- a/tests/kernels/quantization/test_triton_nvfp4_gemm.py
+++ b/tests/kernels/quantization/test_triton_nvfp4_gemm.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the Triton NVFP4 GEMM kernel.
+
+Compares the Triton kernel output against a PyTorch reference that
+dequantizes FP4 values with linear (non-swizzled) block scales and
+performs a standard matmul.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+if not current_platform.has_device_capability(100):
+    pytest.skip(
+        reason="NVFP4 requires compute capability of 10.0 or above (Blackwell).",
+        allow_module_level=True,
+    )
+
+# Add the benchmarks/kernels directory so we can import the Triton kernel
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[3] / "benchmarks" / "kernels")
+)
+from nvfp4_utils import FLOAT4_E2M1_MAX, FLOAT8_E4M3_MAX, break_fp4_bytes
+from triton_nvfp4_gemm import triton_scaled_fp4_mm
+
+DTYPES = [torch.bfloat16]
+# (M, N, K) where K is the logical (unpacked) dimension
+SHAPES = [
+    (128, 128, 128),
+    (256, 128, 128),
+    (128, 256, 256),
+    (256, 256, 256),
+    (512, 512, 256),
+    (128, 128, 256),
+]
+SEEDS = [42]
+
+
+def dequantize_linear_scales(
+    fp4: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Dequantize FP4 tensor with linear (non-swizzled) block scales."""
+    m, k_packed = fp4.shape
+    k = k_packed * 2
+    block_size = 16
+
+    # Unpack FP4 nibbles to float values
+    values = break_fp4_bytes(fp4, torch.float32).reshape(m, k // block_size,
+                                                         block_size)
+    # Apply block scales: dequant = fp4_val * (block_scale / global_scale)
+    scale_f32 = scale.to(torch.float32) / global_scale
+    out = (values * scale_f32.unsqueeze(-1)).reshape(m, k)
+    return out.to(dtype)
+
+
+def get_ref_results(
+    a_fp4: torch.Tensor,
+    b_fp4: torch.Tensor,
+    a_scale: torch.Tensor,
+    b_scale: torch.Tensor,
+    a_global_scale: torch.Tensor,
+    b_global_scale: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Compute reference output by dequantizing then doing matmul."""
+    a_deq = dequantize_linear_scales(a_fp4, a_scale, a_global_scale, dtype)
+    b_deq = dequantize_linear_scales(b_fp4, b_scale, b_global_scale, dtype)
+    return torch.matmul(a_deq, b_deq.t())
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@torch.inference_mode()
+def test_triton_nvfp4_gemm_correctness(
+    dtype: torch.dtype,
+    shape: tuple[int, int, int],
+    seed: int,
+) -> None:
+    """Test Triton NVFP4 GEMM against dequantized reference."""
+    set_random_seed(seed)
+    m, n, k = shape
+    device = "cuda"
+
+    a_bf16 = torch.randn((m, k), dtype=dtype, device=device)
+    b_bf16 = torch.randn((n, k), dtype=dtype, device=device)
+
+    # Compute global scales
+    a_global_scale = (
+        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(a_bf16).max().float()
+    )
+    b_global_scale = (
+        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(b_bf16).max().float()
+    )
+    alpha = 1.0 / (a_global_scale * b_global_scale)
+
+    # Quantize with linear (non-swizzled) scales for Triton
+    a_fp4, a_scale = ops.scaled_fp4_quant(
+        a_bf16, a_global_scale, is_sf_swizzled_layout=False
+    )
+    b_fp4, b_scale = ops.scaled_fp4_quant(
+        b_bf16, b_global_scale, is_sf_swizzled_layout=False
+    )
+
+    # Triton kernel
+    out = triton_scaled_fp4_mm(a_fp4, b_fp4, a_scale, b_scale, alpha, dtype)
+
+    # Reference
+    expected = get_ref_results(
+        a_fp4, b_fp4, a_scale, b_scale,
+        a_global_scale, b_global_scale, dtype,
+    )
+
+    assert out.shape == expected.shape
+    assert out.dtype == dtype
+    # FP4 quantization introduces significant rounding error;
+    # use tolerances consistent with existing NVFP4 tests.
+    torch.testing.assert_close(
+        out,
+        expected.to(dtype),
+        atol=1e-1,
+        rtol=1e-1,
+        msg=f"Mismatch at M={m}, N={n}, K={k}, dtype={dtype}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_triton_nvfp4_gemm_output_shape(dtype: torch.dtype) -> None:
+    """Verify output has correct shape and dtype."""
+    m, n, k = 256, 128, 256
+    device = "cuda"
+
+    a_bf16 = torch.randn((m, k), dtype=dtype, device=device)
+    b_bf16 = torch.randn((n, k), dtype=dtype, device=device)
+
+    a_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(a_bf16).max().float()
+    b_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(b_bf16).max().float()
+    alpha = 1.0 / (a_gs * b_gs)
+
+    a_fp4, a_scale = ops.scaled_fp4_quant(
+        a_bf16, a_gs, is_sf_swizzled_layout=False
+    )
+    b_fp4, b_scale = ops.scaled_fp4_quant(
+        b_bf16, b_gs, is_sf_swizzled_layout=False
+    )
+
+    out = triton_scaled_fp4_mm(a_fp4, b_fp4, a_scale, b_scale, alpha, dtype)
+
+    assert out.shape == (m, n)
+    assert out.dtype == dtype
+    assert out.device.type == "cuda"
+
+
+@pytest.mark.parametrize(
+    "m,n,k",
+    [(128, 128, 128), (256, 256, 256), (512, 256, 128)],
+)
+@torch.inference_mode()
+def test_triton_vs_cutlass_nvfp4(m: int, n: int, k: int) -> None:
+    """Cross-check Triton output against CUTLASS kernel output.
+
+    Both kernels quantize the same input data (with their respective
+    scale layouts) and should agree to within FP4 quantization error.
+    """
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    a_bf16 = torch.randn((m, k), dtype=dtype, device=device)
+    b_bf16 = torch.randn((n, k), dtype=dtype, device=device)
+
+    a_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(a_bf16).max().float()
+    b_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(b_bf16).max().float()
+    alpha = 1.0 / (a_gs * b_gs)
+
+    # CUTLASS: swizzled scales
+    a_fp4_sw, a_scale_sw = ops.scaled_fp4_quant(a_bf16, a_gs)
+    b_fp4_sw, b_scale_sw = ops.scaled_fp4_quant(b_bf16, b_gs)
+    cutlass_out = ops.cutlass_scaled_fp4_mm(
+        a_fp4_sw, b_fp4_sw, a_scale_sw, b_scale_sw, alpha, dtype
+    )
+
+    # Triton: linear scales
+    a_fp4_lin, a_scale_lin = ops.scaled_fp4_quant(
+        a_bf16, a_gs, is_sf_swizzled_layout=False
+    )
+    b_fp4_lin, b_scale_lin = ops.scaled_fp4_quant(
+        b_bf16, b_gs, is_sf_swizzled_layout=False
+    )
+    triton_out = triton_scaled_fp4_mm(
+        a_fp4_lin, b_fp4_lin, a_scale_lin, b_scale_lin, alpha, dtype
+    )
+
+    # Both should produce similar results despite different scale layouts
+    torch.testing.assert_close(
+        triton_out,
+        cutlass_out,
+        atol=1e-1,
+        rtol=1e-1,
+        msg=f"Triton vs CUTLASS mismatch at M={m}, N={n}, K={k}",
+    )


### PR DESCRIPTION
## Purpose

Add a Triton-based FP4 × FP4 → BF16 matrix multiplication kernel using `tl.dot_scaled` as a portable reference/fallback for NVFP4 GEMM. This closes #21014.

Currently, NVFP4 GEMMs only have CUTLASS implementations (SM100/SM120). A Triton reference implementation:
- Serves as a **fallback** when CUTLASS kernels are unavailable
- Enables **portability** across hardware via Triton's multi-backend support
- Provides a **readable reference** for the NVFP4 GEMM computation

### Approach

The kernel uses Triton's `tl.dot_scaled` instruction with:
- **E2M1 format** (FP4): 2 values packed per uint8 byte along K dimension
- **float8_e4m3fn block scales**: 1 scale per 16 FP4 elements (linear/non-swizzled layout)
- **Global alpha scaling**: Applied post-matmul as `C = alpha * dot_scaled(A, B^T)`

Uses non-swizzled (linear) block scale layout via `ops.scaled_fp4_quant(..., is_sf_swizzled_layout=False)` to avoid the CUTLASS-specific scale swizzling, making the kernel hardware-portable.

### Why not duplicate of existing PRs

No open PRs exist for this issue. The original assignee (`hardikkgupta`) from July 2025 never delivered; the issue has been stale for 8+ months with community members asking for updates.

### AI Assistance

This PR was developed with AI assistance (Claude). All code has been reviewed and understood by the human submitter.

## Files Changed

| File | Change |
|---|---|
| `benchmarks/kernels/triton_nvfp4_gemm.py` | **New** — Triton NVFP4 GEMM kernel + Python wrapper |
| `benchmarks/kernels/benchmark_nvfp4_gemm.py` | Added `triton-nvfp4` and `triton-nvfp4-noquant` benchmark providers |
| `tests/kernels/quantization/test_triton_nvfp4_gemm.py` | **New** — Correctness tests + cross-check vs CUTLASS |

## Test Plan

```bash
# Run correctness tests (requires SM100+ GPU)
pytest tests/kernels/quantization/test_triton_nvfp4_gemm.py -v

# Run benchmark comparison (requires SM100+ GPU)
python benchmarks/kernels/benchmark_nvfp4_gemm.py
```

### Test coverage:
- **Correctness**: Triton output vs dequantized PyTorch reference across matrix sizes (128-512) and dtypes
- **Shape validation**: Output shape and dtype verification
- **Cross-kernel**: Triton vs CUTLASS output comparison (atol/rtol=0.1, consistent with existing FP4 tests)

## Test Results

Tests require Blackwell (SM100+) hardware and are not runnable locally on this machine. The kernel follows the exact `tl.dot_scaled` API pattern from [Triton's upstream FP4 GEMM test](https://github.com/triton-lang/triton/blob/620237edd/python/test/unit/language/test_matmul.py#L652) and uses the same block-scaled FP4 data format as the existing CUTLASS implementation.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>