### PR TITLE
[Bugfix] Disallow renderer_num_workers > 1 with mm processor cache

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1131,6 +1131,28 @@ def test_needs_dp_coordination(
     assert vllm_config.needs_dp_coordinator == expected_needs_coordinator
 
 
+def test_renderer_num_workers_with_mm_cache():
+    """Disallow renderer_num_workers > 1 when mm processor cache is enabled,
+    since neither cache type is thread-safe."""
+    mm_model = "Qwen/Qwen2-VL-2B-Instruct"
+
+    # Should raise: multi-worker + cache enabled (default cache_gb=4)
+    with pytest.raises(ValueError, match="renderer-num-workers"):
+        ModelConfig(mm_model, renderer_num_workers=4)
+
+    # Should raise: multi-worker + explicit cache size
+    with pytest.raises(ValueError, match="renderer-num-workers"):
+        ModelConfig(mm_model, renderer_num_workers=2, mm_processor_cache_gb=1.0)
+
+    # Should pass: multi-worker + cache disabled
+    config = ModelConfig(mm_model, renderer_num_workers=4, mm_processor_cache_gb=0)
+    assert config.renderer_num_workers == 4
+
+    # Should pass: single worker + cache enabled (default)
+    config = ModelConfig(mm_model, renderer_num_workers=1)
+    assert config.renderer_num_workers == 1
+
+
 def test_eagle_draft_model_config():
     """Test that EagleDraft model config is correctly set."""
     target_model_config = ModelConfig(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -647,6 +647,19 @@ class ModelConfig:
 
             self.multimodal_config = MultiModalConfig(**mm_config_kwargs)  # type: ignore[arg-type]
 
+            if (
+                self.renderer_num_workers > 1
+                and self.multimodal_config.mm_processor_cache_gb > 0
+            ):
+                raise ValueError(
+                    "Cannot use --renderer-num-workers > 1 with the "
+                    "multimodal processor cache enabled. The cache is "
+                    "not thread-safe and does not support concurrent "
+                    "renderer workers. Please set "
+                    "--renderer-num-workers 1 (the default), or "
+                    "disable the cache with --mm-processor-cache-gb 0."
+                )
+
         # Multimodal GGUF models must use original repo for mm processing
         if is_gguf(self.tokenizer) and self.is_multimodal_model:
             raise ValueError(


### PR DESCRIPTION
## Purpose

Fix a bug where `--renderer-num-workers > 1` causes race conditions on the multimodal processor cache, leading to crashes or data corruption.

Neither the LRU nor SHM multimodal processor cache is thread-safe. The renderer's `ThreadPoolExecutor` dispatches multimodal preprocessing to multiple threads, which concurrently read/write the cache without synchronization. The SHM cache uses a `SingleWriterShmRingBuffer` that assumes a single writer, and the LRU cache is backed by `cachetools.LRUCache` which provides no thread-safety guarantees.

This PR adds a config-time validation that raises `ValueError` when `--renderer-num-workers > 1` is used with the cache enabled (`--mm-processor-cache-gb > 0`), directing users to either keep the default single worker or disable the cache.

Closes #38375

## Test Plan

```bash
python -m pytest tests/test_config.py::test_renderer_num_workers_with_mm_cache -v
```

## Test Result

Test covers four cases:
- `renderer_num_workers=4` + default cache (gb=4) → **raises ValueError** ✓
- `renderer_num_workers=2` + explicit cache (gb=1.0) → **raises ValueError** ✓
- `renderer_num_workers=4` + cache disabled (gb=0) → **passes** ✓
- `renderer_num_workers=1` + default cache → **passes** ✓

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results