### PR TITLE
feat(nixl,dcp): Supports MLA DCP for PD disaggregation with nixl connector

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,8 +15,10 @@ import vllm.config.vllm as vllm_config_module
 import vllm.envs as envs
 from vllm.compilation.backends import VllmBackend
 from vllm.config import (
+    CacheConfig,
     CompilationConfig,
     KernelConfig,
+    KVTransferConfig,
     ModelConfig,
     ParallelConfig,
     PoolerConfig,
@@ -37,6 +39,27 @@ from vllm.platforms import current_platform
 from vllm.v1.attention.backend import AttentionCGSupport
 
 DEVICE_TYPE = current_platform.device_type
+
+
+def test_pd_dcp_interleave_size_is_adjusted_to_block_size(caplog):
+    config = VllmConfig(
+        cache_config=CacheConfig(block_size=16),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=2,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=3,
+        ),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="NixlConnector",
+            kv_role="kv_both",
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        config.validate_block_size()
+
+    assert config.parallel_config.cp_kv_cache_interleave_size == 16
+    assert "automatically adjusted from 3 to block_size 16" in caplog.text
 
 
 def test_compile_config_repr_succeeds():

--- a/tests/v1/kv_connector/nixl_integration/nixl_side_channel_probe.py
+++ b/tests/v1/kv_connector/nixl_integration/nixl_side_channel_probe.py
@@ -16,6 +16,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--host", required=True)
     parser.add_argument("--port", required=True, type=int)
     parser.add_argument("--pp-rank", default=0, type=int)
+    parser.add_argument("--pcp-rank", default=0, type=int)
     parser.add_argument("--rank", default=0, type=int)
     parser.add_argument("--timeout-ms", default=1000, type=int)
     return parser.parse_args()
@@ -38,7 +39,11 @@ def main() -> None:
     sock.setsockopt(zmq.RCVTIMEO, args.timeout_ms)
     try:
         sock.connect(make_zmq_path(args.host, args.port))
-        sock.send(msgspec.msgpack.encode((GET_META_MSG, args.pp_rank, args.rank)))
+        sock.send(
+            msgspec.msgpack.encode(
+                (GET_META_MSG, args.pp_rank, args.pcp_rank, args.rank)
+            )
+        )
         sock.recv()
     finally:
         sock.close()

--- a/tests/v1/kv_connector/unit/test_bidirectional_kv_transfer.py
+++ b/tests/v1/kv_connector/unit/test_bidirectional_kv_transfer.py
@@ -1043,7 +1043,7 @@ def test_handshake_listener_appends_perf_counter_frame():
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import zmq_ctx
     from vllm.utils.network_utils import get_open_port, make_zmq_path
 
-    encoded_data = {(0, 0): b"payload-rank-0"}
+    encoded_data = {(0, 0, 0): b"payload-rank-0"}
     ready_event = threading.Event()
     stop_event = threading.Event()
     host = "127.0.0.1"
@@ -1060,7 +1060,7 @@ def test_handshake_listener_appends_perf_counter_frame():
         with zmq_ctx(zmq.REQ, path) as sock:  # type: ignore[attr-defined]
             sock.setsockopt(zmq.RCVTIMEO, 5000)  # type: ignore[attr-defined]
             t0 = time.perf_counter()
-            sock.send(msgspec.msgpack.encode((GET_META_MSG, 0, 0)))
+            sock.send(msgspec.msgpack.encode((GET_META_MSG, 0, 0, 0)))
             parts = sock.recv_multipart()
             t1 = time.perf_counter()
         assert len(parts) == 2

--- a/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
+++ b/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
@@ -36,10 +36,7 @@ class _FakeExecutor:
 
     def get_kv_connector_handshake_metadata(
         self,
-    ) -> (
-        list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None]
-        | None
-    ):
+    ) -> list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None] | None:
         self.handshake_calls += 1
         return self.handshake_metadata
 
@@ -52,8 +49,7 @@ def _run_engine_core_handshake(
     connector: KVConnectorBase_V1,
     *,
     handshake_metadata: (
-        list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None]
-        | None
+        list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None] | None
     ),
 ) -> _FakeExecutor:
     class _FakeScheduler:

--- a/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
+++ b/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
@@ -21,7 +21,7 @@ class _Metadata(KVConnectorHandshakeMetadata):
 
 class _FakeExecutor:
     handshake_metadata_src: (
-        list[dict[tuple[int, int], KVConnectorHandshakeMetadata] | None] | None
+        list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None] | None
     )
     last_instance: "_FakeExecutor | None" = None
 
@@ -36,7 +36,10 @@ class _FakeExecutor:
 
     def get_kv_connector_handshake_metadata(
         self,
-    ) -> list[dict[tuple[int, int], KVConnectorHandshakeMetadata] | None] | None:
+    ) -> (
+        list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None]
+        | None
+    ):
         self.handshake_calls += 1
         return self.handshake_metadata
 
@@ -49,7 +52,8 @@ def _run_engine_core_handshake(
     connector: KVConnectorBase_V1,
     *,
     handshake_metadata: (
-        list[dict[tuple[int, int], KVConnectorHandshakeMetadata] | None] | None
+        list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None]
+        | None
     ),
 ) -> _FakeExecutor:
     class _FakeScheduler:
@@ -95,6 +99,7 @@ def _run_engine_core_handshake(
     )
 
     vllm_config = SimpleNamespace(
+        adjust_dcp_kv_cache_interleave_size=lambda: None,
         parallel_config=SimpleNamespace(data_parallel_rank_local=0),
         scheduler_config=SimpleNamespace(
             get_scheduler_cls=lambda: _FakeScheduler,
@@ -161,11 +166,11 @@ class _PPAwareConnector(_LegacyConnector):
     def __init__(self) -> None:
         super().__init__()
         self.pp_aware_metadata: (
-            dict[tuple[int, int], KVConnectorHandshakeMetadata] | None
+            dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None
         ) = None
 
     def set_xfer_handshake_metadata_pp_aware(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self, metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata]
     ) -> None:
         self.pp_aware_metadata = metadata
 
@@ -173,9 +178,9 @@ class _PPAwareConnector(_LegacyConnector):
 def test_engine_unwraps_handshake_metadata_for_legacy_connector(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Engine core always asks workers for `(pp_rank, tp_rank)`-keyed metadata,
+    """Engine core asks for `(pp_rank, pcp_rank, tp_rank)`-keyed metadata,
     then unwraps to `{tp_rank: metadata}` for a connector that has not opted
-    into PP-aware handshake (single-PP producer, all `pp_rank == 0`)."""
+    into PP/PCP-aware handshake (all `pp_rank == pcp_rank == 0`)."""
     metadata_0 = _Metadata()
     metadata_1 = _Metadata()
     connector = _LegacyConnector()
@@ -184,9 +189,9 @@ def test_engine_unwraps_handshake_metadata_for_legacy_connector(
         monkeypatch,
         connector,
         handshake_metadata=[
-            {(0, 0): metadata_0},
+            {(0, 0, 0): metadata_0},
             None,
-            {(0, 1): metadata_1},
+            {(0, 0, 1): metadata_1},
         ],
     )
 
@@ -194,26 +199,29 @@ def test_engine_unwraps_handshake_metadata_for_legacy_connector(
     assert connector.legacy_metadata == {0: metadata_0, 1: metadata_1}
 
 
-def test_engine_rejects_pp_producer_for_legacy_connector(
+@pytest.mark.parametrize("remote_key", [(1, 0, 0), (0, 1, 0)])
+def test_engine_rejects_pp_or_pcp_producer_for_legacy_connector(
     monkeypatch: pytest.MonkeyPatch,
+    remote_key: tuple[int, int, int],
 ) -> None:
-    """A connector that has not opted into PP-aware handshake must not silently
-    drop metadata from `pp_rank > 0`; engine core init raises instead."""
+    """A connector without topology-aware handshake rejects PP/PCP metadata."""
     connector = _LegacyConnector()
 
-    with pytest.raises(ValueError, match="does not support PP-disaggregated"):
+    with pytest.raises(ValueError, match="does not support PP/PCP-disaggregated"):
         _run_engine_core_handshake(
             monkeypatch,
             connector,
-            handshake_metadata=[{(0, 0): _Metadata()}, {(1, 0): _Metadata()}],
+            handshake_metadata=[
+                {(0, 0, 0): _Metadata()},
+                {remote_key: _Metadata()},
+            ],
         )
 
 
 def test_engine_passes_handshake_metadata_through_for_pp_aware_connector(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A PP-aware connector receives the full `(pp_rank, tp_rank)`-keyed dict
-    unchanged."""
+    """A PP/PCP-aware connector receives the full topology-keyed dict."""
     metadata_0 = _Metadata()
     metadata_1 = _Metadata()
     connector = _PPAwareConnector()
@@ -221,12 +229,15 @@ def test_engine_passes_handshake_metadata_through_for_pp_aware_connector(
     executor = _run_engine_core_handshake(
         monkeypatch,
         connector,
-        handshake_metadata=[{(0, 0): metadata_0}, {(1, 0): metadata_1}],
+        handshake_metadata=[
+            {(0, 0, 0): metadata_0},
+            {(1, 0, 0): metadata_1},
+        ],
     )
 
     assert executor.handshake_calls == 1
     assert connector.legacy_metadata is None
     assert connector.pp_aware_metadata == {
-        (0, 0): metadata_0,
-        (1, 0): metadata_1,
+        (0, 0, 0): metadata_0,
+        (1, 0, 0): metadata_1,
     }

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -433,6 +433,8 @@ def test_kv_transfer_handshake(dist_init):
         )
         assert delay
 
+        assert "pp_size" in kv_connector_metadata
+        assert kv_connector_metadata["pp_size"] == 1
         # Decode connector will be able to create handshake with the prefill connector.
         decode_connector = NixlConnector(
             vllm_config, KVConnectorRole.WORKER, kv_cache_config
@@ -454,10 +456,12 @@ def test_kv_transfer_handshake(dist_init):
                 kv_connector_metadata["remote_engine_id"],
             )
 
-            received_metadata = mock_add_remote_agent.call_args.args
-            assert received_metadata[0] == expected_agent_metadata
-            assert received_metadata[1] == 0  # remote_tp_rank
-            assert received_metadata[2] == 1  # remote_tp_size
+            received_call = mock_add_remote_agent.call_args
+            assert received_call.args[0] == expected_agent_metadata
+            assert received_call.kwargs["remote_tp_rank"] == 0
+            assert received_call.kwargs["remote_tp_size"] == 1
+            assert received_call.kwargs["remote_pp_rank"] == 0
+            assert received_call.kwargs["remote_pp_size"] == 1
 
         # Need to shutdown the background thread to release NIXL side channel port
         scheduler_connector.shutdown()

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -409,9 +409,11 @@ def test_kv_transfer_handshake(dist_init):
         expected_agent_metadata = decoder.decode(metadata.agent_metadata_bytes)
 
         # The scheduler connector expects metadata keyed by
-        # (pp_rank, tp_rank).
+        # (pp_rank, pcp_rank, tp_rank).
         scheduler_connector = scheduler.get_kv_connector()
-        scheduler_connector.set_xfer_handshake_metadata_pp_aware({(0, 0): metadata})
+        scheduler_connector.set_xfer_handshake_metadata_pp_aware(
+            {(0, 0, 0): metadata}
+        )
 
         # Simulate a request that finishes prefill, which returns
         # corresponding NixlConnectorMetadata for decode instance.

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -508,8 +508,10 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         remote_tp_size: int,
         expected_engine_id: str,
         remote_pp_size: int = 1,
+        remote_dcp_size: int = 1,
+        remote_pcp_size: int = 1,
         notif_agents_only: bool = False,
-    ) -> tuple[dict[tuple[int, int], str], float]:
+    ) -> tuple[dict[tuple[int, int, int], str], float]:
         # Mimic slow _nixl_handshake, as well as bypass zmq communication.
         time.sleep(self._hand_shake_latency)
         # These should've been done in register_kv_caches(), called by
@@ -539,7 +541,7 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         # When remote tp_size > local tp_size, handshake with multiple
         # remote ranks.
         num_handshakes = 1 if tp_ratio > 0 else -tp_ratio
-        remote_agents: dict[tuple[int, int], str] = {}
+        remote_agents: dict[tuple[int, int, int], str] = {}
         for remote_tp_rank in range(num_handshakes):
             remote_agent_name = self.add_remote_agent(
                 NixlAgentMetadata(
@@ -557,10 +559,14 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
                     attn_backend_name=self.backend_name,
                     physical_blocks_per_logical_kv_block=1,
                 ),
+                remote_dcp_size=remote_dcp_size,
+                remote_pcp_size=remote_pcp_size,
+                remote_pcp_rank=0,
+                remote_pp_rank=0,
                 remote_tp_rank=remote_tp_rank,
                 remote_tp_size=remote_tp_size,
             )
-            remote_agents[(0, remote_tp_rank)] = remote_agent_name
+            remote_agents[(0, 0, remote_tp_rank)] = remote_agent_name
         # Handshake bypasses zmq, so report a zero clock offset to the peer.
         return remote_agents, 0.0
 
@@ -598,7 +604,7 @@ class TestNixlHandshake:
         worker = connector.connector_worker
         # simulate handshake
         worker.dst_xfer_side_handles = {
-            FakeNixlConnectorWorker.REMOTE_ENGINE_ID: {0: 1}
+            FakeNixlConnectorWorker.REMOTE_ENGINE_ID: {(0, 0, 0): 1}
         }
         worker.kv_cache_layout = "HND"
         num_xfers = 4
@@ -759,7 +765,7 @@ class TestNixlHandshake:
 
         def check_handshake(remote_tp_size: int):
             tp_ratio = remote_tp_size // local_tp_size
-            assert set(remote_agents.keys()) == {(0, r) for r in range(tp_ratio)}
+            assert set(remote_agents.keys()) == {(0, 0, r) for r in range(tp_ratio)}
 
             remote_engine_id = worker.REMOTE_ENGINE_ID
             remote_info = worker.transfer_topo.get_engine_info(remote_engine_id)
@@ -771,7 +777,7 @@ class TestNixlHandshake:
             assert len(worker.src_xfer_handles_by_tp_ratio[split_key]) == tp_ratio
             assert remote_engine_id in worker.dst_xfer_side_handles
             assert set(worker.dst_xfer_side_handles[remote_engine_id].keys()) == set(
-                range(tp_ratio)
+                (0, 0, rank) for rank in range(tp_ratio)
             )
 
         remote_agents, _ = worker._nixl_handshake(
@@ -2094,10 +2100,10 @@ def test_shutdown_cleans_up_resources(default_vllm_config, dist_init):
         worker.src_xfer_handles_by_block_size = {worker.block_size: 455}
         # P TP = 2 * D TP case, we should register 2 local handles
         worker.src_xfer_handles_by_tp_ratio = {(-2, 16): [456, 457]}
-        worker.dst_xfer_side_handles = {"engine1": {0: 789}}
-        worker._remote_agents = {"engine1": {(0, 0): "agent1"}}
+        worker.dst_xfer_side_handles = {"engine1": {(0, 0, 0): 789}}
+        worker._remote_agents = {"engine1": {(0, 0, 0): "agent1"}}
         # _cleanup_remote_engine (called by shutdown) also clears these:
-        worker.kv_caches_base_addr["engine1"] = {0: [0xABC]}
+        worker.kv_caches_base_addr["engine1"] = {(0, 0, 0): [0xABC]}
         worker.dst_num_blocks["engine1"] = 50
         worker.tp_mappings["engine1"] = MagicMock()
         worker._engine_last_active["engine1"] = time.perf_counter()
@@ -2148,9 +2154,12 @@ def _setup_worker_with_remote_engine(
     )
 
     engine_id = "remote-engine-1"
-    worker._remote_agents[engine_id] = {(0, 0): "agent_0", (0, 1): "agent_1"}
-    worker.dst_xfer_side_handles[engine_id] = {0: 100, 1: 200}
-    worker.kv_caches_base_addr[engine_id] = {0: [0xABC]}
+    worker._remote_agents[engine_id] = {
+        (0, 0, 0): "agent_0",
+        (0, 0, 1): "agent_1",
+    }
+    worker.dst_xfer_side_handles[engine_id] = {(0, 0, 0): 100, (0, 0, 1): 200}
+    worker.kv_caches_base_addr[engine_id] = {(0, 0, 0): [0xABC]}
     worker.dst_num_blocks[engine_id] = 50
     worker.tp_mappings[engine_id] = MagicMock()
     worker._engine_last_active[engine_id] = time.perf_counter()
@@ -3050,10 +3059,12 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
             local_block_len=worker.block_size * 4096,
         )
         worker._remote_agents[remote_engine_id] = {
-            (0, rank): f"agent_p{rank}" for rank in range(prefill_tp_size)
+            (0, 0, rank): f"agent_p{rank}" for rank in range(prefill_tp_size)
         }
         worker.dst_xfer_side_handles = {
-            remote_engine_id: {rank: 100 + rank for rank in range(prefill_tp_size)}
+            remote_engine_id: {
+                (0, 0, rank): 100 + rank for rank in range(prefill_tp_size)
+            }
         }
         # Sanity: D TP=1, P TP=4 => tp_ratio = -4 (P > D).
         assert worker.transfer_topo.tp_ratio(prefill_tp_size) == -prefill_tp_size
@@ -3101,7 +3112,7 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
 
         # Broadcast goes to ranks {1, 2, 3} only, never to the read target.
         expected_recipients = {
-            worker._remote_agents[remote_engine_id][(0, r)]
+            worker._remote_agents[remote_engine_id][(0, 0, r)]
             for r in range(1, prefill_tp_size)
         }
         assert {agent for agent, _ in send_notif_calls} == expected_recipients

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -411,9 +411,7 @@ def test_kv_transfer_handshake(dist_init):
         # The scheduler connector expects metadata keyed by
         # (pp_rank, pcp_rank, tp_rank).
         scheduler_connector = scheduler.get_kv_connector()
-        scheduler_connector.set_xfer_handshake_metadata_pp_aware(
-            {(0, 0, 0): metadata}
-        )
+        scheduler_connector.set_xfer_handshake_metadata_pp_aware({(0, 0, 0): metadata})
 
         # Simulate a request that finishes prefill, which returns
         # corresponding NixlConnectorMetadata for decode instance.

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -3,7 +3,7 @@
 """Unit tests for NixlConnectorScheduler with HMA and Mamba N-1 prefill."""
 
 import gc
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -61,6 +61,37 @@ def test_sw_sizes(mock_platform, swa_enabled, expected_sw_sizes):
     assert scheduler.blocks_per_sw == expected_sw_sizes, (
         f"Expected sw_sizes={expected_sw_sizes}, got {scheduler.blocks_per_sw}"
     )
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    "use_mla,source_ranks,tp_ratio,expected",
+    [
+        pytest.param(True, (0,), -2, False, id="pure_mla_with_remote_dcp"),
+        pytest.param(True, (0, 1), -2, True, id="hybrid_mla_ssm"),
+        pytest.param(False, (0,), -2, True, id="full_attention"),
+        pytest.param(False, (0,), 2, False, id="local_tp_greater"),
+    ],
+)
+def test_needs_split_local_xfer_handles(
+    use_mla, source_ranks, tp_ratio, expected
+):
+    """Handle creation and selection must use the same TP-mapping predicate.
+
+    In pure MLA, DCP can target several physical remote workers even though
+    the TP mapping has one replicated attention source. Those workers own
+    disjoint blocks, so every read uses the whole local-region handle.
+    """
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker.use_mla = use_mla
+    plan = MagicMock()
+    plan.all_source_ranks = source_ranks
+
+    assert worker._needs_split_local_xfer_handles(tp_ratio, plan) is expected
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -73,9 +73,7 @@ def test_sw_sizes(mock_platform, swa_enabled, expected_sw_sizes):
         pytest.param(False, (0,), 2, False, id="local_tp_greater"),
     ],
 )
-def test_needs_split_local_xfer_handles(
-    use_mla, source_ranks, tp_ratio, expected
-):
+def test_needs_split_local_xfer_handles(use_mla, source_ranks, tp_ratio, expected):
     """Handle creation and selection must use the same TP-mapping predicate.
 
     In pure MLA, DCP can target several physical remote workers even though

--- a/tests/v1/kv_connector/unit/test_nixl_heartbeat.py
+++ b/tests/v1/kv_connector/unit/test_nixl_heartbeat.py
@@ -7,6 +7,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    HeartbeatInfo,
+    NixlConnectorMetadata,
+)
 from vllm.v1.outputs import KVConnectorOutput
 
 from .utils import create_request, make_nixl_scheduler
@@ -54,6 +58,29 @@ def test_on_new_request_tracks_and_groups():
     r3.kv_transfer_params["remote_engine_id"] = "engine-b"
     s.on_new_request(r3)
     assert len(s._heartbeat_by_engine) == 2
+
+
+def test_on_new_request_preserves_all_parallel_sizes():
+    s = _sched()
+    request = _req(1)
+    request.kv_transfer_params.update(
+        {
+            "tp_size": 4,
+            "dcp_size": 2,
+            "pcp_size": 2,
+            "pp_size": 3,
+        }
+    )
+
+    s.on_new_request(request)
+
+    info = s._heartbeat_by_engine[_ENGINE_A]
+    assert (info.tp_size, info.dcp_size, info.pcp_size, info.pp_size) == (
+        4,
+        2,
+        2,
+        3,
+    )
 
 
 @pytest.mark.parametrize(
@@ -163,3 +190,32 @@ def test_handle_heartbeat():
     assert w._reqs_to_send["req-b"] >= far_future
     # req-unknown: not added.
     assert "req-unknown" not in w._reqs_to_send
+
+
+def test_send_heartbeat_preserves_all_parallel_sizes():
+    w = _worker_stub()
+    w._hb_handshake_notif_only = True
+    w._ensure_handshake = MagicMock(return_value=MagicMock())
+    metadata = NixlConnectorMetadata()
+    metadata.heartbeat_by_engine[_ENGINE_A] = HeartbeatInfo(
+        req_ids={"prefill-1"},
+        host="my-host",
+        port=1234,
+        tp_size=4,
+        dcp_size=2,
+        pcp_size=2,
+        pp_size=3,
+    )
+
+    w._send_heartbeats(metadata)
+
+    w._ensure_handshake.assert_called_once_with(
+        _ENGINE_A,
+        "my-host",
+        1234,
+        4,
+        2,
+        2,
+        3,
+        True,
+    )

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -545,7 +545,7 @@ def test_do_start_push_kv_defers_then_writes_when_handshake_ready():
 
     # Handshake completes: request re-queued for the writer, wake set, but no
     # *direct* WRITE from the callback (wrong thread for NIXL ops).
-    fut.set_result(({(0, 0): "agent"}, 0.0))
+    fut.set_result(({(0, 0, 0): "agent"}, 0.0))
     assert xfer_calls == []
     assert w._push_writer_wake.is_set()
     rid, blocks, reg = w._deferred_push_inbox.get_nowait()
@@ -568,7 +568,7 @@ def test_do_start_push_kv_drops_request_on_handshake_failure():
     the failure is logged. Blocks are reclaimed by the lease/watchdog, matching
     the old blocking behaviour."""
     w = _StubWriterWorker.fresh()
-    w._logical_to_kernel_block_ids = lambda x: x
+    w._logical_to_kernel_block_ids = lambda x, ratio: x
     xfer_calls: list[dict[str, Any]] = []
     w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
     failures: list[dict[str, Any]] = []
