### PR TITLE
[Frontend] Add unified usage behavior control for entrypoint

### DIFF
--- a/tests/entrypoints/conftest.py
+++ b/tests/entrypoints/conftest.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 
 
@@ -217,3 +221,143 @@ def opt125_lora_files() -> str:
     from huggingface_hub import snapshot_download
 
     return snapshot_download(repo_id="peft-internal-testing/opt-125m-dummy-lora")
+
+
+# ---------------------------------------------------------------------------
+# Shared test factories for entrypoint serving unit tests
+# ---------------------------------------------------------------------------
+
+_MODEL_NAME = "test-model"
+
+
+@dataclass
+class _MockModelConfig:
+    task = "generate"
+    runner_type = "generate"
+    model = _MODEL_NAME
+    tokenizer = _MODEL_NAME
+    trust_remote_code = False
+    tokenizer_mode = "auto"
+    max_model_len = 100
+    tokenizer_revision = None
+    encoder_config = None
+    generation_config = "auto"
+    skip_tokenizer_init = False
+    is_encoder_decoder = False
+    is_multimodal_model = False
+    hf_config = SimpleNamespace(model_type="any")
+    hf_text_config = SimpleNamespace(model_type="any")
+
+    def get_diff_sampling_param(self):
+        return {}
+
+
+def _make_engine():
+    engine = MagicMock()
+    engine.model_config = _MockModelConfig()
+    engine.renderer = None
+    engine.input_processor = None
+
+    async def _echo(*args, **kwargs):
+        return []
+
+    engine.generate = _echo
+    return engine
+
+
+def _make_models(engine):
+    from vllm.entrypoints.openai.models.protocol import BaseModelPath
+    from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+
+    return OpenAIServingModels(
+        engine_client=engine,
+        base_model_paths=[
+            BaseModelPath(name=_MODEL_NAME, model_path=_MODEL_NAME),
+        ],
+    )
+
+
+def _make_render_mock(models):
+    mr = MagicMock(spec_set=["model_registry"])
+    mr.model_registry = models.registry
+    return mr
+
+
+def make_base(usage_policy=None, enable_force_include_usage=False):
+    from vllm.entrypoints.openai.engine.serving import OpenAIServing
+
+    engine = _make_engine()
+    models = _make_models(engine)
+    return OpenAIServing(
+        engine_client=engine,
+        models=models,
+        request_logger=None,
+        usage_policy=usage_policy,
+        enable_force_include_usage=enable_force_include_usage,
+    )
+
+
+def make_chat(usage_policy=None, enable_force_include_usage=False):
+    from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+
+    engine = _make_engine()
+    models = _make_models(engine)
+    return OpenAIServingChat(
+        engine_client=engine,
+        models=models,
+        response_role="assistant",
+        openai_serving_render=_make_render_mock(models),
+        request_logger=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+        usage_policy=usage_policy,
+        enable_force_include_usage=enable_force_include_usage,
+    )
+
+
+def make_completion(usage_policy=None, enable_force_include_usage=False):
+    from vllm.entrypoints.openai.completion.serving import OpenAIServingCompletion
+
+    engine = _make_engine()
+    models = _make_models(engine)
+    return OpenAIServingCompletion(
+        engine_client=engine,
+        models=models,
+        openai_serving_render=_make_render_mock(models),
+        request_logger=None,
+        usage_policy=usage_policy,
+        enable_force_include_usage=enable_force_include_usage,
+    )
+
+
+def make_disagg(usage_policy=None, enable_force_include_usage=False):
+    from vllm.entrypoints.serve.disagg.serving import ServingTokens
+
+    engine = _make_engine()
+    models = _make_models(engine)
+    return ServingTokens(
+        engine_client=engine,
+        models=models,
+        openai_serving_render=_make_render_mock(models),
+        request_logger=None,
+        usage_policy=usage_policy,
+        enable_force_include_usage=enable_force_include_usage,
+    )
+
+
+def make_anthropic(usage_policy=None, enable_force_include_usage=False):
+    from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
+
+    engine = _make_engine()
+    models = _make_models(engine)
+    return AnthropicServingMessages(
+        engine_client=engine,
+        models=models,
+        response_role="assistant",
+        openai_serving_render=_make_render_mock(models),
+        request_logger=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+        usage_policy=usage_policy,
+        enable_force_include_usage=enable_force_include_usage,
+    )

--- a/tests/entrypoints/conftest.py
+++ b/tests/entrypoints/conftest.py
@@ -283,17 +283,31 @@ def _make_render_mock(models):
     return mr
 
 
+def _with_force_usage(policy, enable_force, *, set_continuous):
+    """Test helper: convert deprecated flag to UsagePolicy."""
+    from vllm.entrypoints.chat_utils import UsagePolicy
+
+    if enable_force and (policy is None or policy.include_usage is None):
+        return UsagePolicy(
+            include_usage="always",
+            continuous_usage="always" if set_continuous else None,
+        )
+    return policy
+
+
 def make_base(usage_policy=None, enable_force_include_usage=False):
     from vllm.entrypoints.openai.engine.serving import OpenAIServing
 
     engine = _make_engine()
     models = _make_models(engine)
+    policy = _with_force_usage(
+        usage_policy, enable_force_include_usage, set_continuous=False
+    )
     return OpenAIServing(
         engine_client=engine,
         models=models,
         request_logger=None,
-        usage_policy=usage_policy,
-        enable_force_include_usage=enable_force_include_usage,
+        usage_policy=policy,
     )
 
 
@@ -302,6 +316,9 @@ def make_chat(usage_policy=None, enable_force_include_usage=False):
 
     engine = _make_engine()
     models = _make_models(engine)
+    policy = _with_force_usage(
+        usage_policy, enable_force_include_usage, set_continuous=True
+    )
     return OpenAIServingChat(
         engine_client=engine,
         models=models,
@@ -310,8 +327,7 @@ def make_chat(usage_policy=None, enable_force_include_usage=False):
         request_logger=None,
         chat_template=None,
         chat_template_content_format="auto",
-        usage_policy=usage_policy,
-        enable_force_include_usage=enable_force_include_usage,
+        usage_policy=policy,
     )
 
 
@@ -320,13 +336,15 @@ def make_completion(usage_policy=None, enable_force_include_usage=False):
 
     engine = _make_engine()
     models = _make_models(engine)
+    policy = _with_force_usage(
+        usage_policy, enable_force_include_usage, set_continuous=True
+    )
     return OpenAIServingCompletion(
         engine_client=engine,
         models=models,
         openai_serving_render=_make_render_mock(models),
         request_logger=None,
-        usage_policy=usage_policy,
-        enable_force_include_usage=enable_force_include_usage,
+        usage_policy=policy,
     )
 
 
@@ -341,7 +359,6 @@ def make_disagg(usage_policy=None, enable_force_include_usage=False):
         openai_serving_render=_make_render_mock(models),
         request_logger=None,
         usage_policy=usage_policy,
-        enable_force_include_usage=enable_force_include_usage,
     )
 
 
@@ -350,6 +367,9 @@ def make_anthropic(usage_policy=None, enable_force_include_usage=False):
 
     engine = _make_engine()
     models = _make_models(engine)
+    policy = _with_force_usage(
+        usage_policy, enable_force_include_usage, set_continuous=True
+    )
     return AnthropicServingMessages(
         engine_client=engine,
         models=models,
@@ -358,6 +378,5 @@ def make_anthropic(usage_policy=None, enable_force_include_usage=False):
         request_logger=None,
         chat_template=None,
         chat_template_content_format="auto",
-        usage_policy=usage_policy,
-        enable_force_include_usage=enable_force_include_usage,
+        usage_policy=policy,
     )

--- a/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_transcription_inter_chunk_spacing.py
@@ -140,6 +140,7 @@ async def test_transcription_stream_generator_english_inserts_space_between_chun
 
     serving = OpenAIServingTranscription.__new__(OpenAIServingTranscription)
     serving.enable_force_include_usage = False
+    serving.usage_policy = None
     serving.model_cls = _StubTranscriptionModel
     serving.task_type = "transcribe"
     request = SimpleNamespace(
@@ -177,6 +178,7 @@ async def test_transcription_stream_generator_chinese_no_space_between_chunks():
 
     serving = OpenAIServingTranscription.__new__(OpenAIServingTranscription)
     serving.enable_force_include_usage = False
+    serving.usage_policy = None
     serving.model_cls = _StubTranscriptionModel
     serving.task_type = "transcribe"
     request = SimpleNamespace(

--- a/tests/entrypoints/test_enable_force_include_usage.py
+++ b/tests/entrypoints/test_enable_force_include_usage.py
@@ -2,9 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """
-Unit tests: --enable-force-include-usage behavior across all entrypoints.
-
-Each test class covers one scenario with --enable-force-include-usage=True.
+Unit tests: --enable-force-include-usage behavior.
 """
 
 from tests.entrypoints.conftest import (
@@ -16,195 +14,77 @@ from tests.entrypoints.conftest import (
 )
 
 
-class TestForceNonStreaming:
+class TestNonStreaming:
     """Non-streaming with enable_force_include_usage=True."""
 
-    def test_base(self):
+    def test_openai_endpoints(self):
         """Usage in final response, never in chunks."""
-        s = make_base(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=False) == (True, False)
-
-    def test_chat(self):
-        """Usage in final response, never in chunks."""
-        s = make_chat(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=False) == (True, False)
-
-    def test_completion(self):
-        """Usage in final response, never in chunks."""
-        s = make_completion(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=False) == (True, False)
-
-    def test_disagg(self):
-        """Usage in final response, never in chunks."""
-        s = make_disagg(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=False) == (True, False)
+        for make in (make_base, make_chat, make_completion, make_disagg):
+            assert make(enable_force_include_usage=True).should_include_usage(
+                is_streaming=False
+            ) == (True, False)
 
     def test_anthropic(self):
         """Always (True, True) regardless."""
-        s = make_anthropic(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=False) == (True, True)
+        assert make_anthropic(enable_force_include_usage=True).should_include_usage(
+            is_streaming=False
+        ) == (True, True)
 
 
-class TestForceStreamingDefault:
-    """Streaming with enable_force_include_usage=True, no request-level params."""
+class TestStreaming:
+    """Streaming with enable_force_include_usage=True."""
 
     def test_base(self):
-        """Usage in last chunk only, not every chunk."""
+        """Force: usage in last chunk only (include_usage=always)."""
         s = make_base(enable_force_include_usage=True)
         assert s.should_include_usage(is_streaming=True) == (True, False)
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            False,
+        )
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            False,
+        )
 
-    def test_chat(self):
-        """Usage in last chunk, and every chunk."""
-        s = make_chat(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True) == (True, True)
-
-    def test_completion(self):
-        """Usage in last chunk, and every chunk."""
-        s = make_completion(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True) == (True, True)
+    def test_chat_completion(self):
+        """Force: (True, True) regardless of request params."""
+        for make in (make_chat, make_completion):
+            s = make(enable_force_include_usage=True)
+            assert s.should_include_usage(is_streaming=True) == (True, True)
+            assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+                True,
+                True,
+            )
+            assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+                True,
+                True,
+            )
+            assert s.should_include_usage(
+                is_streaming=True, include_usage=True, continuous_usage=True
+            ) == (True, True)
 
     def test_disagg(self):
-        """Disagg ignores enable_force_include_usage, stays at default."""
+        """Disagg ignores the flag, behaves as default."""
         s = make_disagg(enable_force_include_usage=True)
         assert s.should_include_usage(is_streaming=True) == (False, False)
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            False,
+            False,
+        )
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            False,
+        )
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, True)
 
     def test_anthropic(self):
         """Always (True, True) regardless."""
         s = make_anthropic(enable_force_include_usage=True)
         assert s.should_include_usage(is_streaming=True) == (True, True)
-
-
-class TestForceOverridesRequestIncludeUsageFalse:
-    """
-    Streaming with enable_force_include_usage=True
-    and request-level include_usage=False.
-    """
-
-    def test_base(self):
-        """Force overrides to usage in last chunk only."""
-        s = make_base(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            False,
-        )
-
-    def test_chat(self):
-        """Force overrides to usage in last chunk and every chunk."""
-        s = make_chat(enable_force_include_usage=True)
         assert s.should_include_usage(is_streaming=True, include_usage=False) == (
             True,
             True,
         )
-
-    def test_completion(self):
-        """Force overrides to usage in last chunk and every chunk."""
-        s = make_completion(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            True,
-        )
-
-    def test_disagg(self):
-        """Disagg ignores enable_force_include_usage, respects request param."""
-        s = make_disagg(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            False,
-            False,
-        )
-
-    def test_anthropic(self):
-        """Always (True, True) regardless."""
-        s = make_anthropic(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            True,
-        )
-
-
-class TestForceWithRequestIncludeUsageTrue:
-    """
-    Streaming with enable_force_include_usage=True
-    and request-level include_usage=True.
-    """
-
-    def test_base(self):
-        """Usage in last chunk only."""
-        s = make_base(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            False,
-        )
-
-    def test_chat(self):
-        """Usage in last chunk and every chunk."""
-        s = make_chat(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            True,
-        )
-
-    def test_completion(self):
-        """Usage in last chunk and every chunk."""
-        s = make_completion(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            True,
-        )
-
-    def test_disagg(self):
-        """Disagg ignores enable_force_include_usage, respects request param."""
-        s = make_disagg(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            False,
-        )
-
-    def test_anthropic(self):
-        """Always (True, True) regardless."""
-        s = make_anthropic(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            True,
-        )
-
-
-class TestForceWithRequestIncludeUsageAndContinuousTrue:
-    """
-    Streaming with enable_force_include_usage=True
-    and request-level include_usage=True + continuous_usage=True.
-    """
-
-    def test_base(self):
-        """Force short-circuits before reaching request-level continuous."""
-        s = make_base(enable_force_include_usage=True)
-        assert s.should_include_usage(
-            is_streaming=True, include_usage=True, continuous_usage=True
-        ) == (True, False)
-
-    def test_chat(self):
-        """Usage in last chunk and every chunk."""
-        s = make_chat(enable_force_include_usage=True)
-        assert s.should_include_usage(
-            is_streaming=True, include_usage=True, continuous_usage=True
-        ) == (True, True)
-
-    def test_completion(self):
-        """Usage in last chunk and every chunk."""
-        s = make_completion(enable_force_include_usage=True)
-        assert s.should_include_usage(
-            is_streaming=True, include_usage=True, continuous_usage=True
-        ) == (True, True)
-
-    def test_disagg(self):
-        """Usage in last chunk and every chunk."""
-        s = make_disagg(enable_force_include_usage=True)
-        assert s.should_include_usage(
-            is_streaming=True, include_usage=True, continuous_usage=True
-        ) == (True, True)
-
-    def test_anthropic(self):
-        """Always (True, True) regardless."""
-        s = make_anthropic(enable_force_include_usage=True)
-        assert s.should_include_usage(
-            is_streaming=True, include_usage=True, continuous_usage=True
-        ) == (True, True)

