### PR TITLE
[CI] Add temperature=0.0, reduce max_tokens, and add debug prints to audio_in_video tests

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_audio_in_video.py
+++ b/tests/entrypoints/openai/chat_completion/test_audio_in_video.py
@@ -64,11 +64,12 @@ async def test_online_audio_in_video(
     ]
 
     # multi-turn to test mm processor cache as well
-    for _ in range(2):
+    for turn in range(2):
         chat_completion = await client.chat.completions.create(
             model=MODEL_NAME,
             messages=messages,
             max_tokens=16,
+            temperature=0.0,
             extra_body={
                 "mm_processor_kwargs": {
                     "use_audio_in_video": True,
@@ -78,6 +79,12 @@ async def test_online_audio_in_video(
 
         assert len(chat_completion.choices) == 1
         choice = chat_completion.choices[0]
+        print(
+            f"[DEBUG][single-video] turn={turn} "
+            f"finish_reason={choice.finish_reason!r} "
+            f"content={choice.message.content!r} "
+            f"usage={chat_completion.usage}"
+        )
         assert choice.finish_reason == "length"
 
 
@@ -111,11 +118,12 @@ async def test_online_audio_in_video_multi_videos(
     ]
 
     # multi-turn to test mm processor cache as well
-    for _ in range(2):
+    for turn in range(2):
         chat_completion = await client.chat.completions.create(
             model=MODEL_NAME,
             messages=messages,
             max_tokens=16,
+            temperature=0.0,
             extra_body={
                 "mm_processor_kwargs": {
                     "use_audio_in_video": True,
@@ -125,6 +133,12 @@ async def test_online_audio_in_video_multi_videos(
 
         assert len(chat_completion.choices) == 1
         choice = chat_completion.choices[0]
+        print(
+            f"[DEBUG][multi-video] turn={turn} "
+            f"finish_reason={choice.finish_reason!r} "
+            f"content={choice.message.content!r} "
+            f"usage={chat_completion.usage}"
+        )
         assert choice.finish_reason == "length"
 
 

--- a/tests/entrypoints/openai/chat_completion/test_audio_in_video.py
+++ b/tests/entrypoints/openai/chat_completion/test_audio_in_video.py
@@ -68,7 +68,7 @@ async def test_online_audio_in_video(
         chat_completion = await client.chat.completions.create(
             model=MODEL_NAME,
             messages=messages,
-            max_tokens=16,
+            max_tokens=8,
             temperature=0.0,
             extra_body={
                 "mm_processor_kwargs": {
@@ -122,7 +122,7 @@ async def test_online_audio_in_video_multi_videos(
         chat_completion = await client.chat.completions.create(
             model=MODEL_NAME,
             messages=messages,
-            max_tokens=16,
+            max_tokens=8,
             temperature=0.0,
             extra_body={
                 "mm_processor_kwargs": {


### PR DESCRIPTION
- Set `temperature=0.0` in `test_online_audio_in_video` and `test_online_audio_in_video_multi_videos` to make generation deterministic. These tests had no temperature or seed set, which could cause non-deterministic output length and sporadic `finish_reason='stop'` instead of the expected `'length'`.
- Reduce `max_tokens` from 16 to 8 for extra certainty that the model hits the token limit before completing its response.
- Add debug prints showing `finish_reason`, `content`, and `usage` per turn to aid diagnosis if the assertion still fails.

## Test plan
- [x] `pytest tests/entrypoints/openai/chat_completion/test_audio_in_video.py -s -v`

cc @kenroche 