### PR TITLE
[XPU] Prevent MoE collective hangs in XPU External LB mode

### DIFF
--- a/tests/v1/distributed/test_external_lb_dp.py
+++ b/tests/v1/distributed/test_external_lb_dp.py
@@ -130,8 +130,6 @@ def default_server_args():
         "--max-num-seqs",
         "128",
         "--enforce-eager",
-        "--gpu-memory-utilization",
-        "0.8",
     ]
 
 

--- a/tests/v1/distributed/test_external_lb_dp.py
+++ b/tests/v1/distributed/test_external_lb_dp.py
@@ -76,7 +76,6 @@ class ExternalLBServerManager:
                         auto_port=False,
                         env_dict={
                             "VLLM_SERVER_DEV_MODE": "1",
-                            "VLLM_EXTERNAL_LB_FORCE_NO_DP_EP": "1",
                             current_platform.device_control_env_var: ",".join(
                                 str(current_platform.device_id_to_physical_device_id(i))
                                 for i in range(r * TP_SIZE, (r + 1) * TP_SIZE)

--- a/tests/v1/distributed/test_external_lb_dp.py
+++ b/tests/v1/distributed/test_external_lb_dp.py
@@ -76,6 +76,7 @@ class ExternalLBServerManager:
                         auto_port=False,
                         env_dict={
                             "VLLM_SERVER_DEV_MODE": "1",
+                            "VLLM_EXTERNAL_LB_FORCE_NO_DP_EP": "1",
                             current_platform.device_control_env_var: ",".join(
                                 str(current_platform.device_id_to_physical_device_id(i))
                                 for i in range(r * TP_SIZE, (r + 1) * TP_SIZE)
@@ -129,6 +130,8 @@ def default_server_args():
         "--max-num-seqs",
         "128",
         "--enforce-eager",
+        "--gpu-memory-utilization",
+        "0.8",
     ]
 
 

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from typing import Any
 
 import torch
@@ -113,17 +114,10 @@ def maybe_make_prepare_finalize(
 
         # For DP/TP case, fall back to naive P/F.
         if moe.moe_parallel_config.dp_size > 1:
-            is_xpu_restricted_visibility = (
+            if (
                 current_platform.is_xpu()
-                and current_platform.device_count() < moe.moe_parallel_config.dp_size
-            )
-            if is_xpu_restricted_visibility:
-                logger.info_once(
-                    "XPU: Visible device count (%d) < DP size (%d). "
-                    "Using no-DP/EP MoE to avoid cross-rank communication.",
-                    current_platform.device_count(),
-                    moe.moe_parallel_config.dp_size,
-                )
+                and os.environ.get("VLLM_EXTERNAL_LB_FORCE_NO_DP_EP", "0") == "1"
+            ):
                 return make_moe_prepare_and_finalize_no_dp_ep(use_monolithic)
 
             logger.info_once(

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -113,6 +113,19 @@ def maybe_make_prepare_finalize(
 
         # For DP/TP case, fall back to naive P/F.
         if moe.moe_parallel_config.dp_size > 1:
+            is_xpu_restricted_visibility = (
+                current_platform.is_xpu()
+                and current_platform.device_count() < moe.moe_parallel_config.dp_size
+            )
+            if is_xpu_restricted_visibility:
+                logger.info_once(
+                    "XPU: Visible device count (%d) < DP size (%d). "
+                    "Using no-DP/EP MoE to avoid cross-rank communication.",
+                    current_platform.device_count(),
+                    moe.moe_parallel_config.dp_size,
+                )
+                return make_moe_prepare_and_finalize_no_dp_ep(use_monolithic)
+
             logger.info_once(
                 "Detected DP deployment with no --enable-expert-parallel. "
                 "Falling back to AllGather+ReduceScatter dispatch/combine."

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import os
 from typing import Any
 
 import torch
@@ -112,14 +111,16 @@ def maybe_make_prepare_finalize(
         if not allow_new_interface:
             return None
 
+        parallel_config = get_current_vllm_config().parallel_config
+        if parallel_config.data_parallel_external_lb:
+            logger.info_once(
+                "External LB mode detected. "
+                "Disabling DP-EP cross-rank token routing to prevent collective "
+                "communication hangs. Falling back to no_dp_ep."
+            )
+            return make_moe_prepare_and_finalize_no_dp_ep(use_monolithic)
         # For DP/TP case, fall back to naive P/F.
         if moe.moe_parallel_config.dp_size > 1:
-            if (
-                current_platform.is_xpu()
-                and os.environ.get("VLLM_EXTERNAL_LB_FORCE_NO_DP_EP", "0") == "1"
-            ):
-                return make_moe_prepare_and_finalize_no_dp_ep(use_monolithic)
-
             logger.info_once(
                 "Detected DP deployment with no --enable-expert-parallel. "
                 "Falling back to AllGather+ReduceScatter dispatch/combine."


### PR DESCRIPTION



## Purpose
Description
Problem: In External LB mode, DP replicas operate with fully decoupled schedulers. For MoE models, falling back to naive_dp_ep invokes blocking cross-rank collective operations (e.g., dist.all_gather). Since the independent schedulers do not synchronize, this inevitably causes the engine to hang.

Solution: Dynamically check get_current_vllm_config().parallel_config.data_parallel_external_lb. If active, safely disable cross-rank routing by falling back to make_moe_prepare_and_finalize_no_dp_ep (local expert processing only).
## Test Plan
NCCL_CUMEM_HOST_ENABLE=0 TP_SIZE=1 DP_SIZE=2 pytest -v -s tests/v1/distributed/test_external_lb_dp.py
## Test Result
================== 6 passed, 16 warnings in 174.34s (0:02:54) ==================
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

