### PR TITLE
[vLLM IR] add `import_ir_kernels()` to support OOT platforms

### DIFF
--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -68,13 +68,10 @@ class IrOpPriorityConfig:
     def set_priority(self):
         """
         Context manager to set the IR op priority for all op members.
-        It also imports IR kernel implementations for the current platform
-        to ensure all implementations are made available.
+        Kernel implementations must already be registered before calling this
+        (via KernelConfig.set_platform_defaults).
         """
         from vllm.ir.op import IrOp
-        from vllm.platforms import current_platform
-
-        current_platform.import_ir_kernels()
 
         with contextlib.ExitStack() as stack:
             for field in fields(self):
@@ -176,6 +173,10 @@ class KernelConfig:
     def set_platform_defaults(self, vllm_config: "VllmConfig") -> None:
         """Set platform-specific defaults for the kernel config."""
         from vllm.platforms import current_platform
+
+        # Import IR kernels here so that IrOp.registry is fully populated
+        # before compute_hash() or set_priority() are called.
+        current_platform.import_ir_kernels()
 
         platform_op_priority = current_platform.get_default_ir_op_priority(vllm_config)
         logger.debug(

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -68,10 +68,13 @@ class IrOpPriorityConfig:
     def set_priority(self):
         """
         Context manager to set the IR op priority for all op members.
-        Kernel implementations must already be registered before calling this
-        (via KernelConfig.set_platform_defaults).
+        It also imports IR kernel implementations for the current platform
+        to ensure all implementations are made available.
         """
         from vllm.ir.op import IrOp
+        from vllm.platforms import current_platform
+
+        current_platform.import_ir_kernels()
 
         with contextlib.ExitStack() as stack:
             for field in fields(self):
@@ -173,10 +176,6 @@ class KernelConfig:
     def set_platform_defaults(self, vllm_config: "VllmConfig") -> None:
         """Set platform-specific defaults for the kernel config."""
         from vllm.platforms import current_platform
-
-        # Import IR kernels here so that IrOp.registry is fully populated
-        # before compute_hash() or set_priority() are called.
-        current_platform.import_ir_kernels()
 
         platform_op_priority = current_platform.get_default_ir_op_priority(vllm_config)
         logger.debug(

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -68,10 +68,13 @@ class IrOpPriorityConfig:
     def set_priority(self):
         """
         Context manager to set the IR op priority for all op members.
-        It also imports vllm.kernels to ensure all implementations are made available.
+        It also imports IR kernel implementations for the current platform
+        to ensure all implementations are made available.
         """
-        import vllm.kernels  # noqa: F401, registers IR op implementations
         from vllm.ir.op import IrOp
+        from vllm.platforms import current_platform
+
+        current_platform.import_ir_kernels()
 
         with contextlib.ExitStack() as stack:
             for field in fields(self):

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -207,6 +207,8 @@ class Platform:
         """
         return cls.simple_compile_backend
 
+    _ir_kernels_imported: bool = False
+
     @classmethod
     def import_ir_kernels(cls) -> None:
         """
@@ -214,7 +216,11 @@ class Platform:
         the built-in IR op implementations. Out-of-tree (OOT) platforms should
         override this method to import their own kernel modules.
         """
+        if cls._ir_kernels_imported:
+            return
         import vllm.kernels  # noqa: F401
+
+        cls._ir_kernels_imported = True
 
     @classmethod
     def device_id_to_physical_device_id(cls, device_id: int):

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -208,6 +208,15 @@ class Platform:
         return cls.simple_compile_backend
 
     @classmethod
+    def import_ir_kernels(cls) -> None:
+        """
+        The default implementation imports ``vllm.kernels``, which registers
+        the built-in IR op implementations. Out-of-tree (OOT) platforms should
+        override this method to import their own kernel modules.
+        """
+        import vllm.kernels  # noqa: F401
+
+    @classmethod
     def device_id_to_physical_device_id(cls, device_id: int):
         # Treat empty device control env var as unset. This is a valid
         # configuration in Ray setups where the engine is launched in

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -207,8 +207,6 @@ class Platform:
         """
         return cls.simple_compile_backend
 
-    _ir_kernels_imported: bool = False
-
     @classmethod
     def import_ir_kernels(cls) -> None:
         """
@@ -216,11 +214,7 @@ class Platform:
         the built-in IR op implementations. Out-of-tree (OOT) platforms should
         override this method to import their own kernel modules.
         """
-        if cls._ir_kernels_imported:
-            return
         import vllm.kernels  # noqa: F401
-
-        cls._ir_kernels_imported = True
 
     @classmethod
     def device_id_to_physical_device_id(cls, device_id: int):


### PR DESCRIPTION
## Purpose
Extract IR kernel registration from `IrOpPriorityConfig.set_priority()` into a new `Platform.import_ir_kernels()` classmethod. The default implementation imports `vllm.kernels` to preserve existing behavior. OOT platforms can override it to register their own IR op implementations.

RFC: https://github.com/vllm-project/vllm/issues/36459


## Test Plan
local test passed on A100.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

