### PR TITLE
[Bugfix] Fix Step-3.5-Flash MTP acceptance rate by preserving trained shared_head weights

### DIFF
--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1262,6 +1262,11 @@ class SupportsEagleBase(Protocol):
     A flag that indicates this model has trained its own input embeddings.
     """
 
+    has_own_shared_head: bool = False
+    """
+    A flag that indicates this MTP model has trained its own shared_head.head.
+    """
+
 
 @overload
 def supports_any_eagle(model: type[object]) -> TypeIs[type[SupportsEagleBase]]: ...

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -870,6 +870,8 @@ def process_eagle_weight(
         model.has_own_lm_head = True
     if "embed_tokens" in name:
         model.has_own_embed_tokens = True
+    if "shared_head" in name:
+        model.has_own_shared_head = True
 
 
 def get_layer_index(feature_layer_index: int, num_hidden_layers: int) -> int:

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1444,19 +1444,28 @@ class SpecDecodeBaseProposer:
             # ParallelLMHead inside each MTP layer), not self.model.lm_head.
             # If the checkpoint omits a copy of the lm_head weights at the
             # MTP layer path, shared_head.head stays uninitialised and
-            # produces NaN logits. Always share it explicitly.
-            inner = getattr(self.model, "model", None)
-            layers = getattr(inner, "layers", None) if inner else None
-            if layers is not None:
-                items = layers.values() if isinstance(layers, nn.ModuleDict) else layers
-                for layer in items:
-                    sh = getattr(layer, "shared_head", None)
-                    if sh is not None and hasattr(sh, "head"):
-                        del sh.head
-                        sh.head = target_language_model.lm_head
-                        logger.info(
-                            "Shared target model lm_head with MTP shared_head.head."
-                        )
+            # produces NaN logits. Share it explicitly unless the model has
+            # its own trained shared_head weights (e.g., Step-3.5-Flash).
+            if not getattr(self.model, "has_own_shared_head", False):
+                inner = getattr(self.model, "model", None)
+                layers = getattr(inner, "layers", None) if inner else None
+                if layers is not None:
+                    items = (
+                        layers.values() if isinstance(layers, nn.ModuleDict) else layers
+                    )
+                    for layer in items:
+                        sh = getattr(layer, "shared_head", None)
+                        if sh is not None and hasattr(sh, "head"):
+                            del sh.head
+                            sh.head = target_language_model.lm_head
+                            logger.info(
+                                "Shared target model lm_head with MTP shared_head.head."
+                            )
+            else:
+                logger.info(
+                    "MTP model has its own shared_head weights. "
+                    "Keeping separate from target model lm_head."
+                )
 
         if self.use_local_argmax_reduction:
             if not hasattr(self.model, "get_top_tokens"):


### PR DESCRIPTION
## Summary

- Fix Step-3.5-Flash MTP speculative decoding acceptance rate dropping from ~97% to ~4%
- Add `has_own_shared_head` flag to detect if MTP model has trained shared_head weights
- Skip weight sharing when MTP model has its own trained shared_head

## Problem

Step-3.5-Flash MTP has independently trained `shared_head.head` weights in the checkpoint. The existing code was incorrectly overwriting these weights with the target model's `lm_head`, causing the MTP model to lose its learned predictions.

## Solution

Extend the existing `has_own_lm_head` pattern from `SupportsEagleBase` to include `has_own_shared_head`:

1. Add `has_own_shared_head: bool = False` to `SupportsEagleBase` protocol
2. Auto-detect during weight loading in `process_eagle_weight`
3. Check flag before sharing `lm_head` with `shared_head.head`

## Test Plan

Tested with Step-3.5-Flash MTP - acceptance rate restored from ~4% to expected levels.

Fixes #38339