### PR TITLE
[Transformers v5] Add engine_core.shutdown() to LLMEngine.__del__

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1043,7 +1043,6 @@ class EngineCoreProc(EngineCore):
 
         engine_core: EngineCoreProc | None = None
         signal_callback: SignalCallback | None = None
-        exitcode = 0
         try:
             vllm_config: VllmConfig = kwargs["vllm_config"]
             parallel_config: ParallelConfig = vllm_config.parallel_config
@@ -1105,7 +1104,6 @@ class EngineCoreProc(EngineCore):
             logger.debug("EngineCore exiting.")
             raise
         except Exception as e:
-            exitcode = 1
             if engine_core is None:
                 logger.exception("EngineCore failed to start.")
             else:
@@ -1119,17 +1117,6 @@ class EngineCoreProc(EngineCore):
                 signal_callback.stop()
             if engine_core is not None:
                 engine_core.shutdown()
-            try:
-                from huggingface_hub import close_session
-                close_session()
-            except Exception:
-                pass
-            # Bypass threading._shutdown() which hangs when huggingface_hub
-            # >= 1.0.0 creates non-daemon httpx threads that cannot be
-            # reliably closed (client may be recreated during shutdown).
-            # All application cleanup is done by engine_core.shutdown().
-            # See: https://github.com/vllm-project/vllm/issues/38384
-            os._exit(exitcode)
 
     def _init_data_parallel(self, vllm_config: VllmConfig):
         pass

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1043,6 +1043,7 @@ class EngineCoreProc(EngineCore):
 
         engine_core: EngineCoreProc | None = None
         signal_callback: SignalCallback | None = None
+        exitcode = 0
         try:
             vllm_config: VllmConfig = kwargs["vllm_config"]
             parallel_config: ParallelConfig = vllm_config.parallel_config
@@ -1104,6 +1105,7 @@ class EngineCoreProc(EngineCore):
             logger.debug("EngineCore exiting.")
             raise
         except Exception as e:
+            exitcode = 1
             if engine_core is None:
                 logger.exception("EngineCore failed to start.")
             else:
@@ -1117,12 +1119,17 @@ class EngineCoreProc(EngineCore):
                 signal_callback.stop()
             if engine_core is not None:
                 engine_core.shutdown()
-            # Close the global httpx session used by huggingface_hub.
-            # Without this, httpx's non-daemon connection pool threads
-            # block Python's threading._shutdown() indefinitely,
-            # preventing the subprocess from exiting cleanly.
-            from huggingface_hub import close_session
-            close_session()
+            try:
+                from huggingface_hub import close_session
+                close_session()
+            except Exception:
+                pass
+            # Bypass threading._shutdown() which hangs when huggingface_hub
+            # >= 1.0.0 creates non-daemon httpx threads that cannot be
+            # reliably closed (client may be recreated during shutdown).
+            # All application cleanup is done by engine_core.shutdown().
+            # See: https://github.com/vllm-project/vllm/issues/38384
+            os._exit(exitcode)
 
     def _init_data_parallel(self, vllm_config: VllmConfig):
         pass

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1043,6 +1043,7 @@ class EngineCoreProc(EngineCore):
 
         engine_core: EngineCoreProc | None = None
         signal_callback: SignalCallback | None = None
+        exitcode = 0
         try:
             vllm_config: VllmConfig = kwargs["vllm_config"]
             parallel_config: ParallelConfig = vllm_config.parallel_config
@@ -1104,6 +1105,7 @@ class EngineCoreProc(EngineCore):
             logger.debug("EngineCore exiting.")
             raise
         except Exception as e:
+            exitcode = 1
             if engine_core is None:
                 logger.exception("EngineCore failed to start.")
             else:
@@ -1117,6 +1119,12 @@ class EngineCoreProc(EngineCore):
                 signal_callback.stop()
             if engine_core is not None:
                 engine_core.shutdown()
