### PR TITLE
[Bugfix] Fix NaN corruption from CUDA graph padding in NVFP4 models

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1985,7 +1985,11 @@ class GPUModelRunner(
         self.seq_lens[:num_reqs] = (
             self.num_computed_tokens[:num_reqs] + num_scheduled_tokens_gpu
         )
-        self.seq_lens[num_reqs:].fill_(0)
+        # Use 1 instead of 0 to prevent NaN from empty softmax in
+        # attention kernels for padding requests. With seq_lens=0, the
+        # softmax has no elements, producing NaN that contaminates real
+        # tokens via NVFP4 128-row GEMM tiles.
+        self.seq_lens[num_reqs:].fill_(1)
 
         self.input_batch.block_table.compute_slot_mapping(
             num_reqs,
@@ -5367,7 +5371,7 @@ class GPUModelRunner(
                 else:
                     seq_lens = max_query_len  # type: ignore[assignment]
                 self.optimistic_seq_lens_cpu[:num_reqs] = seq_lens
-                self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
+                self.optimistic_seq_lens_cpu[num_reqs:].fill_(1)
                 self.seq_lens.copy_(self.optimistic_seq_lens_cpu, non_blocking=True)
 
                 cum_num_tokens = self._get_cumsum_and_arange(


### PR DESCRIPTION
## Summary
- Pad `seq_lens` with 1 instead of 0 for unused CUDA graph slots
- With `seq_lens=0`, attention softmax has no elements → produces NaN
- NaN contaminates real tokens via NVFP4 128-row quantization tiles where the shared block scale becomes NaN
- `seq_lens=1` makes padding slots attend to position 0 of the KV cache, producing finite output
- Padding outputs are never used for sampling or written to KV cache

## Test plan
- [ ] Run lm_eval (gsm8k) with DeepSeek-R1-NVFP4 on GB200 with `cudagraph_mode: FULL_DECODE_ONLY`
- [ ] Verify no NaN in model output with NVFP4 quantized models under CUDA graph padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)