### PR TITLE
[Bugfix][Core] Fix negative prompt token counter increments with external KV cache accounting

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -116,7 +116,7 @@ def test_prompt_token_stats_all_computed():
     # Case 1: No caching (All tokens computed locally)
     stats.update_from_output(
         num_cached_tokens=0,
-        num_external_computed_tokens=0,
+        num_external_cached_tokens=0,
         prompt_len=1000,
     )
 
@@ -133,7 +133,7 @@ def test_prompt_token_stats_partial_local_cache():
     # Case 2: Partial local cache
     stats.update_from_output(
         num_cached_tokens=300,
-        num_external_computed_tokens=0,
+        num_external_cached_tokens=0,
         prompt_len=1000,
     )
 
@@ -149,7 +149,7 @@ def test_prompt_token_stats_partial_external_transfer():
     # Case 3: Partial external transfer
     stats.update_from_output(
         num_cached_tokens=500,
-        num_external_computed_tokens=500,
+        num_external_cached_tokens=500,
         prompt_len=1000,
     )
 
@@ -165,7 +165,7 @@ def test_prompt_token_stats_mixed_sources():
     # Case 4: Mixed sources
     stats.update_from_output(
         num_cached_tokens=600,
-        num_external_computed_tokens=200,
+        num_external_cached_tokens=200,
         prompt_len=1000,
     )
 
@@ -185,7 +185,7 @@ def test_prompt_token_stats_full_local_cache_recompute():
     # Case 5: Full local cache (999 cached after reduction, 1 recomputed)
     stats.update_from_output(
         num_cached_tokens=999,
-        num_external_computed_tokens=0,
+        num_external_cached_tokens=0,
         prompt_len=1000,
     )
 
@@ -201,7 +201,7 @@ def test_prompt_token_stats_full_external_transfer_recompute():
     # Case 6: Full external transfer (999 cached after reduction, 1 recomputed)
     stats.update_from_output(
         num_cached_tokens=999,
-        num_external_computed_tokens=1000,
+        num_external_cached_tokens=1000,
         prompt_len=1000,
     )
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -829,6 +829,9 @@ class Scheduler(SchedulerInterface):
                 # Count the number of prefix cached tokens.
                 if request.num_cached_tokens < 0:
                     request.num_cached_tokens = num_computed_tokens
+                    request.num_external_cached_tokens = (
+                        request.num_external_computed_tokens
+                    )
                 # Encoder-related.
                 if encoder_inputs_to_schedule:
                     scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
@@ -1468,7 +1471,7 @@ class Scheduler(SchedulerInterface):
                         kv_transfer_params=kv_transfer_params,
                         trace_headers=request.trace_headers,
                         num_cached_tokens=request.num_cached_tokens,
-                        num_external_computed_tokens=request.num_external_computed_tokens,
+                        num_external_cached_tokens=request.num_external_cached_tokens,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
                     )
@@ -2072,6 +2075,7 @@ class Scheduler(SchedulerInterface):
             # Count the number of prefix cached tokens.
             if request.num_cached_tokens < 0:
                 request.num_cached_tokens = request.num_computed_tokens
