### PR TITLE
[torch.compile]  change auto_functionalized return structure to use indexing instead of unpack values

### DIFF
--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -203,7 +203,7 @@ class MatcherRMSNorm(MatcherCustomOp):
             return self.forward_rocm_aiter(input, weight)
 
         result = torch.empty_like(input)
-        _, result = auto_functionalized(
+        out = auto_functionalized(
             self._rmsnorm_op,
             result=result,
             input=input,
@@ -211,7 +211,7 @@ class MatcherRMSNorm(MatcherCustomOp):
             epsilon=self.epsilon,
         )
 
-        return result
+        return out[1]
 
     def forward_native(
         self,
@@ -267,7 +267,7 @@ class MatcherFusedAddRMSNorm(MatcherCustomOp):
         if self.match_rocm_aiter:
             return self.forward_rocm_aiter(input, weight, residual)
 
-        _, result, residual = auto_functionalized(
+        out = auto_functionalized(
             self._rmsnorm_op,
             input=input,
             residual=residual,
@@ -275,7 +275,7 @@ class MatcherFusedAddRMSNorm(MatcherCustomOp):
             epsilon=self.epsilon,
         )
 
-        return result, residual
+        return out[1], out[2]
 
     def forward_native(
         self,
@@ -385,7 +385,7 @@ class MatcherQuantFP8(MatcherCustomOp):
             fp8_min = finfo.min
             fp8_max = finfo.max
 
-            _, result, scale = auto_functionalized(
+            out = auto_functionalized(
                 self.QUANT_OP,
                 input=input,
                 output_q=result,
@@ -398,21 +398,21 @@ class MatcherQuantFP8(MatcherCustomOp):
                 dummy_is_scale_transposed=self.has_col_major_scales,
                 dummy_is_tma_aligned=self.is_tma_aligned,
             )
-            return result, scale
+            return out[1], out[2]
 
         if self.quant_key.scale.static:
             assert scale is not None
-            _, result = auto_functionalized(
+            out = auto_functionalized(
                 self.QUANT_OP, result=result, input=input, scale=scale
             )
-            return result, scale
+            return out[1], scale
         else:
             assert scale is None
             scale = self.make_scale(input)
-            _, result, scale = auto_functionalized(
+            out = auto_functionalized(
                 self.QUANT_OP, result=result, input=input, scale=scale, scale_ub=None
             )
-            return result, scale
+            return out[1], out[2]
 
     def forward_native(
         self,

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -305,7 +305,7 @@ class FusedAddRMSNormGroupQuantPattern(RMSNormQuantPattern):
             fp8_min = finfo.min
             fp8_max = finfo.max
 
-            _, result, scale = auto_functionalized(
+            out = auto_functionalized(
                 self.quant_matcher.QUANT_OP,
                 input=result_rms,
                 output_q=result,
@@ -318,6 +318,7 @@ class FusedAddRMSNormGroupQuantPattern(RMSNormQuantPattern):
                 dummy_is_scale_transposed=self.has_col_major_scales,
                 dummy_is_tma_aligned=self.is_tma_aligned,
             )
+            result, scale = out[1], out[2]
 
             return result, residual, scale
 
@@ -402,7 +403,7 @@ class RMSNormGroupQuantPattern(RMSNormQuantPattern):
             fp8_min = finfo.min
             fp8_max = finfo.max
 
-            _, result, scale = auto_functionalized(
+            out = auto_functionalized(
                 self.quant_matcher.QUANT_OP,
                 input=result_rms,
                 output_q=result,
@@ -415,6 +416,7 @@ class RMSNormGroupQuantPattern(RMSNormQuantPattern):
                 dummy_is_scale_transposed=self.has_col_major_scales,
                 dummy_is_tma_aligned=self.is_tma_aligned,
             )
+            result, scale = out[1], out[2]
 
             return result, scale
 


### PR DESCRIPTION

## Test Plan
vllm bench latency      --model meta-llama/Llama-3.1-8B      -tp 2      --input-len 256 --output-len 128 --batch-size 32      --compilation-config '{"mode": 3, "compile_sizes": [32], "pass_config": {"enable_sp": true, "sp_min_token_num": 256}}'      --output-json /tmp/sp_enabled.json
## Test Result

without this PR:
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/v1/executor/multiproc_executor.py", line 944, in worker_busy_loop
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     output = func(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return func(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/v1/worker/gpu_worker.py", line 370, in determine_available_memory
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     self.model_runner.profile_run()
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/v1/worker/gpu_model_runner.py", line 5770, in profile_run
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     hidden_states, last_hidden_states = self._dummy_run(
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]                                         ^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return func(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/v1/worker/gpu_model_runner.py", line 5462, in _dummy_run
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     outputs = self.model(
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]               ^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return self._call_impl(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return forward_call(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/model_executor/models/llama.py", line 577, in forward
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     model_output = self.model(
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]                    ^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/decorators.py", line 596, in __call__
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     self.aot_compiled_fn = self.aot_compile(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/wrapper.py", line 176, in aot_compile
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return self._compiled_callable.aot_compile((args, kwargs))
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 832, in aot_compile
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return aot_compile_fullgraph(
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/_dynamo/aot_compile.py", line 239, in aot_compile_fullgraph
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     compiled_fn = backend(
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]                   ^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/__init__.py", line 2509, in __call__
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return self.compiler_fn(model_, inputs_, **self.kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/usr/lib/python3.12/contextlib.py", line 81, in inner
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return func(*args, **kwds)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/backends.py", line 1126, in __call__
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     self.configure_post_pass()
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/backends.py", line 910, in configure_post_pass
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     self.pass_manager.configure(self.vllm_config)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/passes/pass_manager.py", line 121, in configure
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     self.passes += [SequenceParallelismPass(config)]
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/passes/inductor_pass.py", line 130, in fn_new
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     result = fn(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]              ^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/passes/fusion/sequence_parallelism.py", line 413, in __init__
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     ).register(self.patterns)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]       ^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/passes/fusion/sequence_parallelism.py", line 275, in register
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     pm.register_replacement(
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/_inductor/pattern_matcher.py", line 1602, in register_replacement
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     pattern, gm = gen_pattern_and_search_gm(
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/usr/lib/python3.12/contextlib.py", line 81, in inner
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return func(*args, **kwds)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/_inductor/pattern_matcher.py", line 1811, in gen_pattern_and_search_gm
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     search_gm = trace_fn(search_fn, flat_inputs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return func(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/_inductor/pattern_matcher.py", line 2190, in fwd_only
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     gm = make_fx(fn, decompositions, tracing_mode="real")(*args)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/fx/experimental/proxy_tensor.py", line 2701, in wrapped
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return make_fx_tracer.trace(f, *args)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/fx/experimental/proxy_tensor.py", line 2626, in trace
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return self._trace_inner(f, *args)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/fx/experimental/proxy_tensor.py", line 2588, in _trace_inner
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     t = dispatch_trace(
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]         ^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/_compile.py", line 54, in inner
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return disable_fn(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 1181, in _fn
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return fn(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/fx/experimental/proxy_tensor.py", line 1460, in dispatch_trace
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     graph = tracer.trace(root, concrete_args)  # type: ignore[arg-type]
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 1181, in _fn
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return fn(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/fx/_symbolic_trace.py", line 879, in trace
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     (self.create_arg(fn(*args)),),
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]                      ^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/opt/venv/lib/python3.12/site-packages/torch/fx/experimental/proxy_tensor.py", line 1526, in wrapped
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     out = f(*tensors)  # type:ignore[call-arg]
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]           ^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/passes/fusion/sequence_parallelism.py", line 259, in pattern
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     rms = self.rmsnorm_matcher(all_reduce, weight)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/passes/fusion/matcher_utils.py", line 68, in __call__
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     return self.forward(*args, **kwargs)
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]   File "/workspace/vllm/compilation/passes/fusion/matcher_utils.py", line 206, in forward_custom
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     _, result = auto_functionalized(
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949]     ^^^^^^^^^
(Worker_TP0 pid=706999) ERROR 03-31 13:25:17 [multiproc_executor.py:949] ValueError: too many values to unpack (expected 2)



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

