### PR TITLE
[Feature] Implement Mean Pool Connector to return mean pooled vector over prompt tokens in response

### DIFF
--- a/tests/v1/kv_connector/mean_pool_integration/__init__.py
+++ b/tests/v1/kv_connector/mean_pool_integration/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+

--- a/tests/v1/kv_connector/mean_pool_integration/test_mean_pool.py
+++ b/tests/v1/kv_connector/mean_pool_integration/test_mean_pool.py
@@ -3,295 +3,117 @@
 """
 Tests for MeanPoolHiddenStatesConnector.
 
-1. Unit test with PredictableLlamaForCausalLM (deterministic values)
-2. E2E accuracy tests with Llama-3.2-1B and Qwen3-0.6B
+1. End-to-end accuracy tests for Llama-3.2-3B-Instruct and Qwen3-0.6B that
+   compare the connector's mean-pooled hidden states against vLLM's own
+   embed task (``runner="pooling"`` + ``pooling_type="MEAN"``), which
+   mean-pools the same hidden states using the standard pooler
+   path.
+2. LoRA test for Llama-3.2-3B-Instruct using the
+   ``jeeejeee/llama32-3b-text2sql-spider`` adapter, verifying the
+   connector keeps working when LoRA is applied at request time.
 """
 
 import gc
+import os
 import tempfile
 
 import pytest
 import torch
 
-from vllm import LLM, ModelRegistry, SamplingParams
+from vllm import LLM, SamplingParams
+from vllm.lora.request import LoRARequest
 
-# =====================================================================
-# Unit test: Predictable model with deterministic hidden states
-# =====================================================================
-
-
-@pytest.fixture(scope="module")
-def predictable_llama_config_path(tmp_path_factory):
-    """Create a minimal LlamaConfig for PredictableLlamaForCausalLM."""
-    from transformers import AutoTokenizer, LlamaConfig
-
-    config_dir = tmp_path_factory.mktemp("predictable_llama_mean_pool")
-
-    config = LlamaConfig(
-        vocab_size=128256,
-        hidden_size=256,
-        intermediate_size=512,
-        num_hidden_layers=24,
-        num_attention_heads=4,
-        num_key_value_heads=4,
-        max_position_embeddings=128,
-        architectures=["PredictableLlamaForCausalLM"],
-    )
-    config.save_pretrained(config_dir)
-
-    tokenizer = AutoTokenizer.from_pretrained(
-        "meta-llama/Llama-3.2-1B",
-        local_files_only=True,
-    )
-    tokenizer.save_pretrained(config_dir)
-
-    return str(config_dir)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def register_predictable_model():
-    """Register the PredictableLlamaForCausalLM model."""
-    from tests.v1.kv_connector.extract_hidden_states_integration.predictable_llama import (  # noqa: E501
-        PredictableLlamaForCausalLM,
-    )
-
-    if "PredictableLlamaForCausalLM" not in ModelRegistry.get_supported_archs():
-        ModelRegistry.register_model(
-            "PredictableLlamaForCausalLM", PredictableLlamaForCausalLM
-        )
-    yield
-
-
-def test_mean_pool_with_predictable_model(predictable_llama_config_path, tmp_path):
-    """Test mean pooling with deterministic hidden states.
-
-    PredictableLlamaForCausalLM produces hidden states where layer i
-    outputs values equal to i. If we extract layer 5, mean pooling over
-    prompt tokens should produce a vector of all 5.0s.
-    """
-    layer_id = 5
-    storage_path = str(tmp_path / "mean_pool")
-
-    llm = LLM(
-        model=predictable_llama_config_path,
-        speculative_config={
-            "method": "extract_hidden_states",
-            "num_speculative_tokens": 1,
-            "draft_model_config": {
-                "hf_config": {"eagle_aux_hidden_state_layer_ids": [layer_id]}
-            },
-        },
-        kv_transfer_config={
-            "kv_connector": "MeanPoolHiddenStatesConnector",
-            "kv_role": "kv_producer",
-            "kv_connector_extra_config": {
-                "shared_storage_path": storage_path,
-            },
-        },
-        max_model_len=128,
-        enforce_eager=True,
-        trust_remote_code=True,
-        load_format="dummy",
-    )
-
-    prompts = [
-        "Short",
-        "Medium length prompt",
-        "Much longer prompt with many tokens for testing",
-        "Much longer prompt with many tokens for testing",  # repeated
-    ]
-    sampling_params = SamplingParams(max_tokens=100, temperature=0.0)
-    hidden_size = llm.llm_engine.model_config.get_hidden_size()
-    outputs = llm.generate(prompts, sampling_params)
-    del llm
-    gc.collect()
-
-    assert len(outputs) == len(prompts)
-
-    for output in outputs:
-        assert output.kv_transfer_params is not None, (
-            "kv_transfer_params should not be None"
-        )
-        pooled_list = output.kv_transfer_params.get("mean_pooled_hidden_states")
-        assert pooled_list is not None, (
-            "mean_pooled_hidden_states not found in kv_transfer_params"
-        )
-
-        pooled = torch.tensor(pooled_list)
-        # With num_heads=1 (single layer), pooled shape is [hidden_size]
-        assert pooled.shape == (hidden_size,), (
-            f"Expected shape ({hidden_size},), got {pooled.shape}"
-        )
-
-        # Mean pooling a constant value = that constant value
-        expected = torch.full((hidden_size,), float(layer_id))
-        assert torch.allclose(pooled, expected, atol=1e-4), (
-            f"Expected all values to be {float(layer_id)}, "
-            f"but got mean={pooled.mean():.4f}, "
-            f"min={pooled.min():.4f}, max={pooled.max():.4f}"
-        )
-
-
-def test_mean_pool_multiple_layers(predictable_llama_config_path, tmp_path):
-    """Test mean pooling with multiple hidden state layers.
-
-    When extracting multiple layers, the pooled result should have shape
-    [num_layers, hidden_size] with each row equal to the layer index.
-    """
-    layer_ids = [3, 7, 15]
-    storage_path = str(tmp_path / "mean_pool_multi")
-
-    llm = LLM(
-        model=predictable_llama_config_path,
-        speculative_config={
-            "method": "extract_hidden_states",
-            "num_speculative_tokens": 1,
-            "draft_model_config": {
-                "hf_config": {"eagle_aux_hidden_state_layer_ids": layer_ids}
-            },
-        },
-        kv_transfer_config={
-            "kv_connector": "MeanPoolHiddenStatesConnector",
-            "kv_role": "kv_producer",
-            "kv_connector_extra_config": {
-                "shared_storage_path": storage_path,
-            },
-        },
-        max_model_len=128,
-        enforce_eager=True,
-        trust_remote_code=True,
-        load_format="dummy",
-    )
-
-    prompts = ["Test prompt for multi-layer mean pooling"]
-    sampling_params = SamplingParams(max_tokens=100, temperature=0.0)
-    hidden_size = llm.llm_engine.model_config.get_hidden_size()
-    outputs = llm.generate(prompts, sampling_params)
-    del llm
-    gc.collect()
-
-    assert len(outputs) == 1
-    output = outputs[0]
-    assert output.kv_transfer_params is not None
-    pooled_list = output.kv_transfer_params.get("mean_pooled_hidden_states")
-    assert pooled_list is not None
-
-    pooled = torch.tensor(pooled_list)
-    # With num_heads > 1, shape is [num_heads, hidden_size]
-    assert pooled.shape == (len(layer_ids), hidden_size), (
-        f"Expected shape ({len(layer_ids)}, {hidden_size}), got {pooled.shape}"
-    )
-
-    # Each row should equal the corresponding layer index
-    for idx, layer_id in enumerate(layer_ids):
-        expected = torch.full((hidden_size,), float(layer_id))
-        assert torch.allclose(pooled[idx], expected, atol=1e-4), (
-            f"Layer {layer_id} at index {idx}: expected {float(layer_id)}, "
-            f"got mean={pooled[idx].mean():.4f}"
-        )
+# Defaults are HF repo IDs and resolve from ~/.cache/huggingface/hub.
+LLAMA_MODEL = os.environ.get(
+    "VLLM_TEST_LLAMA_MODEL", "meta-llama/Llama-3.2-3B-Instruct"
+)
+QWEN_MODEL = os.environ.get("VLLM_TEST_QWEN_MODEL", "Qwen/Qwen3-0.6B")
+LLAMA_LORA_PATH = os.environ.get(
+    "VLLM_TEST_LLAMA_LORA_PATH", "jeeejeee/llama32-3b-text2sql-spider"
+)
 
 
 # =====================================================================
