### PR TITLE
[Minimax-M2.5] Use bfloat16 gate linear

### DIFF
--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -39,6 +39,7 @@ from vllm.distributed import (
 )
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
@@ -110,12 +111,12 @@ class MiniMaxM2MoE(nn.Module):
             router_logits_dtype=torch.float32,
         )
 
-        self.gate = ReplicatedLinear(
-            config.hidden_size,
-            config.num_local_experts,
+        self.gate = GateLinear(
+            input_size=config.hidden_size,
+            output_size=config.num_local_experts,
             bias=False,
-            params_dtype=torch.float32,
-            quant_config=None,
+            params_dtype=torch.bfloat16,
+            out_dtype=torch.float32,
             prefix=f"{prefix}.gate",
         )
 
@@ -129,7 +130,7 @@ class MiniMaxM2MoE(nn.Module):
         hidden_states = hidden_states.view(-1, hidden_dim)
 
         # router_logits: (num_tokens, n_experts)
-        router_logits, _ = self.gate(hidden_states.to(torch.float32))
+        router_logits, _ = self.gate(hidden_states)
         final_hidden_states = self.experts(
             hidden_states=hidden_states, router_logits=router_logits
         )


### PR DESCRIPTION

## Purpose
Use GateLinear with bfloat16 input and fp32 output dtype, to speedup decode.

## Test Plan

## Test Result
gsm8k accuracy
without bf16 gate
<img width="739" height="105" alt="image" src="https://github.com/user-attachments/assets/248c948f-06a2-4d1d-9bbb-a16ea259d9a5" />

with bf16 gate
<img width="743" height="94" alt="image" src="https://github.com/user-attachments/assets/5b2c4e48-60cd-469d-9dbd-4c9f116cd774" />

**Profile comparison**
The latency of the corresponding gemm kernel decreases by 5us.
<img width="1484" height="686" alt="image" src="https://github.com/user-attachments/assets/39a31a6e-20ee-4b55-b9cf-ace9908132c4" />

**Benchmark result**
without the opt
<img width="359" height="580" alt="image" src="https://github.com/user-attachments/assets/dcc7fb00-16cb-4f3b-9be8-8772809d644b" />

with the opt
<img width="360" height="463" alt="image" src="https://github.com/user-attachments/assets/b25a6f8e-7b5c-4761-b3a6-da7c91642d57" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