@@ -930,6 +930,38 @@ class TestPushWriterNegative:
         assert "req-unknown" not in w._reqs_to_send
 
 
+class TestPushTopologyHandshake:
+    def test_reverse_handshake_forwards_decode_topology(self):
+        w = _StubWriterWorker.fresh()
+        w._ensure_handshake = MagicMock(return_value=None)
+        w._logical_to_kernel_block_ids = lambda x, ratio: x
+        w._xfer_blocks_for_req = MagicMock()
+        registration_data = _registration_data(
+            "req",
+            decode_engine_id="decode-engine",
+            decode_host="10.0.0.2",
+            decode_port=5602,
+            decode_tp_size=2,
+        )
+        registration_data.update(
+            decode_dcp_size=2,
+            decode_pcp_size=2,
+            decode_pp_size=2,
+        )
+
+        _real_do_start_push_kv(w, "req", ([1, 2],), registration_data)
+
+        w._ensure_handshake.assert_called_once_with(
+            "decode-engine",
+            "10.0.0.2",
+            5602,
+            2,
+            dcp_size=2,
+            pcp_size=2,
+            pp_size=2,
+        )
+
+
 # ----------------------------------------------------------------- #
 #  Pipeline-parallel producer (push-mode PP-disagg)                  #
 # ----------------------------------------------------------------- #
@@ -946,7 +978,9 @@ class TestPushPipelineParallel:
         w.transfer_topo = MagicMock()
         request_id = "req-pp-2"
         w._recving_metadata[request_id] = MagicMock(pp_size=2)
-        notif = f"{request_id}:1".encode()
+        # The notification payload carries the total physical producer count,
+        # including PP stages.
+        notif = f"{request_id}:2".encode()
 
         # First stage: counted, not yet done.
         w._pending_completion_notifs.put(notif)
@@ -1039,14 +1073,27 @@ class TestPushWriterMlaReplication:
         w = _StubWriterWorker.fresh()
         w.use_mla = True
         w.pp_rank = 0
+        w.pp_size = 1
         w.nixl_wrapper = MagicMock()
         w.transfer_topo = MagicMock()
         w.transfer_topo.get_engine_info.return_value = SimpleNamespace(
             remote_tp_size=len(d_ranks),
+            remote_dcp_size=1,
+            remote_pcp_size=1,
+            remote_pp_size=1,
             remote_block_size=16,
             remote_physical_blocks_per_logical=1,
         )
         w.transfer_topo.resolve_remote_pp_rank.return_value = 0
+        w.transfer_topo.get_target_remote_worker_keys_from_engine_id.return_value = [
+            (0, rank) for rank in d_ranks
+        ]
+        w.transfer_topo.get_dcp_rank.return_value = 0
+        w.transfer_topo.get_matched_blocks.side_effect = (
+            lambda local_ids, remote_ids, *_args: (local_ids, remote_ids)
+        )
+        w.transfer_topo.calculate_local_consumer_count.return_value = 1
+        w.transfer_topo.get_local_pp_producer_count.return_value = 1
         # D_TP > P_TP => negative ratio (one P rank feeds |ratio| D ranks).
         w.transfer_topo.tp_ratio.return_value = -len(d_ranks)
         # The tp-mapping collapses MLA to a single source rank (correct for
@@ -1059,7 +1106,9 @@ class TestPushWriterMlaReplication:
                 rank_offset_factor=0,
             )
         }
+        w._physical_blocks_per_logical_kv_block = 1
         w._logical_to_kernel_block_ids = lambda block_ids, ratio: block_ids
+        w._logical_to_remote_kernel_block_ids = lambda block_ids, ratio: block_ids
         w.dst_xfer_side_handles = {engine_id: {(0, 0, r): 1000 + r for r in d_ranks}}
         w.src_xfer_handles_by_block_size = {16: 2000}
         w._remote_agents = {engine_id: {(0, 0, r): f"agent-{r}" for r in d_ranks}}

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -1038,6 +1038,7 @@ class TestPushWriterMlaReplication:
         engine_id = "decode-engine"
         w = _StubWriterWorker.fresh()
         w.use_mla = True
+        w.pp_rank = 0
         w.nixl_wrapper = MagicMock()
         w.transfer_topo = MagicMock()
         w.transfer_topo.get_engine_info.return_value = SimpleNamespace(
@@ -1045,6 +1046,7 @@ class TestPushWriterMlaReplication:
             remote_block_size=16,
             remote_physical_blocks_per_logical=1,
         )
+        w.transfer_topo.resolve_remote_pp_rank.return_value = 0
         # D_TP > P_TP => negative ratio (one P rank feeds |ratio| D ranks).
         w.transfer_topo.tp_ratio.return_value = -len(d_ranks)
         # The tp-mapping collapses MLA to a single source rank (correct for
@@ -1058,9 +1060,9 @@ class TestPushWriterMlaReplication:
             )
         }
         w._logical_to_kernel_block_ids = lambda block_ids, ratio: block_ids
-        w.dst_xfer_side_handles = {engine_id: {r: 1000 + r for r in d_ranks}}
+        w.dst_xfer_side_handles = {engine_id: {(0, 0, r): 1000 + r for r in d_ranks}}
         w.src_xfer_handles_by_block_size = {16: 2000}
-        w._remote_agents = {engine_id: {(0, r): f"agent-{r}" for r in d_ranks}}
+        w._remote_agents = {engine_id: {(0, 0, r): f"agent-{r}" for r in d_ranks}}
         return w, engine_id
 
     def test_mla_hetero_tp_writes_every_d_rank(self):

--- a/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
+++ b/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
@@ -205,3 +205,28 @@ def test_target_worker_keys_preserve_pcp_identity() -> None:
     )
 
     assert keys == [(0, 0), (1, 0)]
+
+
+def test_pp_stage_routing_matches_equal_size_stage() -> None:
+    assert TransferTopology.get_target_remote_pp_ranks(
+        local_pp_rank=1,
+        local_pp_size=2,
+        remote_pp_size=2,
+    ) == [1]
+
+
+def test_pp_stage_routing_maps_sharded_local_to_unsharded_remote() -> None:
+    assert TransferTopology.get_target_remote_pp_ranks(
+        local_pp_rank=1,
+        local_pp_size=2,
+        remote_pp_size=1,
+    ) == [0]
+
+
+def test_pp_stage_routing_rejects_ambiguous_remote_stages() -> None:
+    with pytest.raises(NotImplementedError, match="multiple remote PP stages"):
+        TransferTopology.get_target_remote_pp_ranks(
+            local_pp_rank=0,
+            local_pp_size=1,
+            remote_pp_size=2,
+        )

--- a/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
+++ b/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
@@ -27,6 +27,9 @@ def _make_topology(
     tp_rank: int = 1,
     tp_size: int = 4,
     total_num_kv_heads: int = 8,
+    dcp_rank: int = 0,
+    dcp_size: int = 1,
+    pcp_size: int = 1,
 ) -> TransferTopology:
     return TransferTopology(
         tp_rank=tp_rank,
@@ -37,6 +40,9 @@ def _make_topology(
         is_mamba=False,
         total_num_kv_heads=total_num_kv_heads,
         attn_backends=[_FakeAttentionBackend],
+        dcp_rank=dcp_rank,
+        dcp_size=dcp_size,
+        pcp_size=pcp_size,
     )
 
 
@@ -144,3 +150,58 @@ def test_engine_info_fields_have_backward_compatible_defaults() -> None:
     assert registered.remote_pp_rank == 0
     assert registered.start_layer == 0
     assert registered.end_layer == 0
+
+
+def test_worker_keys_keep_pcp_workers_distinct_when_dcp_aliases() -> None:
+    keys = TransferTopology.get_valid_worker_keys(
+        tp_size=2,
+        dcp_size=1,
+        pcp_size=2,
+    )
+
+    assert keys == [(0, 0), (0, 1), (1, 0), (1, 1)]
+    assert len(keys) == 4
+
+
+@pytest.mark.parametrize(
+    ("pcp_rank", "tp_rank", "expected_dcp_rank"),
+    [
+        (0, 0, 0),
+        (1, 0, 1),
+        (0, 1, 0),
+        (1, 1, 1),
+    ],
+)
+def test_dcp_rank_is_derived_from_physical_worker_key(
+    pcp_rank: int,
+    tp_rank: int,
+    expected_dcp_rank: int,
+) -> None:
+    assert (
+        TransferTopology.get_dcp_rank(
+            tp_rank=tp_rank,
+            pcp_rank=pcp_rank,
+            pcp_size=2,
+            dcp_size=2,
+        )
+        == expected_dcp_rank
+    )
+
+
+def test_target_worker_keys_preserve_pcp_identity() -> None:
+    topology = _make_topology(
+        tp_rank=0,
+        tp_size=2,
+        total_num_kv_heads=2,
+        dcp_rank=0,
+        dcp_size=1,
+        pcp_size=2,
+    )
+
+    keys = topology.get_target_remote_worker_keys(
+        remote_tp_size=2,
+        remote_dcp_size=1,
+        remote_pcp_size=2,
+    )
+
+    assert keys == [(0, 0), (1, 0)]

--- a/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
+++ b/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
@@ -30,13 +30,14 @@ def _make_topology(
     dcp_rank: int = 0,
     dcp_size: int = 1,
     pcp_size: int = 1,
+    is_mla: bool = False,
 ) -> TransferTopology:
     return TransferTopology(
         tp_rank=tp_rank,
         tp_size=tp_size,
         block_size=16,
         engine_id="local-engine",
-        is_mla=False,
+        is_mla=is_mla,
         is_mamba=False,
         total_num_kv_heads=total_num_kv_heads,
         attn_backends=[_FakeAttentionBackend],
@@ -207,6 +208,78 @@ def test_target_worker_keys_preserve_pcp_identity() -> None:
     assert keys == [(0, 0), (1, 0)]
 
 
+@pytest.mark.parametrize(
+    ("local_pcp_rank", "expected_keys"),
+    [
+        (0, [(0, 0)]),
+        (1, [(1, 0)]),
+    ],
+)
+def test_tp2_pcp2_dcp2_routes_by_head_and_interleave(
+    local_pcp_rank: int,
+    expected_keys: list[tuple[int, int]],
+) -> None:
+    topology = _make_topology(
+        tp_rank=0,
+        tp_size=2,
+        total_num_kv_heads=2,
+        dcp_rank=local_pcp_rank,
+        dcp_size=2,
+        pcp_size=2,
+    )
+
+    assert (
+        topology.get_target_remote_worker_keys(
+            remote_tp_size=2,
+            remote_dcp_size=2,
+            remote_pcp_size=2,
+        )
+        == expected_keys
+    )
+
+
+def test_mla_target_preserves_representative_and_dcp_slice() -> None:
+    topology = _make_topology(
+        tp_rank=0,
+        tp_size=2,
+        total_num_kv_heads=1,
+        dcp_rank=0,
+        dcp_size=2,
+        pcp_size=2,
+        is_mla=True,
+    )
+
+    # One representative TP replica is selected, and the PCP rank still
+    # follows the DCP token slice.
+    assert topology.get_target_remote_worker_keys(
+        remote_tp_size=2,
+        remote_dcp_size=2,
+        remote_pcp_size=2,
+    ) == [(0, 0)]
+
+
+@pytest.mark.parametrize(
+    ("local_pp_size", "remote_pp_size", "expected_count"),
+    [
+        (1, 1, 1),
+        (2, 2, 1),
+        (2, 1, 2),
+    ],
+)
+def test_local_pp_producer_count(
+    local_pp_size: int,
+    remote_pp_size: int,
+    expected_count: int,
+) -> None:
+    assert (
+        TransferTopology.get_local_pp_producer_count(
+            local_pp_size,
+            remote_pp_size,
+        )
+        == expected_count
+    )
+
+
 def test_pp_stage_routing_matches_equal_size_stage() -> None:
     assert TransferTopology.get_target_remote_pp_ranks(
         local_pp_rank=1,
@@ -230,3 +303,12 @@ def test_pp_stage_routing_rejects_ambiguous_remote_stages() -> None:
             local_pp_size=1,
             remote_pp_size=2,
         )
+
+
+def test_notif_only_pp_routing_can_fan_out_to_remote_stages() -> None:
+    assert TransferTopology.get_target_remote_pp_ranks(
+        local_pp_rank=0,
+        local_pp_size=1,
+        remote_pp_size=2,
+        notif_only=True,
+    ) == [0, 1]

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2274,6 +2274,19 @@ class VllmConfig:
                 "than or equal to and divisible by cp_kv_cache_interleave_size "
                 f"({self.parallel_config.cp_kv_cache_interleave_size})."
             )
+            if (
+                self.kv_transfer_config is not None
+                and self.kv_transfer_config.kv_connector is not None
+            ):
+                interleave = self.parallel_config.cp_kv_cache_interleave_size
+                dcp_size = self.parallel_config.decode_context_parallel_size
+                assert interleave == block_size, (
+                    "When using PD disaggregation with DCP "
+                    f"(decode_context_parallel_size={dcp_size}), "
+                    f"cp_kv_cache_interleave_size ({interleave}) must match "
+                    f"block_size ({block_size}) for block-level alignment. "
+                    f"Set --cp-kv-cache-interleave-size to {block_size}."
+                )
 
         # Mamba cache align-mode constraints
         if self.cache_config.mamba_cache_mode == "align":

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2244,6 +2244,43 @@ class VllmConfig:
                 "request parameter. Set VLLM_USE_V2_MODEL_RUNNER=0 if this is required."
             )
 
+    def adjust_dcp_kv_cache_interleave_size(self) -> None:
+        """Normalize DCP interleave size before configs are sent to workers."""
+        dcp_size = self.parallel_config.decode_context_parallel_size
+        if dcp_size <= 1:
+            return
+
+        if self.parallel_config.dcp_kv_cache_interleave_size > 1 and (
+            self.parallel_config.cp_kv_cache_interleave_size
+            != self.parallel_config.dcp_kv_cache_interleave_size
+        ):
+            self.parallel_config.cp_kv_cache_interleave_size = (
+                self.parallel_config.dcp_kv_cache_interleave_size
+            )
+            logger.warning_once(
+                "cp_kv_cache_interleave_size is overridden by dcp_kv_cache"
+                "_interleave_size. And dcp-kv-cache-interleave-size will be "
+                "deprecated when PCP is fully supported."
+            )
+
+        block_size = self.cache_config.block_size
+        if (
+            self.kv_transfer_config is not None
+            and self.kv_transfer_config.kv_connector is not None
+            and self.parallel_config.cp_kv_cache_interleave_size != block_size
+        ):
+            interleave = self.parallel_config.cp_kv_cache_interleave_size
+            self.parallel_config.cp_kv_cache_interleave_size = block_size
+            logger.warning_once(
+                "When using PD disaggregation with DCP "
+                "(decode_context_parallel_size=%d), "
+                "cp_kv_cache_interleave_size is automatically adjusted "
+                "from %d to block_size %d for block-level alignment.",
+                dcp_size,
+                interleave,
+                block_size,
+            )
+
     def validate_block_size(self) -> None:
         """Validate block_size against DCP and mamba constraints.
 
@@ -2251,21 +2288,10 @@ class VllmConfig:
         finalised block_size.
         """
         block_size = self.cache_config.block_size
+        self.adjust_dcp_kv_cache_interleave_size()
 
         # DCP interleave-size compatibility
         if self.parallel_config.decode_context_parallel_size > 1:
-            if self.parallel_config.dcp_kv_cache_interleave_size > 1 and (
-                self.parallel_config.cp_kv_cache_interleave_size
-                != self.parallel_config.dcp_kv_cache_interleave_size
-            ):
-                self.parallel_config.cp_kv_cache_interleave_size = (
-                    self.parallel_config.dcp_kv_cache_interleave_size
-                )
-                logger.warning_once(
-                    "cp_kv_cache_interleave_size is overridden by dcp_kv_cache"
-                    "_interleave_size. And dcp-kv-cache-interleave-size will be "
-                    "deprecated when PCP is fully supported."
-                )
             assert (
                 self.parallel_config.cp_kv_cache_interleave_size <= block_size
                 and block_size % self.parallel_config.cp_kv_cache_interleave_size == 0
@@ -2274,20 +2300,6 @@ class VllmConfig:
                 "than or equal to and divisible by cp_kv_cache_interleave_size "
                 f"({self.parallel_config.cp_kv_cache_interleave_size})."
             )
