### PR TITLE
[Frontend] Fixed tool parsing errors for MinimaxM2

### DIFF
--- a/tests/tool_parsers/test_minimax_m2_tool_parser.py
+++ b/tests/tool_parsers/test_minimax_m2_tool_parser.py
@@ -198,6 +198,17 @@ class TestToolCallNonStreaming:
                 "template_processor",
                 {"template_content": "<div>content</div>"},
             ),
+            pytest.param(
+                (
+                    "<minimax:tool_call>\n"
+                    '<invoke name="whitespace_test">\n'
+                    '<parameter name = "city">Seattle</parameter>\n'
+                    '<parameter name="date" >2000-01-01</parameter>\n'
+                    "</invoke>\n</minimax:tool_call>"
+                ),
+                "whitespace_test",
+                {"city": "Seattle", "date": "2000-01-01"},
+            ),
         ],
     )
     def test_tool_call(self, parser, model_output, expected_name, expected_args):

--- a/tests/tool_parsers/test_minimax_m2_tool_parser.py
+++ b/tests/tool_parsers/test_minimax_m2_tool_parser.py
@@ -144,6 +144,81 @@ class TestContentStreaming:
 # ---------------------------------------------------------------------------
 
 
+class TestToolCallNonStreaming:
+    @pytest.mark.parametrize(
+        "model_output,expected_name,expected_args",
+        [
+            pytest.param(
+                (
+                    "<minimax:tool_call>\n"
+                    '<invoke name="get_weather">\n'
+                    '<parameter name="city">Seattle</parameter>\n'
+                    '<parameter name="date">2000-01-01</parameter>\n'
+                    "</invoke>\n</minimax:tool_call>"
+                ),
+                "get_weather",
+                {"city": "Seattle", "date": "2000-01-01"},
+            ),
+            pytest.param(
+                (
+                    "<minimax:tool_call>\n"
+                    '<invoke name="template_processor">\n'
+                    '<parameter name="template_content">\n'
+                    "<parameter><name>username</name>"
+                    "<type>string</type></parameter>"
+                    "</parameter>\n"
+                    "</invoke>\n</minimax:tool_call>"
+                ),
+                "template_processor",
+                {
+                    "template_content": (
+                        "<parameter><name>username</name>"
+                        "<type>string</type></parameter>"
+                    )
+                },
+            ),
+            pytest.param(
+                (
+                    "<minimax:tool_call>\n"
+                    '<invoke name="judge">\n'
+                    '<parameter name="threshold>100">false</parameter>\n'
+                    "</invoke>\n</minimax:tool_call>"
+                ),
+                "judge",
+                {"threshold>100": "false"},
+            ),
+            pytest.param(
+                (
+                    "<minimax:tool_call>\n"
+                    '<invoke name="template_processor">\n'
+                    '<parameter name="template_content">\n'
+                    "<div>content</div></parameter>\n"
+                    "</invoke>\n</minimax:tool_call>"
+                ),
+                "template_processor",
+                {"template_content": "<div>content</div>"},
+            ),
+        ],
+    )
+    def test_tool_call(self, parser, model_output, expected_name, expected_args):
+        result = parser.extract_tool_calls(
+            model_output=model_output,
+            request=None,
+        )
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+
+        tc = result.tool_calls[0]
+        assert tc.id is not None
+
+        assert tc.function.name == expected_name, (
+            f"expect {expected_name}, got {tc.function.name}"
+        )
+        got_args = json.loads(tc.function.arguments)
+        assert got_args == expected_args, f"expect {expected_args}, got {got_args}"
+
+
 class TestSingleInvoke:
     """Tests for a single <invoke> block."""
 
@@ -152,10 +227,10 @@ class TestSingleInvoke:
         results = _feed(
             parser,
             [
-                "<minimax:tool_call>",
-                '<invoke name="get_weather">',
-                '<parameter name="city">Seattle</parameter>',
-                "</invoke></minimax:tool_call>",
+                "<minimax:tool_call>\n",
+                '<invoke name="get_weather">\n',
+                '<parameter name="city">Seattle</parameter>\n',
+                "</invoke>\n</minimax:tool_call>",
             ],
         )
         tc = _collect_tool_calls(results)
@@ -169,9 +244,10 @@ class TestSingleInvoke:
         results = _feed(
             parser,
             [
-                '<minimax:tool_call><invoke name="get_weather">'
-                '<parameter name="city">Seattle</parameter>'
-                "</invoke></minimax:tool_call>",
+                "<minimax:tool_call>\n"
+                '<invoke name="get_weather">\n'
+                '<parameter name="city">Seattle</parameter>\n'
+                "</invoke>\n</minimax:tool_call>",
             ],
         )
         tc = _collect_tool_calls(results)
