### PR TITLE
fix: vgpu segfault before nccl init

### DIFF
--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -134,13 +134,18 @@ class PyNcclCommunicator:
         self.device = device
         # nccl communicator and stream will use this device
         with torch.accelerator.device_index(device.index):
+            # Allocate warmup data early to force CUDA context creation
+            # before NCCL communicator init. Otherwise, the hooks of HAMI 
+            # will fail to map the devices in time, resulting in a segment 
+            # fault and process crash.
+            data = torch.zeros(1, device=device)
+            
             self.comm: ncclComm_t = self.nccl.ncclCommInitRank(
                 self.world_size, self.unique_id, self.rank
             )
 
             stream = current_stream()
             # A small all_reduce for warmup.
-            data = torch.zeros(1, device=device)
             self.all_reduce(data)
             stream.synchronize()
             del data


### PR DESCRIPTION
## Purpose
Fix SEGFAULT crash when running vLLM with GPU virtualization middlewares (e.g., HAMI/vGPU) and tensor parallelism ≥ 2.

Without an established primary context, when cuMemCreate (called during ncclCommInitRank) reads an uninitialized device id from the middleware's hook, resulting in a SEGFAULT

The error log is shown below:
(APIServer pid=1675) INFO 03-29 12:59:21 [utils.py:297] 
(APIServer pid=1675) INFO 03-29 12:59:21 [utils.py:297]        █     █     █▄   ▄█
(APIServer pid=1675) INFO 03-29 12:59:21 [utils.py:297]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.18.0
(APIServer pid=1675) INFO 03-29 12:59:21 [utils.py:297]   █▄█▀ █     █     █     █  model   /models/custom-llm/
(APIServer pid=1675) INFO 03-29 12:59:21 [utils.py:297]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=1675) INFO 03-29 12:59:21 [utils.py:297] 
(APIServer pid=1675) INFO 03-29 12:59:21 [utils.py:233] non-default args: {'model_tag': '/models/custom-llm/', 'port': 21002, 'model': '/models/custom-llm/', 'max_model_len': 32768, 'served_model_name': ['d0hce33d6ss5jggua640'], 'load_format': 'dummy', 'distributed_executor_backend': 'ray', 'pipeline_parallel_size': 2, 'tensor_parallel_size': 2, 'gpu_memory_utilization': 0.95, 'enable_prefix_caching': False, 'max_num_seqs': 256}
(APIServer pid=1675) INFO 03-29 12:59:23 [model.py:533] Resolved architecture: Qwen3ForCausalLM
(APIServer pid=1675) INFO 03-29 12:59:23 [model.py:1582] Using max model len 32768
(APIServer pid=1675) INFO 03-29 12:59:23 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=8192.
(APIServer pid=1675) WARNING 03-29 12:59:23 [vllm.py:743] Async scheduling will be disabled because it is not supported with the `ray` distributed executor backend (only `mp`, `uni`, and `external_launcher` are supported).
(APIServer pid=1675) INFO 03-29 12:59:23 [vllm.py:754] Asynchronous scheduling is disabled.
(EngineCore pid=1879) INFO 03-29 12:59:30 [core.py:103] Initializing a V1 LLM engine (v0.18.0) with config: model='/models/custom-llm/', speculative_config=None, tokenizer='/models/custom-llm/', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=dummy, tensor_parallel_size=2, pipeline_parallel_size=2, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=d0hce33d6ss5jggua640, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore pid=1879) WARNING 03-29 12:59:30 [ray_utils.py:376] Tensor parallel size (4) exceeds available GPUs (2). This may result in Ray placement group allocation failures. Consider reducing tensor_parallel_size to 2 or less, or ensure your Ray cluster has 4 GPUs available.
(EngineCore pid=1879) 2026-03-29 12:59:30,090   INFO worker.py:1810 -- Connecting to existing Ray cluster at address: 192.168.13.228:6379...
(EngineCore pid=1879) 2026-03-29 12:59:30,100   INFO worker.py:2013 -- Connected to Ray cluster.
(EngineCore pid=1879) 2026-03-29 12:59:30,104   WARNING working_dir.py:86 -- Directory '.git' is now ignored by default when packaging the working directory. To disable this behavior, set the `RAY_OVERRIDE_RUNTIME_ENV_DEFAULT_EXCLUDES=''` environment variable.
(EngineCore pid=1879) 2026-03-29 12:59:30,104   WARNING working_dir.py:86 -- Directory '.venv' is now ignored by default when packaging the working directory. To disable this behavior, set the `RAY_OVERRIDE_RUNTIME_ENV_DEFAULT_EXCLUDES=''` environment variable.
(EngineCore pid=1879) 2026-03-29 12:59:30,105   INFO packaging.py:392 -- Ignoring upload to cluster for these files: [PosixPath('/app/maas-vllm/.gitignore')]
(EngineCore pid=1879) 2026-03-29 12:59:30,105   INFO packaging.py:392 -- Ignoring upload to cluster for these files: [PosixPath('/app/maas-vllm/.venv/.gitignore')]
(EngineCore pid=1879) 2026-03-29 12:59:30,112   INFO packaging.py:691 -- Creating a file package for local module '/app/maas-vllm'.
(EngineCore pid=1879) 2026-03-29 12:59:30,112   INFO packaging.py:392 -- Ignoring upload to cluster for these files: [PosixPath('/app/maas-vllm/.gitignore')]
(EngineCore pid=1879) 2026-03-29 12:59:30,112   INFO packaging.py:392 -- Ignoring upload to cluster for these files: [PosixPath('/app/maas-vllm/.venv/.gitignore')]
(EngineCore pid=1879) 2026-03-29 12:59:30,123   INFO packaging.py:463 -- Pushing file package 'gcs://_ray_pkg_a7b0bdcc4dede8f8.zip' (4.17MiB) to Ray cluster...
(EngineCore pid=1879) 2026-03-29 12:59:30,134   INFO packaging.py:476 -- Successfully pushed file package 'gcs://_ray_pkg_a7b0bdcc4dede8f8.zip'.
(EngineCore pid=1879) /app/maas-vllm/.venv/lib/python3.12/site-packages/ray/_private/worker.py:2052: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
(EngineCore pid=1879)   warnings.warn(
(EngineCore pid=1879) INFO 03-29 12:59:30 [ray_utils.py:441] No current placement group found. Creating a new placement group.
(EngineCore pid=1879) INFO 03-29 12:59:38 [ray_env.py:100] Env var prefixes to copy: ['HF_', 'HUGGING_FACE_', 'LMCACHE_', 'NCCL_', 'UCX_', 'VLLM_']
(EngineCore pid=1879) INFO 03-29 12:59:38 [ray_env.py:101] Copying the following environment variables to workers: ['LD_LIBRARY_PATH', 'NCCL_DEBUG', 'NCCL_IB_DISABLE', 'NCCL_IB_HCA', 'VLLM_USE_DEEP_GEMM', 'VLLM_WORKER_MULTIPROC_METHOD']
(EngineCore pid=1879) INFO 03-29 12:59:38 [ray_env.py:111] To exclude env vars from copying, add them to /root/.config/vllm/ray_non_carry_over_env_vars.json
(EngineCore pid=1879) (RayWorkerWrapper pid=3936) WARNING 03-29 12:59:38 [system_utils.py:38] Overwriting environment variable LD_LIBRARY_PATH from '/app/maas-vllm/.venv/lib/python3.12/site-packages/cv2/../../lib64:' to '/app/maas-vllm/.venv/lib/python3.12/site-packages/cv2/../../lib64:/app/maas-vllm/.venv/lib/python3.12/site-packages/cv2/../../lib64:'
(EngineCore pid=1879) (RayWorkerWrapper pid=3936) WARNING 03-29 12:59:39 [worker_base.py:287] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'.
(EngineCore pid=1879) (RayWorkerWrapper pid=3936) INFO 03-29 12:59:42 [parallel_state.py:1395] world_size=4 rank=0 local_rank=0 distributed_init_method=tcp://192.168.13.228:41161 backend=nccl
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226) WARNING 03-29 12:59:38 [system_utils.py:38] Overwriting environment variable LD_LIBRARY_PATH from '/app/maas-vllm/.venv/lib/python3.12/site-packages/cv2/../../lib64:' to '/app/maas-vllm/.venv/lib/python3.12/site-packages/cv2/../../lib64:/app/maas-vllm/.venv/lib/python3.12/site-packages/cv2/../../lib64:' [repeated 3x across cluster] (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to disable log deduplication, or see https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication for more options.)
(EngineCore pid=1879) (RayWorkerWrapper pid=443, ip=192.168.13.226) WARNING 03-29 12:59:41 [worker_base.py:287] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'. [repeated 3x across cluster]
(EngineCore pid=1879) (RayWorkerWrapper pid=3937) INFO 03-29 12:59:47 [parallel_state.py:1395] world_size=4 rank=1 local_rank=1 distributed_init_method=tcp://192.168.13.228:41161 backend=nccl [repeated 2x across cluster]
(EngineCore pid=1879) (RayWorkerWrapper pid=443, ip=192.168.13.226) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(EngineCore pid=1879) (RayWorkerWrapper pid=443, ip=192.168.13.226) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226) [HAMI-core ERROR (pid:442 thread=140026213426240 multiprocess_memory_limit.c:831)]: Illegal device id: -2104349560
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226) INFO 03-29 12:59:51 [pynccl.py:111] vLLM is using nccl==2.27.5
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226) !!!!!!! Segfault encountered !!!!!!!
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "/libvgpu/src/multiprocess/multiprocess_memory_limit.c", line 251, in get_gpu_memory_usage
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "/libvgpu/src/allocator/allocator.c", line 45, in oom_check
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "/libvgpu/src/cuda/memory.c", line 592, in cuMemCreate
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "misc/cudawrap.cc", line 92, in ncclCuMemHostEnable()
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "misc/cudawrap.cc", line 202, in ncclCuMemHostEnable()
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "misc/cudawrap.cc", line 280, in initOnceFunc
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "misc/cudawrap.cc", line 298, in ncclCudaLibraryInit()
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "/dvs/p4/build/sw/gpgpu/nccl/gitfusion/stable/src/init.cc", line 1852, in ncclCommInitRank
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyObject_MakeTpCall
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyEval_EvalFrameDefault
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyObject_FastCallDictTstate
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyObject_MakeTpCall
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyEval_EvalFrameDefault
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyObject_FastCallDictTstate
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyObject_MakeTpCall
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyEval_EvalFrameDefault
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyObject_FastCallDictTstate
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyObject_MakeTpCall
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyEval_EvalFrameDefault
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyEval_EvalFrameDefault
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in __Pyx_PyObject_Call(_object*, _object*, _object*)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in __pyx_pw_3ray_7_raylet_12execute_task_3function_executor(_object*, _object*, _object*)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in __Pyx_PyObject_Call(_object*, _object*, _object*)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in __pyx_f_3ray_7_raylet_task_execution_handler(ray::rpc::Address const&, ray::rpc::TaskType, std::string, ray::core::RayFunction const&, std::unordered_map<std::string, double, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, double> > > const&, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > > const&, std::vector<ray::rpc::ObjectReference, std::allocator<ray::rpc::ObjectReference> > const&, std::string, std::string, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, bool>, std::allocator<std::pair<ray::ObjectID, bool> > >*, std::shared_ptr<ray::LocalMemoryBuffer>&, bool*, std::string*, std::string*, std::vector<ray::ConcurrencyGroup, std::allocator<ray::ConcurrencyGroup> > const&, std::string, bool, bool, bool, long, std::optional<std::string>)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in std::_Function_handler<ray::Status (ray::rpc::Address const&, ray::rpc::TaskType, std::string, ray::core::RayFunction const&, std::unordered_map<std::string, double, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, double> > > const&, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > > const&, std::vector<ray::rpc::ObjectReference, std::allocator<ray::rpc::ObjectReference> > const&, std::string const&, std::string const&, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, bool>, std::allocator<std::pair<ray::ObjectID, bool> > >*, std::shared_ptr<ray::LocalMemoryBuffer>&, bool*, std::string*, std::string*, std::vector<ray::ConcurrencyGroup, std::allocator<ray::ConcurrencyGroup> > const&, std::string, bool, bool, bool, long, std::optional<std::string> const&), ray::Status (*)(ray::rpc::Address const&, ray::rpc::TaskType, std::string, ray::core::RayFunction const&, std::unordered_map<std::string, double, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, double> > > const&, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > > const&, std::vector<ray::rpc::ObjectReference, std::allocator<ray::rpc::ObjectReference> > const&, std::string, std::string, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, bool>, std::allocator<std::pair<ray::ObjectID, bool> > >*, std::shared_ptr<ray::LocalMemoryBuffer>&, bool*, std::string*, std::string*, std::vector<ray::ConcurrencyGroup, std::allocator<ray::ConcurrencyGroup> > const&, std::string, bool, bool, bool, long, std::optional<std::string>)>::_M_invoke(std::_Any_data const&, ray::rpc::Address const&, ray::rpc::TaskType&&, std::string&&, ray::core::RayFunction const&, std::unordered_map<std::string, double, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, double> > > const&, std::vector<std::shared_ptr<ray::RayObject>, std::allocator<std::shared_ptr<ray::RayObject> > > const&, std::vector<ray::rpc::ObjectReference, std::allocator<ray::rpc::ObjectReference> > const&, std::string const&, std::string const&, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*&&, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*&&, std::vector<std::pair<ray::ObjectID, bool>, std::allocator<std::pair<ray::ObjectID, bool> > >*&&, std::shared_ptr<ray::LocalMemoryBuffer>&, bool*&&, std::string*&&, std::string*&&, std::vector<ray::ConcurrencyGroup, std::allocator<ray::ConcurrencyGroup> > const&, std::string&&, bool&&, bool&&, bool&&, long&&, std::optional<std::string> const&)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in ray::core::CoreWorker::ExecuteTask(ray::TaskSpecification const&, std::optional<std::unordered_map<std::string, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > >, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > > > > > >, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, bool>, std::allocator<std::pair<ray::ObjectID, bool> > >*, google::protobuf::RepeatedPtrField<ray::rpc::ObjectReferenceCount>*, bool*, std::string*, std::string*)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in std::_Function_handler<ray::Status (ray::TaskSpecification const&, std::optional<std::unordered_map<std::string, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > >, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > > > > > >, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, bool>, std::allocator<std::pair<ray::ObjectID, bool> > >*, google::protobuf::RepeatedPtrField<ray::rpc::ObjectReferenceCount>*, bool*, std::string*, std::string*), std::_Bind<ray::Status (ray::core::CoreWorker::*(ray::core::CoreWorker*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>, std::_Placeholder<4>, std::_Placeholder<5>, std::_Placeholder<6>, std::_Placeholder<7>, std::_Placeholder<8>, std::_Placeholder<9>))(ray::TaskSpecification const&, std::optional<std::unordered_map<std::string, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > >, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > > > > > >, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*, std::vector<std::pair<ray::ObjectID, bool>, std::allocator<std::pair<ray::ObjectID, bool> > >*, google::protobuf::RepeatedPtrField<ray::rpc::ObjectReferenceCount>*, bool*, std::string*, std::string*)> >::_M_invoke(std::_Any_data const&, ray::TaskSpecification const&, std::optional<std::unordered_map<std::string, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > >, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::pair<std::string const, std::vector<std::pair<long, double>, std::allocator<std::pair<long, double> > > > > > >&&, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*&&, std::vector<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> >, std::allocator<std::pair<ray::ObjectID, std::shared_ptr<ray::RayObject> > > >*&&, std::vector<std::pair<ray::ObjectID, bool>, std::allocator<std::pair<ray::ObjectID, bool> > >*&&, google::protobuf::RepeatedPtrField<ray::rpc::ObjectReferenceCount>*&&, bool*&&, std::string*&&, std::string*&&)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in std::_Function_handler<void (ray::TaskSpecification const&), ray::core::TaskReceiver::QueueTaskForExecution(ray::rpc::PushTaskRequest, ray::rpc::PushTaskReply*, std::function<void (ray::Status, std::function<void ()>, std::function<void ()>)>)::{lambda(ray::TaskSpecification const&)#1}>::_M_invoke(std::_Any_data const&, ray::TaskSpecification const&)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in ray::core::OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(ray::TaskID, ray::core::TaskToExecute&)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in ray::core::OrderedActorTaskExecutionQueue::ExecuteRequest(ray::core::TaskToExecute&&)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in ray::core::OrderedActorTaskExecutionQueue::ExecuteQueuedTasks()
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in ray::core::OrderedActorTaskExecutionQueue::EnqueueTask(long, long, ray::core::TaskToExecute)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in ray::core::TaskReceiver::QueueTaskForExecution(ray::rpc::PushTaskRequest, ray::rpc::PushTaskReply*, std::function<void (ray::Status, std::function<void ()>, std::function<void ()>)>)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in ray::core::CoreWorker::HandlePushTask(ray::rpc::PushTaskRequest, ray::rpc::PushTaskReply*, std::function<void (ray::Status, std::function<void ()>, std::function<void ()>)>)::{lambda()#1}::operator()()
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in EventTracker::RecordExecution(std::function<void ()> const&, std::shared_ptr<StatsHandle>)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in std::_Function_handler<void (), instrumented_io_context::post(std::function<void ()>, std::string, long)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in boost::asio::detail::executor_op<boost::asio::detail::binder0<std::function<void ()> >, std::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in boost::asio::detail::scheduler::run(boost::system::error_code&)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in boost::asio::io_context::run()
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in ray::core::CoreWorker::RunTaskExecutionLoop()
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in ray::core::CoreWorkerProcessImpl::RunWorkerTaskExecutionLoop()
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in __pyx_pw_3ray_7_raylet_10CoreWorker_5run_task_loop(_object*, _object* const*, long, _object*)
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in PyObject_Vectorcall
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyEval_EvalFrameDefault
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in PyEval_EvalCode
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyRun_SimpleFileObject
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _PyRun_AnyFileObject
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in Py_RunMain
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in Py_BytesMain
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in _start
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226)   File "<unknown>", line 0, in 0xffffffffffffffff
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226) 
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226) model-d736mna5m37nknn1phbg-0-1:442:442 [0] NCCL INFO Bootstrap: Using eth0:192.168.13.226<0>
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226) model-d736mna5m37nknn1phbg-0-1:442:442 [0] NCCL INFO cudaDriverVersion 13000
(EngineCore pid=1879) (RayWorkerWrapper pid=442, ip=192.168.13.226) INFO 03-29 12:59:50 [parallel_state.py:1395] world_size=4 rank=2 local_rank=0 distributed_init_method=tcp://192.168.13.228:41161 backend=nccl
(EngineCore pid=1879) (RayWorkerWrapper pid=3936) 
(EngineCore pid=1879) (raylet) A worker died or was killed while executing a task by an unexpected system error. To troubleshoot the problem, check the logs for the dead worker. Lease ID: 0300000079077fa3da0bf8f1fbd84bafa1cd6a9c6a844e6d60c9b5a5691acb0f Worker ID: 389fd34f25c9d2fc9c7fcb53075f5029ee428fe83fd70f9e183229e8 Node ID: 824dbaf53959a00247d77a2f9342eff09810a8b07f945e3208b13663 Worker IP address: 192.168.13.226 Worker port: 10002 Worker PID: 442 Worker exit type: SYSTEM_ERROR Worker exit detail: Worker unexpectedly exits with a connection error code 2. End of file. Some common causes include: (1) the process was killed by the OOM killer due to high memory usage, (2) ray stop --force was called, or (3) the worker crashed unexpectedly due to SIGSEGV or another unexpected error.
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099] EngineCore failed to start.
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099] Traceback (most recent call last):
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1073, in run_engine_core
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 839, in __init__
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     super().__init__(
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 112, in __init__
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     self.model_executor = executor_class(vllm_config)
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/executor/abstract.py", line 103, in __init__
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     self._init_executor()
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/executor/ray_executor.py", line 96, in _init_executor
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     self._init_workers_ray(placement_group)
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/executor/ray_executor.py", line 387, in _init_workers_ray
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     self.collective_rpc("init_device")
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/executor/ray_executor.py", line 515, in collective_rpc
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     return ray.get(ray_worker_outputs, timeout=timeout)
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     return fn(*args, **kwargs)
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     return func(*args, **kwargs)
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/ray/_private/worker.py", line 2981, in get
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     values, debugger_breakpoint = worker.get_objects(
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]                                   ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]   File "/app/.venv/lib/python3.12/site-packages/ray/_private/worker.py", line 1014, in get_objects
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]     raise value
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099] ray.exceptions.ActorDiedError: The actor died unexpectedly before finishing this task.
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]       class_name: RayWorkerWrapper
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]       actor_id: ab4434edda9ef579aa85b2bf01000000
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]       pid: 442
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]       namespace: 12588323-e8d2-4456-8975-c411275c09e9
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099]       ip: 192.168.13.226
(EngineCore pid=1879) ERROR 03-29 12:59:53 [core.py:1099] The actor is dead because its worker process has died. Worker exit type: SYSTEM_ERROR Worker exit detail: Worker unexpectedly exits with a connection error code 2. End of file. Some common causes include: (1) the process was killed by the OOM killer due to high memory usage, (2) ray stop --force was called, or (3) the worker crashed unexpectedly due to SIGSEGV or another unexpected error.
(EngineCore pid=1879) Process EngineCore:

Affected files:
- `vllm/distributed/device_communicators/pynccl.py`

