### PR TITLE
Fix sarvam forward compatibility with transformers v5

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import asdict
-from functools import cache, partial
+from functools import cache, partial, wraps
 from importlib.metadata import version
 from pathlib import Path
 from typing import Any, Literal, TypeAlias
@@ -121,6 +121,8 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
 
 _SPECULATIVE_DECODING_CONFIGS: set[str] = {"eagle", "speculators"}
 
+_PATCH_HF_VALIDATE_ROPE: set[str] = {"sarvam_mla"}
+
 _CONFIG_ATTRS_MAPPING: dict[str, str] = {
     "llm_config": "text_config",
 }
@@ -152,6 +154,25 @@ def _mistral_patch_hf_hub_constants() -> Iterator[None]:
         constants.SAFETENSORS_SINGLE_FILE = hf_safetensors_single_file
         constants.SAFETENSORS_INDEX_FILE = hf_safetensors_index_file
 
+def _patch_hf_transformers_validate_rope():
+    """Transformers v5 moved the ignore_keys option from the method signature of validate rope 
+    and replaced it with the ignore_keys_at_rope_validation paramter in the PreTrainedConfig class
+    This is a patch to make older versions of validate_rope() with the ignore_keys parameter work with 
+    newer versions of hf transformers (from v5 onnwards)
+    """
+
+    if Version(version("transformers")) >= Version("5.0.0"):
+        _original_validate_rope = PretrainedConfig.validate_rope
+
+        @wraps(_original_validate_rope)
+        def patched_validate_rope(self, *args, **kwargs):
+            ignore_keys_param = kwargs.pop("ignore_keys", None)
+            original_ignore_keys = self.ignore_keys_at_rope_validation
+            self.ignore_keys_at_rope_validation = original_ignore_keys or ignore_keys_param
+            result =  _original_validate_rope(self, *args, **kwargs)
+            return result
+        
+        PretrainedConfig.validate_rope = patched_validate_rope
 
 class HFConfigParser(ConfigParserBase):
     def parse(
@@ -191,6 +212,9 @@ class HFConfigParser(ConfigParserBase):
                 dummy_config = PretrainedConfig(**dummy_kwargs)
                 dummy_model_type = hf_overrides(dummy_config).model_type
                 model_type = dummy_model_type.removeprefix("dummy_")
+        
+        if model_type in _PATCH_HF_VALIDATE_ROPE:
+            _patch_hf_transformers_validate_rope()
 
         if model_type in _SPECULATIVE_DECODING_CONFIGS:
             config_class = _CONFIG_REGISTRY[model_type]

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -162,6 +162,9 @@ def _patch_hf_transformers_validate_rope():
     """
 
     if Version(version("transformers")) >= Version("5.0.0"):
+        if hasattr(PretrainedConfig.validate_rope, "__vllm_patched__"):
+            return
+        
         _original_validate_rope = PretrainedConfig.validate_rope
 
         @wraps(_original_validate_rope)
@@ -172,6 +175,7 @@ def _patch_hf_transformers_validate_rope():
             result =  _original_validate_rope(self, *args, **kwargs)
             return result
         
+        patched_validate_rope.__vllm_patched__ = True
         PretrainedConfig.validate_rope = patched_validate_rope
 
 class HFConfigParser(ConfigParserBase):

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -156,9 +156,9 @@ def _mistral_patch_hf_hub_constants() -> Iterator[None]:
 
 def _patch_hf_transformers_validate_rope():
     """Transformers v5 moved the ignore_keys option from the method signature of validate rope 
-    and replaced it with the ignore_keys_at_rope_validation paramter in the PreTrainedConfig class
+    and replaced it with the ignore_keys_at_rope_validation parameter in the PreTrainedConfig class
     This is a patch to make older versions of validate_rope() with the ignore_keys parameter work with 
-    newer versions of hf transformers (from v5 onnwards)
+    newer versions of hf transformers (from v5 onwards)
     """
 
     if Version(version("transformers")) >= Version("5.0.0"):

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -154,29 +154,34 @@ def _mistral_patch_hf_hub_constants() -> Iterator[None]:
         constants.SAFETENSORS_SINGLE_FILE = hf_safetensors_single_file
         constants.SAFETENSORS_INDEX_FILE = hf_safetensors_index_file
 
+
 def _patch_hf_transformers_validate_rope():
-    """Transformers v5 moved the ignore_keys option from the method signature of validate rope 
-    and replaced it with the ignore_keys_at_rope_validation parameter in the PreTrainedConfig class
-    This is a patch to make older versions of validate_rope() with the ignore_keys parameter work with 
-    newer versions of hf transformers (from v5 onwards)
+    """Transformers v5 moved the ignore_keys option from the method signature of
+    validate_rope and replaced it with the ignore_keys_at_rope_validation parameter
+    in the PreTrainedConfig class. This is a patch to make older versions of
+    validate_rope() with the ignore_keys parameter work with newer versions of
+    hf transformers (from v5 onwards)
     """
 
     if Version(version("transformers")) >= Version("5.0.0"):
         if hasattr(PretrainedConfig.validate_rope, "__vllm_patched__"):
             return
-        
+
         _original_validate_rope = PretrainedConfig.validate_rope
 
         @wraps(_original_validate_rope)
         def patched_validate_rope(self, *args, **kwargs):
             ignore_keys_param = kwargs.pop("ignore_keys", None)
             original_ignore_keys = self.ignore_keys_at_rope_validation
-            self.ignore_keys_at_rope_validation = original_ignore_keys or ignore_keys_param
-            result =  _original_validate_rope(self, *args, **kwargs)
+            self.ignore_keys_at_rope_validation = (
+                original_ignore_keys or ignore_keys_param
+            )
+            result = _original_validate_rope(self, *args, **kwargs)
             return result
-        
-        patched_validate_rope.__vllm_patched__ = True
+
+        patched_validate_rope.__vllm_patched__ = True  # type: ignore[attr-defined]
         PretrainedConfig.validate_rope = patched_validate_rope
+
 
 class HFConfigParser(ConfigParserBase):
     def parse(
@@ -216,7 +221,7 @@ class HFConfigParser(ConfigParserBase):
                 dummy_config = PretrainedConfig(**dummy_kwargs)
                 dummy_model_type = hf_overrides(dummy_config).model_type
                 model_type = dummy_model_type.removeprefix("dummy_")
-        
+
         if model_type in _PATCH_HF_VALIDATE_ROPE:
             _patch_hf_transformers_validate_rope()
 


### PR DESCRIPTION

This PR fixes issue #38734. 

### Root cause 
sarvam_mla has a custom [PretrainedConfig](https://huggingface.co/sarvamai/sarvam-105b/blob/main/configuration_sarvam_moe.py) that is incompatible with transformers v5 as the ignore_keys parameter which was supported in previous versions of transformers was removed from the validate_rope() method. This was replaced with a class var in PretrainedConfig `ignore_keys_at_rope_validation`.
https://github.com/huggingface/transformers/pull/41250

The problematic line is at line 134 in the sarvam config file:
```python
self.validate_rope(ignore_keys=ignore_keys_at_rope_validation)
```

This PR adds a patch that essentially replaces the above code with:
```python
self.ignore_keys_at_rope_validation = ignore_keys_at_rope_validation
self.validate_rope()
```

I chose to use a patch instead of a custom config to ensure easier maintainability.

## Purpose
The below test fails when the transformers package is upgraded to v5 . Fixing the test would allow sarvam-105b to be fully compatible with transformers v5.

## Test Plan

Setup the environment by following the instructions in the issue 
```
git clone https://github.com/huggingface/transformers.git
git clone https://github.com/vllm-project/vllm.git

cd vllm
VLLM_USE_PRECOMPILED=1 uv pip install -e .
uv pip install -e ../transformers
```

The code was tested on transformers v5.5.0dev compiled and downloaded from source.

Post which I ran the below test before and after the fix
```
pytest tests/models/test_initialization.py::test_can_initialize_large_subset[SarvamMLAForCausalLM]
```

## Test Result

### Before:
```
../transformers/src/transformers/configuration_utils.py:267: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   self.validate_rope(ignore_keys=ignore_keys_at_rope_validation)
    ^^^^^^^^^^^^^^^^^
E   TypeError: RotaryEmbeddingConfigMixin.validate_rope() got an unexpected keyword argument 'ignore_keys'


../.hf_home/modules/transformers_modules/sarvamai/sarvam_hyphen_105b/fb187764dbad56ed8b26742a802909e858e9bb72/configuration_sarvam_moe.py:133: TypeError
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../vllm_venv/lib/python3.11/site-packages/torch/jit/_script.py:362: 14 warnings
  /workspace/vllm_venv/lib/python3.11/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/models/test_initialization.py::test_can_initialize_large_subset[SarvamMLAForCausalLM]
======================== 1 failed, 16 warnings in 2.96s ========================
```

### After:
```
sarvamai/sarvam-105b...
(EngineCore pid=28601) INFO 04-02 10:36:12 [cuda.py:362] Using TRITON_MLA attention backend out of potential backends: ['TRITON_MLA'].
(EngineCore pid=28601) INFO 04-02 10:36:12 [mla_attention.py:2151] Using FlashAttention prefill for MLA
(EngineCore pid=28601) INFO 04-02 10:36:12 [unquantized.py:283] Using TRITON Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', 'FlashInfer CUTLASS', 'TRITON', 'BATCHED_TRITON'].
(EngineCore pid=28601) WARNING 04-02 10:36:12 [vllm.py:1839] `torch.compile` is turned on, but the model sarvamai/sarvam-105b does not support it. Please open an issue on GitHub if you want it to be supported.
(EngineCore pid=28601) INFO 04-02 10:36:12 [unquantized.py:340] Using MoEPrepareAndFinalizeNoDPEPModular
(EngineCore pid=28601) INFO 04-02 10:36:12 [gpu_model_runner.py:4818] Model loading took 4.46 GiB memory and 0.516870 seconds
(EngineCore pid=28601) INFO 04-02 10:36:12 [kv_cache_utils.py:1319] GPU KV cache size: 9,320,672 tokens
(EngineCore pid=28601) INFO 04-02 10:36:12 [kv_cache_utils.py:1324] Maximum concurrency for 4,096 tokens per request: 2275.55x
(EngineCore pid=28601) INFO 04-02 10:36:14 [kernel.py:196] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(EngineCore pid=28601) INFO 04-02 10:36:14 [core.py:1210] Shutdown initiated (timeout=0)
(EngineCore pid=28601) INFO 04-02 10:36:14 [core.py:1233] Shutdown complete
.

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../vllm_venv/lib/python3.11/site-packages/torch/jit/_script.py:362: 14 warnings
  /workspace/vllm_venv/lib/python3.11/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 1 passed, 16 warnings in 11.56s ========================
```

Truncated the output files as the stack trace was large.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

