### PR TITLE
[Bugfix] Use importlib.import_module to resolve standalone_compile module

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -373,14 +373,18 @@ class InductorStandaloneAdaptor(CompilerInterface):
                 break
 
         if input_fake_mode is not None:
-            # Use patch.object on the actual module from sys.modules
-            # because in Python <=3.10 the string-based patch() resolves
-            # torch._inductor.standalone_compile to the wrapper function
-            # (defined in __init__.py) instead of the module.
-            import sys
+            # Use importlib to get the actual module object, because
+            # in Python <=3.10 both the string-based patch() and
+            # sys.modules["torch._inductor.standalone_compile"] may
+            # resolve to the wrapper function (defined in __init__.py)
+            # instead of the module.
+            import importlib
 
+            sc_module = importlib.import_module(
+                "torch._inductor.standalone_compile"
+            )
             fake_mode_ctx: Any = patch.object(
-                sys.modules["torch._inductor.standalone_compile"],
+                sc_module,
                 "FakeTensorMode",
                 lambda *a, **kw: input_fake_mode,
             )


### PR DESCRIPTION
In Python <=3.10, both string-based patch() and sys.modules[] may resolve torch._inductor.standalone_compile to the wrapper function (defined in __init__.py) instead of the actual module, causing AttributeError: <function standalone_compile> does not have the attribute 'FakeTensorMode'.

Use importlib.import_module() which always returns the real module object regardless of sys.modules pollution by __init__.py.


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

