### PR TITLE
Change `trust_remote_code` default in test runners

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,7 +364,7 @@ class HfRunner:
         dtype: str = "auto",
         *,
         model_kwargs: dict[str, Any] | None = None,
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         is_sentence_transformer: bool = False,
         is_cross_encoder: bool = False,
         skip_tokenizer_init: bool = False,
@@ -396,7 +396,7 @@ class HfRunner:
         dtype: str = "auto",
         *,
         model_kwargs: dict[str, Any] | None = None,
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         is_sentence_transformer: bool = False,
         is_cross_encoder: bool = False,
         skip_tokenizer_init: bool = False,
@@ -815,7 +815,6 @@ class VllmRunner:
     The default value of some arguments have been modified from
     {class}`~vllm.LLM` as follows:
 
-    - `trust_remote_code`: Set to `True` instead of `False` for convenience.
     - `seed`: Set to `0` instead of `None` for test reproducibility.
     - `max_model_len`: Set to `1024` instead of `None` to reduce memory usage.
     - `block_size`: To reduce memory usage, set default to `64` if on XPU
@@ -832,7 +831,7 @@ class VllmRunner:
         convert: ConvertOption = "auto",
         tokenizer_name: str | None = None,
         tokenizer_mode: str = "auto",
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         seed: int = 0,
         max_model_len: int | None = 1024,
         dtype: str = "auto",

