### PR TITLE
[KVConnector] Remove redundant method KVConnectorOutput::merge()

### DIFF
--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -2,9 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, NamedTuple, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, NamedTuple, TypeAlias
 
 import numpy as np
 import torch
@@ -125,20 +124,6 @@ class SamplerOutput:
     logprobs_tensors: LogprobsTensors | None
 
 
-T = TypeVar("T")
-
-
-def _combine_non_none(f: Callable[[T, T], T], items: list[T | None]) -> T | None:
-    non_none = [item for item in items if item is not None]
-    if len(non_none) == 0:
-        return None
-
-    combined = non_none[0]
-    for item in non_none[1:]:
-        combined = f(combined, item)
-    return combined
-
-
 @dataclass
 class KVConnectorOutput:
     # [req_ids]
@@ -165,43 +150,6 @@ class KVConnectorOutput:
             and not self.kv_cache_events
             and not self.invalid_block_ids
             and not self.kv_connector_worker_meta
-        )
-
-    @classmethod
-    def merge(cls, *outputs: "KVConnectorOutput"):
-        assert len(outputs) > 0, "Cannot merge empty outputs"
-        finished_sending = _combine_non_none(
-            set.union, [output.finished_sending for output in outputs]
-        )
-        finished_recving = _combine_non_none(
-            set.union, [output.finished_recving for output in outputs]
-        )
-        kv_connector_stats = _combine_non_none(
-            lambda x, y: x.aggregate(y),
-            [output.kv_connector_stats for output in outputs],
-        )
-        kv_cache_events = _combine_non_none(
-            lambda x, y: x.merge(y),
-            [output.kv_cache_events for output in outputs],
-        )
-        invalid_block_ids = _combine_non_none(
-            set.union, [output.invalid_block_ids for output in outputs]
-        )
-        assert invalid_block_ids is not None
-
-        assert all(
-            output.expected_finished_count == outputs[0].expected_finished_count
-            for output in outputs
-        )
-        expected_finished_count = outputs[0].expected_finished_count
-
-        return cls(
-            finished_sending=finished_sending,
-            finished_recving=finished_recving,
-            kv_connector_stats=kv_connector_stats,
-            kv_cache_events=kv_cache_events,
-            invalid_block_ids=invalid_block_ids,
-            expected_finished_count=expected_finished_count,
         )
 
 


### PR DESCRIPTION
## Purpose

`merge()` method calling was removed in #37013 and as its no longer used then it better to remove this function for maintainability purposes.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

