### PR TITLE
[Feature] Add completed_at field to ResponsesAPI

### DIFF
--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -46,6 +46,7 @@ async def test_basic(client: OpenAI, model_name: str):
     assert response.incomplete_details is None
     assert response.completed_at is not None
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 async def test_enable_response_messages(client: OpenAI, model_name: str):

--- a/tests/entrypoints/openai/responses/test_simple.py
+++ b/tests/entrypoints/openai/responses/test_simple.py
@@ -44,7 +44,7 @@ async def test_basic(client: OpenAI, model_name: str):
     print("response: ", response)
     assert response.status == "completed"
     assert response.incomplete_details is None
-
+    assert response.completed_at is not None
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -470,6 +470,7 @@ class ResponsesRequest(OpenAIBaseModel):
 class ResponsesResponse(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"resp_{random_uuid()}")
     created_at: int = Field(default_factory=lambda: int(time.time()))
+    completed_at: int | None = None
     # error: Optional[ResponseError] = None
     incomplete_details: IncompleteDetails | None = None
     instructions: str | None = None

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -873,7 +873,7 @@ class OpenAIServingResponses(OpenAIServing):
             usage=usage,
             kv_transfer_params=context.kv_transfer_params,
         )
-
+        response.completed_at = int(time.time()) if status == "completed" else None
         if request.store:
             async with self.response_store_lock:
                 stored_response = self.response_store.get(response.id)


### PR DESCRIPTION


## Purpose
Add completed_at field to ResponsesAPI

follow up https://github.com/vllm-project/vllm/issues/33381


refer https://developers.openai.com/api/reference/resources/responses/methods/create
refer https://www.openresponses.org/reference


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

