### PR TITLE
Splitting MLA attention Triton kernel

### DIFF
--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -49,6 +49,14 @@ if version.parse(triton.__version__) < version.parse("3.2.0"):
         "can be ignored."
     )
 
+# Number of temporary accumulation pages for _fwd_grouped_kernel_stage1_part1.
+# 32 is a reasonable balance. Increasing it may result in marginal speedup
+# for large context lengths, at the cost of increased GPU memory use.
+#
+# Speedup beyond 32 is likely minimal: 32 increases grid size from single digits
+# (severe GPU under-utilization) to the size comparable with the number of CUs.
+_MLA_TEMP_PAGE_COUNT = 32
+
 
 @triton.jit
 def tanh(x):
@@ -256,6 +264,287 @@ def _decode_att_m_fwd(
         Lk=Lk,
         Lv=Lv,
     )
+
+
+def tensor_triton_arg(tensor):
+    return tensor, *tensor.stride()[:-1]
+
+
+@triton.jit
+def _fwd_grouped_kernel_stage1_part1(
+    Q,
+    K_Buffer,
+    V_Buffer,
+    sm_scale,
+    Req_to_tokens,
+    B_Seqlen,
+    Att_Out_1,
+    Att_Out_1_stride0,
+    Att_Out_1_stride1,
+    Att_Out_1_stride2,
+    Att_Out_1_stride3,
+    temp_size: tl.constexpr,
+    stride_req_to_tokens_b,
+    stride_qbs,
+    stride_qh,
+    stride_buf_kbs,
+    stride_buf_kh,
+    stride_buf_vbs,
+    stride_buf_vh,
+    k_scale,
+    v_scale,
+    kv_group_num: tl.constexpr,
+    q_head_num: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    logit_cap: tl.constexpr,
+    Lk: tl.constexpr,
+    Lv: tl.constexpr,
+    IS_MLA: tl.constexpr = False
+):
+    cur_batch = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    cur_kv_head = cur_head_id // tl.cdiv(kv_group_num, BLOCK_H)
+    split_kv_id = tl.program_id(2) % NUM_KV_SPLITS
+    page_id = tl.program_id(2) // NUM_KV_SPLITS
+
+    if kv_group_num > BLOCK_H:
+        VALID_BLOCK_H: tl.constexpr = BLOCK_H
+    else:
+        VALID_BLOCK_H: tl.constexpr = kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = cur_head < (cur_head_id + 1) * VALID_BLOCK_H
+    mask_h = mask_h & (cur_head < q_head_num)
+
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mask_d = offs_d < Lk
+    mask_dv = offs_dv < Lv
+    cur_batch_seq_len = tl.load(B_Seqlen + cur_batch)
+    cur_batch_req_idx = cur_batch
+
+    offs_q = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_d[
+        None, :]
+    q = tl.load(
+        Q + offs_q,
+        mask=(mask_h[:, None]) & (mask_d[None, :]),
+        other=0.0,
+        cache_modifier=".ca",
+    )
+
+    if BLOCK_DPE > 0:
+        offs_dpe = BLOCK_DMODEL + tl.arange(0, BLOCK_DPE)
+        mask_dpe = offs_dpe < Lk
+        off_qpe = (cur_batch * stride_qbs + cur_head[:, None] * stride_qh +
+                   offs_dpe[None, :])
+        qpe = tl.load(Q + off_qpe,
+                      mask=(mask_h[:, None]) & (mask_dpe[None, :]),
+                      other=0.0,
+                      cache_modifier=".ca")
+
+    kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
+    split_kv_start = kv_len_per_split * split_kv_id
+    split_kv_end = tl.minimum(split_kv_start + kv_len_per_split,
+                              cur_batch_seq_len)
+
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
+
+    if split_kv_end > split_kv_start:
+        base_offs_k = cur_kv_head * stride_buf_kh + offs_d[:, None]
+        base_offs_v = cur_kv_head * stride_buf_vh + offs_dv[None, :]
+        if BLOCK_DPE > 0:
+            base_offs_kpe = cur_kv_head * stride_buf_kh + offs_dpe[:, None]
+
+        ks = tl.load(k_scale)
+        vs = tl.load(v_scale)
+        for start_n in tl.range(split_kv_start + page_id * BLOCK_N, split_kv_end,
+                             BLOCK_N * temp_size):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            kv_page_number = tl.load(
+                Req_to_tokens + stride_req_to_tokens_b * cur_batch_req_idx +
+                offs_n // PAGE_SIZE,
+                mask=offs_n < split_kv_end,
+                other=0,
+                cache_modifier=".ca",
+            )
+            kv_loc = kv_page_number * PAGE_SIZE + offs_n % PAGE_SIZE
+            # explicitly facilitate overlapping load/compute
+            offs_buf_k = kv_loc[None, :] * stride_buf_kbs + base_offs_k
+            k = tl.load(
+                K_Buffer + offs_buf_k,
+                mask=(offs_n[None, :] < split_kv_end) & (mask_d[:, None]),
+                other=0.0,
+                cache_modifier=".cg",
+            )
+            if k.dtype.is_fp8():
+                k = (k.to(tl.float32) * ks).to(q.dtype)
+            qk = tl.dot(q, k.to(q.dtype))
+            if BLOCK_DPE > 0:
+                offs_buf_kpe = kv_loc[None, :] * stride_buf_kbs + base_offs_kpe
+                kpe = tl.load(
+                    K_Buffer + offs_buf_kpe,
+                    mask=(offs_n[None, :] < split_kv_end) &
+                    (mask_dpe[:, None]),
+                    other=0.0,
+                    cache_modifier=".cg",
+                )
+                if kpe.dtype.is_fp8():
+                    kpe = (kpe.to(tl.float32) * ks).to(qpe.dtype)
+                qk += tl.dot(qpe, kpe.to(qpe.dtype))
+            qk *= sm_scale
+
+            if logit_cap > 0:
+                qk = logit_cap * tanh(qk / logit_cap)
+
+            qk = tl.where(mask_h[:, None] & (offs_n[None, :] < split_kv_end),
+                          qk, float("-inf"))
+
+            if not IS_MLA:
+                offs_buf_v = kv_loc[:, None] * stride_buf_vbs + base_offs_v
+                v = tl.load(
+                    V_Buffer + offs_buf_v,
+                    mask=(offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
+                    other=0.0,
+                )
+                if v.dtype.is_fp8():
+                    v = (v.to(tl.float32) * vs).to(q.dtype)
+            else:
+                # MLA uses a single c_kv.
+                # loading the same c_kv to interpret it as v is not necessary.
+                # transpose the existing c_kv (aka k) for the dot product.
+                v = tl.trans(k)
+
+            n_e_max = tl.maximum(tl.max(qk, 1), e_max)
+            re_scale = tl.exp(e_max - n_e_max)
+            p = tl.exp(qk - n_e_max[:, None])
+            acc *= re_scale[:, None]
+            acc += tl.dot(p.to(v.dtype), v)
+
+            e_sum = e_sum * re_scale + tl.sum(p, 1)
+            e_max = n_e_max
+
+        store_index0 = page_id
+        store_index1 = cur_batch
+        store_index2 = cur_head[:, None]
+        store_index3 = split_kv_id
+        store_index4 = offs_dv[None, :]
+        row = Att_Out_1 + store_index0 * Att_Out_1_stride0 \
+                        + store_index1 * Att_Out_1_stride1 \
+                        + store_index2 * Att_Out_1_stride2 \
+                        + store_index3 * Att_Out_1_stride3
+        tl.store(
+            row + store_index4,
+            acc,
+            mask=(mask_h[:, None]) & (mask_dv[None, :]),
+        )
+        tl.store(
+            row + Att_Out_1_stride3 - 2,
+            e_sum[:, None],
+            mask=(mask_h[:, None]),
+        )
+        tl.store(
+            row + Att_Out_1_stride3 - 1,
+            e_max[:, None],
+            mask=(mask_h[:, None]),
+        )
+
+
+@triton.jit
+def _fwd_grouped_kernel_stage1_part2(
+    B_Seqlen,
+    Att_Out_1,
+    Att_Out_1_stride0,
+    Att_Out_1_stride1,
+    Att_Out_1_stride2,
+    Att_Out_1_stride3,
+    Att_Out,
+    Att_Out_stride0,
+    Att_Out_stride1,
+    Att_Out_stride2,
+    page_count,
+    kv_group_num: tl.constexpr,
+    q_head_num: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    logit_cap: tl.constexpr,
+    Lk: tl.constexpr,
+    Lv: tl.constexpr,
+    IS_MLA: tl.constexpr = False
+):
+    cur_batch = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    h = tl.program_id(2) % BLOCK_H
+    split_kv_id = tl.program_id(2) // BLOCK_H
+
+    if kv_group_num > BLOCK_H:
+        VALID_BLOCK_H: tl.constexpr = BLOCK_H
+    else:
+        VALID_BLOCK_H: tl.constexpr = kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + h
+    mask_h = cur_head < (cur_head_id + 1) * VALID_BLOCK_H
+    mask_h = mask_h & (cur_head < q_head_num)
+
+    if not mask_h:
+        return
+
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mask_dv = offs_dv < Lv
+
+    cur_batch_seq_len = tl.load(B_Seqlen + cur_batch)
+
+    kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
+    page_count = tl.minimum(
+        page_count,
+        tl.cdiv(
+            tl.minimum(kv_len_per_split,
+                       cur_batch_seq_len - kv_len_per_split * split_kv_id),
+            BLOCK_N))
+
+    e_max = -float("inf")
+    e_sum = 0.0
+    acc = tl.zeros([BLOCK_DV], dtype=tl.float32)
+
+    for i in range(page_count):
+        store_index0 = i
+        store_index1 = cur_batch
+        store_index2 = cur_head
+        store_index3 = split_kv_id
+        store_index4 = offs_dv
+        row = Att_Out_1 + store_index0 * Att_Out_1_stride0 \
+                        + store_index1 * Att_Out_1_stride1 \
+                        + store_index2 * Att_Out_1_stride2 \
+                        + store_index3 * Att_Out_1_stride3
+        d_acc = tl.load(row + store_index4)
+        d_e_max = tl.load(row + Att_Out_1_stride3 - 1)
+        ps = tl.load(row + Att_Out_1_stride3 - 2)
+
+        n_e_max = tl.maximum(d_e_max, e_max)
+        re_scale = tl.exp(e_max - n_e_max)
+        p2 = tl.exp(d_e_max - n_e_max)
+
+        acc *= re_scale
+        acc += d_acc * p2
+        e_sum = e_sum * re_scale + ps * p2
+        e_max = n_e_max
+
+    offs_mid_o = (cur_batch * Att_Out_stride0 + cur_head * Att_Out_stride1 +
+                  split_kv_id * Att_Out_stride2)
+
+    if cur_batch_seq_len > split_kv_id * kv_len_per_split:
+        tl.store(Att_Out + offs_mid_o + offs_dv, acc / e_sum, mask=mask_dv)
+        tl.store(Att_Out + offs_mid_o + Lv, e_max + tl.log(e_sum))
 
 
 @triton.jit
@@ -483,11 +772,6 @@ def _decode_grouped_att_m_fwd(
 
     BLOCK_H = 16
     NUM_KV_SPLITS = num_kv_splits
-    grid = (
-        batch,
-        triton.cdiv(head_num, min(BLOCK_H, kv_group_num)),
-        NUM_KV_SPLITS,
-    )
 
     extra_kargs = {}
     num_stages = 2
@@ -497,43 +781,86 @@ def _decode_grouped_att_m_fwd(
         extra_kargs = {"waves_per_eu": 1, "matrix_instr_nonkdim": 16, "kpack": 2}
         num_stages = 1
 
-    _fwd_grouped_kernel_stage1[grid](
-        q,
-        k_buffer,
-        v_buffer,
-        sm_scale,
-        Req_to_tokens,
-        B_Seqlen,
-        att_out,
+    args = [
         Req_to_tokens.stride(0),
         q.stride(0),
         q.stride(1),
-        k_buffer.stride(-3),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
-        k_buffer.stride(-2),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
-        v_buffer.stride(-3),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
-        v_buffer.stride(-2),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
+        k_buffer.stride(-3),
+        k_buffer.stride(-2),
+        v_buffer.stride(-3),
+        v_buffer.stride(-2),
+    ]
+    args2 = [
         att_out.stride(0),
         att_out.stride(1),
         att_out.stride(2),
         k_scale,
         v_scale,
-        kv_group_num=kv_group_num,
-        q_head_num=head_num,
-        BLOCK_DMODEL=BLOCK_DMODEL,
-        BLOCK_DPE=BLOCK_DPE,
-        BLOCK_DV=BLOCK_DV,
-        BLOCK_N=BLOCK,
-        BLOCK_H=BLOCK_H,
-        NUM_KV_SPLITS=NUM_KV_SPLITS,
-        PAGE_SIZE=page_size,
-        logit_cap=logit_cap,
-        num_warps=4,
-        num_stages=num_stages,
-        Lk=Lk,
-        Lv=Lv,
-        IS_MLA=is_mla,
+    ]
+    kwargs = {
+        "kv_group_num": kv_group_num,
+        "q_head_num": head_num,
+        "BLOCK_DMODEL": BLOCK_DMODEL,
+        "BLOCK_DPE": BLOCK_DPE,
+        "BLOCK_DV": BLOCK_DV,
+        "BLOCK_N": BLOCK,
+        "BLOCK_H": BLOCK_H,
+        "NUM_KV_SPLITS": NUM_KV_SPLITS,
+        "PAGE_SIZE": page_size,
+        "logit_cap": logit_cap,
+        "num_warps": 4,
+        "num_stages": num_stages,
+        "Lk": Lk,
+        "Lv": Lv,
+        "IS_MLA": is_mla,
         **extra_kargs,
-    )
+    }
+    kwargs.update(extra_kargs)
+
+    if batch >= 32:
+        grid = (
+            batch,
+            triton.cdiv(head_num, min(BLOCK_H, kv_group_num)),
+            NUM_KV_SPLITS,
+        )
+        _fwd_grouped_kernel_stage1[grid](
+            q,
+            k_buffer,
+            v_buffer,
+            sm_scale,
+            Req_to_tokens,
+            B_Seqlen,
+            att_out,
+            *args, *args2, **kwargs)
+    else:
+        temp_page_count = _MLA_TEMP_PAGE_COUNT
+
+        sh = (temp_page_count, att_out.shape[0], att_out.shape[1],
+              att_out.shape[2], att_out.shape[3] + 2)
+
+        temp_att_buf = torch.empty(sh, dtype=torch.float32, device=q.device)
+
+        grid2 = (
+            batch,
+            triton.cdiv(head_num, min(BLOCK_H, kv_group_num)),
+            NUM_KV_SPLITS * temp_page_count,
+        )
+        grid3 = (
+            batch,
+            triton.cdiv(head_num, min(BLOCK_H, kv_group_num)),
+            NUM_KV_SPLITS * BLOCK_H,
+        )
+
+        _fwd_grouped_kernel_stage1_part1[grid2](q, k_buffer, v_buffer, sm_scale,
+                                                Req_to_tokens, B_Seqlen,
+                                                *tensor_triton_arg(temp_att_buf),
+                                                temp_page_count, *args, *args2[-2:],
+                                                **kwargs)
+
+        _fwd_grouped_kernel_stage1_part2[grid3](B_Seqlen,
+                                                *tensor_triton_arg(temp_att_buf),
+                                                *tensor_triton_arg(att_out),
+                                                temp_page_count, **kwargs)
 
 
 @triton.jit


### PR DESCRIPTION
A revival of PR #19774  (which, surprisingly, still seems relevant).

This splits _fwd_grouped_kernel_stage1 operation in two parts, using a temporary buffer.

## Rationale
_fwd_grouped_kernel_stage1 becomes a significant bottleneck with large context lengths due to severe GPU under-utilization (very small grid size). This patch breaks it into two kernels:
- _fwd_grouped_kernel_stage1_part1: launched with larger grid, writes into temporary buffer
- _fwd_grouped_kernel_stage1_part2: smaller grid but much lighter operation

## Affected Models
At least on ROCm, this optimization benefits GLM-4.7-Flash, DeepSeek-V3 (when AITER is off), and potentially other GLM models. (DeepSeek can handle longer contexts when AITER is on, but AITER MLA does not support the head size of GLM-4.7-Flash.)

<p>Token/s generation</p>
<p>GLM-4.7-Flash, 1x MI325</p>

Context size | patch | AITER + patch | baseline | AITER
-- | -- | -- | -- | --
16384 | 73.1 | 76.8 | 21.2 | 21.5
32768 | 64.2 | 67.2 | 12.1 | 12.2
65536 | 53.9 | 55.6 | 6.5 | 6.5
100000 | 45.5 | 46.7 | 4.4 | 4.4


<p>'AITER':  VLLM_ROCM_VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MLA=0 VLLM_ROCM_USE_AITER_MOE=1 </p>