### PR TITLE
[Bugfix] Fix platform detection crash when vllm is not installed as a package

### DIFF
--- a/tests/test_platform_detection_uninstalled.py
+++ b/tests/test_platform_detection_uninstalled.py
@@ -1,0 +1,68 @@
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Regression test for vllm_version_matches_substr() when vllm is not installed.
+
+Without the fix, vllm_version_matches_substr() re-raised PackageNotFoundError
+when the vllm package was not found. This caused cuda_platform_plugin() to
+raise, which was silently swallowed by resolve_current_platform_cls_qualname(),
+leaving current_platform as UnspecifiedPlatform with device_type = ''.
+Later, DeviceConfig(device='') called torch.device('') and crashed with:
+  RuntimeError: Device string must not be empty
+
+This regression test verifies that vllm_version_matches_substr() returns False
+(instead of raising) when the vllm package is not installed.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def test_vllm_version_matches_substr_returns_false_when_not_installed():
+    """
+    When the vllm package is not installed, vllm_version_matches_substr()
+    should return False instead of raising PackageNotFoundError.
+    """
+    from importlib.metadata import PackageNotFoundError
+
+    # Simulate vllm not being installed by patching importlib.metadata.version
+    with patch(
+        "importlib.metadata.version",
+        side_effect=PackageNotFoundError("vllm"),
+    ):
+        # Re-import to pick up the patch
+        if "vllm.platforms" in sys.modules:
+            from vllm.platforms import vllm_version_matches_substr
+        else:
+            from vllm.platforms import vllm_version_matches_substr
+
+        # Should return False, not raise
+        result = vllm_version_matches_substr("cpu")
+        assert result is False, (
+            "vllm_version_matches_substr should return False when vllm is not "
+            "installed, but it raised or returned a non-False value."
+        )
+
+
+def test_vllm_version_matches_substr_returns_true_when_matches():
+    """
+    When the vllm package is installed and the version contains the substr,
+    vllm_version_matches_substr() should return True.
+    """
+    with patch("importlib.metadata.version", return_value="0.7.0.cpu"):
+        from vllm.platforms import vllm_version_matches_substr
+        assert vllm_version_matches_substr("cpu") is True
+
+
+def test_vllm_version_matches_substr_returns_false_when_no_match():
+    """
+    When the vllm package is installed but the version does not contain the
+    substr, vllm_version_matches_substr() should return False.
+    """
+    with patch("importlib.metadata.version", return_value="0.7.0"):
+        from vllm.platforms import vllm_version_matches_substr
+        assert vllm_version_matches_substr("cpu") is False

--- a/tests/test_platform_detection_uninstalled.py
+++ b/tests/test_platform_detection_uninstalled.py
@@ -1,4 +1,3 @@
-
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
@@ -16,10 +15,7 @@ This regression test verifies that vllm_version_matches_substr() returns False
 (instead of raising) when the vllm package is not installed.
 """
 
-import sys
 from unittest.mock import patch
-
-import pytest
 
 
 def test_vllm_version_matches_substr_returns_false_when_not_installed():
@@ -29,16 +25,15 @@ def test_vllm_version_matches_substr_returns_false_when_not_installed():
     """
     from importlib.metadata import PackageNotFoundError
 
-    # Simulate vllm not being installed by patching importlib.metadata.version
+    # Simulate vllm not being installed by patching importlib.metadata.version.
+    # The patch works because vllm_version_matches_substr() dynamically imports
+    # `version` from `importlib.metadata` within its own scope on each call,
+    # so the patch is active when the function executes.
     with patch(
         "importlib.metadata.version",
         side_effect=PackageNotFoundError("vllm"),
     ):
-        # Re-import to pick up the patch
-        if "vllm.platforms" in sys.modules:
-            from vllm.platforms import vllm_version_matches_substr
-        else:
-            from vllm.platforms import vllm_version_matches_substr
+        from vllm.platforms import vllm_version_matches_substr
 
         # Should return False, not raise
         result = vllm_version_matches_substr("cpu")
@@ -55,6 +50,7 @@ def test_vllm_version_matches_substr_returns_true_when_matches():
     """
     with patch("importlib.metadata.version", return_value="0.7.0.cpu"):
         from vllm.platforms import vllm_version_matches_substr
+
         assert vllm_version_matches_substr("cpu") is True
 
 
@@ -65,4 +61,5 @@ def test_vllm_version_matches_substr_returns_false_when_no_match():
     """
     with patch("importlib.metadata.version", return_value="0.7.0"):
         from vllm.platforms import vllm_version_matches_substr
+
         assert vllm_version_matches_substr("cpu") is False

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -19,17 +19,26 @@ logger = logging.getLogger(__name__)
 def vllm_version_matches_substr(substr: str) -> bool:
     """
     Check to see if the vLLM version matches a substring.
+
+    Returns False if the vLLM package is not installed (e.g. when running
+    directly from source without ``pip install -e .``). Re-raising
+    ``PackageNotFoundError`` here would propagate through the platform
+    detection plugins and cause the CUDA plugin to be silently skipped,
+    leaving ``current_platform`` as ``UnspecifiedPlatform`` with an empty
+    ``device_type``, which later causes a ``RuntimeError`` when
+    ``torch.device("")`` is called.
     """
     from importlib.metadata import PackageNotFoundError, version
 
     try:
         vllm_version = version("vllm")
-    except PackageNotFoundError as e:
+    except PackageNotFoundError:
         logger.warning(
             "The vLLM package was not found, so its version could not be "
-            "inspected. This may cause platform detection to fail."
+            "inspected. Assuming the version does not match '%s'.",
+            substr,
         )
-        raise e
+        return False
     return substr in vllm_version
 
 


### PR DESCRIPTION
## Purpose

Proactive fix for a regression introduced by #35970 (AMD Zen CPU backend, merged Mar 15 2026), which changed `vllm/platforms/__init__.py` to re-raise `PackageNotFoundError` instead of returning `False`.

### Root Cause

PR #35970 modified `vllm_version_matches_substr()` to `raise e` on `PackageNotFoundError`:

```python
# vllm/platforms/__init__.py (after #35970)
except PackageNotFoundError as e:
    logger.warning(...)
    raise e   # regression: should return False
```

When vllm is not installed as a package (e.g. running from source with `PYTHONPATH=.`), this raises instead of returning `False`. The exception propagates through `cuda_platform_plugin()` and is silently swallowed by `resolve_current_platform_cls_qualname()`, leaving `current_platform = UnspecifiedPlatform` with `device_type = ""`. Any subsequent `DeviceConfig("")` call then crashes with `RuntimeError: Device string must not be empty`.

This is the same pattern that PR #13501 originally fixed — #35970 accidentally reverted it.

### Fix

Return `False` instead of re-raising, matching the original intent of #13501.

## Test Plan

```bash
python3 -m pytest tests/test_platform_detection_uninstalled.py -v
```

## Test Result

```
tests/test_platform_detection_uninstalled.py::test_vllm_version_matches_substr_returns_false_when_not_installed PASSED
tests/test_platform_detection_uninstalled.py::test_vllm_version_matches_substr_returns_true_when_matches        PASSED
tests/test_platform_detection_uninstalled.py::test_vllm_version_matches_substr_returns_false_when_no_match      PASSED
3 passed
```