### PR TITLE
Revert "[Bugfix] Fix DeepGemm E8M0 accuracy degradation for Qwen3.5 FP8 on Blackwell" (#38083)

### DIFF
--- a/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-DEP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-DEP2.yaml
@@ -1,6 +1,5 @@
 model_name: "Qwen/Qwen3.5-35B-A3B"
-accuracy_threshold: 0.84
-tolerance: 0.03
+accuracy_threshold: 0.86
 num_questions: 1319
 num_fewshot: 5
 server_args: >-

--- a/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-FP8-DEP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-FP8-DEP2.yaml
@@ -1,6 +1,5 @@
 model_name: "Qwen/Qwen3.5-35B-A3B-FP8"
-accuracy_threshold: 0.79
-tolerance: 0.03
+accuracy_threshold: 0.86
 num_questions: 1319
 num_fewshot: 5
 server_args: >-

--- a/tests/evals/gsm8k/configs/Qwen3.5-397B-A17B-NVFP4-DEP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-397B-A17B-NVFP4-DEP2.yaml
@@ -1,9 +1,0 @@
-model_name: "nvidia/Qwen3.5-397B-A17B-NVFP4"
-accuracy_threshold: 0.88
-tolerance: 0.03
-num_questions: 1319
-num_fewshot: 5
-server_args: >-
-  --max-model-len 4096
-  --data-parallel-size 2
-  --enable-expert-parallel

--- a/tests/evals/gsm8k/configs/models-qwen35-blackwell.txt
+++ b/tests/evals/gsm8k/configs/models-qwen35-blackwell.txt
@@ -1,3 +1,1 @@
 Qwen3.5-35B-A3B-DEP2.yaml
-Qwen3.5-35B-A3B-FP8-DEP2.yaml
-Qwen3.5-397B-A17B-NVFP4-DEP2.yaml

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -19,6 +19,8 @@ from vllm.platforms import current_platform
 
 from .gsm8k_eval import evaluate_gsm8k
 
+TOL = 0.08  # Absolute tolerance for accuracy comparison
+
 
 def run_gsm8k_eval(eval_config: dict, server_url: str) -> dict:
     """Run GSM8K evaluation using our isolated script."""
@@ -107,20 +109,20 @@ def test_gsm8k_correctness(config_filename):
 
         measured_metric = results["accuracy"]
         expected_metric = eval_config["accuracy_threshold"]
-        tol = eval_config.get("tolerance", 0.08)
 
         print(f"GSM8K Results for {eval_config['model_name']}:")
         print(f"  Measured metric: {measured_metric:.4f}")
         print(f"  Expected metric: {expected_metric:.4f}")
-        print(f"  Tolerance: {tol:.4f}")
+        print(f"  Tolerance: {TOL:.4f}")
         print(f"  Questions: {results['num_questions']}")
         print(f"  Invalid rate: {results['invalid_rate']:.3f}")
         print(f"  Latency: {results['latency']:.1f}s")
         print(f"  QPS: {results['questions_per_second']:.1f}")
 
-        assert measured_metric >= expected_metric - tol, (
+        # Verify metric is within tolerance
+        assert measured_metric >= expected_metric - TOL, (
             f"GSM8K metric too low: {measured_metric:.4f} < "
-            f"{expected_metric:.4f} - {tol:.4f} = {expected_metric - tol:.4f}"
+            f"{expected_metric:.4f} - {TOL:.4f} = {expected_metric - TOL:.4f}"
         )
 
         print(f"✅ GSM8K test passed for {eval_config['model_name']}")

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -701,25 +701,6 @@ class VllmConfig:
                 self.model_config, self.load_config
             )
 
-        if (
-            self.quant_config is not None
-            and self.model_config is not None
-            and hasattr(self.quant_config, "use_deep_gemm")
-            and self.quant_config.use_deep_gemm is None
-        ):
-            from vllm.utils.deep_gemm import should_auto_disable_deep_gemm
-
-            model_type = getattr(self.model_config.hf_text_config, "model_type", None)
-            if should_auto_disable_deep_gemm(model_type):
-                self.quant_config.use_deep_gemm = False
-                logger.warning_once(
-                    "Auto-disabled DeepGemm for model_type=%s on Blackwell. "
-                    "DeepGemm E8M0 scale format causes accuracy degradation "
-                    "for this architecture. Falling back to CUTLASS. "
-                    "To disable DeepGemm globally, set VLLM_USE_DEEP_GEMM=0.",
-                    model_type,
-                )
-
         from vllm.v1.executor.abstract import Executor
 
         executor_backend = self.parallel_config.distributed_executor_backend

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -129,7 +129,6 @@ class Fp8Config(QuantizationConfig):
                     f"{activation_scheme} activation scheme."
                 )
         self.weight_block_size = weight_block_size
