### PR TITLE
bugfix(dcp,mla): Fix empty-shard MLA DCP decode merge

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -265,8 +265,8 @@ from vllm.v1.attention.backends.mla.prefill import (
     get_mla_prefill_backend,
 )
 from vllm.v1.attention.backends.utils import (
-    expand_req_values_to_token,
     get_dcp_local_seq_lens,
+    get_empty_req_mask,
     split_decodes_and_prefills,
 )
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
@@ -788,16 +788,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             # correct dcp attn_out with lse.
             if self.impl.dcp_world_size > 1:
                 assert attn_metadata.decode is not None
-                local_seq_lens_per_token = expand_req_values_to_token(
-                    attn_metadata.decode.seq_lens,
-                    attn_metadata.query_start_loc[: attn_metadata.num_decodes + 1],
-                    num_tokens=attn_out.shape[0],
-                )
                 attn_out = self._dcp_combine(
                     attn_out,
                     lse,
                     get_dcp_group(),
-                    empty_req_mask=local_seq_lens_per_token.eq(0),
+                    empty_req_mask=attn_metadata.decode.empty_req_mask,
                 )
 
             # v_up projection
@@ -1251,6 +1246,7 @@ class MLACommonDecodeMetadata:
     block_table: torch.Tensor
     seq_lens: torch.Tensor
     dcp_tot_seq_lens: torch.Tensor | None
+    empty_req_mask: torch.Tensor | None
 
 
 D = TypeVar("D", bound=MLACommonDecodeMetadata)
