### PR TITLE
[BugFix] Fix shared reference bug in parsers for n>=2 and streaming

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -1971,9 +1971,6 @@ class TestNChoicesParserIsolation:
                 yield  # async generator that yields nothing
 
         tokenizer = get_tokenizer(MODEL_NAME)
-        reasoning_parser = None
-        if getattr(serving_chat, "reasoning_parser_cls", None):
-            reasoning_parser = serving_chat.reasoning_parser_cls(tokenizer)
 
         async for _ in serving_chat.chat_completion_stream_generator(
             request=req,
@@ -1985,7 +1982,6 @@ class TestNChoicesParserIsolation:
             request_metadata=RequestResponseMetadata(
                 request_id=req.request_id, model_name=req.model
             ),
-            reasoning_parser=reasoning_parser,
         ):
             pass
 
@@ -2054,6 +2050,7 @@ class TestNChoicesParserIsolation:
         )
         await self._run_stream(serving_chat, req)
 
+        assert len(instances) <= 2
         first, last = instances[0], instances[-1]
 
         # choice 0 completes its reasoning block: state transitions REASONING → CONTENT.

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -574,6 +574,16 @@ def _build_serving_render(
     )
 
 
+def _make_serving_chat() -> OpenAIServingChat:
+    engine = MagicMock(spec=AsyncLLM)
+    engine.errored = False
+    engine.model_config = MockModelConfig()
+    engine.input_processor = MagicMock()
+    engine.io_processor = MagicMock()
+    engine.renderer = _build_renderer(engine.model_config)
+    return _build_serving_chat(engine)
+
+
 def _build_serving_chat(engine: AsyncLLM) -> OpenAIServingChat:
     models = OpenAIServingModels(
         engine_client=engine,
@@ -1929,3 +1939,135 @@ class TestCreateRemainingArgsDelta:
         assert tc.type == "function"
         assert tc.function.name is None
         assert tc.function.arguments == '{"data": "value"}'
+
+
+class TestNChoicesParserIsolation:
+    """Regression tests for the shared-reference bug when n >= 2.
+
+    Each streaming choice must receive its own parser instance so that
+    accumulated state in one choice does not bleed into another.
+    """
+
+    @pytest.fixture
+    def serving_chat(self):
+        return _make_serving_chat()
+
+    @pytest.fixture
+    def dummy_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+    async def _run_stream(self, serving_chat, req):
+        async def empty_result_generator():
+            if False:
+                yield  # async generator that yields nothing
+
+        tokenizer = get_tokenizer(MODEL_NAME)
+        reasoning_parser = None
+        if getattr(serving_chat, "reasoning_parser_cls", None):
+            reasoning_parser = serving_chat.reasoning_parser_cls(tokenizer)
+
+        async for _ in serving_chat.chat_completion_stream_generator(
+            request=req,
+            result_generator=empty_result_generator(),
+            request_id=req.request_id,
+            model_name=req.model,
+            conversation=[],
+            tokenizer=tokenizer,
+            request_metadata=RequestResponseMetadata(
+                request_id=req.request_id, model_name=req.model
+            ),
+            reasoning_parser=reasoning_parser,
+        ):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_tool_parser_state_is_independent_per_choice(
+        self, serving_chat, dummy_tools
+    ):
+        """Each choice gets its own tool-parser; state from choice 0 must not affect choice 1."""
+        from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
+
+        instances: list[Hermes2ProToolParser] = []
+
+        def tracking_factory(tok, tools=None):
+            inst = Hermes2ProToolParser(get_tokenizer(MODEL_NAME))
+            instances.append(inst)
+            return inst
+
+        serving_chat.tool_parser = tracking_factory
+        serving_chat.enable_auto_tools = True
+
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hi"}],
+            n=2,
+            tools=dummy_tools,
+        )
+        await self._run_stream(serving_chat, req)
+
+        first, last = instances[0], instances[-1]
+
+        # Simulate choice 0 mid-stream.
+        first.current_tool_id = 2
+        first.prev_tool_call_arr = [{"name": "f"}, {"name": "g"}, {"name": "h"}]
+        first.streamed_args_for_tool = ['{"a": 1}', '{"b": 2}', '{"x":']
+
+        # With the bug first IS last, so these fail (state is shared).
+        # With the fix last is independent and retains its initial values.
+        assert last.current_tool_id == -1
+        assert last.prev_tool_call_arr == []
+        assert last.streamed_args_for_tool == []
+
+    @pytest.mark.asyncio
+    async def test_reasoning_parser_state_is_independent_per_choice(self, serving_chat):
+        """Each choice gets its own reasoning-parser; state from choice 0 must not affect choice 1."""
+        from vllm.reasoning.olmo3_reasoning_parser import (
+            Olmo3ReasoningParser,
+            Olmo3ReasoningState,
+        )
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.get_vocab.return_value = {}
+
+        instances: list[Olmo3ReasoningParser] = []
+
+        def tracking_factory(tok, *, chat_template_kwargs=None):
+            inst = Olmo3ReasoningParser(mock_tokenizer)
+            instances.append(inst)
+            return inst
+
+        serving_chat.reasoning_parser_cls = tracking_factory
+
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hi"}],
+            n=2,
+        )
+        await self._run_stream(serving_chat, req)
+
+        first, last = instances[0], instances[-1]
+
+        # choice 0 completes its reasoning block: state transitions REASONING → CONTENT.
+        first.extract_reasoning_streaming(
+            "", "<think>thought</think>", "<think>thought</think>", [], [1], [1]
+        )
+        assert first.buffer.state == Olmo3ReasoningState.CONTENT
+
+        # With the bug first IS last, so last.buffer.state is also CONTENT → fail.
+        # With the fix last is independent and still in the initial REASONING state.
+        assert last.buffer.state == Olmo3ReasoningState.REASONING
+        delta = last.extract_reasoning_streaming(
+            "", "deep thought", "deep thought", [], [2], [2]
+        )
+        assert delta is not None
+        assert delta.reasoning == "deep thought"
+        assert delta.content is None

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -556,6 +556,26 @@ class OpenAIServingChat(OpenAIServing):
         else:
             all_previous_token_ids = None
 
