### PR TITLE
[Feature] Add apply_with_spec_decode() to LogitBiasLogitsProcessor

### DIFF
--- a/tests/v1/logits_processors/test_logit_bias_spec_decode.py
+++ b/tests/v1/logits_processors/test_logit_bias_spec_decode.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for LogitBiasLogitsProcessor.apply_with_spec_decode()."""
+
+import pytest
+import torch
+
+from vllm.v1.sample.logits_processor import BatchUpdate, LogitBiasLogitsProcessor
+from vllm.sampling_params import SamplingParams
+
+VOCAB_SIZE = 128
+DEVICE = torch.device("cpu")
+
+
+def _make_processor(
+    biases: dict[int, dict[int, float]],
+) -> LogitBiasLogitsProcessor:
+    """Create a LogitBiasLogitsProcessor with pre-set biases.
+
+    ``biases`` maps *batch index* → {token_id: bias_value}.
+    We feed each entry through update_state so internal tensors are built.
+    """
+    proc = LogitBiasLogitsProcessor(None, DEVICE, False)
+
+    # Build a BatchUpdate that adds one request per entry.
+    # AddedRequest = (index, params, prompt_tok_ids, output_tok_ids)
+    added = []
+    batch_size = 0
+    for req_idx, token_biases in biases.items():
+        params = SamplingParams(logit_bias=token_biases)
+        added.append((req_idx, params, None, []))
+        batch_size = max(batch_size, req_idx + 1)
+
+    if added:
+        batch_update = BatchUpdate(
+            batch_size=batch_size,
+            added=added,
+            removed=[],
+            moved=[],
+        )
+        proc.update_state(batch_update)
+    return proc
+
+
+class TestLogitBiasApplyWithSpecDecode:
+    """Tests for apply_with_spec_decode on LogitBiasLogitsProcessor."""
+
+    def test_no_biases_returns_logits_unchanged(self):
+        """When no biases are configured the logits tensor is untouched."""
+        proc = LogitBiasLogitsProcessor(None, DEVICE, False)
+        logits = torch.zeros(6, VOCAB_SIZE)
+        result = proc.apply_with_spec_decode(logits, [2, 3, 1])
+        assert torch.equal(result, torch.zeros(6, VOCAB_SIZE))
+
+    def test_single_request_single_token_bias(self):
+        """Bias for one request with one token is applied to all its rows."""
+        biases = {0: {5: 1.5}}
+        proc = _make_processor(biases)
+
+        num_draft_tokens = [3]
+        logits = torch.zeros(3, VOCAB_SIZE)
+        logits = proc.apply_with_spec_decode(logits, num_draft_tokens)
+
+        # All 3 rows should have token 5 biased by 1.5.
+        for row in range(3):
+            assert logits[row, 5].item() == pytest.approx(1.5), (
+                f"row {row}, token 5 should be biased"
+            )
+            # Other tokens remain zero.
+            assert logits[row, 0].item() == pytest.approx(0.0)
+
+    def test_single_request_multiple_token_biases(self):
+        """Multiple token biases for a single request."""
+        biases = {0: {10: 2.0, 20: -1.0}}
+        proc = _make_processor(biases)
+
+        num_draft_tokens = [2]
+        logits = torch.ones(2, VOCAB_SIZE)
+        logits = proc.apply_with_spec_decode(logits, num_draft_tokens)
+
+        for row in range(2):
+            assert logits[row, 10].item() == pytest.approx(3.0)
+            assert logits[row, 20].item() == pytest.approx(0.0)
+            # Unbiased token stays at 1.0.
+            assert logits[row, 0].item() == pytest.approx(1.0)
+
+    def test_multiple_requests_correct_row_assignment(self):
+        """Biases are applied to the correct row ranges per request."""
+        # req 0 → rows 0-1, req 1 → rows 2-4 (no bias), req 2 → row 5
+        biases = {0: {7: 0.5}, 2: {3: -2.0}}
+        proc = _make_processor(biases)
+
+        num_draft_tokens = [2, 3, 1]
+        logits = torch.zeros(6, VOCAB_SIZE)
+        logits = proc.apply_with_spec_decode(logits, num_draft_tokens)
+
+        # Request 0: rows 0-1
+        for row in range(2):
+            assert logits[row, 7].item() == pytest.approx(0.5)
+        # Request 1: rows 2-4 should be untouched (no bias configured)
+        for row in range(2, 5):
+            assert logits[row, 7].item() == pytest.approx(0.0)
+            assert logits[row, 3].item() == pytest.approx(0.0)
+        # Request 2: row 5
+        assert logits[5, 3].item() == pytest.approx(-2.0)
+        assert logits[5, 7].item() == pytest.approx(0.0)
+
+    def test_request_with_zero_draft_tokens_skipped(self):
+        """A request with 0 draft tokens should not cause errors."""
+        biases = {0: {5: 1.0}, 1: {5: 2.0}}
+        proc = _make_processor(biases)
+
+        # Request 0 has 0 draft tokens; request 1 has 2.
+        num_draft_tokens = [0, 2]
+        logits = torch.zeros(2, VOCAB_SIZE)
+        logits = proc.apply_with_spec_decode(logits, num_draft_tokens)
+
+        # Request 0 contributes no rows; request 1 owns rows 0-1.
+        for row in range(2):
+            assert logits[row, 5].item() == pytest.approx(2.0)
+
+    def test_bias_values_are_additive(self):
+        """Biases add to existing logit values (not replace)."""
+        biases = {0: {0: 3.0}}
+        proc = _make_processor(biases)
+
+        logits = torch.full((2, VOCAB_SIZE), 1.0)
+        logits = proc.apply_with_spec_decode(logits, [2])
+
+        assert logits[0, 0].item() == pytest.approx(4.0)
+        assert logits[1, 0].item() == pytest.approx(4.0)
+
+    def test_negative_bias(self):
+        """Negative biases reduce logit values."""
+        biases = {0: {10: -5.0}}
+        proc = _make_processor(biases)
+
+        logits = torch.zeros(1, VOCAB_SIZE)
+        logits = proc.apply_with_spec_decode(logits, [1])
+
+        assert logits[0, 10].item() == pytest.approx(-5.0)
+
+    def test_all_requests_have_biases(self):
+        """Every request in the batch has a bias configured."""
+        biases = {0: {1: 0.1}, 1: {2: 0.2}, 2: {3: 0.3}}
+        proc = _make_processor(biases)
+
+        num_draft_tokens = [1, 2, 1]
+        logits = torch.zeros(4, VOCAB_SIZE)
+        logits = proc.apply_with_spec_decode(logits, num_draft_tokens)
+
+        # req 0 → row 0
+        assert logits[0, 1].item() == pytest.approx(0.1)
+        # req 1 → rows 1-2
+        assert logits[1, 2].item() == pytest.approx(0.2)
+        assert logits[2, 2].item() == pytest.approx(0.2)
+        # req 2 → row 3
+        assert logits[3, 3].item() == pytest.approx(0.3)
+
+    def test_consistency_with_apply(self):
+        """apply_with_spec_decode with 1 draft token per request should
+        produce the same result as apply() on a normal batch."""
+        biases = {0: {5: 1.5, 10: -0.5}, 1: {20: 2.0}}
+        proc = _make_processor(biases)
+
+        batch_size = 2
+        logits_spec = torch.randn(batch_size, VOCAB_SIZE)
+        logits_normal = logits_spec.clone()
+
+        # apply_with_spec_decode: 1 draft token per request = normal batch
+        logits_spec = proc.apply_with_spec_decode(
+            logits_spec, [1] * batch_size
+        )
+        # apply: standard path
+        logits_normal = proc.apply(logits_normal)
+
+        assert torch.allclose(logits_spec, logits_normal), (
+            "apply_with_spec_decode with 1 draft token should match apply()"
+        )

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -203,13 +203,13 @@ def build_logitsprocs(
     if vllm_config.speculative_config:
         if custom_logitsprocs:
             raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
-        logger.warning(
-            "min_p parameter won't work with speculative decoding."
+        logger.warning("min_p parameter won't work with speculative decoding.")
+        return LogitsProcessors(
+            [
+                LogitBiasLogitsProcessor(vllm_config, device, is_pin_memory),
+                MinTokensLogitsProcessor(vllm_config, device, is_pin_memory),
+            ]
         )
-        return LogitsProcessors([
-            LogitBiasLogitsProcessor(vllm_config, device, is_pin_memory),
-            MinTokensLogitsProcessor(vllm_config, device, is_pin_memory),
-        ])
 
     custom_logitsprocs_classes = _load_custom_logitsprocs(custom_logitsprocs)
     return LogitsProcessors(

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -204,11 +204,12 @@ def build_logitsprocs(
         if custom_logitsprocs:
             raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
         logger.warning(
-            "min_p and logit_bias parameters won't work with speculative decoding."
+            "min_p parameter won't work with speculative decoding."
         )
-        return LogitsProcessors(
-            [MinTokensLogitsProcessor(vllm_config, device, is_pin_memory)]
-        )
+        return LogitsProcessors([
+            LogitBiasLogitsProcessor(vllm_config, device, is_pin_memory),
+            MinTokensLogitsProcessor(vllm_config, device, is_pin_memory),
+        ])
 
     custom_logitsprocs_classes = _load_custom_logitsprocs(custom_logitsprocs)
     return LogitsProcessors(

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -213,9 +213,9 @@ class LogitBiasLogitsProcessor(LogitsProcessor):
                 torch.from_numpy(rows_arr).to(self.device, non_blocking=True),
                 torch.from_numpy(toks_arr).to(self.device, non_blocking=True),
             )
-            bias_tensor = torch.from_numpy(
-                bias_arr.astype(np.float32)
-            ).to(self.device, non_blocking=True)
+            bias_tensor = torch.from_numpy(bias_arr.astype(np.float32)).to(
+                self.device, non_blocking=True
+            )
             logits[logits_slice] += bias_tensor
 
         return logits

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -163,6 +163,63 @@ class LogitBiasLogitsProcessor(LogitsProcessor):
             logits[self.logits_slice] += self.bias_tensor
         return logits
 
+    def apply_with_spec_decode(
+        self,
+        logits: torch.Tensor,
+        num_draft_tokens: list[int],
+    ) -> torch.Tensor:
+        """Spec-decode version of apply().
+
+        During speculative decoding the logits tensor is flattened across
+        all draft positions: ``logits`` has shape
+        ``[sum(num_draft_tokens), vocab_size]``.
+        Each request *i* owns rows ``cumsum[i] .. cumsum[i+1]-1``.
+
+        The logit bias must be applied to **every** row that belongs to
+        a request with a configured bias.
+        """
+        if not self.biases:
+            return logits
+
+        num_draft_arr = np.array(num_draft_tokens, dtype=np.int64)
+        cumsum = np.concatenate([[0], np.cumsum(num_draft_arr)])
+
+        all_rows: list[np.ndarray] = []
+        all_toks: list[np.ndarray] = []
+        all_bias: list[np.ndarray] = []
+
+        for req_idx, token_biases in self.biases.items():
+            n_rows = int(num_draft_arr[req_idx])
+            if n_rows == 0:
+                continue
+
+            offset = int(cumsum[req_idx])
+            tok_ids = list(token_biases.keys())
+            bias_vals = list(token_biases.values())
+            n_toks = len(tok_ids)
+
+            row_indices = np.arange(offset, offset + n_rows, dtype=np.int64)
+            # Repeat each row index n_toks times; tile tok_ids n_rows times.
+            all_rows.append(np.repeat(row_indices, n_toks))
+            all_toks.append(np.tile(tok_ids, n_rows))
+            all_bias.append(np.tile(bias_vals, n_rows))
+
+        if all_rows:
+            rows_arr = np.concatenate(all_rows)
+            toks_arr = np.concatenate(all_toks)
+            bias_arr = np.concatenate(all_bias)
+
+            logits_slice = (
+                torch.from_numpy(rows_arr).to(self.device, non_blocking=True),
+                torch.from_numpy(toks_arr).to(self.device, non_blocking=True),
+            )
+            bias_tensor = torch.from_numpy(
+                bias_arr.astype(np.float32)
+            ).to(self.device, non_blocking=True)
+            logits[logits_slice] += bias_tensor
+
+        return logits
+
 
 class MinTokensLogitsProcessor(LogitsProcessor):
     def __init__(

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -10,7 +10,10 @@ import torch.nn as nn
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
-from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
+from vllm.v1.sample.logits_processor.builtin import (
+    LogitBiasLogitsProcessor,
+    MinTokensLogitsProcessor,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
@@ -294,7 +297,8 @@ class RejectionSampler(nn.Module):
             )
 
         for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
-            if isinstance(processor, MinTokensLogitsProcessor):
+            if isinstance(processor,
+                          (LogitBiasLogitsProcessor, MinTokensLogitsProcessor)):
                 logits = processor.apply_with_spec_decode(
                     logits, metadata.num_draft_tokens
                 )

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -10,10 +10,6 @@ import torch.nn as nn
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
-from vllm.v1.sample.logits_processor.builtin import (
-    LogitBiasLogitsProcessor,
-    MinTokensLogitsProcessor,
-)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
@@ -297,8 +293,7 @@ class RejectionSampler(nn.Module):
             )
 
         for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
-            if isinstance(processor,
-                          (LogitBiasLogitsProcessor, MinTokensLogitsProcessor)):
+            if hasattr(processor, "apply_with_spec_decode"):
                 logits = processor.apply_with_spec_decode(
                     logits, metadata.num_draft_tokens
                 )


### PR DESCRIPTION
## Purpose

Fixes #38202

`LogitBiasLogitsProcessor` was not supported during speculative decoding. When spec_decode was enabled, logit_bias parameters were silently ignored with a warning. This PR adds speculative decoding support so logit biases are correctly applied during rejection sampling.

### Changes

1. **`vllm/v1/sample/logits_processor/builtin.py`**: Added `apply_with_spec_decode()` method to `LogitBiasLogitsProcessor` that maps request indices to their corresponding rows in the expanded logits tensor (shape `[sum(num_draft_tokens), vocab_size]`), applying biases to all draft positions for each request.

2. **`vllm/v1/sample/logits_processor/__init__.py`**: Include `LogitBiasLogitsProcessor` in the spec_decode processor list (previously only `MinTokensLogitsProcessor` was included).

3. **`vllm/v1/sample/rejection_sampler.py`**: Update the `apply_logits_processors` dispatch to call `apply_with_spec_decode` for both `LogitBiasLogitsProcessor` and `MinTokensLogitsProcessor`.

## Test Plan

- Run existing logits processor tests: `pytest tests/v1/logits_processors/`
- Verify logit_bias works with speculative decoding enabled
- Verify no regression on non-spec-decode logit_bias behavior

## Test Result

The implementation follows the same pattern as `MinTokensLogitsProcessor.apply_with_spec_decode()` using numpy cumsum for request-to-row mapping and batch tensor construction.