### PR TITLE
[Bugfix] Add CPU profiler summary equivalent to CUDA summary

### DIFF
--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -59,6 +59,12 @@ class ProfilerConfig:
     torch_profiler_dump_cuda_time_total: bool = True
     """If `True`, dumps total CUDA time in torch profiler traces. Enabled by default."""
 
+    torch_profiler_dump_cpu_time_total: bool = False
+    """If `True`, dumps a profiler summary sorted by self_cpu_time_total to a
+    file and (on rank 0) to stdout, mirroring the CUDA summary behavior.
+    Automatically enabled on CPU backends when torch_profiler_dump_cuda_time_total
+    is requested."""
+
     torch_profiler_record_shapes: bool = False
     """If `True`, records tensor shapes in the torch profiler. Disabled by default."""
 

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -253,7 +253,10 @@ class CpuPlatform(Platform):
         if vllm_config.lora_config is not None:
             compilation_config.mode = CompilationMode.NONE
 
-        vllm_config.profiler_config.torch_profiler_dump_cuda_time_total = False
+        profiler_config = vllm_config.profiler_config
+        if profiler_config.torch_profiler_dump_cuda_time_total:
+            profiler_config.torch_profiler_dump_cpu_time_total = True
+        profiler_config.torch_profiler_dump_cuda_time_total = False
 
         assert vllm_config.device_config.device_type == "cpu"
 

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -242,41 +242,40 @@ class TorchProfilerWrapper(WorkerProfiler):
     def _start(self) -> None:
         self.profiler.start()
 
+    def _dump_profiler_summary(
+        self, sort_key: str, file_suffix: str
+    ) -> None:
+        """Dump a profiler summary table sorted by the given key.
+
+        Writes the table to ``{profiler_dir}/profiler_{file_suffix}_{rank}.txt``
+        (skipped for URI paths) and prints it to stdout on rank 0.
+        """
+        profiler_dir = self.profiler_config.torch_profiler_dir
+        rank = self.local_rank
+        table = self.profiler.key_averages().table(sort_by=sort_key)
+
+        # Skip file write for URI paths (gs://, s3://, etc.)
+        # as standard file I/O doesn't work with URI schemes
+        if not _is_uri_path(profiler_dir):
+            profiler_out_file = (
+                f"{profiler_dir}/profiler_{file_suffix}_{rank}.txt"
+            )
+            with open(profiler_out_file, "w") as f:
+                print(table, file=f)
+
+        # only print profiler results on rank 0
+        if rank == 0:
+            print(table)
+
     @override
     def _stop(self) -> None:
         self.profiler.stop()
 
         profiler_config = self.profiler_config
-        rank = self.local_rank
         if profiler_config.torch_profiler_dump_cuda_time_total:
-            profiler_dir = profiler_config.torch_profiler_dir
-            sort_key = "self_cuda_time_total"
-            table = self.profiler.key_averages().table(sort_by=sort_key)
-
-            # Skip file write for URI paths (gs://, s3://, etc.)
-            # as standard file I/O doesn't work with URI schemes
-            if not _is_uri_path(profiler_dir):
-                profiler_out_file = f"{profiler_dir}/profiler_out_{rank}.txt"
-                with open(profiler_out_file, "w") as f:
-                    print(table, file=f)
-
-            # only print profiler results on rank 0
-            if rank == 0:
-                print(table)
+            self._dump_profiler_summary("self_cuda_time_total", "out")
         if profiler_config.torch_profiler_dump_cpu_time_total:
-            profiler_dir = profiler_config.torch_profiler_dir
-            sort_key = "self_cpu_time_total"
-            table = self.profiler.key_averages().table(sort_by=sort_key)
-
-            if not _is_uri_path(profiler_dir):
-                profiler_out_file = (
-                    f"{profiler_dir}/profiler_cpu_out_{rank}.txt"
-                )
-                with open(profiler_out_file, "w") as f:
-                    print(table, file=f)
-
-            if rank == 0:
-                print(table)
+            self._dump_profiler_summary("self_cpu_time_total", "cpu_out")
 
     @override
     def _profiler_step(self) -> bool:

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -198,8 +198,6 @@ class TorchProfilerWrapper(WorkerProfiler):
                 use_gzip=profiler_config.torch_profiler_use_gzip,
             )
 