-        self.use_deep_gemm: bool | None = None
 
     @classmethod
     def get_name(cls) -> QuantizationMethods:
@@ -277,10 +276,7 @@ class Fp8LinearMethod(LinearMethodBase):
         self.marlin_input_dtype = None
 
         self.use_aiter_and_is_supported = rocm_aiter_ops.is_linear_fp8_enabled()
-        if self.quant_config.use_deep_gemm is not None:
-            self.use_deep_gemm = self.quant_config.use_deep_gemm
-        else:
-            self.use_deep_gemm = is_deep_gemm_supported()
+        self.use_deep_gemm = is_deep_gemm_supported()
 
         self.weight_block_size = self.quant_config.weight_block_size
         self.block_quant = self.weight_block_size is not None
@@ -315,7 +311,6 @@ class Fp8LinearMethod(LinearMethodBase):
                 act_quant_group_shape=GroupShape(1, self.weight_block_size[0]),
                 cutlass_block_fp8_supported=self.cutlass_block_fp8_supported,
                 use_aiter_and_is_supported=self.use_aiter_and_is_supported,
-                use_deep_gemm=self.use_deep_gemm,
             )
 
     def create_weights(
@@ -433,7 +428,7 @@ class Fp8LinearMethod(LinearMethodBase):
         else:
             layer.input_scale = None
 
-        if self.block_quant and self.use_deep_gemm:
+        if self.block_quant:
             maybe_post_process_fp8_weight_block(layer)
 
     def apply(

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -91,7 +91,6 @@ class QuantFP8(CustomOp):
 
         if (
             self.is_group_quant
-            and self.use_ue8m0
             and self.use_deep_gemm_supported
             and (DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0)
         ):

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -359,14 +359,10 @@ class W8A8BlockFp8LinearOp:
         act_quant_group_shape: GroupShape,
         cutlass_block_fp8_supported: bool = CUTLASS_BLOCK_FP8_SUPPORTED,
         use_aiter_and_is_supported: bool = False,
-        use_deep_gemm: bool | None = None,
     ):
         self.weight_group_shape = weight_group_shape
         self.act_quant_group_shape = act_quant_group_shape
-        if use_deep_gemm is not None:
-            self.is_deep_gemm_supported = use_deep_gemm
-        else:
-            self.is_deep_gemm_supported = is_deep_gemm_supported()
+        self.is_deep_gemm_supported = is_deep_gemm_supported()
         self.is_hopper = current_platform.is_device_capability(90)
         self.use_deep_gemm_e8m0 = is_deep_gemm_e8m0_used()
         self.is_flashinfer_supported = is_flashinfer_fp8_blockscale_gemm_supported()

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -23,24 +23,6 @@ from vllm.platforms import current_platform
 from vllm.utils.import_utils import has_deep_gemm
 from vllm.utils.math_utils import cdiv
 
-_DEEPGEMM_BLACKWELL_EXCLUDED_MODEL_TYPES: set[str] = {
-    "qwen3_5_text",
-    "qwen3_5_moe_text",
-}
-
-
-def should_auto_disable_deep_gemm(model_type: str | None) -> bool:
-    """Check if DeepGemm should be auto-disabled for this model on Blackwell.
-
-    Returns True if the model is known to have accuracy degradation with
-    DeepGemm's E8M0 scale format on Blackwell GPUs (SM100+).
-    """
-    if model_type is None:
-        return False
-    if not current_platform.is_device_capability_family(100):
-        return False
-    return model_type in _DEEPGEMM_BLACKWELL_EXCLUDED_MODEL_TYPES
-
 
 class DeepGemmQuantScaleFMT(Enum):
     # Float32 scales in Float32 tensor


### PR DESCRIPTION
## Revert of PR #38083

This reverts https://github.com/vllm-project/vllm/pull/38083 (merge commit 5206901) which is suspected of causing **4 new CI failures** in nightly build [#58390](https://buildkite.com/vllm/ci/builds/58390):

- Kernels FP8 MoE Test (1 H100)
- LM Eval Qwen3.5 Models (B200)
- MoE Refactor Integration Test (B200 DP - TEMPORARY)
- Quantized MoE Test (B200)

The PR changed `fp8.py`, `input_quant_fp8.py`, `fp8_utils.py`, `deep_gemm.py`, and `vllm/config/vllm.py`, affecting FP8 quantization and DeepGemm behavior on Blackwell.

---
Auto-generated by CI failure analyzer.