-            if (
-                self.kv_transfer_config is not None
-                and self.kv_transfer_config.kv_connector is not None
-            ):
-                interleave = self.parallel_config.cp_kv_cache_interleave_size
-                dcp_size = self.parallel_config.decode_context_parallel_size
-                assert interleave == block_size, (
-                    "When using PD disaggregation with DCP "
-                    f"(decode_context_parallel_size={dcp_size}), "
-                    f"cp_kv_cache_interleave_size ({interleave}) must match "
-                    f"block_size ({block_size}) for block-level alignment. "
-                    f"Set --cp-kv-cache-interleave-size to {block_size}."
-                )
-
         # Mamba cache align-mode constraints
         if self.cache_config.mamba_cache_mode == "align":
             assert block_size <= self.scheduler_config.max_num_batched_tokens, (

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+import numpy as np
 import torch
 
 from vllm.config import (
@@ -399,6 +400,12 @@ class EngineTransferInfo:
     end_layer: int = 0
     """Exclusive global index after the last layer owned by this PP rank."""
 
+    remote_dcp_size: int = 1
+    """Remote decode context parallel size."""
+
+    remote_pcp_size: int = 1
+    """Remote prefill context parallel size."""
+
 
 # ---- Transfer topology ----
 
@@ -415,6 +422,9 @@ class TransferTopology:
     is_mamba: bool
     total_num_kv_heads: int
     attn_backends: list[type[AttentionBackend]]
+    dcp_rank: int = 0
+    dcp_size: int = 1
+    pcp_size: int = 1
     tensor_shape: torch.Size | None = None
 
     def __post_init__(self):
@@ -582,19 +592,209 @@ class TransferTopology:
         return [self.tp_rank * abs_ratio + i for i in range(abs_ratio)]
 
     def target_remote_ranks(
-        self, remote_engine_id: EngineId, remote_pp_rank: int = 0
+        self,
+        remote_engine_id: EngineId,
+        remote_pp_rank: int = 0,
+        local_tp_rank: int | None = None,
     ) -> list[int]:
         """Get the remote TP rank(s) that the current local TP rank will
         read from.  When remote tp_size > local tp_size, reads from
         multiple remote ranks.
         """
         info = self._engines[(remote_engine_id, remote_pp_rank)]
+        if local_tp_rank is None:
+            local_tp_rank = self.tp_rank
         tp_ratio = self.tp_ratio(info.remote_tp_size)
         if tp_ratio > 0:
-            return [self.tp_rank // tp_ratio]
+            return [local_tp_rank // tp_ratio]
         # remote TP > local TP: read from |tp_ratio| remote workers
         abs_ratio = -tp_ratio
-        return [self.tp_rank * abs_ratio + i for i in range(abs_ratio)]
+        return [local_tp_rank * abs_ratio + i for i in range(abs_ratio)]
+
+    @staticmethod
+    def get_valid_worker_keys(
+        tp_size: int,
+        dcp_size: int,
+        pcp_size: int,
+    ) -> list[tuple[int, int]]:
+        """Return valid ``(tp_rank, dcp_rank)`` keys for a TP x PCP layout.
+
+        DCP groups follow docs/design/dcp_communication_patterns.md:
+        transpose to ``(tp, pcp)`` first, then flatten.  Thus
+        ``flat_idx = tp_rank * pcp_size + pcp_rank`` and
+        ``dcp_rank = flat_idx % dcp_size``.
+        """
+        valid_keys: list[tuple[int, int]] = []
+        seen: set[tuple[int, int]] = set()
+        for pcp_rank in range(pcp_size):
+            for tp_rank in range(tp_size):
+                flat_idx = tp_rank * pcp_size + pcp_rank
+                key = (tp_rank, flat_idx % dcp_size)
+                if key not in seen:
+                    seen.add(key)
+                    valid_keys.append(key)
+        return valid_keys
+
+    def has_kv_cache_overlap(
+        self,
+        remote_tp_rank: int,
+        remote_dcp_rank: int,
+        remote_tp_size: int,
+        remote_dcp_size: int,
+        remote_pcp_size: int,
+    ) -> bool:
+        """Return whether local and remote workers share KV coverage.
+
+        The check follows the PD disaggregation section in
+        docs/design/dcp_communication_patterns.md: both KV head coverage and
+        DCP token-slice coverage must overlap.
+        """
+        return self._has_kv_cache_overlap_for_local_rank(
+            local_tp_rank=self.tp_rank,
+            local_dcp_rank=self.dcp_rank,
+            remote_tp_rank=remote_tp_rank,
+            remote_dcp_rank=remote_dcp_rank,
+            remote_tp_size=remote_tp_size,
+            remote_dcp_size=remote_dcp_size,
+            remote_pcp_size=remote_pcp_size,
+        )
+
+    def _has_kv_cache_overlap_for_local_rank(
+        self,
+        local_tp_rank: int,
+        local_dcp_rank: int,
+        remote_tp_rank: int,
+        remote_dcp_rank: int,
+        remote_tp_size: int,
+        remote_dcp_size: int,
+        remote_pcp_size: int,
+    ) -> bool:
+        # Condition H: KV head overlap. For MLA, TP ranks are KV replicas.
+        # When the remote layout has no DCP token split beyond PCP, choose the
+        # TP-mapped replica as the representative to avoid duplicate reads.
+        if self.is_mla and remote_pcp_size == remote_dcp_size:
+            tp_ratio = self.tp_ratio(remote_tp_size)
+            if tp_ratio > 0:
+                mapped_remote_ranks = [local_tp_rank // tp_ratio]
+            else:
+                abs_ratio = -tp_ratio
+                mapped_remote_ranks = [
+                    local_tp_rank * abs_ratio + i for i in range(abs_ratio)
+                ]
+            head_overlap = remote_tp_rank in mapped_remote_ranks
+        else:
+            local_eff_tp = min(self.tp_size, self.total_num_kv_heads)
+            remote_eff_tp = min(remote_tp_size, self.total_num_kv_heads)
+            local_kv_group = local_tp_rank * local_eff_tp // self.tp_size
+            remote_kv_group = remote_tp_rank * remote_eff_tp // remote_tp_size
+            head_overlap = (
+                local_kv_group * remote_eff_tp < (remote_kv_group + 1) * local_eff_tp
+                and remote_kv_group * local_eff_tp
+                < (local_kv_group + 1) * remote_eff_tp
+            )
+
+        # Condition T: token/interleave overlap.
+        common_dcp = np.gcd(self.dcp_size, remote_dcp_size)
+        token_overlap = local_dcp_rank % common_dcp == remote_dcp_rank % common_dcp
+        return head_overlap and token_overlap
+
+    def get_target_remote_worker_keys(
+        self,
+        remote_tp_size: int,
+        remote_dcp_size: int,
+        remote_pcp_size: int,
+    ) -> list[tuple[int, int]]:
+        return [
+            (remote_tp_rank, remote_dcp_rank)
+            for remote_tp_rank, remote_dcp_rank in self.get_valid_worker_keys(
+                remote_tp_size, remote_dcp_size, remote_pcp_size
+            )
+            if self.has_kv_cache_overlap(
+                remote_tp_rank=remote_tp_rank,
+                remote_dcp_rank=remote_dcp_rank,
+                remote_tp_size=remote_tp_size,
+                remote_dcp_size=remote_dcp_size,
+                remote_pcp_size=remote_pcp_size,
+            )
+        ]
+
+    def get_target_remote_worker_keys_from_engine_id(
+        self,
+        remote_engine_id: EngineId,
+        remote_pp_rank: int = 0,
+    ) -> list[tuple[int, int]]:
+        info = self._engines[(remote_engine_id, remote_pp_rank)]
+        return self.get_target_remote_worker_keys(
+            info.remote_tp_size,
+            info.remote_dcp_size,
+            info.remote_pcp_size,
+        )
+
+    def calculate_local_consumer_count(
+        self,
+        remote_engine_id: EngineId,
+        remote_worker_key: tuple[int, int],
+        remote_pp_rank: int = 0,
+    ) -> int:
+        """Count local workers that will notify a remote worker."""
+        info = self._engines[(remote_engine_id, remote_pp_rank)]
+        remote_tp_rank, remote_dcp_rank = remote_worker_key
+        return sum(
+            self._has_kv_cache_overlap_for_local_rank(
+                local_tp_rank=local_tp_rank,
+                local_dcp_rank=local_dcp_rank,
+                remote_tp_rank=remote_tp_rank,
+                remote_dcp_rank=remote_dcp_rank,
+                remote_tp_size=info.remote_tp_size,
+                remote_dcp_size=info.remote_dcp_size,
+                remote_pcp_size=info.remote_pcp_size,
+            )
+            for local_tp_rank, local_dcp_rank in self.get_valid_worker_keys(
+                self.tp_size, self.dcp_size, self.pcp_size
+            )
+        )
+
+    @staticmethod
+    def get_block_positions(block_num: int, dcp_size: int, dcp_rank: int) -> np.ndarray:
+        return np.arange(block_num) * dcp_size + dcp_rank
+
+    def get_matched_blocks(
+        self,
+        local_block_ids: BlockIds,
+        remote_block_ids: BlockIds,
+        remote_dcp_size: int,
+        remote_dcp_rank: int,
+        local_block_offset: int = 0,
+    ) -> tuple[BlockIds, BlockIds]:
+        """Filter local/remote block ids to their DCP global-position overlap."""
+        if len(local_block_ids) == 0:
+            return [], []
+
+        remote_positions = self.get_block_positions(
+            len(remote_block_ids[0]),
+            remote_dcp_size,
+            remote_dcp_rank,
+        )
+        local_positions = (
+            self.get_block_positions(
+                len(local_block_ids[0]),
+                self.dcp_size,
+                self.dcp_rank,
+            )
+            + local_block_offset
+        )
+        matched_positions = np.intersect1d(remote_positions, local_positions)
+        local_indices = (matched_positions - local_block_offset) // self.dcp_size
+        remote_indices = matched_positions // remote_dcp_size
+        local_matched = [
+            [block_ids[i] for i in local_indices if i < len(block_ids)]
+            for block_ids in local_block_ids
+        ]
+        remote_matched = [
+            [block_ids[i] for i in remote_indices if i < len(block_ids)]
+            for block_ids in remote_block_ids
+        ]
+        return local_matched, remote_matched
 
     def describe(self, remote_engine_id: EngineId, remote_pp_rank: int = 0) -> str:
         """One-line summary of transfer config for logging."""
@@ -606,6 +806,9 @@ class TransferTopology:
             f"local_tp={self.tp_size}, "
             f"remote_tp={info.remote_tp_size}, "
             f"remote_pp={remote_pp_rank}, "
+            f"local_dcp={self.dcp_size}, "
+            f"remote_dcp={info.remote_dcp_size}, "
+            f"remote_pcp={info.remote_pcp_size}, "
             f"local_rank={self.tp_rank}, "
             f"remote_block_len={info.remote_block_len})"
         )

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -656,24 +656,19 @@ class TransferTopology:
         return [self.tp_rank * abs_ratio + i for i in range(abs_ratio)]
 
     def target_remote_ranks(
-        self,
-        remote_engine_id: EngineId,
-        remote_pp_rank: int = 0,
-        local_tp_rank: int | None = None,
+        self, remote_engine_id: EngineId, remote_pp_rank: int = 0
     ) -> list[int]:
         """Get the remote TP rank(s) that the current local TP rank will
         read from.  When remote tp_size > local tp_size, reads from
         multiple remote ranks.
         """
         info = self._engines[(remote_engine_id, remote_pp_rank)]
-        if local_tp_rank is None:
-            local_tp_rank = self.tp_rank
         tp_ratio = self.tp_ratio(info.remote_tp_size)
         if tp_ratio > 0:
-            return [local_tp_rank // tp_ratio]
+            return [self.tp_rank // tp_ratio]
         # remote TP > local TP: read from |tp_ratio| remote workers
         abs_ratio = -tp_ratio
-        return [local_tp_rank * abs_ratio + i for i in range(abs_ratio)]
+        return [self.tp_rank * abs_ratio + i for i in range(abs_ratio)]
 
     @staticmethod
     def get_dcp_rank(

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -503,6 +503,26 @@ class TransferTopology:
     ) -> EngineTransferInfo:
         return self._engines[(remote_engine_id, remote_pp_rank)]
 
+    def resolve_remote_pp_rank(
+        self,
+        remote_engine_id: EngineId,
+        local_pp_rank: int,
+    ) -> int:
+        """Map a local PP stage to a compatible registered remote stage."""
+        remote_pp_ranks = sorted(
+            pp_rank
+            for engine_id, pp_rank in self._engines
+            if engine_id == remote_engine_id
+        )
+        if local_pp_rank in remote_pp_ranks:
+            return local_pp_rank
+        if len(remote_pp_ranks) == 1:
+            return remote_pp_ranks[0]
+        raise RuntimeError(
+            f"No unambiguous remote PP stage for engine {remote_engine_id}: "
+            f"local_pp_rank={local_pp_rank}, remote_pp_ranks={remote_pp_ranks}"
+        )
+
     def unregister_remote_engine(self, remote_engine_id: EngineId) -> None:
         # Remove all pp_rank entries for the remote engine.
         for key in [k for k in self._engines if k[0] == remote_engine_id]:
@@ -612,33 +632,40 @@ class TransferTopology:
         return [local_tp_rank * abs_ratio + i for i in range(abs_ratio)]
 
     @staticmethod
+    def get_dcp_rank(
+        tp_rank: int,
+        pcp_rank: int,
+        pcp_size: int,
+        dcp_size: int,
+    ) -> int:
+        """Derive the DCP coverage rank from a physical PCP/TP worker."""
+        if dcp_size <= 0:
+            raise ValueError(f"dcp_size must be positive, got {dcp_size}")
+        return (tp_rank * pcp_size + pcp_rank) % dcp_size
+
+    @staticmethod
     def get_valid_worker_keys(
         tp_size: int,
         dcp_size: int,
         pcp_size: int,
     ) -> list[tuple[int, int]]:
-        """Return valid ``(tp_rank, dcp_rank)`` keys for a TP x PCP layout.
+        """Return physical ``(pcp_rank, tp_rank)`` worker keys.
 
-        DCP groups follow docs/design/dcp_communication_patterns.md:
-        transpose to ``(tp, pcp)`` first, then flatten.  Thus
-        ``flat_idx = tp_rank * pcp_size + pcp_rank`` and
-        ``dcp_rank = flat_idx % dcp_size``.
+        DCP rank is a derived KV-coverage coordinate and cannot identify a
+        physical worker: multiple PCP ranks may map to the same DCP rank.
         """
-        valid_keys: list[tuple[int, int]] = []
-        seen: set[tuple[int, int]] = set()
-        for pcp_rank in range(pcp_size):
-            for tp_rank in range(tp_size):
-                flat_idx = tp_rank * pcp_size + pcp_rank
-                key = (tp_rank, flat_idx % dcp_size)
-                if key not in seen:
-                    seen.add(key)
-                    valid_keys.append(key)
-        return valid_keys
+        if dcp_size <= 0:
+            raise ValueError(f"dcp_size must be positive, got {dcp_size}")
+        return [
+            (pcp_rank, tp_rank)
+            for pcp_rank in range(pcp_size)
+            for tp_rank in range(tp_size)
+        ]
 
     def has_kv_cache_overlap(
         self,
+        remote_pcp_rank: int,
         remote_tp_rank: int,
-        remote_dcp_rank: int,
         remote_tp_size: int,
         remote_dcp_size: int,
         remote_pcp_size: int,
@@ -649,6 +676,12 @@ class TransferTopology:
         docs/design/dcp_communication_patterns.md: both KV head coverage and
         DCP token-slice coverage must overlap.
         """
+        remote_dcp_rank = self.get_dcp_rank(
+            remote_tp_rank,
+            remote_pcp_rank,
+            remote_pcp_size,
+            remote_dcp_size,
+        )
         return self._has_kv_cache_overlap_for_local_rank(
             local_tp_rank=self.tp_rank,
             local_dcp_rank=self.dcp_rank,
@@ -705,13 +738,13 @@ class TransferTopology:
         remote_pcp_size: int,
     ) -> list[tuple[int, int]]:
         return [
-            (remote_tp_rank, remote_dcp_rank)
-            for remote_tp_rank, remote_dcp_rank in self.get_valid_worker_keys(
+            (remote_pcp_rank, remote_tp_rank)
+            for remote_pcp_rank, remote_tp_rank in self.get_valid_worker_keys(
                 remote_tp_size, remote_dcp_size, remote_pcp_size
             )
             if self.has_kv_cache_overlap(
+                remote_pcp_rank=remote_pcp_rank,
                 remote_tp_rank=remote_tp_rank,
-                remote_dcp_rank=remote_dcp_rank,
                 remote_tp_size=remote_tp_size,
                 remote_dcp_size=remote_dcp_size,
                 remote_pcp_size=remote_pcp_size,
@@ -738,18 +771,26 @@ class TransferTopology:
     ) -> int:
         """Count local workers that will notify a remote worker."""
         info = self._engines[(remote_engine_id, remote_pp_rank)]
-        remote_tp_rank, remote_dcp_rank = remote_worker_key
+        remote_pcp_rank, remote_tp_rank = remote_worker_key
+        remote_dcp_rank = self.get_dcp_rank(
+            remote_tp_rank,
+            remote_pcp_rank,
+            info.remote_pcp_size,
+            info.remote_dcp_size,
+        )
         return sum(
             self._has_kv_cache_overlap_for_local_rank(
                 local_tp_rank=local_tp_rank,
-                local_dcp_rank=local_dcp_rank,
+                local_dcp_rank=self.get_dcp_rank(
+                    local_tp_rank, local_pcp_rank, self.pcp_size, self.dcp_size
+                ),
                 remote_tp_rank=remote_tp_rank,
                 remote_dcp_rank=remote_dcp_rank,
                 remote_tp_size=info.remote_tp_size,
                 remote_dcp_size=info.remote_dcp_size,
                 remote_pcp_size=info.remote_pcp_size,
             )
-            for local_tp_rank, local_dcp_rank in self.get_valid_worker_keys(
+            for local_pcp_rank, local_tp_rank in self.get_valid_worker_keys(
                 self.tp_size, self.dcp_size, self.pcp_size
             )
         )

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -523,6 +523,28 @@ class TransferTopology:
             f"local_pp_rank={local_pp_rank}, remote_pp_ranks={remote_pp_ranks}"
         )
 
+    @staticmethod
+    def get_target_remote_pp_ranks(
+        local_pp_rank: int,
+        local_pp_size: int,
+        remote_pp_size: int,
+    ) -> list[int]:
+        """Select remote PP stages whose layer regions match the local stage."""
+        if local_pp_size <= 0 or remote_pp_size <= 0:
+            raise ValueError(
+                "PP sizes must be positive, got "
+                f"local_pp_size={local_pp_size}, remote_pp_size={remote_pp_size}"
+            )
+        if local_pp_size == remote_pp_size:
+            return [local_pp_rank]
+        if remote_pp_size == 1:
+            return [0]
+        raise NotImplementedError(
+            "NIXL cannot map one local PP stage to multiple remote PP stages: "
+            f"local_pp_rank={local_pp_rank}, local_pp_size={local_pp_size}, "
+            f"remote_pp_size={remote_pp_size}"
+        )
+
     def unregister_remote_engine(self, remote_engine_id: EngineId) -> None:
         # Remove all pp_rank entries for the remote engine.
         for key in [k for k in self._engines if k[0] == remote_engine_id]:

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -394,6 +394,9 @@ class EngineTransferInfo:
     remote_pp_rank: int = 0
     """Remote producer PP rank for this engine."""
 
+    remote_pp_size: int = 1
+    """Number of pipeline stages in the remote engine."""
+
     start_layer: int = 0
     """Global index of the first layer owned by this PP rank."""
 
@@ -528,6 +531,8 @@ class TransferTopology:
         local_pp_rank: int,
         local_pp_size: int,
         remote_pp_size: int,
+        *,
+        notif_only: bool = False,
     ) -> list[int]:
         """Select remote PP stages whose layer regions match the local stage."""
         if local_pp_size <= 0 or remote_pp_size <= 0:
@@ -539,10 +544,27 @@ class TransferTopology:
             return [local_pp_rank]
         if remote_pp_size == 1:
             return [0]
+        if notif_only and local_pp_size == 1:
+            return list(range(remote_pp_size))
         raise NotImplementedError(
             "NIXL cannot map one local PP stage to multiple remote PP stages: "
             f"local_pp_rank={local_pp_rank}, local_pp_size={local_pp_size}, "
             f"remote_pp_size={remote_pp_size}"
+        )
+
+    @staticmethod
+    def get_local_pp_producer_count(
+        local_pp_size: int,
+        remote_pp_size: int,
+    ) -> int:
+        """Count local PP stages mapped to one remote PP stage."""
+        if local_pp_size == remote_pp_size:
+            return 1
+        if remote_pp_size == 1:
+            return local_pp_size
+        raise NotImplementedError(
+            "NIXL cannot map one local PP stage to multiple remote PP stages: "
+            f"local_pp_size={local_pp_size}, remote_pp_size={remote_pp_size}"
         )
 
     def unregister_remote_engine(self, remote_engine_id: EngineId) -> None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -662,20 +662,23 @@ class KVConnectorBase_V1(ABC):
         return None
 
     def set_xfer_handshake_metadata_pp_aware(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self, metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata]
     ) -> None:
         """
-        Set handshake metadata keyed by (pp_rank, tp_rank).
-        - Default implementation assumes pp_rank is always 0
+        Set handshake metadata keyed by (pp_rank, pcp_rank, tp_rank).
+        - Default implementation assumes pp_rank and pcp_rank are always 0
         - PP-aware connectors override this to consume all PP producer shards.
         """
-        if any(pp_rank != 0 for pp_rank, _ in metadata):
+        if any(
+            pp_rank != 0 or pcp_rank != 0
+            for pp_rank, pcp_rank, _ in metadata
+        ):
             raise ValueError(
-                f"{type(self).__name__} received pp_rank > 0 handshake metadata "
-                "but does not support PP-disaggregated KV transfer."
+                f"{type(self).__name__} received PP/PCP-aware handshake metadata "
+                "but does not support PP/PCP-disaggregated KV transfer."
             )
         self.set_xfer_handshake_metadata(
-            {tp_rank: meta for (_, tp_rank), meta in metadata.items()}
+            {tp_rank: meta for (_, _, tp_rank), meta in metadata.items()}
         )
 
     @classmethod

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -669,10 +669,7 @@ class KVConnectorBase_V1(ABC):
         - Default implementation assumes pp_rank and pcp_rank are always 0
         - PP-aware connectors override this to consume all PP producer shards.
         """
-        if any(
-            pp_rank != 0 or pcp_rank != 0
-            for pp_rank, pcp_rank, _ in metadata
-        ):
+        if any(pp_rank != 0 or pcp_rank != 0 for pp_rank, pcp_rank, _ in metadata):
             raise ValueError(
                 f"{type(self).__name__} received PP/PCP-aware handshake metadata "
                 "but does not support PP/PCP-disaggregated KV transfer."

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -471,7 +471,7 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             c.set_xfer_handshake_metadata(metadata)
 
     def set_xfer_handshake_metadata_pp_aware(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self, metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata]
     ) -> None:
         for c in self._connectors:
             c.set_xfer_handshake_metadata_pp_aware(metadata)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -104,7 +104,7 @@ class NixlBaseConnectorScheduler:
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
-        self._reqs_need_recv: dict[ReqId, tuple[Request, BlockIds]] = {}
+        self._reqs_need_recv: dict[ReqId, tuple[Request, BlockIds, int]] = {}
         self._reqs_need_save: dict[ReqId, Request] = {}
         # Reqs to send and their expiration time
         self._reqs_need_send: dict[ReqId, float] = {}
@@ -185,7 +185,8 @@ class NixlBaseConnectorScheduler:
         host = params.get("remote_host")
         port = params.get("remote_port")
         tp_size = params.get("tp_size")
-        pp_size = params.get("pp_size", 1)
+        dcp_size = params.get("dcp_size", 1)
+        pcp_size = params.get("pcp_size", 1)
         if (
             remote_engine_id is None
             or remote_request_id is None
@@ -200,7 +201,8 @@ class NixlBaseConnectorScheduler:
                 host=host,
                 port=port,
                 tp_size=tp_size,
-                pp_size=pp_size,
+                dcp_size=dcp_size,
+                pcp_size=pcp_size,
             )
         self._heartbeat_by_engine[remote_engine_id].req_ids.add(remote_request_id)
         self._heartbeat_req_engine[request.request_id] = (
@@ -256,18 +258,17 @@ class NixlBaseConnectorScheduler:
         """
         encoded_data: dict[tuple[int, int], bytes] = {}
         encoder = msgspec.msgpack.Encoder()
-        for (pp_rank, tp_rank), rank_metadata in metadata.items():
+        for flat_idx, rank_metadata in metadata.items():
             if not isinstance(rank_metadata, NixlHandshakePayload):
                 raise ValueError(
                     "NixlConnectorScheduler expects NixlHandshakePayload for "
                     "handshake metadata."
                 )
-            encoded_data[(pp_rank, tp_rank)] = encoder.encode(rank_metadata)
+            encoded_data[flat_idx] = encoder.encode(rank_metadata)
             logger.debug(
-                "PP rank %d, TP rank %d: encoded NixlHandshakePayload size: %s bytes",
-                pp_rank,
-                tp_rank,
-                str(len(encoded_data[(pp_rank, tp_rank)])),
+                "Flat rank %d: encoded NixlHandshakePayload size: %s bytes",
+                flat_idx,
+                str(len(encoded_data[flat_idx])),
             )
 
         # Only start the listener when we have metadata to serve.
@@ -313,23 +314,15 @@ class NixlBaseConnectorScheduler:
                     if stop_event.is_set():
                         break
                     continue
-                # Decode (GET_META_MSG, pp_rank, tp_rank).
-                msg, target_pp_rank, target_tp_rank = msgspec.msgpack.decode(msg)
+                # Decode the message which contains (GET_META_MSG, flat_idx)
+                msg, target_flat_idx = msgspec.msgpack.decode(msg)
                 logger.debug(
-                    "Received message for pp rank %s, tp rank %s",
-                    target_pp_rank,
-                    target_tp_rank,
+                    "Received message for flat rank %s",
+                    target_flat_idx,
                 )
                 if msg != GET_META_MSG:
                     logger.warning("Connection listener got unexpected message %s", msg)
-                # Echo our perf_counter so P can estimate the clock offset.
-                # perf_counter is only comparable within a process, so this
-                # listener must run in the same process that stamps the block
-                # expiry deadline (`_reqs_need_send`).
-                ts = msgspec.msgpack.encode(time.perf_counter())
-                sock.send_multipart(
-                    (identity, b"", encoded_data[(target_pp_rank, target_tp_rank)], ts)
-                )
+                sock.send_multipart((identity, b"", encoded_data[target_flat_idx]))
 
     def _get_remote_prefill_token_count(self, num_prompt_tokens: int) -> int:
         """D-side only. Returns N-1 for Mamba models since the decoder
@@ -406,12 +399,16 @@ class NixlBaseConnectorScheduler:
         meta = NixlConnectorMetadata()
 
         # Loop through scheduled reqs and convert to ReqMeta.
-        for req_id, (req, block_ids) in self._reqs_need_recv.items():
+        for (
+            req_id,
+            (req, block_ids, local_num_computed_tokens),
+        ) in self._reqs_need_recv.items():
             assert req.kv_transfer_params is not None
             meta.add_new_req_to_recv(
                 request_id=req_id,
                 local_block_ids=block_ids,
                 kv_transfer_params=req.kv_transfer_params,
+                local_num_computed_tokens=local_num_computed_tokens,
             )
 
         if self.use_host_buffer:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -187,6 +187,7 @@ class NixlBaseConnectorScheduler:
         tp_size = params.get("tp_size")
         dcp_size = params.get("dcp_size", 1)
         pcp_size = params.get("pcp_size", 1)
+        pp_size = params.get("pp_size", 1)
         if (
             remote_engine_id is None
             or remote_request_id is None
@@ -203,6 +204,7 @@ class NixlBaseConnectorScheduler:
                 tp_size=tp_size,
                 dcp_size=dcp_size,
                 pcp_size=pcp_size,
+                pp_size=pp_size,
             )
         self._heartbeat_by_engine[remote_engine_id].req_ids.add(remote_request_id)
         self._heartbeat_req_engine[request.request_id] = (

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -248,7 +248,7 @@ class NixlBaseConnectorScheduler:
         )
 
     def set_xfer_handshake_metadata(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self, metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata]
     ) -> None:
         """
         Set the KV connector handshake metadata for this connector.
@@ -256,19 +256,20 @@ class NixlBaseConnectorScheduler:
         Args:
             metadata (dict): the handshake metadata to set.
         """
-        encoded_data: dict[tuple[int, int], bytes] = {}
+        encoded_data: dict[tuple[int, int, int], bytes] = {}
         encoder = msgspec.msgpack.Encoder()
-        for flat_idx, rank_metadata in metadata.items():
+        for rank_key, rank_metadata in metadata.items():
             if not isinstance(rank_metadata, NixlHandshakePayload):
                 raise ValueError(
                     "NixlConnectorScheduler expects NixlHandshakePayload for "
                     "handshake metadata."
                 )
-            encoded_data[flat_idx] = encoder.encode(rank_metadata)
+            encoded_data[rank_key] = encoder.encode(rank_metadata)
             logger.debug(
-                "Flat rank %d: encoded NixlHandshakePayload size: %s bytes",
-                flat_idx,
-                str(len(encoded_data[flat_idx])),
+                "PP rank %d, PCP rank %d, TP rank %d: encoded "
+                "NixlHandshakePayload size: %s bytes",
+                *rank_key,
+                str(len(encoded_data[rank_key])),
             )
 
         # Only start the listener when we have metadata to serve.
@@ -291,7 +292,7 @@ class NixlBaseConnectorScheduler:
 
     @staticmethod
     def _nixl_handshake_listener(
-        encoded_data: dict[tuple[int, int], Any],
+        encoded_data: dict[tuple[int, int, int], Any],
         ready_event: threading.Event,
         stop_event: threading.Event,
         host: str,
@@ -314,15 +315,25 @@ class NixlBaseConnectorScheduler:
                     if stop_event.is_set():
                         break
                     continue
-                # Decode the message which contains (GET_META_MSG, flat_idx)
-                msg, target_flat_idx = msgspec.msgpack.decode(msg)
+                # Decode (GET_META_MSG, pp_rank, pcp_rank, tp_rank).
+                msg, target_pp_rank, target_pcp_rank, target_tp_rank = (
+                    msgspec.msgpack.decode(msg)
+                )
+                target_key = (target_pp_rank, target_pcp_rank, target_tp_rank)
                 logger.debug(
-                    "Received message for flat rank %s",
-                    target_flat_idx,
+                    "Received message for PP rank %s, PCP rank %s, TP rank %s",
+                    *target_key,
                 )
                 if msg != GET_META_MSG:
                     logger.warning("Connection listener got unexpected message %s", msg)
-                sock.send_multipart((identity, b"", encoded_data[target_flat_idx]))
+                # Echo our perf_counter so P can estimate the clock offset.
+                # perf_counter is only comparable within a process, so this
+                # listener must run in the same process that stamps the block
+                # expiry deadline (`_reqs_need_send`).
+                ts = msgspec.msgpack.encode(time.perf_counter())
+                sock.send_multipart(
+                    (identity, b"", encoded_data[target_key], ts)
+                )
 
     def _get_remote_prefill_token_count(self, num_prompt_tokens: int) -> int:
         """D-side only. Returns N-1 for Mamba models since the decoder

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -331,9 +331,7 @@ class NixlBaseConnectorScheduler:
                 # listener must run in the same process that stamps the block
                 # expiry deadline (`_reqs_need_send`).
                 ts = msgspec.msgpack.encode(time.perf_counter())
-                sock.send_multipart(
-                    (identity, b"", encoded_data[target_key], ts)
-                )
+                sock.send_multipart((identity, b"", encoded_data[target_key], ts))
 
     def _get_remote_prefill_token_count(self, num_prompt_tokens: int) -> int:
         """D-side only. Returns N-1 for Mamba models since the decoder

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -37,7 +37,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlAgentMetadata,
     NixlConnectorMetadata,
     NixlHandshakePayload,
-    RemoteWorkerKey,
+    RemoteAgentKey,
     ReqId,
     ReqMeta,
     TransferHandle,
@@ -64,6 +64,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import
 from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
 from vllm.distributed.parallel_state import (
     get_pcp_group,
+    get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
@@ -353,8 +354,8 @@ class NixlBaseConnectorWorker:
             )
 
         self.nixl_wrapper = nixl_wrapper_cls(str(uuid.uuid4()), config)
-        # Map of engine_id -> {(tp_rank, dcp_rank): agent_name}.
-        self._remote_agents: dict[EngineId, dict[RemoteWorkerKey, str]] = defaultdict(
+        # Map of engine_id -> {(pp_rank, pcp_rank, tp_rank): agent_name}.
+        self._remote_agents: dict[EngineId, dict[RemoteAgentKey, str]] = defaultdict(
             dict
         )
         # Map of engine_id -> clock offset.
@@ -364,6 +365,10 @@ class NixlBaseConnectorWorker:
         self.engine_id: EngineId = engine_id
         self.tp_rank = get_tensor_model_parallel_rank()
         self.world_size = get_tensor_model_parallel_world_size()
+        try:
+            self.pp_rank = get_pp_group().rank_in_group
+        except AssertionError:
+            self.pp_rank = 0
         self.tp_size = self.world_size
         self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
         try:
@@ -373,7 +378,11 @@ class NixlBaseConnectorWorker:
             self.pcp_size = 1
             self.pcp_rank = 0
         self.dcp_rank = (self.tp_rank * self.pcp_size + self.pcp_rank) % self.dcp_size
-        self.local_worker_key: RemoteWorkerKey = (self.tp_rank, self.dcp_rank)
+        self.local_worker_key: RemoteAgentKey = (
+            self.pp_rank,
+            self.pcp_rank,
+            self.tp_rank,
+        )
 
         self.num_blocks = kv_cache_config.num_blocks
         self.enable_permute_local_kv = False
@@ -435,9 +444,9 @@ class NixlBaseConnectorWorker:
         # Map of engine_id -> kv_caches_base_addr. For TP case, each local
         self.device_id: int = 0
         # Current rank may pull from multiple remote TP workers.
-        # EngineId, dict[(tp_rank, dcp_rank), list[int]] -> base_addr_for_layer
+        # EngineId, dict[(pp_rank, pcp_rank, tp_rank), list[int]].
         self.kv_caches_base_addr = defaultdict[
-            EngineId, dict[RemoteWorkerKey, list[int]]
+            EngineId, dict[RemoteAgentKey, list[int]]
         ](dict)
 
         # Number of NIXL regions. Currently one region per cache
@@ -471,8 +480,9 @@ class NixlBaseConnectorWorker:
         # Populated dynamically during handshake based on remote configuration.
         # Per-source split handles, keyed by (tp_ratio, remote_block_size).
         self.src_xfer_handles_by_tp_ratio: dict[tuple[int, int], list[int]] = {}
-        # Map of engine_id -> {(tp_rank, dcp_rank): nixl_prepped_dlist_handle}.
-        self.dst_xfer_side_handles = defaultdict[EngineId, dict[RemoteWorkerKey, int]](
+        # Map of engine_id -> {(pp_rank, pcp_rank, tp_rank):
+        # nixl_prepped_dlist_handle}.
+        self.dst_xfer_side_handles = defaultdict[EngineId, dict[RemoteAgentKey, int]](
             dict
         )
 
@@ -507,7 +517,7 @@ class NixlBaseConnectorWorker:
         )
         self._ready_requests = queue.Queue[tuple[ReqId, ReqMeta]]()
         self._handshake_futures: dict[
-            EngineId, Future[tuple[dict[RemoteWorkerKey, str], float]]
+            EngineId, Future[tuple[dict[RemoteAgentKey, str], float]]
         ] = {}
         # Protects _handshake_futures and _remote_agents.
         self._handshake_lock = threading.RLock()
@@ -601,7 +611,7 @@ class NixlBaseConnectorWorker:
         remote_pcp_size: int = 1,
         remote_pp_size: int = 1,
         notif_agents_only: bool = False,
-    ) -> tuple[dict[RemoteWorkerKey, str], float]:
+    ) -> tuple[dict[RemoteAgentKey, str], float]:
         """Do a NIXL handshake with a remote instance."""
 
         # the first time we connect to a remote agent.
@@ -624,7 +634,7 @@ class NixlBaseConnectorWorker:
             remote_dcp_size,
             remote_pcp_size,
         )
-        remote_worker_to_agent_name: dict[RemoteWorkerKey, str] = {}
+        remote_worker_to_agent_name: dict[RemoteAgentKey, str] = {}
         path = make_zmq_path("tcp", host, port)
         # Clock offset to the peer, estimated from the handshake round-trip.
         # Keep the lowest-RTT sample: hop cost is ~uniform across ranks, so a
@@ -636,10 +646,10 @@ class NixlBaseConnectorWorker:
             for remote_pp_rank, remote_worker_key in itertools.product(
                 range(remote_pp_size), remote_worker_keys
             ):
-                remote_tp_rank, remote_dcp_rank = remote_worker_key
-                remote_pcp_rank = self._tp_dcp_to_pcp_rank(
+                remote_pcp_rank, remote_tp_rank = remote_worker_key
+                remote_dcp_rank = self.transfer_topo.get_dcp_rank(
                     remote_tp_rank,
-                    remote_dcp_rank,
+                    remote_pcp_rank,
                     remote_pcp_size,
                     remote_dcp_size,
                 )
@@ -758,8 +768,8 @@ class NixlBaseConnectorWorker:
                         f"dcp_size={metadata.dcp_size})."
                     )
                 if not self.transfer_topo.has_kv_cache_overlap(
+                    metadata.pcp_rank,
                     metadata.tp_rank,
-                    metadata.dcp_rank,
                     metadata.tp_size,
                     metadata.dcp_size,
                     metadata.pcp_size,
@@ -774,27 +784,24 @@ class NixlBaseConnectorWorker:
                 # Register Remote agent.
                 if notif_agents_only:
                     remote_agent_name = self._add_notif_only_remote_agent(
-                        metadata,
-                        remote_tp_size,
-                        remote_dcp_size,
-                        remote_pcp_size,
-                    )
-                    # Notification-only callers iterate over values; use a key
-                    # that remains unique across PP, PCP, and TP workers.
-                    agent_key: RemoteWorkerKey = (
-                        remote_pp_rank,
-                        remote_pcp_rank * remote_tp_size + remote_tp_rank,
+                        metadata, remote_tp_size, remote_pp_rank
                     )
                 else:
                     remote_agent_name = self.add_remote_agent(
                         metadata,
-                        metadata.tp_rank,
-                        metadata.tp_size,
-                        metadata.dcp_rank,
-                        metadata.dcp_size,
-                        metadata.pcp_size,
+                        remote_tp_rank=metadata.tp_rank,
+                        remote_tp_size=metadata.tp_size,
+                        remote_dcp_rank=metadata.dcp_rank,
+                        remote_dcp_size=metadata.dcp_size,
+                        remote_pcp_size=metadata.pcp_size,
+                        remote_pcp_rank=metadata.pcp_rank,
+                        remote_pp_rank=remote_pp_rank,
                     )
-                    agent_key = remote_worker_key
+                agent_key: RemoteAgentKey = (
+                    remote_pp_rank,
+                    remote_pcp_rank,
+                    remote_tp_rank,
+                )
                 setup_agent_time = time.perf_counter()
                 logger.debug(
                     "NIXL handshake: add agent took: %s (notif_agents_only=%s)",
@@ -811,7 +818,10 @@ class NixlBaseConnectorWorker:
         return remote_worker_to_agent_name, best_offset
 
     def _add_notif_only_remote_agent(
-        self, metadata: NixlAgentMetadata, remote_tp_size: int
+        self,
+        metadata: NixlAgentMetadata,
+        remote_tp_size: int,
+        remote_pp_rank: int = 0,
     ) -> str:
         """Load a remote agent for notifs only on the push-mode decode side.
 
@@ -827,56 +837,9 @@ class NixlBaseConnectorWorker:
                 remote_physical_blocks_per_logical=(
                     metadata.physical_blocks_per_logical_kv_block
                 ),
-            ),
-        )
-        return self.nixl_wrapper.add_remote_agent(metadata.agent_metadata)
-
-    @staticmethod
-    def _tp_dcp_to_pcp_rank(
-        tp_rank: int,
-        dcp_rank: int,
-        pcp_size: int,
-        dcp_size: int,
-    ) -> int:
-        if not 0 <= dcp_rank < dcp_size:
-            raise ValueError(f"Invalid dcp_rank={dcp_rank} for dcp_size={dcp_size}")
-
-        pcp_rank = (dcp_rank - tp_rank * pcp_size) % dcp_size
-        if pcp_rank < pcp_size:
-            # dcp_rank is derived from the explicit PCP/TP metadata key.
-            inferred_dcp_rank = (tp_rank * pcp_size + pcp_rank) % dcp_size
-            assert inferred_dcp_rank == dcp_rank
-            # A (tp_rank, dcp_rank) pair may map to multiple PCP ranks when
-            # pcp_size > dcp_size. Pick the smallest valid PCP rank for now.
-            # TODO: Choose among equivalent PCP ranks using load-balance
-            # signals instead of always choosing the smallest rank.
-            return pcp_rank
-
-        raise ValueError(
-            f"No valid pcp_rank for tp_rank={tp_rank}, dcp_rank={dcp_rank}, "
-            f"pcp_size={pcp_size}, dcp_size={dcp_size}"
-        )
-
-    def _add_notif_only_remote_agent(
-        self,
-        metadata: NixlAgentMetadata,
-        remote_tp_size: int,
-        remote_dcp_size: int = 1,
-        remote_pcp_size: int = 1,
-    ) -> str:
-        """Load a remote agent for notifications without transfer descriptors."""
-        assert self.transfer_topo is not None
-        self.transfer_topo.register_remote_engine(
-            metadata.engine_id,
-            EngineTransferInfo(
-                remote_tp_size=remote_tp_size,
-                remote_block_size=metadata.block_size,
-                remote_block_len=metadata.block_lens[0],
-                remote_physical_blocks_per_logical=(
-                    metadata.physical_blocks_per_logical_kv_block
-                ),
-                remote_dcp_size=remote_dcp_size,
-                remote_pcp_size=remote_pcp_size,
+                remote_dcp_size=metadata.dcp_size,
+                remote_pcp_size=metadata.pcp_size,
+                remote_pp_rank=remote_pp_rank,
             ),
         )
         return self.nixl_wrapper.add_remote_agent(metadata.agent_metadata)
@@ -997,7 +960,7 @@ class NixlBaseConnectorWorker:
         pcp_size: int = 1,
         pp_size: int = 1,
         notif_agents_only: bool = False,
-    ) -> Future[tuple[dict[RemoteWorkerKey, str], float]] | None:
+    ) -> Future[tuple[dict[RemoteAgentKey, str], float]] | None:
         """
         Ensure a handshake is in-flight (or already done) for *engine_id*.
 
@@ -1028,7 +991,7 @@ class NixlBaseConnectorWorker:
             self._handshake_futures[engine_id] = fut
 
             def done_callback(
-                f: Future[tuple[dict[RemoteWorkerKey, str], float]],
+                f: Future[tuple[dict[RemoteAgentKey, str], float]],
                 eid=engine_id,
             ):
                 with self._handshake_lock:
@@ -1673,6 +1636,8 @@ class NixlBaseConnectorWorker:
         remote_dcp_rank: int = 0,
         remote_dcp_size: int = 1,
         remote_pcp_size: int = 1,
+        remote_pcp_rank: int = 0,
+        remote_pp_rank: int = 0,
     ) -> str:
         """
         Add the remote NIXL agent and prepare the descriptors for reading cache
@@ -1718,7 +1683,11 @@ class NixlBaseConnectorWorker:
         tp_ratio < 0 (P_TP > D_TP) are supported by the 3-read transfer.
         """  # noqa: E501
         engine_id = nixl_agent_meta.engine_id
-        remote_worker_key: RemoteWorkerKey = (remote_tp_rank, remote_dcp_rank)
+        remote_worker_key: RemoteAgentKey = (
+            remote_pp_rank,
+            remote_pcp_rank,
+            remote_tp_rank,
+        )
         # TODO re-evaluate refreshing for scaling/recovery
         if remote_worker_key in self._remote_agents.get(engine_id, {}):
             logger.debug(
@@ -1760,6 +1729,7 @@ class NixlBaseConnectorWorker:
             remote_physical_blocks_per_logical=physical_blocks_per_logical,
             remote_dcp_size=remote_dcp_size,
             remote_pcp_size=remote_pcp_size,
+            remote_pp_rank=remote_pp_rank,
         )
         transfer_topo.register_remote_engine(engine_id, transfer_info)
         logger.info("Transfer plan: %s", transfer_topo.describe(engine_id))

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -810,6 +810,27 @@ class NixlBaseConnectorWorker:
         assert best_offset is not None
         return remote_worker_to_agent_name, best_offset
 
+    def _add_notif_only_remote_agent(
+        self, metadata: NixlAgentMetadata, remote_tp_size: int
+    ) -> str:
+        """Load a remote agent for notifs only on the push-mode decode side.
+
+        Skips descriptor setup but records engine info for block accounting.
+        """
+        assert self.transfer_topo is not None
+        self.transfer_topo.register_remote_engine(
+            metadata.engine_id,
+            EngineTransferInfo(
+                remote_tp_size=remote_tp_size,
+                remote_block_size=metadata.block_size,
+                remote_block_len=metadata.block_lens[0],
+                remote_physical_blocks_per_logical=(
+                    metadata.physical_blocks_per_logical_kv_block
+                ),
+            ),
+        )
+        return self.nixl_wrapper.add_remote_agent(metadata.agent_metadata)
+
     @staticmethod
     def _tp_dcp_to_pcp_rank(
         tp_rank: int,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -37,6 +37,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlAgentMetadata,
     NixlConnectorMetadata,
     NixlHandshakePayload,
+    RemoteWorkerKey,
     ReqId,
     ReqMeta,
     TransferHandle,
@@ -62,6 +63,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import
 )
 from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
 from vllm.distributed.parallel_state import (
+    get_pcp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
@@ -351,9 +353,8 @@ class NixlBaseConnectorWorker:
             )
 
         self.nixl_wrapper = nixl_wrapper_cls(str(uuid.uuid4()), config)
-        # Map of engine_id -> {(pp_rank, tp_rank): agent_name, ...}.
-        # non-PP remote uses pp_rank 0, i.e. (0, tp_rank).
-        self._remote_agents: dict[EngineId, dict[tuple[int, int], str]] = defaultdict(
+        # Map of engine_id -> {(tp_rank, dcp_rank): agent_name}.
+        self._remote_agents: dict[EngineId, dict[RemoteWorkerKey, str]] = defaultdict(
             dict
         )
         # Map of engine_id -> clock offset.
@@ -363,6 +364,16 @@ class NixlBaseConnectorWorker:
         self.engine_id: EngineId = engine_id
         self.tp_rank = get_tensor_model_parallel_rank()
         self.world_size = get_tensor_model_parallel_world_size()
+        self.tp_size = self.world_size
+        self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
+        try:
+            self.pcp_size = get_pcp_group().world_size
+            self.pcp_rank = get_pcp_group().rank_in_group
+        except AssertionError:
+            self.pcp_size = 1
+            self.pcp_rank = 0
+        self.dcp_rank = (self.tp_rank * self.pcp_size + self.pcp_rank) % self.dcp_size
+        self.local_worker_key: RemoteWorkerKey = (self.tp_rank, self.dcp_rank)
 
         self.num_blocks = kv_cache_config.num_blocks
         self.enable_permute_local_kv = False
@@ -424,8 +435,10 @@ class NixlBaseConnectorWorker:
         # Map of engine_id -> kv_caches_base_addr. For TP case, each local
         self.device_id: int = 0
         # Current rank may pull from multiple remote TP workers.
-        # EngineId, dict[int, list[int]] -> engine_id, tp_rank, base_addr_for_layer
-        self.kv_caches_base_addr = defaultdict[EngineId, dict[int, list[int]]](dict)
+        # EngineId, dict[(tp_rank, dcp_rank), list[int]] -> base_addr_for_layer
+        self.kv_caches_base_addr = defaultdict[
+            EngineId, dict[RemoteWorkerKey, list[int]]
+        ](dict)
 
         # Number of NIXL regions. Currently one region per cache
         # (so 1 per layer for MLA, otherwise 2 per layer)
@@ -458,8 +471,10 @@ class NixlBaseConnectorWorker:
         # Populated dynamically during handshake based on remote configuration.
         # Per-source split handles, keyed by (tp_ratio, remote_block_size).
         self.src_xfer_handles_by_tp_ratio: dict[tuple[int, int], list[int]] = {}
-        # Map of engine_id -> {tp_rank: nixl_prepped_dlist_handle (int)}.
-        self.dst_xfer_side_handles = defaultdict[EngineId, dict[int, int]](dict)
+        # Map of engine_id -> {(tp_rank, dcp_rank): nixl_prepped_dlist_handle}.
+        self.dst_xfer_side_handles = defaultdict[EngineId, dict[RemoteWorkerKey, int]](
+            dict
+        )
 
         # Map of engine_id -> num_blocks. All ranks in the same deployment will
         # have the same number of blocks.
@@ -492,10 +507,11 @@ class NixlBaseConnectorWorker:
         )
         self._ready_requests = queue.Queue[tuple[ReqId, ReqMeta]]()
         self._handshake_futures: dict[
-            EngineId, Future[tuple[dict[tuple[int, int], str], float]]
+            EngineId, Future[tuple[dict[RemoteWorkerKey, str], float]]
         ] = {}
         # Protects _handshake_futures and _remote_agents.
         self._handshake_lock = threading.RLock()
+        self._done_recving_without_xfer: set[ReqId] = set()
 
         # TTL-based eviction of stale remote engine state.
         self._engine_last_active: dict[EngineId, float] = {}
@@ -528,6 +544,7 @@ class NixlBaseConnectorWorker:
         # With heterogeneous TP, P must wait for all assigned D TP workers to
         # finish reading before safely freeing the blocks.
         self.consumer_notification_counts_by_req = defaultdict[ReqId, int](int)
+        self.expected_consumer_notifications_by_req: dict[ReqId, int] = {}
         self.xfer_stats = NixlKVConnectorStats()
 
         self._physical_blocks_per_logical_kv_block = 1
@@ -580,9 +597,11 @@ class NixlBaseConnectorWorker:
         port: int,
         remote_tp_size: int,
         expected_engine_id: str,
+        remote_dcp_size: int = 1,
+        remote_pcp_size: int = 1,
         remote_pp_size: int = 1,
         notif_agents_only: bool = False,
-    ) -> tuple[dict[tuple[int, int], str], float]:
+    ) -> tuple[dict[RemoteWorkerKey, str], float]:
         """Do a NIXL handshake with a remote instance."""
 
         # the first time we connect to a remote agent.
@@ -597,14 +616,15 @@ class NixlBaseConnectorWorker:
         if not self.use_host_buffer:
             current_platform.set_device(self.device_id)
 
-        # When target instance TP > local TP, we need to perform multiple
-        # handshakes. Do it in a single background job for simplicity.
-        # Regardless, only handshake with the remote TP rank(s) that current
-        # local rank will read from. Note that With homogeneous TP,
-        # this happens to be the same single rank_i.
+        # Handshake only with remote workers whose KV head coverage and DCP
+        # token slice overlap this local worker.
         assert self.transfer_topo is not None
-        p_remote_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
-        remote_rank_to_agent_name: dict[tuple[int, int], str] = {}
+        remote_worker_keys = self.transfer_topo.get_target_remote_worker_keys(
+            remote_tp_size,
+            remote_dcp_size,
+            remote_pcp_size,
+        )
+        remote_worker_to_agent_name: dict[RemoteWorkerKey, str] = {}
         path = make_zmq_path("tcp", host, port)
         # Clock offset to the peer, estimated from the handshake round-trip.
         # Keep the lowest-RTT sample: hop cost is ~uniform across ranks, so a
@@ -613,20 +633,24 @@ class NixlBaseConnectorWorker:
         best_offset: float | None = None
 
         with zmq_ctx(zmq.REQ, path) as sock:
-            for remote_pp_rank, remote_rank in itertools.product(
-                range(remote_pp_size), p_remote_ranks
-            ):
+            for remote_worker_key in remote_worker_keys:
+                remote_tp_rank, remote_dcp_rank = remote_worker_key
+                remote_flat_idx = self._tp_dcp_to_flat_idx(
+                    remote_tp_rank,
+                    remote_dcp_rank,
+                    remote_pcp_size,
+                    remote_dcp_size,
+                )
                 logger.debug(
-                    "Querying metadata on path: %s at remote pp rank %s, tp rank %s",
+                    "Querying metadata on path: %s at remote flat_idx %s "
+                    "for worker key %s",
                     path,
-                    remote_pp_rank,
-                    remote_rank,
+                    remote_flat_idx,
+                    remote_worker_key,
                 )
 
                 # Send query for the request.
-                msg = msgspec.msgpack.encode(
-                    (GET_META_MSG, remote_pp_rank, remote_rank)
-                )
+                msg = msgspec.msgpack.encode((GET_META_MSG, remote_flat_idx))
                 # Set receive timeout to 5 seconds to avoid hanging on dead server
                 sock.setsockopt(zmq.RCVTIMEO, 5000)  # milliseconds
                 start_time = time.perf_counter()
@@ -701,15 +725,47 @@ class NixlBaseConnectorWorker:
                         f"Expected {expected_engine_id},"
                         f"received {metadata.engine_id}."
                     )
+                received_flat_idx = metadata.tp_rank * metadata.pcp_size
+                received_flat_idx += metadata.pcp_rank
+                if received_flat_idx != remote_flat_idx:
+                    raise RuntimeError(
+                        "Remote handshake metadata flat_idx mismatch. "
+                        f"Expected flat_idx={remote_flat_idx}, got "
+                        f"flat_idx={received_flat_idx} "
+                        f"(tp_rank={metadata.tp_rank}, "
+                        f"pcp_rank={metadata.pcp_rank}, "
+                        f"dcp_rank={metadata.dcp_rank})."
+                    )
+                if not self.transfer_topo.has_kv_cache_overlap(
+                    metadata.tp_rank,
+                    metadata.dcp_rank,
+                    metadata.tp_size,
+                    metadata.dcp_size,
+                    metadata.pcp_size,
+                ):
+                    logger.debug(
+                        "Skipping remote worker %s because metadata no longer "
+                        "overlaps local KV cache coverage.",
+                        remote_worker_key,
+                    )
+                    continue
 
                 # Register Remote agent.
                 if notif_agents_only:
                     remote_agent_name = self._add_notif_only_remote_agent(
-                        metadata, remote_tp_size
+                        metadata,
+                        remote_tp_size,
+                        remote_dcp_size,
+                        remote_pcp_size,
                     )
                 else:
                     remote_agent_name = self.add_remote_agent(
-                        metadata, remote_rank, remote_tp_size
+                        metadata,
+                        metadata.tp_rank,
+                        metadata.tp_size,
+                        metadata.dcp_rank,
+                        metadata.dcp_size,
+                        metadata.pcp_size,
                     )
                 setup_agent_time = time.perf_counter()
                 logger.debug(
@@ -717,19 +773,48 @@ class NixlBaseConnectorWorker:
                     setup_agent_time - got_metadata_time,
                     notif_agents_only,
                 )
-                remote_ranks = (remote_pp_rank, remote_rank)
-                remote_rank_to_agent_name[remote_ranks] = remote_agent_name
-
+                remote_worker_to_agent_name[remote_worker_key] = remote_agent_name
+        if not remote_worker_to_agent_name:
+            raise RuntimeError(
+                "Handshake completed but found no remote worker with overlapping "
+                "KV cache coverage."
+            )
         assert best_offset is not None
-        return remote_rank_to_agent_name, best_offset
+        return remote_worker_to_agent_name, best_offset
+
+    @staticmethod
+    def _tp_dcp_to_flat_idx(
+        tp_rank: int,
+        dcp_rank: int,
+        pcp_size: int,
+        dcp_size: int,
+    ) -> int:
+        if not 0 <= dcp_rank < dcp_size:
+            raise ValueError(f"Invalid dcp_rank={dcp_rank} for dcp_size={dcp_size}")
+
+        pcp_rank = (dcp_rank - tp_rank * pcp_size) % dcp_size
+        if pcp_rank < pcp_size:
+            # A (tp_rank, dcp_rank) pair may map to multiple PCP ranks when
+            # pcp_size > dcp_size. The worker key does not preserve which PCP
+            # replica produced the DCP shard, so pick the smallest valid PCP
+            # rank for now.
+            # TODO: Choose among equivalent PCP ranks using load-balance
+            # signals instead of always choosing the smallest rank.
+            return tp_rank * pcp_size + pcp_rank
+
+        raise ValueError(
+            f"No valid flat_idx for tp_rank={tp_rank}, dcp_rank={dcp_rank}, "
+            f"pcp_size={pcp_size}, dcp_size={dcp_size}"
+        )
 
     def _add_notif_only_remote_agent(
-        self, metadata: NixlAgentMetadata, remote_tp_size: int
+        self,
+        metadata: NixlAgentMetadata,
+        remote_tp_size: int,
+        remote_dcp_size: int = 1,
+        remote_pcp_size: int = 1,
     ) -> str:
-        """Load a remote agent for notifs only on the push-mode decode side.
-
-        Skips descriptor setup but records engine info for block accounting.
-        """
+        """Load a remote agent for notifications without transfer descriptors."""
         assert self.transfer_topo is not None
         self.transfer_topo.register_remote_engine(
             metadata.engine_id,
@@ -740,6 +825,8 @@ class NixlBaseConnectorWorker:
                 remote_physical_blocks_per_logical=(
                     metadata.physical_blocks_per_logical_kv_block
                 ),
+                remote_dcp_size=remote_dcp_size,
+                remote_pcp_size=remote_pcp_size,
             ),
         )
         return self.nixl_wrapper.add_remote_agent(metadata.agent_metadata)
@@ -856,9 +943,11 @@ class NixlBaseConnectorWorker:
         host: str,
         port: int,
         tp_size: int,
+        dcp_size: int = 1,
+        pcp_size: int = 1,
         pp_size: int = 1,
         notif_agents_only: bool = False,
-    ) -> Future[tuple[dict[tuple[int, int], str], float]] | None:
+    ) -> Future[tuple[dict[RemoteWorkerKey, str], float]] | None:
         """
         Ensure a handshake is in-flight (or already done) for *engine_id*.
 
@@ -881,13 +970,15 @@ class NixlBaseConnectorWorker:
                 port,
                 tp_size,
                 engine_id,
+                dcp_size,
+                pcp_size,
                 pp_size,
                 notif_agents_only,
             )
             self._handshake_futures[engine_id] = fut
 
             def done_callback(
-                f: Future[tuple[dict[tuple[int, int], str], float]],
+                f: Future[tuple[dict[RemoteWorkerKey, str], float]],
                 eid=engine_id,
             ):
                 with self._handshake_lock:
@@ -918,6 +1009,9 @@ class NixlBaseConnectorWorker:
             meta.remote.host,
             meta.remote.port,
             meta.tp_size,
+            meta.dcp_size,
+            meta.pcp_size,
+            meta.pp_size,
         )
         if fut is None:
             # Already handshaked — only happens if caller does not pre-check.
