### PR TITLE
[Feature]: Better base64 to torch tensor (Fixes #26781)

### DIFF
--- a/tests/entrypoints/pooling/embed/test_online.py
+++ b/tests/entrypoints/pooling/embed/test_online.py
@@ -25,6 +25,7 @@ from vllm.entrypoints.pooling.utils import (
 from vllm.platforms import current_platform
 from vllm.tokenizers import get_tokenizer
 from vllm.utils.serial_utils import EMBED_DTYPES, ENDIANNESS, binary2tensor
+from vllm.utils.torch_utils import base64_to_tensor
 
 MODEL_NAME = "intfloat/multilingual-e5-small"
 DUMMY_CHAT_TEMPLATE = """{% for message in messages %}{{message['role'] + ': ' + message['content'] + '\\n'}}{% endfor %}"""  # noqa: E501
@@ -519,7 +520,7 @@ async def test_base64_embedding(hf_model, client: openai.AsyncOpenAI, model_name
     base64_data = []
     for data in responses_base64.data:
         base64_data.append(
-            np.frombuffer(base64.b64decode(data.embedding), dtype="float32").tolist()
+            base64_to_tensor(data.embedding, dtype=torch.float32).tolist()
         )
 
     run_embedding_correctness_test(hf_model, input_texts, base64_data)

--- a/tests/entrypoints/pooling/pooling/test_online.py
+++ b/tests/entrypoints/pooling/pooling/test_online.py
@@ -19,6 +19,7 @@ from vllm.entrypoints.pooling.utils import (
 )
 from vllm.tokenizers import get_tokenizer
 from vllm.utils.serial_utils import EMBED_DTYPES, ENDIANNESS, binary2tensor
+from vllm.utils.torch_utils import base64_to_tensor
 
 MODEL_NAME = "internlm/internlm2-1_8b-reward"
 DUMMY_CHAT_TEMPLATE = """{% for message in messages %}{{message['role'] + ': ' + message['content'] + '\\n'}}{% endfor %}"""  # noqa: E501
@@ -289,7 +290,7 @@ async def test_batch_base64_pooling(server: RemoteOpenAIServer, model_name: str)
     decoded_responses_base64_data = []
     for data in responses_base64.data:
         decoded_responses_base64_data.append(
-            np.frombuffer(base64.b64decode(data.data), dtype="float32").tolist()
+            base64_to_tensor(data.data, dtype=torch.float32).tolist()
         )
 
     check_embeddings_close(

--- a/vllm/utils/serial_utils.py
+++ b/vllm/utils/serial_utils.py
@@ -11,6 +11,8 @@ import numpy.typing as npt
 import pybase64
 import torch
 
+from vllm.utils.torch_utils import from_buffer
+
 sys_byteorder = sys.byteorder
 
 
@@ -90,9 +92,15 @@ def binary2tensor(
 
     dtype_info = EMBED_DTYPES[embed_dtype]
 
-    np_array = np.frombuffer(binary, dtype=dtype_info.numpy_view_dtype).reshape(shape)
+    # Use from_buffer to avoid "non-writable buffer" warning
+    tensor = from_buffer(binary, dtype=dtype_info.torch_view_dtype).reshape(shape)
 
     if endianness != "native" and endianness != sys_byteorder:
-        np_array = np_array.byteswap()
+        # Since the tensor is from a read-only buffer, we need to copy it
+        # before we can byteswap it (if it's not already a copy).
+        # However, .byteswap() on a numpy view of a torch tensor might be tricky.
+        # Given this is a rare case (non-native endianness), we can afford a copy.
+        np_array = tensor.numpy().copy().byteswap()
+        return torch.from_numpy(np_array).view(dtype_info.torch_dtype)
 
-    return torch.from_numpy(np_array).view(dtype_info.torch_dtype)
+    return tensor.view(dtype_info.torch_dtype)

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -9,9 +9,9 @@ from collections.abc import Callable, Collection
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, TypeVar
 
-import base64
 import warnings
 
+import pybase64 as base64
 import numpy as np
 import numpy.typing as npt
 import torch

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -9,6 +9,9 @@ from collections.abc import Callable, Collection
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, TypeVar
 
+import base64
+import warnings
+
 import numpy as np
 import numpy.typing as npt
 import torch
@@ -457,6 +460,23 @@ def async_tensor_h2d(
     """Asynchronously create a tensor and copy it from host to device."""
     t = torch.tensor(data, dtype=dtype, pin_memory=pin_memory, device="cpu")
     return t.to(device=target_device, non_blocking=True)
+
+
+def base64_to_tensor(data: str, dtype: torch.dtype) -> torch.Tensor:
+    """Efficiently convert base64 to torch tensor without non-writable warnings."""
+    decoded = base64.b64decode(data)
+    return from_buffer(decoded, dtype=dtype)
+
+
+def from_buffer(buffer: bytes | bytearray, dtype: torch.dtype) -> torch.Tensor:
+    """Efficiently convert buffer to torch tensor without non-writable warnings."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=UserWarning,
+            message="The given buffer is not writable",
+        )
+        return torch.frombuffer(buffer, dtype=dtype)
 
 
 def make_ndarray_with_pad(


### PR DESCRIPTION
This PR fixes https://github.com/vllm-project/vllm/issues/26781 by introducing a standardized `base64_to_tensor` utility to prevent the 'not writable' UserWarning during base64 decoding. It updates `binary2tensor` and tests to use this new utility.