### PR TITLE
[Fix] handle PaddleOCR-VL image processor max_pixels across Transformers v4/v5

### DIFF
--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -200,7 +200,13 @@ class PaddleOCRVLProcessingInfo(BaseProcessingInfo):
         merge_size = hf_config.vision_config.spatial_merge_size
         patch_size = hf_config.vision_config.patch_size
         factor = merge_size * patch_size
-        max_num_tokens = image_processor.max_pixels // (factor**2)
+        if self.ctx.model_config.trust_remote_code:
+            # Defined in HF Hub repo
+            max_pixels = image_processor.max_pixels
+        else:
+            # Defined in Transformers library (requires v5.0 or above)
+            max_pixels = image_processor.size.longest_edge
+        max_num_tokens = max_pixels // (factor**2)
         # Find factors of max_num_tokens close to its square root
         # to create a dummy image with a reasonable aspect ratio.
         h_patches = int(math.sqrt(max_num_tokens))


### PR DESCRIPTION
This PR fixes `max_pixels` handling for PaddleOCR-VL across different Transformers versions.

This difference is version-related:
- with Transformers 4.x, PaddleOCR-VL must be loaded with `trust_remote_code=True`, and `max_pixels` is available as `image_processor.max_pixels`
- with the Transformers-native implementation, the corresponding value is stored in `image_processor.size.longest_edge`

Because PaddleOCR-VL requires `trust_remote_code=True` on Transformers 4.x, `trust_remote_code` can be used to distinguish the two code paths and read the correct `max_pixels` value.