### PR TITLE
[Bugfix] Harden DP handshake port against non-engine traffic

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1182,13 +1182,31 @@ def wait_for_engine_startup(
             )
 
         # Receive HELLO and READY messages from the input socket.
-        eng_identity, ready_msg_bytes = handshake_socket.recv_multipart()
+        # The handshake port may receive non-engine traffic (e.g. HTTP
+        # health checks or metrics scrapers in K8s).  Rather than
+        # crashing, log the unexpected frame and keep waiting.
+        try:
+            frames = handshake_socket.recv_multipart()
+        except zmq.ZMQError as exc:
+            logger.warning("ZMQ recv error on handshake port: %s", exc)
+            continue
+        if len(frames) != 2:
+            logger.warning(
+                "Ignoring malformed message with %d frame(s) on "
+                "handshake port (expected 2).",
+                len(frames),
+            )
+            continue
+        eng_identity, ready_msg_bytes = frames
         eng_index = int.from_bytes(eng_identity, "little")
         engine = next((e for e in core_engines if e.identity == eng_identity), None)
         if engine is None:
-            raise RuntimeError(
-                f"Message from engine with unexpected data parallel rank: {eng_index}"
+            logger.warning(
+                "Ignoring message from unknown identity on handshake "
+                "port (identity %d bytes). Likely non-engine traffic.",
+                len(eng_identity),
             )
+            continue
         msg = msgspec.msgpack.decode(ready_msg_bytes)
         status, local, headless = msg["status"], msg["local"], msg["headless"]
         if local != engine.local:

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -36,6 +36,17 @@ logger = init_logger(__name__)
 
 STARTUP_POLL_PERIOD_MS = 10000
 
+# Emitted once per process when something other than a valid engine handshake
+# message hits the DP handshake port (e.g. a k8s liveness probe). Defined at
+# module scope so logger.warning_once dedupes across the different branches
+# that spot this in wait_for_engine_startup.
+_INVALID_HANDSHAKE_TRAFFIC_MSG = (
+    "Received invalid traffic on the DP handshake port "
+    "(suppressing further warnings; enable DEBUG for per-packet detail). "
+    "This usually means a health check or unrelated service is polling the "
+    "port."
+)
+
 
 class CoreEngineState(Enum):
     NEW = auto()
@@ -1184,14 +1195,24 @@ def wait_for_engine_startup(
         # Receive HELLO and READY messages from the input socket.
         # The handshake port may receive non-engine traffic (e.g. HTTP
         # health checks or metrics scrapers in K8s).  Rather than
-        # crashing, log the unexpected frame and keep waiting.
+        # crashing, log the unexpected frame and keep waiting. A k8s
+        # liveness probe polling this port would otherwise spam the logs,
+        # so we surface one WARNING for each invalid-traffic path and keep
+        # the per-packet detail at DEBUG.
         try:
             frames = handshake_socket.recv_multipart()
         except zmq.ZMQError as exc:
-            logger.warning("ZMQ recv error on handshake port: %s", exc)
+            logger.warning_once(_INVALID_HANDSHAKE_TRAFFIC_MSG)
+            logger.debug(
+                "ZMQ recv error on handshake port: %s (errno=%s, type=%s)",
+                exc,
+                getattr(exc, "errno", None),
+                type(exc).__name__,
+            )
             continue
         if len(frames) != 2:
-            logger.warning(
+            logger.warning_once(_INVALID_HANDSHAKE_TRAFFIC_MSG)
+            logger.debug(
                 "Ignoring malformed message with %d frame(s) on "
                 "handshake port (expected 2).",
                 len(frames),
@@ -1201,9 +1222,10 @@ def wait_for_engine_startup(
         eng_index = int.from_bytes(eng_identity, "little")
         engine = next((e for e in core_engines if e.identity == eng_identity), None)
         if engine is None:
-            logger.warning(
+            logger.warning_once(_INVALID_HANDSHAKE_TRAFFIC_MSG)
+            logger.debug(
                 "Ignoring message from unknown identity on handshake "
-                "port (identity %d bytes). Likely non-engine traffic.",
+                "port (identity %d bytes).",
                 len(eng_identity),
             )
             continue


### PR DESCRIPTION
## Summary

In multi-node DP serving on Kubernetes, the ZMQ handshake port (`--data-parallel-rpc-port`) crashes startup if it receives a non-engine TCP connection (e.g. Prometheus metrics scraper, HTTP health check). The raw bytes get decoded as an integer identity, producing:

```
RuntimeError: Message from engine with unexpected data parallel rank: 1686319630778293995...
```

This PR makes the handshake loop resilient to stray traffic:
- Catch `ZMQError` on `recv_multipart` 
- Reject frames that don't match the expected 2-part `(identity, payload)` layout
- Log a warning and continue (instead of crashing) when the identity doesn't match any known engine

All three paths log at WARNING level so operators can spot misconfigured scrapers without losing the serving pod.

Fixes #38677

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] Verified the crash traceback from the issue matches the changed code path
- [x] The fix only touches the error-handling branch; the happy path (valid engine traffic) is unchanged
- Manual verification: would require a multi-node DP setup with a metrics scraper hitting the RPC port