### PR TITLE
-[Bugfix] Fix stable ABI build: pass torch::stable::Tensor by value

### DIFF
--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -4,27 +4,27 @@
 #include <torch/csrc/stable/tensor.h>
 
 #ifndef USE_ROCM
-torch::stable::Tensor permute_cols(torch::stable::Tensor const& A,
-                                   torch::stable::Tensor const& perm);
+torch::stable::Tensor permute_cols(torch::stable::Tensor A,
+                                   torch::stable::Tensor perm);
 
-void per_token_group_quant_fp8(const torch::stable::Tensor& input,
-                               torch::stable::Tensor& output_q,
-                               torch::stable::Tensor& output_s,
+void per_token_group_quant_fp8(torch::stable::Tensor input,
+                               torch::stable::Tensor output_q,
+                               torch::stable::Tensor output_s,
                                int64_t group_size, double eps, double fp8_min,
                                double fp8_max, bool scale_ue8m0,
                                bool dummy_is_scale_transposed,
                                bool dummy_is_tma_aligned);
 
 // Fused activation quantisation + DeepGEMM-compatible UE8M0-packed scales.
-void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
-                                       torch::stable::Tensor& output_q,
-                                       torch::stable::Tensor& output_s_packed,
+void per_token_group_quant_8bit_packed(torch::stable::Tensor input,
+                                       torch::stable::Tensor output_q,
+                                       torch::stable::Tensor output_s_packed,
                                        int64_t group_size, double eps,
                                        double min_8bit, double max_8bit);
 
-void per_token_group_quant_int8(const torch::stable::Tensor& input,
-                                torch::stable::Tensor& output_q,
-                                torch::stable::Tensor& output_s,
+void per_token_group_quant_int8(torch::stable::Tensor input,
+                                torch::stable::Tensor output_q,
+                                torch::stable::Tensor output_s,
                                 int64_t group_size, double eps, double int8_min,
                                 double int8_max);
 #endif

--- a/csrc/libtorch_stable/permute_cols.cu
+++ b/csrc/libtorch_stable/permute_cols.cu
@@ -67,8 +67,8 @@ __global__ void permute_cols_kernel(int4 const* __restrict__ a_int4_ptr,
 
 // More efficient version of A[..., perm]
 //  taken from gptq_marlin.cu
-torch::stable::Tensor permute_cols(torch::stable::Tensor const& A,
-                                   torch::stable::Tensor const& perm) {
+torch::stable::Tensor permute_cols(torch::stable::Tensor A,
+                                   torch::stable::Tensor perm) {
   const int32_t dev = A.get_device_index();
   const torch::stable::accelerator::DeviceGuard device_guard(dev);
   const auto stream = get_current_cuda_stream(dev);

--- a/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
@@ -156,9 +156,9 @@ inline int GetGroupsPerBlock(int64_t num_groups) {
   return 1;
 }
 
-void per_token_group_quant_8bit(const torch::stable::Tensor& input,
-                                torch::stable::Tensor& output_q,
-                                torch::stable::Tensor& output_s,
+void per_token_group_quant_8bit(torch::stable::Tensor input,
+                                torch::stable::Tensor output_q,
+                                torch::stable::Tensor output_s,
                                 int64_t group_size, double eps, double min_8bit,
                                 double max_8bit, bool scale_ue8m0) {
   STD_TORCH_CHECK(input.is_contiguous());
@@ -296,9 +296,9 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
                               threads_per_group, y_s, min_8bit, max_8bit);
 }
 
-void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
-                                       torch::stable::Tensor& output_q,
-                                       torch::stable::Tensor& output_s_packed,
+void per_token_group_quant_8bit_packed(torch::stable::Tensor input,
+                                       torch::stable::Tensor output_q,
+                                       torch::stable::Tensor output_s_packed,
                                        int64_t group_size, double eps,
                                        double min_8bit, double max_8bit) {
   STD_TORCH_CHECK(input.is_contiguous());
@@ -379,9 +379,9 @@ void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
 #undef LAUNCH_PACKED_KERNEL
 }
 
-void per_token_group_quant_fp8(const torch::stable::Tensor& input,
-                               torch::stable::Tensor& output_q,
-                               torch::stable::Tensor& output_s,
+void per_token_group_quant_fp8(torch::stable::Tensor input,
+                               torch::stable::Tensor output_q,
+                               torch::stable::Tensor output_s,
                                int64_t group_size, double eps, double fp8_min,
                                double fp8_max, bool scale_ue8m0,
                                bool dummy_is_scale_transposed = false,

--- a/csrc/libtorch_stable/quantization/w8a8/int8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/int8/per_token_group_quant.cu
@@ -2,9 +2,9 @@
 
 #include "libtorch_stable/quantization/w8a8/per_token_group_quant_8bit.h"
 
-void per_token_group_quant_int8(const torch::stable::Tensor& input,
-                                torch::stable::Tensor& output_q,
-                                torch::stable::Tensor& output_s,
+void per_token_group_quant_int8(torch::stable::Tensor input,
+                                torch::stable::Tensor output_q,
+                                torch::stable::Tensor output_s,
                                 int64_t group_size, double eps, double int8_min,
                                 double int8_max) {
   per_token_group_quant_8bit(input, output_q, output_s, group_size, eps,

--- a/csrc/libtorch_stable/quantization/w8a8/per_token_group_quant_8bit.h
+++ b/csrc/libtorch_stable/quantization/w8a8/per_token_group_quant_8bit.h
@@ -3,8 +3,8 @@
 #include <torch/csrc/stable/tensor.h>
 
 // 8-bit per-token-group quantization helper used by both FP8 and INT8
-void per_token_group_quant_8bit(const torch::stable::Tensor& input,
-                                torch::stable::Tensor& output_q,
-                                torch::stable::Tensor& output_s,
+void per_token_group_quant_8bit(torch::stable::Tensor input,
+                                torch::stable::Tensor output_q,
+                                torch::stable::Tensor output_s,
                                 int64_t group_size, double eps, double min_8bit,
                                 double max_8bit, bool scale_ue8m0 = false);


### PR DESCRIPTION
The stable ABI requires copyable types across the C-shim boundary, but all libtorch_stable function signatures used const references (const torch::stable::Tensor&) which are not copyable and cause static_assert failures during compilation.

Change all torch::stable::Tensor reference parameters to pass-by-value. This is safe because torch::stable::Tensor is a lightweight handle; copying it does not copy the underlying tensor data.

Fixes #38420




## Purpose

Fix `_C_stable_libtorch` compilation failure caused by `const torch::stable::Tensor&` references violating the stable ABI `trivially_copyable` requirement. Without this fix, `permute_cols` and `per_token_group_fp8_quant` ops are unavailable, blocking MTP speculative decoding with NVFP4 quantization on platforms like DGX Spark (SM121). Previously identified in #37744 but closed prematurely.

## Test Plan

- Build vLLM from source with PyTorch 2.10+ and verify `_C_stable_libtorch` compiles without errors
- Verify existing tests for `per_token_group_fp8_quant`, `permute_cols`, and `per_token_group_quant_int8` still pass

## Test Result

Built successfully from source with:
- PyTorch 2.10.0+cu128
- CUDA 12.8
- GCC 12.2.0
- NVIDIA L40S (SM89)
- `_C_stable_libtorch` compiled without errors

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1TYyVqrgX4gHfTrstbq8olWUlmOyPCKSGnJ7xtTpmXztlRs/edit?tab=t.0).
</details>