@@ -183,11 +259,11 @@ class TestSingleInvoke:
         results = _feed(
             parser,
             [
-                "<minimax:tool_call>",
-                '<invoke name="get_weather">',
-                '<parameter name="city">Seattle</parameter>',
-                '<parameter name="days">5</parameter>',
-                "</invoke></minimax:tool_call>",
+                "<minimax:tool_call>\n",
+                '<invoke name="get_weather">\n',
+                '<parameter name="city">Seattle</parameter>\n',
+                '<parameter name="days">5</parameter>\n',
+                "</invoke>\n</minimax:tool_call>",
             ],
         )
         tc = _collect_tool_calls(results)
@@ -205,13 +281,13 @@ class TestMultipleInvokes:
         results = _feed(
             parser,
             [
-                "<minimax:tool_call>",
-                '<invoke name="search_web">'
-                '<parameter name="query">OpenAI</parameter>'
-                "</invoke>",
-                '<invoke name="search_web">'
-                '<parameter name="query">Gemini</parameter>'
-                "</invoke>",
+                "<minimax:tool_call>\n",
+                '<invoke name="search_web">\n'
+                '<parameter name="query">OpenAI</parameter>\n'
+                "</invoke>\n",
+                '<invoke name="search_web">\n'
+                '<parameter name="query">Gemini</parameter>\n'
+                "</invoke>\n",
                 "</minimax:tool_call>",
             ],
         )
@@ -227,9 +303,9 @@ class TestMultipleInvokes:
         results = _feed(
             parser,
             [
-                "<minimax:tool_call>",
-                '<invoke name="fn_a"><parameter name="x">1</parameter></invoke>'
-                '<invoke name="fn_b"><parameter name="y">2</parameter></invoke>',
+                "<minimax:tool_call>\n",
+                '<invoke name="fn_a">\n<parameter name="x">1</parameter>\n</invoke>\n',
+                '<invoke name="fn_b">\n<parameter name="y">2</parameter>\n</invoke>\n',
                 "</minimax:tool_call>",
             ],
         )
@@ -243,13 +319,13 @@ class TestMultipleInvokes:
         results = _feed(
             parser,
             [
-                "<minimax:tool_call>",
-                '<invoke name="get_weather">'
-                '<parameter name="city">NYC</parameter>'
-                "</invoke>",
-                '<invoke name="get_stock">'
-                '<parameter name="ticker">AAPL</parameter>'
-                "</invoke>",
+                "<minimax:tool_call>\n",
+                '<invoke name="get_weather">\n'
+                '<parameter name="city">NYC</parameter>\n'
+                "</invoke>\n",
+                '<invoke name="get_stock">\n'
+                '<parameter name="ticker">AAPL</parameter>\n'
+                "</invoke>\n",
                 "</minimax:tool_call>",
             ],
         )
@@ -270,9 +346,10 @@ class TestInternalState:
         _feed(
             parser,
             [
-                '<minimax:tool_call><invoke name="fn">'
-                '<parameter name="a">1</parameter>'
-                "</invoke></minimax:tool_call>",
+                "<minimax:tool_call>\n"
+                '<invoke name="fn">\n'
+                '<parameter name="a">1</parameter>\n'
+                "</invoke>\n</minimax:tool_call>",
             ],
         )
         assert len(parser.prev_tool_call_arr) == 1
@@ -284,9 +361,13 @@ class TestInternalState:
         _feed(
             parser,
             [
-                "<minimax:tool_call>",
-                '<invoke name="search"><parameter name="q">hello</parameter></invoke>',
-                '<invoke name="search"><parameter name="q">world</parameter></invoke>',
+                "<minimax:tool_call>\n"
+                '<invoke name="search">\n'
+                '<parameter name="q">hello</parameter>\n'
+                "</invoke>\n",
+                '<invoke name="search">\n'
+                '<parameter name="q">world</parameter>\n'
+                "</invoke>\n",
                 "</minimax:tool_call>",
             ],
         )
@@ -310,9 +391,10 @@ class TestDeltaMessageFormat:
         results = _feed(
             parser,
             [
-                '<minimax:tool_call><invoke name="fn">'
-                '<parameter name="k">v</parameter>'
-                "</invoke></minimax:tool_call>",
+                "<minimax:tool_call>\n"
+                '<invoke name="fn">\n'
+                '<parameter name="k">v</parameter>\n'
+                "</invoke>\n</minimax:tool_call>",
             ],
         )
         tc_deltas = [tc for r in results for tc in (r.tool_calls or [])]
