### PR TITLE
fix(tokenizer): skip reasoning_effort when None in Mistral tokenizer

### DIFF
--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -432,7 +432,9 @@ class MistralTokenizer(TokenizerLike):
         # NOTE: This is for backward compatibility.
         # Transformers should be passed arguments it knows.
         if self.version >= 15:
-            version_kwargs["reasoning_effort"] = kwargs.get("reasoning_effort")
+            _reasoning_effort = kwargs.get("reasoning_effort")
+            if _reasoning_effort is not None:
+                version_kwargs["reasoning_effort"] = _reasoning_effort
 
         messages, tools = _prepare_apply_chat_template_tools_and_messages(
             messages, tools, continue_final_message, add_generation_prompt


### PR DESCRIPTION
## Summary

When `reasoning_effort` is not set by the user, `kwargs.get("reasoning_effort")` returns `None`, but the key is still unconditionally added to `version_kwargs` in `vllm/tokenizers/mistral.py:434`. This causes `MistralCommonTokenizer.apply_chat_template` from `transformers` to raise:

```
ValueError: Kwargs ['reasoning_effort'] are not supported by
`MistralCommonTokenizer.apply_chat_template`.
```

This breaks **all** chat completion requests on Mistral models with tokenizer version >= 15 (e.g., `Mistral-Small-4-119B-2603-NVFP4`).

## Fix

Only add `reasoning_effort` to `version_kwargs` when it is explicitly set (not `None`).

## Environment

- vLLM 0.18.1rc1 (built from main)
- transformers 4.57.6
- mistral-common 1.10.0
- Model: `mistralai/Mistral-Small-4-119B-2603-NVFP4`
- Flags: `--tokenizer-mode mistral --config-format mistral --load-format mistral`

## Test plan

- [x] Verified fix on NVIDIA DGX Spark (GB10 Blackwell, ARM64)
- [x] Chat completions return 200 after patch (were 400 before)
- [x] Sustained inference stable with fix applied