### PR TITLE
[ROCm][CI] Fix UV install in Dockerfile.rocm to detect curl failures and retry

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -29,8 +29,11 @@ RUN if [ "$USE_SCCACHE" != "1" ]; then \
         rm -f "$(which sccache)" || true; \
     fi
 
-# Install UV
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+# Install UV — download first, then run, so a curl failure is not masked by the pipe
+RUN curl -LsSf --retry 3 --retry-delay 5 https://astral.sh/uv/install.sh -o /tmp/uv-install.sh \
+    && env UV_INSTALL_DIR="/usr/local/bin" sh /tmp/uv-install.sh \
+    && rm -f /tmp/uv-install.sh \
+    && uv --version
 
 # This timeout (in seconds) is necessary when installing some dependencies via uv since it's likely to time out
 # Reference: https://github.com/astral-sh/uv/pull/1694


### PR DESCRIPTION
Fix silent UV installation failure in Dockerfile.rocm that causes uv: not found in the build_rixl stage. The curl ... | sh pipe masks curl failures. When curl times out, sh reads empty stdin and exits 0, so Docker reports the step as successful Download to a file first so curl failure is caught, add --retry 3 for transient SSL timeouts, and verify with uv --version.

cc @kenroche 