+            # Use os._exit() to terminate this subprocess immediately
+            # after cleanup. This skips Python's threading._shutdown()
+            # which can hang indefinitely when third-party libraries
+            # (e.g., httpx from huggingface-hub >= 1.7) create
+            # non-daemon background threads that block interpreter exit.
+            os._exit(exitcode)
 
     def _init_data_parallel(self, vllm_config: VllmConfig):
         pass

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1043,7 +1043,6 @@ class EngineCoreProc(EngineCore):
 
         engine_core: EngineCoreProc | None = None
         signal_callback: SignalCallback | None = None
-        exitcode = 0
         try:
             vllm_config: VllmConfig = kwargs["vllm_config"]
             parallel_config: ParallelConfig = vllm_config.parallel_config
@@ -1105,7 +1104,6 @@ class EngineCoreProc(EngineCore):
             logger.debug("EngineCore exiting.")
             raise
         except Exception as e:
-            exitcode = 1
             if engine_core is None:
                 logger.exception("EngineCore failed to start.")
             else:
@@ -1119,12 +1117,12 @@ class EngineCoreProc(EngineCore):
                 signal_callback.stop()
             if engine_core is not None:
                 engine_core.shutdown()
-            # Use os._exit() to terminate this subprocess immediately
-            # after cleanup. This skips Python's threading._shutdown()
-            # which can hang indefinitely when third-party libraries
-            # (e.g., httpx from huggingface-hub >= 1.0.0) create
-            # non-daemon background threads that block interpreter exit.
-            os._exit(exitcode)
+            # Close the global httpx session used by huggingface_hub.
+            # Without this, httpx's non-daemon connection pool threads
+            # block Python's threading._shutdown() indefinitely,
+            # preventing the subprocess from exiting cleanly.
+            from huggingface_hub import close_session
+            close_session()
 
     def _init_data_parallel(self, vllm_config: VllmConfig):
         pass

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1122,7 +1122,7 @@ class EngineCoreProc(EngineCore):
             # Use os._exit() to terminate this subprocess immediately
             # after cleanup. This skips Python's threading._shutdown()
             # which can hang indefinitely when third-party libraries
-            # (e.g., httpx from huggingface-hub >= 1.7) create
+            # (e.g., httpx from huggingface-hub >= 1.0.0) create
             # non-daemon background threads that block interpreter exit.
             os._exit(exitcode)
 

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -425,6 +425,8 @@ class LLMEngine:
         return self.collective_rpc("apply_model", args=(func,))
 
     def __del__(self):
+        if engine_core := getattr(self, "engine_core", None):
+            engine_core.shutdown()
         dp_group = getattr(self, "dp_group", None)
         if dp_group is not None and not self.external_launcher_dp:
             stateless_destroy_torch_distributed_process_group(dp_group)


### PR DESCRIPTION



## Purpose
fix https://github.com/vllm-project/vllm/issues/38384

huggingface_hub >= 1.0.0 switched the HTTP backend from requests to httpx. httpx creates non-daemon threads, which causes threading._shutdown() to hang when the Python process shuts down.These changes could lead to some unexpected issues in the CI pipeline.


issue https://github.com/vllm-project/vllm/issues/38384 mentioned that "This test seems to be reliably failing in CI when v5 is installed, but I have not been able to reproduce it locally."
This might be related to a specific combination of CI environment conditions (huggingface-hub >= 1.0.0 + no cache + Docker networking), which causes the httpx threads to stay alive when the child process exits.


**update：The current version of huggingface-hub in the main branch CI is 0.36.2. Meanwhile, transformers v5 requires huggingface_hub >= 1.0.0, an update that involves a transition in the HTTP backend**.




## Test Result

CI test result in https://github.com/vllm-project/vllm/pull/30566


link https://buildkite.com/vllm/ci/builds/59212/steps/canvas?jid=019d484e-3c50-4ece-a743-6073d55b5eb5：