+                request.num_external_cached_tokens = request.num_external_computed_tokens
 
         self.finished_recving_kv_req_ids.remove(request.request_id)
 

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -159,8 +159,8 @@ class EngineCoreOutput(
     trace_headers: Mapping[str, str] | None = None
     # The number of tokens with prefix cache hits (local + external).
     num_cached_tokens: int = 0
-    # The number of tokens computed remotely (original count from connector).
-    num_external_computed_tokens: int = 0
+    # The number of tokens with external prefix cache hits.
+    num_external_cached_tokens: int = 0
     routed_experts: np.ndarray | None = None
     # The number of NaNs in logits.
     # A value greater than 0 indicates that the output is corrupted.

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -270,7 +270,7 @@ class PromptTokenStats:
     def update_from_output(
         self,
         num_cached_tokens: int,
-        num_external_computed_tokens: int,
+        num_external_cached_tokens: int,
         prompt_len: int,
     ) -> None:
         """Update stats from a prefill output."""
@@ -280,7 +280,7 @@ class PromptTokenStats:
         recomputed = 1 if (num_cached_tokens + 1 == prompt_len) else 0
 
         self.computed += prompt_len - num_cached_tokens
-        self.external_kv_transfer += num_external_computed_tokens
+        self.external_kv_transfer += num_external_cached_tokens
         # FIXME(yifan): local_cache_hit can go negative after preemption.
         # num_cached_tokens is a one-time snapshot from first scheduling and
         # is never reset on preemption, while num_external_computed_tokens is
@@ -290,7 +290,7 @@ class PromptTokenStats:
         # as a separate metric rather than reusing num_external_computed_tokens
         # for metric directly.
         self.local_cache_hit += max(
-            0, (num_cached_tokens + recomputed - num_external_computed_tokens)
+            0, (num_cached_tokens + recomputed - num_external_cached_tokens)
         )
         self.cached_tokens += num_cached_tokens
         self.recomputed_tokens += recomputed
@@ -352,7 +352,7 @@ class IterationStats:
         if is_prefilling:
             self.prompt_token_stats.update_from_output(
                 num_cached_tokens=output.num_cached_tokens,
-                num_external_computed_tokens=output.num_external_computed_tokens,
+                num_external_cached_tokens=output.num_external_cached_tokens,
                 prompt_len=prompt_len,
             )
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -162,6 +162,9 @@ class Request:
         # The number of tokens that have been computed remotely.
         self.num_external_computed_tokens = 0
 
+        # The number of tokens fetched from an external KV cache.
+        self.num_external_cached_tokens = -1
+
         self.block_hashes: list[BlockHash] = []
         # Store the block hasher without binding self to avoid creating a
         # reference cycle (Request -> partial -> Request) that prevents


### PR DESCRIPTION



## Purpose
Fix a crash in Prometheus metrics reporting:
ValueError: Counters can only be incremented by non-negative amounts
This can happen when external KV cache is enabled (e.g., LMCache), especially when requests are preempted and later rescheduled.
Closes #37354

Root Cause
The crash comes from mixing two values with different update semantics:
num_cached_tokens: snapshot-style value (set once when < 0), representing total cached/skippable tokens.
num_external_computed_tokens: dynamic value, refreshed when prefill restarts (request.num_computed_tokens == 0).
In PromptTokenStats.update_from_output, local_cache_hit was computed as:
This implicitly requires:
num_cached_tokens >= num_external_computed_tokens
After preemption/rescheduling, this may be violated because num_cached_tokens remains a stale snapshot while num_external_computed_tokens is refreshed and may increase.
That can produce a negative delta and eventually trigger a Prometheus counter increment with a negative amount.

Fix
This PR introduces num_external_cached_tokens with the same snapshot semantics as num_cached_tokens:
Set once together with num_cached_tokens (first successful scheduling, or async KV completion path in _update_waiting_for_remote_kv).
Carries the external-cache snapshot used for metrics accounting.
PromptTokenStats.update_from_output now uses this snapshot value for external-cache contribution.
num_external_computed_tokens remains unchanged as a dynamic scheduler-internal field for scheduling and recovery logic (e.g., invalid block handling).
After this fix, both values passed to PromptTokenStats.update_from_output are first-scheduling snapshots, guaranteeing num_cached_tokens >= num_external_cached_tokens at all times and making local_cache_hit always non-negative.

Why not PR #36859?
PR #36859 moves toward the right goal, but its approach (gating assignment with request.num_preemptions == 0) is risky for two reasons.
1) It weakens the existing one-time initialization contract
In current scheduler code, one-time snapshot fields rely on:
if request.num_cached_tokens < 0: ...
This sentinel-based pattern is idempotent and independent of scheduling history.
Using num_preemptions == 0 as the gate ties correctness to runtime history, not field state. That can miss initialization in edge timing/order cases where preemption happens before the first stable initialization point.
2) It can record optimistic values on async KV load path
On load_kv_async=True, the scheduler may set num_computed_tokens optimistically (including external tokens) before remote KV load is actually confirmed, and then move the request to WAITING_FOR_REMOTE_KVS.
If num_cached_tokens is snapshotted at that point, it may include unconfirmed external tokens.
When async load later fails and _update_requests_with_invalid_blocks rolls back computed state, the one-time snapshot cannot be safely corrected, which can permanently skew metrics.
Why this PR’s approach is safer
This PR keeps existing field semantics intact and introduces a dedicated snapshot field (num_external_cached_tokens) for metrics accounting.
That separates:
dynamic scheduler state (num_external_computed_tokens), and
one-time metrics snapshot state (num_external_cached_tokens),
which avoids the above coupling and preserves recovery behavior.


## Test Plan
•Run existing unit tests: pytest tests/v1/test_scheduler.py tests/v1/metrics/
•Integration test: run vLLM with LMCache enabled under concurrent load sufficient to trigger preemptions; verify no ValueError crash occurs and Prometheus metrics remain non-negative.

## Test Result


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

