### PR TITLE
fix: ensure CUDA context initialization before MemorySnapshot in EngineCore

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -278,6 +278,9 @@ class Worker(WorkerBase):
             gc.collect()
             torch.accelerator.empty_cache()
 
+            # Ensure CUDA context is fully initialized (needed for LD_PRELOAD shims)
+            torch.zeros(1, device=self.device)
+
             # take current memory snapshot
             self.init_snapshot = init_snapshot = MemorySnapshot(device=self.device)
             self.requested_memory = request_memory(init_snapshot, self.cache_config)


### PR DESCRIPTION
## Purpose

When vLLM's `EngineCore` subprocess (spawned via `multiprocessing.spawn`) calls
`MemorySnapshot(device=self.device)`, it invokes `torch.cuda.mem_get_info()` before
the CUDA context is fully initialized in the child process. This crashes with
`cudaErrorDeviceUninitialized` when `LD_PRELOAD` CUDA shims (e.g.
[NVIDIA GreenBoost](https://gitlab.com/IsolatedOctopi/nvidia_greenboost)) intercept
and alter the driver initialization sequence.

The fix adds `torch.zeros(1, device=self.device)` before the `MemorySnapshot` call,
which forces PyTorch to fully initialize the CUDA context in the subprocess.

## Duplicate check

```
gh pr list --repo vllm-project/vllm --state open --search "cudaErrorDeviceUninitialized in:title,body"
# [] — no results

gh pr list --repo vllm-project/vllm --state open --search "MemorySnapshot in:title,body"
# #35356 — UMA GPU detection (different issue)
# #35929 — UMA concurrent profiling race (different issue)
```

No existing PR addresses this failure mode.

## Test environment and results

Tested on real hardware with an `LD_PRELOAD` CUDA shim active
([NVIDIA GreenBoost](https://gitlab.com/IsolatedOctopi/nvidia_greenboost) —
VRAM oversubscription via `cuMemHostRegister`):

| Component | Value |
|-----------|-------|
| OS | Ubuntu 25.10 |
| GPU | Quadro RTX 5000 (Turing, sm_75, 16 GB) |
| Driver | NVIDIA 590.48.01 (proprietary) |
| CUDA toolkit | 12.4 |
| vLLM | 0.18.0 |
| Model | Qwen2.5-14B-Instruct FP16 (~28 GB) |

**Before patch**: vLLM crashes at startup with `cudaErrorDeviceUninitialized`
in the EngineCore subprocess when GreenBoost shim is loaded via `LD_PRELOAD`.

**After patch**: vLLM starts successfully, loads the model (14 GB overflow to
host RAM via GreenBoost DMA-BUF Path A), and serves inference at ~0.73 tok/s.

**Without shim**: vLLM starts normally (no regression). The added
`torch.zeros(1, ...)` is a no-op when the context is already initialized.

Full reproduction and setup: https://github.com/amasolov/vllm-greenboost

## AI assistance disclosure

This PR was authored with AI assistance (Cursor). I have reviewed every changed
line, tested the fix on hardware, and can defend the change end-to-end. The
underlying bug was discovered through manual debugging of CUDA context
initialization ordering in the EngineCore subprocess.