--- a/tests/entrypoints/test_enable_force_include_usage.py
+++ b/tests/entrypoints/test_enable_force_include_usage.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests: --enable-force-include-usage behavior across all entrypoints.
+
+Each test class covers one scenario with --enable-force-include-usage=True.
+"""
+
+from tests.entrypoints.conftest import (
+    make_anthropic,
+    make_base,
+    make_chat,
+    make_completion,
+    make_disagg,
+)
+
+
+class TestForceNonStreaming:
+    """Non-streaming with enable_force_include_usage=True."""
+
+    def test_base(self):
+        """Usage in final response, never in chunks."""
+        s = make_base(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=False) == (True, False)
+
+    def test_chat(self):
+        """Usage in final response, never in chunks."""
+        s = make_chat(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=False) == (True, False)
+
+    def test_completion(self):
+        """Usage in final response, never in chunks."""
+        s = make_completion(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=False) == (True, False)
+
+    def test_disagg(self):
+        """Usage in final response, never in chunks."""
+        s = make_disagg(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=False) == (True, False)
+
+    def test_anthropic(self):
+        """Always (True, True) regardless."""
+        s = make_anthropic(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=False) == (True, True)
+
+
+class TestForceStreamingDefault:
+    """Streaming with enable_force_include_usage=True, no request-level params."""
+
+    def test_base(self):
+        """Usage in last chunk only, not every chunk."""
+        s = make_base(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True) == (True, False)
+
+    def test_chat(self):
+        """Usage in last chunk, and every chunk."""
+        s = make_chat(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_completion(self):
+        """Usage in last chunk, and every chunk."""
+        s = make_completion(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_disagg(self):
+        """Usage in last chunk, and every chunk."""
+        s = make_disagg(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_anthropic(self):
+        """Always (True, True) regardless."""
+        s = make_anthropic(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+
+class TestForceOverridesRequestIncludeUsageFalse:
+    """
+    Streaming with enable_force_include_usage=True
+    and request-level include_usage=False.
+    """
+
+    def test_base(self):
+        """Force overrides to usage in last chunk only."""
+        s = make_base(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            False,
+        )
+
+    def test_chat(self):
+        """Force overrides to usage in last chunk and every chunk."""
+        s = make_chat(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )
+
+    def test_completion(self):
+        """Force overrides to usage in last chunk and every chunk."""
+        s = make_completion(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )
+
+    def test_disagg(self):
+        """Force overrides to usage in last chunk and every chunk."""
+        s = make_disagg(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )
+
+    def test_anthropic(self):
+        """Always (True, True) regardless."""
+        s = make_anthropic(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )
+
+
+class TestForceWithRequestIncludeUsageTrue:
+    """
+    Streaming with enable_force_include_usage=True
+    and request-level include_usage=True.
+    """
+
+    def test_base(self):
+        """Usage in last chunk only."""
+        s = make_base(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            False,
+        )
+
+    def test_chat(self):
+        """Usage in last chunk and every chunk."""
+        s = make_chat(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            True,
+        )
+
+    def test_completion(self):
+        """Usage in last chunk and every chunk."""
+        s = make_completion(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            True,
+        )
+
+    def test_disagg(self):
+        """Usage in last chunk and every chunk."""
+        s = make_disagg(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            True,
+        )
+
+    def test_anthropic(self):
+        """Always (True, True) regardless."""
+        s = make_anthropic(enable_force_include_usage=True)
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            True,
+        )
+
+
+class TestForceWithRequestIncludeUsageAndContinuousTrue:
+    """
+    Streaming with enable_force_include_usage=True
+    and request-level include_usage=True + continuous_usage=True.
+    """
+
+    def test_base(self):
+        """Force short-circuits before reaching request-level continuous."""
+        s = make_base(enable_force_include_usage=True)
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, False)
+
+    def test_chat(self):
+        """Usage in last chunk and every chunk."""
+        s = make_chat(enable_force_include_usage=True)
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, True)
+
+    def test_completion(self):
+        """Usage in last chunk and every chunk."""
+        s = make_completion(enable_force_include_usage=True)
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, True)
+
+    def test_disagg(self):
+        """Usage in last chunk and every chunk."""
+        s = make_disagg(enable_force_include_usage=True)
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, True)
+
+    def test_anthropic(self):
+        """Always (True, True) regardless."""
+        s = make_anthropic(enable_force_include_usage=True)
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, True)

--- a/tests/entrypoints/test_enable_force_include_usage.py
+++ b/tests/entrypoints/test_enable_force_include_usage.py
@@ -64,9 +64,9 @@ class TestForceStreamingDefault:
         assert s.should_include_usage(is_streaming=True) == (True, True)
 
     def test_disagg(self):
-        """Usage in last chunk, and every chunk."""
+        """Disagg ignores enable_force_include_usage, stays at default."""
         s = make_disagg(enable_force_include_usage=True)
-        assert s.should_include_usage(is_streaming=True) == (True, True)
+        assert s.should_include_usage(is_streaming=True) == (False, False)
 
     def test_anthropic(self):
         """Always (True, True) regardless."""
@@ -105,11 +105,11 @@ class TestForceOverridesRequestIncludeUsageFalse:
         )
 
     def test_disagg(self):
-        """Force overrides to usage in last chunk and every chunk."""
+        """Disagg ignores enable_force_include_usage, respects request param."""
         s = make_disagg(enable_force_include_usage=True)
         assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            True,
+            False,
+            False,
         )
 
     def test_anthropic(self):
@@ -152,11 +152,11 @@ class TestForceWithRequestIncludeUsageTrue:
         )
 
     def test_disagg(self):
-        """Usage in last chunk and every chunk."""
+        """Disagg ignores enable_force_include_usage, respects request param."""
         s = make_disagg(enable_force_include_usage=True)
         assert s.should_include_usage(is_streaming=True, include_usage=True) == (
             True,
-            True,
+            False,
         )
 
     def test_anthropic(self):

--- a/tests/entrypoints/test_should_include_usage.py
+++ b/tests/entrypoints/test_should_include_usage.py
@@ -18,131 +18,48 @@ from tests.entrypoints.conftest import (
 )
 
 
-class TestBaseClassShouldIncludeUsage:
-    """Base class (OpenAIServing) — used by Speech-to-Text endpoints."""
+class TestNonStreaming:
+    """Non-streaming: usage always in final response."""
 
-    def test_non_streaming(self):
+    def test_openai_endpoints(self):
         """Usage in final response, never in chunks."""
-        s = make_base()
-        assert s.should_include_usage(is_streaming=False) == (True, False)
+        for make in (make_base, make_chat, make_completion, make_disagg):
+            entryoint = make()
+            assert entryoint.should_include_usage(is_streaming=False) == (True, False)
 
-    def test_streaming_default(self):
-        """Usage in last chunk only, not every chunk."""
-        s = make_base()
-        assert s.should_include_usage(is_streaming=True) == (True, False)
-
-    def test_request_include_usage_true(self):
-        """include_usage=True → usage in last chunk only."""
-        s = make_base()
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            False,
-        )
-
-    def test_request_include_usage_false(self):
-        """include_usage=False → no usage."""
-        s = make_base()
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            False,
-            False,
-        )
-
-    def test_request_both_flags_true(self):
-        """include_usage=True + continuous_usage=True → usage in every chunk."""
-        s = make_base()
-        assert s.should_include_usage(
-            is_streaming=True, include_usage=True, continuous_usage=True
+    def test_anthropic(self):
+        """Anthropic always (True, True) regardless."""
+        entryoint = make_anthropic()
+        assert entryoint.should_include_usage(is_streaming=False) == (True, True)
+        assert entryoint.should_include_usage(
+            is_streaming=True, include_usage=False
         ) == (True, True)
 
 
-class TestChatShouldIncludeUsage:
-    """Chat Completions endpoint (OpenAIServingChat)."""
+class TestStreamingDefault:
+    """Default streaming behavior (no request params)."""
 
-    def test_non_streaming(self):
-        """Usage in final response, never in chunks."""
-        s = make_chat()
-        assert s.should_include_usage(is_streaming=False) == (True, False)
+    def test_base(self):
+        """Base: usage in last chunk only."""
+        entryoint = make_base()
+        assert entryoint.should_include_usage(is_streaming=True) == (True, False)
 
-    def test_streaming_default(self):
-        """No usage in streaming by default."""
-        s = make_chat()
-        assert s.should_include_usage(is_streaming=True) == (False, False)
+    def test_openai_endpoints(self):
+        """Chat/Completion/Disagg: no usage by default."""
+        for make in (make_chat, make_completion, make_disagg):
+            entryoint = make()
+            assert entryoint.should_include_usage(is_streaming=True) == (False, False)
+            assert entryoint.should_include_usage(
+                is_streaming=True, include_usage=False
+            ) == (False, False)
+            assert entryoint.should_include_usage(
+                is_streaming=True, include_usage=True
+            ) == (True, False)
+            assert entryoint.should_include_usage(
+                is_streaming=True, include_usage=True, continuous_usage=True
+            ) == (True, True)
 
-    def test_request_include_usage_true(self):
-        """include_usage=True → usage in last chunk only."""
-        s = make_chat()
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            False,
-        )
-
-    def test_request_include_usage_false(self):
-        """include_usage=False → no usage."""
-        s = make_chat()
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            False,
-            False,
-        )
-
-    def test_request_both_flags_true(self):
-        """include_usage=True + continuous_usage=True → usage in every chunk."""
-        s = make_chat()
-        assert s.should_include_usage(
-            is_streaming=True, include_usage=True, continuous_usage=True
-        ) == (True, True)
-
-
-class TestCompletionShouldIncludeUsage:
-    """Completions endpoint (OpenAIServingCompletion)."""
-
-    def test_streaming_default(self):
-        """No usage in streaming by default."""
-        s = make_completion()
-        assert s.should_include_usage(is_streaming=True) == (False, False)
-
-    def test_request_include_usage_true(self):
-        """include_usage=True → usage in last chunk only."""
-        s = make_completion()
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            False,
-        )
-
-
-class TestDisaggShouldIncludeUsage:
-    """Disaggregated serving endpoint (ServingTokens)."""
-
-    def test_streaming_default(self):
-        """No usage in streaming by default."""
-        s = make_disagg()
-        assert s.should_include_usage(is_streaming=True) == (False, False)
-
-    def test_request_include_usage_true(self):
-        """include_usage=True → usage in last chunk only."""
-        s = make_disagg()
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            False,
-        )
-
-
-class TestAnthropicShouldIncludeUsage:
-    """Anthropic Messages endpoint (AnthropicServingMessages)."""
-
-    def test_non_streaming(self):
-        """Always (True, True) — Anthropic API spec."""
-        s = make_anthropic()
-        assert s.should_include_usage(is_streaming=False) == (True, True)
-
-    def test_streaming_default(self):
-        """Always (True, True) regardless of parameters."""
-        s = make_anthropic()
-        assert s.should_include_usage(is_streaming=True) == (True, True)
-
-    def test_request_include_usage_false(self):
-        """Request include_usage=False is ignored."""
-        s = make_anthropic()
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            True,
-        )
+    def test_anthropic(self):
+        """Anthropic always (True, True)."""
+        entryoint = make_anthropic()
+        assert entryoint.should_include_usage(is_streaming=True) == (True, True)

--- a/tests/entrypoints/test_should_include_usage.py
+++ b/tests/entrypoints/test_should_include_usage.py
@@ -56,6 +56,9 @@ class TestStreamingDefault:
                 is_streaming=True, include_usage=True
             ) == (True, False)
             assert entryoint.should_include_usage(
+                is_streaming=True, include_usage=False, continuous_usage=True
+            ) == (False, False)
+            assert entryoint.should_include_usage(
                 is_streaming=True, include_usage=True, continuous_usage=True
             ) == (True, True)
 

--- a/tests/entrypoints/test_should_include_usage.py
+++ b/tests/entrypoints/test_should_include_usage.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests for should_include_usage base method and subclass overrides.
+
+Covers default behavior only — no server-level flags (enable_force_include_usage
+or usage_policy). All request-level params (include_usage / continuous_usage)
+are tested per endpoint.
+"""
+
+from tests.entrypoints.conftest import (
+    make_anthropic,
+    make_base,
+    make_chat,
+    make_completion,
+    make_disagg,
+)
+
+
+class TestBaseClassShouldIncludeUsage:
+    """Base class (OpenAIServing) — used by Speech-to-Text endpoints."""
+
+    def test_non_streaming(self):
+        """Usage in final response, never in chunks."""
+        s = make_base()
+        assert s.should_include_usage(is_streaming=False) == (True, False)
+
+    def test_streaming_default(self):
+        """Usage in last chunk only, not every chunk."""
+        s = make_base()
+        assert s.should_include_usage(is_streaming=True) == (True, False)
+
+    def test_request_include_usage_true(self):
+        """include_usage=True → usage in last chunk only."""
+        s = make_base()
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            False,
+        )
+
+    def test_request_include_usage_false(self):
+        """include_usage=False → no usage."""
+        s = make_base()
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            False,
+            False,
+        )
+
+    def test_request_both_flags_true(self):
+        """include_usage=True + continuous_usage=True → usage in every chunk."""
+        s = make_base()
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, True)
+
+
+class TestChatShouldIncludeUsage:
+    """Chat Completions endpoint (OpenAIServingChat)."""
+
+    def test_non_streaming(self):
+        """Usage in final response, never in chunks."""
+        s = make_chat()
+        assert s.should_include_usage(is_streaming=False) == (True, False)
+
+    def test_streaming_default(self):
+        """No usage in streaming by default."""
+        s = make_chat()
+        assert s.should_include_usage(is_streaming=True) == (False, False)
+
+    def test_request_include_usage_true(self):
+        """include_usage=True → usage in last chunk only."""
+        s = make_chat()
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            False,
+        )
+
+    def test_request_include_usage_false(self):
+        """include_usage=False → no usage."""
+        s = make_chat()
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            False,
+            False,
+        )
+
+    def test_request_both_flags_true(self):
+        """include_usage=True + continuous_usage=True → usage in every chunk."""
+        s = make_chat()
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, True)
+
+
+class TestCompletionShouldIncludeUsage:
+    """Completions endpoint (OpenAIServingCompletion)."""
+
+    def test_streaming_default(self):
+        """No usage in streaming by default."""
+        s = make_completion()
+        assert s.should_include_usage(is_streaming=True) == (False, False)
+
+    def test_request_include_usage_true(self):
+        """include_usage=True → usage in last chunk only."""
+        s = make_completion()
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            False,
+        )
+
+
+class TestDisaggShouldIncludeUsage:
+    """Disaggregated serving endpoint (ServingTokens)."""
+
+    def test_streaming_default(self):
+        """No usage in streaming by default."""
+        s = make_disagg()
+        assert s.should_include_usage(is_streaming=True) == (False, False)
+
+    def test_request_include_usage_true(self):
+        """include_usage=True → usage in last chunk only."""
+        s = make_disagg()
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            False,
+        )
+
+
+class TestAnthropicShouldIncludeUsage:
+    """Anthropic Messages endpoint (AnthropicServingMessages)."""
+
+    def test_non_streaming(self):
+        """Always (True, True) — Anthropic API spec."""
+        s = make_anthropic()
+        assert s.should_include_usage(is_streaming=False) == (True, True)
+
+    def test_streaming_default(self):
+        """Always (True, True) regardless of parameters."""
+        s = make_anthropic()
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_request_include_usage_false(self):
+        """Request include_usage=False is ignored."""
+        s = make_anthropic()
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )

