### PR TITLE
[Misc] Fix typos in test comments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -858,7 +858,7 @@ class VllmRunner:
             # being captured which can trigger edge cases that we don't handle yet.
             kwargs["compilation_config"] = {"cudagraph_capture_sizes": [4]}
 
-            # Make sure we have atleast one cudagraph large enough for a single decode.
+            # Make sure we have at least one cudagraph large enough for a single decode.
             if (speculative_config := kwargs.get("speculative_config")) and (
                 num_speculative_tokens := speculative_config["num_speculative_tokens"]
             ):

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -1530,7 +1530,7 @@ def test_register_kv_caches(
         head_size = 16
 
         # TODO (NickLucche) the fact that connector depends on kv_cache_config for init
-        # but cross-layer preference cant be inferred prior to creating kv_cache_config
+        # but cross-layer preference can't be inferred prior to creating kv_cache_config
         # is a bit awkward.
         dummy_connector = NixlConnector(
             vllm_config,


### PR DESCRIPTION
## Purpose
Fix minor typos in test code comments:
- `atleast` → `at least` in conftest.py
- `cant` → `can't` in test_nixl_connector.py

## Test Plan
No functional changes — comment-only fixes.

## Test Result
N/A (comments only)