### PR TITLE
[Transformers v5] Fix NemotronParse image_size tuple unpack

### DIFF
--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -69,6 +69,10 @@ def _get_image_size_tuple(image_size: int | Iterable[int]) -> tuple[int, int]:
     if isinstance(image_size, int):
         return (image_size, image_size)
     size = tuple(image_size)
+    if len(size) == 0:
+        raise ValueError(
+            f"image_size must not be empty, got {image_size!r}"
+        )
     if len(size) == 1:
         return (size[0], size[0])
     return (size[0], size[1])

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -420,7 +420,7 @@ class NemotronParseDummyInputsBuilder(
     ) -> MultiModalDataDict:
         num_images = mm_counts.get("image", 0)
 
-        target_width, target_height = _get_image_size_tuple(
+        target_height, target_width = _get_image_size_tuple(
             self.info.get_hf_config().image_size)
 
         return {

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -61,6 +61,19 @@ from vllm.v1.attention.backend import AttentionType
 logger = init_logger(__name__)
 
 
+def _get_image_size_tuple(image_size: int | Iterable[int]) -> tuple[int, int]:
+    """Normalize image_size to a (height, width) tuple.
+
+    Transformers v5 may return a scalar int instead of a tuple.
+    """
+    if isinstance(image_size, int):
+        return (image_size, image_size)
+    size = tuple(image_size)
+    if len(size) == 1:
+        return (size[0], size[0])
+    return (size[0], size[1])
+
+
 class BartScaledWordEmbedding(VocabParallelEmbedding):
     """
     This module overrides VocabParallelEmbedding's
@@ -379,7 +392,7 @@ class NemotronParseProcessingInfo(BaseProcessingInfo):
 
     def get_num_image_tokens(self) -> int:
         config = self.get_hf_config()
-        final_size = config.image_size
+        final_size = _get_image_size_tuple(config.image_size)
         patch_size = config.encoder.patch_size
 
         return (final_size[0] // patch_size) * ((final_size[1] // patch_size) // 4) + 1
@@ -407,7 +420,8 @@ class NemotronParseDummyInputsBuilder(
     ) -> MultiModalDataDict:
         num_images = mm_counts.get("image", 0)
 
-        target_width, target_height = self.info.get_hf_config().image_size
+        target_width, target_height = _get_image_size_tuple(
+            self.info.get_hf_config().image_size)
 
         return {
             "image": self._get_dummy_images(
@@ -626,7 +640,7 @@ class NemotronParseForConditionalGeneration(nn.Module, SupportsMultiModal):
             raise ValueError("Both pixel values and image embeds are provided.")
 
         if pixel_values is not None:
-            h, w = self.config.image_size
+            h, w = _get_image_size_tuple(self.config.image_size)
             return NemotronParsePixelInputs(
                 type="pixel_values",
                 data=pixel_values,

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -421,7 +421,8 @@ class NemotronParseDummyInputsBuilder(
         num_images = mm_counts.get("image", 0)
 
         target_height, target_width = _get_image_size_tuple(
-            self.info.get_hf_config().image_size)
+            self.info.get_hf_config().image_size
+        )
 
         return {
             "image": self._get_dummy_images(

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -70,9 +70,7 @@ def _get_image_size_tuple(image_size: int | Iterable[int]) -> tuple[int, int]:
         return (image_size, image_size)
     size = tuple(image_size)
     if len(size) == 0:
-        raise ValueError(
-            f"image_size must not be empty, got {image_size!r}"
-        )
+        raise ValueError(f"image_size must not be empty, got {image_size!r}")
     if len(size) == 1:
         return (size[0], size[0])
     return (size[0], size[1])


### PR DESCRIPTION
Fixes #38740 (part of #38379)

Transformers v5 changed image_size to scalar int for this model config. vllm was unpacking it as a (height, width) tuple in 3 places which caused ValueError on init.

Fixed by normalizing image_size to a 2-tuple wherever its used, same approach as interns1_vit.py already does.

Test:
```
pytest tests/models/multimodal/generation/test_nemotron_parse.py::test_models[5-bfloat16-nvidia/NVIDIA-Nemotron-Parse-v1.1]
```