+        try:
+            if self.reasoning_parser_cls:
+                if tokenizer is None:
+                    raise ValueError(
+                        "Tokenizer not available when `skip_tokenizer_init=True`"
+                    )
+
+                reasoning_parsers = [
+                    self.reasoning_parser_cls(
+                        tokenizer,
+                        chat_template_kwargs=request.chat_template_kwargs,  # type: ignore
+                    )
+                    for _ in range(num_choices)
+                ]
+        except Exception as e:
+            logger.exception("Error in reasoning parser creation.")
+            data = self.create_streaming_error_response(str(e))
+            yield f"data: {data}\n\n"
+            yield "data: [DONE]\n\n"
+            return
         # Prepare the tool parser if it's needed
         try:
             if tool_choice_auto and self.tool_parser:
@@ -566,7 +586,8 @@ class OpenAIServingChat(OpenAIServing):
 
                 tool_parsers: list[ToolParser | None] = [
                     self.tool_parser(tokenizer, request.tools)
-                ] * num_choices
+                    for _ in range(num_choices)
+                ]
             else:
                 tool_parsers = [None] * num_choices
         except Exception as e:
@@ -675,6 +696,8 @@ class OpenAIServingChat(OpenAIServing):
                 for output in res.outputs:
                     i = output.index
                     tool_parser = tool_parsers[i]
+                    if self.reasoning_parser_cls:
+                        reasoning_parser = reasoning_parsers[i]
 
                     if (
                         reasoning_parser


### PR DESCRIPTION


## Purpose

Fix a shared-reference bug in tool parsers and reasoning parsers when `n >= 2`.

Previously, `tool_parsers` was initialized as:

```python
tool_parsers = [self.tool_parser(tokenizer, request.tools)] * num_choices
```

The `* num_choices` list multiplication creates `num_choices` references to the **same** parser instance. As a result, stateful accumulation in one choice (e.g., `current_tool_id`, `prev_tool_call_arr`, `streamed_args_for_tool`) bleeds into all other choices mid-stream.

The same pattern was present for reasoning parsers: each choice shared a single parser instance instead of owning one.

This PR fixes both issues by using list comprehensions so that each choice receives its own independent parser instance. It also assigns the per-choice reasoning parser inside the per-output loop so that `reasoning_parser` always refers to the correct instance for the current `output.index`.

## Test Plan

Regression tests added in `tests/entrypoints/openai/chat_completion/test_serving_chat.py` (`TestNChoicesParserIsolation`):

```bash
pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py::TestNChoicesParserIsolation -v
```

## Test Result

```
tests/entrypoints/openai/chat_completion/test_serving_chat.py::TestNChoicesParserIsolation::test_tool_parser_state_is_independent_per_choice PASSED
tests/entrypoints/openai/chat_completion/test_serving_chat.py::TestNChoicesParserIsolation::test_reasoning_parser_state_is_independent_per_choice PASSED
```

Both tests fail on the code before this patch (the shared-reference bug is reproduced) and pass after.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

