### PR TITLE
[Transformers v5] Fix Ernie4_5_VLMoeForConditionalGeneration rope_theta config

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -42,6 +42,12 @@ class DeepseekV32ForCausalLM(VerifyAndUpdateConfig):
 
 class Ernie4_5_VLMoeForConditionalGenerationConfig(VerifyAndUpdateConfig):
     @staticmethod
+    def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+        from vllm.transformers_utils.config import set_default_rope_theta
+
+        set_default_rope_theta(model_config.hf_config, default_theta=500000)
+
+    @staticmethod
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
         # Ernie4.5-VL conditionally executes text/vision MoE branches, so
         # fast_moe_cold_start can silently produce incorrect execution order.

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -42,12 +42,6 @@ class DeepseekV32ForCausalLM(VerifyAndUpdateConfig):
 
 class Ernie4_5_VLMoeForConditionalGenerationConfig(VerifyAndUpdateConfig):
     @staticmethod
-    def verify_and_update_model_config(model_config: "ModelConfig") -> None:
-        from vllm.transformers_utils.config import set_default_rope_theta
-
-        set_default_rope_theta(model_config.hf_config, default_theta=500000)
-
-    @staticmethod
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
         # Ernie4.5-VL conditionally executes text/vision MoE branches, so
         # fast_moe_cold_start can silently produce incorrect execution order.

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -413,6 +413,20 @@ def patch_rope_parameters(config: PretrainedConfig) -> None:
             config.partial_rotary_factor = partial_rotary_factor
         # Standardize and validate RoPE parameters
         config.standardize_rope_params()
+        # standardize_rope_params uses setdefault and won't overwrite an
+        # existing None value. This can happen when rope_parameters is
+        # populated via the rope_scaling property setter (Transformers v5
+        # maps rope_scaling -> rope_parameters) before self.rope_theta is
+        # assigned in the subclass __init__ — causing rope_theta: None to
+        # be set by an earlier standardize call, which setdefault won't fix.
+        if rope_theta is not None:
+            rp = getattr(config, "rope_parameters", None)
+            if (
+                isinstance(rp, dict)
+                and not is_rope_parameters_nested(rp)
+                and rp.get("rope_theta") is None
+            ):
+                rp["rope_theta"] = rope_theta
         config.validate_rope()
 
     # No RoPE parameters to patch

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -154,6 +154,40 @@ def _mistral_patch_hf_hub_constants() -> Iterator[None]:
         constants.SAFETENSORS_INDEX_FILE = hf_safetensors_index_file
 
 
+def _disable_rope_auto_validation() -> None:
+    """Remove the Transformers v5 ``validate_rope`` auto-validator.
+
+    Transformers v5 runs ``validate_rope`` during
+    ``PretrainedConfig.__init__()`` via ``__class_validators__``.  Some
+    upstream configs (e.g. Ernie-4.5) assign ``rope_theta`` after
+    ``super().__init__()``, so the validator fires before the value exists
+    and raises a ``KeyError``.
+
+    vLLM calls ``validate_rope()`` explicitly in
+    :func:`patch_rope_parameters` after all RoPE fields are propagated,
+    so the auto-validation is redundant.
+    """
+    if Version(version("transformers")) < Version("5.0.0"):
+        return
+    validators = getattr(PretrainedConfig, "__class_validators__", None)
+    if not validators:
+        return
+    groups: list[list] = (
+        list(validators.values())
+        if isinstance(validators, dict)
+        else [validators]
+    )
+    for group in groups:
+        if not isinstance(group, list):
+            continue
+        for i in range(len(group) - 1, -1, -1):
+            if getattr(group[i], "__name__", None) == "validate_rope":
+                group.pop(i)
+
+
+_disable_rope_auto_validation()
+
+
 class HFConfigParser(ConfigParserBase):
     def parse(
         self,
@@ -414,11 +448,11 @@ def patch_rope_parameters(config: PretrainedConfig) -> None:
         # Standardize and validate RoPE parameters
         config.standardize_rope_params()
         # standardize_rope_params uses setdefault and won't overwrite an
-        # existing None value. This can happen when rope_parameters is
+        # existing None value.  This can happen when rope_parameters is
         # populated via the rope_scaling property setter (Transformers v5
         # maps rope_scaling -> rope_parameters) before self.rope_theta is
-        # assigned in the subclass __init__ — causing rope_theta: None to
-        # be set by an earlier standardize call, which setdefault won't fix.
+        # assigned in the subclass __init__, causing rope_theta=None to
+        # persist from an earlier standardize call.
         if rope_theta is not None:
             rp = getattr(config, "rope_parameters", None)
             if (


### PR DESCRIPTION
## Summary

Fixes #38735 (part of #38379)

Transformers v5 runs `validate_rope` during `PretrainedConfig.__init__()` via `__class_validators__`. Some upstream configs (e.g. Ernie-4.5) assign `rope_theta` after `super().__init__()`, so the validator fires before the value exists and raises a `KeyError`.

Two fixes in `vllm/transformers_utils/config.py`:

1. **Remove premature auto-validation**: `_disable_rope_auto_validation()` strips the `validate_rope` class validator at module load for Transformers >= 5. vLLM already calls `validate_rope()` explicitly in `patch_rope_parameters()`, so no validation coverage is lost.

2. **Propagate rope_theta after standardize**: `standardize_rope_params()` uses `setdefault` which won't overwrite a `None` written by the `rope_scaling` property setter during `__init__`. After standardize, force-set `rope_parameters["rope_theta"]` from `config.rope_theta` when needed.

## Test Plan

```bash
pytest tests/models/test_initialization.py::test_can_initialize_large_subset[Ernie4_5_VLMoeForConditionalGeneration] -v
```