[2026-04-01T09:46:39Z] (EngineCore pid=663) INFO 04-01 09:46:39 [core.py:1210] Shutdown initiated (timeout=0)
[2026-04-01T09:46:39Z] (EngineCore pid=663) INFO 04-01 09:46:39 [core.py:1233] Shutdown complete
[2026-04-01T09:46:40Z] gpu memory used/total (GiB): 0=0.45/22.49;
[2026-04-01T09:46:40Z] Done waiting for free GPU memory on devices devices=[0] (threshold='2.0 GiB') dur_s=0.00
[2026-04-01T09:46:40Z] PASSED


The GPU memory wasn't released at all after del llm—it remained stuck at 20.65 GiB right up until the timeout. The clearance threshold is 2.0 GiB, but the memory was pinned at 20.65 GiB.：

[2026-04-01T09:48:18Z] gpu memory used/total (GiB): 0=20.65/22.49; 1=20.65/22.49;
[2026-04-01T09:48:23Z] gpu memory used/total (GiB): 0=20.65/22.49; 1=20.65/22.49;
[2026-04-01T09:48:28Z] gpu memory used/total (GiB): 0=20.65/22.49; 1=20.65/22.49;
[2026-04-01T09:48:33Z] gpu memory used/total (GiB): 0=20.65/22.49; 1=20.65/22.49;
[2026-04-01T09:48:38Z] gpu memory used/total (GiB): 0=20.65/22.49; 1=20.65/22.49;
[2026-04-01T09:48:43Z] gpu memory used/total (GiB): 0=20.65/22.49; 1=20.65/22.49;
[2026-04-01T09:48:48Z] gpu memory used/total (GiB): 0=20.65/22.49; 1=20.65/22.49;
[2026-04-01T09:48:53Z] gpu memory used/total (GiB): 0=20.65/22.49; 1=20.65/22.49;
[2026-04-01T09:48:58Z] gpu memory used/total (GiB): 0=20.65/22.49; 1=20.65/22.49;
[2026-04-01T09:48:59Z] +++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++

**update: Notice this detail 👆: if the child process had actually been SIGKILLed, the OS should have reclaimed the GPU memory within a few seconds. Instead, the logs show it pinned at 20.65 GiB for a full 2 minutes. This strongly implies that the child process is still alive, rather than "killed but memory not released." It seems a GC delay might be preventing the SIGTERM from being dispatched. But here is the question: would this cause the test to fail reliably in CI while remaining un-reproducible locally?🤔**

I took a look at the code related to Worker. I initially suspected a GC delay, but test_vllm_gc_ed confirms there are no circular references — del llm triggers cleanup immediately. The 2-minute memory hold is better explained by orphaned Worker processes: once EngineCore is SIGKILLed, its Worker children become orphans outside kill_process_tree's reach, and they continue holding GPU memory indefinitely.

So, a more complete picture of the situation looks like this: EngineCore likely hangs at threading._shutdown() due to httpx background threads from huggingface_hub. The parent process's 5-second join timeout then expires, and it SIGKILLs EngineCore. At that point, _ensure_worker_termination() never runs, so Worker processes become orphaned and continue holding ~20 GiB of GPU memory indefinitely.

Adding os._exit() after engine_core.shutdown() bypasses threading._shutdown(), allowing EngineCore to exit cleanly within the parent's timeout. This preserves the entire shutdown chain: engine_core.shutdown() → model_executor.shutdown() → _ensure_worker_termination() gets to run, which SIGTERMs/SIGKILLs Workers while they are still child processes of EngineCore, so the OS properly reclaims their GPU memory.

cc @hmellor

update:
weakref.finalize relies on the reference count reaching zero or garbage collection (GC). However, the global httpx client in huggingface_hub >= 1.0.0 may indirectly hold references to MPClient or its higher-level objects through mechanisms such as callbacks or caching. In a CI environment (no cache → triggers HTTP download → httpx client is created), this reference chain prevents the reference count from dropping to zero, causing weakref.finalize to never trigger.