@@ -1558,11 +1554,13 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        empty_req_mask: torch.Tensor | None,
     ) -> MLACommonDecodeMetadata:
         return MLACommonDecodeMetadata(
             block_table=block_table_tensor,
             seq_lens=seq_lens_device,
             dcp_tot_seq_lens=dcp_tot_seq_lens_device,
+            empty_req_mask=empty_req_mask,
         )
 
     def build_for_cudagraph_capture(
@@ -1816,6 +1814,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         decode_metadata = None
         if num_decodes > 0:
             dcp_tot_seq_lens_device = None
+            empty_req_mask = None
             if self.dcp_world_size > 1:
                 dcp_tot_seq_lens_device = seq_lens[:num_decodes]
                 seq_lens = dcp_local_seq_lens
@@ -1829,6 +1828,11 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 max_seq_len = (
                     (max_seq_len + num_partitions - 1) // num_partitions
                 ) * self.cp_kv_cache_interleave_size
+                empty_req_mask = get_empty_req_mask(
+                    seq_lens[:num_decodes],
+                    query_start_loc[: num_decodes + 1],
+                    num_tokens=num_decode_tokens,
+                )
 
             decode_metadata = self._build_decode(
                 block_table_tensor=block_table_tensor[:num_decodes, ...],
@@ -1838,6 +1842,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 query_start_loc_device=query_start_loc[: num_decodes + 1],
                 num_decode_tokens=num_decode_tokens,
                 dcp_tot_seq_lens_device=dcp_tot_seq_lens_device,
+                empty_req_mask=empty_req_mask,
             )
 
         attn_metadata = self.metadata_cls(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1818,6 +1818,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             if self.dcp_world_size > 1:
                 dcp_tot_seq_lens_device = seq_lens[:num_decodes]
                 seq_lens = dcp_local_seq_lens
+                assert seq_lens is not None
 
                 # After DCP distribution, the maximum number of tokens for any rank is
                 # ceil(L / (N * I)) * I, where L is max_seq_len, N is dcp_world_size,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -265,6 +265,7 @@ from vllm.v1.attention.backends.mla.prefill import (
     get_mla_prefill_backend,
 )
 from vllm.v1.attention.backends.utils import (
+    expand_req_values_to_token,
     get_dcp_local_seq_lens,
     split_decodes_and_prefills,
 )
@@ -485,11 +486,22 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         self.use_sparse = use_sparse
 
         _vllm_config = get_current_vllm_config_or_none()
-        self.dcp_a2a = (
+        dcp_a2a = (
             _vllm_config is not None
             and _vllm_config.parallel_config.decode_context_parallel_size > 1
             and _vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
+
+        if dcp_a2a:
+            self._dcp_combine = functools.partial(
+                dcp_a2a_lse_reduce,
+                is_lse_base_on_e=True,
+            )
+        else:
+            self._dcp_combine = functools.partial(
+                cp_lse_ag_out_rs,
+                is_lse_base_on_e=True,
+            )
 
         # Initialize q/k/v range constants.
         self.q_range = torch.tensor(envs.Q_SCALE_CONSTANT, dtype=torch.float32)
@@ -775,20 +787,18 @@ class MLAAttention(nn.Module, AttentionLayerBase):
 
             # correct dcp attn_out with lse.
             if self.impl.dcp_world_size > 1:
-                if self.dcp_a2a:
-                    attn_out = dcp_a2a_lse_reduce(
-                        attn_out,
-                        lse,
-                        get_dcp_group(),
-                        is_lse_base_on_e=True,
-                    )
-                else:
-                    attn_out = cp_lse_ag_out_rs(
-                        attn_out,
-                        lse,
-                        get_dcp_group(),
-                        is_lse_base_on_e=True,
-                    )
+                assert attn_metadata.decode is not None
+                local_seq_lens_per_token = expand_req_values_to_token(
+                    attn_metadata.decode.seq_lens,
+                    attn_metadata.query_start_loc[: attn_metadata.num_decodes + 1],
+                    num_tokens=attn_out.shape[0],
+                )
+                attn_out = self._dcp_combine(
+                    attn_out,
+                    lse,
+                    get_dcp_group(),
+                    empty_req_mask=local_seq_lens_per_token.eq(0),
+                )
 
             # v_up projection
             self._v_up_proj(attn_out, out=mqa_output_slice)

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -194,6 +194,7 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        empty_req_mask: torch.Tensor | None,
     ) -> FlashAttnMLADecodeMetadata:
         query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         max_query_len = query_lens_cpu.max().item()
@@ -248,6 +249,7 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
             scheduler_metadata=scheduler_metadata,
             max_num_splits=max_num_splits,
             dcp_tot_seq_lens=dcp_tot_seq_lens_device,
+            empty_req_mask=empty_req_mask,
         )
         return metadata
 

--- a/vllm/v1/attention/backends/mla/flashmla.py
+++ b/vllm/v1/attention/backends/mla/flashmla.py
@@ -158,6 +158,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        empty_req_mask: torch.Tensor | None,
     ) -> FlashMLADecodeMetadata:
         query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         # we use the max but all should be the same due to uniform length requirement
@@ -198,6 +199,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
             seq_lens=seq_lens_device,
             scheduler_metadata=scheduler_metadata,
             dcp_tot_seq_lens=dcp_tot_seq_lens_device,
+            empty_req_mask=empty_req_mask,
         )
 
 

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -418,6 +418,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        empty_req_mask: torch.Tensor | None,
     ) -> AiterMLADecodeMetadata:
         device = self.device
         num_reqs = seq_lens_device.size(0)
@@ -516,6 +517,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             paged_kv_last_page_len=paged_kv_last_page_len,
             qo_indptr=qo_indptr,
             dcp_tot_seq_lens=dcp_tot_seq_lens_device,
