### PR TITLE
[ROCm] Fix aiter persistent mode mla with q/o nhead<16 for kimi-k2.5 tp8

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -129,16 +129,10 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         from aiter import dtypes, get_mla_metadata_info_v1
 
-        num_attention_heads = vllm_config.model_config.get_num_attention_heads(
-            vllm_config.parallel_config
-        )
         # For num_attention_heads < 16 (e.g. kimi-k2.5 head=8 with TP8),
         # make sure get_mla_metadata_info_v1 / get_mla_metadata_v1 are consistent
         # with the actual tensor shape passed to mla_decode_fwd.
-        if num_attention_heads in (4, 8):
-            self._num_attention_heads = 16
-        else:
-            self._num_attention_heads = num_attention_heads
+        self._num_attention_heads = max(16, self.num_heads)
         q_dtype = self.decode_attn_out_dtype
         kv_cache_dtype_str = getattr(vllm_config.cache_config, "cache_dtype", "auto")
         if kv_cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -129,9 +129,16 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         from aiter import dtypes, get_mla_metadata_info_v1
 
-        self._num_attention_heads = vllm_config.model_config.get_num_attention_heads(
+        num_attention_heads = vllm_config.model_config.get_num_attention_heads(
             vllm_config.parallel_config
         )
+        # For num_attention_heads < 16 (e.g. kimi-k2.5 head=8 with TP8),
+        # make sure get_mla_metadata_info_v1 / get_mla_metadata_v1 are consistent
+        # with the actual tensor shape passed to mla_decode_fwd.
+        if num_attention_heads in (4, 8):
+            self._num_attention_heads = 16
+        else:
+            self._num_attention_heads = num_attention_heads
         q_dtype = self.decode_attn_out_dtype
         kv_cache_dtype_str = getattr(vllm_config.cache_config, "cache_dtype", "auto")
         if kv_cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):


### PR DESCRIPTION



## Purpose
AiterMLAImpl already contains a head-padding mechanism: when num_heads is 4 or 8 (e.g., Kimi-K2.5 with 64 heads under TP=8 yields 8 heads per GPU), the q tensor is padded to 16 heads via repeat_interleave before being passed to the kernel.

persistent mode mla implementation allocated buffer for the original head count (e.g., 8), while the kernel receives a q tensor with 16 heads — causing a shape mismatch between the pre-allocated metadata buffers and the actual kernel inputs.
## Test Plan
image: vllm/vllm-openai-rocm:v0.18.0
aiter: 0.1.10.post2 build in image

### server cmd:
```
MODEL_PATH="/raid0/data/Kimi-K2.5-MXFP4" # MXFP4

HOST="${HOST:-0.0.0.0}"
PORT="${PORT:-8000}"

export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_LOGGING_LEVEL=INFO
export VLLM_USE_V1=1
export VLLM_ROCM_USE_AITER_MLA=1

vllm serve "${MODEL_PATH}" \
  --host "${HOST}" \
  --port "${PORT}" \
  --tensor-parallel-size 8 \
  --max-model-len 100000 \
  --enable-prefix-caching \
  --trust-remote-code
```

### acc test
```
lm_eval \
  --model local-completions \
  --model_args "model=/raid0/data/Kimi-K2.5-MXFP4,base_url=http://0.0.0.0:8000/v1/completions,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" \
  --tasks gsm8k \
  --num_fewshot 5
```

### performance test
Not involved

## Test Result
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9340|±  |0.0068|
|     |       |strict-match    |     5|exact_match|↑  |0.9325|±  |0.0069|

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

CC: @billishyahao 