--- a/tests/entrypoints/test_usage_policy.py
+++ b/tests/entrypoints/test_usage_policy.py
@@ -18,208 +18,67 @@ from tests.entrypoints.conftest import (
 from vllm.entrypoints.chat_utils import UsagePolicy
 
 
-class TestPolicyNone:
-    """UsagePolicy() with all None fields — default behavior per endpoint."""
-
-    def test_base(self):
-        """Base defaults to usage in last chunk only."""
-        s = make_base(UsagePolicy())
-        assert s.should_include_usage(is_streaming=True) == (True, False)
-
-    def test_chat(self):
-        """Chat defaults to no usage in streaming."""
-        s = make_chat(UsagePolicy())
-        assert s.should_include_usage(is_streaming=True) == (False, False)
-
-    def test_completion(self):
-        """Completion defaults to no usage in streaming."""
-        s = make_completion(UsagePolicy())
-        assert s.should_include_usage(is_streaming=True) == (False, False)
-
-    def test_disagg(self):
-        """Disagg defaults to no usage in streaming."""
-        s = make_disagg(UsagePolicy())
-        assert s.should_include_usage(is_streaming=True) == (False, False)
-
-    def test_anthropic(self):
-        """Anthropic always (True, True) regardless of policy."""
-        s = make_anthropic(UsagePolicy())
-        assert s.should_include_usage(is_streaming=True) == (True, True)
-
-    def test_base_request_include_usage_true(self):
-        """Base + request include_usage=True → usage in last chunk only."""
-        s = make_base(UsagePolicy())
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            False,
-        )
-
-    def test_chat_request_include_usage_true(self):
-        """Chat + request include_usage=True → usage in last chunk only."""
-        s = make_chat(UsagePolicy())
-        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
-            True,
-            False,
-        )
-
-    def test_chat_request_both_flags_true(self):
-        """Chat + both request flags → usage in every chunk."""
-        s = make_chat(UsagePolicy())
-        assert s.should_include_usage(
-            is_streaming=True, include_usage=True, continuous_usage=True
-        ) == (True, True)
-
-    def test_chat_request_include_usage_false(self):
-        """Chat + request include_usage=False → no usage."""
-        s = make_chat(UsagePolicy())
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            False,
-            False,
-        )
-
-
 class TestPolicyIncludeAlways:
-    """UsagePolicy(include_usage="always") — force usage in final chunk."""
+    """UsagePolicy(include_usage="always"), force usage in final chunk."""
 
-    def test_base(self):
-        """Overrides request include_usage=False."""
-        s = make_base(UsagePolicy(include_usage="always"))
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            False,
-        )
+    def test_endpoints(self):
+        """Overrides request include_usage=False; continuous falls back to request."""
+        for make in (make_base, make_chat, make_completion, make_disagg):
+            s = make(UsagePolicy(include_usage="always"))
 
-    def test_chat(self):
-        """Overrides request include_usage=False."""
-        s = make_chat(UsagePolicy(include_usage="always"))
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            False,
-        )
-
-    def test_completion(self):
-        """Overrides request include_usage=False."""
-        s = make_completion(UsagePolicy(include_usage="always"))
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            False,
-        )
-
-    def test_disagg(self):
-        """Overrides request include_usage=False."""
-        s = make_disagg(UsagePolicy(include_usage="always"))
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            False,
-        )
+            assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+                True,
+                False,
+            )
+            assert s.should_include_usage(
+                is_streaming=True, include_usage=True, continuous_usage=True
+            ) == (True, True)
 
     def test_anthropic(self):
         """Anthropic ignores policy, still (True, True)."""
         s = make_anthropic(UsagePolicy(include_usage="always"))
+
         assert s.should_include_usage(is_streaming=True, include_usage=False) == (
             True,
             True,
         )
-
-    def test_chat_continuous_true(self):
-        """Chat + request continuous_usage=True is ignored by policy."""
-        s = make_chat(UsagePolicy(include_usage="always"))
         assert s.should_include_usage(
             is_streaming=True, include_usage=True, continuous_usage=True
-        ) == (True, False)
+        ) == (True, True)
+
+    def test_all_endpoints_always_policy(self):
+        """all non-streaming return (True, False)."""
+        p = UsagePolicy(include_usage="always")
+        for make in (make_base, make_chat, make_completion, make_disagg):
+            s = make(p)
+            assert s.should_include_usage(is_streaming=False) == (True, False)
 
 
 class TestPolicyBothAlways:
     """UsagePolicy(include_usage="always", continuous_usage="always")."""
 
-    def test_base(self):
-        """Usage in every chunk."""
-        s = make_base(UsagePolicy(include_usage="always", continuous_usage="always"))
-        assert s.should_include_usage(is_streaming=True) == (True, True)
+    def test_non_streaming(self):
+        """all non-streaming return (True, False)."""
+        p = UsagePolicy(include_usage="always", continuous_usage="always")
+        for make in (make_base, make_chat, make_completion, make_disagg):
+            s = make(p)
+            assert s.should_include_usage(is_streaming=False) == (True, False)
 
-    def test_chat(self):
-        """Usage in every chunk."""
-        s = make_chat(UsagePolicy(include_usage="always", continuous_usage="always"))
-        assert s.should_include_usage(is_streaming=True) == (True, True)
+    def test_endpoints(self):
+        """Usage in every chunk by default."""
+        for make in (make_base, make_chat, make_completion, make_disagg):
+            s = make(UsagePolicy(include_usage="always", continuous_usage="always"))
 
-    def test_completion(self):
-        """Usage in every chunk."""
-        s = make_completion(
-            UsagePolicy(include_usage="always", continuous_usage="always")
-        )
-        assert s.should_include_usage(is_streaming=True) == (True, True)
-
-    def test_disagg(self):
-        """Usage in every chunk."""
-        s = make_disagg(UsagePolicy(include_usage="always", continuous_usage="always"))
-        assert s.should_include_usage(is_streaming=True) == (True, True)
+            assert s.should_include_usage(is_streaming=True) == (True, True)
+            assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+                True,
+                True,
+            )
 
     def test_anthropic(self):
         """Anthropic ignores policy, still (True, True)."""
         s = make_anthropic(
             UsagePolicy(include_usage="always", continuous_usage="always")
         )
+
         assert s.should_include_usage(is_streaming=True) == (True, True)
-
-    def test_base_overrides_request(self):
-        """Overrides request include_usage=False."""
-        s = make_base(UsagePolicy(include_usage="always", continuous_usage="always"))
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            True,
-        )
-
-    def test_chat_overrides_request(self):
-        """Overrides request include_usage=False."""
-        s = make_chat(UsagePolicy(include_usage="always", continuous_usage="always"))
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            True,
-        )
-
-    def test_completion_overrides_request(self):
-        """Overrides request include_usage=False."""
-        s = make_completion(
-            UsagePolicy(include_usage="always", continuous_usage="always")
-        )
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            True,
-        )
-
-    def test_disagg_overrides_request(self):
-        """Overrides request include_usage=False."""
-        s = make_disagg(UsagePolicy(include_usage="always", continuous_usage="always"))
-        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-            True,
-            True,
-        )
-
-
-class TestPolicyNonStreaming:
-    """Non-streaming with various UsagePolicy configurations."""
-
-    def test_all_endpoints_none_policy(self):
-        """All non-streaming endpoints return (True, False)."""
-        for make in [make_base, make_chat, make_completion, make_disagg]:
-            s = make(UsagePolicy())
-            assert s.should_include_usage(is_streaming=False) == (True, False)
-
-    def test_anthropic(self):
-        """Anthropic non-streaming → always (True, True)."""
-        s = make_anthropic(UsagePolicy())
-        assert s.should_include_usage(is_streaming=False) == (True, True)
-
-    def test_all_endpoints_always_policy(self):
-        """Policy include_usage=always: all non-streaming return (True, False)."""
-        p = UsagePolicy(include_usage="always")
-        for make in [make_base, make_chat, make_completion, make_disagg]:
-            s = make(p)
-            assert s.should_include_usage(is_streaming=False) == (True, False)
-
-    def test_all_endpoints_both_always_policy(self):
-        """Policy both=always: all non-streaming return (True, False)."""
-        p = UsagePolicy(include_usage="always", continuous_usage="always")
-        for make in [make_base, make_chat, make_completion, make_disagg]:
-            s = make(p)
-            assert s.should_include_usage(is_streaming=False) == (True, False)

