### PR TITLE
[Bugfix] Fix glm4_moe_tool_parser for tools in the responses API format

### DIFF
--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import Mock
 
 import pytest
+from openai.types.responses import FunctionTool
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
@@ -12,6 +13,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     FunctionDefinition,
 )
 from vllm.entrypoints.openai.engine.protocol import FunctionCall, ToolCall
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.glm4_moe_tool_parser import (
     Glm4MoeModelToolParser,
@@ -750,9 +752,9 @@ if __name__ == "__main__":
 
     # For true incremental streaming, we expect many fragments (10+)
     # Old buffered implementation would give only 1-3 fragments
-    assert fragment_count >= 10, (
-        f"Expected >=10 fragments for incremental streaming, got {fragment_count}"
-    )
+    assert (
+        fragment_count >= 10
+    ), f"Expected >=10 fragments for incremental streaming, got {fragment_count}"
 
     # Verify final result is valid JSON
     assert len(glm4_moe_tool_parser.streamed_args_for_tool) == 1
@@ -1333,3 +1335,85 @@ def test_stream_interval_content_between_tool_calls(
     args1 = json.loads("".join(tools_found[1]["args_fragments"]))
     assert args0 == {"city": "Beijing"}
     assert args1 == {"city": "Shanghai"}
+
+
+def test_extract_tool_calls_with_responses_format_tools(glm4_moe_tool_parser):
+    """Test extract tool call with Responses API input."""
+    request = Mock(spec=ResponsesRequest)
+    request.tools = [
+        FunctionTool(
+            type="function",
+            name="get_weather",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                },
+            },
+        )
+    ]
+
+    model_output = """<tool_call>get_weather
+<arg_key>city</arg_key>
+<arg_value>Beijing</arg_value>
+</tool_call>"""
+
+    extracted_tool_calls = glm4_moe_tool_parser.extract_tool_calls(
+        model_output, request=request
+    )
+
+    assert extracted_tool_calls.tools_called
+    assert len(extracted_tool_calls.tool_calls) == 1
+    assert extracted_tool_calls.tool_calls[0].function.name == "get_weather"
+
+    args = json.loads(extracted_tool_calls.tool_calls[0].function.arguments)
+
+    assert args["city"] == "Beijing"
+    assert isinstance(args["city"], str)
+
+
+def test_extract_tool_calls_with_responses_format_tools_streaming(glm4_moe_tool_parser):
+    """Test streaming extract tool call with Responses API input."""
+    _reset_streaming_state(glm4_moe_tool_parser)
+
+    request = Mock(spec=ResponsesRequest)
+    request.tools = [
+        FunctionTool(
+            type="function",
+            name="get_weather",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                },
+            },
+        )
+    ]
+
+    chunks = [
+        "<tool_call>",
+        "get_weather\n",
+        "<arg_key>city</arg_key>",
+        "<arg_value>",
+        "Bei",
+        "jing",
+        "</arg_value>",
+        "</tool_call>",
+    ]
+
+    for chunk in chunks:
+        glm4_moe_tool_parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text="",
+            delta_text=chunk,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=request,
+        )
+
+    assert len(glm4_moe_tool_parser.streamed_args_for_tool) == 1
+    args = json.loads(glm4_moe_tool_parser.streamed_args_for_tool[0])
+
+    assert args["city"] == "Beijing"
+    assert isinstance(args["city"], str)

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -17,7 +17,6 @@ from collections.abc import Sequence
 from typing import Any
 
 import regex as re
-from openai.types.responses import FunctionTool
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -130,12 +129,14 @@ class Glm4MoeModelToolParser(ToolParser):
         if tools is None:
             return False
         for tool in tools:
-            if isinstance(tool, FunctionTool):
+            if hasattr(tool, "function"):
+                name = tool.function.name
+                parameters = tool.function.parameters
+            elif hasattr(tool, "name") and hasattr(tool, "parameters"):
                 name = tool.name
                 parameters = tool.parameters
             else:
-                name = tool.function.name
-                parameters = tool.function.parameters
+                continue
             if name != tool_name:
                 continue
             if parameters is None:

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -17,6 +17,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import regex as re
+from openai.types.responses import FunctionTool
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -124,19 +125,23 @@ class Glm4MoeModelToolParser(ToolParser):
     def _is_string_type(
         tool_name: str,
         arg_name: str,
-        tools: list[Tool] | None,
+        tools: list[ChatCompletionToolsParam | FunctionTool] | None,
     ) -> bool:
         if tools is None:
             return False
         for tool in tools:
-            if tool.function.name != tool_name:
+            if isinstance(tool, FunctionTool):
+                name = tool.name
+                parameters = tool.parameters
+            else:
+                name = tool.function.name
+                parameters = tool.function.parameters
+            if name != tool_name:
                 continue
-            if tool.function.parameters is None:
+            if parameters is None:
                 return False
             arg_type = (
-                tool.function.parameters.get("properties", {})
-                .get(arg_name, {})
-                .get("type", None)
+                parameters.get("properties", {}).get(arg_name, {}).get("type", None)
             )
             return arg_type == "string"
         logger.debug("No tool named '%s'.", tool_name)

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -124,7 +124,7 @@ class Glm4MoeModelToolParser(ToolParser):
     def _is_string_type(
         tool_name: str,
         arg_name: str,
-        tools: list[ChatCompletionToolsParam | FunctionTool] | None,
+        tools: list[Tool] | None,
     ) -> bool:
         if tools is None:
             return False


### PR DESCRIPTION

## Purpose
While playing around with various models after https://github.com/vllm-project/vllm/pull/29947, that added support for toolcalls to non-harmony  models in the Responses API, was merged, I noticed that GLM4.5 didn't seem to output correct tool calls. After further investigation, I traced it to the fact that the tool parser didn't account for cases when the `function` attribute doesn't exist, which is the case in the Responses API.

I was unable to find an existing issue referencing this, feel free to correct me if I missed it.

## Test Plan
I added two new tests to `tests/tool_parsers/test_glm4_moe_tool_parser.py`, one for streaming and one for non-streaming.

## Test Result
Before change in `vllm/tool_parsers/glm4_moe_tool_parser.py`, the two new tests fail, with error `AttributeError: 'FunctionTool' object has no attribute 'function'`. After change, the two new tests pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>