### PR TITLE
[ROCm][CI/Build] Fix the pytest hook to properly print out the summary

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -392,15 +392,16 @@ RUN mkdir src && mv vllm src/vllm
 # This is a workaround to ensure pytest exits with the correct status code in CI tests.
 RUN cat << 'EOF' > /vllm-workspace/conftest.py
 import os
-import pytest
 
-_exit_code = 0
+_exit_code = 1
 
 def pytest_sessionfinish(session, exitstatus):
     global _exit_code
     _exit_code = int(exitstatus)
 
 def pytest_unconfigure(config):
+    sys.stdout.flush()
+    sys.stderr.flush()
     os._exit(_exit_code)
 EOF
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -390,7 +390,19 @@ ENV MIOPEN_DEBUG_CONV_GEMM=0
 RUN mkdir src && mv vllm src/vllm
 
 # This is a workaround to ensure pytest exits with the correct status code in CI tests.
-RUN echo "import os\n\ndef pytest_sessionfinish(session, exitstatus):\n    os._exit(int(exitstatus))" > /vllm-workspace/conftest.py
+RUN cat << 'EOF' > /vllm-workspace/conftest.py
+import os
+import pytest
+
+_exit_code = 0
+
+def pytest_sessionfinish(session, exitstatus):
+    global _exit_code
+    _exit_code = int(exitstatus)
+
+def pytest_unconfigure(config):
+    os._exit(_exit_code)
+EOF
 
 # -----------------------
 # Final vLLM image


### PR DESCRIPTION
A follow up for #38252

Modifying the ROCm7.2.1 pytest workaround to properly finish including printing the summary, in addition to preserving the exit code