@@ -329,9 +411,11 @@ class TestDeltaMessageFormat:
         results = _feed(
             parser,
             [
-                "<minimax:tool_call>",
-                '<invoke name="a"><parameter name="x">1</parameter></invoke>',
-                '<invoke name="b"><parameter name="x">2</parameter></invoke>',
+                "<minimax:tool_call>\n"
+                '<invoke name="a">\n'
+                '<parameter name="x">1</parameter>\n'
+                "</invoke>\n",
+                '<invoke name="b">\n<parameter name="x">2</parameter>\n</invoke>\n',
                 "</minimax:tool_call>",
             ],
         )
@@ -353,8 +437,10 @@ class TestEOSHandling:
         results = _feed(
             parser,
             [
-                "<minimax:tool_call>",
-                '<invoke name="fn"><parameter name="k">v</parameter></invoke>',
+                "<minimax:tool_call>\n"
+                '<invoke name="fn">\n'
+                '<parameter name="k">v</parameter>\n'
+                "</invoke>\n"
                 "</minimax:tool_call>",
                 # EOS: empty delta_text, non-special token id
                 ("", [EOS_ID]),
@@ -368,8 +454,11 @@ class TestEOSHandling:
         results = _feed(
             parser,
             [
-                "<minimax:tool_call>",
-                '<invoke name="fn"><parameter name="k">v</parameter></invoke>',
+                "<minimax:tool_call>\n"
+                '<invoke name="fn">\n'
+                '<parameter name="k">v</parameter>\n'
+                "</invoke>\n"
+                "</minimax:tool_call>",
                 # </minimax:tool_call> arrives as special token
                 ("", [TC_END_ID]),
             ],
@@ -416,11 +505,11 @@ class TestLargeChunks:
 
     def test_header_and_params_in_separate_chunks(self, parser):
         """Header in chunk 1, all params + close in chunk 2, then EOS."""
-        chunk1 = '<minimax:tool_call><invoke name="get_weather">'
+        chunk1 = '<minimax:tool_call>\n<invoke name="get_weather">\n'
         chunk2 = (
-            '<parameter name="city">Seattle</parameter>'
-            '<parameter name="days">5</parameter>'
-            "</invoke></minimax:tool_call>"
+            '<parameter name="city">Seattle</parameter>\n'
+            '<parameter name="days">5</parameter>\n'
+            "</invoke>\n</minimax:tool_call>"
         )
 
         results = _feed(

--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -50,6 +50,13 @@ class MinimaxM2ToolParser(ToolParser):
         self.invoke_complete_regex = re.compile(
             r"<invoke name=(.*?)</invoke>", re.DOTALL
         )
+        self.parameter_tag_pattern = re.compile(
+            r"<parameter\s+name\s*=\s*"  # Allow whitespace around =
+            r'(?:"([^"]*)"|'  # double quotes (group 1)
+            r"'([^']*)'|"  # single quotes (group 2)
+            r"([^\s>]+))"  # unquoted (group 3)
+            r"\s*>"
+        )
 
         if not self.model_tokenizer:
             raise ValueError(
@@ -99,14 +106,18 @@ class MinimaxM2ToolParser(ToolParser):
         """
         results: list[tuple[str, str]] = []
 
-        param_tag_pattern = re.compile(r"<parameter\s+name=([\"'])(.*?)\1>")
-        param_tag_matches = list(param_tag_pattern.finditer(invoke_str))
+        param_tag_matches = list(self.parameter_tag_pattern.finditer(invoke_str))
 
         if not param_tag_matches:
             return results
 
         for current_param_idx, current_match in enumerate(param_tag_matches):
-            param_name = current_match.group(2)
+            # Extract name from one of the three capture groups
+            param_name = (
+                current_match.group(1)
+                or current_match.group(2)
+                or current_match.group(3)
+            )
             param_value_start_pos = current_match.end()
 
             if current_param_idx + 1 < len(param_tag_matches):
@@ -114,8 +125,11 @@ class MinimaxM2ToolParser(ToolParser):
             else:
                 next_param_start_pos = len(invoke_str)
 
-            text_before_next_param = invoke_str[:next_param_start_pos]
-            closing_tag_pos = text_before_next_param.rfind("</parameter>")
+            # Search for </parameter> only within the current parameter's range
+            # to avoid incorrectly matching a previous parameter's closing tag
+            closing_tag_pos = invoke_str.rfind(
+                "</parameter>", param_value_start_pos, next_param_start_pos
+            )
 
             if closing_tag_pos == -1:
                 continue

--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -50,9 +50,6 @@ class MinimaxM2ToolParser(ToolParser):
         self.invoke_complete_regex = re.compile(
             r"<invoke name=(.*?)</invoke>", re.DOTALL
         )
-        self.parameter_complete_regex = re.compile(
-            r"<parameter name=(.*?)</parameter>", re.DOTALL
-        )
 
         if not self.model_tokenizer:
             raise ValueError(
@@ -85,6 +82,48 @@ class MinimaxM2ToolParser(ToolParser):
         ):
             return name_str[1:-1]
         return name_str
+
+    def _extract_parameters(self, invoke_str: str) -> list[tuple[str, str]]:
+        """
+        Extract parameters from an invoke string using positional matching.
+
+        Key insight: a parameter's value ends at the LAST '</parameter>' that appears
+        BEFORE the next parameter starts (or before the string ends if no next param).
+        This correctly handles cases where the parameter value itself contains
+        '</parameter>' as a literal string.
+
+        Can't works great with nested <parameter name="">, but it works for most cases.
+
+        Returns:
+            List of (param_name, param_value) tuples.
+        """
+        results: list[tuple[str, str]] = []
+
+        param_tag_pattern = re.compile(r"<parameter\s+name=([\"'])(.*?)\1>")
+        param_tag_matches = list(param_tag_pattern.finditer(invoke_str))
+
+        if not param_tag_matches:
+            return results
+
+        for current_param_idx, current_match in enumerate(param_tag_matches):
+            param_name = current_match.group(2)
+            param_value_start_pos = current_match.end()
+
+            if current_param_idx + 1 < len(param_tag_matches):
+                next_param_start_pos = param_tag_matches[current_param_idx + 1].start()
+            else:
+                next_param_start_pos = len(invoke_str)
+
+            text_before_next_param = invoke_str[:next_param_start_pos]
+            closing_tag_pos = text_before_next_param.rfind("</parameter>")
+
+            if closing_tag_pos == -1:
+                continue
+
+            param_value = invoke_str[param_value_start_pos:closing_tag_pos]
+            results.append((param_name, param_value))
+
+        return results
 
     def _extract_types_from_schema(self, schema: Any) -> list[str]:
         """
@@ -267,21 +306,16 @@ class MinimaxM2ToolParser(ToolParser):
                         param_config = params["properties"]
                     break
 
-        # Extract parameters
+        # Extract parameters using the new positional matching method
         param_dict = {}
-        for match in self.parameter_complete_regex.findall(invoke_str):
-            param_match = re.search(r"^([^>]+)>(.*)", match, re.DOTALL)
-            if param_match:
-                param_name = self._extract_name(param_match.group(1))
-                param_value = param_match.group(2).strip()
+        for param_name, param_value in self._extract_parameters(invoke_str):
+            # Get parameter types (supports anyOf/oneOf/allOf)
+            param_type = self._get_param_types_from_config(param_name, param_config)
 
-                # Get parameter types (supports anyOf/oneOf/allOf)
-                param_type = self._get_param_types_from_config(param_name, param_config)
-
-                # Convert value
-                param_dict[param_name] = self._convert_param_value_with_types(
-                    param_value, param_type
-                )
+            # Convert value
+            param_dict[param_name] = self._convert_param_value_with_types(
+                param_value.strip(), param_type
+            )
 
         return ToolCall(
             type="function",


### PR DESCRIPTION
## Purpose

In production environments, certain tool call responses were not being parsed correctly. The root cause was that the regular expression used for parameter extraction failed to handle some edge cases.

This PR addresses two specific issues:
1. When generating XML, if a parameter value contains a `</parameter>` tag, the parser fails to extract it correctly.
2. Parsing also fails when a parameter key contains a greater-than sign (`>`).

To resolve these issues, I have replaced the regex‑based parameter extraction with a straightforward function.

>  **Why not use a stack:**
> Although a stack could technically parse nested `<parameter>` tags, correctly handling various edge cases would be overly complex. Since we have not encountered such nesting in actual requests, a direct extraction function is sufficient for current needs. To aid future maintainers, I have documented this trade‑off in the function comments.

## Test Plan

```bash
# Run tool parser tests
.venv/bin/python -m pytest tests/tool_parsers/test_minimax_m2_tool_parser.py -v
```

## Test Results

Before
```
====================================== short test summary info ======================================
FAILED tests/tool_parsers/test_minimax_m2_tool_parser.py::TestToolCallNonStreaming::test_tool_call[<minimax:tool_call><invoke name="template_processor"><parameter name="template_content"><parameter><name>username</name><type>string</type></parameter></parameter></invoke></minimax:tool_call>-template_processor-expected_args1] - AssertionError: expect {'template_content': '<parameter><name>username</name><type>string</type>...
FAILED tests/tool_parsers/test_minimax_m2_tool_parser.py::TestToolCallNonStreaming::test_tool_call[<minimax:tool_call><invoke name="judge"><parameter name="threshold>100">false</parameter></invoke></minimax:tool_call>-judge-expected_args2] - AssertionError: expect {'threshold>100': 'false'}, got {'"threshold': '100">false'}
============================= 2 failed, 19 passed, 3 warnings in 4.80s ==============================
```