### PR TITLE
Revert "[CI] Add batch invariant test for b200" (#38014)

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -205,21 +205,6 @@ steps:
     - pytest -v -s v1/determinism/test_rms_norm_batch_invariant.py
     - VLLM_TEST_MODEL=deepseek-ai/DeepSeek-V2-Lite-Chat pytest -v -s v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[TRITON_MLA]
     - VLLM_TEST_MODEL=Qwen/Qwen3-30B-A3B-Thinking-2507-FP8 pytest -v -s v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[FLASH_ATTN]
-
-- label: Batch Invariance (B200)
-  timeout_in_minutes: 30
-  device: b200
-  source_file_dependencies:
-    - vllm/v1/attention
-    - vllm/model_executor/layers
-    - tests/v1/determinism/
-  commands:
-    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-    - pip install pytest-timeout pytest-forked
-    - pytest -v -s v1/determinism/test_batch_invariance.py
-    - pytest -v -s v1/determinism/test_rms_norm_batch_invariant.py
-    - VLLM_TEST_MODEL=deepseek-ai/DeepSeek-V2-Lite-Chat pytest -v -s v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[TRITON_MLA]
-    - VLLM_TEST_MODEL=Qwen/Qwen3-30B-A3B-Thinking-2507-FP8 pytest -v -s v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[FLASH_ATTN]
   
 - label: Acceptance Length Test (Large Models) # optional
   timeout_in_minutes: 25


### PR DESCRIPTION
## Revert of PR #38014

This reverts https://github.com/vllm-project/vllm/pull/38014 (merge commit e054f15) which is suspected of causing **1 new CI failure** in nightly build [#58390](https://buildkite.com/vllm/ci/builds/58390):

- Batch Invariance (B200)

The PR added the Batch Invariance test for B200. The H100 variant of this test passed, but the B200 variant fails, suggesting a pre-existing B200 determinism issue or test configuration problem exposed by the new test.

---
Auto-generated by CI failure analyzer.