### PR TITLE
Restore non-hf processor path for Nano-Nemotron-VL (bypass `call_hf_processor_mm_only`) - fixes #38018

### DIFF
--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -307,6 +307,20 @@ class NanoNemotronVLProcessingInfo(BaseProcessingInfo):
 class NanoNemotronVLMultiModalProcessor(
     BaseMultiModalProcessor[NanoNemotronVLProcessingInfo]
 ):
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        """
+        Bypass `call_hf_processor_mm_only` by no-op overriding`_call_hf_processor`,
+        so it chooses this path:
+        `type(self)._call_hf_processor != BaseMultiModalProcessor._call_hf_processor`
+        """
+        return super()._call_hf_processor(prompt, mm_data, mm_kwargs, tok_kwargs)
+
     def _get_image_fields_config(self, hf_inputs: BatchFeature):
         if self.info.is_dynamic_tiler:
             pixel_values_flat = MultiModalFieldConfig.batched("image")


### PR DESCRIPTION
Run old processing path for nano-nemotron-vl by no-op overriding `BaseMultiModalProcessor._call_hf_processor`, thus bypassing `call_hf_processor_mm_only` which assumes the processor is a transformers `ProcessorMixin`.

The regression was introduced in: https://github.com/vllm-project/vllm/pull/38018 [cc @DarkLight1337]
The pr just re-routes nano-nemotron-vl processing to take the old processing path.

This shows the regressing code:
<img width="2389" height="1018" alt="image" src="https://github.com/user-attachments/assets/777757e1-218b-4550-a493-678b065d6dd2" />
