### PR TITLE
[CI][ROCm] Add Qwen3.5-35B-A3B-MXFP4 model eval into CI

### DIFF
--- a/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-TP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-TP2.yaml
@@ -1,4 +1,4 @@
-model_name: "/shareddata/amd/Qwen3.5-35B-A3B-MXFP4"
+model_name: "amd/Qwen3.5-35B-A3B-MXFP4"
 accuracy_threshold: 0.82
 tolerance: 0.03
 num_questions: 1319

--- a/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-TP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-MXFP4-TP2.yaml
@@ -1,0 +1,8 @@
+model_name: "/shareddata/amd/Qwen3.5-35B-A3B-MXFP4"
+accuracy_threshold: 0.82
+tolerance: 0.03
+num_questions: 1319
+num_fewshot: 5
+server_args: >-
+  --max-model-len 4096
+  --tensor-parallel-size 2

--- a/tests/evals/gsm8k/configs/models-qwen35-mi355.txt
+++ b/tests/evals/gsm8k/configs/models-qwen35-mi355.txt
@@ -1,1 +1,2 @@
 Qwen3.5-35B-A3B-DEP2.yaml
+Qwen3.5-35B-A3B-MXFP4-TP2.yaml


### PR DESCRIPTION
As title, TP2 validated to work locally with https://huggingface.co/amd/Qwen3.5-35B-A3B-MXFP4.

Will mark this PR as ready once the mxfp4 model is made public.