### PR TITLE
[Bugfix] Fix TypeError in response_input_to_harmony when assistant content is None

### DIFF
--- a/tests/unit/entrypoints/openai/responses/test_harmony_none_content.py
+++ b/tests/unit/entrypoints/openai/responses/test_harmony_none_content.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for response_input_to_harmony handling None content."""
+
+from vllm.entrypoints.openai.responses.harmony import response_input_to_harmony
+
+
+class TestResponseInputToHarmonyNoneContent:
+
+    def test_assistant_message_none_content(self):
+        """Assistant message with content=None (tool-call-only) should be skipped."""
+        msg_dict = {
+            "type": "message",
+            "role": "assistant",
+            "content": None,
+        }
+        result = response_input_to_harmony(msg_dict, [])
+        assert result is None
+
+    def test_user_message_string_content(self):
+        """Normal string content should still work after the fix."""
+        msg_dict = {
+            "type": "message",
+            "role": "user",
+            "content": "Hello world",
+        }
+        result = response_input_to_harmony(msg_dict, [])
+        assert result is not None
+        assert result.content[0].text == "Hello world"

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -148,11 +148,17 @@ def response_input_to_harmony(
         response_msg = response_msg.model_dump()
     if "type" not in response_msg or response_msg["type"] == "message":
         role = response_msg["role"]
-        content = response_msg["content"]
+        content = response_msg.get("content")
         # Add prefix for developer messages.
         # <|start|>developer<|message|># Instructions {instructions}<|end|>
         text_prefix = "Instructions:\n" if role == "developer" else ""
-        if isinstance(content, str):
+        if content is None:
+            if role == "assistant":
+                # Assistant messages with only tool calls may have no content.
+                # These should be skipped to avoid empty messages in history.
+                return None
+            msg = Message.from_role_and_content(role, text_prefix)
+        elif isinstance(content, str):
             msg = Message.from_role_and_content(role, text_prefix + content)
         else:
             contents = [TextContent(text=text_prefix + c["text"]) for c in content]


### PR DESCRIPTION
## Purpose

Fix `TypeError: 'NoneType' is not iterable` crash in `response_input_to_harmony()` when processing an assistant message with `content=None`. This happens in multi-turn Responses API conversations where the assistant's previous turn contained only tool calls (no text content).

The `reasoning` branch of the same function already handles `None` content correctly via `.get()` + explicit check. This PR applies the same pattern to the `message` branch.

## Test Plan

```bash
python -m pytest tests/unit/entrypoints/openai/responses/test_harmony_none_content.py -v
```

## Test Result

2/2 tests pass.