### PR TITLE
[ROCm][CI] Fix cross-attention dispatch for encoder-decoder models

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -173,7 +173,7 @@ Priority is **1 = highest** (tried first).
 | `FLASH_ATTN` | FA4* | fp16, bf16 | `auto`, `float16`, `bfloat16` | %16 | Any | ❌ | ❌ | ✅ | All | ≥10.0 |
 | `FLASH_ATTN_DIFFKV` | | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | ✅ | Decoder | Any |
 | `FLEX_ATTENTION` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16` | Any | Any | ❌ | ✅ | ❌ | Decoder, Encoder Only | Any |
-| `ROCM_AITER_FA` | | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32 | 64, 128, 256 | ❌ | ❌ | ❌ | Decoder, Enc-Dec | N/A |
+| `ROCM_AITER_FA` | | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32 | 64, 128, 256 | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_UNIFIED_ATTN` | | fp16, bf16 | `auto` | %16 | Any | ✅ | ✅ | ❌ | All | N/A |
 | `ROCM_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | 32, 64, 80, 96, 128, 160, 192, 224, 256 | ❌ | ✅ | ❌ | All | N/A |
 | `TREE_ATTN` | | fp16, bf16 | `auto`, `float16`, `bfloat16` | %16 | 32, 64, 96, 128, 160, 192, 224, 256 | ❌ | ❌ | ❌ | Decoder | Any |

--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -175,7 +175,7 @@ Priority is **1 = highest** (tried first).
 | `FLEX_ATTENTION` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16` | Any | Any | ❌ | ✅ | ❌ | Decoder, Encoder Only | Any |
 | `ROCM_AITER_FA` | | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32 | 64, 128, 256 | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_UNIFIED_ATTN` | | fp16, bf16 | `auto` | %16 | Any | ✅ | ✅ | ❌ | All | N/A |
-| `ROCM_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | 32, 64, 80, 96, 128, 160, 192, 224, 256 | ❌ | ✅ | ❌ | All | N/A |
+| `ROCM_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | 32, 64, 80, 96, 128, 160, 192, 224, 256 | ❌ | ✅ | ❌ | Decoder, Encoder, Encoder Only | N/A |
 | `TREE_ATTN` | | fp16, bf16 | `auto`, `float16`, `bfloat16` | %16 | 32, 64, 96, 128, 160, 192, 224, 256 | ❌ | ❌ | ❌ | Decoder | Any |
 | `TRITON_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | Any | ✅ | ✅ | ❌ | All | Any |
 

--- a/tests/entrypoints/openai/speech_to_text/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/speech_to_text/test_transcription_validation_whisper.py
@@ -14,13 +14,62 @@ import pytest_asyncio
 import soundfile as sf
 
 from tests.utils import RemoteOpenAIServer
+from vllm.platforms import current_platform
 
 MODEL_NAME = "openai/whisper-large-v3-turbo"
 
+# Disable prefix caching on ROCm to reduce non-determinism in
+# streaming-vs-non-streaming comparisons.
+_ROCM_ARGS = ["--no-enable-prefix-caching"] if current_platform.is_rocm() else []
 
-@pytest.fixture(scope="module")
-def server():
-    with RemoteOpenAIServer(MODEL_NAME, []) as remote_server:
+
+def _get_attention_backend_params() -> list[str | None]:
+    """Return attention backends to parametrize the server fixture with.
+
+    On ROCm, we test multiple backends explicitly:
+      - None: default auto-selection (ROCM_ATTN for decoder self-attention,
+              falls back to ROCM_AITER_UNIFIED_ATTN or TRITON_ATTN for
+              cross-attention since ROCM_ATTN doesn't support ENCODER_DECODER)
+      - TRITON_ATTN: always available on ROCm
+      - ROCM_AITER_UNIFIED_ATTN: only on gfx942/gfx950
+
+    On non-ROCm platforms, we just run with the default backend.
+    """
+    try:
+        from vllm.platforms import current_platform
+
+        if current_platform.is_rocm():
+            backends: list[str | None] = [None, "TRITON_ATTN"]
+            from vllm.platforms.rocm import _ON_MI3XX
+
+            if _ON_MI3XX:
+                backends.append("ROCM_AITER_UNIFIED_ATTN")
+            return backends
+    except Exception:
+        pass
+    return [None]
+
+
+# Aiter backends need VLLM_ROCM_USE_AITER=1 (and MHA=1 for ROCM_AITER_FA)
+# to be enabled in the server subprocess.
+_AITER_ENV = {
+    "VLLM_ROCM_USE_AITER": "1",
+    "VLLM_ROCM_USE_AITER_MHA": "1",
+}
+
+_ATTN_BACKENDS = _get_attention_backend_params()
+_ATTN_IDS = [b or "default" for b in _ATTN_BACKENDS]
+
+
+@pytest.fixture(scope="module", params=_ATTN_BACKENDS, ids=_ATTN_IDS)
+def server(request):
+    args = [*_ROCM_ARGS]
+    env_dict = None
+    if request.param is not None:
+        args += ["--attention-backend", request.param]
+        if "AITER" in request.param:
+            env_dict = _AITER_ENV
+    with RemoteOpenAIServer(MODEL_NAME, args, env_dict=env_dict) as remote_server:
         yield remote_server
 
 

