### PR TITLE
openshift-compatibility

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -821,3 +821,33 @@ FROM vllm-openai-base AS vllm-openai
 
 ENTRYPOINT ["vllm", "serve"]
 #################### OPENAI API SERVER ####################
+
+#################### OPENAI API SERVER (OpenShift) ####################
+FROM vllm-openai AS vllm-openai-openshift
+
+ENV HOME=/tmp \
+    XDG_CACHE_HOME=/cache \
+    XDG_CONFIG_HOME=/cache/config \
+    HF_HOME=/cache/huggingface \
+    VLLM_CACHE_ROOT=/cache/vllm \
+    VLLM_CONFIG_ROOT=/cache/config/vllm \
+    TRITON_CACHE_DIR=/cache/triton \
+    TORCHINDUCTOR_CACHE_DIR=/cache/torch_inductor \
+    NUMBA_CACHE_DIR=/cache/numba \
+    OUTLINES_CACHE_DIR=/cache/outlines
+
+RUN mkdir -p ${HF_HOME} \
+    ${VLLM_CACHE_ROOT} \
+    ${VLLM_CONFIG_ROOT} \
+    ${TRITON_CACHE_DIR} \
+    ${TORCHINDUCTOR_CACHE_DIR} \
+    ${NUMBA_CACHE_DIR} \
+    ${OUTLINES_CACHE_DIR} \
+    ${HOME}/.config && \
+    chgrp -R 0 /cache ${HOME} && \
+    chmod -R g+rwX /cache ${HOME}
+
+USER 1001
+
+EXPOSE 8000
+#################### OPENAI API SERVER (OpenShift) ####################


### PR DESCRIPTION


## Purpose

Add a new Dockerfile stage `vllm-openai-openshift` that produces an OpenShift-compatible variant of the `vllm-openai` image.

OpenShift runs containers with an arbitrary non-root UID in group 0. The default image fails because vLLM, HuggingFace, Triton, and other libraries attempt to write to cache/config directories under `$HOME` that don't exist or aren't writable for arbitrary UIDs.

This new image/stage:
- Redirects all runtime cache/config paths to `/cache/*` via environment variables (`HF_HOME`, `VLLM_CACHE_ROOT`, `TRITON_CACHE_DIR`, `TORCHINDUCTOR_CACHE_DIR`, `NUMBA_CACHE_DIR`, `OUTLINES_CACHE_DIR`, `VLLM_CONFIG_ROOT`, `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`)
- Makes `/cache` and `$HOME` group-0-writable (`chgrp -R 0` + `chmod -R g+rwX`)
- Sets `USER 1001` so the image never accidentally runs as root outside OpenShift
- Users can mount a volume at `/cache/huggingface` to persist downloaded models

## Test Plan

- Build the new target: `docker build --target vllm-openai-openshift -t vllm-openai-openshift .`
- Run with an arbitrary UID (simulating OpenShift): `docker run --user 12345:0 vllm-openai-openshift Qwen/Qwen3-VL-2B-Instruct`
- Verify all cache directories are writable and the server starts without permission errors

## Test Result

Manually verified that the image builds and starts without permission errors when run as an arbitrary non-root UID in group 0.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

