### PR TITLE
[WIP][Model Runner V2] Implement flash sampling for the draft model

### DIFF
--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -2,6 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
 
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbeddingShardIndices,
+)
 from vllm.triton_utils import tl, triton
 
 
@@ -62,6 +69,66 @@ def tl_rand64(seed, offset, includes_zero: tl.constexpr):
     if not includes_zero:
         u = tl.maximum(u, 2.2250738585072014e-308)  # float64 tiny
     return u
+
+
+@triton.jit
+def tl_rand32(seed, offset, includes_zero: tl.constexpr):
+    # Generate uniform random in fp64 and then truncate fo fp32
+    # to preserve full 64-bit entropy.
+    u = tl_rand64(seed, offset, includes_zero=includes_zero)
+    return u.to(tl.float32)
+
+
+@triton.jit
+def _gumbel_block_argmax(
+    logits,
+    token_block,
+    token_mask,
+    vocab_block,
+    vocab_mask,
+    expanded_idx_mapping_ptr,
+    temp_ptr,
+    seeds_ptr,
+    pos_ptr,
+    APPLY_TEMPERATURE: tl.constexpr,
+):
+    req_state_idxs = tl.load(
+        expanded_idx_mapping_ptr + token_block, mask=token_mask, other=0
+    )
+    temps = tl.load(temp_ptr + req_state_idxs, mask=token_mask, other=1.0).to(
+        tl.float32
+    )
+    is_greedy = temps == 0.0
+
+    if APPLY_TEMPERATURE:
+        # Apply temperature.
+        # NOTE(woosuk): Match the behavior of _temperature_kernel.
+        # E.g., if the kernel uses tl.div_rn, we should use tl.div_rn here too.
+        temps = tl.where(is_greedy, 1.0, temps)
+        logits = logits / temps[:, None]
+
+    # Calculate the seeds and offsets for gumbel noise.
+    seeds = tl.load(seeds_ptr + req_state_idxs, mask=token_mask, other=0)
+    positions = tl.load(pos_ptr + token_block, mask=token_mask, other=0)
+    gumbel_seed = tl.randint(seeds, positions)
+
+    # FP32 noise is used because FP64 ops are significantly slower on recent
+    # hardware (e.g B300).
+    u = tl_rand32(gumbel_seed[:, None], vocab_block[None, :], includes_zero=False)
+    gumbel_noise = -tl.log(-tl.log(u))
+
+    # Zero out noise for greedy rows so that argmax sees raw logits.
+    gumbel_noise = tl.where(is_greedy[:, None], 0.0, gumbel_noise)
+
+    # Apply gumbel noise.
+    logits = tl.where(
+        token_mask[:, None] & vocab_mask[None, :],
+        logits + gumbel_noise,
+        float("-inf"),
+    )
+
+    values, idxs = tl.max(logits, axis=1, return_indices=True)
+    return values, idxs
 
 
 @triton.jit
