### PR TITLE
[CI/Build] Fix GH200 build: add --torch-only flag to use_existing_torch.py to preserve torchvision dependency

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-gh200-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-gh200-test.sh
@@ -4,8 +4,10 @@
 # It serves a sanity check for compilation and basic model usage.
 set -ex
 
-# Skip the new torch installation during build since we are using the specified version for arm64 in the Dockerfile
-python3 use_existing_torch.py
+# Strip only the core torch version pin so the pre-installed arm64 torch is reused.
+# --torch-only preserves torchvision and torchaudio version pins so they are still
+# installed from requirements/cuda.txt during the Docker build.
+python3 use_existing_torch.py --torch-only
 
 # Try building the docker image
 DOCKER_BUILDKIT=1 docker build . \

--- a/tests/test_use_existing_torch.py
+++ b/tests/test_use_existing_torch.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for use_existing_torch.py to verify the three stripping modes:
+  - default (no flag): removes ALL lines containing the word 'torch'
+  - --prefix:          removes lines whose content starts with a torch lib prefix
+  - --torch-only:      removes only the core torch version pin, preserving
+                       torchvision and torchaudio version pins
+
+Regression test for: GH200 CI build failure where run-gh200-test.sh called
+use_existing_torch.py without any flag, causing torchvision and comment lines
+to be incorrectly stripped from requirements/cuda.txt, breaking the Docker
+build for arm64 (GH200) targets.
+"""
+import os
+import sys
+import textwrap
+
+import pytest
+
+# Add repo root to path so we can import use_existing_torch directly
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from use_existing_torch import main
+
+
+SAMPLE_CUDA_TXT = textwrap.dedent("""\
+    # Common dependencies
+    -r common.txt
+
+    # Dependencies for NVIDIA GPUs
+    torch==2.10.0
+    torchaudio==2.10.0
+    # These must be updated alongside torch
+    torchvision==0.25.0 # Required for phi3v processor
+
+    # FlashInfer
+    flashinfer-python==0.6.6
+""")
+
+SAMPLE_PYPROJECT = textwrap.dedent("""\
+    [project]
+    dependencies = [
+        "torch == 2.10.0",
+        "torchvision == 0.25.0",
+    ]
+    no-build-isolation-package = ["torch"]
+""")
+
+
+@pytest.fixture
+def tmp_requirements(tmp_path):
+    """Create a temporary directory with sample requirements and pyproject files."""
+    req_dir = tmp_path / "requirements"
+    req_dir.mkdir()
+    (req_dir / "cuda.txt").write_text(SAMPLE_CUDA_TXT)
+    (tmp_path / "pyproject.toml").write_text(SAMPLE_PYPROJECT)
+    return tmp_path
+
+
+def test_torch_only_mode_strips_only_torch_pin(tmp_requirements, monkeypatch):
+    """--torch-only mode should remove only the core torch version pin.
+
+    torchvision and torchaudio version pins must be preserved so they are
+    still installed from requirements files (critical for GH200 arm64 builds
+    where torchvision is needed for the phi3v processor).
+    """
+    monkeypatch.chdir(tmp_requirements)
+    main(["--torch-only"])
+
+    cuda_content = (tmp_requirements / "requirements" / "cuda.txt").read_text()
+    # Core torch version pin must be removed
+    assert "torch==2.10.0" not in cuda_content
+    # torchvision and torchaudio pins must be PRESERVED
+    assert "torchaudio==2.10.0" in cuda_content
+    assert "torchvision==0.25.0" in cuda_content
+    # Comment lines must be preserved
+    assert "# These must be updated alongside torch" in cuda_content
+    # Unrelated deps preserved
+    assert "flashinfer-python==0.6.6" in cuda_content
+
+    pyproject_content = (tmp_requirements / "pyproject.toml").read_text()
+    assert '"torch == 2.10.0"' not in pyproject_content
+    # torchvision pin preserved
+    assert '"torchvision == 0.25.0"' in pyproject_content
+    # no-build-isolation-package line preserved
+    assert 'no-build-isolation-package = ["torch"]' in pyproject_content
+
+
+def test_prefix_mode_strips_all_torch_lib_pins(tmp_requirements, monkeypatch):
+    """--prefix mode should remove torch, torchvision, and torchaudio version pins.
+
+    Comment lines and lines that only contain the word 'torch' as part of
+    another token (e.g. no-build-isolation-package) must be preserved.
+    """
+    monkeypatch.chdir(tmp_requirements)
+    main(["--prefix"])
+
+    cuda_content = (tmp_requirements / "requirements" / "cuda.txt").read_text()
+    # All three lib version pins removed
+    assert "torch==2.10.0" not in cuda_content
+    assert "torchaudio==2.10.0" not in cuda_content
+    assert "torchvision==0.25.0" not in cuda_content
+    # Comment line preserved (does not start with a torch lib prefix)
+    assert "# These must be updated alongside torch" in cuda_content
+    # Unrelated deps preserved
+    assert "flashinfer-python==0.6.6" in cuda_content
+
+    pyproject_content = (tmp_requirements / "pyproject.toml").read_text()
+    assert '"torch == 2.10.0"' not in pyproject_content
+    assert '"torchvision == 0.25.0"' not in pyproject_content
+    # no-build-isolation-package line preserved
+    assert 'no-build-isolation-package = ["torch"]' in pyproject_content
+
+
+def test_no_flag_mode_strips_all_torch_lines(tmp_requirements, monkeypatch):
+    """Without any flag, ALL lines containing the word 'torch' are removed."""
+    monkeypatch.chdir(tmp_requirements)
+    main([])
+
+    cuda_content = (tmp_requirements / "requirements" / "cuda.txt").read_text()
+    assert "torch==2.10.0" not in cuda_content
+    assert "torchaudio==2.10.0" not in cuda_content
+    assert "torchvision==0.25.0" not in cuda_content
+    # Comment line also removed (contains 'torch')
+    assert "# These must be updated alongside torch" not in cuda_content
+    # Unrelated lines preserved
+    assert "flashinfer-python==0.6.6" in cuda_content
+
+
+def test_gh200_ci_uses_torch_only_flag():
+    """Regression test: GH200 CI script must call use_existing_torch.py --torch-only.
+
+    Using no flag or --prefix incorrectly strips torchvision from
+    requirements/cuda.txt, causing the phi3v processor to be unavailable
+    in the resulting Docker image.
+    """
+    script_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        ".buildkite",
+        "scripts",
+        "hardware_ci",
+        "run-gh200-test.sh",
+    )
+    with open(script_path) as f:
+        content = f.read()
+
+    # Every non-comment invocation of use_existing_torch.py must use --torch-only
+    lines_with_script = [
+        line
+        for line in content.splitlines()
+        if "use_existing_torch.py" in line and not line.strip().startswith("#")
+    ]
+    assert lines_with_script, "run-gh200-test.sh must invoke use_existing_torch.py"
+    for line in lines_with_script:
+        assert "--torch-only" in line, (
+            f"run-gh200-test.sh calls use_existing_torch.py without --torch-only: {line!r}\n"
+            "This causes torchvision to be stripped, breaking the GH200 Docker build."
+        )

--- a/tests/test_use_existing_torch.py
+++ b/tests/test_use_existing_torch.py
@@ -12,6 +12,7 @@ use_existing_torch.py without any flag, causing torchvision and comment lines
 to be incorrectly stripped from requirements/cuda.txt, breaking the Docker
 build for arm64 (GH200) targets.
 """
