### PR TITLE
fix(metrics): capture num_preemptions before _reset() clears it in log()

### DIFF
--- a/tests/v1/metrics/test_logging_stat_logger.py
+++ b/tests/v1/metrics/test_logging_stat_logger.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for LoggingStatLogger."""
+
+from unittest.mock import patch
+
+from vllm.config import VllmConfig
+from vllm.v1.metrics.loggers import LoggingStatLogger
+from vllm.v1.metrics.stats import IterationStats
+
+
+def _make_logger() -> LoggingStatLogger:
+    return LoggingStatLogger(vllm_config=VllmConfig())
+
+
+def _make_iteration_stats_with_preemptions(n: int) -> IterationStats:
+    stats = IterationStats()
+    stats.num_preempted_reqs = n
+    return stats
+
+
+def test_preemptions_appear_in_log_when_nonzero():
+    """Preemption count must be logged when preemptions occurred."""
+    logger = _make_logger()
+    logger._track_iteration_stats(_make_iteration_stats_with_preemptions(3))
+
+    logged_messages = []
+    with patch("vllm.v1.metrics.loggers.logger") as mock_log:
+        mock_log.info.side_effect = lambda msg, *args: logged_messages.append(
+            msg % args
+        )
+        mock_log.debug.side_effect = lambda msg, *args: logged_messages.append(
+            msg % args
+        )
+        logger.log()
+
+    assert any(
+        "Preemptions" in msg for msg in logged_messages
+    ), "Expected 'Preemptions' in log output, but it was missing"
+
+
+def test_preemptions_not_in_log_when_zero():
+    """Preemption count must not appear in log when no preemptions occurred."""
+    logger = _make_logger()
+    # No preemptions tracked
+
+    logged_messages = []
+    with patch("vllm.v1.metrics.loggers.logger") as mock_log:
+        mock_log.info.side_effect = lambda msg, *args: logged_messages.append(
+            msg % args
+        )
+        mock_log.debug.side_effect = lambda msg, *args: logged_messages.append(
+            msg % args
+        )
+        logger.log()
+
+    assert not any(
+        "Preemptions" in msg for msg in logged_messages
+    ), "Expected 'Preemptions' to be absent from log output, but it was present"

--- a/tests/v1/metrics/test_logging_stat_logger.py
+++ b/tests/v1/metrics/test_logging_stat_logger.py
@@ -13,9 +13,28 @@ def _make_logger() -> LoggingStatLogger:
     return LoggingStatLogger(vllm_config=VllmConfig())
 
 
+def _collect_log_output(logger: LoggingStatLogger) -> list[str]:
+    messages: list[str] = []
+    with patch("vllm.v1.metrics.loggers.logger") as mock_log:
+        mock_log.info.side_effect = lambda msg, *args: messages.append(
+            msg % args
+        )
+        mock_log.debug.side_effect = lambda msg, *args: messages.append(
+            msg % args
+        )
+        logger.log()
+    return messages
+
+
 def _make_iteration_stats_with_preemptions(n: int) -> IterationStats:
     stats = IterationStats()
     stats.num_preempted_reqs = n
+    return stats
+
+
+def _make_iteration_stats_with_corrupted(n: int) -> IterationStats:
+    stats = IterationStats()
+    stats.num_corrupted_reqs = n
     return stats
 
 
@@ -24,36 +43,47 @@ def test_preemptions_appear_in_log_when_nonzero():
     logger = _make_logger()
     logger._track_iteration_stats(_make_iteration_stats_with_preemptions(3))
 
-    logged_messages = []
-    with patch("vllm.v1.metrics.loggers.logger") as mock_log:
-        mock_log.info.side_effect = lambda msg, *args: logged_messages.append(
-            msg % args
-        )
-        mock_log.debug.side_effect = lambda msg, *args: logged_messages.append(
-            msg % args
-        )
-        logger.log()
+    messages = _collect_log_output(logger)
 
     assert any(
-        "Preemptions" in msg for msg in logged_messages
+        "Preemptions" in msg for msg in messages
     ), "Expected 'Preemptions' in log output, but it was missing"
 
 
 def test_preemptions_not_in_log_when_zero():
     """Preemption count must not appear in log when no preemptions occurred."""
     logger = _make_logger()
-    # No preemptions tracked
 
-    logged_messages = []
-    with patch("vllm.v1.metrics.loggers.logger") as mock_log:
-        mock_log.info.side_effect = lambda msg, *args: logged_messages.append(
-            msg % args
-        )
-        mock_log.debug.side_effect = lambda msg, *args: logged_messages.append(
-            msg % args
-        )
-        logger.log()
+    messages = _collect_log_output(logger)
 
     assert not any(
-        "Preemptions" in msg for msg in logged_messages
+        "Preemptions" in msg for msg in messages
     ), "Expected 'Preemptions' to be absent from log output, but it was present"
+
+
+def test_corrupted_reqs_appear_in_log_when_nonzero():
+    """Corrupted req count must be logged when VLLM_COMPUTE_NANS_IN_LOGITS is set."""
+    logger = _make_logger()
+    logger._track_iteration_stats(_make_iteration_stats_with_corrupted(2))
+
+    with patch("vllm.v1.metrics.loggers.envs") as mock_envs:
+        mock_envs.VLLM_COMPUTE_NANS_IN_LOGITS = True
+        messages = _collect_log_output(logger)
+
+    assert any(
+        "Corrupted" in msg for msg in messages
+    ), "Expected 'Corrupted' in log output, but it was missing"
+
+
+def test_corrupted_reqs_value_correct_in_log():
+    """Corrupted req count must reflect actual count, not post-reset zero."""
+    logger = _make_logger()
+    logger._track_iteration_stats(_make_iteration_stats_with_corrupted(5))
+
+    with patch("vllm.v1.metrics.loggers.envs") as mock_envs:
+        mock_envs.VLLM_COMPUTE_NANS_IN_LOGITS = True
+        messages = _collect_log_output(logger)
+
+    assert any(
+        "5" in msg and "Corrupted" in msg for msg in messages
+    ), "Expected corrupted count of 5 in log output"

--- a/tests/v1/metrics/test_logging_stat_logger.py
+++ b/tests/v1/metrics/test_logging_stat_logger.py
@@ -39,15 +39,19 @@ def _make_iteration_stats_with_corrupted(n: int) -> IterationStats:
 
 
 def test_preemptions_appear_in_log_when_nonzero():
-    """Preemption count must be logged when preemptions occurred."""
+    """Preemption count must be logged when preemptions occurred.
+
+    This test would have failed before the fix: _update_stats() called _reset()
+    which zeroed num_preemptions before the > 0 guard was checked.
+    """
     logger = _make_logger()
     logger._track_iteration_stats(_make_iteration_stats_with_preemptions(3))
 
     messages = _collect_log_output(logger)
 
     assert any(
-        "Preemptions" in msg for msg in messages
-    ), "Expected 'Preemptions' in log output, but it was missing"
+        "Preemptions: 3" in msg for msg in messages
+    ), "Expected 'Preemptions: 3' in log output, but it was missing"
 
 
 def test_preemptions_not_in_log_when_zero():
@@ -61,22 +65,12 @@ def test_preemptions_not_in_log_when_zero():
     ), "Expected 'Preemptions' to be absent from log output, but it was present"
 
 
-def test_corrupted_reqs_appear_in_log_when_nonzero():
-    """Corrupted req count must be logged when VLLM_COMPUTE_NANS_IN_LOGITS is set."""
-    logger = _make_logger()
-    logger._track_iteration_stats(_make_iteration_stats_with_corrupted(2))
-
-    with patch("vllm.v1.metrics.loggers.envs") as mock_envs:
-        mock_envs.VLLM_COMPUTE_NANS_IN_LOGITS = True
-        messages = _collect_log_output(logger)
-
-    assert any(
-        "Corrupted" in msg for msg in messages
-    ), "Expected 'Corrupted' in log output, but it was missing"
-
-
 def test_corrupted_reqs_value_correct_in_log():
-    """Corrupted req count must reflect actual count, not post-reset zero."""
+    """Corrupted req count must reflect actual count, not post-reset zero.
+
+    This test would have failed before the fix: _update_stats() called _reset()
+    which zeroed num_corrupted_reqs before it was read for logging.
+    """
     logger = _make_logger()
     logger._track_iteration_stats(_make_iteration_stats_with_corrupted(5))
 
@@ -85,5 +79,5 @@ def test_corrupted_reqs_value_correct_in_log():
         messages = _collect_log_output(logger)
 
     assert any(
-        "5" in msg and "Corrupted" in msg for msg in messages
-    ), "Expected corrupted count of 5 in log output"
+        "Corrupted: 5 reqs" in msg for msg in messages
+    ), "Expected 'Corrupted: 5 reqs' in log output, but it was missing"

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -211,6 +211,7 @@ class LoggingStatLogger(StatLoggerBase):
         return
 
     def log(self):
+        num_preemptions = self.num_preemptions
         self._update_stats()
         self.aggregate_scheduler_stats()
         # Avoid log noise on an idle production system
@@ -229,9 +230,9 @@ class LoggingStatLogger(StatLoggerBase):
             self.last_scheduler_stats.num_waiting_reqs,
         ]
 
-        if self.num_preemptions > 0:
+        if num_preemptions > 0:
             log_parts.append("Preemptions: %d")
-            log_args.append(self.num_preemptions)
+            log_args.append(num_preemptions)
 
         log_parts.extend(
             [

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -212,6 +212,7 @@ class LoggingStatLogger(StatLoggerBase):
 
     def log(self):
         num_preemptions = self.num_preemptions
+        num_corrupted_reqs = self.num_corrupted_reqs
         self._update_stats()
         self.aggregate_scheduler_stats()
         # Avoid log noise on an idle production system
@@ -249,7 +250,7 @@ class LoggingStatLogger(StatLoggerBase):
 
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
             log_parts.append("Corrupted: %d reqs")
-            log_args.append(self.num_corrupted_reqs)
+            log_args.append(num_corrupted_reqs)
         if not self.connector_prefix_caching_metrics.empty:
             log_parts.append("External prefix cache hit rate: %.1f%%")
             log_args.append(self.connector_prefix_caching_metrics.hit_rate * 100)


### PR DESCRIPTION
## Summary

`LoggingStatLogger.log()` called `_update_stats()` first, which internally calls `_reset()` and zeros out accumulated counters. Two counters were affected:

- `num_preemptions` — the `if self.num_preemptions > 0` guard was always false, so preemptions were never logged
- `num_corrupted_reqs` — same issue, value was always 0 when read

Fix: snapshot both values into local variables before calling `_update_stats()`.

## Related

Follows up on #28522 which introduced the preemption logging feature.

## Why this is not a duplicate

#28522 has already been merged. This is a bug fix for a defect in that implementation.

## Test plan

- [x] Added `tests/v1/metrics/test_logging_stat_logger.py` with two unit tests:
  - `test_preemptions_appear_in_log_when_nonzero` — verifies "Preemptions" appears in log when preemptions occurred
  - `test_preemptions_not_in_log_when_zero` — verifies "Preemptions" is absent when no preemptions occurred
- [ ] CI passes

## AI assistance

This fix was identified and implemented with Claude assistance. All changed lines reviewed by the submitting author.