### PR TITLE
[LongCat flash] Fix `ZeroExpertFusedMoE` missing `select_experts()` in router and MTP fix

### DIFF
--- a/vllm/model_executor/layers/fused_moe/zero_expert_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/zero_expert_fused_moe.py
@@ -81,9 +81,12 @@ class ZeroExpertFusedMoE(FusedMoE):
         self.custom_routing_function = custom_routing_function
 
     @contextmanager
-    def _temporarily_set_attrs(self, **attrs):
+    def _temporarily_set_attrs(self, target=None, **attrs):
         """
         Temporarily set attributes using object.__setattr__ and restore them.
+
+        Args:
+            target: The object on which to set attributes. Defaults to self.
 
         This bypasses nn.Module.__setattr__ to avoid Dynamo tracing issues.
         When PyTorch Dynamo traces the forward pass, it cannot handle
@@ -92,14 +95,16 @@ class ZeroExpertFusedMoE(FusedMoE):
         sets the attribute without triggering nn.Module's custom __setattr__,
         allowing Dynamo to trace the code successfully.
         """
-        originals = {key: getattr(self, key) for key in attrs}
+        if target is None:
+            target = self
+        originals = {key: getattr(target, key) for key in attrs}
         try:
             for key, value in attrs.items():
-                object.__setattr__(self, key, value)
+                object.__setattr__(target, key, value)
             yield
         finally:
             for key, value in originals.items():
-                object.__setattr__(self, key, value)
+                object.__setattr__(target, key, value)
 
     def _compute_zero_expert_result(
         self,
@@ -138,20 +143,28 @@ class ZeroExpertFusedMoE(FusedMoE):
         Returns:
             Combined output from real experts and zero experts
         """
-        # Prepare temporary attribute overrides for routing computation
-        temp_attrs = {
-            "custom_routing_function": None,  # Disable for first routing
-        }
-        if self._router is not None:
-            temp_attrs["e_score_correction_bias"] = self._router.e_score_correction_bias
+        # Temporarily set the full e_score_correction_bias on the internal
+        # router so that routing considers all experts (including zero experts).
+        # The router was created with a sliced bias (real experts only), but for
+        # the initial routing we need the full bias to properly score zero experts.
+        temp_router_attrs = {}
+        if (
+            self._router is not None
+            and hasattr(self.router, "e_score_correction_bias")
+        ):
+            temp_router_attrs["e_score_correction_bias"] = (
+                self._router.e_score_correction_bias
+            )
 
-        # Compute routing with temporary attributes
-        # Pass full router_logits (including zero experts) so that zero experts
-        # can be properly identified in topk_ids
-        with self._temporarily_set_attrs(**temp_attrs):
-            topk_weights, topk_ids = self.select_experts(
+        # Compute routing via the router with full router_logits (including
+        # zero experts) so that zero experts can be properly identified in
+        # topk_ids.
+        with self._temporarily_set_attrs(
+            target=self.router, **temp_router_attrs
+        ):
+            topk_weights, topk_ids = self.router.select_experts(
                 hidden_states=hidden_states,
-                router_logits=router_logits,  # Full logits (includes zero experts)
+                router_logits=router_logits,
             )
 
         # Compute zero expert result if needed

--- a/vllm/model_executor/models/longcat_flash_mtp.py
+++ b/vllm/model_executor/models/longcat_flash_mtp.py
@@ -345,4 +345,6 @@ class LongCatFlashMTP(nn.Module):
     ) -> int | None:
         if "model.mtp" in weight_name:
             return config.num_hidden_layers * 2
+        if weight_name == "lm_head.weight":
+            return config.num_hidden_layers * 2
         return None


### PR DESCRIPTION
Fixes 2 issues on LongCat flash 560B model:
1. `ZeroExpertFusedMoE` didnt have select_experts
2. MTP had missing lm_head

Issue 1:
Error: AttributeError: 'ZeroExpertFusedMoE' object has no attribute 'select_experts' during torch.compile/Dynamo tracing at zero_expert_fused_moe.py:151.

Fix: The select_experts method was refactored from FusedMoE to the router objects (BaseRouter.select_experts()), but ZeroExpertFusedMoE.forward() still called self.select_experts(...) which no longer exists on the layer.

Changes in zero_expert_fused_moe.py:
1. _temporarily_set_attrs - Added a target parameter (defaults to self) so it can set attributes on the router object instead of just self. This is needed because routing attributes like e_score_correction_bias now live on the router, not the layer.
3. forward() - Two key changes:
* Target the router: Temporarily set e_score_correction_bias on self.router (the internal router object used for actual routing) rather than on self (the FusedMoE layer). The old code set it on self, which only affected the monolithic kernel path.
* Use self.router.select_experts(): Replaced the non-existent self.select_experts(...) with self.router.select_experts(...), which is where the method now lives after the router refactor.

Issue 2:
ValueError: Following weights were not initialized from checkpoint: {'lm_head.weight'}
Fix: weight loading