@@ -967,10 +1061,15 @@ class NixlBaseConnectorWorker:
             block_size=self.block_size,
             engine_id=self.engine_id,
             is_mla=self.use_mla,
-            total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
+            total_num_kv_heads=1
+            if self.use_mla
+            else self.model_config.get_total_num_kv_heads(),
             attn_backends=self.attn_backends,
             tensor_shape=None,
             is_mamba=self._has_mamba,
+            dcp_rank=self.dcp_rank,
+            dcp_size=self.dcp_size,
+            pcp_size=self.pcp_size,
         )
         self.compat_hash = compute_nixl_compatibility_hash(
             self.vllm_config,
@@ -998,7 +1097,7 @@ class NixlBaseConnectorWorker:
         self.block_len_per_layer = [block_stride]
         self.num_regions = 1
         self.num_descs = self.num_blocks
-        self.kv_caches_base_addr[self.engine_id][self.tp_rank] = [base_addr]
+        self.kv_caches_base_addr[self.engine_id][self.local_worker_key] = [base_addr]
 
         descs = self.nixl_wrapper.get_reg_descs(caches_data, self.nixl_memory_type)
         self.nixl_wrapper.register_memory(descs, backends=self.nixl_backends)
@@ -1014,9 +1113,9 @@ class NixlBaseConnectorWorker:
             engine_id=self.engine_id,
             agent_metadata=self.nixl_wrapper.get_agent_metadata(),
             device_id=self.device_id,
-            kv_caches_base_addr=(
-                self.kv_caches_base_addr[self.engine_id][self.tp_rank]
-            ),
+            kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][
+                self.local_worker_key
+            ],
             num_blocks=self.num_blocks,
             block_lens=self.block_len_per_layer,
             kv_cache_layout=self.kv_cache_layout,
