### PR TITLE
[Bugfix] Fix Anthropic adapter missing content field on assistant tool-call messages

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -452,8 +452,9 @@ class TestThinkingBlockConversion:
         asst = asst_msgs[0]
 
         assert asst.get("reasoning") == "Just thinking..."
-        # No visible text → content should be absent or None.
-        assert asst.get("content") is None
+        # No visible text → content should be empty string (not absent),
+        # because some tokenizers (e.g. mistral-common) require the field.
+        assert asst.get("content") == ""
 
     def test_thinking_plus_tool_use_in_assistant_message(self):
         """thinking + tool_use: reasoning field set, tool_calls populated."""
@@ -498,8 +499,115 @@ class TestThinkingBlockConversion:
         tool_calls = list(asst.get("tool_calls", []))
         assert len(tool_calls) == 1
         assert tool_calls[0]["function"]["name"] == "calculator"
-        # No text content alongside reasoning + tool_use.
-        assert asst.get("content") is None
+        # No text content alongside reasoning + tool_use → empty string
+        # (not absent) for tokenizer compatibility.
+        assert asst.get("content") == ""
+
+    def test_tool_use_only_in_assistant_message(self):
+        """tool_use only (no text, no thinking): content must be empty str."""
+        request = _make_request(
+            [
+                {"role": "user", "content": "What is 2+2?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_001",
+                            "name": "calculator",
+                            "input": {"expression": "2+2"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_001",
+                            "content": "4",
+                        }
+                    ],
+                },
+            ]
+        )
+        result = _convert(request)
+
+        asst_msgs = [m for m in result.messages if m.get("role") == "assistant"]
+        assert len(asst_msgs) == 1
+        asst = asst_msgs[0]
+
+        assert asst.get("content") == ""
+        tool_calls = list(asst.get("tool_calls", []))
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["function"]["name"] == "calculator"
+
+    def test_multi_turn_tool_calling_content_always_set(self):
+        """Multi-turn tool calling must always set content on assistant msgs.
+
+        Regression test for https://github.com/vllm-project/vllm/issues/38738.
+        """
+        request = _make_request(
+            [
+                {"role": "user", "content": "Search for vLLM"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_001",
+                            "name": "search",
+                            "input": {"query": "vLLM"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_001",
+                            "content": "vLLM is a fast LLM inference engine",
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Based on the search...",
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "call_002",
+                            "name": "search",
+                            "input": {"query": "vLLM performance"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_002",
+                            "content": "vLLM achieves high throughput",
+                        }
+                    ],
+                },
+            ]
+        )
+        result = _convert(request)
+
+        asst_msgs = [m for m in result.messages if m.get("role") == "assistant"]
+        assert len(asst_msgs) == 2
+        # First assistant: tool_use only → content must be ""
+        assert asst_msgs[0].get("content") == ""
+        assert len(list(asst_msgs[0].get("tool_calls", []))) == 1
+        # Second assistant: text + tool_use → content is the text
+        assert asst_msgs[1].get("content") == "Based on the search..."
+        assert len(list(asst_msgs[1].get("tool_calls", []))) == 1
 
     def test_multiple_thinking_blocks_concatenated(self):
         """Multiple thinking blocks should be joined in order."""

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -205,10 +205,11 @@ class AnthropicServingMessages(OpenAIServingChat):
                 openai_msg["content"] = content_parts[0]["text"]
             else:
                 openai_msg["content"] = content_parts  # type: ignore
-        elif tool_calls or reasoning_parts:
-            # Ensure content is always set when tool_calls or reasoning are
-            # present.  Some tokenizers (e.g. mistral-common) require the
-            # content field to exist on assistant messages.
+        elif msg.role == "assistant":
+            # Ensure content is always present on assistant messages.
+            # Some tokenizers (e.g. mistral-common) require the content
+            # field on every assistant message, even when only tool_calls,
+            # reasoning, or redacted thinking blocks are present.
             openai_msg["content"] = ""
 
     @classmethod

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -205,8 +205,11 @@ class AnthropicServingMessages(OpenAIServingChat):
                 openai_msg["content"] = content_parts[0]["text"]
             else:
                 openai_msg["content"] = content_parts  # type: ignore
