### PR TITLE
[CI] Fix online FP8 quantization materializing tensors on CPU

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1012,8 +1012,12 @@ class Fp8OnlineMoEMethod(Fp8MoEMethod):
         fp8_dtype = current_platform.fp8_dtype()
         w13 = torch.empty_like(layer.w13_weight, dtype=fp8_dtype)
         w2 = torch.empty_like(layer.w2_weight, dtype=fp8_dtype)
-        w13_scale = torch.ones(layer.num_experts, dtype=torch.float32)
-        w2_scale = torch.ones(layer.num_experts, dtype=torch.float32)
+        w13_scale = torch.ones(
+            layer.num_experts, dtype=torch.float32, device=layer.w13_weight.device
+        )
+        w2_scale = torch.ones(
+            layer.num_experts, dtype=torch.float32, device=layer.w2_weight.device
+        )
         layer.w13_input_scale = None
         layer.w2_input_scale = None
 

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -9,6 +9,7 @@ from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.reload.meta import materialize_meta_tensor
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
 from vllm.model_executor.model_loader.weight_utils import initialize_dummy_weights
+from vllm.platforms import current_platform
 
 
 class DummyModelLoader(BaseModelLoader):
@@ -30,7 +31,13 @@ class DummyModelLoader(BaseModelLoader):
         for layer in model.modules():
             for name, param in get_layer_tensors(layer).items():
                 if param.device == torch.device("meta"):
-                    setattr(layer, name, materialize_meta_tensor(param))
+                    setattr(
+                        layer,
+                        name,
+                        materialize_meta_tensor(
+                            param, device=current_platform.device_type
+                        ),
+                    )
 
         # NOTE(woosuk): For accurate performance evaluation, we assign
         # random values to the weights.

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -12,6 +12,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.platforms import current_platform
 
 from .meta import (
     capture_layer_to_meta,
@@ -211,7 +212,7 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
         elif info.load_numel <= 0:
             # first load but received no weights. This happens on dummy load
             if info.kernel_tensors is None:
-                materialize_layer(layer)
+                materialize_layer(layer, device=current_platform.device_type)
 
             # reloading: place kernel tensors back as a fallback
             else:
@@ -244,7 +245,7 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
     4. Copies processed values back to original tensor storage
     """
     # Materialize layer tensors onto device
-    materialize_layer(layer)
+    materialize_layer(layer, device=current_platform.device_type)
 
     # Reset online quantization flag so process_weights_after_loading
     # will run again during reload

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -38,15 +38,23 @@ def to_meta_tensor(tensor: torch.Tensor) -> torch.Tensor:
     return meta_tensor
 
 
-def materialize_meta_tensor(meta_tensor: torch.Tensor) -> torch.Tensor:
+def materialize_meta_tensor(
+    meta_tensor: torch.Tensor,
+    device: torch.types.Device = None,
+) -> torch.Tensor:
     """
-    Materialize a meta tensor into an actual tensor on the current device.
-    Should be called within the torch device context for the given rank.
+    Materialize a meta tensor into an actual tensor.
+
+    :param meta_tensor: tensor on the meta device to materialize
+    :param device: target device for the materialized tensor. If ``None``,
+        uses the ambient ``torch.device`` context (the caller must ensure
+        one is active, e.g. via ``with torch.device(target):``).
     """
     tensor = torch.empty_strided(
         size=tuple(meta_tensor.size()),
         stride=tuple(meta_tensor.stride()),
         dtype=meta_tensor.dtype,
+        device=device,
         requires_grad=False,
     )
     tensor.__class__ = meta_tensor.__class__
@@ -94,14 +102,17 @@ def restore_layer_on_meta(layer: torch.nn.Module, info: LayerReloadingInfo):
             layer.register_buffer(name, buffer)
 
 
-def materialize_layer(layer: torch.nn.Module) -> None:
+def materialize_layer(
+    layer: torch.nn.Module,
+    device: torch.types.Device = None,
+) -> None:
     """Materialize all meta tensors in a layer to actual tensors."""
     if layer.__class__.__name__ in SKIP_MODULES:
         return
 
     for name, tensor in get_layer_tensors(layer).items():
         if name not in SKIP_TENSORS:
-            setattr(layer, name, materialize_meta_tensor(tensor))
+            setattr(layer, name, materialize_meta_tensor(tensor, device=device))
 
 
 class CopyCounter(TorchDispatchMode):


### PR DESCRIPTION
## Purpose

Address CI failures:
- https://buildkite.com/vllm/ci/builds/58606/steps/canvas?sid=019d36b8-7870-4d4e-abce-ba03d2561896&tab=output
- https://buildkite.com/vllm/ci/builds/58628/steps/canvas?sid=019d382e-c763-4230-a089-84d52dd42e6a&tab=output

After #38426 moved `load_weights()` outside the `with target_device:` context (to fix OOM), online FP8 quantization broke in two ways:

1. `materialize_meta_tensor()` uses `torch.empty_strided()` without a `device=` arg, relying on the ambient device context. Without it, tensors are created on CPU and `process_weights_after_loading` fails with `NotImplementedError: Could not run '_C::dynamic_scaled_fp8_quant' with arguments from the 'CPU' backend`.

2. `Fp8OnlineMoEMethod.process_weights_after_loading()` creates scale tensors with `torch.ones(...)` without `device=`, causing them to land on CPU and crash the Triton fused MoE kernel with `ValueError: Pointer argument (at 5) cannot be accessed from Triton (cpu tensor?)`.

## Test Plan

```bash
pytest tests/quantization/test_fp8.py::test_online_quantization \
  tests/quantization/test_fp8.py::test_online_quant_peak_mem \
  tests/quantization/test_fp8.py::test_online_quant_load_format_dummy \
  tests/compile/fullgraph/test_full_graph.py::test_fp8_kv_scale_compile[Qwen/Qwen2-0.5B-None-0] \
  tests/compile/fullgraph/test_full_graph.py::test_fp8_kv_scale_compile[Qwen/Qwen2-0.5B-None-3] -v
```

## Test Result

All 8 tests pass:

```
tests/quantization/test_fp8.py::test_online_quantization[False-False-auto] PASSED
tests/quantization/test_fp8.py::test_online_quantization[False-False-fp8] PASSED
tests/quantization/test_fp8.py::test_online_quantization[False-True-auto] PASSED
tests/quantization/test_fp8.py::test_online_quantization[False-True-fp8] PASSED
tests/quantization/test_fp8.py::test_online_quant_peak_mem PASSED
tests/quantization/test_fp8.py::test_online_quant_load_format_dummy PASSED
tests/compile/fullgraph/test_full_graph.py::test_fp8_kv_scale_compile[Qwen/Qwen2-0.5B-None-0] PASSED
tests/compile/fullgraph/test_full_graph.py::test_fp8_kv_scale_compile[Qwen/Qwen2-0.5B-None-3] PASSED
```