--- a/tests/lora/test_default_mm_loras.py
+++ b/tests/lora/test_default_mm_loras.py
@@ -29,6 +29,7 @@ RESPONSE_SUFFIX_WITHOUT_LORA = "Certainly! Here is the transcription of the audi
 
 VLLM_RUNNER_BASE_KWARGS = {
     "model_name": MODEL_PATH,
+    "trust)_remote_code": True,
     "dtype": "half",
     "enable_lora": "True",
     "max_num_seqs": 2,

--- a/tests/lora/test_default_mm_loras.py
+++ b/tests/lora/test_default_mm_loras.py
@@ -29,7 +29,7 @@ RESPONSE_SUFFIX_WITHOUT_LORA = "Certainly! Here is the transcription of the audi
 
 VLLM_RUNNER_BASE_KWARGS = {
     "model_name": MODEL_PATH,
-    "trust)_remote_code": True,
+    "trust_remote_code": True,
     "dtype": "half",
     "enable_lora": "True",
     "max_num_seqs": 2,

--- a/tests/models/language/pooling/test_colbert.py
+++ b/tests/models/language/pooling/test_colbert.py
@@ -45,6 +45,7 @@ COLBERT_MODELS = {
     },
     "jina": {
         "model": "jinaai/jina-colbert-v2",
+        "trust_remote_code": True,
         "colbert_dim": 128,
         "max_model_len": 8192,
         "extra_kwargs": {

--- a/tests/models/language/pooling/test_nomic_max_model_len.py
+++ b/tests/models/language/pooling/test_nomic_max_model_len.py
@@ -24,7 +24,7 @@ max_model_len = int(original_max_position_embeddings * factor)
 @pytest.mark.parametrize("model_info", MODELS)
 def test_default(model_info, vllm_runner):
     with vllm_runner(
-        model_info.name, runner="pooling", max_model_len=None
+        model_info.name, runner="pooling", max_model_len=None, trust_remote_code=True
     ) as vllm_model:
         model_config = vllm_model.llm.llm_engine.model_config
         if model_info.name == "nomic-ai/nomic-embed-text-v2-moe":

--- a/tests/models/language/pooling_mteb_test/mteb_embed_utils.py
+++ b/tests/models/language/pooling_mteb_test/mteb_embed_utils.py
@@ -153,6 +153,7 @@ def mteb_test_embed_models(
         model_info.name,
         runner="pooling",
         max_model_len=model_info.max_model_len,
+        trust_remote_code=model_info.trust_remote_code,
         **vllm_extra_kwargs,
     ) as vllm_model:
         model_config = vllm_model.llm.llm_engine.model_config
@@ -203,6 +204,7 @@ def mteb_test_embed_models(
             model_info.name,
             is_sentence_transformer=True,
             dtype=ci_envs.VLLM_CI_HF_DTYPE or model_info.hf_dtype,
+            trust_remote_code=model_info.trust_remote_code,
         ) as hf_model:
             # e.g. setting default parameters for the encode method of hf_runner
             if hf_model_callback is not None:

--- a/tests/models/language/pooling_mteb_test/test_ernie.py
+++ b/tests/models/language/pooling_mteb_test/test_ernie.py
@@ -22,7 +22,7 @@ MODELS = [
 ]
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -> None:
     mteb_test_embed_models(
         hf_runner,
@@ -32,7 +32,7 @@ def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -
     )
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_correctness(
     hf_runner, vllm_runner, model_info: EmbedModelInfo, example_prompts
 ) -> None:

--- a/tests/models/language/pooling_mteb_test/test_gte.py
+++ b/tests/models/language/pooling_mteb_test/test_gte.py
@@ -42,6 +42,7 @@ MODELS = [
     # So only test one (the most widely used) model
     EmbedModelInfo(
         "Alibaba-NLP/gte-multilingual-base",
+        trust_remote_code=True,
         architecture="GteNewModel",
         mteb_score=0.775074696,
         hf_overrides={"architectures": ["GteNewModel"]},
@@ -53,12 +54,14 @@ MODELS = [
     ),
     EmbedModelInfo(
         "Alibaba-NLP/gte-base-en-v1.5",
+        trust_remote_code=True,
         architecture="GteNewModel",
         hf_overrides={"architectures": ["GteNewModel"]},
         enable_test=False,
     ),
     EmbedModelInfo(
         "Alibaba-NLP/gte-large-en-v1.5",
+        trust_remote_code=True,
         architecture="GteNewModel",
         hf_overrides={"architectures": ["GteNewModel"]},
         enable_test=False,
@@ -66,6 +69,7 @@ MODELS = [
     ########### Qwen2ForCausalLM
     EmbedModelInfo(
         "Alibaba-NLP/gte-Qwen2-1.5B-instruct",
+        trust_remote_code=True,
         mteb_score=0.758473459018872,
         architecture="Qwen2ForCausalLM",
         seq_pooling_type="LAST",
@@ -77,6 +81,7 @@ MODELS = [
     ########## ModernBertModel
     EmbedModelInfo(
         "Alibaba-NLP/gte-modernbert-base",
+        trust_remote_code=True,
         mteb_score=0.748193353,
         architecture="ModernBertModel",
         seq_pooling_type="CLS",
@@ -129,19 +134,21 @@ RERANK_MODELS = [
 ]
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -> None:
     mteb_test_embed_models(hf_runner, vllm_runner, model_info)
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_correctness(
     hf_runner, vllm_runner, model_info: EmbedModelInfo, example_prompts
 ) -> None:
     correctness_test_embed_models(hf_runner, vllm_runner, model_info, example_prompts)
 
 
-@pytest.mark.parametrize("model_info", RERANK_MODELS)
+@pytest.mark.parametrize(
+    "model_info", RERANK_MODELS, ids=lambda model_info: model_info.name
+)
 def test_rerank_models_mteb(vllm_runner, model_info: RerankModelInfo) -> None:
     vllm_extra_kwargs = {}
     if current_platform.is_rocm():

--- a/tests/models/language/pooling_mteb_test/test_intfloat.py
+++ b/tests/models/language/pooling_mteb_test/test_intfloat.py
@@ -48,12 +48,12 @@ MODELS = [
 ]
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -> None:
     mteb_test_embed_models(hf_runner, vllm_runner, model_info)
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_correctness(
     hf_runner, vllm_runner, model_info: EmbedModelInfo, example_prompts
 ) -> None:

--- a/tests/models/language/pooling_mteb_test/test_jina.py
+++ b/tests/models/language/pooling_mteb_test/test_jina.py
@@ -44,7 +44,9 @@ RERANK_MODELS = [
 ]
 
 
-@pytest.mark.parametrize("model_info", EMBEDDING_MODELS)
+@pytest.mark.parametrize(
+    "model_info", EMBEDDING_MODELS, ids=lambda model_info: model_info.name
+)
 def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -> None:
     def hf_model_callback(model):
         model.encode = partial(model.encode, task="text-matching")
@@ -54,7 +56,9 @@ def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -
     )
 
 
-@pytest.mark.parametrize("model_info", EMBEDDING_MODELS)
+@pytest.mark.parametrize(
+    "model_info", EMBEDDING_MODELS, ids=lambda model_info: model_info.name
+)
 def test_embed_models_correctness(
     hf_runner, vllm_runner, model_info: EmbedModelInfo, example_prompts
 ) -> None:
@@ -70,12 +74,16 @@ def test_embed_models_correctness(
     )
 
 
-@pytest.mark.parametrize("model_info", RERANK_MODELS)
+@pytest.mark.parametrize(
+    "model_info", RERANK_MODELS, ids=lambda model_info: model_info.name
+)
 def test_rerank_models_mteb(vllm_runner, model_info: RerankModelInfo) -> None:
     mteb_test_rerank_models(vllm_runner, model_info)
 
 
-@pytest.mark.parametrize("model_info", EMBEDDING_MODELS)
+@pytest.mark.parametrize(
+    "model_info", EMBEDDING_MODELS, ids=lambda model_info: model_info.name
+)
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("dimensions", [16, 32])
 def test_matryoshka(

--- a/tests/models/language/pooling_mteb_test/test_nemotron.py
+++ b/tests/models/language/pooling_mteb_test/test_nemotron.py
@@ -40,11 +40,15 @@ RERANK_MODELS = [
 ]
 
 
-@pytest.mark.parametrize("model_info", EMBEDDING_MODELS)
+@pytest.mark.parametrize(
+    "model_info", EMBEDDING_MODELS, ids=lambda model_info: model_info.name
+)
 def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -> None:
     mteb_test_embed_models(hf_runner, vllm_runner, model_info)
 
 
-@pytest.mark.parametrize("model_info", RERANK_MODELS)
+@pytest.mark.parametrize(
+    "model_info", RERANK_MODELS, ids=lambda model_info: model_info.name
+)
 def test_rerank_models_mteb(vllm_runner, model_info: RerankModelInfo) -> None:
     mteb_test_rerank_models(vllm_runner, model_info)

--- a/tests/models/language/pooling_mteb_test/test_nomic.py
+++ b/tests/models/language/pooling_mteb_test/test_nomic.py
@@ -40,12 +40,12 @@ MODELS = [
 ]
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -> None:
     mteb_test_embed_models(hf_runner, vllm_runner, model_info)
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_correctness(
     hf_runner, vllm_runner, model_info: EmbedModelInfo, example_prompts
 ) -> None:

--- a/tests/models/language/pooling_mteb_test/test_snowflake_arctic_embed.py
+++ b/tests/models/language/pooling_mteb_test/test_snowflake_arctic_embed.py
@@ -85,12 +85,12 @@ MODELS = [
 ]
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -> None:
     mteb_test_embed_models(hf_runner, vllm_runner, model_info)
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_correctness(
     hf_runner, vllm_runner, model_info: EmbedModelInfo, example_prompts
 ) -> None:

--- a/tests/models/language/pooling_mteb_test/test_st_projector.py
+++ b/tests/models/language/pooling_mteb_test/test_st_projector.py
@@ -33,6 +33,8 @@ ST_PROJECTOR_MODELS = [
 ]
 
 
-@pytest.mark.parametrize("model_info", ST_PROJECTOR_MODELS)
+@pytest.mark.parametrize(
+    "model_info", ST_PROJECTOR_MODELS, ids=lambda model_info: model_info.name
+)
 def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -> None:
     mteb_test_embed_models(hf_runner, vllm_runner, model_info)

--- a/tests/models/language/pooling_mteb_test/test_voyage.py
+++ b/tests/models/language/pooling_mteb_test/test_voyage.py
@@ -34,7 +34,7 @@ MODELS = [
 ]
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -> None:
     # Encoder-only attention models need enforce_eager=True to avoid
     # CUDA graph capture issues with piecewise compilation
@@ -43,7 +43,7 @@ def test_embed_models_mteb(hf_runner, vllm_runner, model_info: EmbedModelInfo) -
     )
 
 
-@pytest.mark.parametrize("model_info", MODELS)
+@pytest.mark.parametrize("model_info", MODELS, ids=lambda model_info: model_info.name)
 def test_embed_models_correctness(
     hf_runner, vllm_runner, model_info: EmbedModelInfo, example_prompts
 ) -> None:

--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -179,6 +179,7 @@ VLM_TEST_SETTINGS = {
     ),
     "ultravox": VLMTestInfo(
         models=["fixie-ai/ultravox-v0_5-llama-3_2-1b"],
+        trust_remote_code=True,
         test_type=VLMTestType.AUDIO,
         prompt_formatter=lambda audio_prompt: f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{audio_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n",  # noqa: E501
         audio_idx_to_prompt=lambda idx: "<|audio|>",

--- a/tests/models/multimodal/generation/test_ultravox.py
+++ b/tests/models/multimodal/generation/test_ultravox.py
@@ -152,6 +152,7 @@ def test_models_with_multiple_audios(
         dtype=dtype,
         max_tokens=max_tokens,
         num_logprobs=num_logprobs,
+        trust_remote_code=True,
         **vllm_kwargs,
     )
 

--- a/tests/models/multimodal/generation/vlm_utils/types.py
+++ b/tests/models/multimodal/generation/vlm_utils/types.py
@@ -95,6 +95,7 @@ class VLMTestInfo(NamedTuple):
 
     models: list[str]
     test_type: VLMTestType | Iterable[VLMTestType]
+    trust_remote_code: bool = False
 
     # Should be None only if this is a CUSTOM_INPUTS test
     prompt_formatter: Callable[[str], str] | None = None
@@ -183,6 +184,7 @@ class VLMTestInfo(NamedTuple):
         test cases.
         """
         return {
+            "trust_remote_code": self.trust_remote_code,
             "enforce_eager": self.enforce_eager,
             "max_model_len": self.max_model_len,
             "max_num_seqs": self.max_num_seqs,

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -58,11 +58,11 @@ def check_implementation(
 
 
 @pytest.mark.parametrize(
-    "model,model_impl",
+    "model,model_impl,trust_remote_code",
     [
-        ("meta-llama/Llama-3.2-1B-Instruct", "transformers"),
-        ("hmellor/Ilama-3.2-1B", "auto"),  # CUSTOM CODE
-        ("allenai/OLMoE-1B-7B-0924", "transformers"),  # MoE
+        ("meta-llama/Llama-3.2-1B-Instruct", "transformers", False),
+        ("hmellor/Ilama-3.2-1B", "auto", True),  # CUSTOM CODE
+        ("allenai/OLMoE-1B-7B-0924", "transformers", False),  # MoE
     ],
 )  # trust_remote_code=True by default
 def test_models(
@@ -71,6 +71,7 @@ def test_models(
     example_prompts: list[str],
     model: str,
     model_impl: str,
+    trust_remote_code: bool,
 ) -> None:
     import transformers
     from packaging.version import Version
@@ -84,7 +85,13 @@ def test_models(
         )
 
     check_implementation(
-        hf_runner, vllm_runner, example_prompts, model, model_impl=model_impl
+        hf_runner,
+        vllm_runner,
+        example_prompts,
+        model,
+        model_impl=model_impl,
+        kwargs_ref={"trust_remote_code": trust_remote_code},
+        kwargs_test={"trust_remote_code": trust_remote_code},
     )
 
 

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -375,6 +375,7 @@ def softmax(data):
 @dataclass
 class ModelInfo:
     name: str
+    trust_remote_code: bool = False
     architecture: str = ""
     dtype: str = "auto"
     max_model_len: int | None = None


### PR DESCRIPTION
It is going to become increasingly common for remote code and local code to coexist as remote code models are upstreamed with cleaner and better maintained implementations.

By setting the default to `trust_remote_code=True`, the tests will default to using the remote code even if better local code exists.

This PR flips the default and manually annotates the models that are truly remote code only.