### PR TITLE
[Core] Use tuple_return in split_module for tuple-conformant subgraphs

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -31,6 +31,7 @@ from vllm.logging_utils import lazy
 from vllm.platforms import current_platform
 from vllm.tracing import instrument, instrument_manual
 from vllm.utils.import_utils import resolve_obj_by_qualname
+from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from .compiler_interface import (
     CompilerInterface,
@@ -575,11 +576,14 @@ def split_graph(
     # the semantics of the graph will change when we
     # have mutations in the graph
     with _use_lazy_graph_module(True):
+        has_tuple_return = is_torch_equal_or_newer("2.12.0.dev")
+        tuple_return_kwarg = {"tuple_return": True} if has_tuple_return else {}
         split_gm = torch.fx.passes.split_module.split_module(
             graph,
             None,
             lambda node: node_to_subgraph_id[node],
             keep_original_order=True,
+            **tuple_return_kwarg,
         )
 
     outputs = []


### PR DESCRIPTION
## Purpose

Pass tuple_return=True to split_module (torch >= 2.12) so all piecewise
subgraphs return tuples, even when they have a single output value. This
matches the convention expected by compile_fx, which internally normalizes
non-tuple outputs via make_graph_return_tuple before computing cache keys.

When split_module is called without tuple_return, single-output subgraphs
return a bare tensor. During compilation, compile_fx wraps this into a
tuple via make_graph_return_tuple, which changes the graph structure and
therefore the cache key (problematic for follow-up PR). Multi-output
subgraphs already return tuples and are unaffected. By passing
tuple_return=True, split_module wraps all subgraph outputs in tuples
upfront, so the graph structure seen by compile_fx is stable regardless
of the number of outputs.

For PyTorch older than 2.12, the tuple_return kwarg is not available and
the behavior is unchanged.

This is a prerequisite for switching to the standalone autograd_cache_key
API for compilation dedup (follow-up commit).

## Test Plan

- Run meta-llama/Meta-Llama-3-70B-Instruct with TP=4. We expect no
functional changes.
- New unit test test_single_output_subgraph_returns_tuple in
tests/compile/test_graph_partition.py verifies that every subgraph's
output node returns a tuple after splitting, including single-output
subgraphs.

## Test Result

Unit tests pass. Serving meta-llama/Meta-Llama-3-70B-Instruct also
passed with PyTorch 2.12 (or what I have of it), and the model does
include single-output submodules.

Cold-compile benchmark (Llama 3 70B, TP=4, 4 runs each):
Before (98e1a43): mean 34.7s ± 0.7s, median 34.7s
After  (18b5f3e): mean 35.0s ± 1.3s, median 34.7s
No significant difference (within noise)