--- a/tools/pre_commit/generate_attention_backend_docs.py
+++ b/tools/pre_commit/generate_attention_backend_docs.py
@@ -446,7 +446,7 @@ def parse_attention_types(node: ast.ClassDef) -> str:
 
     if not types:
         return "Decoder"
-    return "All" if len(types) >= 3 else ", ".join(sorted(types))
+    return "All" if types >= set(type_map.values()) else ", ".join(sorted(types))
 
 
 def parse_impl_bool_attr(

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -439,7 +439,10 @@ class RocmPlatform(Platform):
                     f"this configuration. Reason: {invalid_reasons}"
                 )
             else:
-                logger.info("Using %s backend.", selected_backend)
+                logger.info_once(
+                    "Using %s backend (selected via --attention-backend).",
+                    selected_backend.name,
+                )
                 return selected_backend.get_path()
 
         # No selected backend or the selected backend is invalid,
@@ -476,12 +479,25 @@ class RocmPlatform(Platform):
         )
         selected_index = sorted_indices[0]
         selected_backend = valid_backends_priorities[selected_index][0]
-        logger.info_once(
-            "Using %s attention backend out of potential backends: %s.",
-            selected_backend.name,
-            "[" + ", ".join(f"'{b[0].name}'" for b in valid_backends_priorities) + "]",
-            scope="local",
+        valid_str = (
+            "[" + ", ".join(f"'{b[0].name}'" for b in valid_backends_priorities) + "]"
         )
+        if invalid_reasons:
+            rejected_str = ", ".join(b.name for b in invalid_reasons)
+            logger.info(
+                "Found incompatible backend(s) [%s] with %s. "
+                "Overriding with %s out of potential backends: %s.",
+                rejected_str,
+                attn_selector_config.attn_type,
+                selected_backend.name,
+                valid_str,
+            )
+        else:
+            logger.info_once(
+                "Using %s backend out of potential backends: %s.",
+                selected_backend.name,
+                valid_str,
+            )
 
         return selected_backend.get_path()
 

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -758,11 +758,12 @@ class AiterFlashAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_attn_type(cls, attn_type: str) -> bool:
-        """ROCM AITER FA supports decoder and encoder-decoder (cross) attention."""
-        return attn_type in (
-            AttentionType.DECODER,
-            AttentionType.ENCODER_DECODER,
-        )
+        """ENCODER_DECODER is not supported because the prefill path uses
+        flash_attn_varlen_func with cu_seqlens_k set to decoder
+        query_start_loc (not encoder seq lens) and causal=True, both of
+        which are incorrect for cross-attention layers.
+        """
+        return attn_type in (AttentionType.DECODER,)
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -212,12 +212,17 @@ class RocmAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_attn_type(cls, attn_type: str) -> bool:
-        """RocmAttention supports all attention types."""
+        """ENCODER_DECODER is not supported because
+        chunked_prefill_paged_decode's prefill kernel (context_attention_fwd)
+        assumes self-attention semantics: it treats passed K/V as new tokens
+        to mix with cached K/V. For cross-attention layers the encoder K/V
+        are already fully cached, so mixing them again produces incorrect
+        results when max_query_len > 1 (e.g. beam search).
+        """
         return attn_type in (
             AttentionType.DECODER,
             AttentionType.ENCODER,
             AttentionType.ENCODER_ONLY,
-            AttentionType.ENCODER_DECODER,
         )
 
     @staticmethod


### PR DESCRIPTION
Cross-attention layers in encoder-decoder models (Whisper, BART, etc.) produce incorrect beam search results on `ROCM_ATTN` and `ROCM_AITER_FA`. This PR removes `ENCODER_DECODER` from their `supports_attn_type` so the backend
dispatch selects a working backend for cross-attention layers instead.

### Motivation

The test `test_whisper_beam_search_single_beam` fails on ROCm because single-beam beam search does not match greedy decoding. The mismatch is caused by two backends computing cross-attention incorrectly when `max_query_len > 1`.

Greedy decoding is unaffected because `max_query_len=1` skips the faulty code path in both backends.

### Observed results

WER comparison across all ROCm backends on Whisper (`openai/whisper-large-v3-turbo`), transcribing `mary_had_lamb` audio. Greedy and beam search (n=1) should produce identical output:

| Backend | Greedy == Beam(n=1) |
|---------|---------------------|
| ROCM_ATTN | No |
| ROCM_AITER_FA | No |
| ROCM_AITER_UNIFIED_ATTN | Yes |
| TRITON_ATTN | Yes |

Example difference for ROCM_ATTN:
```
Greedy: "...its streets were quite as slow..."
Beam:   "...its streets were quite as snow..."
```

---

### Technical explanation

<details>
<summary>Background: how cross-attention works in vLLM</summary>

In encoder-decoder models each decoder layer has two attention sublayers:

1. **Self-attention** (`AttentionType.DECODER`): decoder tokens attend to previous decoder tokens. Q, K, V all come from the decoder hidden state.
2. **Cross-attention** (`AttentionType.ENCODER_DECODER`): decoder tokens attend to encoder output. Q comes from the decoder, K/V come from the encoder.

vLLM handles cross-attention through `CrossAttentionImpl` (`vllm/model_executor/layers/attention/cross_attention.py`), which wraps the selected backend. On the first decoder step it calls `do_kv_cache_update` to write the encoder K/V into the paged cache. On subsequent steps the cache already contains the full encoder output.

The backend dispatch (`vllm/platforms/rocm.py`) selects a backend per attention type. Different layers in the same model can use different backends. This is the mechanism this PR relies on.

</details>

<details>
<summary>ROCM_ATTN: prefill kernel assumes self-attention</summary>

`RocmAttentionImpl.forward` calls `chunked_prefill_paged_decode`, which has two phases:

```
chunked_prefill_paged_decode(query, key, value, key_cache, value_cache, ...)
    if max_query_len > 1:
        context_attention_fwd(q=query, k=key, v=value, k_cache, v_cache, ...)
    paged_decode(query, key_cache, value_cache, ...)
```

`context_attention_fwd` is a Triton prefill kernel that assumes self-attention semantics. It treats the passed `key`/`value` tensors as **new tokens being appended** to the sequence, and reads earlier tokens from the cache. It effectively computes attention over `[cached_kv..., new_kv]`.

For decoder self-attention this is correct: new K/V are projections of new decoder tokens that have not yet been cached.

For cross-attention this is wrong: the `key`/`value` passed to `forward` are encoder outputs, which `CrossAttentionImpl` has **already written to the cache**. The prefill kernel sees the encoder tokens twice -- once from the raw tensors, once from the cache -- double-counting some and missing others depending on the slot mapping.

When `max_query_len=1` (greedy decode), the prefill kernel is skipped entirely and only `paged_decode` runs. `paged_decode` reads exclusively from the cache, which is correct. This is why greedy works but beam search does not.

</details>

<details>
<summary>ROCM_AITER_FA: prefill uses wrong sequence boundaries</summary>

`AiterFlashAttentionImpl.forward` has a separate prefill path that calls `flash_attn_varlen_func`:

```python
rocm_aiter_ops.flash_attn_varlen_func(
    q=prefill_query,
    k=prefill_key,         # encoder K/V
    v=prefill_value,       # encoder K/V
    cu_seqlens_q=...,      # decoder query boundaries
    cu_seqlens_k=attn_metadata.prefill_metadata.query_start_loc,  # BUG
    causal=True,           # BUG
)
```

Two problems:

1. `cu_seqlens_k` is set to `query_start_loc`, which contains decoder query cumulative lengths. For cross-attention, the K/V come from the encoder and have different sequence lengths. This tells the kernel the wrong number of key tokens per sequence.

2. `causal=True` applies a lower-triangular mask, which is wrong for cross-attention where every decoder token should attend to every encoder token.

</details>

<details>
<summary>Why TRITON_ATTN and ROCM_AITER_UNIFIED_ATTN work</summary>

Both backends call `unified_attention(k=key_cache, v=value_cache, ...)`, passing the **paged cache tensors** directly as K/V arguments. The raw `key`/`value` from the forward call are never passed to the attention kernel. Since the cache was correctly populated by `CrossAttentionImpl.do_kv_cache_update`, the attention computation reads the right data.

`unified_attention` does pass `causal=True`, but with paged attention the causal offset is `context_len + query_pos`. For cross-attention `context_len` is large (encoder_seq_len - decoder_prompt_len), so the mask is effectively open for all practical decoder prompt sizes.

</details>

---

### Changes

**`vllm/v1/attention/backends/rocm_attn.py`**

Removed `AttentionType.ENCODER_DECODER` from `supports_attn_type`. When the dispatch runs for a cross-attention layer, `ROCM_ATTN` is now skipped and the next valid backend is selected.

**`vllm/v1/attention/backends/rocm_aiter_fa.py`**

Same change. Removed `AttentionType.ENCODER_DECODER` from `supports_attn_type`. 

**`vllm/platforms/rocm.py`**

Improved backend selection logging:
- Primary backend is logged once with `info_once`.
- When a backend is selected via fallback (some higher-priority backends were skipped), a separate line is logged showing the attention type and which backends were skipped. This makes it clear when cross-attention layers use a different backend than decoder self-attention.

### Test plan

- [x] `pytest -s -v tests/entrypoints/openai/speech_to_text/test_transcription_validation_whisper.py`
- [x] `pytest -s -v tests/v1/attention`

cc @kenroche 