### PR TITLE
[Doc] fix selector/label mismatch in helm chart

### DIFF
--- a/docs/deployment/frameworks/helm.md
+++ b/docs/deployment/frameworks/helm.md
@@ -103,7 +103,7 @@ The following table describes configurable parameters of the chart in `values.ya
 | secrets | object | {} | Secrets configuration |
 | serviceName | string | "" | Service name |
 | servicePort | int | 80 | Service port |
-| labels.environment | string | test | Environment name |
+| labels | object | {} | Additional labels for Kubernetes resources |
 
 ## Configuration Examples
 

--- a/examples/online_serving/chart-helm/templates/_helpers.tpl
+++ b/examples/online_serving/chart-helm/templates/_helpers.tpl
@@ -156,10 +156,28 @@ runAsUser:
 {{- end }}
 
 {{/*
+  Create the chart name and version used for the helm.sh/chart label
+*/}}
+{{- define "chart.chartLabel" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end  }}
+
+{{/*
+  Define labels used for selector
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
   Define chart labels
 */}}
 {{- define "chart.labels" -}}
-{{-   with .Values.labels -}}
+{{ include "chart.selectorLabels" . }}
+helm.sh/chart: {{ include "chart.chartLabel" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.labels }}
 {{      toYaml . }}
-{{-   end }}
+{{- end }}
 {{- end }}

--- a/examples/online_serving/chart-helm/templates/configmap.yaml
+++ b/examples/online_serving/chart-helm/templates/configmap.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: "{{ .Release.Name }}-configs"
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "chart.labels" . | nindent 4 }}
 data:
   {{- with .Values.configs }}
   {{- toYaml . | nindent 2 }}

--- a/examples/online_serving/chart-helm/templates/deployment.yaml
+++ b/examples/online_serving/chart-helm/templates/deployment.yaml
@@ -8,16 +8,14 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- include "chart.strategy" . | nindent 2 }}
-  selector:                                                                                                                                  
+  selector:
     matchLabels:
-      environment: "test"
-      release: "test"
+    {{- include "chart.selectorLabels" . | nindent 6 }}
   progressDeadlineSeconds: 1200
   template:
     metadata:
       labels:
-        environment: "test"
-        release: "test"
+      {{- include "chart.labels" . | nindent 8 }}
     spec:
       containers:
         - name: "vllm"
@@ -128,4 +126,4 @@ spec:
                   values:
                     {{- toYaml . | nindent 20 }}
                   {{- end }}
-      {{- end }} 
+      {{- end }}

--- a/examples/online_serving/chart-helm/templates/hpa.yaml
+++ b/examples/online_serving/chart-helm/templates/hpa.yaml
@@ -4,6 +4,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ .Release.Name }}-hpa"
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "chart.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/examples/online_serving/chart-helm/templates/job.yaml
+++ b/examples/online_serving/chart-helm/templates/job.yaml
@@ -4,6 +4,8 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-init-vllm"
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "chart.labels" . | nindent 4 }}
 spec:
   ttlSecondsAfterFinished: 100
   template:

--- a/examples/online_serving/chart-helm/templates/poddisruptionbudget.yaml
+++ b/examples/online_serving/chart-helm/templates/poddisruptionbudget.yaml
@@ -3,5 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: "{{ .Release.Name }}-pdb"
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "chart.labels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ default 1 .Values.maxUnavailablePodDisruptionBudget }}

--- a/examples/online_serving/chart-helm/templates/pvc.yaml
+++ b/examples/online_serving/chart-helm/templates/pvc.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: "{{ .Release.Name }}-storage-claim"
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "chart.labels" . | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/examples/online_serving/chart-helm/templates/secrets.yaml
+++ b/examples/online_serving/chart-helm/templates/secrets.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: "{{ .Release.Name }}-secrets"
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "chart.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- range $key, $val := .Values.secrets }}

--- a/examples/online_serving/chart-helm/templates/service.yaml
+++ b/examples/online_serving/chart-helm/templates/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: "{{ .Release.Name }}-service"
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "chart.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
@@ -11,4 +13,4 @@ spec:
       targetPort: {{ include "chart.container-port-name" . }}
       protocol: TCP
   selector:
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/examples/online_serving/chart-helm/tests/labels_test.yaml
+++ b/examples/online_serving/chart-helm/tests/labels_test.yaml
@@ -1,0 +1,107 @@
+suite: test label consistency
+templates:
+  - deployment.yaml
+  - service.yaml
+tests:
+  # Deployment selector must use stable selector labels
+  - it: should use app.kubernetes.io selector labels on Deployment
+    template: deployment.yaml
+    asserts:
+      - isNotEmpty:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+      - isNotEmpty:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+
+  - it: should include selector labels in Deployment pod template labels
+    template: deployment.yaml
+    asserts:
+      - isNotEmpty:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+      - isNotEmpty:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+
+  # Service selector must match Deployment pod selector labels
+  - it: should use same selector labels on Service as on Deployment
+    template: service.yaml
+    asserts:
+      - isNotEmpty:
+          path: spec.selector["app.kubernetes.io/name"]
+      - isNotEmpty:
+          path: spec.selector["app.kubernetes.io/instance"]
+
+  # Selector labels must be derived from Chart.Name and Release.Name
+  - it: should derive selector labels from chart name and release name
+    release:
+      name: my-release
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: chart-vllm
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: my-release
+
+  # Custom user labels must NOT break selectors
+  - it: should keep stable selectors when user changes labels
+    set:
+      labels:
+        environment: "production"
+        team: "ml-infra"
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: chart-vllm
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  # Custom labels appear in pod metadata but NOT in selector
+  - it: should include custom labels in pod template metadata
+    set:
+      labels:
+        environment: "staging"
+        team: "ml-infra"
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.environment
+          value: staging
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: ml-infra
+
+  # Empty user labels must not break the chart
+  - it: should render valid Deployment when user labels are empty
+    set:
+      labels: {}
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - isNotEmpty:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+
+  - it: should render valid Service when user labels are empty
+    set:
+      labels: {}
+    template: service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - isNotEmpty:
+          path: spec.selector["app.kubernetes.io/name"]
+
+  # Deployment metadata labels include both selector and user labels
+  - it: should include both selector and user labels in Deployment metadata
+    set:
+      labels:
+        environment: "dev"
+    template: deployment.yaml
+    asserts:
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/name"]
+      - equal:
+          path: metadata.labels.environment
+          value: dev

--- a/examples/online_serving/chart-helm/values.schema.json
+++ b/examples/online_serving/chart-helm/values.schema.json
@@ -291,18 +291,9 @@
         },
         "labels": {
             "type": "object",
-            "properties": {
-                "environment": {
-                    "type": "string"
-                },
-                "release": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "environment",
-                "release"
-            ]
+            "additionalProperties": {
+              "type": "string"
+            }
         }
     },
     "required": [

--- a/examples/online_serving/chart-helm/values.yaml
+++ b/examples/online_serving/chart-helm/values.yaml
@@ -169,6 +169,5 @@ livenessProbe:
     # -- Name or number of the port to access on the container, on which the server is listening
     port: 8000
 
-labels:
-  environment: "test"
-  release: "test"
+# -- Additional labels for all resources
+labels: {}


### PR DESCRIPTION
## Purpose

Fixes #37942

This fixes label/selector consistency in `examples/online_serving/chart-helm` by:
- introducing stable selector labels (`app.kubernetes.io/name`, `app.kubernetes.io/instance`) for Deployment/Service selectors,
- applying common chart labels across resources
- and updating `values.schema.json` so `.Values.labels` supports arbitrary string key/value pairs instead of only `environment`/`release`.

Breaking change note:
- `Deployment.spec.selector.matchLabels` changed from hardcoded `environment`/`release` to `app.kubernetes.io/name`/`app.kubernetes.io/instance`.
- Existing releases may require recreation (or equivalent force-replace flow) when upgrading because Deployment selectors are immutable in Kubernetes.

## Test Plan

- `helm lint examples/online_serving/chart-helm`
- `helm template test examples/online_serving/chart-helm`
- `helm unittest examples/online_serving/chart-helm`

## Test Result

- [x] helm lint passes
- [x] helm template renders expected selectors/labels
- [x] helm unittest passes

<details>
<summary> Test Result Details </summary>

<pre><code>
$ helm lint examples/online_serving/chart-helm
==> Linting examples/online_serving/chart-helm
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
</code></pre>

<pre><code>
$ helm template test examples/online_serving/chart-helm
---
# Source: chart-vllm/templates/poddisruptionbudget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: "test-pdb"
  namespace: default
  labels:
    app.kubernetes.io/name: chart-vllm
    app.kubernetes.io/instance: test
    helm.sh/chart: chart-vllm-0.0.1
    app.kubernetes.io/managed-by: Helm
spec:
  maxUnavailable: 1
---
# Source: chart-vllm/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: "test-secrets"
  namespace: default
  labels:
    app.kubernetes.io/name: chart-vllm
    app.kubernetes.io/instance: test
    helm.sh/chart: chart-vllm-0.0.1
    app.kubernetes.io/managed-by: Helm
type: Opaque
data:
---
# Source: chart-vllm/templates/pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: "test-storage-claim"
  namespace: default
  labels:
    app.kubernetes.io/name: chart-vllm
    app.kubernetes.io/instance: test
    helm.sh/chart: chart-vllm-0.0.1
    app.kubernetes.io/managed-by: Helm
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
---
# Source: chart-vllm/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: "test-service"
  namespace: default
  labels:
    app.kubernetes.io/name: chart-vllm
    app.kubernetes.io/instance: test
    helm.sh/chart: chart-vllm-0.0.1
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - name: "service-port"
      port: 80
      targetPort: "container-port"
      protocol: TCP
  selector:
    app.kubernetes.io/name: chart-vllm
    app.kubernetes.io/instance: test
---
# Source: chart-vllm/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: "test-deployment-vllm"
  namespace: default
  labels:
    app.kubernetes.io/name: chart-vllm
    app.kubernetes.io/instance: test
    helm.sh/chart: chart-vllm-0.0.1
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  strategy:
    rollingUpdate:
      maxSurge: 100%
      maxUnavailable: 0
  selector:
    matchLabels:
      app.kubernetes.io/name: chart-vllm
      app.kubernetes.io/instance: test
  progressDeadlineSeconds: 1200
  template:
    metadata:
      labels:
        app.kubernetes.io/name: chart-vllm
        app.kubernetes.io/instance: test
        helm.sh/chart: chart-vllm-0.0.1
        app.kubernetes.io/managed-by: Helm
    spec:
      containers:
        - name: "vllm"
          image: "vllm/vllm-openai:latest"
          command :
          - vllm
          - serve
          - /data/
          - --served-model-name
          - opt-125m
          - --enforce-eager
          - --dtype
          - bfloat16
          - --block-size
          - "16"
          - --host
          - 0.0.0.0
          - --port
          - "8000"
          securityContext:
            runAsNonRoot: false
          imagePullPolicy: IfNotPresent
          env: []
          ports:
            - name: "container-port"
              containerPort: 8000

          readinessProbe:
            failureThreshold: 3
            httpGet:
              path: /health
              port: 8000
            initialDelaySeconds: 5
            periodSeconds: 5
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /health
              port: 8000
            initialDelaySeconds: 15
            periodSeconds: 10
          resources:
            requests:
              memory: "16Gi"
              cpu: "4"
              nvidia.com/gpu: "1"
            limits:
              memory: "16Gi"
              cpu: "4"
              nvidia.com/gpu: "1"
          volumeMounts:
          - name: test-storage
            mountPath: /data
      initContainers:
      - name: wait-download-model
        image: amazon/aws-cli:2.6.4
        imagePullPolicy: IfNotPresent
        command: ["/bin/bash"]
        args:
          - -eucx
          - while aws --endpoint-url $S3_ENDPOINT_URL s3 sync --dryrun s3://$S3_BUCKET_NAME/$S3_PATH
            /data | grep -q download; do sleep 10; done
        env:
          - name: S3_ENDPOINT_URL
            valueFrom:
              secretKeyRef:
                name: test-secrets
                key: s3endpoint
          - name: S3_BUCKET_NAME
            valueFrom:
              secretKeyRef:
                name: test-secrets
                key: s3bucketname
          - name: AWS_ACCESS_KEY_ID
            valueFrom:
              secretKeyRef:
                name: test-secrets
                key: s3accesskeyid
          - name: AWS_SECRET_ACCESS_KEY
            valueFrom:
              secretKeyRef:
                name: test-secrets
                key: s3accesskey
          - name: S3_PATH
            value: "relative_s3_model_path/opt-125m"
          - name: AWS_EC2_METADATA_DISABLED
            value: "true"
        resources:
          requests:
            cpu: 200m
            memory: 1Gi
          limits:
            cpu: 500m
            memory: 2Gi
        volumeMounts:
        - name: test-storage
          mountPath: /data
      volumes:
        - name: test-storage
          persistentVolumeClaim:
            claimName: test-storage-claim
      runtimeClassName: nvidia
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                - key: nvidia.com/gpu.product
                  operator: In
                  values:
                    - TYPE_GPU_USED
---
# Source: chart-vllm/templates/job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: "test-init-vllm"
  namespace: default
  labels:
    app.kubernetes.io/name: chart-vllm
    app.kubernetes.io/instance: test
    helm.sh/chart: chart-vllm-0.0.1
    app.kubernetes.io/managed-by: Helm
spec:
  ttlSecondsAfterFinished: 100
  template:
   metadata:
     name: init-vllm
   spec:
    containers:
    - name: job-download-model
      image: amazon/aws-cli:2.6.4
      imagePullPolicy: IfNotPresent
      command: ["/bin/bash"]
      args:
        - -eucx
        - aws --endpoint-url $S3_ENDPOINT_URL s3 sync s3://$S3_BUCKET_NAME/$S3_PATH /data
      env:
        - name: S3_ENDPOINT_URL
          valueFrom:
            secretKeyRef:
              name: test-secrets
              key: s3endpoint
        - name: S3_BUCKET_NAME
          valueFrom:
            secretKeyRef:
              name: test-secrets
              key: s3bucketname
        - name: AWS_ACCESS_KEY_ID
          valueFrom:
            secretKeyRef:
              name: test-secrets
              key: s3accesskeyid
        - name: AWS_SECRET_ACCESS_KEY
          valueFrom:
            secretKeyRef:
              name: test-secrets
              key: s3accesskey
        - name: S3_PATH
          value: "relative_s3_model_path/opt-125m"
        - name: AWS_EC2_METADATA_DISABLED
          value: "true"
      volumeMounts:
        - name: test-storage
          mountPath: /data
      resources:
        requests:
          cpu: 200m
          memory: 1Gi
        limits:
          cpu: 500m
          memory: 2Gi
    restartPolicy: OnFailure
    volumes:
    - name: test-storage
      persistentVolumeClaim:
        claimName: "test-storage-claim"
</code></pre>

<pre><code>
$ helm unittest examples/online_serving/chart-helm

### Chart [ chart-vllm ] examples/online_serving/chart-helm

 PASS  test deployment  examples/online_serving/chart-helm/tests/deployment_test.yaml
 PASS  test job examples/online_serving/chart-helm/tests/job_test.yaml
 PASS  test pvc examples/online_serving/chart-helm/tests/pvc_test.yaml

Charts:      1 passed, 1 total
Test Suites: 3 passed, 3 total
Tests:       6 passed, 6 total
Snapshot:    0 passed, 0 total
Time:        44.598564ms
</code></pre>
</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>