### PR TITLE
[Feature] Add GCS support for sharded state loader

### DIFF
--- a/tests/model_executor/model_loader/test_gcs_utils.py
+++ b/tests/model_executor/model_loader/test_gcs_utils.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+from vllm.transformers_utils.gcs_utils import glob, list_files
+
+
+def _make_mock_blob(name: str) -> MagicMock:
+    blob = MagicMock()
+    blob.name = name
+    return blob
+
+
+def _make_mock_client(blob_names: list[str]) -> MagicMock:
+    client = MagicMock()
+    bucket = MagicMock()
+    bucket.list_blobs.return_value = [_make_mock_blob(n) for n in blob_names]
+    client.bucket.return_value = bucket
+    return client
+
+
+class TestListFiles:
+    def test_basic_listing(self):
+        mock_client = _make_mock_client([
+            "models/model-rank-0-part-0.safetensors",
+            "models/model-rank-0-part-1.safetensors",
+            "models/config.json",
+        ])
+        bucket_name, prefix, paths = list_files(
+            mock_client, path="gs://my-bucket/models/"
+        )
+        assert bucket_name == "my-bucket"
+        assert prefix == "models/"
+        assert len(paths) == 3
+
+    def test_allow_pattern(self):
+        mock_client = _make_mock_client([
+            "models/model-rank-0-part-0.safetensors",
+            "models/model-rank-0-part-1.safetensors",
+            "models/model-rank-1-part-0.safetensors",
+            "models/config.json",
+        ])
+        _, _, paths = list_files(
+            mock_client,
+            path="gs://my-bucket/models/",
+            allow_pattern=["*model-rank-0-part-*.safetensors"],
+        )
+        assert len(paths) == 2
+        assert all("rank-0" in p for p in paths)
+
+    def test_ignore_pattern(self):
+        mock_client = _make_mock_client([
+            "models/model-rank-0-part-0.safetensors",
+            "models/config.json",
+        ])
+        _, _, paths = list_files(
+            mock_client,
+            path="gs://my-bucket/models/",
+            ignore_pattern=["*.json"],
+        )
+        assert len(paths) == 1
+        assert paths[0].endswith(".safetensors")
+
+
+class TestGlob:
+    def test_returns_full_gs_paths(self):
+        mock_client = _make_mock_client([
+            "models/model-rank-0-part-0.safetensors",
+            "models/model-rank-0-part-1.safetensors",
+        ])
+        result = glob(
+            client=mock_client,
+            path="gs://my-bucket/models/",
+            allow_pattern=["*model-rank-0-part-*.safetensors"],
+        )
+        assert len(result) == 2
+        assert all(p.startswith("gs://my-bucket/") for p in result)
+        assert all(p.endswith(".safetensors") for p in result)
+
+    def test_adds_trailing_slash(self):
+        mock_client = _make_mock_client([])
+        glob(client=mock_client, path="gs://my-bucket/models")
+        mock_client.bucket.assert_called_once_with("my-bucket")
+        bucket = mock_client.bucket.return_value
+        bucket.list_blobs.assert_called_once_with(prefix="models/")
+
+    def test_filters_by_rank_pattern(self):
+        mock_client = _make_mock_client([
+            "models/model-rank-0-part-0.safetensors",
+            "models/model-rank-1-part-0.safetensors",
+            "models/model-rank-2-part-0.safetensors",
+            "models/config.json",
+            "models/tokenizer.json",
+        ])
+        result = glob(
+            client=mock_client,
+            path="gs://my-bucket/models",
+            allow_pattern=["*model-rank-2-part-*.safetensors"],
+        )
+        assert len(result) == 1
+        assert "rank-2" in result[0]

--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -20,8 +20,9 @@ from vllm.model_executor.model_loader.weight_utils import (
     download_weights_from_hf,
     runai_safetensors_weights_iterator,
 )
+from vllm.transformers_utils.gcs_utils import glob as gcs_glob
 from vllm.transformers_utils.s3_utils import glob as s3_glob
-from vllm.transformers_utils.utils import is_s3
+from vllm.transformers_utils.utils import is_gcs, is_s3
 
 logger = init_logger(__name__)
 
@@ -92,7 +93,9 @@ class ShardedStateLoader(BaseModelLoader):
         return result
 
     def _prepare_weights(self, model_name_or_path: str, revision: str | None):
