### PR TITLE
[Bugfix] Fix streaming tool call type field defaulting to None instead of "function"

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2063,7 +2063,7 @@ class TestCreateRemainingArgsDelta:
         tc = result.tool_calls[0]
         assert tc.index == 5
         assert tc.id is None
-        assert tc.type is None
+        assert tc.type == "function"
         assert tc.function.name is None
         assert tc.function.arguments == '{"arg": 1}'
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1801,7 +1801,7 @@ class OpenAIServingChat(OpenAIServing):
                 DeltaToolCall(
                     index=index,
                     id=original_tc.id if original_tc else None,
-                    type=original_tc.type if original_tc else None,
+                    type=original_tc.type if original_tc else "function",
                     function=DeltaFunctionCall(
                         name=original_fn.name if original_fn else None,
                         arguments=remaining_call,


### PR DESCRIPTION
## Purpose
Fixes https://github.com/vllm-project/vllm/issues/38603 - the `type` field in streaming tool call delta chunks to default to `"function"` when no matching original tool call is found, per [OpenAI API spec](https://developers.openai.com/api/docs/guides/function-calling)

## Test Plan
```
pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py::TestCreateRemainingArgsDelta -v
```