-# E2E accuracy tests with real models
+# End-to-end accuracy: connector vs. vLLM's own embed (MEAN) task
 # =====================================================================
 
 
-def _get_hf_mean_pooled_hidden_states(
+def _get_vllm_mean_pooled_embeddings(
     model_name: str,
     prompts: list[str],
-    layer_ids: list[int],
-    device: str = "cuda",
+    lora_path: str | None = None,
+    max_lora_rank: int = 8,
 ) -> list[torch.Tensor]:
-    """Get mean-pooled hidden states from HuggingFace model as reference.
+    """Run vLLM's embed task with MEAN pooling as a reference.
 
-    Returns a list of tensors, one per prompt. Each tensor shape:
-    - [hidden_size] if single layer
-    - [num_layers, hidden_size] if multiple layers
+    Both the connector and the embed task operate on the
+    hidden states from ``LlamaForCausalLM`` / ``Qwen3ForCausalLM``, so
+    their mean-pooled outputs should match (modulo dtype precision).
+
+    If ``lora_path`` is provided, the LoRA adapter is loaded and applied to
+    every embed request, so the reference reflects LoRA-modified hidden
+    states.
     """
-    from transformers import AutoModelForCausalLM, AutoTokenizer
+    llm_kwargs: dict = {}
+    lora_request = None
+    if lora_path is not None:
+        llm_kwargs["enable_lora"] = True
+        llm_kwargs["max_loras"] = 1
+        llm_kwargs["max_lora_rank"] = max_lora_rank
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        model_name,
-        local_files_only=True,
+    llm = LLM(
+        model=model_name,
+        runner="pooling",
+        convert="embed",
+        pooler_config={
+            "pooling_type": "MEAN",
+            "use_activation": False,
+        },
+        max_model_len=128,
+        enforce_eager=True,
+        dtype="bfloat16",
+        **llm_kwargs,
     )
-    model = AutoModelForCausalLM.from_pretrained(
-        model_name,
-        local_files_only=True,
-        torch_dtype=torch.bfloat16,
-    ).to(device)
-    model.eval()
+    if lora_path is not None:
+        lora_request = LoRARequest("ref_lora", 1, lora_path)
+        llm.llm_engine.add_lora(lora_request)
 
-    results = []
-    with torch.no_grad():
-        for prompt in prompts:
-            inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=True).to(
-                device
-            )
-            outputs = model(
-                **inputs,
-                output_hidden_states=True,
-            )
-            # outputs.hidden_states is a tuple:
-            # (embedding, layer_0_output, layer_1_output, ..., layer_N_output)
-            # layer_ids index into this tuple (0 = embedding, 1 = layer_0, etc.)
-            selected = []
-            for lid in layer_ids:
-                # HF hidden_states[0] = embedding, [1] = after layer 0, etc.
-                # vLLM's _maybe_add_hidden_state captures at idx=0
-                # (pre-first-layer) and idx=i+1 (post-layer-i).
-                # So layer_id in vLLM corresponds to hidden_states[layer_id]
-                # in HF.
-                hs = outputs.hidden_states[lid]  # [1, seq_len, hidden_size]
-                hs = hs.squeeze(0)  # [seq_len, hidden_size]
-                selected.append(hs.mean(dim=0, dtype=torch.float32))
-
-            if len(selected) == 1:
-                results.append(selected[0].cpu())
-            else:
-                results.append(torch.stack(selected, dim=0).cpu())
-
-    del model
+    outputs = llm.embed(prompts, lora_request=lora_request, use_tqdm=False)
+    embeddings = [torch.tensor(o.outputs.embedding) for o in outputs]
+    del llm
     gc.collect()
     torch.accelerator.empty_cache()
-    return results
+    return embeddings
 
 
 @pytest.mark.parametrize(
-    "model_name,layer_ids",
+    "model_name",
     [
-        ("meta-llama/Llama-3.2-1B", [8]),  # middle layer
-        ("Qwen/Qwen3-0.6B", [14]),  # middle layer
+        LLAMA_MODEL,
+        QWEN_MODEL,
     ],
 )
 @torch.inference_mode()
-def test_mean_pool_accuracy_vs_hf(model_name: str, layer_ids: list[int]):
-    """Compare vLLM mean-pooled hidden states against HuggingFace reference.
+def test_mean_pool_accuracy_vs_embed_task(model_name: str):
+    """Compare connector mean-pool against vLLM's embed-task MEAN pooler.
 
-    Tests that the mean-pooled hidden states from vLLM's
-    MeanPoolHiddenStatesConnector match HuggingFace's output within
-    tolerance (accounting for FlashAttention numerical differences).
+    The connector caches hidden states (via the embedded
+    ``CacheOnlyAttentionLayer``) and mean-pools over prompt tokens. The
+    embed task applies ``MeanPool`` to the same hidden states.
+    Outputs should match within bf16 precision.
     """
     prompts = [
         "The quick brown fox jumps over the lazy dog.",
         "Machine learning is a subset of artificial intelligence.",
     ]
 
-    # Get HF reference
-    hf_results = _get_hf_mean_pooled_hidden_states(model_name, prompts, layer_ids)
+    # Reference: vLLM embed task with MEAN pooling.
+    embed_results = _get_vllm_mean_pooled_embeddings(model_name, prompts)
 
-    # Get vLLM results
+    # System under test: generate task with MeanPoolHiddenStatesConnector.
     with tempfile.TemporaryDirectory() as storage_path:
         llm = LLM(
             model=model_name,
-            speculative_config={
-                "method": "extract_hidden_states",
-                "num_speculative_tokens": 1,
-                "draft_model_config": {
-                    "hf_config": {
-                        "eagle_aux_hidden_state_layer_ids": layer_ids,
-                    }
-                },
-            },
             kv_transfer_config={
                 "kv_connector": "MeanPoolHiddenStatesConnector",
                 "kv_role": "kv_producer",
@@ -311,7 +133,7 @@ def test_mean_pool_accuracy_vs_hf(model_name: str, layer_ids: list[int]):
 
     assert len(outputs) == len(prompts)
 
-    for i, (output, hf_ref) in enumerate(zip(outputs, hf_results)):
+    for i, (output, ref) in enumerate(zip(outputs, embed_results)):
         assert output.kv_transfer_params is not None, (
             f"Prompt {i}: kv_transfer_params should not be None"
         )
@@ -320,19 +142,104 @@ def test_mean_pool_accuracy_vs_hf(model_name: str, layer_ids: list[int]):
             f"Prompt {i}: mean_pooled_hidden_states not found"
         )
 
-        vllm_pooled = torch.tensor(pooled_list)
-        assert vllm_pooled.shape == hf_ref.shape, (
-            f"Prompt {i}: shape mismatch: vLLM {vllm_pooled.shape} vs HF {hf_ref.shape}"
+        connector_pooled = torch.tensor(pooled_list)
+        assert connector_pooled.shape == ref.shape, (
+            f"Prompt {i}: shape mismatch: "
+            f"connector {connector_pooled.shape} vs embed {ref.shape}"
         )
 
-        # Absolute accuracy check.
-        # FlashAttention vs standard attention introduces numerical
-        # differences in bf16. Max observed diff is ~0.08 on Qwen3-0.6B
-        # (relative to values of magnitude ~40, this is <0.2%).
-        max_diff = (vllm_pooled - hf_ref).abs().max().item()
-        assert max_diff < 0.1, (
-            f"Prompt {i} ({model_name}): max absolute diff {max_diff:.4f} "
-            f"exceeds tolerance 0.1. "
-            f"vLLM mean={vllm_pooled.mean():.4f}, "
-            f"HF mean={hf_ref.mean():.4f}"
+        cos_sim = torch.nn.functional.cosine_similarity(
+            connector_pooled.float().unsqueeze(0),
+            ref.float().unsqueeze(0),
+        ).item()
+        assert cos_sim > 0.999, (
+            f"Prompt {i} ({model_name}): cosine similarity {cos_sim:.6f} "
+            f"below threshold 0.999."
+        )
+
+
+# =====================================================================
+# LoRA: connector still returns pooled hidden states with adapters
+# =====================================================================
+
+
+@torch.inference_mode()
+def test_mean_pool_with_lora_vs_embed_task():
+    """Compare LoRA-applied connector mean-pool against LoRA-applied embed.
+
+    Same comparison as ``test_mean_pool_accuracy_vs_embed_task`` but with the
+    ``jeeejeee/llama32-3b-text2sql-spider`` adapter applied to every request
+    on both sides. Confirms the connector reflects LoRA-modified
+    hidden states and matches what the standard MeanPool pooler produces
+    when LoRA is active.
+    """
+    hidden_size = 3072  # Llama-3.2-3B-Instruct
+    prompts = [
+        "Translate to SQL: list the names of all employees.",
+        "Translate to SQL: count the number of orders per customer.",
+    ]
+
+    # Reference: vLLM embed task with MEAN pooling, LoRA applied.
+    embed_results = _get_vllm_mean_pooled_embeddings(
+        LLAMA_MODEL, prompts, lora_path=LLAMA_LORA_PATH, max_lora_rank=8
+    )
+
+    # System under test: generate task with the connector, LoRA applied.
+    with tempfile.TemporaryDirectory() as storage_path:
+        llm = LLM(
+            model=LLAMA_MODEL,
+            kv_transfer_config={
+                "kv_connector": "MeanPoolHiddenStatesConnector",
+                "kv_role": "kv_producer",
+                "kv_connector_extra_config": {
+                    "shared_storage_path": storage_path,
+                },
+            },
+            enable_lora=True,
+            max_loras=1,
+            max_lora_rank=8,
+            max_model_len=128,
+            enforce_eager=True,
+            dtype="bfloat16",
+        )
+
+        lora_request = LoRARequest("text2sql", 1, LLAMA_LORA_PATH)
+        llm.llm_engine.add_lora(lora_request)
+        assert 1 in llm.llm_engine.list_loras()
+
+        sampling_params = SamplingParams(max_tokens=32, temperature=0.0)
+        outputs = llm.generate(
+            prompts,
+            sampling_params,
+            lora_request=lora_request,
+            use_tqdm=False,
+        )
+
+        del llm
+        gc.collect()
+        torch.accelerator.empty_cache()
+
+    assert len(outputs) == len(prompts)
+
+    for i, (output, ref) in enumerate(zip(outputs, embed_results)):
+        assert output.kv_transfer_params is not None, (
+            f"Prompt {i}: kv_transfer_params should not be None"
+        )
+        pooled_list = output.kv_transfer_params.get("mean_pooled_hidden_states")
+        assert pooled_list is not None, (
+            f"Prompt {i}: mean_pooled_hidden_states not found"
+        )
+
+        connector_pooled = torch.tensor(pooled_list)
+        assert connector_pooled.shape == (hidden_size,), (
+            f"Prompt {i}: shape {connector_pooled.shape} != ({hidden_size},)"
+        )
+        assert connector_pooled.shape == ref.shape
+
+        cos_sim = torch.nn.functional.cosine_similarity(
+            connector_pooled.float().unsqueeze(0),
+            ref.float().unsqueeze(0),
+        ).item()
+        assert cos_sim > 0.999, (
+            f"Prompt {i}: LoRA cosine similarity {cos_sim:.6f} below 0.999"
         )

--- a/tests/v1/kv_connector/mean_pool_integration/test_mean_pool.py
+++ b/tests/v1/kv_connector/mean_pool_integration/test_mean_pool.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for MeanPoolHiddenStatesConnector.
+
+1. Unit test with PredictableLlamaForCausalLM (deterministic values)
+2. E2E accuracy tests with Llama-3.2-1B and Qwen3-0.6B
+"""
+
+import gc
+import tempfile
+
+import pytest
+import torch
+
+from vllm import LLM, ModelRegistry, SamplingParams
+
+# =====================================================================
+# Unit test: Predictable model with deterministic hidden states
+# =====================================================================
+
+
+@pytest.fixture(scope="module")
+def predictable_llama_config_path(tmp_path_factory):
+    """Create a minimal LlamaConfig for PredictableLlamaForCausalLM."""
+    from transformers import AutoTokenizer, LlamaConfig
+
+    config_dir = tmp_path_factory.mktemp("predictable_llama_mean_pool")
+
+    config = LlamaConfig(
+        vocab_size=128256,
+        hidden_size=256,
+        intermediate_size=512,
+        num_hidden_layers=24,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=128,
+        architectures=["PredictableLlamaForCausalLM"],
+    )
+    config.save_pretrained(config_dir)
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        "meta-llama/Llama-3.2-1B",
+        local_files_only=True,
+    )
+    tokenizer.save_pretrained(config_dir)
+
+    return str(config_dir)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def register_predictable_model():
+    """Register the PredictableLlamaForCausalLM model."""
+    from tests.v1.kv_connector.extract_hidden_states_integration.predictable_llama import (  # noqa: E501
+        PredictableLlamaForCausalLM,
+    )
+
+    if "PredictableLlamaForCausalLM" not in ModelRegistry.get_supported_archs():
+        ModelRegistry.register_model(
+            "PredictableLlamaForCausalLM", PredictableLlamaForCausalLM
+        )
+    yield
+
+
+def test_mean_pool_with_predictable_model(predictable_llama_config_path, tmp_path):
+    """Test mean pooling with deterministic hidden states.
+
+    PredictableLlamaForCausalLM produces hidden states where layer i
+    outputs values equal to i. If we extract layer 5, mean pooling over
+    prompt tokens should produce a vector of all 5.0s.
+    """
+    layer_id = 5
+    storage_path = str(tmp_path / "mean_pool")
+
+    llm = LLM(
+        model=predictable_llama_config_path,
+        speculative_config={
+            "method": "extract_hidden_states",
+            "num_speculative_tokens": 1,
+            "draft_model_config": {
+                "hf_config": {"eagle_aux_hidden_state_layer_ids": [layer_id]}
+            },
+        },
+        kv_transfer_config={
+            "kv_connector": "MeanPoolHiddenStatesConnector",
+            "kv_role": "kv_producer",
+            "kv_connector_extra_config": {
+                "shared_storage_path": storage_path,
+            },
+        },
+        max_model_len=128,
+        enforce_eager=True,
+        trust_remote_code=True,
+        load_format="dummy",
+    )
+
+    prompts = [
+        "Short",
+        "Medium length prompt",
+        "Much longer prompt with many tokens for testing",
+        "Much longer prompt with many tokens for testing",  # repeated
+    ]
+    sampling_params = SamplingParams(max_tokens=100, temperature=0.0)
+    hidden_size = llm.llm_engine.model_config.get_hidden_size()
+    outputs = llm.generate(prompts, sampling_params)
+    del llm
+    gc.collect()
+
+    assert len(outputs) == len(prompts)
+
+    for output in outputs:
+        assert output.kv_transfer_params is not None, (
+            "kv_transfer_params should not be None"
+        )
+        pooled_list = output.kv_transfer_params.get("mean_pooled_hidden_states")
+        assert pooled_list is not None, (
+            "mean_pooled_hidden_states not found in kv_transfer_params"
+        )
+
+        pooled = torch.tensor(pooled_list)
+        # With num_heads=1 (single layer), pooled shape is [hidden_size]
+        assert pooled.shape == (hidden_size,), (
+            f"Expected shape ({hidden_size},), got {pooled.shape}"
+        )
+
+        # Mean pooling a constant value = that constant value
+        expected = torch.full((hidden_size,), float(layer_id))
+        assert torch.allclose(pooled, expected, atol=1e-4), (
+            f"Expected all values to be {float(layer_id)}, "
+            f"but got mean={pooled.mean():.4f}, "
+            f"min={pooled.min():.4f}, max={pooled.max():.4f}"
+        )
+
+
+def test_mean_pool_multiple_layers(predictable_llama_config_path, tmp_path):
+    """Test mean pooling with multiple hidden state layers.
+
+    When extracting multiple layers, the pooled result should have shape
+    [num_layers, hidden_size] with each row equal to the layer index.
+    """
+    layer_ids = [3, 7, 15]
+    storage_path = str(tmp_path / "mean_pool_multi")
+
+    llm = LLM(
+        model=predictable_llama_config_path,
+        speculative_config={
+            "method": "extract_hidden_states",
+            "num_speculative_tokens": 1,
+            "draft_model_config": {
+                "hf_config": {"eagle_aux_hidden_state_layer_ids": layer_ids}
+            },
+        },
+        kv_transfer_config={
+            "kv_connector": "MeanPoolHiddenStatesConnector",
+            "kv_role": "kv_producer",
+            "kv_connector_extra_config": {
+                "shared_storage_path": storage_path,
+            },
+        },
+        max_model_len=128,
+        enforce_eager=True,
+        trust_remote_code=True,
+        load_format="dummy",
+    )
+
+    prompts = ["Test prompt for multi-layer mean pooling"]
+    sampling_params = SamplingParams(max_tokens=100, temperature=0.0)
+    hidden_size = llm.llm_engine.model_config.get_hidden_size()
+    outputs = llm.generate(prompts, sampling_params)
+    del llm
+    gc.collect()
+
+    assert len(outputs) == 1
+    output = outputs[0]
+    assert output.kv_transfer_params is not None
+    pooled_list = output.kv_transfer_params.get("mean_pooled_hidden_states")
+    assert pooled_list is not None
+
+    pooled = torch.tensor(pooled_list)
+    # With num_heads > 1, shape is [num_heads, hidden_size]
+    assert pooled.shape == (len(layer_ids), hidden_size), (
+        f"Expected shape ({len(layer_ids)}, {hidden_size}), got {pooled.shape}"
+    )
+
+    # Each row should equal the corresponding layer index
+    for idx, layer_id in enumerate(layer_ids):
+        expected = torch.full((hidden_size,), float(layer_id))
+        assert torch.allclose(pooled[idx], expected, atol=1e-4), (
+            f"Layer {layer_id} at index {idx}: expected {float(layer_id)}, "
+            f"got mean={pooled[idx].mean():.4f}"
+        )
+
+
+# =====================================================================
+# E2E accuracy tests with real models
+# =====================================================================
+
+
+def _get_hf_mean_pooled_hidden_states(
+    model_name: str,
+    prompts: list[str],
+    layer_ids: list[int],
+    device: str = "cuda",
+) -> list[torch.Tensor]:
+    """Get mean-pooled hidden states from HuggingFace model as reference.
+
+    Returns a list of tensors, one per prompt. Each tensor shape:
+    - [hidden_size] if single layer
+    - [num_layers, hidden_size] if multiple layers
+    """
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name,
+        local_files_only=True,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        local_files_only=True,
+        torch_dtype=torch.bfloat16,
+    ).to(device)
+    model.eval()
+
+    results = []
+    with torch.no_grad():
+        for prompt in prompts:
+            inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=True).to(
+                device
+            )
+            outputs = model(
+                **inputs,
+                output_hidden_states=True,
+            )
+            # outputs.hidden_states is a tuple:
+            # (embedding, layer_0_output, layer_1_output, ..., layer_N_output)
+            # layer_ids index into this tuple (0 = embedding, 1 = layer_0, etc.)
+            selected = []
+            for lid in layer_ids:
+                # HF hidden_states[0] = embedding, [1] = after layer 0, etc.
+                # vLLM's _maybe_add_hidden_state captures at idx=0
+                # (pre-first-layer) and idx=i+1 (post-layer-i).
+                # So layer_id in vLLM corresponds to hidden_states[layer_id]
+                # in HF.
+                hs = outputs.hidden_states[lid]  # [1, seq_len, hidden_size]
+                hs = hs.squeeze(0)  # [seq_len, hidden_size]
+                selected.append(hs.mean(dim=0, dtype=torch.float32))
+
+            if len(selected) == 1:
+                results.append(selected[0].cpu())
+            else:
+                results.append(torch.stack(selected, dim=0).cpu())
+
+    del model
+    gc.collect()
+    torch.accelerator.empty_cache()
+    return results
+
+
+@pytest.mark.parametrize(
+    "model_name,layer_ids",
+    [
+        ("meta-llama/Llama-3.2-1B", [8]),  # middle layer
+        ("Qwen/Qwen3-0.6B", [14]),  # middle layer
+    ],
+)
+@torch.inference_mode()
+def test_mean_pool_accuracy_vs_hf(model_name: str, layer_ids: list[int]):
+    """Compare vLLM mean-pooled hidden states against HuggingFace reference.
+
+    Tests that the mean-pooled hidden states from vLLM's
+    MeanPoolHiddenStatesConnector match HuggingFace's output within
+    tolerance (accounting for FlashAttention numerical differences).
+    """
+    prompts = [
+        "The quick brown fox jumps over the lazy dog.",
+        "Machine learning is a subset of artificial intelligence.",
+    ]
+
+    # Get HF reference
+    hf_results = _get_hf_mean_pooled_hidden_states(model_name, prompts, layer_ids)
+
+    # Get vLLM results
+    with tempfile.TemporaryDirectory() as storage_path:
+        llm = LLM(
+            model=model_name,
+            speculative_config={
+                "method": "extract_hidden_states",
+                "num_speculative_tokens": 1,
+                "draft_model_config": {
+                    "hf_config": {
+                        "eagle_aux_hidden_state_layer_ids": layer_ids,
+                    }
+                },
+            },
+            kv_transfer_config={
+                "kv_connector": "MeanPoolHiddenStatesConnector",
+                "kv_role": "kv_producer",
+                "kv_connector_extra_config": {
+                    "shared_storage_path": storage_path,
+                },
+            },
+            max_model_len=128,
+            enforce_eager=True,
+            dtype="bfloat16",
+        )
+        sampling_params = SamplingParams(max_tokens=100, temperature=0.0)
+        outputs = llm.generate(prompts, sampling_params)
+        del llm
+        gc.collect()
+        torch.accelerator.empty_cache()
+
+    assert len(outputs) == len(prompts)
+
+    for i, (output, hf_ref) in enumerate(zip(outputs, hf_results)):
+        assert output.kv_transfer_params is not None, (
+            f"Prompt {i}: kv_transfer_params should not be None"
+        )
+        pooled_list = output.kv_transfer_params.get("mean_pooled_hidden_states")
+        assert pooled_list is not None, (
+            f"Prompt {i}: mean_pooled_hidden_states not found"
+        )
+
+        vllm_pooled = torch.tensor(pooled_list)
+        assert vllm_pooled.shape == hf_ref.shape, (
+            f"Prompt {i}: shape mismatch: vLLM {vllm_pooled.shape} vs HF {hf_ref.shape}"
+        )
+
+        # Absolute accuracy check.
+        # FlashAttention vs standard attention introduces numerical
+        # differences in bf16. Max observed diff is ~0.08 on Qwen3-0.6B
+        # (relative to values of magnitude ~40, this is <0.2%).
+        max_diff = (vllm_pooled - hf_ref).abs().max().item()
+        assert max_diff < 0.1, (
+            f"Prompt {i} ({model_name}): max absolute diff {max_diff:.4f} "
+            f"exceeds tolerance 0.1. "
+            f"vLLM mean={vllm_pooled.mean():.4f}, "
+            f"HF mean={hf_ref.mean():.4f}"
+        )

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -159,6 +159,12 @@ KVConnectorFactory.register_connector(
 )
 
 KVConnectorFactory.register_connector(
+    "MeanPoolHiddenStatesConnector",
+    "vllm.distributed.kv_transfer.kv_connector.v1.mean_pool_hidden_states_connector",
+    "MeanPoolHiddenStatesConnector",
+)
+
+KVConnectorFactory.register_connector(
     "P2pNcclConnector",
     "vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_connector",
     "P2pNcclConnector",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mean_pool_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mean_pool_hidden_states_connector.py
@@ -1,0 +1,409 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Mean-pool hidden states connector for vLLM.
+
+Extracts hidden states from a CacheOnlyAttentionLayer's KV cache,
+mean-pools over prompt tokens, and returns the resulting vector via
+kv_transfer_params in the API response.
+
+Usage (server launch — requires extract_hidden_states spec decode method):
+    --speculative-config '{
+        "method": "extract_hidden_states",
+        "num_speculative_tokens": 1,
+        "draft_model_config": {
+            "hf_config": {"eagle_aux_hidden_state_layer_ids": [16]}
+        }
+    }'
+    --kv-transfer-config '{
+        "kv_connector": "MeanPoolHiddenStatesConnector",
+        "kv_role": "kv_producer",
+        "kv_connector_extra_config": {
+            "shared_storage_path": "/dev/shm/vllm_mean_pool"
+        }
+    }'
+
+WARNING: This connector uses a shared directory for communication.
+If running multiple vLLM instances, you MUST provide a unique `shared_storage_path`
+for each instance to avoid conflicts.
+
+Files for completed requests are removed automatically.
+However, in case of a server crash, stale files may accumulate in
+the `shared_storage_path`. It is the user's responsibility to handle
+periodic cleanup of this directory.
+
+Limitations:
+    The extract_hidden_states method piggybacks on the speculative decoding
+    framework.
+
+    - Online serving (``vllm serve``): NOT supported.
+    - Offline batched inference (``llm.generate(prompts, ...)``): Supported
+      ONLY with ``max_tokens=1``.
+    - Offline single-request inference: Fully supported
+"""
+
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+
+from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+
+if TYPE_CHECKING:
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class _ReqMeta:
+    """Lightweight per-request metadata sent from scheduler to worker.
+
+    Only carries what the worker needs: request ID, prompt length, and
+    the slot mapping into the hidden state KV cache.
+    """
+
+    req_id: str
+    prompt_len: int
+    slot_mapping: list[int]
+
+    @staticmethod
+    def make(
+        req_id: str,
+        prompt_len: int,
+        block_ids: list[int],
+        block_size: int,
+    ) -> "_ReqMeta":
+        slot_mapping = [
+            bid * block_size + offset
+            for bid in block_ids
+            for offset in range(block_size)
+        ]
+        return _ReqMeta(
+            req_id=req_id,
+            prompt_len=prompt_len,
+            slot_mapping=slot_mapping,
+        )
+
+
+@dataclass
+class MeanPoolConnectorMetadata(KVConnectorMetadata):
+    requests: list[_ReqMeta] = field(default_factory=list)
+    finished_req_ids: list[str] = field(default_factory=list)
+
+
+def extract_from_kv_cache(
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    num_tokens: int,
+) -> torch.Tensor:
+    """Extract data from KV cache.
+
+    Args:
+        kv_cache: shape (num_pages, page_size, num_heads, head_size)
+        slot_mapping: linear indices into flattened (pages * page_size) dim
+        num_tokens: number of actual tokens (slot_mapping may be padded)
+
+    Returns:
+        Tensor of shape (num_tokens, num_heads, head_size)
+    """
+    return kv_cache.flatten(0, 1)[slot_mapping[:num_tokens]]
+
+
+class MeanPoolHiddenStatesConnector(KVConnectorBase_V1):
+    """
+    Connector that mean-pools prompt hidden states and returns the
+    resulting vector in the API response (via kv_transfer_params).
+
+    Works with the extract_hidden_states speculative decoding method.
+    This connector extracts those hidden states, mean-pools over prompt
+    tokens, and saves the result for retrieval when the request finishes.
+    """
+
+    @property
+    def prefer_cross_layer_blocks(self) -> bool:
+        return False
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: Optional["KVCacheConfig"] = None,
+    ):
+        super().__init__(
+            vllm_config=vllm_config,
+            role=role,
+            kv_cache_config=kv_cache_config,
+        )
+        self._block_size = vllm_config.cache_config.block_size
+
+        # Shared storage for passing mean-pooled vectors from worker to
+        # scheduler (they run in separate processes with V1 multiprocessing).
+        # Default to /dev/shm/vllm_mean_pool for lower latency on Linux,
+        self._storage_path = self._kv_transfer_config.get_from_extra_config(
+            "shared_storage_path",
+            "/dev/shm/vllm_mean_pool",
+        )
+        os.makedirs(self._storage_path, exist_ok=True)
+
+        self._num_heads: int = 0  # set in register_kv_caches
+        self.cache_layers: list[str] = []
+
+        # Which block_ids group index has the CacheOnlyAttentionLayer.
+        self._kv_group_id: int = self._find_cache_group(kv_cache_config)
+
+        # --- Scheduler-side state ---
+        self._req_blocks: dict[str, list[int]] = {}
+        self._prompt_lens: dict[str, int] = {}
+        # Once we've sent metadata with blocks covering the full prompt,
+        # the worker will pool on that step.  We stop including the request
+        # in subsequent metadata to avoid O(N) per-step overhead.
+        self._pooling_metadata_sent: set[str] = set()
+        # Buffer of request IDs that have finished since the last
+        # build_connector_meta call, drained into metadata so the
+        # worker can clean up _completed_pools.
+        self._pending_finished_ids: list[str] = []
+
+        # --- Worker-side state ---
+        # Requests that have completed mean pooling on the worker.
+        self._completed_pools: set[str] = set()
+        self._kv_device: torch.device | None = None
+
+    @staticmethod
+    def _find_cache_group(
+        kv_cache_config: Optional["KVCacheConfig"],
+    ) -> int:
+        """Find which block_ids group holds the CacheOnlyAttentionLayer."""
+        if kv_cache_config is None:
+            return 0
+        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+            for layer_name in group.layer_names:
+                if "cache_only" in layer_name.lower():
+                    return gid
+        raise ValueError(
+            "MeanPoolHiddenStatesConnector requires a CacheOnlyAttentionLayer "
+            "but none was found in kv_cache_groups. Ensure "
+            "--speculative-config with method='extract_hidden_states' is set."
+        )
+
+    # ==============================
+    # Worker-side methods
+    # ==============================
+    def start_load_kv(self, *args, **kwargs: Any) -> None:
+        pass
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        pass
+
+    def wait_for_save(self):
+        pass
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        from vllm.model_executor.models.extract_hidden_states import (
+            CacheOnlyAttentionLayer,
+        )
+
+        layers = get_layers_from_vllm_config(
+            self._vllm_config, CacheOnlyAttentionLayer, list(kv_caches.keys())
+        )
+        self.cache_layers = list(layers.keys())
+        assert len(self.cache_layers) == 1, (
+            f"Expected 1 CacheOnlyAttentionLayer, got {len(self.cache_layers)}"
+        )
+
+        layer_name = self.cache_layers[0]
+        kv_cache = kv_caches[layer_name]
+        # kv_cache shape: (num_pages, page_size, num_heads, head_size)
+        self._num_heads = kv_cache.shape[2]
+        self._kv_device = kv_cache.device
+        logger.info(
+            "MeanPoolHiddenStatesConnector: pooling %d hidden state layer(s) "
+            "on device %s",
+            self._num_heads,
+            self._kv_device,
+        )
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs: Any,
+    ) -> None:
+        """Extract hidden states from KV cache, mean-pool prompt tokens,
+        and save the result for each request."""
+        if layer_name not in self.cache_layers:
+            return
+
+        from vllm.model_executor.models.extract_hidden_states import (
+            CacheOnlyAttentionMetadata,
+        )
+
+        assert isinstance(attn_metadata, CacheOnlyAttentionMetadata)
+
+        connector_metadata = self._get_connector_metadata()
+        assert isinstance(connector_metadata, MeanPoolConnectorMetadata)
+
+        # Fast path: no requests to process (common during pure decode).
+        if not connector_metadata.requests:
+            return
+
+        for request in connector_metadata.requests:
+            # Skip if already pooled (avoid re-computing on every
+            # decode step — only pool once after prefill completes).
+            if request.req_id in self._completed_pools:
+                continue
+
+            prompt_len = request.prompt_len
+            num_slots = len(request.slot_mapping)
+
+            # Only mean-pool when all prompt tokens are in the cache.
+            # With chunked prefill, early steps have fewer blocks.
+            if num_slots < prompt_len:
+                continue
+
+            slot_mapping = torch.tensor(
+                request.slot_mapping, dtype=torch.int64, device=self._kv_device
+            )
+
+            # Extract hidden states for prompt tokens from KV cache
+            # shape: [prompt_len, num_heads, head_size]
+            hidden_states = extract_from_kv_cache(kv_layer, slot_mapping, prompt_len)
+
+            # Mean-pool over prompt tokens (dim=0), independently per head.
+            # [prompt_len, num_heads, head_size] -> [num_heads, head_size]
+            pooled = hidden_states.mean(dim=0, dtype=torch.float32)
+
+            # Single head: flatten [1, head_size] -> [head_size]
+            if self._num_heads == 1:
+                pooled = pooled.squeeze(0)
+
+            # Save using torch binary format (faster than JSON).
+            out_path = os.path.join(self._storage_path, f"{request.req_id}.pt")
+            torch.save(pooled.cpu(), out_path)
+            self._completed_pools.add(request.req_id)
+
+        for req_id in connector_metadata.finished_req_ids:
+            self._completed_pools.discard(req_id)
+
+    # ==============================
+    # Scheduler-side methods
+    # ==============================
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int | None, bool]:
+        return 0, False
+
+    def update_state_after_alloc(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        num_external_tokens: int,
+    ):
+        assert num_external_tokens == 0
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> KVConnectorMetadata:
+        meta = MeanPoolConnectorMetadata()
+
+        # Drain finished request IDs so the worker can clean up.
+        meta.finished_req_ids = self._pending_finished_ids
+        self._pending_finished_ids = []
+
+        for new_req in scheduler_output.scheduled_new_reqs:
+            token_ids = new_req.prompt_token_ids or []
+            prompt_len = len(token_ids)
+            block_ids = new_req.block_ids[self._kv_group_id]
+
+            meta.requests.append(
+                _ReqMeta.make(
+                    req_id=new_req.req_id,
+                    prompt_len=prompt_len,
+                    block_ids=block_ids,
+                    block_size=self._block_size,
+                )
+            )
+            self._req_blocks[new_req.req_id] = list(block_ids)
+            self._prompt_lens[new_req.req_id] = prompt_len
+
+            # If blocks already cover the full prompt, the worker will
+            # pool on this step.  Mark so we skip on future steps.
+            if len(block_ids) * self._block_size >= prompt_len:
+                self._pooling_metadata_sent.add(new_req.req_id)
+
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for i, req_id in enumerate(cached_reqs.req_ids):
+            if req_id not in self._req_blocks:
+                continue
+
+            # Skip requests that have already had pooling metadata sent.
+            if req_id in self._pooling_metadata_sent:
+                continue
+
+            new_block_ids = cached_reqs.new_block_ids[i]
+            req_block_ids = self._req_blocks[req_id]
+            prompt_len = self._prompt_lens[req_id]
+
+            if new_block_ids is not None:
+                req_block_ids.extend(new_block_ids[self._kv_group_id])
+
+            if len(req_block_ids) * self._block_size < prompt_len:
+                continue
+
+            meta.requests.append(
+                _ReqMeta.make(
+                    req_id=req_id,
+                    prompt_len=prompt_len,
+                    block_ids=req_block_ids,
+                    block_size=self._block_size,
+                )
+            )
+
+            if len(req_block_ids) * self._block_size >= prompt_len:
+                self._pooling_metadata_sent.add(req_id)
+
+        return meta
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Return mean-pooled hidden states in kv_transfer_params."""
+        req_id = request.request_id
+        self._req_blocks.pop(req_id, None)
+        self._prompt_lens.pop(req_id, None)
+        self._pooling_metadata_sent.discard(req_id)
+        self._pending_finished_ids.append(req_id)
+
+        # Read the mean-pooled tensor from shared storage.
+        out_path = os.path.join(self._storage_path, f"{req_id}.pt")
+        try:
+            pooled = torch.load(out_path, weights_only=True, map_location="cpu")
+            os.remove(out_path)
+            return False, {"mean_pooled_hidden_states": pooled.tolist()}
+        except FileNotFoundError:
+            logger.warning(
+                "Mean-pooled hidden states not found for request %s. ",
+                req_id,
+            )
+            return False, None
+
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
+        return "NHD"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mean_pool_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mean_pool_hidden_states_connector.py
@@ -32,14 +32,20 @@ However, in case of a server crash, stale files may accumulate in
 the `shared_storage_path`. It is the user's responsibility to handle
 periodic cleanup of this directory.
 
+Note on last-layer hidden states:
+    Hidden states are captured by ``_maybe_add_hidden_state`` **before** the
+    final RMSNorm (``model.norm``). This means the last valid layer index
+    (``num_hidden_layers``) returns the **pre-norm** output, which differs
+    from HuggingFace's ``output_hidden_states`` where the last entry is
+    **post-norm**. For indices < ``num_hidden_layers``, vLLM and HF match.
+
 Limitations:
     The extract_hidden_states method piggybacks on the speculative decoding
     framework.
 
     - Online serving (``vllm serve``): NOT supported.
-    - Offline batched inference (``llm.generate(prompts, ...)``): Supported
-      ONLY with ``max_tokens=1``.
-    - Offline single-request inference: Fully supported
+    - Offline batched inference (``llm.generate(prompts, ...)``): Fully
+      supported.
 """
 
 import os

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mean_pool_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mean_pool_hidden_states_connector.py
@@ -7,14 +7,7 @@ Extracts hidden states from a CacheOnlyAttentionLayer's KV cache,
 mean-pools over prompt tokens, and returns the resulting vector via
 kv_transfer_params in the API response.
 
-Usage (server launch — requires extract_hidden_states spec decode method):
-    --speculative-config '{
-        "method": "extract_hidden_states",
-        "num_speculative_tokens": 1,
-        "draft_model_config": {
-            "hf_config": {"eagle_aux_hidden_state_layer_ids": [16]}
-        }
-    }'
+Usage (server launch):
     --kv-transfer-config '{
         "kv_connector": "MeanPoolHiddenStatesConnector",
         "kv_role": "kv_producer",
