### PR TITLE
[Bugfix] Support [TOOL_CALLS] single-token format in Jamba tool parser

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -278,10 +278,13 @@ Recommended flags: `--tool-call-parser internlm --chat-template examples/tool_ch
 
 ### Jamba Models (`jamba`)
 
-AI21's Jamba-1.5 models are supported.
+Models using either `<tool_calls>`/`</tool_calls>` XML-style tags or the Mistral-style `[TOOL_CALLS]` single token are supported. The parser auto-detects the format from the tokenizer vocabulary at startup.
+
+Supported models include:
 
 * `ai21labs/AI21-Jamba-1.5-Mini`
 * `ai21labs/AI21-Jamba-1.5-Large`
+* `ServiceNow-AI/Apriel-Nemotron-15b-Thinker`
 
 Flags: `--tool-call-parser jamba`
 

--- a/tests/tool_parsers/test_jamba_tool_parser.py
+++ b/tests/tool_parsers/test_jamba_tool_parser.py
@@ -13,7 +13,8 @@ from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.tokenizers.detokenizer_utils import detokenize_incrementally
 from vllm.tool_parsers.jamba_tool_parser import JambaToolParser
 
-MODEL = "ai21labs/Jamba-tiny-dev"
+MODEL = "ai21labs/Jamba-tiny-dev"  # uses <tool_calls>...</tool_calls> tags
+SINGLE_TOKEN_MODEL = "ServiceNow-AI/Apriel-Nemotron-15b-Thinker"  # uses [TOOL_CALLS]
 
 
 @pytest.fixture(scope="module")
@@ -24,6 +25,16 @@ def jamba_tokenizer():
 @pytest.fixture
 def jamba_tool_parser(jamba_tokenizer):
     return JambaToolParser(jamba_tokenizer)
+
+
+@pytest.fixture(scope="module")
+def single_token_tokenizer():
+    return get_tokenizer(tokenizer_name=SINGLE_TOKEN_MODEL)
+
+
+@pytest.fixture
+def single_token_tool_parser(single_token_tokenizer):
+    return JambaToolParser(single_token_tokenizer)
 
 
 def assert_tool_calls(
@@ -287,6 +298,204 @@ def test_extract_tool_calls_streaming(
                     # make sure they're a string and then add them to the list
                     assert isinstance(tool_call.function.arguments, str)
 
+                    function_args_strs[tool_call.index] += tool_call.function.arguments
+
+    assert other_content == expected_content
+
+    actual_tool_calls = [
+        ToolCall(
+            id=tool_call_id,
+            function=FunctionCall(
+                name=function_name,
+                arguments=partial_json_parser.ensure_json(
+                    function_args_str, Allow.OBJ | Allow.STR
+                ),
+            ),
+        )
+        for tool_call_id, function_name, function_args_str in zip(
+            tool_call_ids, function_names, function_args_strs
+        )
+    ]
+    assert_tool_calls(actual_tool_calls, expected_tool_calls)
+
+
+def test_tagged_parser_ignores_single_token_output(jamba_tool_parser):
+    # parser with <tool_calls> vocab must not extract [TOOL_CALLS] output
+    model_output = '[TOOL_CALLS] [{"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}]'  # noqa: E501
+    extracted = jamba_tool_parser.extract_tool_calls(
+        model_output, request=None
+    )  # type: ignore[arg-type]
+    assert not extracted.tools_called
+    assert extracted.tool_calls == []
+
+
+@pytest.mark.parametrize(
+    ids=[
+        "single_tool",
+        "single_tool_with_content",
+        "parallel_tools",
+        "array_in_arguments",
+    ],
+    argnames=["model_output", "expected_tool_calls", "expected_content"],
+    argvalues=[
+        (
+            """[TOOL_CALLS] [{"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}]""",  # noqa: E501
+            [
+                ToolCall(
+                    function=FunctionCall(
+                        name="get_current_weather",
+                        arguments=json.dumps(
+                            {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}
+                        ),
+                    )
+                )
+            ],
+            None,
+        ),
+        (
+            """Sure! let me call the tool for you.[TOOL_CALLS] [{"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}]""",  # noqa: E501
+            [
+                ToolCall(
+                    function=FunctionCall(
+                        name="get_current_weather",
+                        arguments=json.dumps(
+                            {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}
+                        ),
+                    )
+                )
+            ],
+            "Sure! let me call the tool for you.",
+        ),
+        (
+            """[TOOL_CALLS] [{"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}, {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}]""",  # noqa: E501
+            [
+                ToolCall(
+                    function=FunctionCall(
+                        name="get_current_weather",
+                        arguments=json.dumps(
+                            {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}
+                        ),
+                    )
+                ),
+                ToolCall(
+                    function=FunctionCall(
+                        name="get_current_weather",
+                        arguments=json.dumps(
+                            {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}
+                        ),
+                    )
+                ),
+            ],
+            None,
+        ),
+        (
+            """[TOOL_CALLS] [{"name": "filter_items", "arguments": {"ids": [1, 2, 3], "active": true}}]""",  # noqa: E501
+            [
+                ToolCall(
+                    function=FunctionCall(
+                        name="filter_items",
+                        arguments=json.dumps(
+                            {"ids": [1, 2, 3], "active": True}
+                        ),
+                    )
+                )
+            ],
+            None,
+        ),
+    ],
+)
+def test_extract_tool_calls_single_token(
+    single_token_tool_parser, model_output, expected_tool_calls, expected_content
+):
+    extracted = single_token_tool_parser.extract_tool_calls(
+        model_output, request=None
+    )  # type: ignore[arg-type]
+    assert extracted.tools_called
+    assert_tool_calls(extracted.tool_calls, expected_tool_calls)
+    assert extracted.content == expected_content
+
+
+@pytest.mark.parametrize(
+    ids=[
+        "no_tools",
+        "single_tool",
+        "single_tool_with_content",
+    ],
+    argnames=["model_output", "expected_tool_calls", "expected_content"],
+    argvalues=[
+        ("""This is a test""", [], """This is a test"""),
+        (
+            """[TOOL_CALLS] [{"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}]""",  # noqa: E501
+            [
+                ToolCall(
+                    function=FunctionCall(
+                        name="get_current_weather",
+                        arguments=json.dumps(
+                            {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}
+                        ),
+                    )
+                )
+            ],
+            "",
+        ),
+        (
+            """Sure! let me call the tool for you.[TOOL_CALLS] [{"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}]""",  # noqa: E501
+            [
+                ToolCall(
+                    function=FunctionCall(
+                        name="get_current_weather",
+                        arguments=json.dumps(
+                            {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}
+                        ),
+                    )
+                )
+            ],
+            "Sure! let me call the tool for you.",
+        ),
+    ],
+)
+def test_extract_tool_calls_streaming_single_token(
+    single_token_tool_parser,
+    single_token_tokenizer,
+    model_output,
+    expected_tool_calls,
+    expected_content,
+):
+    other_content: str = ""
+    function_names: list[str] = []
+    function_args_strs: list[str] = []
+    tool_call_idx: int = -1
+    tool_call_ids: list[str | None] = []
+
+    for delta_message in stream_delta_message_generator(
+        single_token_tool_parser, single_token_tokenizer, model_output
+    ):
+        assert not delta_message.role
+
+        if delta_message.content:
+            other_content += delta_message.content
+
+        streamed_tool_calls = delta_message.tool_calls
+
+        if streamed_tool_calls and len(streamed_tool_calls) > 0:
+            assert len(streamed_tool_calls) == 1
+            tool_call = streamed_tool_calls[0]
+
+            if tool_call.index != tool_call_idx:
+                tool_call_idx = tool_call.index
+                function_args_strs.append("")
+                tool_call_ids.append(None)
+
+            if tool_call.id and not tool_call_ids[tool_call.index]:
+                tool_call_ids[tool_call.index] = tool_call.id
+
+            if tool_call.function:
+                if tool_call.function.name:
+                    assert isinstance(tool_call.function.name, str)
+                    function_names.append(tool_call.function.name)
+
+                if tool_call.function.arguments:
+                    assert isinstance(tool_call.function.arguments, str)
                     function_args_strs[tool_call.index] += tool_call.function.arguments
 
     assert other_content == expected_content

--- a/vllm/tool_parsers/jamba_tool_parser.py
+++ b/vllm/tool_parsers/jamba_tool_parser.py
@@ -45,27 +45,48 @@ class JambaToolParser(ToolParser):
             str
         ] = []  # map what has been streamed for each tool so far to a list
 
-        self.tool_calls_start_token: str = "<tool_calls>"
-        self.tool_calls_end_token: str = "</tool_calls>"
-
-        self.tool_calls_regex = re.compile(
-            rf"{self.tool_calls_start_token}(.*?){self.tool_calls_end_token}", re.DOTALL
-        )
-
         if not self.model_tokenizer:
             raise ValueError(
                 "The model tokenizer must be passed to the ToolParser "
                 "constructor during construction."
             )
-        self.tool_calls_start_token_id = self.vocab.get(self.tool_calls_start_token)
-        self.tool_calls_end_token_id = self.vocab.get(self.tool_calls_end_token)
-        if (
-            self.tool_calls_start_token_id is None
-            or self.tool_calls_end_token_id is None
+
+        # Detect tool call format from tokenizer vocabulary.
+        # Some models (e.g., Apriel-Nemotron) use a single [TOOL_CALLS]
+        # token (Mistral-style), while others (e.g., AI21 Jamba 1.5)
+        # use <tool_calls>...</tool_calls> XML-style tags.
+        single_token = "[TOOL_CALLS]"
+        tagged_start = "<tool_calls>"
+        tagged_end = "</tool_calls>"
+
+        if self.vocab.get(single_token) is not None:
+            # Single-token format: one start token, no end token
+            self.tool_calls_start_token: str = single_token
+            self.tool_calls_end_token: str | None = None
+            self.tool_calls_start_token_id: int = self.vocab[single_token]
+            self.tool_calls_end_token_id: int | None = None
+            self.tool_calls_regex = re.compile(
+                rf"{re.escape(self.tool_calls_start_token)}\s*(\[.*\])",
+                re.DOTALL,
+            )
+        elif (
+            self.vocab.get(tagged_start) is not None
+            and self.vocab.get(tagged_end) is not None
         ):
+            # Tagged format: start and end tokens
+            self.tool_calls_start_token = tagged_start
+            self.tool_calls_end_token = tagged_end
+            self.tool_calls_start_token_id = self.vocab[tagged_start]
+            self.tool_calls_end_token_id = self.vocab[tagged_end]
+            self.tool_calls_regex = re.compile(
+                rf"{self.tool_calls_start_token}(.*?){self.tool_calls_end_token}",
+                re.DOTALL,
+            )
+        else:
             raise RuntimeError(
-                "Jamba Tool parser could not locate tool calls start/end "
-                "tokens in the tokenizer!"
+                "Jamba tool parser could not locate tool call tokens in "
+                "the tokenizer. Expected either '[TOOL_CALLS]' or both "
+                "'<tool_calls>' and '</tool_calls>'."
             )
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
@@ -88,12 +109,16 @@ class JambaToolParser(ToolParser):
 
         else:
             try:
-                # use a regex to find the tool call between the tags
-                function_calls = self.tool_calls_regex.findall(model_output)[0]
+                # use a regex to find the tool call JSON array
+                matches = self.tool_calls_regex.findall(model_output)
+                if not matches:
+                    return ExtractedToolCallInformation(
+                        tools_called=False, tool_calls=[], content=model_output
+                    )
 
                 # load the JSON, and then use it to build the Function and
                 # Tool Call
-                raw_function_calls = json.loads(function_calls)
+                raw_function_calls = json.loads(matches[0])
                 tool_calls = [
                     ToolCall(
                         type="function",
@@ -155,10 +180,12 @@ class JambaToolParser(ToolParser):
         # seen) allows sending the entire tool/ function name at once.
         flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
         try:
-            # Extract the tool calls between the special tool call tokens
-            parsable_arr = current_text.split(self.tool_calls_start_token)[-1].split(
-                self.tool_calls_end_token
-            )[0]
+            # Extract the tool call JSON after the start token
+            raw = current_text.split(self.tool_calls_start_token)[-1]
+            if self.tool_calls_end_token is not None:
+                parsable_arr = raw.split(self.tool_calls_end_token)[0]
+            else:
+                parsable_arr = raw.strip()
 
             # tool calls are generated in an array, so do partial JSON
             # parsing on the entire array


### PR DESCRIPTION
The Jamba tool parser hardcodes `<tool_calls>`/`</tool_calls>` XML tags, crashing on models that use a `[TOOL_CALLS]` single token (e.g., Apriel-Nemotron-15b-Thinker). Auto-detect the format from tokenizer vocabulary.

Fixes #38674

## Purpose

The `jamba` tool call parser crashes with `RuntimeError` on the first tool call request when used with models that have `[TOOL_CALLS]` in their tokenizer vocabulary instead of `<tool_calls>`/`</tool_calls>` XML tags (e.g., `ServiceNow-AI/Apriel-Nemotron-15b-Thinker`).

## Changes

* **`vllm/tool_parsers/jamba_tool_parser.py`**: Replace hardcoded `<tool_calls>`/`</tool_calls>` token setup with vocabulary-based auto-detection. Check for `[TOOL_CALLS]` first (single-token format), fall back to `<tool_calls>`/`</tool_calls>` (tagged format), raise `RuntimeError` if neither found. Update `extract_tool_calls` to guard against empty regex matches. Update `extract_tool_calls_streaming` to branch extraction based on detected format.

* **`tests/tool_parsers/test_jamba_tool_parser.py`**: Add `ServiceNow-AI/Apriel-Nemotron-15b-Thinker` as a second test model for the single-token format. Add test proving the tagged parser ignores single-token output. Add parametrized extraction and streaming tests for single-token format including array-in-arguments edge case.

* **`docs/features/tool_calling.md`**: Update Jamba section to document both supported formats and add `Apriel-Nemotron-15b-Thinker` to the supported models list.

## Test Plan

```bash
pytest tests/tool_parsers/test_jamba_tool_parser.py -v
```

```bash
vllm serve ServiceNow-AI/Apriel-Nemotron-15b-Thinker \
    --enable-auto-tool-choice --tool-call-parser jamba --max-model-len 4096
```

```bash
curl -s http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" \
  -d '{"model":"ServiceNow-AI/Apriel-Nemotron-15b-Thinker", \
       "messages":[{"role":"user","content":"What is the weather in SF?"}], \
       "tools":[{"type":"function","function":{"name":"get_weather", \
       "description":"Get weather","parameters":{"type":"object", \
       "properties":{"location":{"type":"string"}},"required":["location"]}}}], \
       "tool_choice":"required","max_tokens":200}'
```

## Test Result

**Unit tests:** 16 passed (8 tagged format with `Jamba-tiny-dev`, 8 single-token format with `Apriel-Nemotron-15b-Thinker`)

| Test | Result |
|---|---|
| Existing tagged format tests (extraction + streaming) | 8 passed, no regression |
| Tagged parser ignores single-token output | Passed |
| Single-token extraction (single, with content, parallel, array args) | 4 passed |
| Single-token streaming (no tools, single, with content) | 3 passed |
