### PR TITLE
[Misc] Fix typos in source code comments

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -292,7 +292,7 @@ class LMCacheMPRequestMetadata:
         # Store the blocks that has block hashes
         # NOTE: the invariant here is that `num_stored_blocks` should
         # always be a multiple of `blocks_in_chunk`
-        # TODO: This should be checked everytime we update the num_stored_blocks
+        # TODO: This should be checked every time we update the num_stored_blocks
         min_available_blocks = min(
             len(tracker.block_hashes),
             len(tracker.allocated_block_ids),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1024,14 +1024,14 @@ class MoRIIOConnectorWorker:
             if len(self.local_kv_cache_metadata) > 0:
                 logger.warning(
                     "len(self.local_kv_cache_metadata) = %s,"
-                    "maybe you didnt clear this buffer correctly",
+                    "maybe you didn't clear this buffer correctly",
                     len(self.local_kv_cache_metadata),
                 )
                 self.local_kv_cache_metadata = []
             if len(self.remote_kv_cache_metadata) > 0:
                 logger.warning(
                     "len(self.remote_kv_cache_metadata) = %s,"
-                    "maybe you didnt clear this buffer correctly",
+                    "maybe you didn't clear this buffer correctly",
                     len(self.remote_kv_cache_metadata),
                 )
                 self.remote_kv_cache_metadata = []

--- a/vllm/model_executor/models/cohere_asr.py
+++ b/vllm/model_executor/models/cohere_asr.py
@@ -2036,7 +2036,7 @@ class CohereAsrForConditionalGeneration(
             )
 
         # NOTE: this function is used only by online inference and not offline inference
-        # CohereASR doesnt have encoder prompt
+        # CohereASR doesn't have encoder prompt
         language_tag = f"<|{language}|><|{language}|>"
         pnc = True  # TODO(ekagra): make this configurable later
         pnc_tag = "<|pnc|>" if pnc else "<|nopnc|>"

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -584,7 +584,7 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
     ) -> M:
         """
         Update the block table for the attention metadata.
-        Faster when theres multiple kv-cache groups that create virtually the
+        Faster when there's multiple kv-cache groups that create virtually the
         same metadata but just with different block tables.
 
         Only needs to be implemented if supports_update_block_table is True.

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -198,7 +198,7 @@ def kv_spans_from_batches(
                     (So the attended KV slice is kv[start:end].)
 
     Assumes each batch contributes its full `seq_len_per_batch[i]`
-    keys to the KV cache, andthe selected tokens within a batch
+    keys to the KV cache, and the selected tokens within a batch
     are the **last** `counts[i]` positions of that sequence.
     """
     q = start_seq_loc.to(dtype=torch.long)


### PR DESCRIPTION
## Purpose
Fix minor typos in source code comments across several files:
- `theres` → `there's` in attention backend
- `andthe` → `and the` in MLA indexer
- `everytime` → `every time` in lmcache connector
- `didnt` → `didn't` in moriio connector
- `doesnt` → `doesn't` in cohere_asr model

## Test Plan
No functional changes — comment-only fixes.

## Test Result
N/A (comments only)