@@ -1026,6 +1125,15 @@ class NixlBaseConnectorWorker:
             physical_blocks_per_logical_kv_block=(
                 self._physical_blocks_per_logical_kv_block
             ),
+            dcp_rank=self.dcp_rank,
+            tp_size=self.world_size,
+            dcp_size=self.dcp_size,
+            pcp_size=self.pcp_size,
+            num_kv_heads=1
+            if self.use_mla
+            else self.model_config.get_total_num_kv_heads(),
+            tp_rank=self.tp_rank,
+            pcp_rank=self.pcp_rank,
         )
         assert self.compat_hash is not None
         encoder = msgspec.msgpack.Encoder()
@@ -1057,13 +1165,18 @@ class NixlBaseConnectorWorker:
             block_size=self.block_size,
             engine_id=self.engine_id,
             is_mla=self.use_mla,
-            total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
+            total_num_kv_heads=1
+            if self.use_mla
+            else self.model_config.get_total_num_kv_heads(),
             attn_backends=self.attn_backends,
             # SSM States come in tuples (ssm, conv)
             tensor_shape=next(iter(kv_caches.values())).shape
             if not self._has_mamba
             else None,
             is_mamba=self._has_mamba,
+            dcp_rank=self.dcp_rank,
+            dcp_size=self.dcp_size,
+            pcp_size=self.pcp_size,
         )
         self.compat_hash = compute_nixl_compatibility_hash(
             self.vllm_config, self.backend_name, self.transfer_topo.cross_layers_blocks
@@ -1207,7 +1320,9 @@ class NixlBaseConnectorWorker:
             == len(self._region_is_mla)
         )
 
-        self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
+        self.kv_caches_base_addr[self.engine_id][self.local_worker_key] = (
+            seen_base_addresses
+        )
         self.num_regions = len(caches_data)
 
         if self.pp_size > 1:
@@ -1255,7 +1370,9 @@ class NixlBaseConnectorWorker:
             engine_id=self.engine_id,
             agent_metadata=self.nixl_wrapper.get_agent_metadata(),
             device_id=self.device_id,
-            kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][self.tp_rank],
+            kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][
+                self.local_worker_key
+            ],
             num_blocks=self.num_blocks,
             block_lens=self.block_len_per_layer,
             kv_cache_layout=self.kv_cache_layout
@@ -1267,6 +1384,15 @@ class NixlBaseConnectorWorker:
             physical_blocks_per_logical_kv_block=(
                 self._physical_blocks_per_logical_kv_block
             ),
+            dcp_rank=self.dcp_rank,
+            tp_size=self.world_size,
+            dcp_size=self.dcp_size,
+            pcp_size=self.pcp_size,
+            num_kv_heads=1
+            if self.use_mla
+            else self.model_config.get_total_num_kv_heads(),
+            tp_rank=self.tp_rank,
+            pcp_rank=self.pcp_rank,
         )
         # Wrap metadata in payload with hash for defensive decoding
         assert self.compat_hash is not None
@@ -1461,7 +1587,9 @@ class NixlBaseConnectorWorker:
         """
         assert self.transfer_topo is not None
         block_size_ratio = self.block_size // block_size
-        local_base_addresses = self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+        local_base_addresses = self.kv_caches_base_addr[self.engine_id][
+            self.local_worker_key
+        ]
 
         blocks_data = self._build_fa_local(local_base_addresses, block_size_ratio)
         logger.debug(
@@ -1492,6 +1620,9 @@ class NixlBaseConnectorWorker:
         nixl_agent_meta: NixlAgentMetadata,
         remote_tp_rank: int = 0,
         remote_tp_size: int = 1,
+        remote_dcp_rank: int = 0,
+        remote_dcp_size: int = 1,
+        remote_pcp_size: int = 1,
     ) -> str:
         """
         Add the remote NIXL agent and prepare the descriptors for reading cache
@@ -1537,15 +1668,16 @@ class NixlBaseConnectorWorker:
         tp_ratio < 0 (P_TP > D_TP) are supported by the 3-read transfer.
         """  # noqa: E501
         engine_id = nixl_agent_meta.engine_id
+        remote_worker_key: RemoteWorkerKey = (remote_tp_rank, remote_dcp_rank)
         # TODO re-evaluate refreshing for scaling/recovery
-        if (0, remote_tp_rank) in self._remote_agents.get(engine_id, {}):
+        if remote_worker_key in self._remote_agents.get(engine_id, {}):
             logger.debug(
                 "Remote agent with engine_id %s and rank"
                 "%s already exchanged metadata, skip handshake.",
                 engine_id,
-                remote_tp_rank,
+                remote_worker_key,
             )
-            return self._remote_agents[engine_id][(0, remote_tp_rank)]
+            return self._remote_agents[engine_id][remote_worker_key]
 
         # Number of physical regions registered locally (one per layer/tensor).
         num_local_regions = len(self.block_len_per_layer)
@@ -1575,6 +1707,8 @@ class NixlBaseConnectorWorker:
             remote_block_size=nixl_agent_meta.block_size,
             remote_block_len=nixl_agent_meta.block_lens[0],
             remote_physical_blocks_per_logical=physical_blocks_per_logical,
+            remote_dcp_size=remote_dcp_size,
+            remote_pcp_size=remote_pcp_size,
         )
         transfer_topo.register_remote_engine(engine_id, transfer_info)
         logger.info("Transfer plan: %s", transfer_topo.describe(engine_id))
@@ -1602,10 +1736,15 @@ class NixlBaseConnectorWorker:
             self.dst_num_blocks[engine_id] = nixl_agent_meta.num_blocks
 
         # Keep track of remote agent kv caches base addresses.
-        self.kv_caches_base_addr[engine_id][remote_tp_rank] = (
+        self.kv_caches_base_addr[engine_id][remote_worker_key] = (
             nixl_agent_meta.kv_caches_base_addr
         )
-        self._validate_remote_agent_handshake(nixl_agent_meta, remote_tp_size)
+        self._validate_remote_agent_handshake(
+            nixl_agent_meta,
+            remote_tp_size,
+            remote_dcp_size,
+            remote_pcp_size,
+        )
 
         # This is 1 when P and D `--tensor-parallel-size` match. Otherwise,
         # this is the ratio between the two sizes.
@@ -1614,7 +1753,7 @@ class NixlBaseConnectorWorker:
         logger.debug(
             "Registering remote agent (%s, rank %s) memory regions with tp_ratio %s",
             engine_id,
-            remote_tp_rank,
+            remote_worker_key,
             tp_ratio,
         )
 
@@ -1689,14 +1828,18 @@ class NixlBaseConnectorWorker:
 
         # Register with NIXL.
         descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
-        self.dst_xfer_side_handles[engine_id][remote_tp_rank] = (
+        self.dst_xfer_side_handles[engine_id][remote_worker_key] = (
             self.nixl_wrapper.prep_xfer_dlist(remote_agent_name, descs)
         )
 
         return remote_agent_name
 
     def _validate_remote_agent_handshake(
-        self, nixl_agent_meta: NixlAgentMetadata, remote_tp_size: int
+        self,
+        nixl_agent_meta: NixlAgentMetadata,
+        remote_tp_size: int,
+        remote_dcp_size: int = 1,
+        remote_pcp_size: int = 1,
     ):
         """
         Validate the remote agent handshake metadata ensuring the
@@ -1707,6 +1850,8 @@ class NixlBaseConnectorWorker:
         assert self.transfer_topo is not None
         remote_info = self.transfer_topo.get_engine_info(remote_engine_id)
         assert remote_info.remote_tp_size == remote_tp_size
+        assert remote_info.remote_dcp_size == remote_dcp_size
+        assert remote_info.remote_pcp_size == remote_pcp_size
 
         tp_ratio = self.transfer_topo.tp_ratio(remote_tp_size)
         block_size_ratio = self.transfer_topo.block_size_ratio(
@@ -2050,6 +2195,8 @@ class NixlBaseConnectorWorker:
         assert self.transfer_topo is not None
         done_sending = self._get_new_notifs()
         done_recving = self._pop_done_transfers(self._recving_transfers)
+        done_recving.update(self._done_recving_without_xfer)
+        self._done_recving_without_xfer.clear()
 
         # Drain queue of requests where handshake or transfer setup failed.
         failed_recv_reqs = set[ReqId]()
@@ -2150,6 +2297,7 @@ class NixlBaseConnectorWorker:
             if now < expires:
                 break
             count = self.consumer_notification_counts_by_req.pop(req_id, 0)
+            self.expected_consumer_notifications_by_req.pop(req_id, None)
             self.xfer_stats.record_kv_expired_req()
             logger.warning(
                 "Releasing expired KV blocks for request %s which were "
@@ -2285,8 +2433,8 @@ class NixlBaseConnectorWorker:
                     hb_info.host,
                     hb_info.port,
                     hb_info.tp_size,
-                    hb_info.pp_size,
-                    self._hb_handshake_notif_only and hb_info.pp_size > 1,
+                    hb_info.dcp_size,
+                    hb_info.pcp_size,
                 )
                 is not None
             ):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -388,7 +388,12 @@ class NixlBaseConnectorWorker:
         except AssertionError:
             self.pcp_size = 1
             self.pcp_rank = 0
-        self.dcp_rank = (self.tp_rank * self.pcp_size + self.pcp_rank) % self.dcp_size
+        self.dcp_rank = TransferTopology.get_dcp_rank(
+            tp_rank=self.tp_rank,
+            pcp_rank=self.pcp_rank,
+            pcp_size=self.pcp_size,
+            dcp_size=self.dcp_size,
+        )
         self.local_worker_key: RemoteAgentKey = (
             self.pp_rank,
             self.pcp_rank,
@@ -768,9 +773,12 @@ class NixlBaseConnectorWorker:
                         f"({remote_pcp_rank}, {remote_tp_rank}), got "
                         f"({metadata.pcp_rank}, {metadata.tp_rank})."
                     )
-                inferred_dcp_rank = (
-                    metadata.tp_rank * metadata.pcp_size + metadata.pcp_rank
-                ) % metadata.dcp_size
+                inferred_dcp_rank = TransferTopology.get_dcp_rank(
+                    metadata.tp_rank,
+                    metadata.pcp_rank,
+                    metadata.pcp_size,
+                    metadata.dcp_size,
+                )
                 if (
                     inferred_dcp_rank != remote_dcp_rank
                     or metadata.dcp_rank != inferred_dcp_rank

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -220,9 +220,7 @@ class NixlBaseConnectorWorker:
                     handle.append((addr + p_idx * chunk, chunk, dev))
             yield handle
 
-    def _needs_split_local_xfer_handles(
-        self, tp_ratio: int, plan: TPMapping
-    ) -> bool:
+    def _needs_split_local_xfer_handles(self, tp_ratio: int, plan: TPMapping) -> bool:
         """Whether reads need per-source slices of the local KV region.
 
         Pure MLA attention is replicated across TP ranks and writes the whole
@@ -231,9 +229,7 @@ class NixlBaseConnectorWorker:
         splitting the local region. Hybrid MLA+SSM is different: its mapping
         contains multiple source ranks for the sharded SSM state.
         """
-        return tp_ratio < 0 and (
-            not self.use_mla or len(plan.all_source_ranks) > 1
-        )
+        return tp_ratio < 0 and (not self.use_mla or len(plan.all_source_ranks) > 1)
 
     def _fa_desc_replicated(self, num_fa_descs: int) -> list[bool]:
         """Per-FA-descriptor replicate flag, in _build_fa_local emission order
@@ -661,6 +657,7 @@ class NixlBaseConnectorWorker:
             self.pp_rank,
             self.pp_size,
             remote_pp_size,
+            notif_only=notif_agents_only,
         )
         with zmq_ctx(zmq.REQ, path) as sock:
             for remote_pp_rank, remote_worker_key in itertools.product(
@@ -804,7 +801,10 @@ class NixlBaseConnectorWorker:
                 # Register Remote agent.
                 if notif_agents_only:
                     remote_agent_name = self._add_notif_only_remote_agent(
-                        metadata, remote_tp_size, remote_pp_rank
+                        metadata,
+                        remote_tp_size,
+                        remote_pp_rank,
+                        remote_pp_size,
                     )
                 else:
                     remote_agent_name = self.add_remote_agent(
@@ -843,6 +843,7 @@ class NixlBaseConnectorWorker:
         metadata: NixlAgentMetadata,
         remote_tp_size: int,
         remote_pp_rank: int = 0,
+        remote_pp_size: int = 1,
     ) -> str:
         """Load a remote agent for notifs only on the push-mode decode side.
 
@@ -861,6 +862,7 @@ class NixlBaseConnectorWorker:
                 remote_dcp_size=metadata.dcp_size,
                 remote_pcp_size=metadata.pcp_size,
                 remote_pp_rank=remote_pp_rank,
+                remote_pp_size=remote_pp_size,
             ),
         )
         return self.nixl_wrapper.add_remote_agent(metadata.agent_metadata)
@@ -1753,6 +1755,7 @@ class NixlBaseConnectorWorker:
             remote_dcp_size=remote_dcp_size,
             remote_pcp_size=remote_pcp_size,
             remote_pp_rank=remote_pp_rank,
+            remote_pp_size=remote_pp_size,
         )
         transfer_topo.register_remote_engine(engine_id, transfer_info)
         logger.info(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -633,7 +633,9 @@ class NixlBaseConnectorWorker:
         best_offset: float | None = None
 
         with zmq_ctx(zmq.REQ, path) as sock:
-            for remote_worker_key in remote_worker_keys:
+            for remote_pp_rank, remote_worker_key in itertools.product(
+                range(remote_pp_size), remote_worker_keys
+            ):
                 remote_tp_rank, remote_dcp_rank = remote_worker_key
                 remote_pcp_rank = self._tp_dcp_to_pcp_rank(
                     remote_tp_rank,
@@ -641,7 +643,6 @@ class NixlBaseConnectorWorker:
                     remote_pcp_size,
                     remote_dcp_size,
                 )
-                remote_pp_rank = 0
                 logger.debug(
                     "Querying metadata on path: %s at PP rank %s, PCP rank %s, "
                     "TP rank %s for worker key %s",
@@ -778,6 +779,12 @@ class NixlBaseConnectorWorker:
                         remote_dcp_size,
                         remote_pcp_size,
                     )
+                    # Notification-only callers iterate over values; use a key
+                    # that remains unique across PP, PCP, and TP workers.
+                    agent_key: RemoteWorkerKey = (
+                        remote_pp_rank,
+                        remote_pcp_rank * remote_tp_size + remote_tp_rank,
+                    )
                 else:
                     remote_agent_name = self.add_remote_agent(
                         metadata,
@@ -787,13 +794,14 @@ class NixlBaseConnectorWorker:
                         metadata.dcp_size,
                         metadata.pcp_size,
                     )
+                    agent_key = remote_worker_key
                 setup_agent_time = time.perf_counter()
                 logger.debug(
                     "NIXL handshake: add agent took: %s (notif_agents_only=%s)",
                     setup_agent_time - got_metadata_time,
                     notif_agents_only,
                 )
-                remote_worker_to_agent_name[remote_worker_key] = remote_agent_name
+                remote_worker_to_agent_name[agent_key] = remote_agent_name
         if not remote_worker_to_agent_name:
             raise RuntimeError(
                 "Handshake completed but found no remote worker with overlapping "

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -1729,7 +1729,8 @@ class NixlBaseConnectorWorker:
             )
             return self._remote_agents[engine_id][remote_worker_key]
 
-        # Number of physical regions registered locally (one per layer/tensor).
+        # Compare physical regions, not self.num_regions (doubled by
+        # FlashInfer's virtual K/V split).
         num_local_regions = len(self.block_len_per_layer)
         if (
             self.pp_size > 1
@@ -2485,6 +2486,8 @@ class NixlBaseConnectorWorker:
                     hb_info.tp_size,
                     hb_info.dcp_size,
                     hb_info.pcp_size,
+                    hb_info.pp_size,
+                    self._hb_handshake_notif_only and hb_info.pp_size > 1,
                 )
                 is not None
             ):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -220,6 +220,21 @@ class NixlBaseConnectorWorker:
                     handle.append((addr + p_idx * chunk, chunk, dev))
             yield handle
 
