### PR TITLE
[Bug fix][Quantization] Fix dummy weight loading

### DIFF
--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.reload.layerwise import get_layerwise_info
 from vllm.model_executor.model_loader.reload.meta import materialize_meta_tensor
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
 from vllm.model_executor.model_loader.weight_utils import initialize_dummy_weights
@@ -28,6 +29,9 @@ class DummyModelLoader(BaseModelLoader):
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
         # materialize meta tensors as part of online quantization lifecycle
         for layer in model.modules():
+            info = get_layerwise_info(layer)
+            if info.can_load():
+                continue
             for name, param in get_layer_tensors(layer).items():
                 if param.device == torch.device("meta"):
                     setattr(layer, name, materialize_meta_tensor(param))

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -1,14 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import torch
 import torch.nn as nn
 
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
-from vllm.model_executor.model_loader.reload.layerwise import get_layerwise_info
-from vllm.model_executor.model_loader.reload.meta import materialize_meta_tensor
-from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
 from vllm.model_executor.model_loader.weight_utils import initialize_dummy_weights
 
 
@@ -27,15 +23,6 @@ class DummyModelLoader(BaseModelLoader):
         pass  # Nothing to download
 
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
-        # materialize meta tensors as part of online quantization lifecycle
-        for layer in model.modules():
-            info = get_layerwise_info(layer)
-            if info.can_load():
-                continue
-            for name, param in get_layer_tensors(layer).items():
-                if param.device == torch.device("meta"):
-                    setattr(layer, name, materialize_meta_tensor(param))
-
         # NOTE(woosuk): For accurate performance evaluation, we assign
         # random values to the weights.
         initialize_dummy_weights(model, model_config)

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -163,11 +163,8 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         )
 
         # Process and copy when all weights are loaded
-        if (
-            info.load_numel >= info.load_numel_total
-            and not isinstance(  # type: ignore[operator]
-                layer, (Attention, MLAAttention)
-            )
+        if info.load_numel >= info.load_numel_total and not isinstance(  # type: ignore[operator]
+            layer, (Attention, MLAAttention)
         ):
             _layerwise_process(layer, info)
 

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -211,7 +211,8 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
         elif info.load_numel <= 0:
             # first load but received no weights. This happens on dummy load
             if info.kernel_tensors is None:
-                materialize_layer(layer)
+                _layerwise_process(layer, info)
+                continue
 
             # reloading: place kernel tensors back as a fallback
             else:

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -11,7 +11,10 @@ from vllm.config import ModelConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    initialize_single_dummy_weight,
+)
 
 from .meta import (
     capture_layer_to_meta,
@@ -246,6 +249,12 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
     """
     # Materialize layer tensors onto device
     materialize_layer(layer)
+
+    # If no weights were loaded (e.g. dummy loading), initialize with
+    # small random values to avoid NaN from zero/garbage data
+    if not info.loaded_weights:
+        for tensor in get_layer_tensors(layer).values():
+            initialize_single_dummy_weight(tensor)
 
     # Reset online quantization flag so process_weights_after_loading
     # will run again during reload

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -163,8 +163,11 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         )
 
         # Process and copy when all weights are loaded
-        if info.load_numel >= info.load_numel_total and not isinstance(  # type: ignore[operator]
-            layer, (Attention, MLAAttention)
+        if (
+            info.load_numel >= info.load_numel_total
+            and not isinstance(  # type: ignore[operator]
+                layer, (Attention, MLAAttention)
+            )
         ):
             _layerwise_process(layer, info)
 
@@ -252,7 +255,7 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
 
     # If no weights were loaded (e.g. dummy loading), initialize with
     # small random values to avoid NaN from zero/garbage data
-    if not info.loaded_weights:
+    if len(info.loaded_weights) <= 0:
         for tensor in get_layer_tensors(layer).values():
             initialize_single_dummy_weight(tensor)
 

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -239,10 +239,12 @@ def convert_bin_to_safetensor_file(
     sf_size = os.stat(sf_filename).st_size
     pt_size = os.stat(pt_filename).st_size
     if (sf_size - pt_size) / pt_size > 0.01:
-        raise RuntimeError(f"""The file size different is more than 1%:
+        raise RuntimeError(
+            f"""The file size different is more than 1%:
          - {sf_filename}: {sf_size}
          - {pt_filename}: {pt_size}
-         """)
+         """
+        )
 
     # check if the tensors are the same
     reloaded = load_file(sf_filename)
@@ -1334,6 +1336,9 @@ def initialize_single_dummy_weight(
     high: float = 1e-3,
     seed: int = 1234,
 ) -> None:
+    if param.device.type == "meta":
+        return  # deferred to finalize_layerwise_processing (e.g. online quant)
+
     if not torch.is_floating_point(param):
         if current_platform.is_rocm():
             # On ROCm, integer params (e.g. GPTQ qweight/qzeros) are left


### PR DESCRIPTION
## Purpose
Fix OOM when using `--load-format dummy` with online quantization methods (e.g. `--quantization fp8` with dynamic activation scaling).

## Test Plan
`vllm serve <large-MoE-model> --quantization fp8 --load-format dummy` no longer OOMs
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