@@ -23,29 +16,18 @@ Usage (server launch — requires extract_hidden_states spec decode method):
         }
     }'
 
-WARNING: This connector uses a shared directory for communication.
-If running multiple vLLM instances, you MUST provide a unique `shared_storage_path`
-for each instance to avoid conflicts.
+Requires the target model to embed a ``CacheOnlyAttentionLayer`` whose
+prefix contains ``"hidden_state_cache"``. Supported architectures (which
+embed the layer automatically when this connector is configured):
+    - LlamaForCausalLM
+    - Qwen3ForCausalLM
 
-Files for completed requests are removed automatically.
-However, in case of a server crash, stale files may accumulate in
-the `shared_storage_path`. It is the user's responsibility to handle
-periodic cleanup of this directory.
+The model writes its hidden states into the layer; this
+connector then reads the cached values, mean-pools over prompt tokens,
+and returns the pooled vector.
 
-Note on last-layer hidden states:
-    Hidden states are captured by ``_maybe_add_hidden_state`` **before** the
-    final RMSNorm (``model.norm``). This means the last valid layer index
-    (``num_hidden_layers``) returns the **pre-norm** output, which differs
-    from HuggingFace's ``output_hidden_states`` where the last entry is
-    **post-norm**. For indices < ``num_hidden_layers``, vLLM and HF match.
-
-Limitations:
-    The extract_hidden_states method piggybacks on the speculative decoding
-    framework.
-
-    - Online serving (``vllm serve``): NOT supported.
-    - Offline batched inference (``llm.generate(prompts, ...)``): Fully
-      supported.
+Supports both offline batched inference (``llm.generate(...)``) and
+online serving (``vllm serve``).
 """
 
 import os
@@ -53,14 +35,21 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
+from torch import nn
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.distributed import get_pp_group
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
 )
 from vllm.logger import init_logger
+from vllm.model_executor.models.extract_hidden_states import (
+    CacheOnlyAttentionLayer,
+    CacheOnlyAttentionMetadata,
+)
+from vllm.model_executor.models.utils import maybe_prefix
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -70,6 +59,66 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+
+CONNECTOR_NAME = "MeanPoolHiddenStatesConnector"
+HIDDEN_STATE_CACHE_PREFIX = "hidden_state_cache"
+
+
+def has_mean_pool_connector(vllm_config: "VllmConfig") -> bool:
+    """Return True if MeanPoolHiddenStatesConnector is configured.
+
+    Models call this in __init__ to decide whether to embed a
+    CacheOnlyAttentionLayer for capturing hidden states.
+    """
+    kv_transfer_config = vllm_config.kv_transfer_config
+    if kv_transfer_config is None:
+        return False
+    return kv_transfer_config.kv_connector == CONNECTOR_NAME
+
+
+def maybe_init_hidden_state_cache(
+    vllm_config: "VllmConfig",
+    hidden_size: int,
+    num_hidden_layers: int,
+    prefix: str = "",
+) -> nn.Module | None:
+    """Create a CacheOnlyAttentionLayer if the connector is active.
+
+    Returns ``None`` when the connector is not configured or this is not
+    the last pipeline-parallel rank, so callers can safely assign the
+    result and check for ``None`` before forwarding hidden states.
+    """
+    if not get_pp_group().is_last_rank:
+        return None
+    if not has_mean_pool_connector(vllm_config):
+        return None
+
+    return CacheOnlyAttentionLayer(
+        num_heads=1,
+        head_size=hidden_size,
+        cache_config=vllm_config.cache_config,
+        prefix=maybe_prefix(prefix, f"{HIDDEN_STATE_CACHE_PREFIX}.{num_hidden_layers}"),
+    )
+
+
+def maybe_cache_hidden_states(
+    hidden_state_cache: nn.Module | None,
+    model_output: Any,
+) -> None:
+    """Push the model's post-norm hidden states into the cache layer.
+
+    No-op when ``hidden_state_cache`` is ``None`` (connector inactive or
+    non-last PP rank) or when ``model_output`` does not carry a hidden
+    state tensor (e.g. ``IntermediateTensors`` on intermediate PP ranks).
+    """
+    if hidden_state_cache is None:
+        return
+
+    hidden_states = model_output[0] if isinstance(model_output, tuple) else model_output
+    if isinstance(hidden_states, torch.Tensor):
+        # CacheOnlyAttentionLayer expects [num_tokens, num_heads, head_size].
+        hidden_state_cache(hidden_states.unsqueeze(1))
 
 
 @dataclass
@@ -132,9 +181,11 @@ class MeanPoolHiddenStatesConnector(KVConnectorBase_V1):
     Connector that mean-pools prompt hidden states and returns the
     resulting vector in the API response (via kv_transfer_params).
 
-    Works with the extract_hidden_states speculative decoding method.
-    This connector extracts those hidden states, mean-pools over prompt
-    tokens, and saves the result for retrieval when the request finishes.
+    Requires a CacheOnlyAttentionLayer (prefix containing
+    ``"hidden_state_cache"``) embedded in the target model. The layer
+    writes hidden states to its KV cache; this connector
+    extracts them, mean-pools over prompt tokens, and saves the result
+    for retrieval when the request finishes.
     """
 
     @property