+    def _needs_split_local_xfer_handles(
+        self, tp_ratio: int, plan: TPMapping
+    ) -> bool:
+        """Whether reads need per-source slices of the local KV region.
+
+        Pure MLA attention is replicated across TP ranks and writes the whole
+        local region. Multiple physical remote workers may still participate
+        because DCP assigns them disjoint blocks, but that does not require
+        splitting the local region. Hybrid MLA+SSM is different: its mapping
+        contains multiple source ranks for the sharded SSM state.
+        """
+        return tp_ratio < 0 and (
+            not self.use_mla or len(plan.all_source_ranks) > 1
+        )
+
     def _fa_desc_replicated(self, num_fa_descs: int) -> list[bool]:
         """Per-FA-descriptor replicate flag, in _build_fa_local emission order
         (region-major; one desc per block, with K/V packed). Length ``num_fa_descs``.
@@ -1806,10 +1821,8 @@ class NixlBaseConnectorWorker:
 
         ### (Optional) Register local agent memory regions. MLA is not split.
         split_key = (tp_ratio, remote_block_size)
-        if (
-            tp_ratio < 0
-            and (not self.use_mla or len(plan.all_source_ranks) > 1)
-            and split_key not in self.src_xfer_handles_by_tp_ratio
+        if self._needs_split_local_xfer_handles(tp_ratio, plan) and (
+            split_key not in self.src_xfer_handles_by_tp_ratio
         ):
             # Remote tp_size > local tp_size: read from multiple remote ranks.
             # Logically "split" own regions into per-source chunks. Hybrid

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -642,9 +642,14 @@ class NixlBaseConnectorWorker:
         best_rtt = float("inf")
         best_offset: float | None = None
 
+        remote_pp_ranks = self.transfer_topo.get_target_remote_pp_ranks(
+            self.pp_rank,
+            self.pp_size,
+            remote_pp_size,
+        )
         with zmq_ctx(zmq.REQ, path) as sock:
             for remote_pp_rank, remote_worker_key in itertools.product(
-                range(remote_pp_size), remote_worker_keys
+                remote_pp_ranks, remote_worker_keys
             ):
                 remote_pcp_rank, remote_tp_rank = remote_worker_key
                 remote_dcp_rank = self.transfer_topo.get_dcp_rank(
@@ -796,6 +801,7 @@ class NixlBaseConnectorWorker:
                         remote_pcp_size=metadata.pcp_size,
                         remote_pcp_rank=metadata.pcp_rank,
                         remote_pp_rank=remote_pp_rank,
+                        remote_pp_size=remote_pp_size,
                     )
                 agent_key: RemoteAgentKey = (
                     remote_pp_rank,
@@ -1638,6 +1644,7 @@ class NixlBaseConnectorWorker:
         remote_pcp_size: int = 1,
         remote_pcp_rank: int = 0,
         remote_pp_rank: int = 0,
+        remote_pp_size: int = 1,
     ) -> str:
         """
         Add the remote NIXL agent and prepare the descriptors for reading cache
@@ -1703,6 +1710,7 @@ class NixlBaseConnectorWorker:
         num_local_regions = len(self.block_len_per_layer)
         if (
             self.pp_size > 1
+            and remote_pp_size == 1
             and len(nixl_agent_meta.kv_caches_base_addr) > num_local_regions
         ):
             # This worker holds a PP layer-slice; the PP=1 remote registered
@@ -1732,7 +1740,9 @@ class NixlBaseConnectorWorker:
             remote_pp_rank=remote_pp_rank,
         )
         transfer_topo.register_remote_engine(engine_id, transfer_info)
-        logger.info("Transfer plan: %s", transfer_topo.describe(engine_id))
+        logger.info(
+            "Transfer plan: %s", transfer_topo.describe(engine_id, remote_pp_rank)
+        )
 
         self.tp_mappings[engine_id] = compute_tp_mapping(
             transfer_topology=transfer_topo,
@@ -1764,6 +1774,7 @@ class NixlBaseConnectorWorker:
             nixl_agent_meta,
             remote_tp_size,
             remote_dcp_size,
+            remote_pp_rank,
             remote_pcp_size,
         )
 
@@ -1860,6 +1871,7 @@ class NixlBaseConnectorWorker:
         nixl_agent_meta: NixlAgentMetadata,
         remote_tp_size: int,
         remote_dcp_size: int = 1,
+        remote_pp_rank: int = 0,
         remote_pcp_size: int = 1,
     ):
         """
@@ -1869,7 +1881,9 @@ class NixlBaseConnectorWorker:
         remote_engine_id = nixl_agent_meta.engine_id
 
         assert self.transfer_topo is not None
-        remote_info = self.transfer_topo.get_engine_info(remote_engine_id)
+        remote_info = self.transfer_topo.get_engine_info(
+            remote_engine_id, remote_pp_rank
+        )
         assert remote_info.remote_tp_size == remote_tp_size
         assert remote_info.remote_dcp_size == remote_dcp_size
         assert remote_info.remote_pcp_size == remote_pcp_size
@@ -1883,7 +1897,10 @@ class NixlBaseConnectorWorker:
         # MLA models do not need to handle kv replication.
         if not self.use_mla and not self._has_mamba:
             assert not (
-                tp_ratio < 0 and self.transfer_topo.is_kv_replicated(remote_engine_id)
+                tp_ratio < 0
+                and self.transfer_topo.is_kv_replicated(
+                    remote_engine_id, remote_pp_rank
+                )
             )
 
         remote_physical_per_logical = (
@@ -1957,7 +1974,9 @@ class NixlBaseConnectorWorker:
         if (
             abs(tp_ratio) != 1
             and not self.use_mla
-            and not self.transfer_topo.is_kv_replicated(remote_engine_id)
+            and not self.transfer_topo.is_kv_replicated(
+                remote_engine_id, remote_pp_rank
+            )
             and kv_cache_layout != "HND"
             and not self.enable_permute_local_kv
         ):
@@ -2266,7 +2285,12 @@ class NixlBaseConnectorWorker:
             # granularity, when equal kernel pages meet differing logical
             # block sizes and _apply_prefix_caching front-trims to the
             # minimum count (hybrid heterogeneous TP).
-            remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id)
+            remote_pp_rank = self.transfer_topo.resolve_remote_pp_rank(
+                meta.remote.engine_id, self.pp_rank
+            )
+            remote_info = self.transfer_topo.get_engine_info(
+                meta.remote.engine_id, remote_pp_rank
+            )
             block_size_ratio = self.transfer_topo.block_size_ratio(
                 remote_info.remote_block_size
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -635,22 +635,27 @@ class NixlBaseConnectorWorker:
         with zmq_ctx(zmq.REQ, path) as sock:
             for remote_worker_key in remote_worker_keys:
                 remote_tp_rank, remote_dcp_rank = remote_worker_key
-                remote_flat_idx = self._tp_dcp_to_flat_idx(
+                remote_pcp_rank = self._tp_dcp_to_pcp_rank(
                     remote_tp_rank,
                     remote_dcp_rank,
                     remote_pcp_size,
                     remote_dcp_size,
                 )
+                remote_pp_rank = 0
                 logger.debug(
-                    "Querying metadata on path: %s at remote flat_idx %s "
-                    "for worker key %s",
+                    "Querying metadata on path: %s at PP rank %s, PCP rank %s, "
+                    "TP rank %s for worker key %s",
                     path,
-                    remote_flat_idx,
+                    remote_pp_rank,
+                    remote_pcp_rank,
+                    remote_tp_rank,
                     remote_worker_key,
                 )
 
                 # Send query for the request.
-                msg = msgspec.msgpack.encode((GET_META_MSG, remote_flat_idx))
+                msg = msgspec.msgpack.encode(
+                    (GET_META_MSG, remote_pp_rank, remote_pcp_rank, remote_tp_rank)
+                )
                 # Set receive timeout to 5 seconds to avoid hanging on dead server
                 sock.setsockopt(zmq.RCVTIMEO, 5000)  # milliseconds
                 start_time = time.perf_counter()
@@ -725,16 +730,31 @@ class NixlBaseConnectorWorker:
                         f"Expected {expected_engine_id},"
                         f"received {metadata.engine_id}."
                     )
-                received_flat_idx = metadata.tp_rank * metadata.pcp_size
-                received_flat_idx += metadata.pcp_rank
-                if received_flat_idx != remote_flat_idx:
+                if (
+                    metadata.tp_rank != remote_tp_rank
+                    or metadata.pcp_rank != remote_pcp_rank
+                ):
                     raise RuntimeError(
-                        "Remote handshake metadata flat_idx mismatch. "
-                        f"Expected flat_idx={remote_flat_idx}, got "
-                        f"flat_idx={received_flat_idx} "
-                        f"(tp_rank={metadata.tp_rank}, "
-                        f"pcp_rank={metadata.pcp_rank}, "
-                        f"dcp_rank={metadata.dcp_rank})."
+                        "Remote handshake metadata rank mismatch. "
+                        f"Expected (pcp_rank, tp_rank)="
+                        f"({remote_pcp_rank}, {remote_tp_rank}), got "
+                        f"({metadata.pcp_rank}, {metadata.tp_rank})."
+                    )
+                inferred_dcp_rank = (
+                    metadata.tp_rank * metadata.pcp_size + metadata.pcp_rank
+                ) % metadata.dcp_size
+                if (
+                    inferred_dcp_rank != remote_dcp_rank
+                    or metadata.dcp_rank != inferred_dcp_rank
+                ):
+                    raise RuntimeError(
+                        "Remote handshake metadata DCP rank mismatch. "
+                        f"Expected dcp_rank={remote_dcp_rank}, inferred "
+                        f"dcp_rank={inferred_dcp_rank}, metadata "
+                        f"dcp_rank={metadata.dcp_rank} from "
+                        f"(pcp_rank={metadata.pcp_rank}, "
+                        f"tp_rank={metadata.tp_rank}, "
+                        f"dcp_size={metadata.dcp_size})."
                     )
                 if not self.transfer_topo.has_kv_cache_overlap(
                     metadata.tp_rank,
@@ -783,7 +803,7 @@ class NixlBaseConnectorWorker:
         return remote_worker_to_agent_name, best_offset
 
     @staticmethod
-    def _tp_dcp_to_flat_idx(
+    def _tp_dcp_to_pcp_rank(
         tp_rank: int,
         dcp_rank: int,
         pcp_size: int,
@@ -794,16 +814,17 @@ class NixlBaseConnectorWorker:
 
         pcp_rank = (dcp_rank - tp_rank * pcp_size) % dcp_size
         if pcp_rank < pcp_size:
+            # dcp_rank is derived from the explicit PCP/TP metadata key.
+            inferred_dcp_rank = (tp_rank * pcp_size + pcp_rank) % dcp_size
+            assert inferred_dcp_rank == dcp_rank
             # A (tp_rank, dcp_rank) pair may map to multiple PCP ranks when
-            # pcp_size > dcp_size. The worker key does not preserve which PCP
-            # replica produced the DCP shard, so pick the smallest valid PCP
-            # rank for now.
+            # pcp_size > dcp_size. Pick the smallest valid PCP rank for now.
             # TODO: Choose among equivalent PCP ranks using load-balance
             # signals instead of always choosing the smallest rank.
-            return tp_rank * pcp_size + pcp_rank
+            return pcp_rank
 
         raise ValueError(
-            f"No valid flat_idx for tp_rank={tp_rank}, dcp_rank={dcp_rank}, "
+            f"No valid pcp_rank for tp_rank={tp_rank}, dcp_rank={dcp_rank}, "
             f"pcp_size={pcp_size}, dcp_size={dcp_size}"
         )
 
@@ -2542,6 +2563,39 @@ class NixlBaseConnectorWorker:
                     ).tolist()
                 )
         return physical_block_ids
+
+    def _logical_to_remote_kernel_block_ids(
+        self, block_ids: BlockIds, remote_physical_per_logical: int
+    ) -> BlockIds:
+        """Map logical block IDs to physical kernel block IDs on the remote.
+
+        Args:
+            block_ids: per-group lists of logical block IDs.
+            remote_physical_per_logical: remote engine's physical blocks
+                per logical block.
+
+        Returns:
+            Same structure with FA groups expanded (each logical block L
+            becomes kernel blocks [L*remote_physical_per_logical, ..
+            L*remote_physical_per_logical +
+            remote_physical_per_logical - 1]).
+            Mamba groups are passed through unchanged.
+        """
+        if remote_physical_per_logical == 1:
+            return block_ids
+        remote_arange = np.arange(remote_physical_per_logical).reshape(1, -1)
+        group_specs = self.kv_cache_config.kv_cache_groups
+        result = [
+            BlockTable.map_to_kernel_blocks(
+                np.array(group),
+                remote_physical_per_logical,
+                remote_arange,
+            ).tolist()
+            if not isinstance(group_specs[i].kv_cache_spec, MambaSpec)
+            else group
+            for i, group in enumerate(block_ids)
+        ]
+        return result
 
     def _apply_prefix_caching(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
@@ -208,11 +208,11 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
         return self.connector_scheduler.request_finished(request, block_ids)
 
     def set_xfer_handshake_metadata_pp_aware(
-        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+        self, metadata: dict[tuple[int, int, int], KVConnectorHandshakeMetadata]
     ) -> None:
         """
-        Set handshake metadata keyed by (pp_rank, tp_rank) so the side
-        channel can serve every PP stage's agent metadata.
+        Set handshake metadata keyed by (pp_rank, pcp_rank, tp_rank) so the
+        side channel can serve every PP/PCP/TP producer shard's agent metadata.
 
         Args:
             metadata (dict): the handshake metadata to set.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -160,6 +160,7 @@ class HeartbeatInfo:
     tp_size: int
     dcp_size: int = 1
     pcp_size: int = 1
+    pp_size: int = 1
 
 
 @dataclass
@@ -218,6 +219,7 @@ class NixlConnectorMetadata(KVConnectorMetadata):
             remote_block_size=kv_transfer_params.get("remote_block_size"),
             dcp_size=kv_transfer_params.get("dcp_size", 1),
             pcp_size=kv_transfer_params.get("pcp_size", 1),
+            pp_size=kv_transfer_params.get("pp_size", 1),
             local_num_computed_tokens=local_num_computed_tokens,
         )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -17,7 +17,11 @@ logger = init_logger(__name__)
 
 TransferHandle = int
 ReqId = str
+# Physical worker identity, matching the last two dimensions of handshake keys.
+# DCP rank is derived from this key and the remote parallel sizes.
 RemoteWorkerKey = tuple[int, int]
+# Full remote agent identity: (pp_rank, pcp_rank, tp_rank).
+RemoteAgentKey = tuple[int, int, int]
 
 GET_META_MSG = b"get_meta_msg"
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -17,6 +17,7 @@ logger = init_logger(__name__)
 
 TransferHandle = int
 ReqId = str
+RemoteWorkerKey = tuple[int, int]
 
 GET_META_MSG = b"get_meta_msg"
 
@@ -41,8 +42,9 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #   4: Add KV block lease renewal through heartbeats
 #   5: Add remote_blocks_expiry_time to kv_transfer_params + handshake
 #      clock-sync timestamp
+#   6: Add DCP/PCP rank metadata for context-parallel KV transfer
 #
-NIXL_CONNECTOR_VERSION: int = 5
+NIXL_CONNECTOR_VERSION: int = 6
 
 
 @dataclass
@@ -58,6 +60,13 @@ class NixlAgentMetadata:
     ssm_sizes: tuple[int, int]
     attn_backend_name: str
     physical_blocks_per_logical_kv_block: int
+    dcp_rank: int = 0
+    tp_size: int = 1
+    dcp_size: int = 1
+    pcp_size: int = 1
+    num_kv_heads: int = 0
+    tp_rank: int = 0
+    pcp_rank: int = 0
 
 
 @dataclass
@@ -149,7 +158,8 @@ class HeartbeatInfo:
     host: str
     port: int
     tp_size: int
-    pp_size: int = 1
+    dcp_size: int = 1
+    pcp_size: int = 1
 
 
 @dataclass
@@ -168,6 +178,9 @@ class ReqMeta:
     # To be used when logical block size does not match the kernel block size
     local_physical_block_ids: BlockIds
     tp_size: int
+    dcp_size: int = 1
+    pcp_size: int = 1
+    local_num_computed_tokens: int = 0
     remote: RemoteMeta | None = None
     # Remote block size, discovered during NIXL handshake (push mode).
     remote_block_size: int | None = None
@@ -195,14 +208,17 @@ class NixlConnectorMetadata(KVConnectorMetadata):
         self,
         local_block_ids: BlockIds,
         kv_transfer_params: dict[str, Any],
+        local_num_computed_tokens: int = 0,
     ) -> ReqMeta:
         return ReqMeta(
             local_block_ids=local_block_ids,
             local_physical_block_ids=local_block_ids,
-            # P workers don't need to receive tp_size from proxy here.
+            # P workers don't need to receive these from proxy here.
             tp_size=kv_transfer_params.get("tp_size", 1),
             remote_block_size=kv_transfer_params.get("remote_block_size"),
-            pp_size=kv_transfer_params.get("pp_size", 1),
+            dcp_size=kv_transfer_params.get("dcp_size", 1),
+            pcp_size=kv_transfer_params.get("pcp_size", 1),
+            local_num_computed_tokens=local_num_computed_tokens,
         )
 
     def add_new_req_to_save(
@@ -220,8 +236,13 @@ class NixlConnectorMetadata(KVConnectorMetadata):
         request_id: ReqId,
         local_block_ids: BlockIds,
         kv_transfer_params: dict[str, Any],
+        local_num_computed_tokens: int = 0,
     ):
