### PR TITLE
[Bugfix] Fix limit_mm_per_prompt being ignored for encoder cache profiling

### DIFF
--- a/vllm/multimodal/encoder_budget.py
+++ b/vllm/multimodal/encoder_budget.py
@@ -88,8 +88,7 @@ class MultiModalBudget:
                 model_config,
                 mm_registry,
                 processor,
-                mm_counts={m: mm_limits.get(m, 1)
-                           for m in active_modalities},
+                mm_counts={m: mm_limits.get(m, 1) for m in active_modalities},
             )
 
         if embed_only_modalities:

--- a/vllm/multimodal/encoder_budget.py
+++ b/vllm/multimodal/encoder_budget.py
@@ -88,7 +88,8 @@ class MultiModalBudget:
                 model_config,
                 mm_registry,
                 processor,
-                mm_counts=dict.fromkeys(active_modalities, 1),
+                mm_counts={m: mm_limits.get(m, 1)
+                           for m in active_modalities},
             )
 
         if embed_only_modalities:


### PR DESCRIPTION
## Purpose

Fixes #38459

The encoder cache profiling in `MultiModalBudget` always used a hardcoded count of `1` for each modality when computing max tokens per item via `get_mm_max_toks_per_item()`. This caused models like Qwen3-VL to always profile with a single image/video item regardless of the user-configured `limit_mm_per_prompt`, leading to incorrect encoder cache sizing.

### Root Cause

In `vllm/multimodal/encoder_budget.py`, the call to `get_mm_max_toks_per_item()` was:
```python
mm_counts=dict.fromkeys(active_modalities, 1)
```

This hardcodes all modality counts to 1, so for Qwen2-VL/Qwen3-VL where `get_max_video_tokens()` divides total frames by `mm_counts["video"]`, the per-item token count was always maximized regardless of the actual limit.

### Fix

Use the actual `mm_limits` (derived from `limit_mm_per_prompt` and model's supported limits) instead of hardcoded 1:
```python
mm_counts={m: mm_limits.get(m, 1) for m in active_modalities}
```

## Test Plan

- Verify Qwen3-VL with `--limit-mm-per-prompt '{"video": 5}'` now reports profiling with the correct item count in logs
- Existing multimodal tests should continue to pass since default behavior (no explicit limit) uses the model's default limits

## Test Result

The fix changes one line in `encoder_budget.py`. Encoder cache profiling will now correctly respect `limit_mm_per_prompt` for all multimodal models.