### PR TITLE
Bugfix/multi node dp tcp placement

### DIFF
--- a/tests/entrypoints/test_api_server_process_manager.py
+++ b/tests/entrypoints/test_api_server_process_manager.py
@@ -89,6 +89,37 @@ def test_api_server_process_manager_init(api_server_args, with_stats_update):
             assert not proc.is_alive()
 
 
+def test_api_server_process_manager_closes_parent_held_sockets(api_server_args):
+    global WORKER_RUNTIME_SECONDS
+    WORKER_RUNTIME_SECONDS = 0.5
+
+    args = api_server_args.copy()
+    held_input_sockets = []
+    held_output_sockets = []
+    for _ in range(args["num_servers"]):
+        input_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        input_sock.bind(("127.0.0.1", 0))
+        held_input_sockets.append(input_sock)
+
+        output_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        output_sock.bind(("127.0.0.1", 0))
+        held_output_sockets.append(output_sock)
+
+    args["held_input_sockets"] = held_input_sockets
+    args["held_output_sockets"] = held_output_sockets
+
+    manager = APIServerProcessManager(**args)
+    try:
+        assert len(manager._held_socket_ready_events) == args["num_servers"]
+        assert all(event.is_set() for event in manager._held_socket_ready_events)
+        assert all(sock.fileno() == -1 for sock in held_input_sockets)
+        assert all(sock.fileno() == -1 for sock in held_output_sockets)
+        assert all(proc.is_alive() for proc in manager.processes)
+    finally:
+        manager.shutdown()
+        time.sleep(0.2)
+
+
 @patch("vllm.v1.utils.run_api_server_worker_proc", mock_run_api_server_worker)
 def test_wait_for_completion_or_failure(api_server_args):
     """Test that wait_for_completion_or_failure works with failures."""

