### PR TITLE
fix(v1): Handle max_model_len overflow gracefully instead of crashing

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3428,11 +3428,20 @@ class GPUModelRunner(
 
             start_idx = self.input_batch.num_tokens_no_spec[req_idx]
             end_idx = start_idx + num_sampled_ids
-            assert end_idx <= self.max_model_len, (
-                "Sampled token IDs exceed the max model length. "
-                f"Total number of tokens: {end_idx} > max_model_len: "
-                f"{self.max_model_len}"
-            )
+
+            # Instead of crashing the entire engine with an assertion,
+            # mark requests that exceed max_model_len as invalid.
+            # The scheduler will handle them as FINISHED_LENGTH_CAPPED.
+            if end_idx > self.max_model_len:
+                # Add this request to invalid indices so it's filtered out
+                if req_idx not in invalid_req_indices:
+                    invalid_req_indices.append(req_idx)
+                if self.use_async_scheduling:
+                    invalid_req_indices_set.add(req_idx)
+                else:
+                    # Clear sampled tokens for this request
+                    valid_sampled_token_ids[req_idx].clear()
+                continue
 
             self.input_batch.token_ids_cpu[req_idx, start_idx:end_idx] = sampled_ids
             self.input_batch.is_token_ids[req_idx, start_idx:end_idx] = True


### PR DESCRIPTION
Fixes #38428

## Problem
When using the V1 engine/scheduler with realtime audio models, reaching the `max_model_len` limit results in a hard crash (`EngineDeadError`) of the entire engine instead of a graceful termination of the stream. This happens because of a strict assertion in `_bookkeeping_sync`:

```python
assert end_idx <= self.max_model_len, (
    "Sampled token IDs exceed the max model length. "
    f"Total number of tokens: {end_idx} > max_model_len: "
    f"{self.max_model_len}"
)
```

This brings down the entire EngineCore instead of simply stopping generation for that specific request with `finish_reason="length"`.

## Solution
Replace the hard assertion with graceful overflow handling:

1. **Mark exceeded requests as invalid** - Add them to `invalid_req_indices` so they get properly filtered out
2. **Clear their sampled tokens** - Prevent further processing of the overflow tokens  
3. **Allow engine to continue** - Other requests can continue to be served normally

The existing scheduler infrastructure already handles `FINISHED_LENGTH_CAPPED` status which maps to `FinishReason.LENGTH`, so this change integrates seamlessly with the current architecture.

## Impact
- **Critical bug fix** - Prevents entire engine crashes on token limit overflow
- **Maintains compatibility** - Uses existing `invalid_req_indices` pattern and `FINISHED_LENGTH_CAPPED` status
- **Enables streaming use cases** - Realtime audio and other continuous generation scenarios can handle length limits gracefully
- **No breaking changes** - Existing behavior for valid requests is unchanged

## Testing
- Validated the fix logic with a simulation test
- Confirmed proper handling of both async and sync scheduling modes
- Syntax and import checks pass