+
 import os
 import sys
 import textwrap
@@ -21,7 +22,6 @@ import pytest
 # Add repo root to path so we can import use_existing_torch directly
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from use_existing_torch import main
-
 
 SAMPLE_CUDA_TXT = textwrap.dedent("""\
     # Common dependencies
@@ -154,6 +154,7 @@ def test_gh200_ci_uses_torch_only_flag():
     assert lines_with_script, "run-gh200-test.sh must invoke use_existing_torch.py"
     for line in lines_with_script:
         assert "--torch-only" in line, (
-            f"run-gh200-test.sh calls use_existing_torch.py without --torch-only: {line!r}\n"
+            f"run-gh200-test.sh calls use_existing_torch.py without "
+            f"--torch-only: {line!r}\n"
             "This causes torchvision to be stripped, breaking the GH200 Docker build."
         )

--- a/use_existing_torch.py
+++ b/use_existing_torch.py
@@ -17,17 +17,48 @@ TORCH_LIB_PREFIXES = (
     '"torchaudio =',
 )
 
+# Prefixes for torch-only mode: strip only the core torch package version pin,
+# preserving torchvision and torchaudio as standalone runtime dependencies.
+TORCH_ONLY_PREFIXES = (
+    # requirements/*.txt/in
+    "torch=",
+    # pyproject.toml
+    '"torch =',
+)
+
 
 def main(argv):
     parser = argparse.ArgumentParser(
         description="Strip torch lib requirements to use installed version."
     )
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--prefix",
         action="store_true",
-        help="Strip prefix matches only (default: False)",
+        help=(
+            "Strip prefix matches only (default: False). Removes lines whose "
+            "stripped content starts with torch=, torchvision=, or torchaudio= "
+            "(and their pyproject.toml equivalents)."
+        ),
+    )
+    mode.add_argument(
+        "--torch-only",
+        action="store_true",
+        help=(
+            "Strip only the core torch version pin, leaving torchvision and "
+            "torchaudio version pins intact. Use this when the pre-installed "
+            "torch must be reused but torchvision/torchaudio still need to be "
+            "installed from requirements (e.g. GH200 arm64 builds)."
+        ),
     )
     args = parser.parse_args(argv)
+
+    if args.torch_only:
+        active_prefixes = TORCH_ONLY_PREFIXES
+    elif args.prefix:
+        active_prefixes = TORCH_LIB_PREFIXES
+    else:
+        active_prefixes = None  # strip all lines containing 'torch'
 
     for file in (
         *glob.glob("requirements/*.txt"),
@@ -39,12 +70,11 @@ def main(argv):
         if "torch" in "".join(lines).lower():
             with open(file, "w") as f:
                 for line in lines:
-                    if (
-                        args.prefix
-                        and not line.lower().strip().startswith(TORCH_LIB_PREFIXES)
-                        or not args.prefix
-                        and "torch" not in line.lower()
-                    ):
+                    if active_prefixes is not None:
+                        keep = not line.lower().strip().startswith(active_prefixes)
+                    else:
+                        keep = "torch" not in line.lower()
+                    if keep:
                         f.write(line)
                     else:
                         print(f">>> removed from {file}:", line.strip())

--- a/use_existing_torch.py
+++ b/use_existing_torch.py
@@ -5,16 +5,28 @@ import argparse
 import glob
 import sys
 
-# Only strip targeted libraries when checking prefix
+# Only strip targeted libraries when checking prefix.
+# pyproject.toml dependencies can appear with double or single quotes and
+# with or without spaces around the version operator, so we cover all variants.
 TORCH_LIB_PREFIXES = (
     # requirements/*.txt/in
     "torch=",
     "torchvision=",
     "torchaudio=",
-    # pyproject.toml
+    # pyproject.toml – double-quoted, with/without space
+    '"torch==',
     '"torch =',
+    '"torchvision==',
     '"torchvision =',
+    '"torchaudio==',
     '"torchaudio =',
+    # pyproject.toml – single-quoted, with/without space
+    "'torch==",
+    "'torch =",
+    "'torchvision==",
+    "'torchvision =",
+    "'torchaudio==",
+    "'torchaudio =",
 )
 
 # Prefixes for torch-only mode: strip only the core torch package version pin,
@@ -22,8 +34,12 @@ TORCH_LIB_PREFIXES = (
 TORCH_ONLY_PREFIXES = (
     # requirements/*.txt/in
     "torch=",
-    # pyproject.toml
+    # pyproject.toml – double-quoted, with/without space
+    '"torch==',
     '"torch =',
+    # pyproject.toml – single-quoted, with/without space
+    "'torch==",
+    "'torch =",
 )
 
 


### PR DESCRIPTION
## Purpose

Fix GH200 CI build failure where `run-gh200-test.sh` called `use_existing_torch.py` without any flag, stripping **all** lines containing the word `torch` from requirements files. This incorrectly removed the `torchvision==0.25.0` dependency from `requirements/cuda.txt`, causing the phi3v processor to be unavailable in the resulting Docker image.

Fixes: GH200 Test CI failure — `python3 use_existing_torch.py` (no flag) strips `torchvision` from `requirements/cuda.txt`.

### Root Cause

`use_existing_torch.py` has two modes:
- **No flag** (default): removes every line that contains the word `torch` — including `torchvision==0.25.0` and comment lines.
- **`--prefix`**: removes lines whose stripped content starts with `torch=`, `torchvision=`, or `torchaudio=` — still removes `torchvision==0.25.0`.

Neither mode was correct for the GH200 use case, where we want to reuse the pre-installed arm64 `torch` but still install `torchvision` and `torchaudio` from `requirements/cuda.txt`.

### Fix

Introduces a new `--torch-only` flag in `use_existing_torch.py` that strips **only** the core `torch` version pin (`torch=` / `"torch =`), leaving `torchvision` and `torchaudio` version pins intact. Updates `run-gh200-test.sh` to use `--torch-only`.

## Test Plan

```bash
python3 -m pytest tests/test_use_existing_torch.py -v
```

## Test Result

```
tests/test_use_existing_torch.py::test_torch_only_mode_strips_only_torch_pin PASSED
tests/test_use_existing_torch.py::test_prefix_mode_strips_all_torch_lib_pins PASSED
tests/test_use_existing_torch.py::test_no_flag_mode_strips_all_torch_lines   PASSED
tests/test_use_existing_torch.py::test_gh200_ci_uses_torch_only_flag         PASSED
4 passed in 1.32s
```

**Before fix:** `torchvision==0.25.0` was stripped from `requirements/cuda.txt`, breaking the GH200 Docker build.

**After fix:** Only `torch==2.10.0` is stripped; `torchvision==0.25.0` and `torchaudio==2.10.0` are preserved.
