### PR TITLE
[Bugfix][Quantization] Fix PerTensorScale loading with tuple shard_id in MergedColumnParallelLinear

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -910,7 +910,15 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         self.validate_shard_id(loaded_shard_id)
         if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
             if isinstance(param, PerTensorScaleParameter):
-                param.load_merged_column_weight(loaded_weight=loaded_weight, shard_id=0)
+                if isinstance(loaded_shard_id, tuple):
+                    for idx in loaded_shard_id:
+                        param.load_merged_column_weight(
+                            loaded_weight=loaded_weight, shard_id=idx
+                        )
+                else:
+                    param.load_merged_column_weight(
+                        loaded_weight=loaded_weight, shard_id=0
+                    )
                 return
             elif type(param) in (RowvLLMParameter, BasevLLMParameter):
                 param.load_merged_column_weight(loaded_weight=loaded_weight)


### PR DESCRIPTION
## Purpose

Fix a bug(https://github.com/vllm-project/vllm/issues/38197) in `MergedColumnParallelLinear.weight_loader_v2` where `PerTensorScaleParameter` loading with a **tuple `shard_id`** (e.g., `(0, 1, 2)`) incorrectly hardcodes `shard_id=0`, causing only the first scale slot to be populated. This results in corrupted weights and garbage output for models using fused projections with tuple shard IDs under FP8 static per-tensor quantization.

**Affected models**: Qwen3.5 (both dense and MoE variants) with FP8 static per-tensor quantization (compressed-tensors).

### Bug Location

In `vllm/model_executor/layers/linear.py`, `MergedColumnParallelLinear.weight_loader_v2`:

```python
if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
    if isinstance(param, PerTensorScaleParameter):
        # BUG: hardcodes shard_id=0, ignoring the tuple
        param.load_merged_column_weight(loaded_weight=loaded_weight, shard_id=0)
        return
```

### Root Cause

Qwen3.5 introduces **Gated Delta Net (GDN)** layers with a fused projection `in_proj_qkvz`, which merges `in_proj_qkv` (3 partitions) and `in_proj_z` (1 partition) into a single `MergedColumnParallelLinear` with `output_sizes=[key_dim, key_dim, value_dim, value_dim]` (4 output partitions).

The `stacked_params_mapping` defines:
```python
("in_proj_qkvz", "in_proj_qkv", (0, 1, 2)),  # tuple shard_id
("in_proj_qkvz", "in_proj_z", 3),             # int shard_id
```

When loading `in_proj_qkv.weight_scale` (a per-tensor scalar), `shard_id=(0, 1, 2)` means this scale applies to partitions 0, 1, and 2. But the buggy code only writes to position 0, leaving positions 1 and 2 at the initialization value of `torch.finfo(torch.float32).min` (≈ -3.4e38).

This causes `requantize_with_max_scale` to dequantize partitions 1 and 2 (K and V projections) with the garbage scale value, completely destroying the weight data.

### Why only Qwen3.5 + per-tensor is affected

| Configuration | Affected | Reason |
|---|---|---|
| Qwen3 | No | No GDN layers, no tuple shard_id |
| Per-channel quant | No | Doesn't use `requantize_with_max_scale` |
| Dynamic quant | No | Scales computed at runtime |
| SGLang | No | Doesn't fuse `in_proj_qkv` and `in_proj_z` into one layer |

## Test Plan

Reproduce by running Qwen3.5 models with FP8 static per-tensor quantized checkpoints:

```bash
# Garbled output before fix:
vllm serve /path/to/Qwen3.5-0.8B_static_per_tensor \
    --quantization compressed-tensors

# Verify weight_scale values with:
python -c "
import torch
from vllm import LLM
llm = LLM(model='/path/to/Qwen3.5-0.8B_static_per_tensor',
           quantization='compressed-tensors')
for name, param in llm.llm_engine.model_executor.driver_worker.model_runner.model.named_parameters():
    if 'in_proj_qkvz' in name and 'weight_scale' in name:
        print(f'{name}: {param.data}')
        # Before fix: tensor([0.05, -3.4e38, -3.4e38, 0.04])
        # After fix:  tensor([0.05,  0.05,    0.05,   0.04])
"
```

## Test Result

**Before fix:**

| Model | Quantization | Result |
|-------|-------------|--------|
| Qwen3.5-MoE static per-tensor | FP8 | ❌ Garbled output |
| Qwen3.5-dense static per-tensor | FP8 | ❌ Garbled output |

**After fix:**

| Model | Quantization | Result |
|-------|-------------|--------|
| Qwen3.5-MoE static per-tensor | FP8 | ✅ Normal output |
| Qwen3.5-dense static per-tensor | FP8 | ✅ Normal output |
| Qwen3-MoE static per-tensor | FP8 | ✅ Normal (no regression) |
| Qwen3.5-dense static per-channel | FP8 | ✅ Normal (no regression) |
| Qwen3.5-MoE dynamic | FP8 | ✅ Normal (no regression) |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
