### PR TITLE
[CI] fix LM Eval Qwen3.5 Models (B200)

### DIFF
--- a/tests/evals/gsm8k/configs/Qwen3.5-397B-A17B-NVFP4-DEP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-397B-A17B-NVFP4-DEP2.yaml
@@ -7,3 +7,4 @@ server_args: >-
   --max-model-len 4096
   --data-parallel-size 2
   --enable-expert-parallel
+  --max-num-seqs 512


### PR DESCRIPTION
https://buildkite.com/vllm/ci/builds/58942/steps/canvas?sid=019d427b-900f-4987-9ed9-07480b73fc65&tab=output
```
(EngineCore_DP0 pid=10078) RuntimeError: Worker failed with error 'max_num_seqs (1024) exceeds available Mamba cache blocks (600). Each decode sequence requires one Mamba cache block, so CUDA graph capture cannot proceed. Please lower max_num_seqs to at most 600 or increase gpu_memory_utilization.', please check the stack trace above for the root cause
```
This was introduced in https://github.com/vllm-project/vllm/pull/38270 cc @NickLucche 


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

