### PR TITLE
Fix MLA runs when use_inductor_graph_partition=True

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -929,12 +929,14 @@ def unified_mla_kv_cache_update(
     the data dependency between them to ensure torch.compile preserves ordering.
     """
     forward_context = get_forward_context()
-    if forward_context.attn_metadata is None:
-        # Dummy/profile forwards should not update live KV cache pages.
-        return torch.empty(0, device=kv_c_normed.device, dtype=kv_c_normed.dtype)
-
     attn_layer = forward_context.no_compile_layers[layer_name]
     kv_cache = attn_layer.kv_cache
+
+    # This needs to run even when we don't have metadata yet, so that the op
+    # is correctly captured.
+    if kv_cache.numel() == 0:
+        # Can't update an empty KV cache.
+        return torch.empty(0, device=kv_c_normed.device, dtype=kv_c_normed.dtype)
 
     slot_mapping = forward_context.slot_mapping
     assert isinstance(slot_mapping, dict), (


### PR DESCRIPTION
Before this PR, running offline inference with

```
llm = LLM(model="deepseek-ai/DeepSeek-V2-Lite",
          compilation_config=CompilationConfig(
            use_inductor_graph_partition=True,
           ),
    )
```
would yield gibberish-y output, despite good eval results. With the changes from this PR, the output is sane.

### Eval

Ran with
```
lm-eval --model vllm --model_args '{"pretrained": "deepseek-ai/DeepSeek-V2-Lite", "compilation_config": {"use_inductor_graph_partition": "True"}}' --tasks gsm8k --batch_size auto
```

Results before and after fix remain unchanged:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3776|±  |0.0134|
|     |       |strict-match    |     5|exact_match|↑  |0.3738|±  |0.0133|