-        elif not tool_calls and not reasoning_parts:
-            return
+        elif tool_calls or reasoning_parts:
+            # Ensure content is always set when tool_calls or reasoning are
+            # present.  Some tokenizers (e.g. mistral-common) require the
+            # content field to exist on assistant messages.
+            openai_msg["content"] = ""
 
     @classmethod
     def _convert_block(


### PR DESCRIPTION
## Essential Checks
- [x] Searched existing PRs - no duplicate
- [x] AI-assisted: used Claude Code for analysis, code changes reviewed by human
- [x] Tests added and passing

## Purpose

Fixes #38738

When using the Anthropic Messages API (`/v1/messages`) with a Mistral model, multi-turn tool calling crashes on the second turn because downstream tokenizer validation does not receive a valid `content` field for an assistant message.

## Root Cause

In `_convert_message_content()`, complex assistant content without visible text could leave the OpenAI-compatible assistant message without `content`. Tokenizers that validate assistant message structure, such as `mistral-common`, require the field even when the message contains tool calls or opaque reasoning content.

## Fix

When an assistant message has no visible text content, explicitly set `content = ""` while preserving generated `tool_calls` and `reasoning`. Checking the assistant role directly covers tool-use-only, thinking-only, and redacted-thinking-only messages.

## Test Plan

- [x] Added `test_tool_use_only_in_assistant_message` for a pure `tool_use` assistant message
- [x] Added `test_multi_turn_tool_calling_content_always_set` as regression coverage for #38738
- [x] Updated thinking-only and thinking-plus-tool-use coverage for the normalized empty-content behavior
- [x] Covered redacted thinking acceptance addressed during review
- [x] All 28 targeted conversion tests pass

<details>
<summary>Before (reported failure in #38738)</summary>

The issue reporter reproduced the failure on the second Anthropic tool-calling turn with a Mistral model. Full reported failure trace:

```text
File "vllm/renderers/mistral.py", line 34, in safe_apply_chat_template
    return tokenizer.apply_chat_template(messages, **kwargs)
File "vllm/tokenizers/mistral.py", line 444, in apply_chat_template
    return self.transformers_tokenizer.apply_chat_template(
File "transformers/tokenization_mistral_common.py", line 1510, in apply_chat_template
    tokenized_request = self.tokenizer.encode_chat_completion(chat_request)
File "mistral_common/tokens/tokenizers/mistral.py", line 389, in encode_chat_completion
    return self.instruct_tokenizer.encode_instruct(instruct_request)
File "mistral_common/tokens/tokenizers/instruct.py", line 200, in encode_instruct
    new_tokens = self.encode_assistant_message(
File "mistral_common/tokens/tokenizers/instruct.py", line 1131, in encode_assistant_message
    raise TokenizerException(f"Invalid assistant message: {message}")
TokenizerException: Invalid assistant message: role='assistant' content='' tool_calls=None prefix=False

Originating from:
File "vllm/entrypoints/anthropic/api_router.py", line 70, in create_messages
    generator = await handler.create_messages(request, raw_request)
File "vllm/entrypoints/anthropic/serving.py", line 422, in create_messages
    generator = await self.create_chat_completion(chat_req, raw_request)
```

</details>

<details>
<summary>After (regression tests on patched branch)</summary>

The local path in the captured output has been redacted.

```text
$ python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0
rootdir: <redacted>/workspace/vllm
configfile: pyproject.toml
plugins: rerunfailures-15.1, order-1.3.0, anyio-4.13.0, xdist-3.8.0, rich-0.2.0, hypothesis-6.151.9, asyncio-1.3.0, random-order-1.2.0, timeout-2.4.0, env-1.2.0
asyncio: mode=Mode.STRICT, debug=False
collecting ... collected 28 items

test_anthropic_messages_conversion.py::TestConvertImageSourceToUrl::test_base64_source PASSED [  3%]
test_anthropic_messages_conversion.py::TestConvertImageSourceToUrl::test_base64_png PASSED [  7%]
test_anthropic_messages_conversion.py::TestConvertImageSourceToUrl::test_url_source PASSED [ 10%]
test_anthropic_messages_conversion.py::TestConvertImageSourceToUrl::test_missing_type_defaults_to_base64 PASSED [ 14%]
test_anthropic_messages_conversion.py::TestConvertImageSourceToUrl::test_missing_media_type_defaults_to_jpeg PASSED [ 17%]
test_anthropic_messages_conversion.py::TestConvertImageSourceToUrl::test_url_source_missing_url_returns_empty PASSED [ 21%]
test_anthropic_messages_conversion.py::TestConvertImageSourceToUrl::test_empty_source_returns_data_uri_shell PASSED [ 25%]
test_anthropic_messages_conversion.py::TestImageContentBlocks::test_base64_image_in_user_message PASSED [ 28%]
test_anthropic_messages_conversion.py::TestImageContentBlocks::test_url_image_in_user_message PASSED [ 32%]
test_anthropic_messages_conversion.py::TestToolResultContent::test_tool_result_string_content PASSED [ 35%]
test_anthropic_messages_conversion.py::TestToolResultContent::test_tool_result_text_blocks PASSED [ 39%]
test_anthropic_messages_conversion.py::TestToolResultContent::test_tool_result_with_image PASSED [ 42%]
test_anthropic_messages_conversion.py::TestToolResultContent::test_tool_result_with_text_and_image PASSED [ 46%]
test_anthropic_messages_conversion.py::TestToolResultContent::test_tool_result_with_multiple_images PASSED [ 50%]
test_anthropic_messages_conversion.py::TestToolResultContent::test_tool_result_none_content PASSED [ 53%]
test_anthropic_messages_conversion.py::TestToolResultContent::test_tool_result_no_follow_up_when_no_images PASSED [ 57%]
test_anthropic_messages_conversion.py::TestAttributionHeaderStripping::test_billing_header_stripped_from_system PASSED [ 60%]
test_anthropic_messages_conversion.py::TestAttributionHeaderStripping::test_system_without_billing_header_unchanged PASSED [ 64%]
test_anthropic_messages_conversion.py::TestAttributionHeaderStripping::test_system_string_unchanged PASSED [ 67%]
test_anthropic_messages_conversion.py::TestThinkingBlockConversion::test_thinking_plus_text_in_assistant_message PASSED [ 71%]
test_anthropic_messages_conversion.py::TestThinkingBlockConversion::test_thinking_only_in_assistant_message PASSED [ 75%]
test_anthropic_messages_conversion.py::TestThinkingBlockConversion::test_thinking_plus_tool_use_in_assistant_message PASSED [ 78%]
test_anthropic_messages_conversion.py::TestThinkingBlockConversion::test_tool_use_only_in_assistant_message PASSED [ 82%]
test_anthropic_messages_conversion.py::TestThinkingBlockConversion::test_multi_turn_tool_calling_content_always_set PASSED [ 85%]
test_anthropic_messages_conversion.py::TestThinkingBlockConversion::test_multiple_thinking_blocks_concatenated PASSED [ 89%]
test_anthropic_messages_conversion.py::TestThinkingBlockConversion::test_no_thinking_blocks_unchanged PASSED [ 92%]
test_anthropic_messages_conversion.py::TestThinkingBlockConversion::test_multi_turn_with_thinking_blocks PASSED [ 96%]
test_anthropic_messages_conversion.py::TestThinkingBlockConversion::test_redacted_thinking_block_is_accepted PASSED [100%]

======================== 28 passed, 2 warnings in 6.96s ========================
```

</details>

## Validation Limits

The current workstation does not have the required Ministral model assets for a fresh service-level reproduction. This description therefore records the issue reporter's full Before failure trace and the existing targeted regression-test run without claiming a new model-serving end-to-end run.
