### PR TITLE
AIFQA-397 BLK-011: [vLLM] DeepSeek-OCR-2 — DeepseekOCR2ForCausalLM arch not supported

### DIFF
--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -363,6 +363,23 @@ VLM_TEST_SETTINGS = {
         stop_str=["<｜end▁of▁sentence｜>", "<｜begin▁of▁sentence｜>"],
         image_size_factors=[(1.0,), (1.0, 1.0, 1.0), (0.1, 0.5, 1.0)],
     ),
+    "deepseek_ocr_v2": VLMTestInfo(
+        models=["deepseek-ai/DeepSeek-OCR-2"],
+        test_type=VLMTestType.IMAGE,
+        prompt_formatter=lambda img_prompt: f"<|User|>: {img_prompt}\n\n<|Assistant|>: ",  # noqa: E501
+        max_model_len=4096,
+        max_num_seqs=2,
+        single_image_prompts=IMAGE_ASSETS.prompts(
+            {
+                "stop_sign": "<image>\nWhat's the content in the center of the image?",
+                "cherry_blossom": "<image>\nDescribe this image briefly.",
+            }
+        ),
+        patch_hf_runner=model_utils.deepseekvl2_patch_hf_runner,
+        hf_output_post_proc=model_utils.deepseekvl2_trunc_hf_output,
+        stop_str=["<｜end▁of▁sentence｜>", "<｜begin▁of▁sentence｜>"],
+        image_size_factors=[(1.0,), (0.25, 0.5, 1.0)],
+    ),
     "fuyu": VLMTestInfo(
         models=["adept/fuyu-8b"],
         test_type=VLMTestType.IMAGE,

--- a/tests/models/multimodal/generation/test_deepseek_ocr2.py
+++ b/tests/models/multimodal/generation/test_deepseek_ocr2.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for DeepSeek-OCR-2 multimodal generation.
+
+Includes:
+  1. Unit test verifying the architecture is in the model registry.
+  2. Integration test that loads the model and runs image+text generation.
+  3. Comparison test against HuggingFace reference outputs for numerical
+     equivalence.
+"""
+
+import pytest
+from transformers import AutoModelForCausalLM, BatchFeature
+
+from tests.models.utils import check_logprobs_close
+from vllm.assets.image import ImageAsset
+from vllm.model_executor.models.registry import ModelRegistry
+
+from ....conftest import HfRunner, PromptImageInput, VllmRunner
+
+MODEL_NAME = "deepseek-ai/DeepSeek-OCR-2"
+
+STOP_STR = ["<｜end▁of▁sentence｜>", "<｜begin▁of▁sentence｜>"]
+
+IMAGE = ImageAsset("cherry_blossom").pil_image.convert("RGB")
+
+PROMPT = "<|User|>: <image>\nDescribe this image in one sentence.\n\n<|Assistant|>: "
+
+
+# --------------------------------------------------------------------------- #
+# 1. Unit test: architecture is registered
+# --------------------------------------------------------------------------- #
+def test_deepseek_ocr2_registered():
+    """DeepseekOCR2ForCausalLM must be discoverable in the model registry."""
+    supported = ModelRegistry.get_supported_archs()
+    assert "DeepseekOCR2ForCausalLM" in supported
+
+
+def test_deepseek_ocr2_importable():
+    """The model class must be importable from the registry."""
+    model_cls = ModelRegistry._try_load_model_cls("DeepseekOCR2ForCausalLM")
+    assert model_cls is not None
+
+
+# --------------------------------------------------------------------------- #
+# 2. Integration test: load model and generate
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("dtype", ["half"])
+@pytest.mark.parametrize("max_tokens", [32])
+def test_deepseek_ocr2_generation(
+    vllm_runner: type[VllmRunner],
+    dtype: str,
+    max_tokens: int,
+) -> None:
+    """Load DeepSeek-OCR-2 in vLLM and verify it can generate text from an
+    image prompt."""
+    with vllm_runner(
+        MODEL_NAME,
+        dtype=dtype,
+        max_model_len=4096,
+        max_num_seqs=2,
+        enforce_eager=True,
+        limit_mm_per_prompt={"image": 1},
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(
+            [PROMPT],
+            max_tokens,
+            images=[IMAGE],
+        )
+
+    assert len(outputs) == 1
+    output_ids, output_str = outputs[0]
+    # The model should produce a non-trivial response
+    assert len(output_ids) > 0
+    assert len(output_str.strip()) > 0
+
+
+# --------------------------------------------------------------------------- #
+# 3. Comparison test: vLLM vs HuggingFace reference outputs
+# --------------------------------------------------------------------------- #
+def _patch_hf_runner(hf_model: HfRunner) -> HfRunner:
+    """Patch HfRunner to use the custom DeepseekOCRProcessor for OCR-2."""
+    hf_processor = hf_model.processor
+
+    def processor(*args, text="", images=None, **kwargs):
+        from PIL.Image import Image
+
+        if isinstance(images, Image):
+            images = [images]
+        inputs = hf_processor(
+            *args,
+            prompt=text,
+            images=images,
+            **kwargs,
+        )
+        inputs = {
+            k: inputs[k]
+            for k in inputs.keys()  # noqa: SIM118
+            if k not in ("seq_lens", "sft_format")
+        }
+        return BatchFeature(data=inputs, tensor_type="pt")
+
+    hf_model.processor = processor
+    hf_model.model.get_output_embeddings = (
+        lambda: hf_model.model.language.model.embed_tokens
+    )
+    return hf_model
+
+
+def _trunc_hf_output(
+    hf_output: tuple[list[int], str, object],
+    model: str,
+) -> tuple[list[int], str, object]:
+    output_ids, output_str, out_logprobs = hf_output
+    for stop in STOP_STR:
+        if output_str.endswith(stop):
+            output_str = output_str.split(stop)[0]
+    return output_ids, output_str, out_logprobs
+
+
+def _run_comparison(
+    hf_runner: type[HfRunner],
+    vllm_runner: type[VllmRunner],
+    inputs: list[tuple[list[str], PromptImageInput]],
+    model: str,
+    *,
+    dtype: str,
+    max_tokens: int,
+    num_logprobs: int,
+) -> None:
+    with vllm_runner(
+        model,
+        dtype=dtype,
+        max_model_len=4096,
+        max_num_seqs=2,
+        enforce_eager=True,
+        limit_mm_per_prompt={"image": 1},
+    ) as vllm_model:
+        vllm_outputs_per_case = [
+            vllm_model.generate_greedy_logprobs(
+                prompts,
+                max_tokens,
+                num_logprobs=num_logprobs,
+                images=images,
+            )
+            for prompts, images in inputs
+        ]
+
+    with hf_runner(
+        model,
+        dtype=dtype,
+        auto_cls=AutoModelForCausalLM,
+    ) as hf_model:
+        hf_model = _patch_hf_runner(hf_model)
+        hf_outputs_per_case = [
+            hf_model.generate_greedy_logprobs_limit(
+                prompts,
+                max_tokens,
+                num_logprobs=num_logprobs,
+                images=images,
+            )
+            for prompts, images in inputs
+        ]
+
+    for hf_outputs, vllm_outputs in zip(
+        hf_outputs_per_case, vllm_outputs_per_case
+    ):
+        check_logprobs_close(
+            outputs_0_lst=[
+                _trunc_hf_output(o, model) for o in hf_outputs
+            ],
+            outputs_1_lst=vllm_outputs,
+            name_0="hf",
+            name_1="vllm",
+        )
+
+
+@pytest.mark.parametrize("model", [MODEL_NAME])
+@pytest.mark.parametrize("dtype", ["half"])
+@pytest.mark.parametrize("num_logprobs", [5])
+def test_deepseek_ocr2_vs_hf(
+    hf_runner: type[HfRunner],
+    vllm_runner: type[VllmRunner],
+    model: str,
+    dtype: str,
+    num_logprobs: int,
+) -> None:
+    """Compare vLLM generation with HuggingFace reference for numerical
+    equivalence on a single-image prompt."""
+    _run_comparison(
+        hf_runner,
+        vllm_runner,
+        inputs=[
+            ([PROMPT], [IMAGE]),
+        ],
+        model=model,
+        dtype=dtype,
+        max_tokens=32,
+        num_logprobs=num_logprobs,
+    )

--- a/tests/models/multimodal/processing/test_deepseek_ocr2.py
+++ b/tests/models/multimodal/processing/test_deepseek_ocr2.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Processing tests for DeepSeek-OCR-2.
+
+Validates that the processor handles images correctly with the v2 strategy
+(IMAGE_SIZE=768, BASE_SIZE=1024, CROP_MODE=True).  The tests mirror the
+structure of test_deepseek_ocr.py but use the OCR-2 specific configuration.
+
+Run with:
+  pytest tests/models/multimodal/processing/test_deepseek_ocr2.py -v
+"""
+
+import pytest
+from PIL import Image
+from transformers import AutoTokenizer
+
+from vllm.model_executor.models.deepseek_ocr import DeepseekOCRImagePixelInputs
+from vllm.transformers_utils.processors.deepseek_ocr import DeepseekOCRProcessor
+
+MODEL_ID = "deepseek-ai/DeepSeek-OCR-2"
+
+# OCR-2 uses different image_size (768) from OCR (640), same base_size (1024)
+IMAGE_SIZE = 768
+BASE_SIZE = 1024
+
+
+@pytest.fixture(scope="module")
+def processor():
+    """Load DeepseekOCRProcessor with v2 strategy for OCR-2."""
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+    return DeepseekOCRProcessor(
+        tokenizer=tokenizer,
+        image_size=IMAGE_SIZE,
+        base_size=BASE_SIZE,
+        crop_mode=True,
+        strategy="v2",
+    )
+
+
+class TestDeepseekOCR2Processing:
+    """Verify processing behaviour for DeepSeek-OCR-2."""
+
+    def test_small_image_produces_empty_crop(self, processor):
+        """An image smaller than IMAGE_SIZE should produce an empty
+        images_crop tensor with the correct spatial dimension (768)."""
+        small_image = Image.new("RGB", (100, 100), color="red")
+
+        result = processor(
+            prompt="<image>\nDescribe this image.",
+            images=[small_image],
+        )
+
+        pixel_values = result["pixel_values"]
+        images_crop = result["images_crop"]
+
+        # Small image: no crops needed
+        assert images_crop.shape[0] == 0
+        # The base image should use BASE_SIZE
+        assert pixel_values.shape[-1] == BASE_SIZE
+        # Crop tensor spatial dim should be IMAGE_SIZE
+        assert images_crop.shape[-1] == IMAGE_SIZE
+
+    def test_large_image_produces_crops(self, processor):
+        """An image larger than IMAGE_SIZE should produce non-empty
+        images_crop tiles."""
+        large_image = Image.new("RGB", (1200, 800), color="blue")
+
+        result = processor(
+            prompt="<image>\nDescribe this image.",
+            images=[large_image],
+        )
+
+        images_crop = result["images_crop"]
+
+        assert images_crop.shape[0] > 0
+        assert images_crop.shape[-1] == IMAGE_SIZE
+
+    def test_tensor_schema_with_empty_crop(self, processor):
+        """TensorSchema validation must succeed when images_crop is empty,
+        reading image_size from the tensor shape rather than falling back
+        to base_size."""
+        small_image = Image.new("RGB", (100, 100), color="green")
+
+        result = processor(
+            prompt="<image>\nDescribe this image.",
+            images=[small_image],
+        )
+
+        pixel_values = result["pixel_values"]
+        images_crop = result["images_crop"]
+        images_spatial_crop = result["images_spatial_crop"]
+
+        base_size = pixel_values.shape[-1]
+        image_size = images_crop.shape[-1] if images_crop is not None else base_size
+
+        # Should not raise
+        schema = DeepseekOCRImagePixelInputs(
+            type="pixel_values",
+            data=pixel_values,
+            images_crop=images_crop,
+            images_spatial_crop=images_spatial_crop,
+            resolve_bindings={
+                "base_size": base_size,
+                "image_size": image_size,
+            },
+        )
+
+        assert schema.data.shape == (1, 3, BASE_SIZE, BASE_SIZE)
+        assert schema.images_crop.shape == (0, 3, IMAGE_SIZE, IMAGE_SIZE)
+
+    def test_tensor_schema_with_populated_crop(self, processor):
+        """TensorSchema validation must succeed when images_crop is
+        populated."""
+        large_image = Image.new("RGB", (1200, 800), color="blue")
+
+        result = processor(
+            prompt="<image>\nDescribe this image.",
+            images=[large_image],
+        )
+
+        pixel_values = result["pixel_values"]
+        images_crop = result["images_crop"]
+        images_spatial_crop = result["images_spatial_crop"]
+
+        base_size = pixel_values.shape[-1]
+        image_size = images_crop.shape[-1]
+
+        schema = DeepseekOCRImagePixelInputs(
+            type="pixel_values",
+            data=pixel_values,
+            images_crop=images_crop,
+            images_spatial_crop=images_spatial_crop,
+            resolve_bindings={
+                "base_size": base_size,
+                "image_size": image_size,
+            },
+        )
+
+        assert schema.data.shape == (1, 3, BASE_SIZE, BASE_SIZE)
+        assert schema.images_crop.shape[-1] == IMAGE_SIZE
+
+    def test_mismatched_image_size_raises(self, processor):
+        """Deliberately wrong image_size binding should be caught by
+        TensorSchema validation."""
+        small_image = Image.new("RGB", (100, 100), color="yellow")
+
+        result = processor(
+            prompt="<image>\nDescribe this image.",
+            images=[small_image],
+        )
+
+        pixel_values = result["pixel_values"]
+        images_crop = result["images_crop"]
+        images_spatial_crop = result["images_spatial_crop"]
+
+        with pytest.raises(ValueError, match="images_crop"):
+            DeepseekOCRImagePixelInputs(
+                type="pixel_values",
+                data=pixel_values,
+                images_crop=images_crop,
+                images_spatial_crop=images_spatial_crop,
+                resolve_bindings={
+                    "base_size": BASE_SIZE,
+                    "image_size": BASE_SIZE,  # Wrong! Tensor has IMAGE_SIZE
+                },
+            )

--- a/vllm/model_executor/models/deepencoder2.py
+++ b/vllm/model_executor/models/deepencoder2.py
@@ -258,8 +258,10 @@ class Qwen2Decoder2Encoder(nn.Module):
 
         token_type_ids = torch.cat(
             [
-                torch.zeros(bs, n_query, dtype=torch.long),
-                torch.ones(bs, n_query, dtype=torch.long),
+                torch.zeros(bs, n_query, dtype=torch.long,
+                            device=x_combined.device),
+                torch.ones(bs, n_query, dtype=torch.long,
+                           device=x_combined.device),
             ],
             dim=1,
         )

--- a/vllm/model_executor/models/deepseek_ocr2.py
+++ b/vllm/model_executor/models/deepseek_ocr2.py
@@ -327,7 +327,12 @@ class DeepseekOCR2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, Support
         if pixel_values is None or torch.sum(pixel_values).item() == 0:
             return None
 
-        base_size = self.vision_config.image_size
+        # Use actual tensor spatial dims instead of config values for
+        # robustness across model variants (matching deepseek_ocr v1).
+        base_size = pixel_values.shape[-1]
+        image_size = (
+            images_crop.shape[-1] if images_crop is not None else base_size
+        )
         return DeepseekOCRImagePixelInputs(
             type="pixel_values",
             data=pixel_values,
@@ -335,6 +340,7 @@ class DeepseekOCR2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, Support
             images_spatial_crop=images_spatial_crop,
             resolve_bindings={
                 "base_size": base_size,
+                "image_size": image_size,
             },
         )
 


### PR DESCRIPTION
Automated implementation for **AIFQA-397**.

**Summary:** BLK-011: [vLLM] DeepSeek-OCR-2 — DeepseekOCR2ForCausalLM arch not supported

Branch: `dev/sys_qaplatformbot/AIFQA-397--20260330160201`