### PR TITLE
fix(scheduler): discard async tokens on all V1 preemption paths

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -962,6 +962,12 @@ class Scheduler(SchedulerInterface):
         if request.spec_token_ids:
             request.spec_token_ids = []
         request.num_preemptions += 1
+        
+        # NOTE(zhuohan): For async scheduling, we need to discard the latest
+        # output token on the fly to avoid a redundant repetitive output token.
+        request.num_output_placeholders = 0
+        request.discard_latest_async_tokens = True
+        
         if self.log_stats:
             request.record_event(EngineCoreEventType.PREEMPTED, timestamp)
 
@@ -1874,10 +1880,6 @@ class Scheduler(SchedulerInterface):
             while self.running:
                 request = self.running.pop()
                 self._preempt_request(request, timestamp)
-                # NOTE(zhuohan): For async scheduling, we need to discard the latest
-                # output token on the fly to avoid a redundant repetitive output token.
-                request.num_output_placeholders = 0
-                request.discard_latest_async_tokens = True
 
             # Clear scheduled request ids cache. Since we are forcing preemption
             # + resumption in the same step, we must act as if these requests were


### PR DESCRIPTION
Fixes a stale state window in the V1 Async Scheduler where async placeholders were incorrectly retained during standard memory-pressure or priority-driven preemptions.

Currently, `discard_latest_async_tokens` and `num_output_placeholders` are only reset during forced context cache resets (`reset_prefix_cache()`). Standard preemptions triggered inside the scheduler loop (`_schedule_running`) bypass this cleanup because they call the generic `_preempt_request()` method which lacked this logic.

This PR moves the async token discard hook directly into `_preempt_request()`, ensuring that **all** preemption avenues safely drop their async output placeholders native to the V1 scheduling path.

### Why is it important?
With async scheduling enabled, if a request is preempted mid-batch due to an influx of higher-priority requests or sudden memory pressure, failing to discard the most recent placeholder results in duplicate/repetitive tokens upon resumption. This aligns with the ongoing Q1 roadmap push to harden the async scheduling and make it the reliable default.

### Changes Made
* Moved `request.discard_latest_async_tokens = True` and `request.num_output_placeholders = 0` from `reset_prefix_cache()` directly into `_preempt_request()`.

### Testing
* Verified that `_preempt_request` now cleanly strips the placeholder state.
* Does not conflict with the existing async output consume logic (`async_scheduler.py:_update_request_with_output()`).
