### PR TITLE
[CPU] Fix chained comparison static_assert for Clang 21+

### DIFF
--- a/csrc/cpu/cpu_attn_vec.hpp
+++ b/csrc/cpu/cpu_attn_vec.hpp
@@ -53,7 +53,7 @@ class TileGemm82 {
                          const int64_t ldb, const int64_t ldc,
                          const int32_t block_size, const int32_t dynamic_k_size,
                          const bool accum_c) {
-    static_assert(0 < M <= 8);
+    static_assert(0 < M && M <= 8);
     using load_vec_t = typename VecTypeTrait<kv_cache_t>::vec_t;
 
     kv_cache_t* __restrict__ curr_b_0 = b_tile;

--- a/csrc/cpu/cpu_attn_vec16.hpp
+++ b/csrc/cpu/cpu_attn_vec16.hpp
@@ -68,7 +68,7 @@ class TileGemm161 {
                          const int64_t ldb, const int64_t ldc,
                          const int32_t block_size, const int32_t dynamic_k_size,
                          const bool accum_c) {
-    static_assert(0 < M <= 16);
+    static_assert(0 < M && M <= 16);
     using load_vec_t = typename VecTypeTrait<kv_cache_t>::vec_t;
 
     kv_cache_t* __restrict__ curr_b_0 = b_tile;

--- a/csrc/cpu/micro_gemm/cpu_micro_gemm_vec.hpp
+++ b/csrc/cpu/micro_gemm/cpu_micro_gemm_vec.hpp
@@ -39,7 +39,7 @@ class TileGemm82 {
 
   template <int32_t M>
   static void gemm_micro(DEFINE_CPU_MICRO_GEMM_PARAMS) {
-    static_assert(0 < M <= 8);
+    static_assert(0 < M && M <= 8);
     using load_vec_t = typename cpu_utils::VecTypeTrait<scalar_t>::vec_t;
 
     scalar_t* __restrict__ curr_b_0 = b_ptr;


### PR DESCRIPTION
Clang 21 (LLVM PR #128145) promotes chained comparisons like `0 < M <= 8` from warning to hard error (`-Wparentheses`). This breaks the CPU extension build on macOS with Xcode 26+.

Fix by splitting into `0 < M && M <= 8`, matching the existing style in `cpu_attn_neon.hpp` and `cpu_attn_vxe.hpp`.

## References
- [LLVM PR #128145](https://github.com/llvm/llvm-project/pull/128145) — promoted chained comparison diagnostic to default error
- [Clang 21 Release Notes](https://releases.llvm.org/21.1.0/tools/clang/docs/ReleaseNotes.html)
- [vllm-metal#223](https://github.com/vllm-project/vllm-metal/pull/223) — downstream report of this build failure