### PR TITLE
[CI] Avoid concurrent docker pull in intel XPU CI runners to prevent rate limit issues

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-intel-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-intel-test.sh
@@ -239,8 +239,6 @@ fi
 # --- Docker housekeeping ---
 cleanup_docker
 
-aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
-aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
 aws ecr-public get-login-password \
   --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7
 

--- a/.buildkite/scripts/hardware_ci/run-intel-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-intel-test.sh
@@ -241,11 +241,35 @@ cleanup_docker
 
 # --- Build or pull test image ---
 if [[ -n "${IMAGE_TAG_XPU:-}" ]]; then
-  echo "Using prebuilt XPU image: ${IMAGE_TAG_XPU}"
-  docker pull "${IMAGE_TAG_XPU}"
+  IMAGE="${IMAGE_TAG_XPU}"
 else
-  echo "Using prebuilt XPU image: ${image_name}"
-  docker pull "${image_name}"
+  IMAGE="${image_name}"
+fi
+
+echo "Using image: ${IMAGE}"
+
+if docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+  echo "Image already exists locally, skip pull"
+else
+  echo "Image not found locally"
+
+  if flock -w 300 /tmp/docker-pull.lock bash -c "
+    if ! docker image inspect '${IMAGE}' >/dev/null 2>&1; then
+      echo 'Pulling image...'
+      timeout 600 docker pull '${IMAGE}'
+    else
+      echo 'Image pulled by another runner'
+    fi
+  "; then
+    echo "Pull step finished"
+  else
+    echo "Timeout waiting for lock, fallback check..."
+
+    if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+      echo "Fallback pulling..."
+      timeout 600 docker pull "${IMAGE}"
+    fi
+  fi
 fi
 
 remove_docker_container() {

--- a/.buildkite/scripts/hardware_ci/run-intel-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-intel-test.sh
@@ -239,8 +239,8 @@ fi
 # --- Docker housekeeping ---
 cleanup_docker
 
-aws ecr-public get-login-password \
-  --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin "$REGISTRY"
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 936637512419.dkr.ecr.us-east-1.amazonaws.com
 
 # --- Build or pull test image ---
 IMAGE="${IMAGE_TAG_XPU:-${image_name}}"

--- a/.buildkite/scripts/hardware_ci/run-intel-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-intel-test.sh
@@ -239,6 +239,11 @@ fi
 # --- Docker housekeeping ---
 cleanup_docker
 
+aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+aws ecr-public get-login-password \
+  --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7
+
 # --- Build or pull test image ---
 IMAGE="${IMAGE_TAG_XPU:-${image_name}}"
 

--- a/.buildkite/scripts/hardware_ci/run-intel-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-intel-test.sh
@@ -240,36 +240,25 @@ fi
 cleanup_docker
 
 # --- Build or pull test image ---
-if [[ -n "${IMAGE_TAG_XPU:-}" ]]; then
-  IMAGE="${IMAGE_TAG_XPU}"
-else
-  IMAGE="${image_name}"
-fi
+IMAGE="${IMAGE_TAG_XPU:-${image_name}}"
 
 echo "Using image: ${IMAGE}"
 
 if docker image inspect "${IMAGE}" >/dev/null 2>&1; then
-  echo "Image already exists locally, skip pull"
+  echo "Image already exists locally, skipping pull"
 else
-  echo "Image not found locally"
+  echo "Image not found locally, waiting for lock..."
 
-  if flock -w 300 /tmp/docker-pull.lock bash -c "
-    if ! docker image inspect '${IMAGE}' >/dev/null 2>&1; then
-      echo 'Pulling image...'
-      timeout 600 docker pull '${IMAGE}'
+  flock /tmp/docker-pull.lock bash -c "
+    if docker image inspect '${IMAGE}' >/dev/null 2>&1; then
+      echo 'Image already pulled by another runner'
     else
-      echo 'Image pulled by another runner'
+      echo 'Pulling image...'
+      timeout 900 docker pull '${IMAGE}'
     fi
-  "; then
-    echo "Pull step finished"
-  else
-    echo "Timeout waiting for lock, fallback check..."
+  "
 
-    if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
-      echo "Fallback pulling..."
-      timeout 600 docker pull "${IMAGE}"
-    fi
-  fi
+  echo "Pull step completed"
 fi
 
 remove_docker_container() {


### PR DESCRIPTION



## Purpose
- Uses `/tmp/docker-pull.lock` as a global lock
- Double-checks image existence after acquiring lock
- Adds `timeout` to prevent hanging pulls

## Example Scenario

Before:
- 4 runners → 4 concurrent pulls → rate limit hit ❌

After:
- 4 runners → 1 pull + 3 reuse → stable ✅

## Testing

- Verified on multi-runner setup
- Confirmed no duplicate pulls
- Confirmed no blocking issues with timeout in place

## Notes

This assumes all runners share the same Docker daemon.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

