### PR TITLE
[ROCm][perf] Use workspace manager for sparse indexer allocations

### DIFF
--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -280,6 +280,13 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             else 0
         )
         next_n = self.num_speculative_tokens + 1
+        if self.num_speculative_tokens > 2 and current_platform.is_rocm():
+            logger.warning_once(
+                "num_speculative_tokens > 2 (=%d) with ROCm AITER "
+                "sparse indexer kernel may crash or produce incorrect results. "
+                "num_speculative_tokens <= 2 is recommended.",
+                self.num_speculative_tokens,
+            )
         self.reorder_batch_threshold += self.num_speculative_tokens
         self.use_flattening = next_n not in self.natively_supported_next_n
 

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -12,6 +12,7 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import LayerNameType
 from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerMetadata
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
+from vllm.v1.worker.workspace import current_workspace_manager
 
 if current_platform.is_cuda_alike():
     from vllm import _custom_ops as ops
@@ -333,12 +334,11 @@ def rocm_fp8_paged_mqa_logits(
             aiter_paged_mqa_logits_module.deepgemm_fp8_paged_mqa_logits_stage1
         )
         batch_size, next_n, heads, _ = q_fp8.shape
-        out_qk = torch.full(
-            (heads, batch_size * next_n, max_model_len),
-            float("-inf"),
-            device="cuda",
-            dtype=torch.float32,
+        actual_batch = batch_size * next_n
+        (out_qk,) = current_workspace_manager().get_simultaneous(
+            ((heads, actual_batch, max_model_len), torch.float32),
         )
+        out_qk.fill_(float("-inf"))
         deepgemm_fp8_paged_mqa_logits_stage1(
             q_fp8,
             kv_cache_fp8,
@@ -473,15 +473,6 @@ def rocm_aiter_sparse_attn_indexer_fake(
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor | None,
 ) -> torch.Tensor:
-    # profile run
-    # NOTE(Chen): create the max possible flattened_kv. So that
-    # profile_run can get correct memory usage.
-    _flattened_kv = torch.empty(
-        [total_seq_lens, head_dim + 4], device=k.device, dtype=torch.uint8
-    )
-    fp8_dtype = current_platform.fp8_dtype()
-    _k_fp8 = _flattened_kv[..., :head_dim].view(fp8_dtype).contiguous()
-    _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
     return topk_indices_buffer
 
 
@@ -508,6 +499,20 @@ def rocm_aiter_sparse_attn_indexer(
     k_cache_prefix = _resolve_layer_name(k_cache_prefix)
     # assert isinstance(attn_metadata, dict)
     if not isinstance(attn_metadata, dict):
+        # Reserve workspace during profiling run (real tensors, not
+        # FakeTensor mode). Must NOT be in the fake impl — torch.compile
+        # calls the fake impl under FakeTensor mode where workspace
+        # manager operations on the locked real workspace would corrupt
+        # PyTorch's dispatch state.
+        workspace_manager = current_workspace_manager()
+        workspace_manager.get_simultaneous(
+            ((total_seq_lens, head_dim), fp8_dtype),
+            ((total_seq_lens, 4), torch.uint8),
+        )
+        heads = q_fp8.shape[1]
+        workspace_manager.get_simultaneous(
+            ((heads, hidden_states.shape[0], max_model_len), torch.float32),
+        )
         return rocm_aiter_sparse_attn_indexer_fake(
             hidden_states,
             k_cache_prefix,
@@ -544,17 +549,15 @@ def rocm_aiter_sparse_attn_indexer(
     if has_prefill:
         prefill_metadata = layer_attn_metadata.prefill
         assert prefill_metadata is not None
+
+        workspace_manager = current_workspace_manager()
+        k_fp8_full, k_scale_full = workspace_manager.get_simultaneous(
+            ((total_seq_lens, head_dim), fp8_dtype),
+            ((total_seq_lens, 4), torch.uint8),
+        )
         for chunk in prefill_metadata.chunks:
-            k_fp8 = torch.empty(
-                [chunk.total_seq_lens, head_dim],
-                device=k.device,
-                dtype=fp8_dtype,
-            )
-            k_scale = torch.empty(
-                [chunk.total_seq_lens, 4],
-                device=k.device,
-                dtype=torch.uint8,
-            )
+            k_fp8 = k_fp8_full[: chunk.total_seq_lens]
+            k_scale = k_scale_full[: chunk.total_seq_lens]
 
             ops.cp_gather_indexer_k_quant_cache(
                 kv_cache,

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -6,6 +6,7 @@ from importlib.util import find_spec
 
 import torch
 
+import vllm.envs as envs
 from vllm.forward_context import get_forward_context
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -499,20 +500,37 @@ def rocm_aiter_sparse_attn_indexer(
     k_cache_prefix = _resolve_layer_name(k_cache_prefix)
     # assert isinstance(attn_metadata, dict)
     if not isinstance(attn_metadata, dict):
-        # Reserve workspace during profiling run (real tensors, not
-        # FakeTensor mode). Must NOT be in the fake impl — torch.compile
-        # calls the fake impl under FakeTensor mode where workspace
-        # manager operations on the locked real workspace would corrupt
-        # PyTorch's dispatch state.
+        # Profiling early-exit: reserve memory to account for runtime
+        # allocations. Must be in the real impl, not the fake impl —
+        # torch.compile calls the fake impl under FakeTensor mode where
+        # workspace manager operations on the locked real workspace
+        # would corrupt PyTorch's dispatch state.
         workspace_manager = current_workspace_manager()
+
+        # Prefill k_fp8 and k_scale buffers, used by
+        # rocm_aiter_sparse_attn_indexer's prefill path
         workspace_manager.get_simultaneous(
             ((total_seq_lens, head_dim), fp8_dtype),
             ((total_seq_lens, 4), torch.uint8),
         )
+
+        # Decode out_qk buffer, used by rocm_fp8_paged_mqa_logits.
+        # actual_batch <= hidden_states.shape[0] == max_num_batched_tokens
         heads = q_fp8.shape[1]
         workspace_manager.get_simultaneous(
             ((heads, hidden_states.shape[0], max_model_len), torch.float32),
         )
+
+        # Transient logits tensor peak memory, produced by
+        # rocm_fp8_mqa_logits (prefill) and rocm_fp8_paged_mqa_logits
+        # (decode). Prefill logits are bounded by
+        # VLLM_SPARSE_INDEXER_MAX_LOGITS_MB via chunking in
+        # split_indexer_prefill_chunks; decode logits are smaller.
+        max_logits_elems = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
+        _ = torch.empty(
+            max_logits_elems, dtype=torch.uint8, device=hidden_states.device
+        )
+
         return rocm_aiter_sparse_attn_indexer_fake(
             hidden_states,
             k_cache_prefix,


### PR DESCRIPTION

Replace dynamic per-call allocations in the ROCm sparse attention indexer with a workspace manager.
This eliminates caching allocator bloat that caused OOM crashes under sustained MTP load.

## Purpose

With MTP speculative decoding enabled on ROCm, the sparse attention indexer dynamically allocates temporary buffers
(`k_fp8, k_scale` per prefill chunk; `out_qk` per decode call) on every invocation.
These varying-size allocations cause PyTorch's caching allocator to retain large amounts of unused memory (reserved >> allocated), eventually exhausting GPU memory available to the HIP runtime for kernel scratch space.
This manifests as non-deterministic memory access faults or `HSA_STATUS_ERROR_OUT_OF_RESOURCES` errors.

## Solution

- **Prefill path:** Replace per-chunk `torch.empty` for k_fp8/k_scale with a single `workspace_manager.get_simultaneous()` call, slicing per chunk. Matches the existing CUDA path in `sparse_attn_indexer.py`.
- **Decode path:** Replace `torch.full` for `out_qk` in `rocm_fp8_paged_mqa_logits` with a workspace manager view filled with -inf.
- **Memory profiling path**: Reserve workspace for both prefill and decode buffer sizes in the real impl's early-exit path (not the fake impl, which runs under FakeTensor mode during torch.compile).

## Test Plan

image: vllm/vllm-openai-rocm:nightly-3e802e8786e05ba94e8a585630f14c86f83b8ad4

```
vllm serve deepseek-ai/DeepSeek-V3.2 \
    --host 0.0.0.0 \
    --port 8004 \
    --seed 4321 \
    --dtype auto \
    --gpu_memory_utilization 0.75 \
    --max_num_seqs 256 \
    --max_model_len 16384 \
    --max_num_batched_tokens 4096 \
    --no_enable_prefix_caching \
    --profiler-config '{"profiler": "torch", "torch_profiler_dir": "/tmp/traces", "torch_profiler_with_stack":"False"}' \
    --no-async_scheduling \
    --compilation_config '{"custom_ops": ["-rms_norm", "-silu_and_mul", "-quant_fp8"]}' \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 2}' \
    --chat_template "{% for message in messages %}{{ '<|' + message['role'] + '|>\\n' + message['content'] }}{% endfor %}<|assistant|>\\n" \
    --block-size 64 \
    --attention-backend ROCM_AITER_MLA_SPARSE \
    --tensor_parallel_size 8
    
vllm bench serve \
  --backend vllm \
  --dataset_name random \
  --ignore_eos \
  --model deepseek-ai/DeepSeek-V3.2 \
  --ready_check_timeout_sec 3600 \
  --percentile_metrics ttft,tpot,itl,e2el \
  --random_input_len 8192 \
  --random_output_len 1024 \
  --max_concurrency 128 \
  --temperature 0 \
  --seed 3 \
  --num_warmups 128 \
  --num_prompts 3840 \
  --port 8004
```

## Test Result

### Before

- MTP with `num_speculative_tokens 2` crashes on this image. Fixed in #37887
```
ValueError: Unsupported attention metadata type for speculative decoding with num_speculative_tokens > 1: <class 'vllm.v1.attention.backends.mla.indexer.DeepseekV32IndexerMetadata'>. Supported types are: (<class 'vllm.v1.attention.backends.triton_attn.TritonAttentionMetadata'>, <class 'vllm.v1.attention.backends.rocm_attn.RocmAttentionMetadata'>, <class 'vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse.ROCMAiterMLASparseMetadata'>, <class 'vllm.v1.attention.backends.rocm_aiter_fa.AiterFlashAttentionMetadata'>, <class 'vllm.model_executor.layers.attention.mla_attention.MLACommonMetadata'>, <class 'vllm.v1.attention.backends.flex_attention.FlexAttentionMetadata'>)
```

- With the patch from #37887, MTP with `num_speculative_tokens 2` intermittently crashes with 
`Memory access fault by GPU node-7 (Agent handle: 0xfa3df70) on address 0x7f593a600000. Reason: Unknown.`
or
```
:0:rocdevice.cpp            :3671: 1562113386266 us:  Callback: Queue 0x706685e00000 Aborting with error : HSA_STATUS_ERROR_OUT_OF_RESOURCES: The runtime failed to allocate the necessary resources. This error may also occur when the core runtime library needs to spawn threads or create internal OS-specific events. Code: 0x1008 Available Free mem : 0 MB
```

### This PR
```

                                         nightly,no MTP  PR,MTP=2
============ Serving Benchmark Result ============================
Successful requests:                     384             384
Failed requests:                         0               0
Maximum request concurrency:             128             128
Benchmark duration (s):                  419.93          404.20
Total input tokens:                      3145728         3145728
Total generated tokens:                  393216          393216
Request throughput (req/s):              0.91            0.95
Output token throughput (tok/s):         936.38          972.82
Peak output token throughput (tok/s):    1792.00         768.00
Peak concurrent requests:                130.00          133.00
Total token throughput (tok/s):          8427.43         8755.42
---------------Time to First Token--------------------------------
Mean TTFT (ms):                          12571.44        16055.43
Median TTFT (ms):                        2018.57         5799.43
P99 TTFT (ms):                           67803.13        81753.81
-----Time per Output Token (excl. 1st token)----------------------
Mean TPOT (ms):                          122.57          108.58
Median TPOT (ms):                        129.53          109.84
P99 TPOT (ms):                           135.18          170.45
---------------Inter-token Latency--------------------------------
Mean ITL (ms):                           122.57          293.31
Median ITL (ms):                         76.83           340.02
P99 ITL (ms):                            305.24          454.13
----------------End-to-end Latency--------------------------------
Mean E2EL (ms):                          137959.32       127134.05
Median E2EL (ms):                        139979.00       120887.23
P99 E2EL (ms):                           201122.45       224996.07
---------------Speculative Decoding-------------------------------
Acceptance rate (%):                                     85.18
Acceptance length:                                       2.70
Drafts:                                                  145424
Draft tokens:                                            290848
Accepted tokens:                                         247738
Per-position acceptance (%):
  Position 0:                                            97.08
  Position 1:                                            73.27
==================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