-        if is_s3(model_name_or_path) or os.path.isdir(model_name_or_path):
+        if is_s3(model_name_or_path) or is_gcs(model_name_or_path) or os.path.isdir(
+            model_name_or_path
+        ):
             return model_name_or_path
         else:
             allow_patterns = ["*.safetensors"]
@@ -125,6 +128,11 @@ class ShardedStateLoader(BaseModelLoader):
         if is_s3(local_model_path):
             file_pattern = f"*{self.pattern.format(rank=rank, part='*')}"
             filepaths = s3_glob(path=local_model_path, allow_pattern=[file_pattern])
+        elif is_gcs(local_model_path):
+            file_pattern = f"*{self.pattern.format(rank=rank, part='*')}"
+            filepaths = gcs_glob(
+                path=local_model_path, allow_pattern=[file_pattern]
+            )
         else:
             filepaths = glob.glob(pattern)
         if not filepaths:

--- a/vllm/transformers_utils/gcs_utils.py
+++ b/vllm/transformers_utils/gcs_utils.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import fnmatch
+from typing import TYPE_CHECKING
+
+from vllm.utils.import_utils import PlaceholderModule
+
+if TYPE_CHECKING:
+    from google.cloud.storage import Client
+
+try:
+    from google.cloud import storage
+except ImportError:
+    storage = PlaceholderModule("google.cloud.storage")  # type: ignore[assignment]
+
+
+def _filter_allow(paths: list[str], patterns: list[str]) -> list[str]:
+    return [
+        path
+        for path in paths
+        if any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+    ]
+
+
+def _filter_ignore(paths: list[str], patterns: list[str]) -> list[str]:
+    return [
+        path
+        for path in paths
+        if not any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+    ]
+
+
+def glob(
+    client: "Client | None" = None,
+    path: str = "",
+    allow_pattern: list[str] | None = None,
+) -> list[str]:
+    """
+    List full file names from GCS path and filter by allow pattern.
+
+    Args:
+        client: GCS client to use.
+        path: The GCS path to list from.
+        allow_pattern: A list of patterns of which files to pull.
+
+    Returns:
+        list[str]: List of full GCS paths allowed by the pattern
+    """
+    if client is None:
+        client = storage.Client()
+    if not path.endswith("/"):
+        path = path + "/"
+    bucket_name, _, paths = list_files(
+        client, path=path, allow_pattern=allow_pattern
+    )
+    return [f"gs://{bucket_name}/{p}" for p in paths]
+
+
+def list_files(
+    client: "Client",
+    path: str,
+    allow_pattern: list[str] | None = None,
+    ignore_pattern: list[str] | None = None,
+) -> tuple[str, str, list[str]]:
+    """
+    List files from GCS path and filter by pattern.
+
+    Args:
+        client: GCS client to use.
+        path: The GCS path to list from.
+        allow_pattern: A list of patterns of which files to pull.
+        ignore_pattern: A list of patterns of which files not to pull.
+
+    Returns:
+        tuple[str, str, list[str]]: A tuple where:
+            - The first element is the bucket name
+            - The second element is the prefix string
+            - The third element is a list of files allowed or
+              disallowed by pattern
+    """
+    parts = path.removeprefix("gs://").split("/")
+    bucket_name = parts[0]
+    prefix = "/".join(parts[1:])
+
+    bucket = client.bucket(bucket_name)
+    blobs = bucket.list_blobs(prefix=prefix)
+    paths = [blob.name for blob in blobs]
+
+    paths = _filter_ignore(paths, ["*/"])
+    if allow_pattern is not None:
+        paths = _filter_allow(paths, allow_pattern)
+
+    if ignore_pattern is not None:
+        paths = _filter_ignore(paths, ignore_pattern)
+
+    return bucket_name, prefix, paths


### PR DESCRIPTION
The ShardedStateLoader currently only supports S3 (via s3_glob) and local filesystem (via glob.glob) for discovering checkpoint files. GCS paths (gs://) fall through to glob.glob which cannot resolve remote URIs, causing runai_streamer_sharded to fail with GCS.

This adds a gcs_utils module mirroring s3_utils that uses google-cloud-storage (already a dependency via runai-model-streamer[gcs]) to list and filter blobs from GCS buckets. The sharded_state_loader is updated to use gcs_glob for gs:// paths.


## Purpose

Support GCS in the `runai_streamer_sharded` load format.


## Test Plan

Tested directly on a k8s cluster that pulls the model weights from GCS.

## Test Result

Passed and the vLLM pod started-up successfully.

Closes https://github.com/vllm-project/vllm/issues/38568


