### PR TITLE
Fix potential infinite loop in SonnetDataset.sample

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2441,7 +2441,7 @@ class SonnetDataset(BenchmarkDataset):
             raise RuntimeError(
                 f"Failed to generate {num_requests} samples within "
                 f"{self.DEFAULT_MAX_SAMPLE_ATTEMPTS} attempts. Consider increasing "
-                f"'input_len' or using 'no_oversample=True'."
+                f"'input_len'."
             )
         return samples
 

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2415,7 +2415,8 @@ class SonnetDataset(BenchmarkDataset):
         samples = []
         ind = 0
         attempts = 0
-        while len(samples) < num_requests and attempts < self.DEFAULT_MAX_SAMPLE_ATTEMPTS:
+        while (len(samples) < num_requests and
+               attempts < self.DEFAULT_MAX_SAMPLE_ATTEMPTS):
             attempts += 1
             extra_lines = random.choices(
                 self.data, k=num_input_lines - num_prefix_lines

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2363,6 +2363,7 @@ class SonnetDataset(BenchmarkDataset):
     DEFAULT_PREFIX_LEN = 200
     DEFAULT_INPUT_LEN = 550
     DEFAULT_OUTPUT_LEN = 150
+    DEFAULT_MAX_SAMPLE_ATTEMPTS = 1000
 
     def __init__(
         self,
@@ -2413,7 +2414,9 @@ class SonnetDataset(BenchmarkDataset):
 
         samples = []
         ind = 0
-        while len(samples) < num_requests:
+        attempts = 0
+        while len(samples) < num_requests and attempts < DEFAULT_MAX_SAMPLE_ATTEMPTS:
+            attempts += 1
             extra_lines = random.choices(
                 self.data, k=num_input_lines - num_prefix_lines
             )
@@ -2433,6 +2436,12 @@ class SonnetDataset(BenchmarkDataset):
                     )
                 )
                 ind += 1
+        if len(samples) < num_requests:
+            raise RuntimeError(
+                f"Failed to generate {num_requests} samples within "
+                f"{DEFAULT_MAX_SAMPLE_ATTEMPTS} attempts. Consider increasing "
+                f"'input_len' or using 'no_oversample=True'."
+            )
         return samples
 
 

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2415,7 +2415,7 @@ class SonnetDataset(BenchmarkDataset):
         samples = []
         ind = 0
         attempts = 0
-        while len(samples) < num_requests and attempts < DEFAULT_MAX_SAMPLE_ATTEMPTS:
+        while len(samples) < num_requests and attempts < self.DEFAULT_MAX_SAMPLE_ATTEMPTS:
             attempts += 1
             extra_lines = random.choices(
                 self.data, k=num_input_lines - num_prefix_lines
@@ -2439,7 +2439,7 @@ class SonnetDataset(BenchmarkDataset):
         if len(samples) < num_requests:
             raise RuntimeError(
                 f"Failed to generate {num_requests} samples within "
-                f"{DEFAULT_MAX_SAMPLE_ATTEMPTS} attempts. Consider increasing "
+                f"{self.DEFAULT_MAX_SAMPLE_ATTEMPTS} attempts. Consider increasing "
                 f"'input_len' or using 'no_oversample=True'."
             )
         return samples


### PR DESCRIPTION
Add DEFAULT_MAX_SAMPLE_ATTEMPTS constant to prevent infinite loop when randomly selected poem lines exceed input_len. If generation fails after max attempts, raise RuntimeError with helpful message.

Co-authored-by: Claude




## Purpose
Fix bug https://github.com/vllm-project/vllm/issues/38470
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

