### PR TITLE
[Build] Add SM121 (DGX Spark / GB10) to published build targets

### DIFF
--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -14,7 +14,7 @@ $python_executable -m pip install -r requirements/build.txt -r requirements/cuda
 # Limit the number of parallel jobs to avoid OOM
 export MAX_JOBS=1
 # Make sure release wheels are built for the following architectures
-export TORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 8.6 8.9 9.0+PTX"
+export TORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 8.6 8.9 9.0 10.0 12.0 12.1+PTX"
 
 bash tools/check_repo.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,7 +188,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Explicitly set the list to avoid issues with torch 2.2
 # See https://github.com/pytorch/pytorch/pull/123243
 # From versions.json: .torch.cuda_arch_list
-ARG torch_cuda_arch_list='7.0 7.5 8.0 8.9 9.0 10.0 12.0'
+ARG torch_cuda_arch_list='7.0 7.5 8.0 8.9 9.0 10.0 12.0 12.1'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 #################### BUILD BASE IMAGE ####################
 
@@ -801,7 +801,7 @@ ARG PIP_EXTRA_INDEX_URL UV_EXTRA_INDEX_URL
 ENV UV_HTTP_TIMEOUT=500
 
 # install kv_connectors if requested
-ARG torch_cuda_arch_list='7.0 7.5 8.0 8.9 9.0 10.0 12.0'
+ARG torch_cuda_arch_list='7.0 7.5 8.0 8.9 9.0 10.0 12.0 12.1'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=requirements/kv_connectors.txt,target=/tmp/kv_connectors.txt,ro \

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -20,7 +20,7 @@ variable "NVCC_THREADS" {
 }
 
 variable "TORCH_CUDA_ARCH_LIST" {
-  default = "8.0 8.9 9.0 10.0"
+  default = "8.0 8.9 9.0 10.0 12.0 12.1"
 }
 
 variable "COMMIT" {

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -32,7 +32,7 @@
       "default": "false"
     },
     "TORCH_CUDA_ARCH_LIST": {
-      "default": "7.0 7.5 8.0 8.9 9.0 10.0 12.0"
+      "default": "7.0 7.5 8.0 8.9 9.0 10.0 12.0 12.1"
     },
     "MAX_JOBS": {
       "default": "2"

--- a/tools/flashinfer-build.sh
+++ b/tools/flashinfer-build.sh
@@ -35,7 +35,7 @@ elif [[ "${CUDA_VERSION}" == 12.[8-9]* ]]; then
     FI_TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0"
 else
     # CUDA 13.0+
-    FI_TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a 10.0f 12.0"
+    FI_TORCH_CUDA_ARCH_LIST="7.5 8.0 8.9 9.0a 10.0f 12.0 12.1"
 fi
 
 echo "🏗️ Building FlashInfer AOT for arches: ${FI_TORCH_CUDA_ARCH_LIST}"


### PR DESCRIPTION
## Summary

- Add compute capability 12.1 (SM121) to `TORCH_CUDA_ARCH_LIST` in all build configurations: release wheel CI, Dockerfile, docker-bake.hcl, versions.json, and FlashInfer AOT build
- `CMakeLists.txt` already lists 12.1 in `CUDA_SUPPORTED_ARCHS` for CUDA 12.8+ and 13.0+, and all kernel-specific arch lists (CUTLASS, Marlin FP8, MoE, NVFP4) already include 12.1 — but the build scripts never passed 12.1 in `TORCH_CUDA_ARCH_LIST`, so the intersection filtering excluded it from all published artifacts
- This is the minimal change needed so that published wheels and Docker images include SM121 kernels for DGX Spark / GB10 users out of the box

## Context

The NVIDIA GB10 GPU in DGX Spark reports compute capability 12.1 (SM121). Without native kernels in published builds, users must either build from source or rely on PTX JIT compilation via the 12.0+PTX forward-compat path (slower first-run, no guarantee of correctness for all kernels).

**Upstream PyTorch fix:** The CMake auto-detection bug that corrupts `12.1` → `12.1(2.0)` when building PyTorch from source on SM121 hardware has fixes in review: [pytorch/pytorch#174065](https://github.com/pytorch/pytorch/pull/174065) and [pytorch/pytorch#173754](https://github.com/pytorch/pytorch/pull/173754). I independently reproduced and verified both fixes on DGX Spark hardware (see comments on those PRs). PyTorch cu130 aarch64 nightly wheels already ship with `12.0+PTX` which covers SM121 via JIT.

**Relationship to existing PRs:** [#31740](https://github.com/vllm-project/vllm/pull/31740) includes these build config changes among 27 files of broader SM121 platform support, but has been `CONFLICTING` since January. This PR extracts just the build target additions — 5 files, 6 lines changed — to unblock SM121 in published artifacts independently.

Addresses #36821.

## Test evidence

Tested on NVIDIA DGX Spark:

| Component | Value |
|-----------|-------|
| GPU | NVIDIA GB10 |
| Compute capability | 12.1 (SM121) |
| Architecture | aarch64 |
| OS | Ubuntu 24.04.4 LTS |
| CUDA | 13.0, V13.0.88 |
| Driver | 590.48.01 |

Confirmed that `CMakeLists.txt` already supports 12.1 in `CUDA_SUPPORTED_ARCHS` and all kernel-specific arch lists (`SCALED_MM_ARCHS`, `FP4_ARCHS`, `MLA_ARCHS`, `CUTLASS_MOE_DATA_ARCHS`, `MARLIN_FP8_ARCHS`, `MARLIN_MOE_FP8_ARCHS`). The only gap was the `TORCH_CUDA_ARCH_LIST` in build scripts.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/scripts/build.sh` | Add `10.0 12.0 12.1+PTX` to release wheel arch list |
| `docker/Dockerfile` | Add `12.1` to both `torch_cuda_arch_list` ARGs (lines 191, 804) |
| `docker/docker-bake.hcl` | Add `12.0 12.1` to default arch list |
| `docker/versions.json` | Match Dockerfile ARG update |
| `tools/flashinfer-build.sh` | Add `12.1` to CUDA 13.0+ FlashInfer AOT arch list |

## Test plan

- [ ] Verify `docker buildx bake --print` shows 12.1 in resolved `torch_cuda_arch_list`
- [ ] Verify wheel build with CUDA 13.0 includes SM121 kernels (`cuobjdump` check)
- [ ] Run vLLM inference on DGX Spark with published image (no `--enforce-eager` needed)