### PR TITLE
[Bugfix]Fix incorrect KV cache log output

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1294,33 +1294,14 @@ def _report_kv_cache_config(
         vllm_config: The global VllmConfig
         kv_cache_config: The resolved KV cache configuration
     """
-    min_block_size = min(
-        [group.kv_cache_spec.block_size for group in kv_cache_config.kv_cache_groups]
-    )
-
     # Log the KV cache size and maximum concurrency.
-    num_tokens = (
-        kv_cache_config.num_blocks
-        // len(kv_cache_config.kv_cache_groups)
-        * min_block_size
-    )
-    dcp_size = vllm_config.parallel_config.decode_context_parallel_size
-    pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
-    if pcp_size * dcp_size > 1:
-        num_tokens *= pcp_size * dcp_size
-        logger.info(
-            "Multiplying the GPU KV cache size by the cp_world_size %d "
-            "(pcp_world_size %d * dcp_world_size %d).",
-            pcp_size * dcp_size,
-            pcp_size,
-            dcp_size,
-        )
-    num_tokens_str = f"{num_tokens:,}"
-    logger.info_once("GPU KV cache size: %s tokens", num_tokens_str, scope="local")
     max_model_len_str = f"{vllm_config.model_config.max_model_len:,}"
     max_concurrency = get_max_concurrency_for_kv_cache_config(
         vllm_config, kv_cache_config
     )
+    num_tokens = int(vllm_config.model_config.max_model_len * max_concurrency)
+    num_tokens_str = f"{num_tokens:,}"
+    logger.info_once("GPU KV cache size: %s tokens", num_tokens_str, scope="local")
     logger.info_once(
         "Maximum concurrency for %s tokens per request: %.2fx",
         max_model_len_str,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1295,12 +1295,23 @@ def _report_kv_cache_config(
         kv_cache_config: The resolved KV cache configuration
     """
     # Log the KV cache size and maximum concurrency.
-    max_model_len_str = f"{vllm_config.model_config.max_model_len:,}"
     max_concurrency = get_max_concurrency_for_kv_cache_config(
         vllm_config, kv_cache_config
     )
     num_tokens = int(vllm_config.model_config.max_model_len * max_concurrency)
+    dcp_size = vllm_config.parallel_config.decode_context_parallel_size
+    pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+    if pcp_size * dcp_size > 1:
+        num_tokens *= pcp_size * dcp_size
+        logger.info(
+            "Multiplying the GPU KV cache size by the cp_world_size %d "
+            "(pcp_world_size %d * dcp_world_size %d).",
+            pcp_size * dcp_size,
+            pcp_size,
+            dcp_size,
+        )
     num_tokens_str = f"{num_tokens:,}"
+    max_model_len_str = f"{vllm_config.model_config.max_model_len:,}"
     logger.info_once("GPU KV cache size: %s tokens", num_tokens_str, scope="local")
     logger.info_once(
         "Maximum concurrency for %s tokens per request: %.2fx",


### PR DESCRIPTION
The current GPU KV cache size display is incorrect, while the max_concurrency value is accurate. This is because different kv_cache_groups may occupy different numbers of blocks, so it is invalid to assume an equal distribution of blocks across all groups.

Therefore, the following code is incorrect:

`num_tokens = (kv_cache_config.num_blocks // len(kv_cache_config.kv_cache_groups) * min_block_size)`

Instead, the total token capacity can be estimated using:

`max_concurrency * vllm_config.model_config.max_model_len`