### PR TITLE
[Benchmark] Fix Dataset infinite loop when input_len is too small

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2426,7 +2426,7 @@ class SonnetDataset(BenchmarkDataset):
 
         prefix_lines = self.data[:num_prefix_lines]
 
-        _MAX_SAMPLE_ATTEMPTS = num_requests * 10
+        _MAX_SAMPLE_ATTEMPTS = num_requests * 100
         samples = []
         ind = 0
         attempts = 0

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2409,11 +2409,37 @@ class SonnetDataset(BenchmarkDataset):
         # Determine how many poem lines to use.
         num_input_lines = round((input_len - base_offset) / avg_len)
         num_prefix_lines = max(round((prefix_len - base_offset) / avg_len), 0)
+
+        if num_input_lines <= 0:
+            raise ValueError(
+                f"'input_len' ({input_len}) is too small to fit any poem "
+                f"lines after the base prompt ({base_offset} tokens). "
+                f"Please increase 'input_len'."
+            )
+        if num_input_lines <= num_prefix_lines:
+            raise ValueError(
+                f"'input_len' ({input_len}) leaves room for only "
+                f"{num_input_lines} poem line(s), which is not enough to "
+                f"exceed the prefix ({num_prefix_lines} line(s)). "
+                f"Please increase 'input_len' or decrease 'prefix_len'."
+            )
+
         prefix_lines = self.data[:num_prefix_lines]
 
+        _MAX_SAMPLE_ATTEMPTS = num_requests * 10
         samples = []
         ind = 0
+        attempts = 0
         while len(samples) < num_requests:
+            if attempts >= _MAX_SAMPLE_ATTEMPTS:
+                raise RuntimeError(
+                    f"Failed to generate {num_requests} samples after "
+                    f"{_MAX_SAMPLE_ATTEMPTS} attempts. The requested "
+                    f"'input_len' ({input_len}) may be too small relative "
+                    f"to the variance in poem line lengths. "
+                    f"Please increase 'input_len'."
+                )
+            attempts += 1
             extra_lines = random.choices(
                 self.data, k=num_input_lines - num_prefix_lines
             )


### PR DESCRIPTION
## What this PR does

Fixes #38470.

When `input_len` is close to the base prompt length, `num_input_lines` rounds to zero or is not large enough to exceed `num_prefix_lines`. This causes the `while` loop in `SonnetDataset.sample()` to spin forever at 100% CPU with no error output or progress, making the benchmark completely unusable.

## Root cause

After computing:
```python
num_input_lines = round((input_len - base_offset) / avg_len)
num_prefix_lines = max(round((prefix_len - base_offset) / avg_len), 0)
```

If `num_input_lines <= 0` or `num_input_lines <= num_prefix_lines`, then `random.choices(self.data, k=num_input_lines - num_prefix_lines)` either returns nothing or is called with a non-positive `k`. Every generated prompt then exceeds `input_len`, so `prompt_len <= input_len` is never satisfied and the loop never terminates.

The existing guard (`if input_len <= base_offset`) only catches the exact boundary; values just above `base_offset` (e.g. 220 tokens with a ~200-token base prompt) slip through.

## Fix

- Add two upfront `ValueError` checks after computing `num_input_lines`, reporting the problem immediately with a clear, actionable message.
- Add a `_MAX_SAMPLE_ATTEMPTS` guard (10× `num_requests`) to the sampling loop as a safety net for edge cases where per-line length variance causes repeated misses, raising a `RuntimeError` that suggests increasing `input_len`.

## Before / After

**Before:** benchmark hangs indefinitely at 100% CPU, no output.

**After:**
```
ValueError: 'input_len' (220) is too small to fit any poem lines after
the base prompt (200 tokens). Please increase 'input_len'.
```