### PR TITLE
[CI] Fix Ernie4.5-VL initialization test

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -791,7 +791,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "Ernie4_5_VLMoeForConditionalGeneration": _HfExamplesInfo(
         "baidu/ERNIE-4.5-VL-28B-A3B-PT",
         trust_remote_code=True,
-        revision="refs/pr/14",
+        revision="refs/pr/17",
     ),
     "FireRedASR2ForConditionalGeneration": _HfExamplesInfo(
         "allendou/FireRedASR2-LLM-vllm",


### PR DESCRIPTION
## Summary
- Update HF revision for `Ernie4_5_VLMoeForConditionalGeneration` test from `refs/pr/14` to `refs/pr/17`
- The upstream HF repo (`baidu/ERNIE-4.5-VL-28B-A3B-PT`) had two bugs fixed in [PR #17](https://huggingface.co/baidu/ERNIE-4.5-VL-28B-A3B-PT/discussions/17):
  1. `Ernie4_5_MoEConfig.__init__` accessed `self.num_hidden_layers` before parent set it, crashing `to_diff_dict()`
  2. Top-level `import decord` in `processing_ernie4_5_vl.py` blocked tokenizer loading when decord is not installed

## Test plan
- [x] `pytest tests/models/test_initialization.py::test_can_initialize_large_subset -k Ernie4_5_VLMoeForConditionalGeneration` passes