-        req = self._add_new_req(local_block_ids, kv_transfer_params)
+        req = self._add_new_req(
+            local_block_ids,
+            kv_transfer_params,
+            local_num_computed_tokens=local_num_computed_tokens,
+        )
         req.remote = RemoteMeta(
             block_ids=kv_transfer_params["remote_block_ids"],
             engine_id=kv_transfer_params["remote_engine_id"],

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -46,7 +46,8 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #   4: Add KV block lease renewal through heartbeats
 #   5: Add remote_blocks_expiry_time to kv_transfer_params + handshake
 #      clock-sync timestamp
-#   6: Add DCP/PCP rank metadata for context-parallel KV transfer
+#   6: Add PP/PCP/DCP rank and push-registration topology metadata for
+#      context-parallel KV transfer
 #
 NIXL_CONNECTOR_VERSION: int = 6
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -158,12 +158,17 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                     local_block_ids = self.get_sw_clipped_blocks(
                         unhashed_local_block_ids
                     )
-                    dcp_size = params.get("dcp_size", 1)
-                    pcp_size = params.get("pcp_size", 1)
+                    parallel_config = self.vllm_config.parallel_config
+                    dcp_size = parallel_config.decode_context_parallel_size
+                    pcp_size = parallel_config.prefill_context_parallel_size
                     scheduler_block_size = self.block_size * dcp_size * pcp_size
-                    num_hashed_blocks = sum(
-                        block.block_hash is not None and not block.is_null
-                        for block in blocks.blocks[0]
+                    num_hashed_blocks = (
+                        sum(
+                            block.block_hash is not None and not block.is_null
+                            for block in blocks.blocks[0]
+                        )
+                        if blocks.blocks
+                        else 0
                     )
                     local_num_computed_tokens = num_hashed_blocks * scheduler_block_size
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -160,8 +160,7 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                     )
                     parallel_config = self.vllm_config.parallel_config
                     dcp_size = parallel_config.decode_context_parallel_size
-                    pcp_size = parallel_config.prefill_context_parallel_size
-                    scheduler_block_size = self.block_size * dcp_size * pcp_size
+                    scheduler_block_size = self.block_size * dcp_size
                     num_hashed_blocks = (
                         sum(
                             block.block_hash is not None and not block.is_null

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -158,12 +158,21 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                     local_block_ids = self.get_sw_clipped_blocks(
                         unhashed_local_block_ids
                     )
+                    dcp_size = params.get("dcp_size", 1)
+                    pcp_size = params.get("pcp_size", 1)
+                    scheduler_block_size = self.block_size * dcp_size * pcp_size
+                    num_hashed_blocks = sum(
+                        block.block_hash is not None and not block.is_null
+                        for block in blocks.blocks[0]
+                    )
+                    local_num_computed_tokens = num_hashed_blocks * scheduler_block_size
 
                     # Get unhashed blocks to pull from remote. Mind that a full prefix
                     # cache hit is indicated with an empty list.
                     self._reqs_need_recv[request.request_id] = (
                         request,
                         local_block_ids,
+                        local_num_computed_tokens,
                     )
 
                 else:
@@ -216,7 +225,7 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             # To avoid stranding the prefill blocks in the prefill instance,
             # we must add empty block_ids to _reqs_need_recv so that our
             # worker side will notify and free blocks in the prefill instance.
-            self._reqs_need_recv[request.request_id] = (request, [])
+            self._reqs_need_recv[request.request_id] = (request, [], 0)
             params["do_remote_prefill"] = False
             return False, None
 
@@ -275,6 +284,8 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
+            dcp_size=self.vllm_config.parallel_config.decode_context_parallel_size,
+            pcp_size=self.vllm_config.parallel_config.prefill_context_parallel_size,
             remote_num_tokens=remote_num_tokens,
             remote_blocks_expiry_time=blocks_expiry_time,
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -291,6 +291,7 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
             dcp_size=self.vllm_config.parallel_config.decode_context_parallel_size,
             pcp_size=self.vllm_config.parallel_config.prefill_context_parallel_size,
+            pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,
             remote_num_tokens=remote_num_tokens,
             remote_blocks_expiry_time=blocks_expiry_time,
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -119,6 +119,17 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # Update last activity from this remote. Mind that cleanup is done on main
         # thread (this one), so we don't race on this structure.
         self._engine_last_active[engine_id] = time.perf_counter()
+
+        if self._bidirectional_kv_xfer_enabled and self._is_turn2_read_expired(meta):
+            logger.warning(
+                "Declining expired remote read for %s from engine %s.",
+                req_id,
+                engine_id,
+            )
+            self.xfer_stats.record_kv_expired_req()
+            self._handle_failed_transfer(req_id, None)
+            return
+
         remote_pp_rank = self.transfer_topo.resolve_remote_pp_rank(
             engine_id, self.pp_rank
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -10,6 +10,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlConnectorMetadata,
+    RemoteWorkerKey,
     ReqMeta,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
@@ -117,60 +118,53 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # Update last activity from this remote. Mind that cleanup is done on main
         # thread (this one), so we don't race on this structure.
         self._engine_last_active[engine_id] = time.perf_counter()
-
-        if self._bidirectional_kv_xfer_enabled and self._is_turn2_read_expired(meta):
-            logger.warning(
-                "Declining expired remote read for %s from engine %s.",
-                req_id,
-                engine_id,
-            )
-            self.xfer_stats.record_kv_expired_req()
-            self._handle_failed_transfer(req_id, None)
-            return
-
-        plan = self.tp_mappings[engine_id]
         remote_info = self.transfer_topo.get_engine_info(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
-
-        meta.remote.block_ids = self._logical_to_kernel_block_ids(
-            meta.remote.block_ids,
-            remote_info.remote_physical_blocks_per_logical,
+        remote_worker_keys = (
+            self.transfer_topo.get_target_remote_worker_keys_from_engine_id(engine_id)
         )
-        remote_block_ids = meta.remote.block_ids
-        local_block_ids = meta.local_physical_block_ids
-        num_groups = len(local_block_ids)
-        read_specs = [
-            ReadSpec(
-                remote_rank=rank,
-                local_block_ids=[
-                    list(local_block_ids[g])
-                    if rank in plan.source_ranks_per_group[g]
-                    else []
-                    for g in range(num_groups)
-                ],
-                remote_block_ids=[
-                    list(remote_block_ids[g])
-                    if rank in plan.source_ranks_per_group[g]
-                    else []
-                    for g in range(num_groups)
-                ],
+        logical_local_block_ids = meta.local_block_ids
+        logical_remote_block_ids = meta.remote.block_ids
+        local_block_offset = (
+            meta.local_num_computed_tokens // self._local_logical_block_size()
+        ) * self.dcp_size
+
+        launched_read = False
+        for remote_worker_key in remote_worker_keys:
+            remote_tp_rank, remote_dcp_rank = remote_worker_key
+            if len(logical_local_block_ids) == 0:
+                local_block_ids = []
+                remote_block_ids = []
+            else:
+                local_logical_ids, remote_logical_ids = (
+                    self.transfer_topo.get_matched_blocks(
+                        logical_local_block_ids,
+                        logical_remote_block_ids,
+                        remote_info.remote_dcp_size,
+                        remote_dcp_rank,
+                        local_block_offset,
+                    )
+                )
+                local_block_ids = self._logical_to_kernel_block_ids(local_logical_ids)
+                remote_block_ids = self._logical_to_remote_kernel_block_ids(
+                    remote_logical_ids,
+                    remote_info.remote_physical_blocks_per_logical,
+                )
+
+            if any(len(group) > 0 for group in local_block_ids):
+                launched_read = True
+
+            spec = ReadSpec(
+                remote_rank=remote_tp_rank,
+                local_block_ids=local_block_ids,
+                remote_block_ids=remote_block_ids,
             )
-            for rank in plan.all_source_ranks
-        ]
-
-        # D may have to perform multiple reads from different remote ranks.
-        # Pure MLA reads once because its cache is replicated. Hybrid
-        # MLA+SSM still needs one read per SSM source rank.
-        if self.use_mla and tp_ratio < 0 and not self._has_mamba:
-            assert len(read_specs) == 1
-
-        for i, spec in enumerate(read_specs):
             remote_block_size = remote_info.remote_block_size
             logger.debug(
                 "Remote agent %s available, calling _read_blocks"
-                " on remote rank %s with remote block size %s for req %s",
+                " on remote worker %s with remote block size %s for req %s",
                 meta.remote.engine_id,
-                spec.remote_rank,
+                remote_worker_key,
                 remote_block_size,
                 req_id,
             )
@@ -179,7 +173,9 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 # Remote tp_size > local tp_size: we must perform multiple
                 # reads. Get the memory chunk onto which we will write to.
                 split_key = (tp_ratio, remote_block_size)
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][i]
+                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][
+                    remote_tp_rank - self.tp_rank * (-tp_ratio)
+                ]
             else:
                 # Single read from remote, we write to the whole memory region.
                 # Also handle remote block size different from local block size.
@@ -187,10 +183,14 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     remote_block_size
                 ]
 
-            # Destination handle: remote_engine_id -> remote_rank -> handle.
+            # Destination handle: remote_engine_id -> (tp_rank, dcp_rank) -> handle.
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
+                remote_worker_key
             ]
+            expected_consumers = self.transfer_topo.calculate_local_consumer_count(
+                engine_id,
+                remote_worker_key,
+            )
 
             self._read_blocks(
                 read_spec=spec,
@@ -199,16 +199,17 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
+                remote_worker_key=remote_worker_key,
+                expected_consumers=expected_consumers,
             )
 
-        if self.use_mla and tp_ratio < 0 and len(read_specs) == 1:
-            # ..but we still need to notify the other remote ranks that we
-            # have the blocks we need so they can update the request state.
-            notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
-            remote_agents = self._remote_agents[meta.remote.engine_id]
-            for rank_to_notify, agent in remote_agents.items():
-                if rank_to_notify != (0, read_specs[0].remote_rank):
-                    self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
+        if not launched_read:
+            self._done_recving_without_xfer.add(req_id)
+
+    def _local_logical_block_size(self) -> int:
+        return (
+            self.block_size * self._physical_blocks_per_logical_kv_block * self.dcp_size
+        )
 
     def _read_blocks(
         self,
@@ -218,6 +219,8 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
+        remote_worker_key: RemoteWorkerKey | None = None,
+        expected_consumers: int | None = None,
     ):
         """
         Post a READ point-to-point xfer request from a single local worker to
@@ -225,8 +228,35 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         """
         assert self.transfer_topo is not None
         remote_rank = read_spec.remote_rank
+        if remote_worker_key is None:
+            remote_worker_key = (remote_rank, 0)
+        if expected_consumers is None:
+            expected_consumers = self.world_size
         local_block_ids = read_spec.local_block_ids
         remote_block_ids = read_spec.remote_block_ids
+        # Number of local workers that will notify this producer worker.
+        notif_id = f"{remote_request_id}:{expected_consumers}".encode()
+
+        # Full prefix cache hit: do not need to read remote blocks,
+        # just notify P worker that we have the blocks we need.
+        if not any(len(group) > 0 for group in local_block_ids):
+            # A full prefix cache hit is indicated with an empty list.
+            agent_name = self._remote_agents[dst_engine_id][remote_worker_key]
+            try:
+                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="notification_failed",
+                    msg="P worker blocks will be freed after timeout. "
+                    "This may indicate network issues.",
+                    req_id=request_id,
+                    error=e,
+                    dst_engine_id=dst_engine_id,
+                    remote_worker_key=remote_worker_key,
+                    remote_agent_name=agent_name,
+                )
+                self.xfer_stats.record_failed_notification()
+            return
 
         remote_info = self.transfer_topo.get_engine_info(dst_engine_id)
         block_size_ratio = self.transfer_topo.block_size_ratio(
@@ -246,31 +276,6 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
 
         # NOTE(rob): according to nvidia the staging blocks are used to
         # saturate IB with heterogeneous TP sizes.
-
-        # Number of D TP workers that will read from dst P. Propagate info
-        # on notification so that dst worker can wait before freeing blocks.
-        notif_id = f"{remote_request_id}:{self.world_size}".encode()
-
-        # Full prefix cache hit: do not need to read remote blocks,
-        # just notify P worker that we have the blocks we need.
-        if len(local_block_ids) == 0:
-            # A full prefix cache hit is indicated with an empty list.
-            agent_name = self._remote_agents[dst_engine_id][(0, remote_rank)]
-            try:
-                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
-            except Exception as e:
-                self._log_failure(
-                    failure_type="notification_failed",
-                    msg="P worker blocks will be freed after timeout. "
-                    "This may indicate network issues.",
-                    req_id=request_id,
-                    error=e,
-                    dst_engine_id=dst_engine_id,
-                    remote_rank=remote_rank,
-                    remote_agent_name=agent_name,
-                )
-                self.xfer_stats.record_failed_notification()
-            return
 
         assert (
             len(remote_block_ids)
@@ -327,7 +332,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 msg="Marking blocks as invalid",
                 error=e,
                 dst_engine_id=dst_engine_id,
-                remote_rank=remote_rank,
+                remote_worker_key=remote_worker_key,
             )
             self._handle_failed_transfer(request_id, handle)
 
@@ -351,7 +356,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     self._handle_heartbeat(msg[3:])
                     continue
 
-                req_id, tp_size = msg.rsplit(":", 1)
+                req_id, expected_consumers = msg.rsplit(":", 1)
                 if (
                     req_id not in self._reqs_to_send
                     and req_id not in self._reqs_to_process
@@ -364,24 +369,21 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     )
                     continue
 
-                # NOTE: `tp_ratio` is the opposite when swapping local<>remote
-                n_consumers = int(tp_size)
-                tp_ratio = self.transfer_topo.tp_ratio(n_consumers)
-
-                # Number of reads *per producer* to wait for.
-                # When remote D TP > local P TP we expect `tp_ratio` reads.
-                consumers_per_producer = (
-                    -tp_ratio if n_consumers > self.world_size else 1
+                consumers_per_producer = int(expected_consumers)
+                self.expected_consumer_notifications_by_req[req_id] = max(
+                    consumers_per_producer,
+                    self.expected_consumer_notifications_by_req.get(req_id, 0),
                 )
 
                 self.consumer_notification_counts_by_req[req_id] += 1
                 # Wait all consumers (D) to be done reading before freeing.
                 if (
                     self.consumer_notification_counts_by_req[req_id]
-                    == consumers_per_producer
+                    == self.expected_consumer_notifications_by_req[req_id]
                 ):
                     notified_req_ids.add(req_id)
                     del self.consumer_notification_counts_by_req[req_id]
+                    del self.expected_consumer_notifications_by_req[req_id]
                     self._reqs_to_process.remove(req_id)
                     self._reqs_to_send.pop(req_id, None)
         return notified_req_ids

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -147,9 +147,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         ) * self.dcp_size
 
         plan = self.tp_mappings[engine_id]
-        needs_split_local_handles = self._needs_split_local_xfer_handles(
-            tp_ratio, plan
-        )
+        needs_split_local_handles = self._needs_split_local_xfer_handles(tp_ratio, plan)
         launched_read = False
         for remote_worker_key in remote_worker_keys:
             remote_pcp_rank, remote_tp_rank = remote_worker_key

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -135,7 +135,10 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             meta.local_num_computed_tokens // self._local_logical_block_size()
         ) * self.dcp_size
 
-        remote_tp_rank_count = len({key[1] for key in remote_worker_keys})
+        plan = self.tp_mappings[engine_id]
+        needs_split_local_handles = self._needs_split_local_xfer_handles(
+            tp_ratio, plan
+        )
         launched_read = False
         for remote_worker_key in remote_worker_keys:
             remote_pcp_rank, remote_tp_rank = remote_worker_key
@@ -187,7 +190,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 req_id,
             )
             # Get side handles.
-            if tp_ratio < 0 and (not self.use_mla or remote_tp_rank_count > 1):
+            if needs_split_local_handles:
                 # Remote tp_size > local tp_size: we must perform multiple
                 # reads. Get the memory chunk onto which we will write to.
                 split_key = (tp_ratio, remote_block_size)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -11,7 +11,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlConnectorMetadata,
-    RemoteWorkerKey,
+    RemoteAgentKey,
     ReqMeta,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
@@ -119,10 +119,15 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # Update last activity from this remote. Mind that cleanup is done on main
         # thread (this one), so we don't race on this structure.
         self._engine_last_active[engine_id] = time.perf_counter()
-        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        remote_pp_rank = self.transfer_topo.resolve_remote_pp_rank(
+            engine_id, self.pp_rank
+        )
+        remote_info = self.transfer_topo.get_engine_info(engine_id, remote_pp_rank)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
         remote_worker_keys = (
-            self.transfer_topo.get_target_remote_worker_keys_from_engine_id(engine_id)
+            self.transfer_topo.get_target_remote_worker_keys_from_engine_id(
+                engine_id, remote_pp_rank
+            )
         )
         logical_local_block_ids = meta.local_block_ids
         logical_remote_block_ids = meta.remote.block_ids
@@ -130,10 +135,17 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             meta.local_num_computed_tokens // self._local_logical_block_size()
         ) * self.dcp_size
 
-        remote_tp_rank_count = len({key[0] for key in remote_worker_keys})
+        remote_tp_rank_count = len({key[1] for key in remote_worker_keys})
         launched_read = False
         for remote_worker_key in remote_worker_keys:
-            remote_tp_rank, remote_dcp_rank = remote_worker_key
+            remote_pcp_rank, remote_tp_rank = remote_worker_key
+            remote_dcp_rank = self.transfer_topo.get_dcp_rank(
+                remote_tp_rank,
+                remote_pcp_rank,
+                remote_info.remote_pcp_size,
+                remote_info.remote_dcp_size,
+            )
+            remote_agent_key: RemoteAgentKey = (remote_pp_rank, *remote_worker_key)
             local_block_ids: BlockIds
             remote_block_ids: BlockIds
             if len(logical_local_block_ids) == 0:
@@ -189,13 +201,14 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     remote_block_size
                 ]
 
-            # Destination handle: remote_engine_id -> (tp_rank, dcp_rank) -> handle.
+            # Destination handle: engine -> (pp_rank, pcp_rank, tp_rank) -> handle.
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                remote_worker_key
+                remote_agent_key
             ]
             expected_consumers = self.transfer_topo.calculate_local_consumer_count(
                 engine_id,
                 remote_worker_key,
+                remote_pp_rank,
             )
 
             self._read_blocks(
@@ -205,7 +218,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
-                remote_worker_key=remote_worker_key,
+                remote_agent_key=remote_agent_key,
                 expected_consumers=expected_consumers,
             )
 
@@ -225,7 +238,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
-        remote_worker_key: RemoteWorkerKey | None = None,
+        remote_agent_key: RemoteAgentKey | None = None,
         expected_consumers: int | None = None,
     ):
         """
@@ -234,8 +247,8 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         """
         assert self.transfer_topo is not None
         remote_rank = read_spec.remote_rank
-        if remote_worker_key is None:
-            remote_worker_key = (remote_rank, 0)
+        if remote_agent_key is None:
+            remote_agent_key = (self.pp_rank, 0, remote_rank)
         if expected_consumers is None:
             expected_consumers = self.world_size
         local_block_ids = read_spec.local_block_ids
@@ -247,7 +260,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # just notify P worker that we have the blocks we need.
         if not any(len(group) > 0 for group in local_block_ids):
             # A full prefix cache hit is indicated with an empty list.
-            agent_name = self._remote_agents[dst_engine_id][remote_worker_key]
+            agent_name = self._remote_agents[dst_engine_id][remote_agent_key]
             try:
                 self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
             except Exception as e:
@@ -258,13 +271,15 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     req_id=request_id,
                     error=e,
                     dst_engine_id=dst_engine_id,
-                    remote_worker_key=remote_worker_key,
+                    remote_agent_key=remote_agent_key,
                     remote_agent_name=agent_name,
                 )
                 self.xfer_stats.record_failed_notification()
             return
 
-        remote_info = self.transfer_topo.get_engine_info(dst_engine_id)
+        remote_info = self.transfer_topo.get_engine_info(
+            dst_engine_id, remote_agent_key[0]
+        )
         block_size_ratio = self.transfer_topo.block_size_ratio(
             remote_info.remote_block_size
         )
@@ -338,7 +353,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 msg="Marking blocks as invalid",
                 error=e,
                 dst_engine_id=dst_engine_id,
-                remote_worker_key=remote_worker_key,
+                remote_agent_key=remote_agent_key,
             )
             self._handle_failed_transfer(request_id, handle)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -145,7 +145,9 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                         local_block_offset,
                     )
                 )
-                local_block_ids = self._logical_to_kernel_block_ids(local_logical_ids)
+                local_block_ids = self._logical_to_kernel_block_ids(
+                    local_logical_ids, self._physical_blocks_per_logical_kv_block
+                )
                 remote_block_ids = self._logical_to_remote_kernel_block_ids(
                     remote_logical_ids,
                     remote_info.remote_physical_blocks_per_logical,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -5,6 +5,7 @@
 import time
 from typing import TYPE_CHECKING
 
+from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
     NixlBaseConnectorWorker,
 )
@@ -129,9 +130,12 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             meta.local_num_computed_tokens // self._local_logical_block_size()
         ) * self.dcp_size
 
+        remote_tp_rank_count = len({key[0] for key in remote_worker_keys})
         launched_read = False
         for remote_worker_key in remote_worker_keys:
             remote_tp_rank, remote_dcp_rank = remote_worker_key
+            local_block_ids: BlockIds
+            remote_block_ids: BlockIds
             if len(logical_local_block_ids) == 0:
                 local_block_ids = []
                 remote_block_ids = []
@@ -171,7 +175,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 req_id,
             )
             # Get side handles.
-            if tp_ratio < 0 and (not self.use_mla or len(read_specs) > 1):
+            if tp_ratio < 0 and (not self.use_mla or remote_tp_rank_count > 1):
                 # Remote tp_size > local tp_size: we must perform multiple
                 # reads. Get the memory chunk onto which we will write to.
                 split_key = (tp_ratio, remote_block_size)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -288,6 +288,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
             dcp_size=self.vllm_config.parallel_config.decode_context_parallel_size,
             pcp_size=self.vllm_config.parallel_config.prefill_context_parallel_size,
+            pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,
             remote_num_tokens=remote_num_tokens,
         )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -172,6 +172,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         local_block_ids: BlockIds = blocks.get_unhashed_block_ids_all_groups()
         local_block_ids = self.get_sw_clipped_blocks(local_block_ids)
 
+        parallel_config = self.vllm_config.parallel_config
         # ``remote_*`` fields are P's coordinates (from D's perspective).
         # ``decode_*`` fields are D's own info that P needs for the
         # reverse handshake before WRITE-ing.
@@ -180,12 +181,17 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             "decode_engine_id": self.engine_id,
             "decode_host": self.side_channel_host,
             "decode_port": self.side_channel_port,
-            "decode_tp_size": (self.vllm_config.parallel_config.tensor_parallel_size),
+            "decode_tp_size": parallel_config.tensor_parallel_size,
+            "decode_dcp_size": parallel_config.decode_context_parallel_size,
+            "decode_pcp_size": parallel_config.prefill_context_parallel_size,
+            "decode_pp_size": parallel_config.pipeline_parallel_size,
             "local_block_ids": local_block_ids,
             "remote_engine_id": params["remote_engine_id"],
             "remote_host": params["remote_host"],
             "remote_port": params["remote_port"],
             "remote_tp_size": params["tp_size"],
+            "remote_dcp_size": params.get("dcp_size", 1),
+            "remote_pcp_size": params.get("pcp_size", 1),
             "remote_pp_size": params.get("pp_size", 1),
         }
         self._push_registration_deadlines[request.request_id] = (

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -199,7 +199,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         # ReqMeta without a KeyError — the actual remote block IDs are
         # learned by P over the NIXL handshake at WRITE time.
         params["remote_block_ids"] = ()
-        self._reqs_need_recv[request.request_id] = (request, local_block_ids)
+        self._reqs_need_recv[request.request_id] = (request, local_block_ids, 0)
 
         # Mark as processed so a re-entry (e.g. preemption + reschedule)
         # doesn't re-stage the registration.
@@ -239,9 +239,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             # serving layer via abort_immediately. To keep P from
             # stranding the prefill blocks, we still register an empty
             # recv so the worker emits a notif that lets P free them.
-            # Seed remote_block_ids so add_new_req_to_recv won't KeyError.
-            params["remote_block_ids"] = ()
-            self._reqs_need_recv[request.request_id] = (request, [])
+            self._reqs_need_recv[request.request_id] = (request, [], 0)
             params["do_remote_prefill"] = False
             return False, None
 
@@ -288,7 +286,8 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
-            pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,
+            dcp_size=self.vllm_config.parallel_config.decode_context_parallel_size,
+            pcp_size=self.vllm_config.parallel_config.prefill_context_parallel_size,
             remote_num_tokens=remote_num_tokens,
         )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -245,6 +245,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             # serving layer via abort_immediately. To keep P from
             # stranding the prefill blocks, we still register an empty
             # recv so the worker emits a notif that lets P free them.
+            params["remote_block_ids"] = ()
             self._reqs_need_recv[request.request_id] = (request, [], 0)
             params["do_remote_prefill"] = False
             return False, None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -55,7 +55,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
     ReadSpec,
-    _is_attention_spec,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import get_base_request_id
 from vllm.logger import init_logger
@@ -301,6 +300,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             reg_data["remote_host"],
             reg_data["remote_port"],
             reg_data["remote_tp_size"],
+            dcp_size=reg_data.get("remote_dcp_size", 1),
+            pcp_size=reg_data.get("remote_pcp_size", 1),
             pp_size=remote_pp_size,
             # D only ever sends PUSH_REG notifs to P and never reads or writes
             # P's memory in push mode, so it never needs the transfer
@@ -424,11 +425,14 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             registration_data["decode_host"],
             registration_data["decode_port"],
             registration_data["decode_tp_size"],
+            dcp_size=registration_data.get("decode_dcp_size", 1),
+            pcp_size=registration_data.get("decode_pcp_size", 1),
+            pp_size=registration_data.get("decode_pp_size", 1),
         )
         if fut is not None:
 
             def _on_handshake(
-                f: Future[tuple[dict[tuple[int, int], str], float]],
+                f: Future[tuple[dict[RemoteAgentKey, str], float]],
                 rid: str = request_id,
                 blocks: BlockIds = local_block_ids,
                 rd: dict[str, Any] = registration_data,
@@ -491,7 +495,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         return block_ids
 
     def _xfer_blocks_for_req(self, req_id: str, meta: ReqMeta):
-        """Issue WRITE transfers to one or more remote TP ranks."""
+        """Issue WRITE transfers to all remote workers with KV overlap."""
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
         plan = self.tp_mappings[engine_id]
@@ -501,84 +505,78 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         remote_info = self.transfer_topo.get_engine_info(engine_id, remote_pp_rank)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
 
-        # Expand D's logical IDs using the ratio learned during the
-        # NIXL handshake. ``meta`` is freshly built by
-        # ``_do_start_push_kv`` so mutating it here is safe.
-        meta.remote.block_ids = self._logical_to_kernel_block_ids(
-            meta.remote.block_ids,
-            remote_info.remote_physical_blocks_per_logical,
-        )
-        remote_block_ids = meta.remote.block_ids
-        local_block_ids = meta.local_physical_block_ids
-        num_groups = len(local_block_ids)
-
-        # MLA latent is replicated across D's TP ranks: the tp-mapping
-        # collapses it to one rank (fine for reads), but push must WRITE every
-        # D rank or the rest decode stale KV. For hybrid MLA+SSM the sharded
-        # SSM state already targets every covered D rank, so only the
-        # attention groups need widening; pure MLA writes to all handshaked
-        # ranks (only the dst differs per rank).
-        replicate_attn = self.use_mla and tp_ratio < 0
-        mla_remote_agent_keys: list[RemoteAgentKey] = []
-        if replicate_attn and not self._has_mamba:
-            assert len(plan.all_source_ranks) == 1
-            mla_remote_agent_keys = [
-                key
-                for key in self.dst_xfer_side_handles[engine_id]
-                if key[0] == remote_pp_rank
-            ]
-            write_ranks = [agent_key[2] for agent_key in mla_remote_agent_keys]
-        else:
-            write_ranks = list(plan.all_source_ranks)
-
-        def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
-            return [
-                list(block_ids[g])
-                if (replicate_attn and _is_attention_spec(self._group_spec_types[g]))
-                or rank in plan.source_ranks_per_group[g]
-                else []
-                for g in range(num_groups)
-            ]
-
-        read_specs = [
-            ReadSpec(
-                remote_rank=rank,
-                local_block_ids=group_ids(local_block_ids, rank),
-                remote_block_ids=group_ids(remote_block_ids, rank),
+        remote_worker_keys = (
+            self.transfer_topo.get_target_remote_worker_keys_from_engine_id(
+                engine_id,
+                remote_pp_rank,
             )
-            for rank in write_ranks
-        ]
+        )
+        logical_local_block_ids = meta.local_block_ids
+        logical_remote_block_ids = meta.remote.block_ids
+        needs_split_local_handles = self._needs_split_local_xfer_handles(tp_ratio, plan)
 
         handles: list[int] = []
-        for i, spec in enumerate(read_specs):
+        for remote_worker_key in remote_worker_keys:
+            remote_pcp_rank, remote_tp_rank = remote_worker_key
+            remote_dcp_rank = self.transfer_topo.get_dcp_rank(
+                remote_tp_rank,
+                remote_pcp_rank,
+                remote_info.remote_pcp_size,
+                remote_info.remote_dcp_size,
+            )
+            local_logical_ids, remote_logical_ids = (
+                self.transfer_topo.get_matched_blocks(
+                    logical_local_block_ids,
+                    logical_remote_block_ids,
+                    remote_info.remote_dcp_size,
+                    remote_dcp_rank,
+                )
+            )
+            local_block_ids = self._logical_to_kernel_block_ids(
+                local_logical_ids, self._physical_blocks_per_logical_kv_block
+            )
+            remote_block_ids = self._logical_to_remote_kernel_block_ids(
+                remote_logical_ids,
+                remote_info.remote_physical_blocks_per_logical,
+            )
+            spec = ReadSpec(
+                remote_rank=remote_tp_rank,
+                local_block_ids=local_block_ids,
+                remote_block_ids=remote_block_ids,
+            )
             remote_block_size = remote_info.remote_block_size
             logger.debug(
                 "Remote agent %s available, calling _xfer_blocks"
-                " on remote rank %s with remote block size %s for req %s",
+                " on remote worker %s with remote block size %s for req %s",
                 meta.remote.engine_id,
-                spec.remote_rank,
+                remote_worker_key,
                 remote_block_size,
                 req_id,
             )
-            if tp_ratio < 0 and (not self.use_mla or len(plan.all_source_ranks) > 1):
+            if needs_split_local_handles:
                 # Multiple targets: write each rank its chunk of local memory.
                 # Hybrid MLA+SSM also lands here: its split handles replicate
                 # the attention descriptors and chunk only the SSM state.
                 split_key = (tp_ratio, remote_block_size)
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][i]
+                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][
+                    remote_tp_rank - self.tp_rank * (-tp_ratio)
+                ]
             else:
                 local_xfer_side_handle = self.src_xfer_handles_by_block_size[
                     remote_block_size
                 ]
 
