### PR TITLE
Revert "[Bugfix][MLA] Change default SM100 MLA prefill backend back to TRT-LLM" (#38562)

### DIFF
--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -30,7 +30,7 @@ class AttentionConfig:
     use_cudnn_prefill: bool = False
     """Whether to use cudnn prefill."""
 
-    use_trtllm_ragged_deepseek_prefill: bool = True
+    use_trtllm_ragged_deepseek_prefill: bool = False
     """Whether to use TRTLLM ragged deepseek prefill."""
 
     use_trtllm_attention: bool | None = None


### PR DESCRIPTION
## Revert of #38562

This reverts commit 2c734ed0e06a48808522fe8f59f6b4ffe0cf0397.

**Original PR:** https://github.com/vllm-project/vllm/pull/38562
**Failure count:** 1 new failure in build [#58877](https://buildkite.com/vllm/ci/builds/58877)

### Failed tests
- **GPQA Eval (GPT-OSS) (B200)** — Evaluation timed out (30 min) on `test_gpqa_correctness[gpt-oss-20b-sm100-fi-mxfp4-mxfp8-trtllm]`. Switching the SM100 MLA prefill backend to TRT-LLM appears to have caused a significant performance regression on B200, leading to timeout.

---
*Auto-generated by CI failure analyzer*