### PR TITLE
[Feature]: add presence_penalty and frequency_penalty fields to Responses API

### DIFF
--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -173,6 +173,20 @@ class ResponsesRequest(OpenAIBaseModel):
     user: str | None = None
     skip_special_tokens: bool = True
     include_stop_str_in_output: bool = False
+    presence_penalty: float | None = Field(
+        default=None,
+        description=(
+            "The presence penalty that was used to penalize new tokens based on "
+            "whether they appear in the text so far."
+        ),
+    )
+    frequency_penalty: float | None = Field(
+        default=None,
+        description=(
+            "The frequency penalty that was used to penalize new tokens based on "
+            "their frequency in the text so far."
+        ),
+    )
     prompt_cache_key: str | None = Field(
         default=None,
         description=(
@@ -328,6 +342,12 @@ class ResponsesRequest(OpenAIBaseModel):
         if (repetition_penalty := self.repetition_penalty) is None:
             repetition_penalty = default_sampling_params.get("repetition_penalty", 1.0)
 
+        if (presence_penalty := self.presence_penalty) is None:
+            presence_penalty = default_sampling_params.get("presence_penalty", 0.0)
+
+        if (frequency_penalty := self.frequency_penalty) is None:
+            frequency_penalty = default_sampling_params.get("frequency_penalty", 0.0)
+
         stop_token_ids = default_sampling_params.get("stop_token_ids")
 
         # Structured output
@@ -367,6 +387,8 @@ class ResponsesRequest(OpenAIBaseModel):
             logprobs=self.top_logprobs if self.is_include_output_logprobs() else None,
             stop_token_ids=stop_token_ids,
             stop=stop,
+            frequency_penalty=frequency_penalty,
+            presence_penalty=presence_penalty,
             repetition_penalty=repetition_penalty,
             seed=self.seed,
             ignore_eos=self.ignore_eos,
@@ -496,6 +518,21 @@ class ResponsesResponse(OpenAIBaseModel):
     usage: ResponseUsage | None = None
     user: str | None = None
 
+    presence_penalty: float | None = Field(
+        default=None,
+        description=(
+            "The presence penalty that was used to penalize new tokens based on "
+            "whether they appear in the text so far."
+        ),
+    )
+    frequency_penalty: float | None = Field(
+        default=None,
+        description=(
+            "The frequency penalty that was used to penalize new tokens based on "
+            "their frequency in the text so far."
+        ),
+    )
+
     # vLLM-specific fields that are not in OpenAI spec
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None, description="KVTransfer parameters."
@@ -574,6 +611,8 @@ class ResponsesResponse(OpenAIBaseModel):
             prompt=request.prompt,
             reasoning=request.reasoning,
             service_tier=request.service_tier,
+            presence_penalty=sampling_params.presence_penalty,
+            frequency_penalty=sampling_params.frequency_penalty,
             status=status,
             text=request.text,
             top_logprobs=sampling_params.logprobs,

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -175,6 +175,8 @@ class ResponsesRequest(OpenAIBaseModel):
     include_stop_str_in_output: bool = False
     presence_penalty: float | None = Field(
         default=None,
+        ge=-2.0,
+        le=2.0,
         description=(
             "The presence penalty that was used to penalize new tokens based on "
             "whether they appear in the text so far."
@@ -182,6 +184,8 @@ class ResponsesRequest(OpenAIBaseModel):
     )
     frequency_penalty: float | None = Field(
         default=None,
+        ge=-2.0,
+        le=2.0,
         description=(
             "The frequency penalty that was used to penalize new tokens based on "
             "their frequency in the text so far."
@@ -520,6 +524,8 @@ class ResponsesResponse(OpenAIBaseModel):
 
     presence_penalty: float | None = Field(
         default=None,
+        ge=-2.0,
+        le=2.0,
         description=(
             "The presence penalty that was used to penalize new tokens based on "
             "whether they appear in the text so far."
@@ -527,6 +533,8 @@ class ResponsesResponse(OpenAIBaseModel):
     )
     frequency_penalty: float | None = Field(
         default=None,
+        ge=-2.0,
+        le=2.0,
         description=(
             "The frequency penalty that was used to penalize new tokens based on "
             "their frequency in the text so far."


### PR DESCRIPTION


## Purpose
follow up https://github.com/vllm-project/vllm/issues/33381

add presence_penalty and frequency_penalty fields to Responses API

refer https://developers.openai.com/api/reference/resources/responses/methods/create
refer https://www.openresponses.org/reference
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

