### PR TITLE
fix: pin 1 unpinned action

### DIFF
--- a/.github/workflows/macos-smoke-test.yml
+++ b/.github/workflows/macos-smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: |


### PR DESCRIPTION
Re-submission of #38275. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins a GitHub Action to an immutable commit SHA instead of a mutable version tag.

- Pin `astral-sh/setup-uv@v7` to full 40-character SHA

## How to verify

Review the diff, the change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v7` becomes `action@abc123 # v7`, original version preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)