--- a/tests/v1/engine/test_zmq_address_reservations.py
+++ b/tests/v1/engine/test_zmq_address_reservations.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+from types import SimpleNamespace
+
+
+def _reload_core_client_module():
+    module = importlib.import_module("vllm.v1.engine.core_client")
+    return importlib.reload(module)
+
+
+def _reload_engine_utils_module():
+    module = importlib.import_module("vllm.v1.engine.utils")
+    return importlib.reload(module)
+
+
+def test_mp_client_releases_held_sockets_before_bind(monkeypatch):
+    core_client_mod = _reload_core_client_module()
+
+    class ShadowSocket:
+        def poll(self, timeout: int) -> int:
+            return 1
+
+        def recv_multipart(self):
+            return (b"\x00\x00", b"ready")
+
+    class DummySocket:
+        def send_multipart(self, _msg, *, copy: bool = False, track: bool = False):
+            if track:
+                return SimpleNamespace(done=True)
+
+        def recv_multipart(self, *, copy: bool = False):
+            return (b"", b"")
+
+        def close(self, *, linger: int = 0):
+            pass
+
+        def bind(self, _address):
+            pass
+
+        def connect(self, _address):
+            pass
+
+        def setsockopt(self, *_args, **_kwargs):
+            pass
+
+    class HeldSocket:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class ReadyEvent:
+        def __init__(self):
+            self.wait_calls = 0
+
+        def wait(self):
+            self.wait_calls += 1
+
+    held_input_socket = HeldSocket()
+    held_output_socket = HeldSocket()
+    held_socket_ready = ReadyEvent()
+
+    def make_zmq_socket(_ctx, address, *_args, **_kwargs):
+        if address == "inproc://input":
+            assert held_input_socket.closed
+            assert not held_output_socket.closed
+        elif address == "inproc://output":
+            assert held_output_socket.closed
+        return DummySocket()
+
+    monkeypatch.setattr(core_client_mod.zmq.Socket, "shadow", lambda *_: ShadowSocket())
+    monkeypatch.setattr(core_client_mod, "make_zmq_socket", make_zmq_socket)
+
+    parallel_config = SimpleNamespace(
+        data_parallel_size=1,
+        data_parallel_rank=0,
+        data_parallel_index=0,
+        data_parallel_size_local=1,
+        data_parallel_rank_local=None,
+        data_parallel_hybrid_lb=False,
+        data_parallel_external_lb=False,
+        local_engines_only=False,
+        enable_elastic_ep=False,
+    )
+    vllm_config = SimpleNamespace(parallel_config=parallel_config)
+
+    client = core_client_mod.MPClient(
+        asyncio_mode=False,
+        vllm_config=vllm_config,
+        executor_class=object,
+        log_stats=False,
+        client_addresses={
+            "input_address": "inproc://input",
+            "output_address": "inproc://output",
+            "held_input_socket": held_input_socket,
+            "held_output_socket": held_output_socket,
+            "held_socket_ready": held_socket_ready,
+        },
+    )
+    try:
+        assert held_socket_ready.wait_calls == 1
+        assert held_input_socket.closed
+        assert held_output_socket.closed
+    finally:
+        client.shutdown()
+
+
+def test_get_engine_zmq_addresses_reserves_ipv6_sockets(monkeypatch):
+    engine_utils_mod = _reload_engine_utils_module()
+
+    created_sockets = []
+
+    class ReservedSocket:
+        next_port = 5500
+
+        def __init__(self, family, socktype):
+            self.family = family
+            self.socktype = socktype
+            self.bound_address = None
+            self.port = ReservedSocket.next_port
+            ReservedSocket.next_port += 1
+            created_sockets.append(self)
+
+        def bind(self, address):
+            self.bound_address = address
+
+        def getsockname(self):
+            return ("::1", self.port, 0, 0)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(engine_utils_mod.stdlib_socket, "socket", ReservedSocket)
+
+    parallel_config = SimpleNamespace(
+        data_parallel_size_local=1,
+        data_parallel_rank_local=None,
+        data_parallel_size=2,
+        data_parallel_master_ip="::1",
+        local_engines_only=False,
+        enable_elastic_ep=False,
+    )
+    vllm_config = SimpleNamespace(parallel_config=parallel_config)
+
+    addresses = engine_utils_mod.get_engine_zmq_addresses(
+        vllm_config, num_api_servers=2
+    )
+
+    assert addresses.inputs == ["tcp://[::1]:5500", "tcp://[::1]:5501"]
+    assert addresses.outputs == ["tcp://[::1]:5502", "tcp://[::1]:5503"]
+    assert all(
+        sock.family == engine_utils_mod.stdlib_socket.AF_INET6
+        for sock in created_sockets
+    )
+    assert all(sock.bound_address == ("::1", 0, 0, 0) for sock in created_sockets)

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -687,8 +687,10 @@ class ParallelConfig:
             self.data_parallel_size = envs.VLLM_DP_SIZE
             self.data_parallel_rank = envs.VLLM_DP_RANK
             self.data_parallel_rank_local = envs.VLLM_DP_RANK_LOCAL
-            self.data_parallel_master_ip = envs.VLLM_DP_MASTER_IP
-            self.data_parallel_master_port = envs.VLLM_DP_MASTER_PORT
+            if "VLLM_DP_MASTER_IP" in os.environ:
+                self.data_parallel_master_ip = envs.VLLM_DP_MASTER_IP
+            if "VLLM_DP_MASTER_PORT" in os.environ:
+                self.data_parallel_master_port = envs.VLLM_DP_MASTER_PORT
 
             if self.data_parallel_size > 1 and self.is_moe_model is False:
                 raise ValueError(

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -279,6 +279,8 @@ def run_multi_api_server(args: argparse.Namespace):
     with launch_core_engines(
         vllm_config, executor_class, log_stats, addresses, num_api_servers
     ) as (local_engine_manager, coordinator, addresses, tensor_queue):
+        held_input_sockets, held_output_sockets = addresses.pop_held_ports()
+
         # Construct common args for the APIServerProcessManager up-front.
         api_server_manager_kwargs = dict(
             listen_address=listen_address,
@@ -291,6 +293,8 @@ def run_multi_api_server(args: argparse.Namespace):
             if coordinator
             else None,
             tensor_queue=tensor_queue,
+            held_input_sockets=held_input_sockets,
+            held_output_sockets=held_output_sockets,
         )
 
         # For dp ranks > 0 in external/hybrid DP LB modes, we must delay the
@@ -299,7 +303,6 @@ def run_multi_api_server(args: argparse.Namespace):
         # since we get the front-end stats update address from the coordinator
         # via the handshake with the local engine.
         if dp_rank == 0 or not parallel_config.local_engines_only:
-            # Start API servers using the manager.
             api_server_manager = APIServerProcessManager(**api_server_manager_kwargs)
 
     # Start API servers now if they weren't already started.

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -83,7 +83,7 @@ class AsyncLLM(EngineClient):
         start_engine_loop: bool = True,
         stat_loggers: list[StatLoggerFactory] | None = None,
         aggregate_engine_logging: bool = False,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ) -> None:
@@ -217,7 +217,7 @@ class AsyncLLM(EngineClient):
         enable_log_requests: bool = False,
         aggregate_engine_logging: bool = False,
         disable_log_stats: bool = False,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ) -> "AsyncLLM":

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -107,7 +107,7 @@ class EngineCoreClient(ABC):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ) -> "AsyncMPClient":
@@ -456,6 +456,14 @@ class ElasticScalingCache:
     pending_notifications: dict[EEPNotificationType, set[int]]
 
 
+def _close_held_socket(sock: Any) -> None:
+    if sock is None:
+        return
+
+    with contextlib.suppress(OSError):
+        sock.close()
+
+
 class MPClient(EngineCoreClient):
     """
     MPClient: base client for multi-proc EngineCore.
@@ -475,7 +483,7 @@ class MPClient(EngineCoreClient):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
     ):
         self.vllm_config = vllm_config
 
@@ -507,19 +515,35 @@ class MPClient(EngineCoreClient):
                 self.stats_update_address = client_addresses.get("stats_update_address")
                 # Tensor queues passed via client_addresses for multi-API-server case
                 tensor_queue = client_addresses.get("tensor_queue")  # type: ignore[assignment]
-                self.input_socket = self.resources.input_socket = make_zmq_socket(
-                    self.ctx,
-                    input_address,
-                    zmq.ROUTER,
-                    bind=True,
-                    router_handover=enable_input_socket_handover,
-                )
-                self.resources.output_socket = make_zmq_socket(
-                    self.ctx, output_address, zmq.PULL
-                )
+                held_socket_ready = client_addresses.get("held_socket_ready")
+                held_input_socket = client_addresses.get("held_input_socket")
+                held_output_socket = client_addresses.get("held_output_socket")
+                if held_socket_ready is not None:
+                    held_socket_ready.wait()
+
+                try:
+                    _close_held_socket(held_input_socket)
+                    held_input_socket = None
+                    self.input_socket = self.resources.input_socket = make_zmq_socket(
+                        self.ctx,
+                        input_address,
+                        zmq.ROUTER,
+                        bind=True,
+                        router_handover=enable_input_socket_handover,
+                    )
+
+                    _close_held_socket(held_output_socket)
+                    held_output_socket = None
+                    self.resources.output_socket = make_zmq_socket(
+                        self.ctx, output_address, zmq.PULL
+                    )
+                finally:
+                    _close_held_socket(held_input_socket)
+                    _close_held_socket(held_output_socket)
             else:
                 # Engines are managed by this client.
                 addresses = get_engine_zmq_addresses(vllm_config)
+                addresses.release_held_ports()
                 self.input_socket = self.resources.input_socket = make_zmq_socket(
                     self.ctx,
                     addresses.inputs[0],
@@ -865,7 +889,7 @@ class AsyncMPClient(MPClient):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ):
@@ -1115,7 +1139,7 @@ class DPAsyncMPClient(AsyncMPClient):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ):
@@ -1295,7 +1319,7 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
-        client_addresses: dict[str, str] | None = None,
+        client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
     ):

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import os
+import socket as stdlib_socket
 import threading
 import weakref
 from collections.abc import Callable, Iterator
@@ -22,7 +23,12 @@ from vllm.config import CacheConfig, ParallelConfig, VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
-from vllm.utils.network_utils import get_open_zmq_ipc_path, zmq_socket_ctx
+from vllm.utils.network_utils import (
+    get_open_zmq_ipc_path,
+    get_tcp_uri,
+    is_valid_ipv6_address,
+    zmq_socket_ctx,
+)
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.engine.coordinator import DPCoordinator
 from vllm.v1.executor import Executor
@@ -66,6 +72,37 @@ class EngineZmqAddresses:
     # Not used by engine, just relayed to front-end in handshake response.
     # Only required for external DP LB case.
     frontend_stats_publish_address: str | None = None
+
+    def release_held_ports(self) -> None:
+        """Release pre-bound TCP sockets right before ZMQ binds.
+
+        Sockets are stored as a plain attribute (not a dataclass field)
+        to avoid breaking msgspec serialization in the handshake path.
+        """
+        for attr in ("_held_input_sockets", "_held_output_sockets"):
+            for s in getattr(self, attr, []):
+                s.close()
+            setattr(self, attr, [])
+
+    def pop_held_ports(
+        self,
+    ) -> tuple[list[stdlib_socket.socket], list[stdlib_socket.socket]]:
+        """Transfer ownership of any reserved TCP sockets."""
+        input_sockets = getattr(self, "_held_input_sockets", [])
+        output_sockets = getattr(self, "_held_output_sockets", [])
+        self._held_input_sockets = []
+        self._held_output_sockets = []
+        return input_sockets, output_sockets
+
+    def __getstate__(self):
+        # Exclude held sockets from pickling (e.g. Ray actor serialization).
+        state = self.__dict__.copy()
+        state.pop("_held_input_sockets", None)
+        state.pop("_held_output_sockets", None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
 
 @dataclass
@@ -445,6 +482,19 @@ class CoreEngineActorManager:
         placement_groups: list[PlacementGroup] = []
         local_dp_ranks: list[int] = []
 
+        def make_control_bundle(node_ip: str) -> dict[str, float]:
+            # The engine actor is scheduled on the final CPU-only bundle. Keep
+            # that bundle colocated with the group's first GPU bundle so the
+            # actor does not float to an unrelated node and reorder worker
+            # ranks away from the advertised DP bootstrap host.
+            return {"CPU": 1.0, "node:" + node_ip: 0.001}
+
+        def get_bundle_node_ip(bundle: dict[str, float]) -> str:
+            for key in bundle:
+                if key.startswith("node:"):
+                    return key.split(":", 1)[1]
+            raise ValueError(f"Missing node affinity in placement bundle: {bundle}")
+
         dp_master_ip_key = f"node:{dp_master_ip}"
         nodes = sorted(
             available_resources.values(), key=lambda x: dp_master_ip_key not in x
@@ -576,10 +626,15 @@ class CoreEngineActorManager:
                     if len(collected_bundles) < world_size:
                         continue
 
-                    bundles = collected_bundles + [{"CPU": 1.0}]
+                    control_node_ip = get_bundle_node_ip(collected_bundles[0])
+                    bundles = collected_bundles + [
+                        make_control_bundle(control_node_ip)
+                    ]
                     collected_bundles = []
                 else:
-                    bundles = device_bundle * world_size + [{"CPU": 1.0}]
+                    bundles = device_bundle * world_size + [
+                        make_control_bundle(node_ip)
+                    ]
 
                 pg = ray.util.placement_group(
                     name=f"dp_rank_{len(placement_groups)}",
@@ -892,6 +947,41 @@ class CoreEngineActorManager:
             ray.util.remove_placement_group(pg)
 
 
+def _get_tcp_socket_family(host: str) -> int:
+    if is_valid_ipv6_address(host):
+        return stdlib_socket.AF_INET6
+
+    try:
+        addrinfos = stdlib_socket.getaddrinfo(
+            host,
+            None,
+            type=stdlib_socket.SOCK_STREAM,
+            proto=stdlib_socket.IPPROTO_TCP,
+        )
+    except stdlib_socket.gaierror:
+        return stdlib_socket.AF_INET
+
+    for family, socktype, _, _, _ in addrinfos:
+        if (socktype == stdlib_socket.SOCK_STREAM
+                and family in (stdlib_socket.AF_INET, stdlib_socket.AF_INET6)):
+            return family
+
+    return stdlib_socket.AF_INET
+
+
+def _reserve_tcp_port(host: str, family: int) -> stdlib_socket.socket:
+    bind_host = host
+    if not bind_host:
+        bind_host = "::" if family == stdlib_socket.AF_INET6 else ""
+
+    sock = stdlib_socket.socket(family, stdlib_socket.SOCK_STREAM)
+    if family == stdlib_socket.AF_INET6:
+        sock.bind((bind_host, 0, 0, 0))
+    else:
+        sock.bind((bind_host, 0))
+    return sock
+
+
 def get_engine_zmq_addresses(
     vllm_config: VllmConfig,
     num_api_servers: int = 1,
@@ -918,16 +1008,35 @@ def get_engine_zmq_addresses(
     if parallel_config.enable_elastic_ep:
         client_local_only = False
 
-    return EngineZmqAddresses(
-        inputs=[
-            get_engine_client_zmq_addr(client_local_only, host)
-            for _ in range(num_api_servers)
-        ],
-        outputs=[
-            get_engine_client_zmq_addr(client_local_only, host)
-            for _ in range(num_api_servers)
-        ],
+    if client_local_only:
+        return EngineZmqAddresses(
+            inputs=[
+                get_open_zmq_ipc_path() for _ in range(num_api_servers)
+            ],
+            outputs=[
+                get_open_zmq_ipc_path() for _ in range(num_api_servers)
+            ],
+        )
+
+    # TCP path: batch-allocate ports and hold sockets to prevent
+    # TOCTOU race between allocation and ZMQ bind (see parallel.py:483).
+    family = _get_tcp_socket_family(host)
+    held_inputs = [_reserve_tcp_port(host, family) for _ in range(num_api_servers)]
+    held_outputs = [_reserve_tcp_port(host, family) for _ in range(num_api_servers)]
+    ports = [
+        *(sock.getsockname()[1] for sock in held_inputs),
+        *(sock.getsockname()[1] for sock in held_outputs),
+    ]
+
+    addrs = EngineZmqAddresses(
+        inputs=[get_tcp_uri(host, p) for p in ports[:num_api_servers]],
+        outputs=[get_tcp_uri(host, p) for p in ports[num_api_servers:]],
     )
+    # Store as plain attribute (not a dataclass field) so msgspec
+    # serialization in the handshake path doesn't try to encode sockets.
+    addrs._held_input_sockets = held_inputs
+    addrs._held_output_sockets = held_outputs
+    return addrs
 
 
 @contextlib.contextmanager

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -3,6 +3,7 @@
 import argparse
 import contextlib
 import multiprocessing
+import socket
 import threading
 import time
 import weakref
@@ -177,6 +178,8 @@ class APIServerProcessManager:
         target_server_fn: Callable | None = None,
         stats_update_address: str | None = None,
         tensor_queue: Queue | None = None,
+        held_input_sockets: Sequence[socket.socket | None] | None = None,
+        held_output_sockets: Sequence[socket.socket | None] | None = None,
     ):
         """Initialize and start API server worker processes.
 
