### PR TITLE
fix/TokenizerRepeatedInitialization

### DIFF
--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -513,9 +513,9 @@ def load_weights_using_from_2_way_softmax(
         )
         loaded_weights = pooling_model_cls.load_weights(model, weights)
 
-    from vllm.tokenizers import get_tokenizer
+    from vllm.tokenizers import cached_get_tokenizer
 
-    tokenizer = get_tokenizer(
+    tokenizer = cached_get_tokenizer(
         model_config.tokenizer,
         revision=model_config.tokenizer_revision,
         tokenizer_mode=model_config.tokenizer_mode,
@@ -586,9 +586,9 @@ def load_weights_no_post_processing(model, weights: Iterable[tuple[str, torch.Te
         # Skip ModelForSequenceClassification in MRO to avoid infinite recursion
         loaded_weights = pooling_model_cls.load_weights(model, weights)
 
-    from vllm.tokenizers import get_tokenizer
+    from vllm.tokenizers import cached_get_tokenizer
 
-    tokenizer = get_tokenizer(
+    tokenizer = cached_get_tokenizer(
         model_config.tokenizer,
         revision=model_config.tokenizer_revision,
         tokenizer_mode=model_config.tokenizer_mode,


### PR DESCRIPTION
---                                                                                                                                                     
  [Bugfix] Avoid repeated tokenizer initialization in pooling weight loaders
                                                                                                                                                          
  What this PR does
                                                                                                                                                          
  load_weights_using_from_2_way_softmax and load_weights_no_post_processing in vllm/model_executor/models/adapters.py both called get_tokenizer() during  
  model weight loading. Each call invokes AutoTokenizer.from_pretrained() unconditionally, which re-initializes the tokenizer from disk every time — even
  when the same model is loaded multiple times (e.g., across workers or successive calls).                                                                
                  
  vllm/tokenizers/registry.py already provides cached_get_tokenizer, an lru_cache-wrapped version of get_tokenizer. This PR replaces the two bare         
  get_tokenizer calls with cached_get_tokenizer, so repeated calls with identical arguments return the already-loaded tokenizer instead of constructing a
  new one.                                                                                                                                                
                  
  Changes

  - vllm/model_executor/models/adapters.py: replace get_tokenizer → cached_get_tokenizer in both load_weights_using_from_2_way_softmax and                
  load_weights_no_post_processing.
                                                                                                                                                          
  Why this is not duplicating an existing PR

  Searched open PRs for cached_get_tokenizer, TokenizerRepeatedInitialization, and adapters.py tokenizer — no existing PR addresses this.                 
  
  Testing                                                                                                                                                 
                  
  # Smoke test: load a Qwen3-Reranker-style pooling model and verify weights load correctly
  .venv/bin/python -m pytest tests/models/pooling/ -v -k "rerank or classifier"                                                                           
                                                                                                                                                          
  ▎ ⚠️  Full GPU tests require hardware not available in this environment. The change is purely a call-site substitution with no logic difference; the     
  cached function is already used throughout the codebase.                                                                                                
                                                                                                                                                          
  AI assistance disclosure

  This fix was identified and implemented with AI assistance (Claude). Every changed line has been reviewed by the submitter. The change is a 2-line      
  substitution (get_tokenizer → cached_get_tokenizer) in two symmetric call sites.
                                                                                                                                                          
  --- 