### PR TITLE
[Bugfix] Fix bench_serve UTF-8 decode crash on split multi-byte chars

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """The request function for API endpoints."""
 
+import codecs
 import io
 import json
 import os
@@ -25,11 +26,12 @@ class StreamedResponseHandler:
 
     def __init__(self):
         self.buffer = ""
+        self._decoder = codecs.getincrementaldecoder("utf-8")()
 
     def add_chunk(self, chunk_bytes: bytes) -> list[str]:
         """Add a chunk of bytes to the buffer and return any complete
         messages."""
-        chunk_str = chunk_bytes.decode("utf-8")
+        chunk_str = self._decoder.decode(chunk_bytes)
         self.buffer += chunk_str
 
         messages = []


### PR DESCRIPTION
## Summary

`StreamedResponseHandler.add_chunk()` calls `chunk_bytes.decode("utf-8")` directly, which crashes when a multi-byte UTF-8 character (e.g. Chinese) is split across HTTP chunk boundaries:

```
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 65527-65528: unexpected end of data
```

The reporter hit this at ~0.4% rate (4/1000 requests) during bench_serve with H100x8.

Replace the one-shot decode with `codecs.IncrementalDecoder` which buffers incomplete byte sequences across `add_chunk()` calls and decodes them once the next chunk completes the character. This is the standard Python approach for streaming byte-to-str conversion.

Fixes #38717

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] Verified the crash traceback matches `endpoint_request_func.py:32`
- [x] `IncrementalDecoder` correctly handles split multi-byte sequences (tested locally with artificially split bytes of Chinese characters)