@@ -190,6 +193,8 @@ class APIServerProcessManager:
             output_addresses: Output addresses for each API server
             stats_update_address: Optional stats update address
             tensor_queue: Optional tensor IPC queue for sharing MM tensors
+            held_input_sockets: Reserved input sockets to transfer to workers
+            held_output_sockets: Reserved output sockets to transfer to workers
         """
         self.listen_address = listen_address
         self.sock = sock
@@ -198,28 +203,78 @@ class APIServerProcessManager:
         # Start API servers
         spawn_context = multiprocessing.get_context("spawn")
         self.processes: list[BaseProcess] = []
+        # Keep synchronization primitives alive until workers finish unpickling
+        # their startup config. Dropping the last parent-side reference too soon
+        # can make spawned children fail rebuilding the underlying SemLock.
+        self._held_socket_ready_events: list[Any] = []
+        held_input_sockets = (
+            list(held_input_sockets)
+            if held_input_sockets
+            else [None] * num_servers
+        )
+        held_output_sockets = (
+            list(held_output_sockets)
+            if held_output_sockets
+            else [None] * num_servers
+        )
+        if len(held_input_sockets) != num_servers:
+            raise ValueError("held_input_sockets must match num_servers")
+        if len(held_output_sockets) != num_servers:
+            raise ValueError("held_output_sockets must match num_servers")
 
-        for i, in_addr, out_addr in zip(
-            range(num_servers), input_addresses, output_addresses
-        ):
-            client_config = {
-                "input_address": in_addr,
-                "output_address": out_addr,
-                "client_count": num_servers,
-                "client_index": i,
-            }
-            if stats_update_address is not None:
-                client_config["stats_update_address"] = stats_update_address
-            if tensor_queue is not None:
-                client_config["tensor_queue"] = tensor_queue
+        try:
+            for i, in_addr, out_addr, held_in_sock, held_out_sock in zip(
+                range(num_servers),
+                input_addresses,
+                output_addresses,
+                held_input_sockets,
+                held_output_sockets,
+            ):
+                client_config = {
+                    "input_address": in_addr,
+                    "output_address": out_addr,
+                    "client_count": num_servers,
+                    "client_index": i,
+                }
+                if stats_update_address is not None:
+                    client_config["stats_update_address"] = stats_update_address
+                if tensor_queue is not None:
+                    client_config["tensor_queue"] = tensor_queue
 
-            proc = spawn_context.Process(
-                target=target_server_fn or run_api_server_worker_proc,
-                name=f"ApiServer_{i}",
-                args=(listen_address, sock, args, client_config),
-            )
-            self.processes.append(proc)
-            proc.start()
+                held_socket_ready = None
+                if held_in_sock is not None or held_out_sock is not None:
+                    held_socket_ready = spawn_context.Event()
+                    self._held_socket_ready_events.append(held_socket_ready)
+                    client_config["held_socket_ready"] = held_socket_ready
+                if held_in_sock is not None:
+                    client_config["held_input_socket"] = held_in_sock
+                if held_out_sock is not None:
+                    client_config["held_output_socket"] = held_out_sock
+
+                proc = spawn_context.Process(
+                    target=target_server_fn or run_api_server_worker_proc,
+                    name=f"ApiServer_{i}",
+                    args=(listen_address, sock, args, client_config),
+                )
+                self.processes.append(proc)
+                proc.start()
+
+                if held_in_sock is not None:
+                    with contextlib.suppress(OSError):
+                        held_in_sock.close()
+                if held_out_sock is not None:
+                    with contextlib.suppress(OSError):
+                        held_out_sock.close()
+                if held_socket_ready is not None:
+                    held_socket_ready.set()
+        except Exception:
+            for held_sock in (*held_input_sockets, *held_output_sockets):
+                if held_sock is None:
+                    continue
+                with contextlib.suppress(OSError):
+                    held_sock.close()
+            shutdown(self.processes)
+            raise
 
         logger.info("Started %d API server processes", len(self.processes))
 


### PR DESCRIPTION

## Summary

Fixes three distinct bugs affecting multi-node Data Parallel serving with the Ray backend:

1. **DP master IP/port environment variable override** — `VLLM_DP_MASTER_IP` and `VLLM_DP_MASTER_PORT` were unconditionally read from environment variables, overriding values already set via CLI arguments (e.g. `--data-parallel-address`). Now only reads them if explicitly set in the environment.

2. **TCP port allocation race condition (TOCTOU)** — ZMQ socket addresses were allocated by picking free ports, but between allocation and the actual `socket.bind()` call, another process could claim the same port. Fixed by pre-allocating TCP sockets (binding to port 0 to get OS-assigned ports) and holding them until ZMQ is ready to bind. Also required making the held sockets invisible to msgspec serialization and Ray pickling (`__getstate__`/`__setstate__`).

3. **Ray placement-group control-bundle drift in multi-node `span` DP layouts** — the engine actor is scheduled on the final CPU-only bundle of the placement group. That bundle was previously unconstrained, so
  Ray could place the engine actor on an unrelated node instead of the node that owns the group's first GPU bundle. Fixed by pinning the control bundle to the same node as the first GPU bundle for that DP group.

## Evidence

### Bug 1: NCCL collective timeout from DP IP/port misconfiguration

Multi-node DP=2 TP=4 run on two nodes (10.109.17.30, 10.109.27.104). After initialization, NCCL collectives hung and timed out after 600 seconds:

```
[rank5]:[E319 04:10:16.865321732 ProcessGroupNCCL.cpp:688] [Rank 1] Watchdog caught collective
operation timeout: WorkNCCL(SeqNum=12773, OpType=_ALLGATHER_BASE, NumelIn=262144,
NumelOut=1048576, Timeout(ms)=600000) ran for 600070 milliseconds before timing out.

[rank5]:[E319 04:10:16.865422372 ProcessGroupNCCL.cpp:2277] [PG ID 2 PG GUID 5 Rank 1]
failure detected by watchdog at work sequence id: 12773

[rank5]:[E319 04:11:16.865598292 ProcessGroupNCCL.cpp:763] [Rank 1] To avoid data
inconsistency, we are taking the entire process down.
```

Configuration:
```
vllm serve ... --tensor-parallel-size 4 --data-parallel-size 2 \
  --data-parallel-backend ray --data-parallel-address 10.109.17.30
```

**Root cause**: The `--data-parallel-address` CLI argument was being overridden by `VLLM_DP_MASTER_IP` which defaulted to an incorrect value when the env var wasn't explicitly set, causing workers to attempt connecting to the wrong master address.

### Bug 2: ZMQ "Address already in use" from TCP port race condition

Multi-node DP=16 TP=4 run. Multiple API server actors failed to bind ZMQ sockets because ports were claimed between allocation and binding:

```
(ApiServer_12 pid=3207025) zmq.error.ZMQError: Address already in use (addr='tcp://10.109.22.39:10069')

(ApiServer_5 pid=3207018) zmq.error.ZMQError: Address already in use (addr='tcp://10.109.22.39:63911')
```

Full traceback:
```
(ApiServer_12 pid=3207025) File "vllm/utils/network_utils.py", line 338, in make_zmq_socket
(ApiServer_12 pid=3207025)     socket.bind(path)
(ApiServer_12 pid=3207025)   File "zmq/sugar/socket.py", line 320, in bind
(ApiServer_12 pid=3207025)     super().bind(addr)
(ApiServer_12 pid=3207025) zmq.error.ZMQError: Address already in use (addr='tcp://10.109.22.39:10069')
```

**Root cause**: `get_engine_zmq_addresses()` found free ports, but by the time `make_zmq_socket()` tried to bind, another process had already claimed those ports. The fix pre-allocates sockets (bind to port 0) and holds them until ZMQ bind, eliminating the TOCTOU window.

### Bug 3: Engine actor could drift to an unrelated node in multi-node span DP layouts

  Multi-node DP span runs create each DP group's placement group from GPU bundles plus one final CPU-only control bundle. Before this change, that final control bundle had no node affinity, e.g.:

  ```
  bundles = collected_bundles + [{"CPU": 1.0}]
  ```

  or

  ```
  bundles = device_bundle * world_size + [{"CPU": 1.0}]
  ```

**Root cause**: Ray schedules the engine actor on that final CPU-only bundle. Since the bundle was unconstrained, the engine actor could land on an arbitrary node instead of the node that owns the first GPU bundle
  for the group. In multi-node span layouts, that can misalign actor placement with the worker topology / advertised DP bootstrap host and destabilize startup.

**Fix**: Pin the control bundle to the same node as the group's first GPU bundle:

  ```
  {"CPU": 1.0, "node:<first-worker-node-ip>": 0.001}
  ```

  This keeps the engine actor colocated with the group's first worker node and makes placement deterministic in multi-node span DP startup.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