--- a/tests/entrypoints/test_usage_policy.py
+++ b/tests/entrypoints/test_usage_policy.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests: --include-usage-policy / --continuous-usage-policy
+combinations across all entrypoints.
+
+Each test class covers one UsagePolicy configuration.
+"""
+
+from tests.entrypoints.conftest import (
+    make_anthropic,
+    make_base,
+    make_chat,
+    make_completion,
+    make_disagg,
+)
+from vllm.entrypoints.chat_utils import UsagePolicy
+
+
+class TestPolicyNone:
+    """UsagePolicy() with all None fields — default behavior per endpoint."""
+
+    def test_base(self):
+        """Base defaults to usage in last chunk only."""
+        s = make_base(UsagePolicy())
+        assert s.should_include_usage(is_streaming=True) == (True, False)
+
+    def test_chat(self):
+        """Chat defaults to no usage in streaming."""
+        s = make_chat(UsagePolicy())
+        assert s.should_include_usage(is_streaming=True) == (False, False)
+
+    def test_completion(self):
+        """Completion defaults to no usage in streaming."""
+        s = make_completion(UsagePolicy())
+        assert s.should_include_usage(is_streaming=True) == (False, False)
+
+    def test_disagg(self):
+        """Disagg defaults to no usage in streaming."""
+        s = make_disagg(UsagePolicy())
+        assert s.should_include_usage(is_streaming=True) == (False, False)
+
+    def test_anthropic(self):
+        """Anthropic always (True, True) regardless of policy."""
+        s = make_anthropic(UsagePolicy())
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_base_request_include_usage_true(self):
+        """Base + request include_usage=True → usage in last chunk only."""
+        s = make_base(UsagePolicy())
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            False,
+        )
+
+    def test_chat_request_include_usage_true(self):
+        """Chat + request include_usage=True → usage in last chunk only."""
+        s = make_chat(UsagePolicy())
+        assert s.should_include_usage(is_streaming=True, include_usage=True) == (
+            True,
+            False,
+        )
+
+    def test_chat_request_both_flags_true(self):
+        """Chat + both request flags → usage in every chunk."""
+        s = make_chat(UsagePolicy())
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, True)
+
+    def test_chat_request_include_usage_false(self):
+        """Chat + request include_usage=False → no usage."""
+        s = make_chat(UsagePolicy())
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            False,
+            False,
+        )
+
+
+class TestPolicyIncludeAlways:
+    """UsagePolicy(include_usage="always") — force usage in final chunk."""
+
+    def test_base(self):
+        """Overrides request include_usage=False."""
+        s = make_base(UsagePolicy(include_usage="always"))
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            False,
+        )
+
+    def test_chat(self):
+        """Overrides request include_usage=False."""
+        s = make_chat(UsagePolicy(include_usage="always"))
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            False,
+        )
+
+    def test_completion(self):
+        """Overrides request include_usage=False."""
+        s = make_completion(UsagePolicy(include_usage="always"))
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            False,
+        )
+
+    def test_disagg(self):
+        """Overrides request include_usage=False."""
+        s = make_disagg(UsagePolicy(include_usage="always"))
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            False,
+        )
+
+    def test_anthropic(self):
+        """Anthropic ignores policy, still (True, True)."""
+        s = make_anthropic(UsagePolicy(include_usage="always"))
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )
+
+    def test_chat_continuous_true(self):
+        """Chat + request continuous_usage=True is ignored by policy."""
+        s = make_chat(UsagePolicy(include_usage="always"))
+        assert s.should_include_usage(
+            is_streaming=True, include_usage=True, continuous_usage=True
+        ) == (True, False)
+
+
+class TestPolicyBothAlways:
+    """UsagePolicy(include_usage="always", continuous_usage="always")."""
+
+    def test_base(self):
+        """Usage in every chunk."""
+        s = make_base(UsagePolicy(include_usage="always", continuous_usage="always"))
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_chat(self):
+        """Usage in every chunk."""
+        s = make_chat(UsagePolicy(include_usage="always", continuous_usage="always"))
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_completion(self):
+        """Usage in every chunk."""
+        s = make_completion(
+            UsagePolicy(include_usage="always", continuous_usage="always")
+        )
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_disagg(self):
+        """Usage in every chunk."""
+        s = make_disagg(UsagePolicy(include_usage="always", continuous_usage="always"))
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_anthropic(self):
+        """Anthropic ignores policy, still (True, True)."""
+        s = make_anthropic(
+            UsagePolicy(include_usage="always", continuous_usage="always")
+        )
+        assert s.should_include_usage(is_streaming=True) == (True, True)
+
+    def test_base_overrides_request(self):
+        """Overrides request include_usage=False."""
+        s = make_base(UsagePolicy(include_usage="always", continuous_usage="always"))
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )
+
+    def test_chat_overrides_request(self):
+        """Overrides request include_usage=False."""
+        s = make_chat(UsagePolicy(include_usage="always", continuous_usage="always"))
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )
+
+    def test_completion_overrides_request(self):
+        """Overrides request include_usage=False."""
+        s = make_completion(
+            UsagePolicy(include_usage="always", continuous_usage="always")
+        )
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )
+
+    def test_disagg_overrides_request(self):
+        """Overrides request include_usage=False."""
+        s = make_disagg(UsagePolicy(include_usage="always", continuous_usage="always"))
+        assert s.should_include_usage(is_streaming=True, include_usage=False) == (
+            True,
+            True,
+        )
+
+
+class TestPolicyNonStreaming:
+    """Non-streaming with various UsagePolicy configurations."""
+
+    def test_all_endpoints_none_policy(self):
+        """All non-streaming endpoints return (True, False)."""
+        for make in [make_base, make_chat, make_completion, make_disagg]:
+            s = make(UsagePolicy())
+            assert s.should_include_usage(is_streaming=False) == (True, False)
+
+    def test_anthropic(self):
+        """Anthropic non-streaming → always (True, True)."""
+        s = make_anthropic(UsagePolicy())
+        assert s.should_include_usage(is_streaming=False) == (True, True)
+
+    def test_all_endpoints_always_policy(self):
+        """Policy include_usage=always: all non-streaming return (True, False)."""
+        p = UsagePolicy(include_usage="always")
+        for make in [make_base, make_chat, make_completion, make_disagg]:
+            s = make(p)
+            assert s.should_include_usage(is_streaming=False) == (True, False)
+
+    def test_all_endpoints_both_always_policy(self):
+        """Policy both=always: all non-streaming return (True, False)."""
+        p = UsagePolicy(include_usage="always", continuous_usage="always")
+        for make in [make_base, make_chat, make_completion, make_disagg]:
+            s = make(p)
+            assert s.should_include_usage(is_streaming=False) == (True, False)

--- a/tests/entrypoints/test_usage_policy.py
+++ b/tests/entrypoints/test_usage_policy.py
@@ -26,12 +26,14 @@ class TestPolicyIncludeAlways:
         for make in (make_base, make_chat, make_completion, make_disagg):
             s = make(UsagePolicy(include_usage="always"))
 
-            assert s.should_include_usage(is_streaming=True, include_usage=False) == (
-                True,
-                False,
-            )
+            assert s.should_include_usage(
+                is_streaming=True, include_usage=False, continuous_usage=False
+            ) == (True, False)
             assert s.should_include_usage(
                 is_streaming=True, include_usage=True, continuous_usage=True
+            ) == (True, True)
+            assert s.should_include_usage(
+                is_streaming=True, include_usage=False, continuous_usage=True
             ) == (True, True)
 
     def test_anthropic(self):
@@ -46,7 +48,7 @@ class TestPolicyIncludeAlways:
             is_streaming=True, include_usage=True, continuous_usage=True
         ) == (True, True)
 
-    def test_all_endpoints_always_policy(self):
+    def test_non_streaming(self):
         """all non-streaming return (True, False)."""
         p = UsagePolicy(include_usage="always")
         for make in (make_base, make_chat, make_completion, make_disagg):
@@ -59,9 +61,8 @@ class TestPolicyBothAlways:
 
     def test_non_streaming(self):
         """all non-streaming return (True, False)."""
-        p = UsagePolicy(include_usage="always", continuous_usage="always")
         for make in (make_base, make_chat, make_completion, make_disagg):
-            s = make(p)
+            s = make(UsagePolicy(include_usage="always", continuous_usage="always"))
             assert s.should_include_usage(is_streaming=False) == (True, False)
 
     def test_endpoints(self):
@@ -74,6 +75,12 @@ class TestPolicyBothAlways:
                 True,
                 True,
             )
+            assert s.should_include_usage(
+                is_streaming=True, include_usage=False, continuous_usage=True
+            ) == (True, True)
+            assert s.should_include_usage(
+                is_streaming=True, include_usage=True, continuous_usage=True
+            ) == (True, True)
 
     def test_anthropic(self):
         """Anthropic ignores policy, still (True, True)."""

--- a/tests/entrypoints/test_utils.py
+++ b/tests/entrypoints/test_utils.py
@@ -3,11 +3,9 @@
 
 import pytest
 
-from vllm.entrypoints.openai.engine.protocol import StreamOptions
 from vllm.entrypoints.utils import (
     get_max_tokens,
     sanitize_message,
-    should_include_usage,
 )
 
 
@@ -16,25 +14,6 @@ def test_sanitize_message():
         sanitize_message("<_io.BytesIO object at 0x7a95e299e750>")
         == "<_io.BytesIO object>"
     )
-
-
-@pytest.mark.parametrize(
-    ("stream_options", "expected"),
-    [
-        (None, (True, True)),
-        (StreamOptions(include_usage=False), (True, True)),
-        (
-            StreamOptions(include_usage=False, continuous_usage_stats=False),
-            (True, True),
-        ),
-        (
-            StreamOptions(include_usage=True, continuous_usage_stats=False),
-            (True, True),
-        ),
-    ],
-)
-def test_should_include_usage_force_enables_continuous_usage(stream_options, expected):
-    assert should_include_usage(stream_options, True) == expected
 
 
 class TestGetMaxTokens:

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -71,7 +71,6 @@ class AnthropicServingMessages(OpenAIServingChat):
         enable_auto_tools: bool = False,
         tool_parser: str | None = None,
         enable_prompt_tokens_details: bool = False,
-        enable_force_include_usage: bool = False,
         usage_policy: UsagePolicy | None = None,
         default_chat_template_kwargs: dict[str, Any] | None = None,
     ):
@@ -88,7 +87,6 @@ class AnthropicServingMessages(OpenAIServingChat):
             enable_auto_tools=enable_auto_tools,
             tool_parser=tool_parser,
             enable_prompt_tokens_details=enable_prompt_tokens_details,
-            enable_force_include_usage=enable_force_include_usage,
             usage_policy=usage_policy,
             default_chat_template_kwargs=default_chat_template_kwargs,
         )

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -72,7 +72,7 @@ class AnthropicServingMessages(OpenAIServingChat):
         tool_parser: str | None = None,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
-        usage_policy: "UsagePolicy | None" = None,
+        usage_policy: UsagePolicy | None = None,
         default_chat_template_kwargs: dict[str, Any] | None = None,
     ):
         super().__init__(

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -27,7 +27,7 @@ from vllm.entrypoints.anthropic.protocol import (
     AnthropicStreamEvent,
     AnthropicUsage,
 )
-from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
+from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption, UsagePolicy
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
@@ -72,6 +72,7 @@ class AnthropicServingMessages(OpenAIServingChat):
         tool_parser: str | None = None,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
+        usage_policy: "UsagePolicy | None" = None,
         default_chat_template_kwargs: dict[str, Any] | None = None,
     ):
         super().__init__(
@@ -88,6 +89,7 @@ class AnthropicServingMessages(OpenAIServingChat):
             tool_parser=tool_parser,
             enable_prompt_tokens_details=enable_prompt_tokens_details,
             enable_force_include_usage=enable_force_include_usage,
+            usage_policy=usage_policy,
             default_chat_template_kwargs=default_chat_template_kwargs,
         )
         self.stop_reason_map = {
@@ -837,3 +839,13 @@ class AnthropicServingMessages(OpenAIServingChat):
         )
 
         return response
+
+    def should_include_usage(
+        self,
+        *,
+        is_streaming: bool,
+        include_usage: bool | None = None,
+        continuous_usage: bool | None = None,
+    ) -> tuple[bool, bool]:
+        """Anthropic always includes usage in every response/chunk."""
+        return (True, True)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1233,6 +1233,25 @@ class ChatTemplateConfig:
     trust_request_chat_template: bool = False
 
 
+@dataclass
+class UsagePolicy:
+    """
+    Policy for controlling usage statistics return behavior.
+
+    Fields:
+        include_usage: Controls when to include usage in responses.
+            - always: Always include usage information in responses.
+            - None: No effect, keep entrypoint default's behavior.
+        continuous_usage: Controls continuous usage stats during streaming.
+            - always: Send usage on every chunk (only valid if include_usage
+              is enabled).
+            - None: No effect, keep entrypoint default's behavior.
+    """
+
+    include_usage: Literal["always"] | None = None
+    continuous_usage: Literal["always"] | None = None
+
+
 def validate_chat_template(chat_template: Path | str | None):
     """Raises if the provided chat template appears invalid."""
     if chat_template is None:

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -102,7 +102,7 @@ class OpenAIServingChat(OpenAIServing):
         tool_parser: str | None = None,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
-        usage_policy: "UsagePolicy | None" = None,
+        usage_policy: UsagePolicy | None = None,
         enable_log_outputs: bool = False,
         enable_log_deltas: bool = True,
         default_chat_template_kwargs: dict[str, Any] | None = None,
@@ -495,20 +495,12 @@ class OpenAIServingChat(OpenAIServing):
             return
 
         stream_options = request.stream_options
-        include_usage_param = (
-            bool(stream_options.include_usage)
-            if stream_options and stream_options.include_usage is not None
-            else None
-        )
-        continuous_usage_param = (
-            bool(stream_options.continuous_usage_stats)
-            if stream_options and stream_options.continuous_usage_stats is not None
-            else None
-        )
         include_usage, include_continuous_usage = self.should_include_usage(
             is_streaming=True,
-            include_usage=include_usage_param,
-            continuous_usage=continuous_usage_param,
+            include_usage=stream_options.include_usage if stream_options else None,
+            continuous_usage=(
+                stream_options.continuous_usage_stats if stream_options else None
+            ),
         )
 
         try:

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1616,12 +1616,7 @@ class OpenAIServingChat(OpenAIServing):
         if policy is not None and policy.include_usage == "always":
             if policy.continuous_usage is not None:
                 return (True, policy.continuous_usage == "always")
-            in_chunks = (
-                bool(include_usage and continuous_usage)
-                if include_usage is not None
-                else False
-            )
-            return (True, in_chunks)
+            return (True, bool(continuous_usage))
 
         if include_usage is not None:
             in_chunks = bool(include_usage and continuous_usage)

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -101,7 +101,6 @@ class OpenAIServingChat(OpenAIServing):
         exclude_tools_when_tool_choice_none: bool = False,
         tool_parser: str | None = None,
         enable_prompt_tokens_details: bool = False,
-        enable_force_include_usage: bool = False,
         usage_policy: UsagePolicy | None = None,
         enable_log_outputs: bool = False,
         enable_log_deltas: bool = True,
@@ -113,7 +112,6 @@ class OpenAIServingChat(OpenAIServing):
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
             usage_policy=usage_policy,
-            enable_force_include_usage=enable_force_include_usage,
         )
 
         self.openai_serving_render = openai_serving_render
@@ -153,7 +151,6 @@ class OpenAIServingChat(OpenAIServing):
         self.exclude_tools_when_tool_choice_none = exclude_tools_when_tool_choice_none
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
-        self.enable_force_include_usage = enable_force_include_usage
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
         mc = self.model_config
         self.override_max_tokens = (
@@ -1625,9 +1622,6 @@ class OpenAIServingChat(OpenAIServing):
                 else False
             )
             return (True, in_chunks)
-
-        if self.enable_force_include_usage:
-            return (True, True)
 
         if include_usage is not None:
             in_chunks = bool(include_usage and continuous_usage)

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1617,7 +1617,13 @@ class OpenAIServingChat(OpenAIServing):
 
         policy = self.usage_policy
         if policy is not None and policy.include_usage == "always":
-            in_chunks = policy.continuous_usage == "always"
+            if policy.continuous_usage is not None:
+                return (True, policy.continuous_usage == "always")
+            in_chunks = (
+                bool(include_usage and continuous_usage)
+                if include_usage is not None
+                else False
+            )
             return (True, in_chunks)
 
         if self.enable_force_include_usage:

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -18,6 +18,7 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
     ConversationMessage,
+    UsagePolicy,
     get_history_tool_calls_cnt,
     get_tool_call_id_type,
     make_tool_call_id,
@@ -62,7 +63,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     parse_chat_output,
 )
 from vllm.entrypoints.openai.utils import maybe_filter_parallel_tool_calls
-from vllm.entrypoints.utils import get_max_tokens, should_include_usage
+from vllm.entrypoints.utils import get_max_tokens
 from vllm.inputs import EngineInput
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
@@ -101,6 +102,7 @@ class OpenAIServingChat(OpenAIServing):
         tool_parser: str | None = None,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
+        usage_policy: "UsagePolicy | None" = None,
         enable_log_outputs: bool = False,
         enable_log_deltas: bool = True,
         default_chat_template_kwargs: dict[str, Any] | None = None,
@@ -110,6 +112,8 @@ class OpenAIServingChat(OpenAIServing):
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
+            usage_policy=usage_policy,
+            enable_force_include_usage=enable_force_include_usage,
         )
 
         self.openai_serving_render = openai_serving_render
@@ -491,8 +495,20 @@ class OpenAIServingChat(OpenAIServing):
             return
 
         stream_options = request.stream_options
-        include_usage, include_continuous_usage = should_include_usage(
-            stream_options, self.enable_force_include_usage
+        include_usage_param = (
+            bool(stream_options.include_usage)
+            if stream_options and stream_options.include_usage is not None
+            else None
+        )
+        continuous_usage_param = (
+            bool(stream_options.continuous_usage_stats)
+            if stream_options and stream_options.continuous_usage_stats is not None
+            else None
+        )
+        include_usage, include_continuous_usage = self.should_include_usage(
+            is_streaming=True,
+            include_usage=include_usage_param,
+            continuous_usage=continuous_usage_param,
         )
 
         try:
@@ -1596,3 +1612,27 @@ class OpenAIServingChat(OpenAIServing):
                 )
             ]
         )
+
+    def should_include_usage(
+        self,
+        *,
+        is_streaming: bool,
+        include_usage: bool | None = None,
+        continuous_usage: bool | None = None,
+    ) -> tuple[bool, bool]:
+        if not is_streaming:
+            return (True, False)
+
+        policy = self.usage_policy
+        if policy is not None and policy.include_usage == "always":
+            in_chunks = policy.continuous_usage == "always"
+            return (True, in_chunks)
+
+        if self.enable_force_include_usage:
+            return (True, True)
+
+        if include_usage is not None:
+            in_chunks = bool(include_usage and continuous_usage)
+            return (include_usage, in_chunks)
+
+        return (False, False)

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -141,22 +141,27 @@ class BaseFrontendArgs:
     Policy for usage statistics return behavior.
     Possible values:
         - "always": Always include usage in responses.
-        - None: Do not include usage by default.
+        - None: No effect, keep the entrypoint's default behavior.
     """
     continuous_usage_policy: str | None = None
     """
     Policy for continuous usage statistics during streaming.
     Possible values:
-        - "always": Send usage on every chunk, if include_usage is enabled.
-        - None: No continuous usage stats.
+        - "always": Send usage on every chunk (only valid if
+          include_usage is enabled).
+        - None: No effect, keep the entrypoint's default behavior.
     """
     enable_force_include_usage: bool = False
     """
-    [Deprecated]
-    If set to True, including usage on every request.
-    Cannot be used together with --include-usage-policy or
-    --continuous-usage-policy.
-    Use `--include-usage-policy=always` instead.
+    [Deprecated] Consider using `--include-usage-policy` and
+    `--continuous-usage-policy` instead.
+
+    If set to True, force-include usage in streaming responses.
+
+    Configuring this parameter together with `--include-usage-policy` or
+    `--continuous-usage-policy` is not recommended. The two mechanisms
+    currently coexist without validation, but the behavior may change in
+    future versions.
     """
     enable_tokenizer_info_endpoint: bool = False
     """Enable the `/tokenizer_info` endpoint. May expose chat

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -153,15 +153,16 @@ class BaseFrontendArgs:
     """
     enable_force_include_usage: bool = False
     """
-    [Deprecated] Consider using `--include-usage-policy` and
+    [Deprecated] Use `--include-usage-policy` and
     `--continuous-usage-policy` instead.
 
     If set to True, force-include usage in streaming responses.
+    Internally converted to ``--include-usage-policy=always``
+    (plus ``--continuous-usage-policy=always`` for Chat / Completion
+    endpoints).
 
-    Configuring this parameter together with `--include-usage-policy` or
-    `--continuous-usage-policy` is not recommended. The two mechanisms
-    currently coexist without validation, but the behavior may change in
-    future versions.
+    Must NOT be combined with ``--include-usage-policy`` or
+    ``--continuous-usage-policy``.
     """
     enable_tokenizer_info_endpoint: bool = False
     """Enable the `/tokenizer_info` endpoint. May expose chat

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -136,8 +136,28 @@ class BaseFrontendArgs:
     """If set to True, enable prompt_tokens_details in usage."""
     enable_server_load_tracking: bool = False
     """If set to True, enable tracking server_load_metrics in the app state."""
+    include_usage_policy: str | None = None
+    """
+    Policy for usage statistics return behavior.
+    Possible values:
+        - "always": Always include usage in responses.
+        - None: Do not include usage by default.
+    """
+    continuous_usage_policy: str | None = None
+    """
+    Policy for continuous usage statistics during streaming.
+    Possible values:
+        - "always": Send usage on every chunk, if include_usage is enabled.
+        - None: No continuous usage stats.
+    """
     enable_force_include_usage: bool = False
-    """If set to True, including usage on every request."""
+    """
+    [Deprecated]
+    If set to True, including usage on every request.
+    Cannot be used together with --include-usage-policy or
+    --continuous-usage-policy.
+    Use `--include-usage-policy=always` instead.
+    """
     enable_tokenizer_info_endpoint: bool = False
     """Enable the `/tokenizer_info` endpoint. May expose chat
     templates and other tokenizer configuration."""
@@ -397,6 +417,42 @@ def validate_parsed_serve_args(args: argparse.Namespace):
         raise TypeError("Error: --enable-auto-tool-choice requires --tool-call-parser")
     if args.enable_log_outputs and not args.enable_log_requests:
         raise TypeError("Error: --enable-log-outputs requires --enable-log-requests")
+
+    valid_usage_policies = (None, "always")
+    if args.include_usage_policy not in valid_usage_policies:
+        raise TypeError(
+            f"Error: --include-usage-policy must be "
+            f"{list(valid_usage_policies)}, "
+            f"but got '{args.include_usage_policy}'"
+        )
+
+    valid_continuous_usage_policies = (None, "always")
+    if args.continuous_usage_policy not in valid_continuous_usage_policies:
+        raise TypeError(
+            f"Error: --continuous-usage-policy must be "
+            f"{list(valid_continuous_usage_policies)}, "
+            f"but got '{args.continuous_usage_policy}'"
+        )
+
+    # Handle deprecated enable_force_include_usage
+    if args.enable_force_include_usage and (
+        args.include_usage_policy is not None
+        or args.continuous_usage_policy is not None
+    ):
+        raise TypeError(
+            "--enable-force-include-usage cannot be used together with "
+            "--include-usage-policy or --continuous-usage-policy. "
+            "Use --include-usage-policy=always "
+            "[--continuous-usage-policy=always] instead."
+        )
+
+    if args.continuous_usage_policy == "always" and args.include_usage_policy is None:
+        logger.warning_once(
+            "--continuous-usage-policy=always requires "
+            "--include-usage-policy to be set. "
+            "Automatically setting --include-usage-policy=always."
+        )
+        args.include_usage_policy = "always"
 
     if args.data_parallel_multi_port_external_lb:
         from vllm.entrypoints.openai.dp_supervisor import (

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -708,12 +708,7 @@ class OpenAIServingCompletion(OpenAIServing):
         if policy is not None and policy.include_usage == "always":
             if policy.continuous_usage is not None:
                 return (True, policy.continuous_usage == "always")
-            in_chunks = (
-                bool(include_usage and continuous_usage)
-                if include_usage is not None
-                else False
-            )
-            return (True, in_chunks)
+            return (True, bool(continuous_usage))
 
         if include_usage is not None:
             in_chunks = bool(include_usage and continuous_usage)

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -62,7 +62,6 @@ class OpenAIServingCompletion(OpenAIServing):
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
         enable_prompt_tokens_details: bool = False,
-        enable_force_include_usage: bool = False,
         usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
@@ -71,12 +70,10 @@ class OpenAIServingCompletion(OpenAIServing):
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
             usage_policy=usage_policy,
-            enable_force_include_usage=enable_force_include_usage,
         )
 
         self.openai_serving_render = openai_serving_render
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
-        self.enable_force_include_usage = enable_force_include_usage
 
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
         mc = self.model_config
@@ -717,9 +714,6 @@ class OpenAIServingCompletion(OpenAIServing):
                 else False
             )
             return (True, in_chunks)
-
-        if self.enable_force_include_usage:
-            return (True, True)
 
         if include_usage is not None:
             in_chunks = bool(include_usage and continuous_usage)

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -709,7 +709,13 @@ class OpenAIServingCompletion(OpenAIServing):
 
         policy = self.usage_policy
         if policy is not None and policy.include_usage == "always":
-            in_chunks = policy.continuous_usage == "always"
+            if policy.continuous_usage is not None:
+                return (True, policy.continuous_usage == "always")
+            in_chunks = (
+                bool(include_usage and continuous_usage)
+                if include_usage is not None
+                else False
+            )
             return (True, in_chunks)
 
         if self.enable_force_include_usage:

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -63,7 +63,7 @@ class OpenAIServingCompletion(OpenAIServing):
         return_tokens_as_token_ids: bool = False,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
-        usage_policy: "UsagePolicy | None" = None,
+        usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
             engine_client=engine_client,
@@ -301,20 +301,12 @@ class OpenAIServingCompletion(OpenAIServing):
         first_iteration = True
 
         stream_options = request.stream_options
-        include_usage_param = (
-            bool(stream_options.include_usage)
-            if stream_options and stream_options.include_usage is not None
-            else None
-        )
-        continuous_usage_param = (
-            bool(stream_options.continuous_usage_stats)
-            if stream_options and stream_options.continuous_usage_stats is not None
-            else None
-        )
         include_usage, include_continuous_usage = self.should_include_usage(
             is_streaming=True,
-            include_usage=include_usage_param,
-            continuous_usage=continuous_usage_param,
+            include_usage=stream_options.include_usage if stream_options else None,
+            continuous_usage=(
+                stream_options.continuous_usage_stats if stream_options else None
+            ),
         )
 
         try:

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -13,6 +13,7 @@ import pybase64 as base64
 from fastapi import Request
 
 from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.chat_utils import UsagePolicy
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.completion.protocol import (
     CompletionLogProbs,
@@ -34,7 +35,7 @@ from vllm.entrypoints.openai.engine.serving import (
     clamp_prompt_logprobs,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.entrypoints.utils import get_max_tokens, should_include_usage
+from vllm.entrypoints.utils import get_max_tokens
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import EngineInput
 from vllm.logger import init_logger
@@ -62,12 +63,15 @@ class OpenAIServingCompletion(OpenAIServing):
         return_tokens_as_token_ids: bool = False,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
+        usage_policy: "UsagePolicy | None" = None,
     ):
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
+            usage_policy=usage_policy,
+            enable_force_include_usage=enable_force_include_usage,
         )
 
         self.openai_serving_render = openai_serving_render
@@ -297,8 +301,20 @@ class OpenAIServingCompletion(OpenAIServing):
         first_iteration = True
 
         stream_options = request.stream_options
-        include_usage, include_continuous_usage = should_include_usage(
-            stream_options, self.enable_force_include_usage
+        include_usage_param = (
+            bool(stream_options.include_usage)
+            if stream_options and stream_options.include_usage is not None
+            else None
+        )
+        continuous_usage_param = (
+            bool(stream_options.continuous_usage_stats)
+            if stream_options and stream_options.continuous_usage_stats is not None
+            else None
+        )
+        include_usage, include_continuous_usage = self.should_include_usage(
+            is_streaming=True,
+            include_usage=include_usage_param,
+            continuous_usage=continuous_usage_param,
         )
 
         try:
@@ -688,3 +704,27 @@ class OpenAIServingCompletion(OpenAIServing):
             tokens=out_tokens,
             top_logprobs=out_top_logprobs,
         )
+
+    def should_include_usage(
+        self,
+        *,
+        is_streaming: bool,
+        include_usage: bool | None = None,
+        continuous_usage: bool | None = None,
+    ) -> tuple[bool, bool]:
+        if not is_streaming:
+            return (True, False)
+
+        policy = self.usage_policy
+        if policy is not None and policy.include_usage == "always":
+            in_chunks = policy.continuous_usage == "always"
+            return (True, in_chunks)
+
+        if self.enable_force_include_usage:
+            return (True, True)
+
+        if include_usage is not None:
+            in_chunks = bool(include_usage and continuous_usage)
+            return (include_usage, in_chunks)
+
+        return (False, False)

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -144,7 +144,7 @@ class OpenAIServing(BeamSearchOnlineMixin):
         *,
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
-        usage_policy: "UsagePolicy | None" = None,
+        usage_policy: UsagePolicy | None = None,
         enable_force_include_usage: bool = False,
     ):
         super().__init__()
@@ -608,10 +608,12 @@ class OpenAIServing(BeamSearchOnlineMixin):
 
         Args:
             is_streaming: Whether the request is streaming.
-            include_usage: Request-level preference to include usage in final
-                response. If None, uses usage_policy or default behavior.
-            continuous_usage: Request-level preference to include usage in each
-                streaming chunk. If None, uses usage_policy or default behavior.
+            include_usage: Per-request parameter set by the user via
+                ``stream_options.include_usage``. ``None`` means the user
+                did not pass the parameter.
+            continuous_usage: Per-request parameter set by the user via
+                ``stream_options.continuous_usage_stats``. ``None`` means
+                the user did not pass the parameter.
 
         Returns:
             tuple[bool, bool]: (include_in_final, include_in_chunks)
@@ -620,17 +622,20 @@ class OpenAIServing(BeamSearchOnlineMixin):
                 - include_in_chunks: Whether to include usage in each streaming
                   chunk.
 
-        Priority:
-            1. usage_policy.include_usage="always" overrides request-level
-               preferences.
-            2. Request-level include_usage/continuous_usage if provided.
-            3. Default behavior: non-streaming returns usage, streaming returns
-               usage in final chunk.
+        Resolution order:
+            1. ``usage_policy.include_usage == "always"``: force include,
+               override everything else.
+            2. ``enable_force_include_usage == True`` (deprecated): force
+               include usage in the final chunk only.
+            3. Per-request ``include_usage`` / ``continuous_usage``: use the
+               user-supplied values if they were explicitly provided.
+            4. Default: include usage in the final chunk for streaming
+               requests.
 
         Subclass override note:
             Subclasses may override this method to customize usage behavior.
             When overridden, the method can either:
-            1. Consult self.usage_policy and request-level parameters, or
+            1. Consult ``self.usage_policy`` and request-level parameters, or
             2. Ignore all parameters and implement fixed behavior
                (e.g., always return (False, False) for APIs that never
                return usage, or always return (True, True) for APIs that

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -145,7 +145,6 @@ class OpenAIServing(BeamSearchOnlineMixin):
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
         usage_policy: UsagePolicy | None = None,
-        enable_force_include_usage: bool = False,
     ):
         super().__init__()
 
@@ -155,13 +154,6 @@ class OpenAIServing(BeamSearchOnlineMixin):
         self.request_logger = request_logger
         self.return_tokens_as_token_ids = return_tokens_as_token_ids
         self.usage_policy = usage_policy
-        self.enable_force_include_usage = enable_force_include_usage
-        if enable_force_include_usage:
-            logger.warning_once(
-                "`--enable-force-include-usage` is deprecated. "
-                "Consider using `--include-usage-policy` and "
-                "`--continuous-usage-policy` instead."
-            )
 
         self.model_config = engine_client.model_config
         self.renderer = engine_client.renderer
@@ -629,19 +621,17 @@ class OpenAIServing(BeamSearchOnlineMixin):
                   chunk.
 
         Resolution order:
-            1. ``usage_policy.include_usage == "always"``: force include,
+            1. `usage_policy.include_usage == "always"`: force include,
                override everything else.
-            2. ``enable_force_include_usage == True`` (deprecated): force
-               include usage in the final chunk only.
-            3. Per-request ``include_usage`` / ``continuous_usage``: use the
+            2. Per-request `include_usage` / `continuous_usage`: use the
                user-supplied values if they were explicitly provided.
-            4. Default: include usage in the final chunk for streaming
+            3. Default: include usage in the final chunk for streaming
                requests.
 
         Subclass override note:
             Subclasses may override this method to customize usage behavior.
             When overridden, the method can either:
-            1. Consult ``self.usage_policy`` and request-level parameters, or
+            1. Consult `self.usage_policy` and request-level parameters, or
             2. Ignore all parameters and implement fixed behavior
                (e.g., always return (False, False) for APIs that never
                return usage, or always return (True, True) for APIs that
@@ -661,9 +651,6 @@ class OpenAIServing(BeamSearchOnlineMixin):
                 else False
             )
             return (True, in_chunks)
-
-        if self.enable_force_include_usage:
-            return (True, False)
 
         if include_usage is not None:
             in_chunks = bool(include_usage and continuous_usage)

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -653,7 +653,13 @@ class OpenAIServing(BeamSearchOnlineMixin):
 
         policy = self.usage_policy
         if policy is not None and policy.include_usage == "always":
-            in_chunks = policy.continuous_usage == "always"
+            if policy.continuous_usage is not None:
+                return (True, policy.continuous_usage == "always")
+            in_chunks = (
+                bool(include_usage and continuous_usage)
+                if include_usage is not None
+                else False
+            )
             return (True, in_chunks)
 
         if self.enable_force_include_usage:

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -156,6 +156,12 @@ class OpenAIServing(BeamSearchOnlineMixin):
         self.return_tokens_as_token_ids = return_tokens_as_token_ids
         self.usage_policy = usage_policy
         self.enable_force_include_usage = enable_force_include_usage
+        if enable_force_include_usage:
+            logger.warning_once(
+                "`--enable-force-include-usage` is deprecated. "
+                "Consider using `--include-usage-policy` and "
+                "`--continuous-usage-policy` instead."
+            )
 
         self.model_config = engine_client.model_config
         self.renderer = engine_client.renderer

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -645,12 +645,7 @@ class OpenAIServing(BeamSearchOnlineMixin):
         if policy is not None and policy.include_usage == "always":
             if policy.continuous_usage is not None:
                 return (True, policy.continuous_usage == "always")
-            in_chunks = (
-                bool(include_usage and continuous_usage)
-                if include_usage is not None
-                else False
-            )
-            return (True, in_chunks)
+            return (True, bool(continuous_usage))
 
         if include_usage is not None:
             in_chunks = bool(include_usage and continuous_usage)

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -16,7 +16,10 @@ from starlette.datastructures import Headers
 import vllm.envs as envs
 from vllm.config import ModelConfig
 from vllm.engine.protocol import EngineClient
-from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
+from vllm.entrypoints.chat_utils import (
+    ChatTemplateContentFormatOption,
+    UsagePolicy,
+)
 from vllm.entrypoints.generate.beam_search.online import BeamSearchOnlineMixin
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -141,6 +144,8 @@ class OpenAIServing(BeamSearchOnlineMixin):
         *,
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
+        usage_policy: "UsagePolicy | None" = None,
+        enable_force_include_usage: bool = False,
     ):
         super().__init__()
 
@@ -149,6 +154,8 @@ class OpenAIServing(BeamSearchOnlineMixin):
 
         self.request_logger = request_logger
         self.return_tokens_as_token_ids = return_tokens_as_token_ids
+        self.usage_policy = usage_policy
+        self.enable_force_include_usage = enable_force_include_usage
 
         self.model_config = engine_client.model_config
         self.renderer = engine_client.renderer
@@ -588,6 +595,64 @@ class OpenAIServing(BeamSearchOnlineMixin):
             )
 
         return tokenizer.decode([token_id])
+
+    def should_include_usage(
+        self,
+        *,
+        is_streaming: bool,
+        include_usage: bool | None = None,
+        continuous_usage: bool | None = None,
+    ) -> tuple[bool, bool]:
+        """
+        Determine whether usage information should be included in the response.
+
+        Args:
+            is_streaming: Whether the request is streaming.
+            include_usage: Request-level preference to include usage in final
+                response. If None, uses usage_policy or default behavior.
+            continuous_usage: Request-level preference to include usage in each
+                streaming chunk. If None, uses usage_policy or default behavior.
+
+        Returns:
+            tuple[bool, bool]: (include_in_final, include_in_chunks)
+                - include_in_final: Whether to include usage in the final
+                  response/chunk.
+                - include_in_chunks: Whether to include usage in each streaming
+                  chunk.
+
+        Priority:
+            1. usage_policy.include_usage="always" overrides request-level
+               preferences.
+            2. Request-level include_usage/continuous_usage if provided.
+            3. Default behavior: non-streaming returns usage, streaming returns
+               usage in final chunk.
+
+        Subclass override note:
+            Subclasses may override this method to customize usage behavior.
+            When overridden, the method can either:
+            1. Consult self.usage_policy and request-level parameters, or
+            2. Ignore all parameters and implement fixed behavior
+               (e.g., always return (False, False) for APIs that never
+               return usage, or always return (True, True) for APIs that
+               always include usage in every chunk).
+
+        """
+        if not is_streaming:
+            return (True, False)
+
+        policy = self.usage_policy
+        if policy is not None and policy.include_usage == "always":
+            in_chunks = policy.continuous_usage == "always"
+            return (True, in_chunks)
+
+        if self.enable_force_include_usage:
+            return (True, False)
+
+        if include_usage is not None:
+            in_chunks = bool(include_usage and continuous_usage)
+            return (include_usage, in_chunks)
+
+        return (True, False)
 
     def _is_model_supported(self, model_name: str | None) -> bool:
         if not model_name:

--- a/vllm/entrypoints/openai/generate/api_router.py
+++ b/vllm/entrypoints/openai/generate/api_router.py
@@ -92,6 +92,36 @@ async def init_generate_state(
         continuous_usage=args.continuous_usage_policy,
     )
 
+    # ---
+    # Deprecated --enable-force-include-usage → UsagePolicy conversion.
+    #
+    # If the old flag is set and the user has not already configured
+    # --include-usage-policy / --continuous-usage-policy, translate the
+    # per-endpoint historical behaviour into the new policy mechanism.
+    # Once the flag is fully removed this helper and its call sites can
+    # be deleted.
+    # ---
+
+    def _maybe_force_usage(
+        policy: UsagePolicy,
+        enable_force: bool,
+        *,
+        set_continuous: bool,
+    ) -> UsagePolicy:
+        if enable_force and policy.include_usage is None:
+            return UsagePolicy(
+                include_usage="always",
+                continuous_usage="always" if set_continuous else None,
+            )
+        return policy
+
+    # Chat/Completion/Anthropic: flag → (True, True)
+    usage_policy = _maybe_force_usage(
+        usage_policy, args.enable_force_include_usage, set_continuous=True
+    )
+    # Responses: flag was stored but never used → no conversion needed
+    # Disagg: flag has no effect → no conversion needed
+
     # Render endpoints are always backed by OpenAIServingRender so that
     # /v1/chat/completions/render and /v1/completions/render work on both
     # generate-mode and render-only servers. Created in init_app_state.
@@ -110,7 +140,6 @@ async def init_generate_state(
             tool_server=tool_server,
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
-            enable_force_include_usage=args.enable_force_include_usage,
             usage_policy=usage_policy,
             enable_log_outputs=args.enable_log_outputs,
             default_chat_template_kwargs=args.default_chat_template_kwargs,
@@ -134,7 +163,6 @@ async def init_generate_state(
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.structured_outputs_config.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,
-        enable_force_include_usage=args.enable_force_include_usage,
         usage_policy=usage_policy,
         enable_log_outputs=args.enable_log_outputs,
         enable_log_deltas=args.enable_log_deltas,
@@ -157,7 +185,6 @@ async def init_generate_state(
             request_logger=request_logger,
             return_tokens_as_token_ids=args.return_tokens_as_token_ids,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
-            enable_force_include_usage=args.enable_force_include_usage,
             usage_policy=usage_policy,
         )
         if "generate" in supported_tasks
@@ -177,7 +204,6 @@ async def init_generate_state(
             tool_parser=args.tool_call_parser,
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
-            enable_force_include_usage=args.enable_force_include_usage,
             usage_policy=usage_policy,
             default_chat_template_kwargs=args.default_chat_template_kwargs,
         )
@@ -194,7 +220,6 @@ async def init_generate_state(
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_log_outputs=args.enable_log_outputs,
             force_no_detokenize=args.tokens_only,
-            enable_force_include_usage=args.enable_force_include_usage,
             usage_policy=usage_policy,
         )
         if "generate" in supported_tasks

--- a/vllm/entrypoints/openai/generate/api_router.py
+++ b/vllm/entrypoints/openai/generate/api_router.py
@@ -92,35 +92,18 @@ async def init_generate_state(
         continuous_usage=args.continuous_usage_policy,
     )
 
-    # ---
     # Deprecated --enable-force-include-usage → UsagePolicy conversion.
-    #
-    # If the old flag is set and the user has not already configured
-    # --include-usage-policy / --continuous-usage-policy, translate the
-    # per-endpoint historical behaviour into the new policy mechanism.
-    # Once the flag is fully removed this helper and its call sites can
-    # be deleted.
-    # ---
-
-    def _maybe_force_usage(
-        policy: UsagePolicy,
-        enable_force: bool,
-        *,
-        set_continuous: bool,
-    ) -> UsagePolicy:
-        if enable_force and policy.include_usage is None:
-            return UsagePolicy(
-                include_usage="always",
-                continuous_usage="always" if set_continuous else None,
-            )
-        return policy
-
-    # Chat/Completion/Anthropic: flag → (True, True)
-    usage_policy = _maybe_force_usage(
-        usage_policy, args.enable_force_include_usage, set_continuous=True
+    # Once the flag is removed this helper and its use below can be deleted.
+    # Category 1, converted_usage_policy, flag forced both include_usage
+    # and continuous_usage:
+    #   Chat, Completion, Anthropic
+    # Category 3, unchanged_usage_policy, flag had no effect:
+    #   Responses, Disagg (ServingTokens)
+    converted_usage_policy = (
+        UsagePolicy(include_usage="always", continuous_usage="always")
+        if args.enable_force_include_usage
+        else usage_policy
     )
-    # Responses: flag was stored but never used → no conversion needed
-    # Disagg: flag has no effect → no conversion needed
 
     # Render endpoints are always backed by OpenAIServingRender so that
     # /v1/chat/completions/render and /v1/completions/render work on both
@@ -163,7 +146,7 @@ async def init_generate_state(
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.structured_outputs_config.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,
-        usage_policy=usage_policy,
+        usage_policy=converted_usage_policy,
         enable_log_outputs=args.enable_log_outputs,
         enable_log_deltas=args.enable_log_deltas,
     )
@@ -185,7 +168,7 @@ async def init_generate_state(
             request_logger=request_logger,
             return_tokens_as_token_ids=args.return_tokens_as_token_ids,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
-            usage_policy=usage_policy,
+            usage_policy=converted_usage_policy,
         )
         if "generate" in supported_tasks
         else None
@@ -204,7 +187,7 @@ async def init_generate_state(
             tool_parser=args.tool_call_parser,
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
-            usage_policy=usage_policy,
+            usage_policy=converted_usage_policy,
             default_chat_template_kwargs=args.default_chat_template_kwargs,
         )
         if "generate" in supported_tasks

--- a/vllm/entrypoints/openai/generate/api_router.py
+++ b/vllm/entrypoints/openai/generate/api_router.py
@@ -50,7 +50,10 @@ async def init_generate_state(
     supported_tasks: tuple["SupportedTask", ...],
 ):
     from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
-    from vllm.entrypoints.chat_utils import load_chat_template
+    from vllm.entrypoints.chat_utils import (
+        UsagePolicy,
+        load_chat_template,
+    )
     from vllm.entrypoints.mcp.tool_server import (
         DemoToolServer,
         MCPToolServer,
@@ -83,6 +86,12 @@ async def init_generate_state(
         tool_server = None
     resolved_chat_template = load_chat_template(args.chat_template)
 
+    # Build UsagePolicy from CLI args
+    usage_policy = UsagePolicy(
+        include_usage=args.include_usage_policy,
+        continuous_usage=args.continuous_usage_policy,
+    )
+
     # Render endpoints are always backed by OpenAIServingRender so that
     # /v1/chat/completions/render and /v1/completions/render work on both
     # generate-mode and render-only servers. Created in init_app_state.
@@ -102,6 +111,7 @@ async def init_generate_state(
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
+            usage_policy=usage_policy,
             enable_log_outputs=args.enable_log_outputs,
             default_chat_template_kwargs=args.default_chat_template_kwargs,
         )
@@ -125,6 +135,7 @@ async def init_generate_state(
         reasoning_parser=args.structured_outputs_config.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,
         enable_force_include_usage=args.enable_force_include_usage,
+        usage_policy=usage_policy,
         enable_log_outputs=args.enable_log_outputs,
         enable_log_deltas=args.enable_log_deltas,
     )
@@ -147,6 +158,7 @@ async def init_generate_state(
             return_tokens_as_token_ids=args.return_tokens_as_token_ids,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
+            usage_policy=usage_policy,
         )
         if "generate" in supported_tasks
         else None
@@ -166,6 +178,7 @@ async def init_generate_state(
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
+            usage_policy=usage_policy,
             default_chat_template_kwargs=args.default_chat_template_kwargs,
         )
         if "generate" in supported_tasks
@@ -181,6 +194,8 @@ async def init_generate_state(
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_log_outputs=args.enable_log_outputs,
             force_no_detokenize=args.tokens_only,
+            enable_force_include_usage=args.enable_force_include_usage,
+            usage_policy=usage_policy,
         )
         if "generate" in supported_tasks
         else None

--- a/vllm/entrypoints/openai/generative_scoring/api_router.py
+++ b/vllm/entrypoints/openai/generative_scoring/api_router.py
@@ -90,6 +90,5 @@ async def init_generative_scoring_state(
         engine_client,
         state.openai_serving_models,
         request_logger=request_logger,
-        enable_force_include_usage=args.enable_force_include_usage,
         usage_policy=usage_policy,
     )

--- a/vllm/entrypoints/openai/generative_scoring/api_router.py
+++ b/vllm/entrypoints/openai/generative_scoring/api_router.py
@@ -76,12 +76,20 @@ async def init_generative_scoring_state(
     args: "Namespace",
     request_logger: "RequestLogger | None",
 ):
+    from vllm.entrypoints.chat_utils import UsagePolicy
     from vllm.entrypoints.openai.generative_scoring.serving import (
         OpenAIServingGenerativeScoring,
+    )
+
+    usage_policy = UsagePolicy(
+        include_usage=args.include_usage_policy,
+        continuous_usage=args.continuous_usage_policy,
     )
 
     state.serving_generative_scoring = OpenAIServingGenerativeScoring(
         engine_client,
         state.openai_serving_models,
         request_logger=request_logger,
+        enable_force_include_usage=args.enable_force_include_usage,
+        usage_policy=usage_policy,
     )

--- a/vllm/entrypoints/openai/generative_scoring/serving.py
+++ b/vllm/entrypoints/openai/generative_scoring/serving.py
@@ -163,14 +163,12 @@ class OpenAIServingGenerativeScoring(OpenAIServing):
         models: OpenAIServingModels,
         *,
         request_logger: RequestLogger | None,
-        enable_force_include_usage: bool = False,
         usage_policy: UsagePolicy | None = None,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
-            enable_force_include_usage=enable_force_include_usage,
             usage_policy=usage_policy,
         )
 

--- a/vllm/entrypoints/openai/generative_scoring/serving.py
+++ b/vllm/entrypoints/openai/generative_scoring/serving.py
@@ -18,6 +18,7 @@ from fastapi import Request
 from pydantic import Field
 
 from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.chat_utils import UsagePolicy
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
@@ -162,11 +163,15 @@ class OpenAIServingGenerativeScoring(OpenAIServing):
         models: OpenAIServingModels,
         *,
         request_logger: RequestLogger | None,
+        enable_force_include_usage: bool = False,
+        usage_policy: UsagePolicy | None = None,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
+            enable_force_include_usage=enable_force_include_usage,
+            usage_policy=usage_policy,
         )
 
     async def create_generative_scoring(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -167,7 +167,6 @@ class OpenAIServingResponses(OpenAIServing):
         tool_parser: str | None = None,
         tool_server: ToolServer | None = None,
         enable_prompt_tokens_details: bool = False,
-        enable_force_include_usage: bool = False,
         usage_policy: UsagePolicy | None = None,
         enable_log_outputs: bool = False,
         default_chat_template_kwargs: dict[str, Any] | None = None,
@@ -177,7 +176,6 @@ class OpenAIServingResponses(OpenAIServing):
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
-            enable_force_include_usage=enable_force_include_usage,
             usage_policy=usage_policy,
         )
 
@@ -196,7 +194,6 @@ class OpenAIServingResponses(OpenAIServing):
             model_name=self.model_config.model,
         )
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
-        self.enable_force_include_usage = enable_force_include_usage
 
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
         mc = self.model_config

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -30,6 +30,7 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
+    UsagePolicy,
     get_tool_call_id_type,
 )
 from vllm.entrypoints.logger import RequestLogger
@@ -167,6 +168,7 @@ class OpenAIServingResponses(OpenAIServing):
         tool_server: ToolServer | None = None,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
+        usage_policy: UsagePolicy | None = None,
         enable_log_outputs: bool = False,
         default_chat_template_kwargs: dict[str, Any] | None = None,
     ) -> None:
@@ -175,6 +177,8 @@ class OpenAIServingResponses(OpenAIServing):
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
+            enable_force_include_usage=enable_force_include_usage,
+            usage_policy=usage_policy,
         )
 
         self.openai_serving_render = openai_serving_render

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -515,12 +515,7 @@ class ServingTokens(OpenAIServing):
         if policy is not None and policy.include_usage == "always":
             if policy.continuous_usage is not None:
                 return (True, policy.continuous_usage == "always")
-            in_chunks = (
-                bool(include_usage and continuous_usage)
-                if include_usage is not None
-                else False
-            )
-            return (True, in_chunks)
+            return (True, bool(continuous_usage))
 
         if include_usage is not None:
             in_chunks = bool(include_usage and continuous_usage)

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -69,7 +69,7 @@ class ServingTokens(OpenAIServing):
         return_tokens_as_token_ids: bool = False,
         enable_prompt_tokens_details: bool = False,
         enable_log_outputs: bool = False,
-        usage_policy: "UsagePolicy | None" = None,
+        usage_policy: UsagePolicy | None = None,
         enable_force_include_usage: bool = False,
     ):
         super().__init__(
@@ -368,15 +368,11 @@ class ServingTokens(OpenAIServing):
         include_usage, include_continuous_usage = self.should_include_usage(
             is_streaming=True,
             include_usage=(
-                bool(request.stream_options.include_usage)
-                if request.stream_options
-                and request.stream_options.include_usage is not None
-                else None
+                request.stream_options.include_usage if request.stream_options else None
             ),
             continuous_usage=(
-                bool(request.stream_options.continuous_usage_stats)
+                request.stream_options.continuous_usage_stats
                 if request.stream_options
-                and request.stream_options.continuous_usage_stats is not None
                 else None
             ),
         )

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -70,7 +70,6 @@ class ServingTokens(OpenAIServing):
         enable_prompt_tokens_details: bool = False,
         enable_log_outputs: bool = False,
         usage_policy: UsagePolicy | None = None,
-        enable_force_include_usage: bool = False,
     ):
         super().__init__(
             engine_client=engine_client,
@@ -78,7 +77,6 @@ class ServingTokens(OpenAIServing):
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
             usage_policy=usage_policy,
-            enable_force_include_usage=enable_force_include_usage,
         )
         self.openai_serving_render = openai_serving_render
         self.enable_prompt_tokens_details = enable_prompt_tokens_details

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -515,7 +515,13 @@ class ServingTokens(OpenAIServing):
 
         policy = self.usage_policy
         if policy is not None and policy.include_usage == "always":
-            in_chunks = policy.continuous_usage == "always"
+            if policy.continuous_usage is not None:
+                return (True, policy.continuous_usage == "always")
+            in_chunks = (
+                bool(include_usage and continuous_usage)
+                if include_usage is not None
+                else False
+            )
             return (True, in_chunks)
 
         if include_usage is not None:

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -518,9 +518,6 @@ class ServingTokens(OpenAIServing):
             in_chunks = policy.continuous_usage == "always"
             return (True, in_chunks)
 
-        if self.enable_force_include_usage:
-            return (True, True)
-
         if include_usage is not None:
             in_chunks = bool(include_usage and continuous_usage)
             return (include_usage, in_chunks)

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -14,6 +14,7 @@ import pybase64 as base64
 from fastapi import Request
 
 from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.chat_utils import UsagePolicy
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionLogProb,
@@ -38,7 +39,7 @@ from vllm.entrypoints.serve.disagg.protocol import (
     GenerateStreamResponse,
 )
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender
-from vllm.entrypoints.utils import get_max_tokens, should_include_usage
+from vllm.entrypoints.utils import get_max_tokens
 from vllm.inputs import EngineInput, mm_input
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
@@ -68,12 +69,16 @@ class ServingTokens(OpenAIServing):
         return_tokens_as_token_ids: bool = False,
         enable_prompt_tokens_details: bool = False,
         enable_log_outputs: bool = False,
+        usage_policy: "UsagePolicy | None" = None,
+        enable_force_include_usage: bool = False,
     ):
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
+            usage_policy=usage_policy,
+            enable_force_include_usage=enable_force_include_usage,
         )
         self.openai_serving_render = openai_serving_render
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
@@ -360,8 +365,20 @@ class ServingTokens(OpenAIServing):
         num_cached_tokens = None
         sampling_params: SamplingParams = request.sampling_params
 
-        include_usage, include_continuous_usage = should_include_usage(
-            request.stream_options, False
+        include_usage, include_continuous_usage = self.should_include_usage(
+            is_streaming=True,
+            include_usage=(
+                bool(request.stream_options.include_usage)
+                if request.stream_options
+                and request.stream_options.include_usage is not None
+                else None
+            ),
+            continuous_usage=(
+                bool(request.stream_options.continuous_usage_stats)
+                if request.stream_options
+                and request.stream_options.continuous_usage_stats is not None
+                else None
+            ),
         )
 
         try:
@@ -489,3 +506,27 @@ class ServingTokens(OpenAIServing):
                 )
 
         return ChatCompletionLogProbs(content=logprobs_content)
+
+    def should_include_usage(
+        self,
+        *,
+        is_streaming: bool,
+        include_usage: bool | None = None,
+        continuous_usage: bool | None = None,
+    ) -> tuple[bool, bool]:
+        if not is_streaming:
+            return (True, False)
+
+        policy = self.usage_policy
+        if policy is not None and policy.include_usage == "always":
+            in_chunks = policy.continuous_usage == "always"
+            return (True, in_chunks)
+
+        if self.enable_force_include_usage:
+            return (True, True)
+
+        if include_usage is not None:
+            in_chunks = bool(include_usage and continuous_usage)
+            return (include_usage, in_chunks)
+
+        return (False, False)

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -97,7 +97,6 @@ class OpenAISpeechToText(OpenAIServing):
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
         task_type: Literal["transcribe", "translate"] = "transcribe",
-        enable_force_include_usage: bool = False,
         usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
@@ -105,7 +104,6 @@ class OpenAISpeechToText(OpenAIServing):
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
-            enable_force_include_usage=enable_force_include_usage,
             usage_policy=usage_policy,
         )
 
@@ -115,8 +113,6 @@ class OpenAISpeechToText(OpenAIServing):
         self.asr_config = self.model_cls.get_speech_to_text_config(
             self.model_config, task_type
         )
-
-        self.enable_force_include_usage = enable_force_include_usage
 
         self.max_audio_filesize_mb = envs.VLLM_MAX_AUDIO_CLIP_FILESIZE_MB
         if self.model_cls.supports_segment_timestamp:
@@ -133,6 +129,33 @@ class OpenAISpeechToText(OpenAIServing):
                 "Overwriting default completion sampling param with: %s",
                 self.default_sampling_params,
             )
+
+    def should_include_usage(
+        self,
+        *,
+        is_streaming: bool,
+        include_usage: bool | None = None,
+        continuous_usage: bool | None = None,
+    ) -> tuple[bool, bool]:
+        if not is_streaming:
+            return (True, False)
+
+        policy = self.usage_policy
+        if policy is not None and policy.include_usage == "always":
+            if policy.continuous_usage is not None:
+                return (True, policy.continuous_usage == "always")
+            in_chunks = (
+                bool(include_usage and continuous_usage)
+                if include_usage is not None
+                else False
+            )
+            return (True, in_chunks)
+
+        if include_usage is not None:
+            in_chunks = bool(include_usage and continuous_usage)
+            return (include_usage, in_chunks)
+
+        return (False, False)
 
     @cached_property
     def model_cls(self) -> type[SupportsTranscription]:
@@ -651,11 +674,10 @@ class OpenAISpeechToText(OpenAIServing):
         completion_tokens = 0
         num_prompt_tokens = 0
 
-        include_usage = self.enable_force_include_usage or request.stream_include_usage
-        include_continuous_usage = (
-            request.stream_continuous_usage_stats
-            if include_usage and request.stream_continuous_usage_stats
-            else False
+        include_usage, include_continuous_usage = self.should_include_usage(
+            is_streaming=True,
+            include_usage=request.stream_include_usage,
+            continuous_usage=request.stream_continuous_usage_stats,
         )
 
         try:

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -144,12 +144,7 @@ class OpenAISpeechToText(OpenAIServing):
         if policy is not None and policy.include_usage == "always":
             if policy.continuous_usage is not None:
                 return (True, policy.continuous_usage == "always")
-            in_chunks = (
-                bool(include_usage and continuous_usage)
-                if include_usage is not None
-                else False
-            )
-            return (True, in_chunks)
+            return (True, bool(continuous_usage))
 
         if include_usage is not None:
             in_chunks = bool(include_usage and continuous_usage)

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -7,10 +7,7 @@ import time
 import zlib
 from collections.abc import AsyncGenerator, Callable, Set
 from functools import cached_property
-from typing import TYPE_CHECKING, Final, Literal, TypeAlias, TypeVar, cast
-
-if TYPE_CHECKING:
-    from vllm.entrypoints.chat_utils import UsagePolicy
+from typing import Final, Literal, TypeAlias, TypeVar, cast
 
 import numpy as np
 from fastapi import Request
@@ -18,6 +15,7 @@ from transformers import PreTrainedTokenizerBase
 
 import vllm.envs as envs
 from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.chat_utils import UsagePolicy
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
@@ -100,7 +98,7 @@ class OpenAISpeechToText(OpenAIServing):
         return_tokens_as_token_ids: bool = False,
         task_type: Literal["transcribe", "translate"] = "transcribe",
         enable_force_include_usage: bool = False,
-        usage_policy: "UsagePolicy | None" = None,
+        usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
             engine_client=engine_client,

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -7,7 +7,10 @@ import time
 import zlib
 from collections.abc import AsyncGenerator, Callable, Set
 from functools import cached_property
-from typing import Final, Literal, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias, TypeVar, cast
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.chat_utils import UsagePolicy
 
 import numpy as np
 from fastapi import Request
@@ -97,12 +100,15 @@ class OpenAISpeechToText(OpenAIServing):
         return_tokens_as_token_ids: bool = False,
         task_type: Literal["transcribe", "translate"] = "transcribe",
         enable_force_include_usage: bool = False,
+        usage_policy: "UsagePolicy | None" = None,
     ):
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
+            enable_force_include_usage=enable_force_include_usage,
+            usage_policy=usage_policy,
         )
 
         self.default_sampling_params = self.model_config.get_diff_sampling_param()

--- a/vllm/entrypoints/speech_to_text/factories.py
+++ b/vllm/entrypoints/speech_to_text/factories.py
@@ -57,6 +57,25 @@ def init_speech_to_text_state(
         continuous_usage=args.continuous_usage_policy,
     )
 
+    # Deprecated --enable-force-include-usage → UsagePolicy conversion.
+    # STT: flag only forced include_usage=True, continuous still from request.
+    def _maybe_force_usage(
+        policy: UsagePolicy,
+        enable_force: bool,
+        *,
+        set_continuous: bool,
+    ) -> UsagePolicy:
+        if enable_force and policy.include_usage is None:
+            return UsagePolicy(
+                include_usage="always",
+                continuous_usage="always" if set_continuous else None,
+            )
+        return policy
+
+    usage_policy = _maybe_force_usage(
+        usage_policy, args.enable_force_include_usage, set_continuous=False
+    )
+
     if "transcription" in supported_tasks:
         from .transcription.serving import OpenAIServingTranscription
 
@@ -64,7 +83,6 @@ def init_speech_to_text_state(
             engine_client,
             state.openai_serving_models,
             request_logger=request_logger,
-            enable_force_include_usage=args.enable_force_include_usage,
             usage_policy=usage_policy,
         )
 
@@ -74,7 +92,6 @@ def init_speech_to_text_state(
             engine_client,
             state.openai_serving_models,
             request_logger=request_logger,
-            enable_force_include_usage=args.enable_force_include_usage,
             usage_policy=usage_policy,
         )
 
@@ -85,6 +102,5 @@ def init_speech_to_text_state(
             engine_client,
             state.openai_serving_models,
             request_logger=request_logger,
-            enable_force_include_usage=args.enable_force_include_usage,
             usage_policy=usage_policy,
         )

--- a/vllm/entrypoints/speech_to_text/factories.py
+++ b/vllm/entrypoints/speech_to_text/factories.py
@@ -58,22 +58,15 @@ def init_speech_to_text_state(
     )
 
     # Deprecated --enable-force-include-usage → UsagePolicy conversion.
-    # STT: flag only forced include_usage=True, continuous still from request.
-    def _maybe_force_usage(
-        policy: UsagePolicy,
-        enable_force: bool,
-        *,
-        set_continuous: bool,
-    ) -> UsagePolicy:
-        if enable_force and policy.include_usage is None:
-            return UsagePolicy(
-                include_usage="always",
-                continuous_usage="always" if set_continuous else None,
-            )
-        return policy
-
-    usage_policy = _maybe_force_usage(
-        usage_policy, args.enable_force_include_usage, set_continuous=False
+    # Once the flag is removed this helper and its use below can be deleted.
+    # Category 2, converted_usage_policy, flag forced include_usage=True only:
+    #   STT Transcribe, Translate
+    # Category 3, unchanged_usage_policy, flag had no effect:
+    #   Realtime
+    converted_usage_policy = (
+        UsagePolicy(include_usage="always")
+        if args.enable_force_include_usage
+        else usage_policy
     )
 
     if "transcription" in supported_tasks:
@@ -83,7 +76,7 @@ def init_speech_to_text_state(
             engine_client,
             state.openai_serving_models,
             request_logger=request_logger,
-            usage_policy=usage_policy,
+            usage_policy=converted_usage_policy,
         )
 
         from .translation.serving import OpenAIServingTranslation
@@ -92,7 +85,7 @@ def init_speech_to_text_state(
             engine_client,
             state.openai_serving_models,
             request_logger=request_logger,
-            usage_policy=usage_policy,
+            usage_policy=converted_usage_policy,
         )
 
     if "realtime" in supported_tasks:

--- a/vllm/entrypoints/speech_to_text/factories.py
+++ b/vllm/entrypoints/speech_to_text/factories.py
@@ -50,6 +50,13 @@ def init_speech_to_text_state(
     request_logger: RequestLogger | None,
     supported_tasks: tuple["SupportedTask", ...],
 ):
+    from vllm.entrypoints.chat_utils import UsagePolicy
+
+    usage_policy = UsagePolicy(
+        include_usage=args.include_usage_policy,
+        continuous_usage=args.continuous_usage_policy,
+    )
+
     if "transcription" in supported_tasks:
         from .transcription.serving import OpenAIServingTranscription
 
@@ -58,6 +65,7 @@ def init_speech_to_text_state(
             state.openai_serving_models,
             request_logger=request_logger,
             enable_force_include_usage=args.enable_force_include_usage,
+            usage_policy=usage_policy,
         )
 
         from .translation.serving import OpenAIServingTranslation
@@ -67,6 +75,7 @@ def init_speech_to_text_state(
             state.openai_serving_models,
             request_logger=request_logger,
             enable_force_include_usage=args.enable_force_include_usage,
+            usage_policy=usage_policy,
         )
 
     if "realtime" in supported_tasks:
@@ -76,4 +85,6 @@ def init_speech_to_text_state(
             engine_client,
             state.openai_serving_models,
             request_logger=request_logger,
+            enable_force_include_usage=args.enable_force_include_usage,
+            usage_policy=usage_policy,
         )

--- a/vllm/entrypoints/speech_to_text/realtime/serving.py
+++ b/vllm/entrypoints/speech_to_text/realtime/serving.py
@@ -34,14 +34,12 @@ class OpenAIServingRealtime(OpenAIServing):
         models: OpenAIServingModels,
         *,
         request_logger: RequestLogger | None,
-        enable_force_include_usage: bool = False,
         usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
-            enable_force_include_usage=enable_force_include_usage,
             usage_policy=usage_policy,
         )
 

--- a/vllm/entrypoints/speech_to_text/realtime/serving.py
+++ b/vllm/entrypoints/speech_to_text/realtime/serving.py
@@ -9,6 +9,7 @@ from typing import Literal, cast
 import numpy as np
 
 from vllm.engine.protocol import EngineClient, StreamingInput
+from vllm.entrypoints.chat_utils import UsagePolicy
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.engine.serving import OpenAIServing
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
@@ -33,11 +34,15 @@ class OpenAIServingRealtime(OpenAIServing):
         models: OpenAIServingModels,
         *,
         request_logger: RequestLogger | None,
+        enable_force_include_usage: bool = False,
+        usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
+            enable_force_include_usage=enable_force_include_usage,
+            usage_policy=usage_policy,
         )
 
         self.task_type: Literal["realtime"] = "realtime"

--- a/vllm/entrypoints/speech_to_text/transcription/serving.py
+++ b/vllm/entrypoints/speech_to_text/transcription/serving.py
@@ -37,7 +37,6 @@ class OpenAIServingTranscription(OpenAISpeechToText):
         *,
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
-        enable_force_include_usage: bool = False,
         usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
@@ -46,7 +45,6 @@ class OpenAIServingTranscription(OpenAISpeechToText):
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
             task_type="transcribe",
-            enable_force_include_usage=enable_force_include_usage,
             usage_policy=usage_policy,
         )
 

--- a/vllm/entrypoints/speech_to_text/transcription/serving.py
+++ b/vllm/entrypoints/speech_to_text/transcription/serving.py
@@ -1,14 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING
 
 from fastapi import Request
 
-if TYPE_CHECKING:
-    from vllm.entrypoints.chat_utils import UsagePolicy
-
 from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.chat_utils import UsagePolicy
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
@@ -41,7 +38,7 @@ class OpenAIServingTranscription(OpenAISpeechToText):
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
         enable_force_include_usage: bool = False,
-        usage_policy: "UsagePolicy | None" = None,
+        usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
             engine_client=engine_client,

--- a/vllm/entrypoints/speech_to_text/transcription/serving.py
+++ b/vllm/entrypoints/speech_to_text/transcription/serving.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 
 from fastapi import Request
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.chat_utils import UsagePolicy
 
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.logger import RequestLogger
@@ -37,6 +41,7 @@ class OpenAIServingTranscription(OpenAISpeechToText):
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
         enable_force_include_usage: bool = False,
+        usage_policy: "UsagePolicy | None" = None,
     ):
         super().__init__(
             engine_client=engine_client,
@@ -45,6 +50,7 @@ class OpenAIServingTranscription(OpenAISpeechToText):
             return_tokens_as_token_ids=return_tokens_as_token_ids,
             task_type="transcribe",
             enable_force_include_usage=enable_force_include_usage,
+            usage_policy=usage_policy,
         )
 
     async def create_transcription(

--- a/vllm/entrypoints/speech_to_text/translation/serving.py
+++ b/vllm/entrypoints/speech_to_text/translation/serving.py
@@ -37,7 +37,6 @@ class OpenAIServingTranslation(OpenAISpeechToText):
         *,
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
-        enable_force_include_usage: bool = False,
         usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
@@ -46,7 +45,6 @@ class OpenAIServingTranslation(OpenAISpeechToText):
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
             task_type="translate",
-            enable_force_include_usage=enable_force_include_usage,
             usage_policy=usage_policy,
         )
 

--- a/vllm/entrypoints/speech_to_text/translation/serving.py
+++ b/vllm/entrypoints/speech_to_text/translation/serving.py
@@ -1,14 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING
 
 from fastapi import Request
 
-if TYPE_CHECKING:
-    from vllm.entrypoints.chat_utils import UsagePolicy
-
 from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.chat_utils import UsagePolicy
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
@@ -41,7 +38,7 @@ class OpenAIServingTranslation(OpenAISpeechToText):
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
         enable_force_include_usage: bool = False,
-        usage_policy: "UsagePolicy | None" = None,
+        usage_policy: UsagePolicy | None = None,
     ):
         super().__init__(
             engine_client=engine_client,

--- a/vllm/entrypoints/speech_to_text/translation/serving.py
+++ b/vllm/entrypoints/speech_to_text/translation/serving.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 
 from fastapi import Request
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.chat_utils import UsagePolicy
 
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.logger import RequestLogger
@@ -37,6 +41,7 @@ class OpenAIServingTranslation(OpenAISpeechToText):
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
         enable_force_include_usage: bool = False,
+        usage_policy: "UsagePolicy | None" = None,
     ):
         super().__init__(
             engine_client=engine_client,
@@ -45,6 +50,7 @@ class OpenAIServingTranslation(OpenAISpeechToText):
             return_tokens_as_token_ids=return_tokens_as_token_ids,
             task_type="translate",
             enable_force_include_usage=enable_force_include_usage,
+            usage_policy=usage_policy,
         )
 
     async def create_translation(

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -22,7 +22,6 @@ from vllm.entrypoints.openai.engine.protocol import (
     ErrorInfo,
     ErrorResponse,
     GenerationError,
-    StreamOptions,
 )
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
 from vllm.logger import current_formatter_type, init_logger
@@ -276,21 +275,6 @@ def jsonify_non_default_args(
 def log_non_default_args(args: Namespace | EngineArgs):
     non_default_args = get_non_default_args(args)
     logger.info("non-default args: %s", non_default_args)
-
-
-def should_include_usage(
-    stream_options: "StreamOptions | None", enable_force_include_usage: bool
-) -> tuple[bool, bool]:
-    if enable_force_include_usage:
-        return True, True
-    if stream_options:
-        include_usage = bool(stream_options.include_usage)
-        include_continuous_usage = include_usage and bool(
-            stream_options.continuous_usage_stats
-        )
-    else:
-        include_usage, include_continuous_usage = False, False
-    return include_usage, include_continuous_usage
 
 
 def process_lora_modules(


### PR DESCRIPTION
## Purpose
This PR is the first step towards implementing the RFC proposed in #36406, which aims to provide a unified mechanism for controlling usage statistics return behavior across all API endpoints.

In production environments, usage data (token counts) is typically the data source for billing and cost monitoring. Many tools — CherryStudio, Claude Code CLI, and various observability platforms — depend on the `usage` field returned in API responses.

However, vLLM's current behavior around usage statistics is inconsistent across endpoints. The `--enable-force-include-usage` flag behaves differently depending on which endpoint it is applied to, and for some endpoints it has no effect at all. 

Meanwhile, the decision logic for whether to include usage is implemented in three different ways across the codebase, a shared utility function should_include_usage, inline logic in `OpenAISpeechToText`, and hardcoded behavior in several endpoints.

This PR provides two semantically clear, consistently behaved CLI parameters, `--include-usage-policy` and `--continuous-usage-policy`, and introduces `should_include_usage` as a base method on `OpenAIServing`, giving every endpoint a unified interface for dynamic usage return control.

## Changes

### 1. `UsagePolicy` dataclass and CLI arguments

- `--include-usage-policy` (values: `always`)
- `--continuous-usage-policy` (values: `always`)

When `--include-usage-policy=always` is set, usage is always included in responses regardless of the client's request parameters. When `--continuous-usage-policy=always` is also set, usage is sent on every streaming chunk.

### 2. `should_include_usage` method hierarchy

A unified method across all serving classes (optional, for dynamic usage entrypoint), following the same resolution order:

1. Server-level `UsagePolicy`, overrides everything
2. Per-request `include_usage` / `continuous_usage`, when explicitly provided by the client
3. Endpoint-specific default , which varies by endpoint

### 3. Deprecated `--enable-force-include-usage`

The old flag is now converted to `UsagePolicy` at the router layer (`api_router.py`, `factories.py`). Its historical per-endpoint behavior is preserved through the conversion logic.

## No side effects

Without any server-level configuration, all entrypoints behave identically to the original code. The `--enable-force-include-usage` flag continues to work as before where it had effect.