@@ -131,6 +198,175 @@ def _gumbel_sample_kernel(
     tl.store(local_max_ptr + token_idx * local_max_stride + block_idx, value)
 
 
+@triton.jit
+def _fused_mm_gumbel_sample_kernel(
+    local_argmax_ptr,
+    local_argmax_stride,
+    local_max_ptr,
+    local_max_stride,
+    hidden_states_ptr,
+    hidden_states_stride,
+    lm_head_weights_ptr,
+    lm_head_weights_stride,
+    logits_scale_ptr,
+    draft_vocab_offsets_ptr,
+    expanded_idx_mapping_ptr,
+    seeds_ptr,
+    pos_ptr,
+    temp_ptr,
+    num_tokens,
+    hidden_dim,
+    vocab_size,
+    vocab_start,
+    BLOCK_SIZE_T: tl.constexpr,
+    BLOCK_SIZE_H: tl.constexpr,
+    BLOCK_SIZE_V: tl.constexpr,
+    APPLY_TEMPERATURE: tl.constexpr,
+):
+    token_block_idx = tl.program_id(0)
+    token_block = token_block_idx * BLOCK_SIZE_T + tl.arange(0, BLOCK_SIZE_T)
+    token_mask = token_block < num_tokens
+
+    vocab_block_idx = tl.program_id(1)
+    vocab_block = vocab_block_idx * BLOCK_SIZE_V + tl.arange(0, BLOCK_SIZE_V)
+    vocab_mask = vocab_block < vocab_size
+
+    # Matrix multiply hidden states x LM head weights.
+    logits = tl.zeros((BLOCK_SIZE_T, BLOCK_SIZE_V), dtype=tl.float32)
+    for d_start in range(0, hidden_dim, BLOCK_SIZE_H):
+        d_block = d_start + tl.arange(0, BLOCK_SIZE_H)
+        d_mask = d_block < hidden_dim
+        h_tile = tl.load(
+            hidden_states_ptr
+            + token_block[:, None] * hidden_states_stride
+            + d_block[None, :],
+            mask=token_mask[:, None] & d_mask[None, :],
+            other=0.0,
+        )
+        w_tile = tl.load(
+            lm_head_weights_ptr
+            + d_block[:, None]
+            + vocab_block[None, :] * lm_head_weights_stride,
+            mask=d_mask[:, None] & vocab_mask[None, :],
+            other=0.0,
+        )
+        logits += tl.dot(h_tile, w_tile)
+
+    # De-quantize and scale the logits.
+    if logits_scale_ptr is not None:
+        logits *= tl.load(logits_scale_ptr)
+
+    # Offset vocab to ensure consistent gumbel noise RNG
+    # with the target model. This is necessary for TP.
+    vocab_block += vocab_start
+    if draft_vocab_offsets_ptr is not None:
+        # Re-map from draft vocab to target vocab.
+        vocab_block += tl.load(
+            draft_vocab_offsets_ptr + vocab_block,
+            mask=vocab_mask,
+            other=0,
+        )
+
+    # Gumbel sample from the logits.
+    values, idxs = _gumbel_block_argmax(
+        logits,
+        token_block,
+        token_mask,
+        vocab_block,
+        vocab_mask,
+        expanded_idx_mapping_ptr,
+        temp_ptr,
+        seeds_ptr,
+        pos_ptr,
+        APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+    )
+
+    # Convert block-local argmax to global token IDs.
+    token_ids = vocab_start + vocab_block_idx * BLOCK_SIZE_V + idxs
+    if draft_vocab_offsets_ptr is not None:
+        # Re-map from draft token ids to target token ids.
+        token_ids += tl.load(
+            draft_vocab_offsets_ptr + token_ids,
+            mask=token_mask,
+            other=0,
+        )
+
+    tl.store(
+        local_argmax_ptr + token_block * local_argmax_stride + vocab_block_idx,
+        token_ids,
+        mask=token_mask,
+    )
+    tl.store(
+        local_max_ptr + token_block * local_max_stride + vocab_block_idx,
+        values,
+        mask=token_mask,
+    )
+
+
+@triton.jit
+def _block_argmax_kernel(
+    out_ptr,
+    max_out_ptr,
+    block_max_ptr,
+    block_max_row_stride,
+    block_max_col_stride,
+    block_argmax_ptr,
+    block_argmax_row_stride,
+    block_argmax_col_stride,
+    num_blocks,
+    BLOCK_SIZE: tl.constexpr,
+    OUTPUT_MAX: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_blocks
+
+    max_vals = tl.load(
+        block_max_ptr
+        + token_idx * block_max_row_stride
+        + offsets * block_max_col_stride,
+        mask=mask,
+        other=float("-inf"),
+    ).to(tl.float32)
+
+    best_val, best_idx = tl.max(max_vals, axis=0, return_indices=True)
+    best_idx = tl.minimum(best_idx, num_blocks - 1)
+
+    sampled = tl.load(
+        block_argmax_ptr
+        + token_idx * block_argmax_row_stride
+        + best_idx * block_argmax_col_stride,
+    )
+    tl.store(out_ptr + token_idx, sampled.to(tl.int64))
+
+    if OUTPUT_MAX:
+        tl.store(max_out_ptr + token_idx, best_val)
+
+
+def _block_argmax(
+    block_max: torch.Tensor,
+    block_argmax: torch.Tensor,
+    max_out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    num_tokens, num_blocks = block_max.shape
+    out = block_max.new_empty(num_tokens, dtype=torch.int64)
+    BLOCK_SIZE = triton.next_power_of_2(num_blocks)
+    _block_argmax_kernel[(num_tokens,)](
+        out,
+        max_out,
+        block_max,
+        block_max.stride(0),
+        block_max.stride(1),
+        block_argmax,
+        block_argmax.stride(0),
+        block_argmax.stride(1),
+        num_blocks,
+        BLOCK_SIZE=BLOCK_SIZE,
+        OUTPUT_MAX=max_out is not None,
+    )
+    return out
+
+
 def gumbel_sample(
     logits: torch.Tensor,  # [num_tokens, vocab_size]
     expanded_idx_mapping: torch.Tensor,  # [num_tokens]
@@ -166,3 +402,81 @@ def gumbel_sample(
     max_block_idx = local_max.argmax(dim=-1, keepdim=True)
     sampled = local_argmax.gather(dim=-1, index=max_block_idx).view(-1)
     return sampled
+
+
+def gumbel_flash_sample(
+    hidden_states: torch.Tensor,  # [num_tokens, hidden_size]
+    lm_head_weight: torch.Tensor,  # [vocab_size, hidden_size]
+    vocab_shard_indices: VocabParallelEmbeddingShardIndices,
+    expanded_idx_mapping: torch.Tensor,  # [num_tokens]
+    temperature: torch.Tensor,  # [max_num_reqs]
+    seed: torch.Tensor,  # [max_num_reqs]
+    pos: torch.Tensor,  # [max_num_reqs]
+    apply_temperature: bool,
+    logits_scale: torch.Tensor | None = None,
+    draft_vocab_offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    num_tokens, hidden_size = hidden_states.shape
+    vocab_start = vocab_shard_indices.org_vocab_start_index
+    vocab_size = vocab_shard_indices.num_org_elements
+
+    if num_tokens <= 16:
+        BLOCK_SIZE_T = 16
+    elif num_tokens <= 32:
+        BLOCK_SIZE_T = 32
+    else:
+        BLOCK_SIZE_T = 64
+    BLOCK_SIZE_H = 128
+    BLOCK_SIZE_V = 128
+    num_token_blocks = triton.cdiv(num_tokens, BLOCK_SIZE_T)
+    num_vocab_blocks = triton.cdiv(vocab_size, BLOCK_SIZE_V)
+    # [num_tokens, num_blocks]
+    block_argmax = hidden_states.new_empty(
+        num_tokens, num_vocab_blocks, dtype=torch.int64
+    )
+    # [num_tokens, num_blocks]
+    block_max = hidden_states.new_empty(
+        num_tokens, num_vocab_blocks, dtype=torch.float32
+    )
+    _fused_mm_gumbel_sample_kernel[(num_token_blocks, num_vocab_blocks)](
+        block_argmax,
+        block_argmax.stride(0),
+        block_max,
+        block_max.stride(0),
+        hidden_states,
+        hidden_states.stride(0),
+        lm_head_weight,
+        lm_head_weight.stride(0),
+        logits_scale,
+        draft_vocab_offsets,
+        expanded_idx_mapping,
+        seed,
+        pos,
+        temperature,
+        num_tokens,
+        hidden_size,
+        vocab_size,
+        vocab_start,
+        BLOCK_SIZE_T=BLOCK_SIZE_T,
+        BLOCK_SIZE_H=BLOCK_SIZE_H,
+        BLOCK_SIZE_V=BLOCK_SIZE_V,
+        APPLY_TEMPERATURE=apply_temperature,
+        num_warps=8,
+        num_stages=6,
+    )
+
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size == 1:
+        return _block_argmax(block_max, block_argmax)
+
+    # Get local argmax/max.
+    local_max = block_max.new_empty(num_tokens, dtype=torch.float32)
+    local_argmax = _block_argmax(block_max, block_argmax, max_out=local_max)
+
+    # Get argmax/max across TP ranks.
+    local_pair = torch.stack([local_max, local_argmax.float()], dim=-1)
+    # [num_tokens, 2 * tp_size]
+    gathered = tensor_model_parallel_all_gather(local_pair, dim=-1)
+    # [num_tokens, tp_size], [num_tokens, tp_size]
+    tp_max, tp_argmax = gathered.view(num_tokens, tp_size, 2).unbind(-1)
+    return _block_argmax(tp_max, tp_argmax)

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -5,6 +5,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 
+from vllm._custom_ops import scaled_fp8_quant
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
@@ -25,7 +26,7 @@ from vllm.v1.worker.gpu.cudagraph_utils import (
 from vllm.v1.worker.gpu.dp_utils import sync_cudagraph_and_dp_padding
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_flash_sample, gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.eagle.cudagraph import EagleCudaGraphManager
 from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
 
@@ -117,6 +118,19 @@ class EagleSpeculator:
 
         self.model = load_eagle_model(target_model, self.vllm_config)
 
+        if self.draft_logits is None:
+            # Cache quantized draft LM head weights for flash sampling,
+            # which skips materializing the full draft logits tensor.
+            # NOTE: Draft models do not currently have LM head bias.
+            self.lm_head_weight_fp8, self.lm_head_inv_scale = scaled_fp8_quant(
+                self.model.lm_head.weight
+            )
+            self.draft_id_to_target_id = getattr(
+                self.model, "draft_id_to_target_id", None
+            )
+            lp = getattr(self.model, "logits_processor", None)
+            self.logit_scale = lp.scale if lp is not None else 1.0
+
         all_attn_layers = get_layers_from_vllm_config(
             self.vllm_config,
             AttentionLayerBase,  # type: ignore[type-abstract]
@@ -140,6 +154,49 @@ class EagleSpeculator:
             active_layer_names=self.draft_attn_layer_names,
         )
         self.block_tables = block_tables
+
+    def _sample(
+        self,
+        hidden_states: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        pos: torch.Tensor,
+        step: int,
+    ):
+        # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
+        # used for draft and target sampling.
+        shifted_pos = pos + 1
+        if self.draft_logits is None:
+            # Draft logits do not need to be materialized. Use flash sampling to
+            # save on HBM roundtrips.
+            hidden_states_fp8, hidden_states_inv_scale = scaled_fp8_quant(hidden_states)
+            logits_scale = (
+                self.logit_scale * self.lm_head_inv_scale * hidden_states_inv_scale
+            )
+            return gumbel_flash_sample(
+                hidden_states_fp8,
+                self.lm_head_weight_fp8,
+                self.model.lm_head.shard_indices,
+                idx_mapping,
+                self.temperature,
+                self.seeds,
+                shifted_pos,
+                apply_temperature=True,
+                logits_scale=logits_scale,
+                draft_vocab_offsets=self.draft_id_to_target_id,
+            )
+        else:
+            # The draft logits are needed, so they must be fully materialized
+            # on all ranks.
+            logits = self.model.compute_logits(hidden_states)
+            return gumbel_sample(
+                logits,
+                idx_mapping,
+                self.temperature,
+                self.seeds,
+                shifted_pos,
+                apply_temperature=True,
+                processed_logits_out=self.draft_logits[:, step],
+            )
 
     @torch.inference_mode()
     def run_model(
@@ -211,20 +268,13 @@ class EagleSpeculator:
             )
             last_hidden_states = last_hidden_states[:num_reqs]
             hidden_states = hidden_states[:num_reqs]
-            logits = self.model.compute_logits(last_hidden_states)
 
-            # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
-            # used for draft and target sampling.
-            draft_tokens = gumbel_sample(
-                logits,
+            # Sample the draft tokens.
+            draft_tokens = self._sample(
+                last_hidden_states,
                 idx_mapping,
-                self.temperature,
-                self.seeds,
-                pos + 1,
-                apply_temperature=True,
-                processed_logits_out=self.draft_logits[:, step]
-                if self.draft_logits is not None
-                else None,
+                pos,
+                step,
             )
             self.draft_tokens[:num_reqs, step] = draft_tokens
 
@@ -379,7 +429,6 @@ class EagleSpeculator:
             mm_inputs=mm_inputs,
         )
         sample_hidden_states = last_hidden_states[last_token_indices]
-        logits = self.model.compute_logits(sample_hidden_states)
 
         num_reqs = input_batch.num_reqs
         # NOTE(woosuk): For draft sampling, we only consider the temperature
@@ -395,18 +444,13 @@ class EagleSpeculator:
         # Gather the values and copy them to the pre-allocated buffers.
         pos = self.input_buffers.positions[:num_reqs]
         torch.gather(input_batch.positions, 0, last_token_indices, out=pos)
-        # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
-        # used for draft and target sampling.
-        draft_tokens = gumbel_sample(
-            logits,
+
+        # Sample the draft tokens.
+        draft_tokens = self._sample(
+            sample_hidden_states,
             idx_mapping,
-            self.temperature,
-            self.seeds,
-            pos + 1,
-            apply_temperature=True,
-            processed_logits_out=self.draft_logits[:, 0]
-            if self.draft_logits is not None
-            else None,
+            pos,
+            step=0,
         )
 
         if self.num_speculative_steps == 1:


### PR DESCRIPTION
# H200
## Llama3 8B + eagle1 (TP = 1)
**Temperature = 0**
| Concurrency | Req/s |  | Tok/s |  | Total tok/s |  | TTFT (ms) |  | TPOT (ms) |  |
|---|---|---|---|---|---|---|---|---|---|---|
| | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** |
| 1 | 2.27 | 2.40 | 290.65 | 307.12 | 481.39 | 508.66 | 13.46 | 13.25 | 3.36 | 3.18 |
| 2 | 4.39 | 4.64 | 562.22 | 593.73 | 939.97 | 992.64 | 19.75 | 18.94 | 3.37 | 3.20 |
| 4 | 8.53 | 9.07 | 1092.19 | 1160.91 | 1685.00 | 1791.02 | 19.95 | 19.42 | 3.32 | 3.15 |
| 8 | 17.49 | 18.40 | 2238.99 | 2355.56 | 3387.56 | 3563.94 | 21.52 | 23.42 | 3.32 | 3.14 |
| 16 | 31.93 | 34.06 | 4086.83 | 4359.48 | 6250.37 | 6667.36 | 27.10 | 25.77 | 3.53 | 3.31 |
| 32 | 55.09 | 56.42 | 7051.49 | 7221.62 | 10713.92 | 10972.42 | 32.74 | 36.97 | 4.11 | 3.99 |
| 64 | 75.36 | 76.68 | 9645.88 | 9815.24 | 14661.46 | 14918.87 | 52.98 | 54.13 | 6.04 | 5.94 |

**Temperature = 0.6**
| Concurrency | Req/s |  | Tok/s |  | Total tok/s |  | TTFT (ms) |  | TPOT (ms) |  |
|---|---|---|---|---|---|---|---|---|---|---|
| | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** |
| 1 | 2.21 | 2.34 | 283.16 | 299.43 | 468.98 | 495.93 | 13.94 | 14.27 | 3.45 | 3.25 |
| 2 | 4.12 | 4.28 | 527.49 | 548.07 | 881.90 | 916.30 | 21.39 | 19.74 | 3.51 | 3.36 |
| 4 | 8.10 | 8.58 | 1037.41 | 1098.79 | 1600.49 | 1695.19 | 20.96 | 19.85 | 3.51 | 3.35 |
| 8 | 16.79 | 17.56 | 2149.07 | 2247.52 | 3251.52 | 3400.46 | 22.31 | 21.22 | 3.48 | 3.32 |
| 16 | 29.90 | 32.00 | 3827.53 | 4095.96 | 5853.80 | 6264.33 | 28.52 | 27.35 | 3.76 | 3.52 |
| 32 | 50.88 | 53.66 | 6512.66 | 6868.63 | 9895.24 | 10436.09 | 49.91 | 34.42 | 4.35 | 4.26 |
| 64 | 69.12 | 70.93 | 8847.51 | 9079.11 | 13447.95 | 13799.99 | 61.76 | 53.47 | 6.55 | 6.43 |

## Llama3 70B + eagle1 (TP = 4)
**Temperature = 0**
| Concurrency | Req/s |  | Tok/s |  | Total tok/s |  | TTFT (ms) |  | TPOT (ms) |  |
|---|---|---|---|---|---|---|---|---|---|---|
| | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** |
| 1 | 1.20 | 1.22 | 153.23 | 155.86 | 253.78 | 258.14 | 27.67 | 27.66 | 6.36 | 6.25 |
| 2 | 2.18 | 2.18 | 278.44 | 278.68 | 465.51 | 465.92 | 42.82 | 41.81 | 6.75 | 6.66 |
| 4 | 4.16 | 4.20 | 532.73 | 537.28 | 821.88 | 828.91 | 45.25 | 45.27 | 6.89 | 6.83 |
| 8 | 8.04 | 8.18 | 1028.82 | 1046.79 | 1556.59 | 1583.78 | 51.61 | 56.20 | 7.22 | 7.07 |
| 16 | 14.13 | 14.10 | 1808.67 | 1805.37 | 2766.17 | 2761.13 | 63.42 | 60.66 | 7.91 | 7.95 |
| 32 | 23.49 | 23.91 | 3006.54 | 3060.59 | 4568.10 | 4650.21 | 78.18 | 82.00 | 9.68 | 9.51 |
| 64 | 32.02 | 32.47 | 4098.07 | 4155.95 | 6228.94 | 6316.93 | 121.66 | 125.88 | 14.22 | 13.97 |

**Temperature = 0.6**
| Concurrency | Req/s |  | Tok/s |  | Total tok/s |  | TTFT (ms) |  | TPOT (ms) |  |
|---|---|---|---|---|---|---|---|---|---|---|
| | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** |
| 1 | 1.16 | 1.17 | 147.97 | 149.74 | 245.08 | 248.01 | 25.50 | 25.39 | 6.61 | 6.53 |
| 2 | 2.16 | 2.16 | 275.99 | 276.04 | 461.41 | 461.50 | 44.44 | 43.91 | 6.82 | 6.78 |
| 4 | 3.99 | 4.08 | 510.95 | 522.17 | 788.28 | 805.58 | 47.48 | 46.62 | 7.09 | 7.00 |
| 8 | 7.91 | 8.00 | 1012.80 | 1024.40 | 1532.35 | 1549.90 | 53.23 | 52.20 | 7.33 | 7.24 |
| 16 | 13.71 | 13.66 | 1754.44 | 1748.48 | 2683.22 | 2674.12 | 63.19 | 62.61 | 8.30 | 8.20 |
| 32 | 22.76 | 22.73 | 2912.83 | 2908.89 | 4425.71 | 4419.73 | 79.33 | 78.72 | 9.94 | 9.93 |
| 64 | 30.49 | 31.43 | 3902.47 | 4023.17 | 5931.65 | 6115.09 | 161.07 | 120.83 | 14.68 | 14.53 |

## GPT-OSS 20B + eagle3 (TP = 1)
**Temperature = 0**
| Concurrency | Req/s |  | Tok/s |  | Total tok/s |  | TTFT (ms) |  | TPOT (ms) |  |
|---|---|---|---|---|---|---|---|---|---|---|
| | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** |
| 1 | 3.93 | 4.01 | 470.15 | 480.11 | 798.79 | 815.71 | 14.84 | 14.91 | 2.25 | 2.19 |
| 2 | 6.56 | 6.70 | 812.21 | 857.14 | 1372.03 | 1429.01 | 20.35 | 20.26 | 2.41 | 2.16 |
| 4 | 11.54 | 11.44 | 1398.40 | 1435.99 | 2195.67 | 2226.81 | 23.73 | 23.30 | 2.82 | 2.57 |
| 8 | 19.74 | 19.98 | 2436.95 | 2467.24 | 3718.34 | 3764.43 | 26.88 | 26.32 | 3.14 | 3.09 |
| 16 | 32.96 | 33.67 | 4106.94 | 4177.32 | 6316.84 | 6435.40 | 38.30 | 36.86 | 3.61 | 3.58 |
| 32 | 52.62 | 54.59 | 6509.83 | 6784.99 | 9968.47 | 10373.15 | 55.99 | 49.98 | 4.56 | 4.38 |
| 64 | 69.21 | 67.71 | 8593.34 | 8406.53 | 13141.18 | 12855.68 | 147.03 | 196.95 | 6.38 | 6.14 |

**Temperature = 0.6**
| Concurrency | Req/s |  | Tok/s |  | Total tok/s |  | TTFT (ms) |  | TPOT (ms) |  |
|---|---|---|---|---|---|---|---|---|---|---|
| | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** | **main** | **#38399** |
| 1 | 3.83 | 3.90 | 456.55 | 465.44 | 776.49 | 791.61 | 15.97 | 15.57 | 2.30 | 2.26 |
| 2 | 6.21 | 6.39 | 795.07 | 818.33 | 1325.52 | 1364.32 | 20.64 | 19.95 | 2.36 | 2.29 |
| 4 | 10.70 | 10.99 | 1347.08 | 1382.75 | 2086.57 | 2141.82 | 24.02 | 23.88 | 2.72 | 2.65 |
| 8 | 18.81 | 19.15 | 2342.32 | 2384.90 | 3563.09 | 3627.86 | 27.10 | 26.59 | 3.20 | 3.15 |
| 16 | 31.09 | 32.29 | 3925.02 | 4079.22 | 6009.75 | 6244.78 | 37.40 | 37.33 | 3.70 | 3.59 |
| 32 | 44.89 | 46.39 | 5697.51 | 5848.40 | 8648.10 | 8897.94 | 117.47 | 108.32 | 4.61 | 4.57 |
| 64 | 62.58 | 70.27 | 7845.12 | 8796.15 | 11957.19 | 13413.26 | 161.60 | 126.86 | 6.96 | 6.28 |