### PR TITLE
[Bugfix] too many values to unpack in dispatch_cpu_unquantized_gemm

### DIFF
--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -228,6 +228,13 @@ def dispatch_cpu_unquantized_gemm(
         layer.cpu_linear = torch.nn.functional.linear
         return
 
+    # Skip non-2D weights (e.g., Conv layers with 3D/4D/5D weights)
+    # These are not compatible with the optimized GEMM kernels which expect
+    # 2D weight tensors (N, K)
+    if layer.weight.dim() != 2:
+        layer.cpu_linear = torch.nn.functional.linear
+        return
+
     N, K = layer.weight.size()
     dtype = layer.weight.dtype
 


### PR DESCRIPTION



## Purpose

Fix #38591: ValueError when loading Qwen3.5-4B on CPU/Mac environments.

The `dispatch_cpu_unquantized_gemm` function assumes all linear layer weights are exactly 2-dimensional (`N, K = layer.weight.size()`), but multimodal models like Qwen3.5 have vision encoder layers (e.g., `Conv3dLayer`) with 5D weights. This causes a `ValueError: too many values to unpack (expected 2)` crash during model loading on CPU platforms.

**Root Cause**: The function unconditionally unpacks `layer.weight.size()` into two values, which fails for non-2D weight tensors.

**Fix**: Add a dimension check to skip non-2D weights and fall back to standard `torch.nn.functional.linear`. This allows Conv layers (3D/4D/5D weights) to bypass the GEMM optimization path that only supports 2D weight tensors.

## Test Plan

1. Test Qwen3.5-4B loading on CPU:
```bash
python -c "
from vllm import LLM
llm = LLM(
    model='Qwen/Qwen3.5-4B',
    trust_remote_code=True,
    max_model_len=16384,
    enforce_eager=True,
)
print('Model loaded successfully!')
"
```

2. Run existing CPU tests to ensure no regression:
```bash
.venv/bin/python -m pytest tests/kernels/test_onednn.py -v
```

## Test Result

**Before fix**: Model loading crashes with:
ValueError: too many values to unpack (expected 2)
File "vllm/model_executor/layers/utils.py", line 231, in dispatch_cpu_unquantized_gemm
N, K = layer.weight.size()


**After fix**: Model loads successfully on CPU/Mac. Non-2D weight layers (Conv) fall back to standard linear implementation, while 2D weight layers continue to use optimized GEMM kernels.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the `https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0` .

</details>

BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>