### PR TITLE
[Test] Fix flaky race condition in test_abort_final_step

### DIFF
--- a/tests/v1/engine/test_abort_final_step.py
+++ b/tests/v1/engine/test_abort_final_step.py
@@ -259,8 +259,25 @@ async def test_abort_during_final_step(async_scheduling: bool):
                 # Wait for generation to complete
                 await gen_task
 
-                # Give the scheduler a moment to finish cleanup
-                await asyncio.sleep(0.1)
+                # Poll for the KV connector to record the finish status
+                timeout = 5.0
+                start = time.time()
+                captured_statuses = []
+                while time.time() - start < timeout:
+                    with open(status_file) as f4:
+                        status_lines = f4.read().strip().split("\n")
+                        captured_statuses = [
+                            line
+                            for line in status_lines
+                            if line and line.startswith("FINISHED_")
+                        ]
+                    if captured_statuses:
+                        break
+                    await asyncio.sleep(0.05)
+                else:
+                    raise TimeoutError(
+                        "Timeout waiting for KV connector to record finish status."
+                    )
 
                 # Verify we got output
                 assert len(outputs) > 0, "Should have received at least one output"
@@ -274,15 +291,6 @@ async def test_abort_during_final_step(async_scheduling: bool):
                     f"Expected finish_reason='abort' but got "
                     f"'{final_output.outputs[0].finish_reason}'. "
                 )
-
-                with open(status_file) as f4:
-                    status_lines = f4.read().strip().split("\n")
-                    # Filter for actual finish statuses (not INIT or empty lines)
-                    captured_statuses = [
-                        line
-                        for line in status_lines
-                        if line and line.startswith("FINISHED_")
-                    ]
 
                 assert len(captured_statuses) >= 1, (
                     f"Expected at least 1 captured finish status, got "


### PR DESCRIPTION
## Purpose

Fix flaky test `test_abort_during_final_step[False]` ([#38221](https://github.com/vllm-project/vllm/issues/38221)).

The `async_scheduling=False` variant fails intermittently with:

```
AssertionError: Expected at least 1 captured finish status, got 0.
File content: ['INIT:WORKER', 'INIT:SCHEDULER']
```

The root cause seems to be a race condition: in sync mode, after unblocking `execute_model`, the engine core must complete the full step pipeline (forward pass, sampling, GPU-to-CPU copy, abort/output processing) before writing the finish status to the status file. The test only waited a fixed `asyncio.sleep(0.1)` before reading the file, which is insufficient under CI load.

The async variant (`async_scheduling=True`) is not affected because `_process_input_queue()` processes the abort at the start of the next busy-loop iteration — before the sampling future resolves — removing sampling from the critical path for the status file write.

**Fix**: Replace the fixed 100ms sleep with an active poll (50ms intervals, 5s timeout) that waits for the expected `FINISHED_*` status to appear in the file before asserting.

## Test Plan

Verified that the `async_scheduling=False` variant can be reproduced more consistently by using a larger model (gemma-4b-it on a H200 machine). With the fix applied, the test passes reliably under the same conditions.

```bash
python -m pytest tests/v1/engine/test_abort_final_step.py -v
```

```bash
#!/usr/bin/env bash
# Run the flaky test in a loop to verify the fix.
# Usage: ./run_flaky_test.sh [N]
#   N = number of iterations (default: 20)

set -euo pipefail

N="${1:-20}"
TEST="tests/v1/engine/test_abort_final_step.py::test_abort_during_final_step[False]"

for i in $(seq 1 "$N"); do
    printf "=== Run %d/%d === " "$i" "$N"
    if .venv/bin/python -m pytest "$TEST" -x --tb=short -q; then
        echo "PASSED on run $i"
    else
        echo "FAILED on run $i — aborting."
        exit 0
    fi
done

echo ""
echo "===== All $N runs passed ====="
```


## Test Result

Both `test_abort_during_final_step[False]` and `test_abort_during_final_step[True]` pass consistently with the fix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>