### PR TITLE
[Refactor] Simplify FutureWrapper in MultiprocExecutor

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -394,10 +394,7 @@ class MultiprocExecutor(Executor):
             aggregate=aggregate,
         )
 
-        if non_block:
-            return future
-
-        return future.result()
+        return future if non_block else future.result()
 
     @staticmethod
     def _ensure_worker_termination(worker_procs: list[BaseProcess]):

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -67,25 +67,30 @@ logger = init_logger(__name__)
 class FutureWrapper(Future):
     def __init__(
         self,
-        futures_queue: deque[tuple["FutureWrapper", Callable]],
+        futures_queue: deque["FutureWrapper"],
+        get_response: Callable[[], Any],
         aggregate: Callable = lambda x: x,
     ):
         self.futures_queue = futures_queue
+        self.get_response = get_response
         self.aggregate = aggregate
         super().__init__()
+        self.futures_queue.appendleft(self)
 
     def result(self, timeout=None):
         if timeout is not None:
             raise RuntimeError("timeout not implemented")
         # Drain any futures ahead of us in the queue.
-        while not self.done():
-            future, get_response = self.futures_queue.pop()
-            future.wait_for_response(get_response)
+        while self.futures_queue:
+            future = self.futures_queue.pop()
+            future.wait_for_response()
+            if future is self:
+                break
         return super().result()
 
-    def wait_for_response(self, get_response: Callable):
+    def wait_for_response(self):
         try:
-            response = self.aggregate(get_response())
+            response = self.aggregate(self.get_response())
             with suppress(InvalidStateError):
                 self.set_result(response)
         except Exception as e:
@@ -218,7 +223,7 @@ class MultiprocExecutor(Executor):
             for response_mq in self.response_mqs:
                 response_mq.wait_until_ready()
 
-            self.futures_queue = deque[tuple[FutureWrapper, Callable]]()
+            self.futures_queue = deque[FutureWrapper]()
 
             self._post_init_executor()
 
@@ -384,17 +389,16 @@ class MultiprocExecutor(Executor):
                 responses.append(result)
             return responses[0] if output_rank is not None else responses
 
+        future = FutureWrapper(
+            self.futures_queue,
+            get_response=get_response,
+            aggregate=aggregate,
+        )
+
         if non_block:
-            future = FutureWrapper(self.futures_queue, aggregate=aggregate)
-            self.futures_queue.appendleft((future, get_response))
             return future
 
-        # First drain any pending futures in the queue.
-        while self.futures_queue:
-            future, get_fut_response = self.futures_queue.pop()
-            future.wait_for_response(get_fut_response)
-
-        return aggregate(get_response())
+        return future.result()
 
     @staticmethod
     def _ensure_worker_termination(worker_procs: list[BaseProcess]):

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -80,15 +80,14 @@ class FutureWrapper(Future):
     def result(self, timeout=None):
         if timeout is not None:
             raise RuntimeError("timeout not implemented")
+
         # Drain any futures ahead of us in the queue.
-        while self.futures_queue:
+        while not self.done():
             future = self.futures_queue.pop()
-            future.wait_for_response()
-            if future is self:
-                break
+            future._wait_for_response()
         return super().result()
 
-    def wait_for_response(self):
+    def _wait_for_response(self):
         try:
             response = self.aggregate(self.get_response())
             with suppress(InvalidStateError):


### PR DESCRIPTION
## Purpose

Refactor `FutureWrapper` in `MultiprocExecutor` to simplify the response-fetching pattern.

- **`vllm/v1/executor/multiproc_executor.py`**:
  - `FutureWrapper.__init__` now accepts the `get_response` callable directly and appends itself to the futures queue, instead of the caller managing `(future, callable)` tuples.
  - `collective_rpc` always creates a `FutureWrapper` and calls `future.result()` for the blocking path, removing the separate drain loop and the duplicated `aggregate(get_response())` call.

## Test Plan

```bash
.venv/bin/python -m pytest tests/distributed/test_multiproc_executor.py::test_multiproc_executor_multi_node -v
.venv/bin/python -m pytest tests/v1/executor/test_executor.py -v
```

```
vllm bench latency --model meta-llama/Llama-3.1-8B-Instruct --batch-size 256 --input-len 2048 --output-len 2048 -tp 4 --num-iters-warmup 1 --num-iters 5
```

## Test Result

Before:
```
Avg latency: 28.613585791923107 seconds
10% percentile latency: 28.591742496564983 seconds
25% percentile latency: 28.59813041286543 seconds
50% percentile latency: 28.599923849105835 seconds
75% percentile latency: 28.630198312923312 seconds
90% percentile latency: 28.643394824583083 seconds
99% percentile latency: 28.651312731578948 seconds
```

After:
```
Avg latency: 28.51652752822265 seconds
10% percentile latency: 28.48597945421934 seconds
25% percentile latency: 28.486178521066904 seconds
50% percentile latency: 28.500600526109338 seconds
75% percentile latency: 28.55243168771267 seconds
90% percentile latency: 28.55552077302709 seconds
99% percentile latency: 28.557374224215746 seconds
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