@@ -156,7 +207,7 @@ class MeanPoolHiddenStatesConnector(KVConnectorBase_V1):
 
         # Shared storage for passing mean-pooled vectors from worker to
         # scheduler (they run in separate processes with V1 multiprocessing).
-        # Default to /dev/shm/vllm_mean_pool for lower latency on Linux,
+        # Default to /dev/shm/vllm_mean_pool for lower latency on Linux.
         self._storage_path = self._kv_transfer_config.get_from_extra_config(
             "shared_storage_path",
             "/dev/shm/vllm_mean_pool",
@@ -195,12 +246,13 @@ class MeanPoolHiddenStatesConnector(KVConnectorBase_V1):
             return 0
         for gid, group in enumerate(kv_cache_config.kv_cache_groups):
             for layer_name in group.layer_names:
-                if "cache_only" in layer_name.lower():
+                if HIDDEN_STATE_CACHE_PREFIX in layer_name:
                     return gid
         raise ValueError(
             "MeanPoolHiddenStatesConnector requires a CacheOnlyAttentionLayer "
-            "but none was found in kv_cache_groups. Ensure "
-            "--speculative-config with method='extract_hidden_states' is set."
+            f"with '{HIDDEN_STATE_CACHE_PREFIX}' in its prefix, but none was "
+            "found in kv_cache_groups. Ensure the target model embeds the "
+            "layer (currently supported: LlamaForCausalLM, Qwen3ForCausalLM)."
         )
 
     # ==============================
@@ -216,10 +268,6 @@ class MeanPoolHiddenStatesConnector(KVConnectorBase_V1):
         pass
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        from vllm.model_executor.models.extract_hidden_states import (
-            CacheOnlyAttentionLayer,
-        )
-
         layers = get_layers_from_vllm_config(
             self._vllm_config, CacheOnlyAttentionLayer, list(kv_caches.keys())
         )
@@ -251,10 +299,6 @@ class MeanPoolHiddenStatesConnector(KVConnectorBase_V1):
         and save the result for each request."""
         if layer_name not in self.cache_layers:
             return
-
-        from vllm.model_executor.models.extract_hidden_states import (
-            CacheOnlyAttentionMetadata,
-        )
 
         assert isinstance(attn_metadata, CacheOnlyAttentionMetadata)
 

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -34,6 +34,10 @@ from transformers import LlamaConfig
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.distributed.kv_transfer.kv_connector.v1.mean_pool_hidden_states_connector import (  # noqa: E501
+    maybe_cache_hidden_states,
+    maybe_init_hidden_state_cache,
+)
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import (
     Attention,
@@ -556,6 +560,13 @@ class LlamaForCausalLM(
             self.model.make_empty_intermediate_tensors
         )
 
+        self.hidden_state_cache = maybe_init_hidden_state_cache(
+            vllm_config,
+            hidden_size=config.hidden_size,
+            num_hidden_layers=config.num_hidden_layers,
+            prefix=prefix,
+        )
+
     def _init_model(
         self,
         vllm_config: VllmConfig,
@@ -577,6 +588,7 @@ class LlamaForCausalLM(
         model_output = self.model(
             input_ids, positions, intermediate_tensors, inputs_embeds
         )
+        maybe_cache_hidden_states(self.hidden_state_cache, model_output)
         return model_output
 
     def compute_logits(

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -33,6 +33,10 @@ from transformers import Qwen3Config
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.distributed.kv_transfer.kv_connector.v1.mean_pool_hidden_states_connector import (  # noqa: E501
+    maybe_cache_hidden_states,
+    maybe_init_hidden_state_cache,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.encoder_only_attention import (
     Attention,
@@ -310,6 +314,13 @@ class Qwen3ForCausalLM(
             self.model.make_empty_intermediate_tensors
         )
 
+        self.hidden_state_cache = maybe_init_hidden_state_cache(
+            vllm_config,
+            hidden_size=config.hidden_size,
+            num_hidden_layers=config.num_hidden_layers,
+            prefix=prefix,
+        )
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
@@ -323,6 +334,7 @@ class Qwen3ForCausalLM(
         hidden_states = self.model(
             input_ids, positions, intermediate_tensors, inputs_embeds
         )
+        maybe_cache_hidden_states(self.hidden_state_cache, hidden_states)
         return hidden_states
 
     def compute_logits(


### PR DESCRIPTION
## Purpose

Implement **Mean Pool Connector** to return mean pooled hidden states over prompt tokens (`embed`) in `generate` response.
Currently, vLLM doesn't officially support returning both the output text and the pooled vector, which leads to run two vLLM instances to get both results (very inefficient).

However, there are huge community demand for this feature:
- https://github.com/vllm-project/vllm/issues/5449
- https://github.com/vllm-project/vllm/issues/37971
- https://github.com/vllm-project/vllm/issues/11905
- https://github.com/vllm-project/vllm/issues/11577

In many production cases, **mean-pooled hidden states** over prompt tokens are very useful (e.g., retrieval of user content)

Current implementation of `extract_hidden_states` is focused on storing hidden states on disk for speculative decoding training, and cannot support the demanded feature. And piggyback on speculative decoding extremely makes inference slow, which is not appropriate for online serve.

For the performance, the mean-pooling is only done once (after prefill) and temporarily stored in shared memory /dev/shm. It returns mean-pooled vector under `kv_transfer_params` with key `mean_pooled_hidden_states`.

**Current limitation**
- Does not support `stream: True` since it drops `kv_transfer_params`

## Test Plan & Test Results

GPU: A100

**1. Added unit tests to compare output with vllm embed**

output of mean pooled vector and output of embed endpoint shows
**>= 0.999 cosine similarity**
**< 1% element diff**

**2. Checked online serve and response**

```bash
vllm serve meta-llama/Llama-3.2-3B-Instruct \                                                                                                      
--max-model-len 128 --enforce-eager --dtype bfloat16 --port 8765 \                                                                   
--kv-transfer-config '{                                                                                                              
  "kv_connector": "MeanPoolHiddenStatesConnector",                                                                                   
  "kv_role": "kv_producer",                                                                                                          
  "kv_connector_extra_config": {"shared_storage_path": "/dev/shm/vllm_mean_pool_test"}                                               
}' 
```

Tested with API calls `/v1/completions` and `/v1/chat/completions`

```bash
{
  "id": "cmpl-...",
  "object": "text_completion",
  "created": 1745382...,
  "model": "meta-llama/Llama-3.2-3B-Instruct",
  "choices": [
    {
      "index": 0,
      "text": " This is a well-known pangram,",
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "prompt_logprobs": null,
      "token_ids": null
    }
  ],
  "usage": {"prompt_tokens": 11, "completion_tokens": 8, "total_tokens": 19},
  "kv_transfer_params": {
    "mean_pooled_hidden_states": [-1.1253883838653564, -0.5150923728942871, 2.4300427436828613, -1.70556640625, ...3068 more floats...,
 0.7966974377632141, -0.27256083488464355, -0.4936384856700897, 0.25064921379089355]
  }
}
```

**3. Run `bench throughput` and see the performance decrease**

On purpose, I tested with very high concurrent case, and there was -7.7% decrease (for num-prompts 256, much smaller performance regression), which is much efficient than running two separate vLLM instances.

```bash
vllm bench throughput \
    --model meta-llama/Llama-3.2-3B-Instruct \
    --dataset-name random \
    --num-prompts 512 \
    --input-len 1024 \
    --output-len 128 \
    --dtype bfloat16 \
    --max-model-len 2048 \
    --enforce-eager
```

<img width="409" height="218" alt="image" src="https://github.com/user-attachments/assets/82fdb4e5-02a2-40d6-baf7-60e0ac971b9c" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

