### PR TITLE
[ROCM] Optmize redudent d2d copy of moe.

### DIFF
--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1377,6 +1377,12 @@ class FusedMoEKernelModularImpl:
             apply_router_weight_on_input=apply_router_weight_on_input,
             expert_tokens_meta=expert_tokens_meta,
         )
+        if (
+            not self.inplace
+            and fused_out.shape == output.shape
+            and fused_out.is_contiguous()
+        ):
+            output = fused_out
 
         return self._finalize(
             output,

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -437,4 +437,4 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             num_local_tokens=num_local_tokens,
             output_dtype=output.dtype,
         )
-        output.copy_(result)
+        output.data = result

--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -69,7 +69,8 @@ class TopKWeightAndReduceNoOP(mk.TopKWeightAndReduce):
             f"But got output={output.size()}, "
             f"used_expert_output={fused_expert_output.size()}"
         )
-        output.copy_(fused_expert_output, non_blocking=True)
+        if output.data_ptr() != fused_expert_output.data_ptr():
+            output.copy_(fused_expert_output, non_blocking=True)
         return output
 
 


### PR DESCRIPTION


## Purpose
When running MiniMax M2.5, currently the MOE kernel's output will have two d2d copys, which can be optimized.
<img width="1416" height="623" alt="image" src="https://github.com/user-attachments/assets/bf1c111b-9c2d-428d-b514-d5f795a3c473" />

## Test Plan
Run MiniMax M2.5 inference on Mi355.
Confirm output correctness matches the non-aiter fallback path by comparing the accuracy of the model.

## Benchmarking
```bash
export VLLM_ROCM_USE_AITER=1
vllm serve MiniMaxAI/MiniMax-M2.5 \
    --tensor-parallel-size 8 \
    --enable_expert-parallel \
    --max-num-batched-tokens 196608 \
    --max-model-len=10240 \
    --max-num-seqs 512 \
    --block-size=32 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --port=30000
```

```bash
vllm bench serve \
  --model MiniMaxAI/MiniMax-M2.5 \
  --dataset-name sharegpt \
  --dataset-path /A/datasets/ShareGPT_V3_unfiltered_cleaned_split.json \
  --sharegpt-output-len 300 \
  --port 30000 \
  --max-concurrency 8 \
  --num-prompts 1000 \
  --num-warmups 50 \
  --ignore-eos \
  --temperature 0
```

Before:
```bash
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  442.59    
Total input tokens:                      225133    
Total generated tokens:                  300000    
Request throughput (req/s):              2.26      
Output token throughput (tok/s):         677.83    
Peak output token throughput (tok/s):    704.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          1186.49   
---------------Time to First Token----------------
Mean TTFT (ms):                          57.49     
Median TTFT (ms):                        50.00     
P99 TTFT (ms):                           106.37    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.65     
Median TPOT (ms):                        11.65     
P99 TPOT (ms):                           11.90     
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.65     
Median ITL (ms):                         11.54     
P99 ITL (ms):                            13.49     
==================================================
```
After:
```bash
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  427.85    
Total input tokens:                      225133    
Total generated tokens:                  300000    
Request throughput (req/s):              2.34      
Output token throughput (tok/s):         701.18    
Peak output token throughput (tok/s):    736.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          1227.38   
---------------Time to First Token----------------
Mean TTFT (ms):                          57.12     
Median TTFT (ms):                        47.68     
P99 TTFT (ms):                           107.23    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.25     
Median TPOT (ms):                        11.26     
P99 TPOT (ms):                           11.54     
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.25     
Median ITL (ms):                         11.12     
P99 ITL (ms):                            14.14     
==================================================
```

e2e TPOT drop by about 3.4%.

## Accuracy Testing

```bash
python3 -m lm_eval --model local-completions \
  --model_args model=MiniMaxAI/MiniMax-M2.5,base_url=http://127.0.0.1:30000/v1/completions,num_concurrent=64 \
  --tasks gsm8k
```

main:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9234|±  |0.0073|
|     |       |strict-match    |     5|exact_match|↑  |0.9212|±  |0.0074|```
```


PR:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9318|±  |0.0069|
|     |       |strict-match    |     5|exact_match|↑  |0.9280|±  |0.0071|
```

There is no significant difference in accuracy.

cc @gshtras @chunfangamd


- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
