### PR TITLE
Fix invalid logprobs with MTP enabled and sync scheduling

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4192,6 +4192,7 @@ class GPUModelRunner(
         spec_config = self.speculative_config
         propose_drafts_after_bookkeeping = False
         if spec_config is not None:
+            # Decide whether to run the drafter or zero out draft tokens.
             input_fits_in_drafter = spec_decode_common_attn_metadata is not None and (
                 spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
                 <= self.effective_drafter_max_model_len
@@ -4227,10 +4228,6 @@ class GPUModelRunner(
                     self._copy_valid_sampled_token_count(
                         next_token_ids, valid_sampled_tokens_count
                     )
-                    self._draft_token_ids = torch.zeros(
-                        1, device=self.device, dtype=torch.int32
-                    ).expand(len(self.input_batch.req_ids), self.num_spec_tokens)
-                    self._copy_draft_token_ids_to_cpu(scheduler_output, zeros_only=True)
             elif (
                 spec_config.use_ngram_gpu()
                 and not spec_config.disable_padded_drafter_batch
@@ -4253,14 +4250,19 @@ class GPUModelRunner(
                     self._copy_valid_sampled_token_count(
                         next_token_ids, valid_sampled_tokens_count
                     )
-                    # Since we couldn't run the drafter,
-                    # just use zeros for the draft tokens.
-                    self._draft_token_ids = torch.zeros(
-                        1, device=self.device, dtype=torch.int32
-                    ).expand(len(self.input_batch.req_ids), self.num_spec_tokens)
-                    self._copy_draft_token_ids_to_cpu(scheduler_output, zeros_only=True)
             else:
                 propose_drafts_after_bookkeeping = input_fits_in_drafter
+
+            if not input_fits_in_drafter:
+                # Zero out draft tokens so the scheduler doesn't schedule
+                # stale drafts from the previous step.
+                # For Nemotron-H: it is necessary to zero out the draft tokens,
+                # otherwise the stale tokens will corrupt Mamba recurrent
+                # state and logprobs for sequences near max_model_len.
+                self._draft_token_ids = torch.zeros(
+                    1, device=self.device, dtype=torch.int32
+                ).expand(len(self.input_batch.req_ids), self.num_spec_tokens)
+                self._copy_draft_token_ids_to_cpu(scheduler_output, zeros_only=True)
 
         with record_function_or_nullcontext("gpu_model_runner: bookkeep"):
             (


### PR DESCRIPTION
## Purpose

Bug was discovered by @yfw who also did the initial debug.

Model:
https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16

MTP speculative decoding with sync scheduling (used by Ray, and forced for MTP in vLLM) produces catastrophically wrong logprobs when sequences reach within `num_spec_tokens` of `max_model_len`.

### Root cause

In `GPUModelRunner.sample_tokens()`, when `input_fits_in_drafter=False` (sequence too close to `max_model_len` for the drafter to run), draft token **zeroing only happened inside the async-only branch**:

```python
if input_fits_in_drafter:
    ...
elif self.valid_sampled_token_count_event is not None:  # async only!
    ...
    self._draft_token_ids = torch.zeros(...)
```
### Bugfix

When input_fits_in_drafter is False, zero out draft tokens for all drafter types.
Previously only the async path zeroed them, leaving stale drafts that corrupt Mamba state near `max_model_len`.

## Test Plan

### Evals

Use lm_eval to verify accuracy of the model before/after the fix.

And with MTP disabled/enabled.

### Custom test script for logprobs

I wrote a custom debug script to debug this bug.

The script uses different types of prompts (and sampling parameters - temperatures, etc.) to verify the correctness of the logprobs with MTP (using logprobs with MTP disabled for reference).

The script calculates the "TME" (Token-Mean-Exponentiated error):

```
TME = mean(exp(|gen_logprob - ref_logprob|))
```
`gen_logprob` - The logprobs reported during generation with MTP enabled.
`ref_logprob` - Take the exact tokens generated with MTP, feed them as a prompt to vLLM without MTP, and use `prompt_logprobs` to get the reference logprob for each token.

**A "healthy" TME should be around 1.0.**

## Test Result

### lm_eval

Run lm_eval gsm8k with Nemotron Super:
* Baseline with MTP disabled
* MTP enabled with num_speculative_tokens=5

Before the fix:

```
  Task                      Metric                      Baseline      MTP=5      Delta
  ------------------------- ------------------------- ---------- ---------- ----------
  gsm8k                     exact_match,flexible-extract  0.8931     0.8984    +0.0053
  gsm8k                     exact_match,strict-match      0.8893     0.8939    +0.0045
```

With the fix:

```
  Task                      Metric                      Baseline      MTP=5      Delta
  ------------------------- ------------------------- ---------- ---------- ----------
  gsm8k                     exact_match,flexible-extract  0.8969     0.8969    +0.0000
  gsm8k                     exact_match,strict-match      0.8931     0.8916    -0.0015
```

### Custom test script

Output of the script **before the fix**:

```
==========================================================================================
  MML=8192  scheduling=sync  prefix_caching=on  chunked_prefill=on
==========================================================================================
Spec               Config  Status             TME           MaxTME  Diverged  Boundary
   5          count/short    PASS            1.01             1.02       0/8       0/8
   5     count/short/t0.1    PASS            1.01             1.02       0/8       0/8
   5     count/short/t0.5    PASS            1.02             1.02       0/8       0/8
   5     count/short/t1.0    FAIL         1900.01         14066.50       5/8       0/8
   5         count/med512    FAIL  17499380236.61  139390933984.12       7/8       0/8
   5    count/med512/t0.1    FAIL    267113837.67    2107919219.63       6/8       0/8
   5    count/med512/t0.5    FAIL  91815031753.47  733062808674.74       7/8       0/8
   5    count/med512/t1.0    FAIL        15717.27        123781.86       4/8       0/8
   5       count/boundary    FAIL           36.15           282.05       1/8       1/8
   5  count/boundary/t0.1    FAIL            3.78            13.80       2/8       4/8
   5  count/boundary/t0.5    FAIL        17666.76        139961.50       3/8       3/8
   5  count/boundary/t1.0    FAIL          820.79          6559.31       1/8       1/8
==========================================================================================
```

Output of the script **with the fix** - all TME values are "healthy":

```
==========================================================================================
  MML=8192  scheduling=sync  prefix_caching=on  chunked_prefill=on
==========================================================================================
Spec               Config  Status   TME  MaxTME  Diverged  Boundary
   5          count/short    PASS  1.01    1.02       0/8       0/8
   5     count/short/t0.1    PASS  1.01    1.02       0/8       0/8
   5     count/short/t0.5    PASS  1.02    1.03       0/8       0/8
   5     count/short/t1.0    PASS  1.08    1.10       0/8       0/8
   5         count/med512    PASS  1.01    1.01       0/8       0/8
   5    count/med512/t0.1    PASS  1.01    1.02       0/8       0/8
   5    count/med512/t0.5    PASS  1.01    1.02       0/8       0/8
   5    count/med512/t1.0    PASS  1.07    1.11       0/8       0/8
   5       count/boundary    PASS  1.00    1.00       0/8       8/8
   5  count/boundary/t0.1    PASS  1.00    1.00       0/8       8/8
   5  count/boundary/t0.5    PASS  1.00    1.00       0/8       2/8
   5  count/boundary/t1.0    PASS  1.01    1.05       0/8       0/8
==========================================================================================
```

Explanation:
* `Spec` is num_speculative_tokens for MTP.
* `Config` is prompt "type" and sampling params (t0.5 means temperature 0.5)
The "count" in the Config column means that the prompt used was:
* `MML` is max model length.

Example "count" prompt:
```
Count from 1 to 200, writing each number on a new line.
```

I also tested (using the custom script):
* Other kinds of prompt (that will be "easier" or "harder" for the mtp layers to predict).
* Different num_speculative_tokens values - 1/2/3/4/5
* Different top-p / top-k values

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

