### PR TITLE
only patch runtime_env for torch >= 2.10

### DIFF
--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -500,7 +500,7 @@ if is_torch_equal("2.9.0"):
 # This mirrors the fix in https://github.com/pytorch/pytorch/pull/177558
 # and can be removed once torch >=2.12 is the minimum supported version.
 
-if not is_torch_equal_or_newer("2.12.0"):
+if is_torch_equal_or_newer("2.10.0") and not is_torch_equal_or_newer("2.12.0"):
     import builtins as _builtins
     import pickle
 


### PR DESCRIPTION
IIUC #37234 added a patch for #30518 so the transformers backend test works with `can_return_tuple`, but the `GraphRuntimeEnv` and `GraphCaptureOutput` classes were introduced for torch 2.10 onwards. To preserve backwards compatibility, can we gate this patch behind a torch >= 2.10 check? cc @Lucaskabela @zou3519

Motivation: ROCm only moved to torch 2.10 recently via #38252, and we're still testing some vllm mainline builds against older Pytorch versions to check for regressions across ROCm/Pytorch/Triton. I think some other OOT backends (`vllm-tpu`/`vllm-gaudi`) haven't bumped Pytorch versions yet as well.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

