### PR TITLE
[Bugfix] Fix test mocks after SM100 restriction in #38730

### DIFF
--- a/tests/kernels/attention/test_use_trtllm_attention.py
+++ b/tests/kernels/attention/test_use_trtllm_attention.py
@@ -62,7 +62,7 @@ def test_supports_batch_invariant_disables():
 
 @patch("vllm.envs.VLLM_BATCH_INVARIANT", False)
 @patch(
-    "vllm.utils.flashinfer.current_platform.is_device_capability_family",
+    "vllm.utils.flashinfer.current_platform.is_device_capability",
     return_value=True,
 )
 @patch("vllm.utils.flashinfer.has_nvidia_artifactory", return_value=True)
@@ -72,7 +72,7 @@ def test_supports_sm100_with_artifactory(_art, _cap):
 
 @patch("vllm.envs.VLLM_BATCH_INVARIANT", False)
 @patch(
-    "vllm.utils.flashinfer.current_platform.is_device_capability_family",
+    "vllm.utils.flashinfer.current_platform.is_device_capability",
     return_value=False,
 )
 def test_supports_non_sm100_platform(_cap):
@@ -81,7 +81,7 @@ def test_supports_non_sm100_platform(_cap):
 
 @patch("vllm.envs.VLLM_BATCH_INVARIANT", False)
 @patch(
-    "vllm.utils.flashinfer.current_platform.is_device_capability_family",
+    "vllm.utils.flashinfer.current_platform.is_device_capability",
     return_value=True,
 )
 @patch("vllm.utils.flashinfer.has_nvidia_artifactory", return_value=False)


### PR DESCRIPTION
## Summary

- Update three test mocks in `test_use_trtllm_attention.py` from `is_device_capability_family` to `is_device_capability` to match the production code change in #38730
- This is a direct follow-up to #38730 which changed `supports_trtllm_attention()` to use `is_device_capability(100)` instead of `is_device_capability_family(100)`
- Supersedes the auto-revert #38773

## Test plan

- [ ] `pytest tests/kernels/attention/test_use_trtllm_attention.py -v` passes (all 17 tests)

## Why CI missed this on #38730

The "Kernels Attention Test" job's source file dependencies do not include `vllm/utils/flashinfer.py`, so changing only that file did not trigger the attention test job in PR CI, only caught in nightly. This PR changes the test file itself, so it will be picked up. See #38792 for adding the missing source dependency.