### PR TITLE
[Bugfix] Fix set serialization in Qwen3.5 rope validation configs

### DIFF
--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -6,8 +6,12 @@ only get the `eos_token_id` from the tokenizer as defined by
 `BaseRenderer.get_eos_token_id`.
 """
 
+import json
+
 from vllm.tokenizers import get_tokenizer
 from vllm.transformers_utils.config import try_get_generation_config
+from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5TextConfig
+from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
 
 
 def test_get_llama3_eos_token():
@@ -30,3 +34,23 @@ def test_get_blip2_eos_token():
     generation_config = try_get_generation_config(model_name, trust_remote_code=False)
     assert generation_config is not None
     assert generation_config.eos_token_id == 50118
+
+
+def test_qwen3_5_config_json_serializable():
+    """Ensure Qwen3.5 configs can be serialized to JSON.
+
+    Regression test: ignore_keys_at_rope_validation was a set literal,
+    which causes TypeError in json.dumps when huggingface_hub >= 1.7.2
+    triggers config validation via to_json_string().
+    """
+    config = Qwen3_5TextConfig()
+    json.loads(config.to_json_string())
+
+
+def test_qwen3_5_moe_config_json_serializable():
+    """Ensure Qwen3.5-MoE configs can be serialized to JSON.
+
+    Regression test: same set-vs-list issue as the dense config.
+    """
+    config = Qwen3_5MoeTextConfig()
+    json.loads(config.to_json_string())

--- a/vllm/transformers_utils/configs/qwen3_5.py
+++ b/vllm/transformers_utils/configs/qwen3_5.py
@@ -96,10 +96,10 @@ class Qwen3_5TextConfig(PretrainedConfig):
             ]
         if hasattr(self, "validate_layer_type"):
             # Transformers v5
-            kwargs["ignore_keys_at_rope_validation"] = {
+            kwargs["ignore_keys_at_rope_validation"] = [
                 "mrope_section",
                 "mrope_interleaved",
-            }
+            ]
             self.validate_layer_type()
         else:
             # Transformers v4

--- a/vllm/transformers_utils/configs/qwen3_5_moe.py
+++ b/vllm/transformers_utils/configs/qwen3_5_moe.py
@@ -102,10 +102,10 @@ class Qwen3_5MoeTextConfig(PretrainedConfig):
             ]
         if hasattr(self, "validate_layer_type"):
             # Transformers v5
-            kwargs["ignore_keys_at_rope_validation"] = {
+            kwargs["ignore_keys_at_rope_validation"] = [
                 "mrope_section",
                 "mrope_interleaved",
-            }
+            ]
             self.validate_layer_type()
         else:
             # Transformers v4


### PR DESCRIPTION
## Summary

- `ignore_keys_at_rope_validation` in `qwen3_5.py` and `qwen3_5_moe.py` uses a Python `set` literal, which is not JSON-serializable
- `huggingface_hub >= 1.7.2` introduced stricter config validation that calls `to_json_string()`, triggering `TypeError: Object of type set is not JSON serializable`
- Fix: change set `{...}` to list `[...]` in both files
- Added regression tests

## Error

```
File "transformers/configuration_utils.py", line 988, in to_json_string
    return json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
TypeError: Object of type set is not JSON serializable
```

## Test plan

- [ ] `pytest tests/transformers_utils/test_config.py::test_qwen3_5_config_json_serializable`
- [ ] `pytest tests/transformers_utils/test_config.py::test_qwen3_5_moe_config_json_serializable`

## AI disclosure

This PR was co-authored with Claude (Anthropic). All changes were reviewed by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)