### PR TITLE
[Bugfix] Fix Step-3.5-Flash MTP acceptance rate by detecting own shared_head weights

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1444,7 +1444,11 @@ class SpecDecodeBaseProposer:
             # ParallelLMHead inside each MTP layer), not self.model.lm_head.
             # If the checkpoint omits a copy of the lm_head weights at the
             # MTP layer path, shared_head.head stays uninitialised and
-            # produces NaN logits. Always share it explicitly.
+            # produces NaN logits. Share it explicitly only if the MTP model
+            # does not have its own trained shared_head weights.
+            # Some MTP models (e.g., Step-3.5-Flash, DeepSeek V3.2) have
+            # independently trained shared_head weights that should not be
+            # overwritten.
             inner = getattr(self.model, "model", None)
             layers = getattr(inner, "layers", None) if inner else None
             if layers is not None:
@@ -1452,11 +1456,42 @@ class SpecDecodeBaseProposer:
                 for layer in items:
                     sh = getattr(layer, "shared_head", None)
                     if sh is not None and hasattr(sh, "head"):
-                        del sh.head
-                        sh.head = target_language_model.lm_head
-                        logger.info(
-                            "Shared target model lm_head with MTP shared_head.head."
-                        )
+                        # Check if shared_head.head has valid trained weights.
+                        # If it has NaN (uninitialized) or equals target lm_head,
+                        # share the target's lm_head. Otherwise, keep MTP's own
+                        # weights (e.g., Step-3.5-Flash has independently trained
+                        # shared_head weights).
+                        has_own_trained_weights = False
+                        if hasattr(sh.head, "weight") and hasattr(
+                            target_language_model.lm_head, "weight"
+                        ):
+                            mtp_head_weight = sh.head.weight
+                            target_head_weight = target_language_model.lm_head.weight
+                            if isinstance(mtp_head_weight, torch.Tensor) and isinstance(
+                                target_head_weight, torch.Tensor
+                            ):
+                                # Check if weights are valid (not NaN/uninitialized)
+                                if not torch.isnan(mtp_head_weight).any():
+                                    # Weights are initialized, check if different
+                                    # from target lm_head
+                                    if not torch.equal(
+                                        mtp_head_weight.cpu(),
+                                        target_head_weight.cpu(),
+                                    ):
+                                        # MTP has its own trained weights
+                                        has_own_trained_weights = True
+
+                        if has_own_trained_weights:
+                            logger.info(
+                                "MTP model has its own trained shared_head weights. "
+                                "Keeping separate from target model lm_head."
+                            )
+                        else:
+                            del sh.head
+                            sh.head = target_language_model.lm_head
+                            logger.info(
+                                "Shared target model lm_head with MTP shared_head.head."
+                            )
 
         if self.use_local_argmax_reduction:
             if not hasattr(self.model, "get_top_tokens"):


### PR DESCRIPTION
## Summary

- Fix Step-3.5-Flash MTP speculative decoding acceptance rate dropping from ~97% to ~4%
- Detect whether `shared_head.head` has valid trained weights before deciding to share

## Problem

Different MTP models have different `shared_head.head` weight scenarios:

| Scenario | shared_head.head.weight | Behavior Needed |
|----------|------------------------|-----------------|
| Uninitialized (NaN) | NaN | **Must share** target lm_head |
| Already equals target | = target lm_head | Can share (no-op) |
| Independently trained | ≠ target lm_head, valid | **Must NOT share** |

The original code always shared target's lm_head, which broke Step-3.5-Flash and DeepSeek V3.2 that have independently trained shared_head weights.

## Solution

Detect valid trained weights by:
1. Check if `shared_head.head.weight` contains NaN (uninitialized)
2. If valid, check if it differs from target lm_head

```
if has NaN:
    → share target lm_head
elif equals target lm_head:
    → share target lm_head (no-op)
else:
    → keep MTP's own trained weights
```

## Test Plan

Tested with Step-3.5-Flash MTP - acceptance rate restored to expected levels.

Fixes #38339