### PR TITLE
[Bug] Add e_score_correction_bias to SKIP_TENSORS

### DIFF
--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBa
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from .meta import (
+    SKIP_TENSORS,
     capture_layer_to_meta,
     get_numel_loaded,
     materialize_layer,
@@ -124,6 +125,8 @@ def initialize_online_processing(layer: torch.nn.Module):
     # Wrap each parameter's weight loader
     # Note that nested wrapping will occur for shared tensors
     for name, tensor in get_layer_tensors(layer).items():
+        if name in SKIP_TENSORS:
+            continue
         if _get_weight_loader(tensor).__name__ != "online_process_loader":
             tensor.weight_loader = make_online_process_loader(layer, name)
 

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -27,6 +27,7 @@ SKIP_TENSORS: set[str] = {
     "expert_global_to_physical",
     "expert_physical_to_global",
     "expert_local_to_global",
+    "e_score_correction_bias",
 }
 
 


### PR DESCRIPTION



## Purpose
Weight reloading is failing for `moonshotai/Moonlight-16B-A3B` due to `e_score_correction_bias` being counted as part of layer size twice, `restore_layer_on_meta` creates separate meta copies of `e_score_correction_bias` for gate and FusedMoE. FusedMoE's meta copy is never loaded (counted but never reached → 64-element shortfall). Thus, layerwise reload never fires since moe layer is always short.

## Test Plan

used prints to ensure that moe expert layers loading is complete when `finalize_layerwise_reload` is called, before this fix it was not reaching the `load_numel_total`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