-            remote_agent_key: RemoteAgentKey = (
-                mla_remote_agent_keys[i]
-                if mla_remote_agent_keys
-                else (remote_pp_rank, 0, spec.remote_rank)
-            )
-            remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
+            remote_agent_key: RemoteAgentKey = (remote_pp_rank, *remote_worker_key)
+            remote_xfer_side_handle = self.dst_xfer_side_handles[engine_id][
                 remote_agent_key
             ]
+            expected_producers = self.transfer_topo.calculate_local_consumer_count(
+                engine_id,
+                remote_worker_key,
+                remote_pp_rank,
+            ) * self.transfer_topo.get_local_pp_producer_count(
+                self.pp_size, remote_info.remote_pp_size
+            )
 
             handle = self._xfer_blocks(
                 read_spec=spec,
@@ -588,20 +586,14 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
                 remote_pp_rank=remote_pp_rank,
+                remote_agent_key=remote_agent_key,
+                expected_producers=expected_producers,
             )
             if handle is not None:
                 handles.append(handle)
 
         if handles:
             self._sending_transfers[req_id].extend(handles)
-
-        if self.use_mla and tp_ratio < 0 and read_specs:
-            notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
-            written_remote_ranks = {read_spec.remote_rank for read_spec in read_specs}
-            remote_agents = self._remote_agents[meta.remote.engine_id]
-            for rank_to_notify, agent in remote_agents.items():
-                if rank_to_notify[2] not in written_remote_ranks:
-                    self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
 
     def _xfer_blocks(
         self,
@@ -612,6 +604,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
         remote_pp_rank: int = 0,
+        remote_agent_key: RemoteAgentKey | None = None,
+        expected_producers: int | None = None,
     ) -> int | None:
         """Post a WRITE point-to-point xfer request.
 
@@ -620,6 +614,10 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         """
         assert self.transfer_topo is not None
         remote_rank = read_spec.remote_rank
+        if remote_agent_key is None:
+            remote_agent_key = (remote_pp_rank, 0, remote_rank)
+        if expected_producers is None:
+            expected_producers = self.world_size
         local_block_ids = read_spec.local_block_ids
         remote_block_ids = read_spec.remote_block_ids
 
@@ -634,10 +632,23 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 )
             )
 
-        notif_id = f"{remote_request_id}:{self.world_size}".encode()
+        notif_id = f"{remote_request_id}:{expected_producers}".encode()
 
-        if len(local_block_ids) == 0:
-            logger.warning("No blocks to push for request %s", request_id)
+        if not any(len(group) > 0 for group in local_block_ids):
+            agent_name = self._remote_agents[dst_engine_id][remote_agent_key]
+            try:
+                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="notification_failed",
+                    msg="D worker may wait for a push completion that was not sent.",
+                    req_id=request_id,
+                    error=e,
+                    dst_engine_id=dst_engine_id,
+                    remote_agent_key=remote_agent_key,
+                    remote_agent_name=agent_name,
+                )
+                self.xfer_stats.record_failed_notification()
             return None
 
         # Align per-group block counts for push.
@@ -721,16 +732,14 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 self._handle_heartbeat(msg[3:])
                 continue
 
-            req_id, tp_size = msg.rsplit(":", 1)
+            req_id, expected_count = msg.rsplit(":", 1)
 
             # Not tracked as a P-side send/process for this notif.
             if req_id not in self._reqs_to_send and req_id not in self._reqs_to_process:
-                if (meta := self._recving_metadata.get(req_id)) is not None:
-                    # Consumer waits for one notif per producer rank writing
-                    # here: pp_size stages * producers-per-consumer (>1 when
-                    # producer TP > consumer TP; tp_size is the producer TP).
-                    producers_per_consumer = max(1, int(tp_size) // self.world_size)
-                    expected_notifs = meta.pp_size * producers_per_consumer
+                if req_id in self._recving_metadata:
+                    # The producer computes this from the complete physical
+                    # PP/PCP/TP topology and DCP overlap.
+                    expected_notifs = int(expected_count)
                     self.consumer_notification_counts_by_req[req_id] += 1
                     notifs = self.consumer_notification_counts_by_req[req_id]
                     if notifs < expected_notifs:
@@ -749,14 +758,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                     )
                 continue
 
-            n_consumers = int(tp_size)
-            tp_ratio = self.transfer_topo.tp_ratio(n_consumers)
-            consumers_per_producer = -tp_ratio if n_consumers > self.world_size else 1
+            expected_consumers = int(expected_count)
             self.consumer_notification_counts_by_req[req_id] += 1
-            if (
-                self.consumer_notification_counts_by_req[req_id]
-                == consumers_per_producer
-            ):
+            if self.consumer_notification_counts_by_req[req_id] == expected_consumers:
                 notified_req_ids.add(req_id)
                 del self.consumer_notification_counts_by_req[req_id]
                 self._reqs_to_process.remove(req_id)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -48,6 +48,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     PUSH_REG_NOTIF_PREFIX,
     NixlConnectorMetadata,
     RemoteMeta,
+    RemoteWorkerKey,
     ReqId,
     ReqMeta,
     TransferHandle,
@@ -311,7 +312,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             return
 
         def _on_handshake(
-            f: Future[tuple[dict[tuple[int, int], str], float]],
+            f: Future[dict[RemoteWorkerKey, str]],
             rid: str = req_id,
             rd: dict[str, Any] = reg_data,
         ) -> None:
@@ -561,8 +562,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                     remote_block_size
                 ]
 
+            remote_worker_key: RemoteWorkerKey = (spec.remote_rank, 0)
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
+                remote_worker_key
             ]
 
             handle = self._xfer_blocks(
@@ -576,12 +578,12 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             if handle is not None:
                 handles.append(handle)
 
-        # Publish all the request's WRITE handles in one locked update: a
-        # partial set would let ``_pop_done_transfers`` finish the request
-        # early, then double-report it as the remaining writes land.
-        if handles:
-            with self._sending_transfers_lock:
-                self._sending_transfers[req_id].extend(handles)
+        if self.use_mla and tp_ratio < 0 and read_specs:
+            notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
+            remote_agents = self._remote_agents[meta.remote.engine_id]
+            for rank_to_notify, agent in remote_agents.items():
+                if rank_to_notify[0] != read_specs[0].remote_rank:
+                    self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
 
     def _xfer_blocks(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -593,7 +593,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 handles.append(handle)
 
         if handles:
-            self._sending_transfers[req_id].extend(handles)
+            with self._sending_transfers_lock:
+                self._sending_transfers[req_id].extend(handles)
 
     def _xfer_blocks(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -312,7 +312,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             return
 
         def _on_handshake(
-            f: Future[dict[RemoteWorkerKey, str]],
+            f: Future[tuple[dict[RemoteWorkerKey, str], float]],
             rid: str = req_id,
             rd: dict[str, Any] = reg_data,
         ) -> None:
@@ -516,9 +516,11 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # attention groups need widening; pure MLA writes to all handshaked
         # ranks (only the dst differs per rank).
         replicate_attn = self.use_mla and tp_ratio < 0
+        mla_remote_worker_keys: list[RemoteWorkerKey] = []
         if replicate_attn and not self._has_mamba:
             assert len(plan.all_source_ranks) == 1
-            write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
+            mla_remote_worker_keys = list(self.dst_xfer_side_handles[engine_id])
+            write_ranks = [worker_key[0] for worker_key in mla_remote_worker_keys]
         else:
             write_ranks = list(plan.all_source_ranks)
 
@@ -562,7 +564,11 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                     remote_block_size
                 ]
 
-            remote_worker_key: RemoteWorkerKey = (spec.remote_rank, 0)
+            remote_worker_key: RemoteWorkerKey = (
+                mla_remote_worker_keys[i]
+                if mla_remote_worker_keys
+                else (spec.remote_rank, 0)
+            )
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
                 remote_worker_key
             ]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -587,6 +587,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
+                remote_pp_rank=remote_pp_rank,
             )
             if handle is not None:
                 handles.append(handle)
@@ -610,6 +611,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
+        remote_pp_rank: int = 0,
     ) -> int | None:
         """Post a WRITE point-to-point xfer request.
 
@@ -621,7 +623,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         local_block_ids = read_spec.local_block_ids
         remote_block_ids = read_spec.remote_block_ids
 
-        remote_info = self.transfer_topo.get_engine_info(dst_engine_id)
+        remote_info = self.transfer_topo.get_engine_info(dst_engine_id, remote_pp_rank)
         block_size_ratio = self.transfer_topo.block_size_ratio(
             remote_info.remote_block_size
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -47,8 +47,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     PUSH_REG_NOTIF_PREFIX,
     NixlConnectorMetadata,
+    RemoteAgentKey,
     RemoteMeta,
-    RemoteWorkerKey,
     ReqId,
     ReqMeta,
     TransferHandle,
@@ -312,7 +312,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             return
 
         def _on_handshake(
-            f: Future[tuple[dict[RemoteWorkerKey, str], float]],
+            f: Future[tuple[dict[RemoteAgentKey, str], float]],
             rid: str = req_id,
             rd: dict[str, Any] = reg_data,
         ) -> None:
@@ -495,7 +495,10 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
         plan = self.tp_mappings[engine_id]
-        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        remote_pp_rank = self.transfer_topo.resolve_remote_pp_rank(
+            engine_id, self.pp_rank
+        )
+        remote_info = self.transfer_topo.get_engine_info(engine_id, remote_pp_rank)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
 
         # Expand D's logical IDs using the ratio learned during the
@@ -516,11 +519,15 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # attention groups need widening; pure MLA writes to all handshaked
         # ranks (only the dst differs per rank).
         replicate_attn = self.use_mla and tp_ratio < 0
-        mla_remote_worker_keys: list[RemoteWorkerKey] = []
+        mla_remote_agent_keys: list[RemoteAgentKey] = []
         if replicate_attn and not self._has_mamba:
             assert len(plan.all_source_ranks) == 1
-            mla_remote_worker_keys = list(self.dst_xfer_side_handles[engine_id])
-            write_ranks = [worker_key[0] for worker_key in mla_remote_worker_keys]
+            mla_remote_agent_keys = [
+                key
+                for key in self.dst_xfer_side_handles[engine_id]
+                if key[0] == remote_pp_rank
+            ]
+            write_ranks = [agent_key[2] for agent_key in mla_remote_agent_keys]
         else:
             write_ranks = list(plan.all_source_ranks)
 
@@ -564,13 +571,13 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                     remote_block_size
                 ]
 
-            remote_worker_key: RemoteWorkerKey = (
-                mla_remote_worker_keys[i]
-                if mla_remote_worker_keys
-                else (spec.remote_rank, 0)
+            remote_agent_key: RemoteAgentKey = (
+                mla_remote_agent_keys[i]
+                if mla_remote_agent_keys
+                else (remote_pp_rank, 0, spec.remote_rank)
             )
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                remote_worker_key
+                remote_agent_key
             ]
 
             handle = self._xfer_blocks(
@@ -584,11 +591,15 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             if handle is not None:
                 handles.append(handle)
 
+        if handles:
+            self._sending_transfers[req_id].extend(handles)
+
         if self.use_mla and tp_ratio < 0 and read_specs:
             notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
+            written_remote_ranks = {read_spec.remote_rank for read_spec in read_specs}
             remote_agents = self._remote_agents[meta.remote.engine_id]
             for rank_to_notify, agent in remote_agents.items():
-                if rank_to_notify[0] != read_specs[0].remote_rank:
+                if rank_to_notify[2] not in written_remote_ranks:
                     self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
 
     def _xfer_blocks(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -128,6 +128,10 @@ class EngineCore:
         # Opaque weight version supplied by the caller.
         self._weight_version = "default"
 
+        # Normalize values cached by model layers before configs are copied to
+        # executor subprocesses and the model is loaded there.
+        vllm_config.adjust_dcp_kv_cache_interleave_size()
+
         # Setup Model.
         self.model_executor = executor_class(vllm_config)
         self._pooler_config_logged = False

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -191,9 +191,9 @@ class EngineCore:
 
             if xfer_handshake_metadata:
                 # xfer_handshake_metadata is list of dicts from workers
-                # Each dict already has structure {(pp_rank, tp_rank): metadata}
+                # Each dict has {(pp_rank, pcp_rank, tp_rank): metadata}.
                 # Merge all worker dicts into a single dict
-                content: dict[tuple[int, int], Any] = {}
+                content: dict[tuple[int, int, int], Any] = {}
                 for worker_dict in xfer_handshake_metadata:
                     if worker_dict is not None:
                         content.update(worker_dict)

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -203,7 +203,7 @@ class Executor(ABC):
 
     def get_kv_connector_handshake_metadata(
         self,
-    ) -> list[dict[tuple[int, int], KVConnectorHandshakeMetadata]]:
+    ) -> list[dict[tuple[int, int, int], KVConnectorHandshakeMetadata]]:
         return self.collective_rpc("get_kv_connector_handshake_metadata")
 
     @overload

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -43,6 +43,7 @@ from vllm.distributed.parallel_state import (
     Handle,
     checkpoint_prepare_distributed_state,
     checkpoint_restore_distributed_state,
+    get_pcp_group,
     get_pp_group,
     get_tp_group,
 )
@@ -629,7 +630,14 @@ class Worker(WorkerBase):
 
         pp_rank = get_pp_group().rank_in_group
         tp_rank = get_tp_group().rank_in_group
-        return {(pp_rank, tp_rank): metadata}
+        try:
+            pcp_size = get_pcp_group().world_size
+            pcp_rank = get_pcp_group().rank_in_group
+        except AssertionError:
+            pcp_size = 1
+            pcp_rank = 0
+        flat_idx = tp_rank * pcp_size + pcp_rank
+        return {(pp_rank, flat_idx): metadata}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -613,10 +613,10 @@ class Worker(WorkerBase):
 
     def get_kv_connector_handshake_metadata(
         self,
-    ) -> dict[tuple[int, int], KVConnectorHandshakeMetadata] | None:
+    ) -> dict[tuple[int, int, int], KVConnectorHandshakeMetadata] | None:
         """Get KV connector metadata from this worker if available.
 
-        Returned dict is keyed by `(pp_rank, tp_rank)`.
+        Returned dict is keyed by `(pp_rank, pcp_rank, tp_rank)`.
         """
 
         if not has_kv_transfer_group():
@@ -631,13 +631,10 @@ class Worker(WorkerBase):
         pp_rank = get_pp_group().rank_in_group
         tp_rank = get_tp_group().rank_in_group
         try:
-            pcp_size = get_pcp_group().world_size
             pcp_rank = get_pcp_group().rank_in_group
         except AssertionError:
-            pcp_size = 1
             pcp_rank = 0
-        flat_idx = tp_rank * pcp_size + pcp_rank
-        return {(pp_rank, flat_idx): metadata}
+        return {(pp_rank, pcp_rank, tp_rank): metadata}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()


### PR DESCRIPTION
## Purpose
This PR adds support for MLA's DCP in PD disaggregation with the nixl connector, enabling the separated deployment with vary combinations of TP and DCP.

This PR first replace remote key from tp_rank to (tp_rank, dcp_rank). Then it extends `TpKVTopology` to compute remote ranks have both head and sequence overlaps, which are used for handshake with remote engines.
The PR also extends the nixl connector's block matching mechanism, calculating the position of each block in the overall sequence dimension on each rank using DCP rank, DCP size, and other information, and uses this position for matching.

Furthermore, to ensure the kvcache can be properly transferred via blocks, we always require `cp_kv_cache_interleave_size == block_size`, which is the original intent behind setting this parameter.

Finally, I noted that the original prefix cache mechanism always assumed we could select the last common block. However, from a DCP perspective, this does not hold, because when `local_dcp_size != remote_dcp_size`, we cannot accurately determine whether the inconsistent block count is due to prefix cache or unequal DCP sizes. Therefore, we need to explicitly pass `computed_tokens` to the connector side to ensure accurate block matching.
> For example, with P(dcp=4) and D(dcp=1), if a request uses 13 blocks, each rank on the P side will request 4 blocks, resulting in a total of 16 blocks, while the D node will only request 13 blocks.

## Test Plan

Accuracy was evaluated with GSM8K (5-shot, 1,000 samples, concurrency 64).

- DeepSeek-V2-Lite-Chat baseline: collocated pure TP4 on `upstream/main` (`f83de6d44c2473656f95357900d53f1b7401d21c`).
- DeepSeek-V2-Lite-Chat PD matrix: seven prefill/decode TP-DCP combinations on `dcp/nixl.run` (`05ca8d8bd29fe4fa6a59788309cd21e49e86a26e`).
- DeepSeek-V2-Lite-Chat PP matrix: five PP2 prefill/decode TP-DCP combinations, one asymmetric PP1-prefill/PP2-decode combination, plus a post-fix PP2/TP2/DCP2 symmetric regression on `dcp/nixl`.
- Qwen3-32B: pure-TP PD comparison between `upstream/main` and `dcp/nixl.run`, plus PP2/TP2 and PP4/TP1 functional regressions on `dcp/nixl`.

The PD cases used the NIXL connector with `cp_kv_cache_interleave_size=16` and `gpu_memory_utilization=0.85`.

## Test Result

All DeepSeek-V2-Lite-Chat matrix cases below completed successfully.

<details>
<summary>DeepSeek-V2-Lite-Chat TP/DCP results</summary>

| Configuration | Branch | Flexible extract | Strict match |
|---|---|---:|---:|
| Collocated TP4 baseline | `upstream/main` | 0.661 ± 0.0150 | 0.652 ± 0.0151 |
| P TP4/DCP1 → D TP4/DCP1 | `dcp/nixl.run` | 0.677 ± 0.0148 | 0.670 ± 0.0149 |
| P TP2/DCP1 → D TP4/DCP1 | `dcp/nixl.run` | 0.657 ± 0.0150 | 0.649 ± 0.0151 |
| P TP4/DCP4 → D TP4/DCP4 | `dcp/nixl.run` | 0.670 ± 0.0149 | 0.661 ± 0.0150 |
| P TP4/DCP1 → D TP4/DCP4 | `dcp/nixl.run` | 0.681 ± 0.0147 | 0.673 ± 0.0148 |
| P TP4/DCP4 → D TP4/DCP1 | `dcp/nixl.run` | 0.678 ± 0.0148 | 0.672 ± 0.0149 |
| P TP2/DCP2 → D TP4/DCP4 | `dcp/nixl.run` | 0.670 ± 0.0149 | 0.668 ± 0.0149 |
| P TP2/DCP1 → D TP4/DCP4 | `dcp/nixl.run` | 0.664 ± 0.0149 | 0.654 ± 0.0151 |

</details>

<details>
<summary>DeepSeek-V2-Lite-Chat PP-containing accuracy results</summary>

For this PP matrix, the corresponding collocated pure-TP `upstream/main` baseline was 0.653 ± 0.0151 (flexible extract) and 0.645 ± 0.0151 (strict match). Every supported PP combination met or exceeded that baseline.

| Prefill (PP/TP/DCP) | Decode (PP/TP/DCP) | Flexible extract | Strict match | Status |
|---|---|---:|---:|---|
| 2/2/2 | 2/2/2 | 0.668 ± 0.0149 | 0.662 ± 0.0150 | Pass |
| 2/2/1 | 2/2/2 | 0.675 ± 0.0148 | 0.669 ± 0.0149 | Pass |
| 2/2/2 | 2/2/1 | 0.661 ± 0.0150 | 0.652 ± 0.0151 | Pass |
| 2/1/1 | 2/2/2 | 0.672 ± 0.0149 | 0.665 ± 0.0149 | Pass |
| 2/2/2 | 2/1/1 | 0.677 ± 0.0148 | 0.668 ± 0.0149 | Pass |
| 1/4/2 | 2/2/2 | 0.678 ± 0.0148 | 0.664 ± 0.0149 | Pass |

After the PCP/TP/DCP routing fix in `888da545e1`, the symmetric P PP2/TP2/DCP2 → D PP2/TP2/DCP2 case was rerun and passed with 0.674 ± 0.0148 (flexible extract) and 0.663 ± 0.0150 (strict match).

The reverse asymmetric direction P PP2/TP2/DCP2 → D PP1/TP4/DCP2 was also probed. It is currently rejected by the explicit one-local-PP-stage-to-multiple-remote-PP-stages guard during the smoke request, before accuracy evaluation.

</details>

<details>
<summary>Qwen3-32B pure-TP PD comparison and PP functional coverage</summary>

| Configuration | Branch | Flexible extract | Strict match |
|---|---|---:|---:|
| P TP4/DCP1 → D TP4/DCP1 | `upstream/main` | 0.627 ± 0.0153 | 0.749 ± 0.0137 |
| P TP4/DCP1 → D TP4/DCP1 | `dcp/nixl.run` | 0.629 ± 0.0153 | 0.748 ± 0.0137 |

The TP2-prefill/TP4-decode Qwen3-32B case failed during prefill startup on `upstream/main`, so no accuracy score was produced for that topology.

On `dcp/nixl` after `888da545e1`, both PP2/TP2 and PP4/TP1 functional regressions returned HTTP 200 completions; the PP4/TP1 run initialized all four pipeline workers.

</details>
