### PR TITLE
Fix llm_request trace context propagation

### DIFF
--- a/tests/tracing/test_otel.py
+++ b/tests/tracing/test_otel.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from vllm.tracing import SpanKind, extract_trace_context, extract_trace_headers
+from vllm.tracing.otel import (
+    get_trace_headers_from_context,
+    manual_instrument_otel,
+    shutdown_otel_tracer,
+)
+
+
+@pytest.fixture
+def span_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    shutdown_otel_tracer()
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    for env_var in ("traceparent", "tracestate", "TRACEPARENT", "TRACESTATE"):
+        monkeypatch.delenv(env_var, raising=False)
+
+    yield exporter
+
+    shutdown_otel_tracer()
+
+
+def test_extract_trace_headers_is_case_insensitive():
+    headers = {
+        "Traceparent": "00-11111111111111111111111111111111-2222222222222222-01",
+        "TraceState": "rojo=1",
+    }
+
+    assert extract_trace_headers(headers) == {
+        "traceparent": headers["Traceparent"],
+        "tracestate": headers["TraceState"],
+    }
+
+
+def test_get_trace_headers_from_context_preserves_parent(
+    span_exporter: InMemorySpanExporter,
+):
+    tracer = trace.get_tracer(__name__)
+
+    with tracer.start_as_current_span("parent") as parent:
+        parent_context = parent.get_span_context()
+        trace_headers = get_trace_headers_from_context()
+
+    assert trace_headers is not None
+
+    manual_instrument_otel(
+        "llm_request",
+        start_time=1,
+        context=extract_trace_context(trace_headers),
+        kind=SpanKind.SERVER,
+        use_environment_context=False,
+    )
+
+    spans = {span.name: span for span in span_exporter.get_finished_spans()}
+    llm_request_span = spans["llm_request"]
+
+    assert llm_request_span.context.trace_id == parent_context.trace_id
+    assert llm_request_span.parent is not None
+    assert llm_request_span.parent.span_id == parent_context.span_id
+    assert llm_request_span.context.span_id != parent_context.span_id
+
+
+def test_manual_instrument_otel_uses_environment_context_by_default(
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    trace_id = "11111111111111111111111111111111"
+    parent_span_id = "2222222222222222"
+    monkeypatch.setenv("traceparent", f"00-{trace_id}-{parent_span_id}-01")
+
+    manual_instrument_otel("llm_request", start_time=1, kind=SpanKind.SERVER)
+
+    (span,) = span_exporter.get_finished_spans()
+    assert span.parent is not None
+    assert span.parent.trace_id == int(trace_id, 16)
+    assert span.parent.span_id == int(parent_span_id, 16)
+
+
+def test_manual_instrument_otel_can_disable_environment_fallback(
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    trace_id = "11111111111111111111111111111111"
+    parent_span_id = "2222222222222222"
+    monkeypatch.setenv("traceparent", f"00-{trace_id}-{parent_span_id}-01")
+
+    manual_instrument_otel(
+        "llm_request",
+        start_time=1,
+        kind=SpanKind.SERVER,
+        use_environment_context=False,
+    )
+
+    (span,) = span_exporter.get_finished_spans()
+    assert span.parent is None
+    assert span.context.trace_id != int(trace_id, 16)
+    assert span.context.span_id != int(parent_span_id, 16)

--- a/tests/tracing/test_otel.py
+++ b/tests/tracing/test_otel.py
@@ -15,13 +15,20 @@ from vllm.tracing import SpanKind, extract_trace_context, extract_trace_headers
 from vllm.tracing.otel import (
     get_trace_headers_from_context,
     manual_instrument_otel,
-    shutdown_otel_tracer,
 )
+
+
+def _reset_tracer_provider() -> None:
+    provider = getattr(trace, "_TRACER_PROVIDER", None)
+    if provider is not None and hasattr(provider, "shutdown"):
+        provider.shutdown()
+    trace._TRACER_PROVIDER = None
+    trace._TRACER_PROVIDER_SET_ONCE._done = False
 
 
 @pytest.fixture
 def span_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
-    shutdown_otel_tracer()
+    _reset_tracer_provider()
 
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
@@ -33,7 +40,7 @@ def span_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
 
     yield exporter
 
-    shutdown_otel_tracer()
+    _reset_tracer_provider()
 
 
 def test_extract_trace_headers_is_case_insensitive():

--- a/tests/tracing/test_otel.py
+++ b/tests/tracing/test_otel.py
@@ -8,7 +8,9 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
+from starlette.datastructures import Headers
 
+from vllm.entrypoints.openai.engine.serving import OpenAIServing
 from vllm.tracing import SpanKind, extract_trace_context, extract_trace_headers
 from vllm.tracing.otel import (
     get_trace_headers_from_context,
@@ -72,6 +74,43 @@ def test_get_trace_headers_from_context_preserves_parent(
     assert llm_request_span.parent is not None
     assert llm_request_span.parent.span_id == parent_context.span_id
     assert llm_request_span.context.span_id != parent_context.span_id
+
+
+@pytest.mark.asyncio
+async def test_openai_trace_headers_keep_llm_request_in_parent_trace(
+    span_exporter: InMemorySpanExporter,
+):
+    class DummyEngineClient:
+        async def is_tracing_enabled(self) -> bool:
+            return True
+
+    class DummyServing:
+        engine_client = DummyEngineClient()
+
+    tracer = trace.get_tracer(__name__)
+
+    with tracer.start_as_current_span("llm.run_mcp_agent"):
+        trace_headers = await OpenAIServing._get_trace_headers(
+            DummyServing(), Headers({})
+        )
+        assert trace_headers is not None
+
+        manual_instrument_otel(
+            "llm_request",
+            start_time=1,
+            context=extract_trace_context(trace_headers),
+            kind=SpanKind.SERVER,
+            use_environment_context=False,
+        )
+
+    spans = {span.name: span for span in span_exporter.get_finished_spans()}
+    app_span = spans["llm.run_mcp_agent"]
+    llm_request_span = spans["llm_request"]
+
+    assert llm_request_span.context.trace_id == app_span.context.trace_id
+    assert llm_request_span.parent is not None
+    assert llm_request_span.parent.span_id == app_span.context.span_id
+    assert llm_request_span.context.span_id != app_span.context.span_id
 
 
 def test_manual_instrument_otel_uses_environment_context_by_default(

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -75,6 +75,7 @@ from vllm.tool_parsers import ToolParser
 from vllm.tracing import (
     contains_trace_headers,
     extract_trace_headers,
+    get_trace_headers_from_context,
     log_tracing_disabled_warning,
 )
 from vllm.utils import random_uuid
@@ -743,7 +744,11 @@ class OpenAIServing:
         is_tracing_enabled = await self.engine_client.is_tracing_enabled()
 
         if is_tracing_enabled:
-            return extract_trace_headers(headers)
+            trace_headers = extract_trace_headers(headers)
+            if trace_headers:
+                return trace_headers
+
+            return get_trace_headers_from_context()
 
         if contains_trace_headers(headers):
             log_tracing_disabled_warning()

--- a/vllm/entrypoints/pooling/base/serving.py
+++ b/vllm/entrypoints/pooling/base/serving.py
@@ -27,6 +27,7 @@ from vllm.renderers.inputs.preprocess import extract_prompt_components
 from vllm.tracing import (
     contains_trace_headers,
     extract_trace_headers,
+    get_trace_headers_from_context,
     log_tracing_disabled_warning,
 )
 from vllm.utils import random_uuid
@@ -249,7 +250,11 @@ class PoolingServing:
         is_tracing_enabled = await self.engine_client.is_tracing_enabled()
 
         if is_tracing_enabled:
-            return extract_trace_headers(headers)
+            trace_headers = extract_trace_headers(headers)
+            if trace_headers:
+                return trace_headers
+
+            return get_trace_headers_from_context()
 
         if contains_trace_headers(headers):
             log_tracing_disabled_warning()

--- a/vllm/tracing/__init__.py
+++ b/vllm/tracing/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, TypeAlias
 from .otel import (
     SpanKind,
     extract_trace_context,
+    get_trace_headers_from_context,
     init_otel_tracer,
     init_otel_worker_tracer,
     instrument_otel,
@@ -33,6 +34,7 @@ __all__ = [
     "SpanKind",
     "extract_trace_context",
     "extract_trace_headers",
+    "get_trace_headers_from_context",
     "log_tracing_disabled_warning",
     "contains_trace_headers",
     "otel_import_error_traceback",
@@ -125,6 +127,7 @@ def instrument_manual(
     attributes: dict[str, Any] | None = None,
     context: Any = None,
     kind: Any = None,
+    use_environment_context: bool = True,
 ):
     """Manually create a span with explicit timestamps.
 
@@ -135,11 +138,20 @@ def instrument_manual(
         attributes: Optional dict of span attributes.
         context: Optional trace context (e.g., from extract_trace_context).
         kind: Optional SpanKind (e.g., SpanKind.SERVER).
+        use_environment_context: Whether to fall back to trace headers stored
+            in process environment variables when no explicit context is
+            provided.
     """
     is_available, _, _, _, manual_instrument_fn = _REGISTERED_TRACING_BACKENDS["otel"]
     if is_available():
         return manual_instrument_fn(
-            span_name, start_time, end_time, attributes, context, kind
+            span_name,
+            start_time,
+            end_time,
+            attributes,
+            context,
+            kind,
+            use_environment_context,
         )
     else:
         return None

--- a/vllm/tracing/otel.py
+++ b/vllm/tracing/otel.py
@@ -11,7 +11,11 @@ from contextlib import contextmanager
 from typing import Any
 
 from vllm.logger import init_logger
-from vllm.tracing.utils import TRACE_HEADERS, LoadingSpanAttributes
+from vllm.tracing.utils import (
+    TRACE_HEADERS,
+    LoadingSpanAttributes,
+    extract_trace_headers,
+)
 
 logger = init_logger(__name__)
 
@@ -131,6 +135,19 @@ def extract_trace_context(headers: Mapping[str, str] | None) -> Context | None:
     return None
 
 
+def get_trace_headers_from_context(
+    context: Context | None = None,
+) -> Mapping[str, str] | None:
+    """Inject the provided OTel context into a trace-header carrier."""
+    if not _IS_OTEL_AVAILABLE:
+        return None
+
+    carrier: dict[str, str] = {}
+    inject(carrier, context=context)
+    trace_headers = extract_trace_headers(carrier)
+    return trace_headers or None
+
+
 def instrument_otel(func, span_name, attributes, record_exception):
     """Internal wrapper logic for sync and async functions."""
 
@@ -187,6 +204,7 @@ def manual_instrument_otel(
     attributes: dict[str, Any] | None = None,
     context: Context | None = None,
     kind: Any = None,  # SpanKind, but typed as Any for when OTEL unavailable
+    use_environment_context: bool = True,
 ):
     """Manually create and end a span with explicit timestamps."""
     if not _IS_OTEL_AVAILABLE:
@@ -194,7 +212,11 @@ def manual_instrument_otel(
 
     tracer = trace.get_tracer(__name__)
     # Use provided context, or fall back to smart context detection
-    ctx = context if context is not None else _get_smart_context()
+    ctx = (
+        context
+        if context is not None
+        else _get_smart_context(use_environment_context=use_environment_context)
+    )
 
     span_kwargs: dict[str, Any] = {
         "name": span_name,
@@ -213,7 +235,7 @@ def manual_instrument_otel(
         span.end()
 
 
-def _get_smart_context() -> Context | None:
+def _get_smart_context(use_environment_context: bool = True) -> Context | None:
     """
     Determines the parent context.
     1. If a Span is already active in this process, use it.
@@ -221,6 +243,9 @@ def _get_smart_context() -> Context | None:
     """
     current_span = trace.get_current_span()
     if current_span.get_span_context().is_valid:
+        return None
+
+    if not use_environment_context:
         return None
 
     carrier = {}
@@ -232,7 +257,7 @@ def _get_smart_context() -> Context | None:
         carrier["tracestate"] = ts
 
     if not carrier:
-        carrier = dict(os.environ)
+        return None
 
     return TraceContextTextMapPropagator().extract(carrier)
 

--- a/vllm/tracing/utils.py
+++ b/vllm/tracing/utils.py
@@ -56,7 +56,7 @@ class LoadingSpanAttributes:
 
 def contains_trace_headers(headers: Mapping[str, str]) -> bool:
     """Check if the provided headers dictionary contains trace context."""
-    return any(h in headers for h in TRACE_HEADERS)
+    return any(_get_trace_header(headers, h) is not None for h in TRACE_HEADERS)
 
 
 def extract_trace_headers(headers: Mapping[str, str]) -> Mapping[str, str]:
@@ -64,7 +64,24 @@ def extract_trace_headers(headers: Mapping[str, str]) -> Mapping[str, str]:
     Extract only trace-related headers from a larger header dictionary.
     Useful for logging or passing context to a non-OTel client.
     """
-    return {h: headers[h] for h in TRACE_HEADERS if h in headers}
+    return {
+        h: value
+        for h in TRACE_HEADERS
+        if (value := _get_trace_header(headers, h)) is not None
+    }
+
+
+def _get_trace_header(headers: Mapping[str, str], header: str) -> str | None:
+    """Look up a trace header without assuming a particular key casing."""
+    if header in headers:
+        return headers[header]
+
+    header_lower = header.lower()
+    for key, value in headers.items():
+        if key.lower() == header_lower:
+            return value
+
+    return None
 
 
 @run_once

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -26,6 +26,7 @@ from vllm.renderers import BaseRenderer, renderer_from_config
 from vllm.sampling_params import SamplingParams
 from vllm.tasks import GENERATION_TASKS, POOLING_TASKS, SupportedTask
 from vllm.tokenizers import TokenizerLike
+from vllm.tracing import extract_trace_headers
 from vllm.utils import length_from_prompt_token_ids_or_embeds, random_uuid
 from vllm.utils.jsontree import json_iter_leaves
 from vllm.v1.engine import EngineCoreRequest
@@ -280,6 +281,10 @@ class InputProcessor:
         else:
             pooling_params = params.clone()
 
+        normalized_trace_headers = None
+        if trace_headers is not None:
+            normalized_trace_headers = extract_trace_headers(trace_headers) or None
+
         # Multimodal related.
         mm_features: list[MultiModalFeatureSpec] | None = None
 
@@ -330,7 +335,7 @@ class InputProcessor:
             cache_salt=decoder_inputs.get("cache_salt"),
             priority=priority,
             data_parallel_rank=data_parallel_rank,
-            trace_headers=trace_headers,
+            trace_headers=normalized_trace_headers,
             resumable=resumable,
         )
 

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -758,6 +758,7 @@ class OutputProcessor:
             attributes=attributes,
             context=trace_context,
             kind=SpanKind.SERVER,
+            use_environment_context=False,
         )
 
     def _update_stats_from_output(


### PR DESCRIPTION
## Summary
- preserve request-scoped trace context for `llm_request` instead of falling back to ambient process environment state during final span emission
- normalize propagated trace headers case-insensitively and carry them explicitly through serving and engine request processing
- add regression coverage asserting `llm_request` stays in the parent distributed trace while receiving its own unique span id

## Duplicate-work check
- The only related open PR I found is #32162, which adds tracing for aborted requests. It does not address stale trace header reuse, split traces, or `llm_request` span identity.
- This PR supersedes closed PR #38672, which was closed because it was based on the wrong fork base. This replacement is based directly on `vllm-project/vllm:main`.

## Testing
- `./.venv/bin/python -m pytest tests/tracing/test_otel.py -v -s` (`5 passed`)
- `PRE_COMMIT_HOME=/tmp/pre-commit-vllm-upstream-tracing XDG_CACHE_HOME=/tmp/xdg-cache-vllm-upstream-tracing NPM_CONFIG_CACHE=/tmp/npm-cache-vllm-upstream-tracing ./.venv/bin/pre-commit run --files vllm/tracing/utils.py vllm/tracing/otel.py vllm/tracing/__init__.py vllm/entrypoints/openai/engine/serving.py vllm/entrypoints/pooling/base/serving.py vllm/v1/engine/input_processor.py vllm/v1/engine/output_processor.py tests/tracing/test_otel.py` (passed)

## AI assistance
AI assistance was used to draft and implement this change. The submitter reviewed the final diff and validated the tests above.