-        self.dump_cpu_time_total = "CPU" in activities and len(activities) == 1
-
         # Create profiler schedule if warmup or wait iterations are configured
         profiler_schedule = None
         if profiler_config.warmup_iterations > 0 or profiler_config.wait_iterations > 0:
@@ -265,12 +263,20 @@ class TorchProfilerWrapper(WorkerProfiler):
             # only print profiler results on rank 0
             if rank == 0:
                 print(table)
-        if self.dump_cpu_time_total and rank == 0:
-            logger.info(
-                self.profiler.key_averages().table(
-                    sort_by="self_cpu_time_total", row_limit=50
+        if profiler_config.torch_profiler_dump_cpu_time_total:
+            profiler_dir = profiler_config.torch_profiler_dir
+            sort_key = "self_cpu_time_total"
+            table = self.profiler.key_averages().table(sort_by=sort_key)
+
+            if not _is_uri_path(profiler_dir):
+                profiler_out_file = (
+                    f"{profiler_dir}/profiler_cpu_out_{rank}.txt"
                 )
-            )
+                with open(profiler_out_file, "w") as f:
+                    print(table, file=f)
+
+            if rank == 0:
+                print(table)
 
     @override
     def _profiler_step(self) -> bool:

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -242,9 +242,7 @@ class TorchProfilerWrapper(WorkerProfiler):
     def _start(self) -> None:
         self.profiler.start()
 
-    def _dump_profiler_summary(
-        self, sort_key: str, file_suffix: str
-    ) -> None:
+    def _dump_profiler_summary(self, sort_key: str, file_suffix: str) -> None:
         """Dump a profiler summary table sorted by the given key.
 
         Writes the table to ``{profiler_dir}/profiler_{file_suffix}_{rank}.txt``
@@ -257,9 +255,7 @@ class TorchProfilerWrapper(WorkerProfiler):
         # Skip file write for URI paths (gs://, s3://, etc.)
         # as standard file I/O doesn't work with URI schemes
         if not _is_uri_path(profiler_dir):
-            profiler_out_file = (
-                f"{profiler_dir}/profiler_{file_suffix}_{rank}.txt"
-            )
+            profiler_out_file = f"{profiler_dir}/profiler_{file_suffix}_{rank}.txt"
             with open(profiler_out_file, "w") as f:
                 print(table, file=f)
 


### PR DESCRIPTION
## Purpose

Fixes #38131

On CPU backends, `torch_profiler_dump_cuda_time_total` was silently overridden to `False` with no alternative CPU summary, leaving users without any human-readable profiler summary file even when they explicitly enabled it.

### Changes

1. **`vllm/config/profiler.py`**: Added `torch_profiler_dump_cpu_time_total` config field that mirrors the CUDA summary behavior for CPU
2. **`vllm/platforms/cpu.py`**: When the user requests CUDA summary on CPU, automatically enable the CPU summary instead of silently disabling
3. **`vllm/profiler/wrapper.py`**: Write CPU summary (sorted by `self_cpu_time_total`) to `profiler_cpu_out_{rank}.txt` and print to stdout on rank 0, exactly mirroring the CUDA summary path

## Test Plan

```bash
# Run with CPU profiling enabled
python -c "
from vllm import LLM, SamplingParams
from vllm.config import ProfilerConfig

prof_cfg = ProfilerConfig(
    profiler='torch',
    torch_profiler_dir='/tmp/vllm_profile',
    torch_profiler_dump_cuda_time_total=True,
)
llm = LLM(model='meta-llama/Llama-3.1-8B-Instruct', dtype='bfloat16', max_model_len=448)
llm.start_profile()
llm.generate(['Hello'], SamplingParams(max_tokens=32))
llm.stop_profile()
"
# Verify profiler_cpu_out_0.txt exists and contains self_cpu_time_total table
ls /tmp/vllm_profile/profiler_cpu_out_*.txt
```

## Test Result

The CPU summary file is now generated with the same format as the CUDA summary, sorted by `self_cpu_time_total`.