### PR TITLE
Fix Kimi-K2.5 accuracy when Aiter MLA FP8 PS + CUDA graphs are used

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -149,13 +149,14 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # make sure get_mla_metadata_info_v1 / get_mla_metadata_v1 are consistent
         # with the actual tensor shape passed to mla_decode_fwd.
         self._num_attention_heads = max(16, self.num_heads)
-        q_dtype = self.decode_attn_out_dtype
-        kv_cache_dtype_str = getattr(vllm_config.cache_config, "cache_dtype", "auto")
-        if kv_cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):
-            kv_cache_dtype_str = "fp8"
+        _cache_dtype_str = getattr(
+            vllm_config.cache_config, "cache_dtype", "auto"
+        )
+        if _cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):
+            self._metadata_kv_dtype = dtypes.fp8
         else:
-            kv_cache_dtype_str = "bf16"
-        kv_dtype = dtypes.d_dtypes.get(kv_cache_dtype_str, dtypes.bf16)
+            self._metadata_kv_dtype = dtypes.bf16
+        self._metadata_q_dtype = self._metadata_kv_dtype
         (
             (work_meta_data_size, work_meta_data_type),
             (work_indptr_size, work_indptr_type),
@@ -167,8 +168,8 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             max_num_reqs,
             1,
             self._num_attention_heads,
-            q_dtype,
-            kv_dtype,
+            self._metadata_q_dtype,
+            self._metadata_kv_dtype,
             is_sparse=False,
             fast_mode=True,
         )
@@ -298,6 +299,8 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 max_seqlen_qo=max_qo_len,
                 uni_seqlen_qo=max_qo_len,
                 fast_mode=True,
+                dtype_q=self._metadata_q_dtype,
+                dtype_kv=self._metadata_kv_dtype,
             )
             has_persistent_metadata = True
 

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -24,7 +24,7 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.kv_cache_interface import AttentionSpec, is_quantized_kv_cache
 
 
 class AiterMLABackend(MLACommonBackend):
@@ -152,7 +152,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         _cache_dtype_str = getattr(
             vllm_config.cache_config, "cache_dtype", "auto"
         )
-        if _cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):
+        if is_quantized_kv_cache(_cache_dtype_str):
             self._metadata_kv_dtype = dtypes.fp8
         else:
             self._metadata_kv_dtype = dtypes.bf16


### PR DESCRIPTION

## Problem

When running MLA-based models (e.g., Kimi-K2.5-MXFP4) with `--kv-cache-dtype fp8` and FULL CUDA graph mode, the model outputs garbage/gibberish text. The issue does **not** occur with:
- `--enforce-eager` (no CUDA graphs)
- `--compilation-config '{"cudagraph_mode": "NONE"}'`
- `--compilation-config '{"cudagraph_mode": "PIECEWISE"}'` 
- Non-FP8 KV cache (e.g., `--kv-cache-dtype auto`)

There are **two independent bugs**:

1. **KV cache corruption during warmup** — `concat_and_cache_mla` writes garbage FP8 data to slot 0 during dummy runs because `slot_mapping` is uninitialized (zeros).
2. **Missing FP8 dtype in `get_mla_metadata_v1`** — the persistent kernel's work scheduling metadata is computed without `dtype_q` and `dtype_kv`, causing it to assume BF16 data layout. With FP8 KV cache, this produces incorrect memory access patterns, so the kernel reads from wrong KV cache positions.


---

## Bug 1 (Accuracy): KV Cache Corruption During Warmup

### Root Cause

During the CUDA graph warmup phase in `_dummy_run()`, vLLM executes dummy forward passes with `force_attention=True` to warm up the attention kernels. This triggers the full attention pipeline including **KV cache writes** via `concat_and_cache_mla`.

The `slot_mapping` buffer used for these writes is read from `self.input_batch.block_table[gid].slot_mapping.gpu`, which is a `CpuGpuBuffer` initialized to zeros via `torch.zeros()`. Since no real requests have been scheduled at warmup time, the buffer has never been populated by the scheduler.

With `slot_mapping` = all zeros:
1. `concat_and_cache_mla` writes FP8-quantized garbage KV data to **slot 0** of the KV cache for **every layer** and **every dummy token**
2. This corrupts the KV cache state before any real inference begins
3. The persistent MLA decode kernel (`_ps` variant) reads from the corrupted slot 0 via its work scheduling metadata for padded batch entries, producing garbage attention output

### Why PIECEWISE mode is unaffected

The warmup `force_attention` flag is set based on:
```python
force_attention = cudagraph_runtime_mode == CUDAGraphMode.FULL
```

In PIECEWISE mode, the warmup dummy runs use `CUDAGraphMode.NONE`, so `force_attention=False`, and the attention path (including KV cache writes) is skipped entirely. Only FULL mode triggers the problematic warmup path.

## Bug 2 (Accuracy): Missing FP8 Dtype in `get_mla_metadata_v1`

### Root Cause

The `get_mla_metadata_v1()` call in `rocm_aiter_mla.py` (`_build_decode` method) is missing three parameters:

- `dtype_q` — the query data type (should be FP8 when KV cache is FP8)
- `dtype_kv` — the KV cache data type (should be FP8 when KV cache is FP8)
- `max_split_per_batch` — controls the reduction splitting strategy (should be 16)

Without these, `get_mla_metadata_v1` computes work scheduling metadata assuming BF16 data layout. Since FP8 and BF16 have different element sizes (1 byte vs 2 bytes), the resulting work metadata contains incorrect memory offsets and access patterns. The persistent kernel then reads from wrong positions in the KV cache, producing garbage attention output even when the KV cache data itself is correct.

Additionally, `get_mla_metadata_info_v1()` (which computes buffer *sizes*) receives `q_dtype = self.decode_attn_out_dtype` (BF16), while `get_mla_metadata_v1()` needs `dtype_q = FP8`. This dtype mismatch means the persistent buffers (`work_meta_data`, `reduce_indptr`, etc.) are sized for a BF16-query work plan, but the metadata computation tries to write an FP8-query work plan. This can cause the metadata function to produce a constrained or suboptimal scheduling plan.

## Test Plan

- [ x] Verify Kimi-K2.5-MXFP4 with `--kv-cache-dtype fp8 -tp 4` produces correct output (FULL CG mode, default)
- [ x] Verify PIECEWISE mode still works
- [ x] Verify `--enforce-eager` still works
- [ x] Run `lm_eval` accuracy benchmark to confirm no regression

Accuracy with lm_eval and gsm8k before the fix 0.

After the fix:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9287|±  |0.0071|
|     |       |strict-match    |     5|exact_match|↑  |0.9295|±  |0.0071|