+            empty_req_mask=empty_req_mask,
             max_qo_len=max_qo_len,
             attn_out_dtype=self.decode_attn_out_dtype,
             has_persistent_metadata=has_persistent_metadata,

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -894,28 +894,29 @@ def get_dcp_local_seq_lens(
     return dcp_local_seq_lens.squeeze(1)
 
 
-def expand_req_values_to_token(
-    req_values: torch.Tensor,
+def get_empty_req_mask(
+    seq_lens: torch.Tensor,
     query_start_loc: torch.Tensor,
     num_tokens: int | None = None,
 ) -> torch.Tensor:
-    """Expand request-level values to token-level values using query offsets."""
+    """Calculate empty request mask by expanding request-level seq lens
+    to token-level and checking for zero-length (empty) sequences."""
     if num_tokens is None:
         num_tokens = query_start_loc[-1].item()
 
-    if req_values.shape[0] == num_tokens:
-        return req_values
+    if seq_lens.shape[0] == num_tokens:
+        return seq_lens.eq(0)
 
     query_lens = query_start_loc[1:] - query_start_loc[:-1]
-    assert query_lens.shape[0] == req_values.shape[0], (
-        "query_start_loc and req_values must have matching request dimension: "
-        f"{query_lens.shape[0]} vs {req_values.shape[0]}"
+    assert query_lens.shape[0] == seq_lens.shape[0], (
+        "query_start_loc and seq_lens must have matching request dimension: "
+        f"{query_lens.shape[0]} vs {seq_lens.shape[0]}"
     )
     return torch.repeat_interleave(
-        req_values,
+        seq_lens,
         query_lens.to(torch.long),
         output_size=num_tokens,
-    )
+    ).eq(0)
 
 
 def mamba_get_block_table_tensor(

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -898,9 +898,13 @@ def get_empty_req_mask(
     seq_lens: torch.Tensor,
     query_start_loc: torch.Tensor,
     num_tokens: int | None = None,
-) -> torch.Tensor:
+) -> torch.Tensor | None:
     """Calculate empty request mask by expanding request-level seq lens
-    to token-level and checking for zero-length (empty) sequences."""
+    to token-level and checking for zero-length (empty) sequences.
+    Returns None if no seq_lens are zero, avoiding unnecessary masking."""
+    if seq_lens.min() > 0:
+        return None
+
     if num_tokens is None:
         num_tokens = query_start_loc[-1].item()
 

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -894,6 +894,30 @@ def get_dcp_local_seq_lens(
     return dcp_local_seq_lens.squeeze(1)
 
 
+def expand_req_values_to_token(
+    req_values: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    num_tokens: int | None = None,
+) -> torch.Tensor:
+    """Expand request-level values to token-level values using query offsets."""
+    if num_tokens is None:
+        num_tokens = query_start_loc[-1].item()
+
+    if req_values.shape[0] == num_tokens:
+        return req_values
+
+    query_lens = query_start_loc[1:] - query_start_loc[:-1]
+    assert query_lens.shape[0] == req_values.shape[0], (
+        "query_start_loc and req_values must have matching request dimension: "
+        f"{query_lens.shape[0]} vs {req_values.shape[0]}"
+    )
+    return torch.repeat_interleave(
+        req_values,
+        query_lens.to(torch.long),
+        output_size=num_tokens,
+    )
+
+
 def mamba_get_block_table_tensor(
     block_table: torch.Tensor,
     seq_lens: torch.Tensor,

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -121,6 +121,7 @@ def correct_attn_out(
         lses: Tensor of shape [ N, B, H ]
         cp_rank: Current rank in the context-parallel group
         ctx: Triton context to avoid recompilation
+        is_lse_base_on_e: Whether the lse is based on natural log (e) or log2.
 
     Returns:
         Tuple of (out, lse) with corrected attention and final log-sum-exp.
@@ -184,6 +185,7 @@ def _cp_lse_common(
     cp_group: GroupCoordinator,
     ctx: CPTritonContext | None = None,
     is_lse_base_on_e=True,
+    empty_req_mask: torch.Tensor | None = None,
 ):
     """
     cp_attn_out: [ B, H, D ]
@@ -196,6 +198,9 @@ def _cp_lse_common(
         ctx = CPTritonContext()
 
     cp_attn_lse = cp_attn_lse.contiguous()
+    if empty_req_mask is not None:
+        cp_attn_lse.masked_fill_(empty_req_mask[:, None], -float("inf"))
+        cp_attn_out.masked_fill_(empty_req_mask[:, None, None], 0)
     lses = cp_group.all_gather(cp_attn_lse, dim=0).reshape(
         (cp_group.world_size,) + cp_attn_lse.shape
     )
@@ -216,13 +221,19 @@ def cp_lse_ag_out_rs(
     ctx: CPTritonContext | None = None,
     return_lse: bool = False,
     is_lse_base_on_e=True,
+    empty_req_mask: torch.Tensor | None = None,
 ):
     """
     cp_attn_out: [ B, H, D ]
     cp_attn_lse: [ B, H ]
     """
     out, lse = _cp_lse_common(
-        cp_attn_out, cp_attn_lse, cp_group, ctx=ctx, is_lse_base_on_e=is_lse_base_on_e
+        cp_attn_out,
+        cp_attn_lse,
+        cp_group,
+        ctx=ctx,
+        is_lse_base_on_e=is_lse_base_on_e,
+        empty_req_mask=empty_req_mask,
     )
     out = cp_group.reduce_scatter(out, dim=1)
 
@@ -241,13 +252,19 @@ def cp_lse_ag_out_ar(
     ctx: CPTritonContext | None = None,
     return_lse: bool = False,
     is_lse_base_on_e=True,
+    empty_req_mask: torch.Tensor | None = None,
 ):
     """
     cp_attn_out: [ B, H, D ]
     cp_attn_lse: [ B, H ]
     """
     out, lse = _cp_lse_common(
-        cp_attn_out, cp_attn_lse, cp_group, ctx=ctx, is_lse_base_on_e=is_lse_base_on_e
+        cp_attn_out,
+        cp_attn_lse,
+        cp_group,
+        ctx=ctx,
+        is_lse_base_on_e=is_lse_base_on_e,
+        empty_req_mask=empty_req_mask,
     )
     out = cp_group.all_reduce(out)
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -430,8 +430,8 @@ def dcp_a2a_lse_reduce(
     H_per_rank = H // world_size
 
     if empty_req_mask is not None:
-        cp_attn_out.masked_fill_(empty_req_mask[:, None], -float("inf"))
-        cp_attn_lse.masked_fill_(empty_req_mask[:, None, None], 0)
+        cp_attn_lse.masked_fill_(empty_req_mask[:, None], -float("inf"))
+        cp_attn_out.masked_fill_(empty_req_mask[:, None, None], 0)
 
     lse_pack_dim = _dcp_a2a_lse_pack_dim(cp_attn_out.dtype)
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -397,6 +397,7 @@ def dcp_a2a_lse_reduce(
     ctx: CPTritonContext | None = None,
     return_lse: bool = False,
     is_lse_base_on_e: bool = True,
+    empty_req_mask: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     Combine partial attention outputs across DCP ranks using All-to-All.
@@ -427,6 +428,11 @@ def dcp_a2a_lse_reduce(
     if H % world_size != 0:
         raise ValueError(f"H={H} must be divisible by DCP world size {world_size}.")
     H_per_rank = H // world_size
+
+    if empty_req_mask is not None:
+        cp_attn_out.masked_fill_(empty_req_mask[:, None], -float("inf"))
+        cp_attn_lse.masked_fill_(empty_req_mask[:, None, None], 0)
+
     lse_pack_dim = _dcp_a2a_lse_pack_dim(cp_attn_out.dtype)
 
     send_buffer, recv_buffer = _dcp_a2a_send_recv_buffers(


### PR DESCRIPTION
## Purpose
When enabling DCP with the MLA backend, shorter prompts can cause the kvcache on some devices to be empty. Many backends initialize LSE to 0 and cannot correctly handle empty kvcache inputs, leading to request wrong decoding tokens. This PR fixes the issue by resetting the output and LSE for empty kvcaches to 0 and -inf, respectively.

## Test Plan
```
vllm serve deepseek-ai/DeepSeek-V2-Lite-Chat -tp 8 -dcp 8
```
```
curl http://localhost:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "prompt": [
      "The capital of France is",
      "Who are you?",
      "Hello, my name is Tom, I am",
      "AI future is"
    ],
    "max_tokens": 10,
    "temperature": 0.95
  }'
```

## Test Result
Before fix:
```
{
    "id": "cmpl-bc62667af3ddc9fb",
    "object": "text_completion",
    "created": 1774669299,
    "model": "deepseek-ai/DeepSeek-V2-Lite-Chat",
    "choices": [
        {
            "index": 0,
            "text": " Paris!!!!!!!!!",
            "logprobs": null,
            "finish_reason": "length",
            "stop_reason": null,
            "token_ids": null,
            "prompt_logprobs": null,
            "prompt_token_ids": null
        },
        {
            "index": 1,
            "text": "\n!!!!!!!!!",
            "logprobs": null,
            "finish_reason": "length",
            "stop_reason": null,
            "token_ids": null,
            "prompt_logprobs": null,
            "prompt_token_ids": null
        },
        {
            "index": 2,
            "text": " a freelance digital and UI/UX designer living and",
            "logprobs": null,
            "finish_reason": "length",
            "stop_reason": null,
            "token_ids": null,
            "prompt_logprobs": null,
            "prompt_token_ids": null
        },
        {
            "index": 3,
            "text": " bright!!!!!!!!!",
            "logprobs": null,
            "finish_reason": "length",
            "stop_reason": null,
            "token_ids": null,
            "prompt_logprobs": null,
            "prompt_token_ids": null
        }
    ],
    "service_tier": null,
    "system_fingerprint": null,
    "usage": {
        "prompt_tokens": 25,
        "total_tokens": 65,
        "completion_tokens": 40,
        "prompt_tokens_details": null
    },
    "kv_transfer_params": null
}
```
After fix:
```
{
    "id": "cmpl-8c06f523bd39dadc",
    "object": "text_completion",
    "created": 1774665660,
    "model": "deepseek-ai/DeepSeek-V2-Lite-Chat",
    "choices": [
        {
            "index": 0,
            "text": " Paris. After Paris, the second-largest city",
            "logprobs": null,
            "finish_reason": "length",
            "stop_reason": null,
            "token_ids": null,
            "prompt_logprobs": null,
            "prompt_token_ids": null
        },
        {
            "index": 1,
            "text": "\nI am Cailin, I am a",
            "logprobs": null,
            "finish_reason": "length",
            "stop_reason": null,
            "token_ids": null,
            "prompt_logprobs": null,
            "prompt_token_ids": null
        },
        {
            "index": 2,
            "text": " 23 years old and come from the city",
            "logprobs": null,
            "finish_reason": "length",
            "stop_reason": null,
            "token_ids": null,
            "prompt_logprobs": null,
            "prompt_token_ids": null
        },
        {
            "index": 3,
            "text": " bright, says Cheadle MP, as government",
            "logprobs": null,
            "finish_reason": "length",
            "stop_reason": null,
            "token_ids": null,
            "prompt_logprobs": null,
            "prompt_token_ids": null
        }
    ],
    "service_tier": null,
    "system_fingerprint": null,
    "usage": {
        "prompt_tokens": 25,
        "total_tokens": 65,
        "completion_tokens": 40,
        "prompt_tokens_details": null
    },
    "kv_transfer_params": null
}
```

gsm8k result
```
local-completions ({'model': 'deepseek-ai/DeepSeek-V2-Lite-Chat', 'base_url': 'http://127.0.0.1:8000/v1/completions', 'num_concurrent': 128, 'max_retries': 5, 'timeout': 120, 'tokenizer_backend': 'auto', 'tokenized_requests': False}), gen_kwargs: ({}), limit: 1000.0, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.667|±  |0.0149|
|     |       |strict-match    |     5|exact_match|↑  |0.658|±  |0.0150|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

