### PR TITLE
Fix/p2p request id mismatch

### DIFF
--- a/tests/entrypoints/openai/completion/test_completion.py
+++ b/tests/entrypoints/openai/completion/test_completion.py
@@ -10,6 +10,7 @@ from openai import BadRequestError
 
 from tests.utils import RemoteOpenAIServer
 from vllm.tokenizers import get_tokenizer
+from vllm.utils.request_id import normalize_request_id
 
 # any model with a chat template should work here
 MODEL_NAME = "facebook/opt-125m"
@@ -71,6 +72,30 @@ async def test_single_completion(client: openai.AsyncOpenAI, model_name: str) ->
     )
     assert len(completion.choices[0].text) >= 1
     assert completion.choices[0].prompt_logprobs is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [MODEL_NAME],
+)
+async def test_completion_response_id_preserves_public_id(
+    client: openai.AsyncOpenAI, model_name: str
+) -> None:
+    transport_request_id = (
+        "___prefill_addr_10.0.0.1:31000___decode_addr_10.0.0.2:32000_deadbeef"
+    )
+
+    completion = await client.completions.create(
+        model=model_name,
+        prompt="Hello, my name is",
+        max_tokens=1,
+        temperature=0.0,
+        extra_headers={"X-Request-Id": transport_request_id},
+    )
+
+    assert completion.id == f"cmpl-{transport_request_id}"
+    assert normalize_request_id(completion.id) == transport_request_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,0 +1,40 @@
+import pytest
+
+from vllm.utils.request_id import normalize_request_id
+
+
+TRANSPORT_REQUEST_ID = (
+    "___prefill_addr_10.0.0.1:31000___decode_addr_10.0.0.2:32000_deadbeef"
+)
+
+
+@pytest.mark.parametrize(
+    ("request_id", "expected"),
+    [
+        (
+            f"cmpl-{TRANSPORT_REQUEST_ID}-0-a1b2c3d4",
+            TRANSPORT_REQUEST_ID,
+        ),
+        (
+            f"chatcmpl-{TRANSPORT_REQUEST_ID}-a1b2c3d4",
+            TRANSPORT_REQUEST_ID,
+        ),
+        (
+            f"generate-tokens-{TRANSPORT_REQUEST_ID}-a1b2c3d4",
+            TRANSPORT_REQUEST_ID,
+        ),
+        (TRANSPORT_REQUEST_ID, TRANSPORT_REQUEST_ID),
+        (
+            f"chatcmpl-{TRANSPORT_REQUEST_ID}_1-a1b2c3d4",
+            TRANSPORT_REQUEST_ID,
+        ),
+        ("cmpl-not-a-transport-id-0-a1b2c3d4", "cmpl-not-a-transport-id-0-a1b2c3d4"),
+        (
+            "cmpl-___prefill_addr_10.0.0.1:31000___decode_addr_10.0.0.2:32000_-0-a1b2c3d4",
+            "cmpl-___prefill_addr_10.0.0.1:31000___decode_addr_10.0.0.2:32000_-0-a1b2c3d4",
+        ),
+    ],
+)
+def test_normalize_request_id(request_id: str, expected: str) -> None:
+    assert normalize_request_id(request_id) == expected
+    assert normalize_request_id(normalize_request_id(request_id)) == expected

--- a/tests/v1/kv_connector/unit/test_p2p_request_id_normalization.py
+++ b/tests/v1/kv_connector/unit/test_p2p_request_id_normalization.py
@@ -1,0 +1,124 @@
+import threading
+from types import SimpleNamespace
+
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_connector import (
+    P2pNcclConnector,
+    P2pNcclConnectorMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_engine import (
+    P2pNcclEngine,
+)
+from vllm.utils.request_id import normalize_request_id
+
+TRANSPORT_REQUEST_ID = (
+    "___prefill_addr_10.0.0.1:31000___decode_addr_10.0.0.2:32000_deadbeef"
+)
+RAW_REQUEST_ID = f"cmpl-{TRANSPORT_REQUEST_ID}-0-a1b2c3d4"
+NORMALIZED_REQUEST_ID = normalize_request_id(RAW_REQUEST_ID)
+
+
+class FakeP2pNcclEngine:
+    def __init__(self, recv_tensor: torch.Tensor):
+        self._recv_tensor = recv_tensor
+        self.recv_calls: list[tuple[str, str]] = []
+        self.send_calls: list[tuple[str, torch.Tensor, str]] = []
+
+    def recv_tensor(self, tensor_id: str, remote_address: str) -> torch.Tensor:
+        self.recv_calls.append((tensor_id, remote_address))
+        return self._recv_tensor.clone()
+
+    def send_tensor(
+        self, tensor_id: str, tensor: torch.Tensor, remote_address: str
+    ) -> bool:
+        self.send_calls.append((tensor_id, tensor.clone(), remote_address))
+        return True
+
+
+def _make_metadata(request_id: str) -> P2pNcclConnectorMetadata:
+    metadata = P2pNcclConnectorMetadata()
+    metadata.add_request(
+        request_id=request_id,
+        token_ids=[1, 2, 3],
+        block_ids=[0],
+        block_size=16,
+    )
+    return metadata
+
+
+def test_start_load_kv_uses_normalized_tensor_id() -> None:
+    recv_tensor = torch.arange(4, dtype=torch.float32).reshape(1, 2, 2)
+    fake_engine = FakeP2pNcclEngine(recv_tensor)
+    connector = object.__new__(P2pNcclConnector)
+    connector.is_producer = False
+    connector.p2p_nccl_engine = fake_engine
+    connector._rank = 0
+    connector._get_connector_metadata = lambda: _make_metadata(RAW_REQUEST_ID)
+
+    layer = SimpleNamespace(kv_cache=torch.zeros_like(recv_tensor))
+    forward_context = SimpleNamespace(
+        attn_metadata=object(),
+        no_compile_layers={"layer0": layer},
+    )
+
+    connector.start_load_kv(forward_context)
+
+    assert fake_engine.recv_calls == [
+        (f"{NORMALIZED_REQUEST_ID}#layer0", "10.0.0.1:31000")
+    ]
+    assert torch.equal(layer.kv_cache, recv_tensor)
+
+
+def test_save_kv_layer_uses_normalized_tensor_id() -> None:
+    kv_layer = torch.arange(4, dtype=torch.float32).reshape(1, 2, 2)
+    fake_engine = FakeP2pNcclEngine(kv_layer)
+    connector = object.__new__(P2pNcclConnector)
+    connector.is_producer = True
+    connector.p2p_nccl_engine = fake_engine
+    connector._rank = 0
+    connector._get_connector_metadata = lambda: _make_metadata(RAW_REQUEST_ID)
+
+    connector.save_kv_layer(
+        layer_name="layer0",
+        kv_layer=kv_layer,
+        attn_metadata=object(),
+    )
+
+    assert len(fake_engine.send_calls) == 1
+    tensor_id, tensor, remote_address = fake_engine.send_calls[0]
+    assert tensor_id == f"{NORMALIZED_REQUEST_ID}#layer0"
+    assert remote_address == "10.0.0.2:32000"
+    assert torch.equal(tensor, kv_layer)
+
+
+def test_get_finished_cleans_up_normalized_request_state() -> None:
+    engine = object.__new__(P2pNcclEngine)
+    engine.recv_store_cv = threading.Condition()
+    engine.send_store_cv = threading.Condition()
+    engine.pool = SimpleNamespace(free=lambda *_args, **_kwargs: None)
+    engine.send_type = "GET"
+
+    normalized_tensor_id = f"{NORMALIZED_REQUEST_ID}#layer0"
+    send_tensor = torch.ones(2, dtype=torch.float32)
+
+    engine.recv_store = {normalized_tensor_id: torch.ones(1, dtype=torch.float32)}
+    engine.send_store = {normalized_tensor_id: send_tensor}
+    engine.recv_request_id_to_tensor_ids = {NORMALIZED_REQUEST_ID: {normalized_tensor_id}}
+    engine.send_request_id_to_tensor_ids = {NORMALIZED_REQUEST_ID: {normalized_tensor_id}}
+    engine.buffer_size = send_tensor.element_size() * send_tensor.numel()
+
+    engine.have_sent_tensor_id(f"{RAW_REQUEST_ID}#layer1")
+    engine.have_received_tensor_id(f"{RAW_REQUEST_ID}#layer1")
+
+    assert NORMALIZED_REQUEST_ID in engine.send_request_id_to_tensor_ids
+    assert NORMALIZED_REQUEST_ID in engine.recv_request_id_to_tensor_ids
+
+    finished = engine.get_finished({RAW_REQUEST_ID}, ["layer0"])
+
+    assert finished == (None, None)
+    assert normalized_tensor_id not in engine.recv_store
+    assert normalized_tensor_id not in engine.send_store
+    assert NORMALIZED_REQUEST_ID not in engine.recv_request_id_to_tensor_ids
+    assert NORMALIZED_REQUEST_ID not in engine.send_request_id_to_tensor_ids
+    assert engine.buffer_size == 0

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -19,6 +19,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_engine import (
 from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
+from vllm.utils.request_id import normalize_request_id
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -201,8 +202,22 @@ class P2pNcclConnector(KVConnectorBase_V1):
 
         # Load the KV for each request each layer
         for request in metadata.requests:
-            request_id = request.request_id
-            ip, port = self.parse_request_id(request_id, False)
+            raw_request_id = request.request_id
+            normalized_request_id = normalize_request_id(raw_request_id)
+            logger.debug(
+                "Request ID normalized: raw=%s normalized=%s",
+                raw_request_id,
+                normalized_request_id,
+            )
+            try:
+                ip, port = self.parse_request_id(normalized_request_id, False)
+            except ValueError:
+                logger.warning(
+                    "Failed to parse request ID for KV load: raw=%s normalized=%s",
+                    raw_request_id,
+                    normalized_request_id,
+                )
+                continue
             remote_address = ip + ":" + str(port + self._rank)
             for layer_name in forward_context.no_compile_layers:
                 layer = forward_context.no_compile_layers[layer_name]
@@ -216,16 +231,33 @@ class P2pNcclConnector(KVConnectorBase_V1):
 
                 layer = kv_cache
 
-                kv_cache = self.p2p_nccl_engine.recv_tensor(
-                    request.request_id + "#" + layer_name, remote_address
+                tensor_id = normalized_request_id + "#" + layer_name
+                logger.debug(
+                    "Loading KV tensor: raw_request_id=%s normalized_request_id=%s "
+                    "tensor_id=%s layer_name=%s remote_address=%s",
+                    raw_request_id,
+                    normalized_request_id,
+                    tensor_id,
+                    layer_name,
+                    remote_address,
                 )
+                kv_cache = self.p2p_nccl_engine.recv_tensor(tensor_id, remote_address)
 
                 if kv_cache is None:
-                    logger.warning("🚧kv_cache is None, %s", request.request_id)
+                    logger.warning(
+                        "KV cache miss during load: raw_request_id=%s "
+                        "normalized_request_id=%s tensor_id=%s layer_name=%s "
+                        "remote_address=%s",
+                        raw_request_id,
+                        normalized_request_id,
+                        tensor_id,
+                        layer_name,
+                        remote_address,
+                    )
                     continue
 
                 inject_kv_into_layer(
-                    layer, kv_cache, request.block_ids, request.request_id
+                    layer, kv_cache, request.block_ids, raw_request_id
                 )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -297,13 +329,47 @@ class P2pNcclConnector(KVConnectorBase_V1):
         connector_metadata = self._get_connector_metadata()
         assert isinstance(connector_metadata, P2pNcclConnectorMetadata)
         for request in connector_metadata.requests:
-            request_id = request.request_id
-            ip, port = self.parse_request_id(request_id, True)
+            raw_request_id = request.request_id
+            normalized_request_id = normalize_request_id(raw_request_id)
+            logger.debug(
+                "Request ID normalized: raw=%s normalized=%s",
+                raw_request_id,
+                normalized_request_id,
+            )
+            try:
+                ip, port = self.parse_request_id(normalized_request_id, True)
+            except ValueError:
+                logger.warning(
+                    "Failed to parse request ID for KV save: raw=%s normalized=%s",
+                    raw_request_id,
+                    normalized_request_id,
+                )
+                continue
             remote_address = ip + ":" + str(port + self._rank)
 
             kv_cache = extract_kv_from_layer(kv_layer, request.block_ids)
+            if kv_cache is None:
+                logger.warning(
+                    "Skipping KV tensor send for unsupported layout: "
+                    "raw_request_id=%s normalized_request_id=%s layer_name=%s",
+                    raw_request_id,
+                    normalized_request_id,
+                    layer_name,
+                )
+                continue
+
+            tensor_id = normalized_request_id + "#" + layer_name
+            logger.debug(
+                "Saving KV tensor: raw_request_id=%s normalized_request_id=%s "
+                "tensor_id=%s layer_name=%s remote_address=%s",
+                raw_request_id,
+                normalized_request_id,
+                tensor_id,
+                layer_name,
+                remote_address,
+            )
             self.p2p_nccl_engine.send_tensor(
-                request_id + "#" + layer_name, kv_cache, remote_address
+                tensor_id, kv_cache, remote_address
             )
 
     def wait_for_save(self):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -26,12 +26,14 @@ from vllm.distributed.device_communicators.pynccl_wrapper import (
 from vllm.distributed.kv_transfer.kv_connector.v1.p2p.tensor_memory_pool import (  # noqa: E501
     TensorMemoryPool,
 )
+from vllm.utils.request_id import normalize_request_id
 from vllm.utils.network_utils import get_ip
 from vllm.utils.torch_utils import current_stream
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_MEM_POOL_SIZE_GB = 32
+RECV_TENSOR_WAIT_LOG_INTERVAL_S = 5.0
 
 
 @contextmanager
@@ -312,9 +314,25 @@ class P2pNcclEngine:
     ) -> torch.Tensor:
         if self.send_type == "PUT" or self.send_type == "PUT_ASYNC":
             start_time = time.time()
+            last_wait_log_time = start_time
             with self.recv_store_cv:
                 while tensor_id not in self.recv_store:
-                    self.recv_store_cv.wait()
+                    self.recv_store_cv.wait(timeout=RECV_TENSOR_WAIT_LOG_INTERVAL_S)
+                    now = time.time()
+                    if tensor_id not in self.recv_store and (
+                        now - last_wait_log_time
+                    ) >= RECV_TENSOR_WAIT_LOG_INTERVAL_S:
+                        logger.warning(
+                            "Still waiting for KV tensor: tensor_id=%s "
+                            "remote_address=%s rank=%d elapsed_ms=%.3f "
+                            "buffered_tensors=%d",
+                            tensor_id,
+                            remote_address,
+                            self.rank,
+                            (now - start_time) * 1000,
+                            len(self.recv_store),
+                        )
+                        last_wait_log_time = now
                 tensor = self.recv_store[tensor_id]
 
             if tensor is not None:
@@ -323,6 +341,13 @@ class P2pNcclEngine:
                     tensor = self.pool.load_tensor(addr, dtype, shape, self.device)
                 else:
                     self.buffer_size -= tensor.element_size() * tensor.numel()
+                logger.debug(
+                    "KV tensor received from store: tensor_id=%s remote_address=%s "
+                    "rank=%d",
+                    tensor_id,
+                    remote_address,
+                    self.rank,
+                )
             else:
                 duration = time.time() - start_time
                 logger.warning(
@@ -462,13 +487,13 @@ class P2pNcclEngine:
                 )
 
     def have_sent_tensor_id(self, tensor_id: str):
-        request_id = tensor_id.split("#")[0]
+        request_id = self._request_id_from_tensor_id(tensor_id)
         if request_id not in self.send_request_id_to_tensor_ids:
             self.send_request_id_to_tensor_ids[request_id] = set()
         self.send_request_id_to_tensor_ids[request_id].add(tensor_id)
 
     def have_received_tensor_id(self, tensor_id: str):
-        request_id = tensor_id.split("#")[0]
+        request_id = self._request_id_from_tensor_id(tensor_id)
         if request_id not in self.recv_request_id_to_tensor_ids:
             self.recv_request_id_to_tensor_ids[request_id] = set()
         self.recv_request_id_to_tensor_ids[request_id].add(tensor_id)
@@ -552,17 +577,29 @@ class P2pNcclEngine:
         """
 
         # Clear the buffer upon request completion.
-        for request_id in finished_req_ids:
+        for raw_request_id in finished_req_ids:
+            request_id = normalize_request_id(raw_request_id)
+            logger.debug(
+                "Cleaning up finished request tensors: raw_request_id=%s "
+                "normalized_request_id=%s",
+                raw_request_id,
+                request_id,
+            )
+            self._cleanup_send_store(request_id)
+            tensor_ids = self.recv_request_id_to_tensor_ids.pop(request_id, set())
+            if not tensor_ids:
+                tensor_ids = {
+                    request_id + "#" + layer_name for layer_name in no_compile_layers
+                }
             for layer_name in no_compile_layers:
-                tensor_id = request_id + "#" + layer_name
-                if tensor_id in self.recv_store:
-                    with self.recv_store_cv:
-                        tensor = self.recv_store.pop(tensor_id, None)
-                        self.send_request_id_to_tensor_ids.pop(request_id, None)
-                        self.recv_request_id_to_tensor_ids.pop(request_id, None)
-                    if isinstance(tensor, tuple):
-                        addr, _, _ = tensor
-                        self.pool.free(addr)
+                tensor_ids.add(request_id + "#" + layer_name)
+            for tensor_id in tensor_ids:
+                with self.recv_store_cv:
+                    tensor = self.recv_store.pop(tensor_id, None)
+                if isinstance(tensor, tuple):
+                    addr, _, _ = tensor
+                    self.pool.free(addr)
+            self.send_request_id_to_tensor_ids.pop(request_id, None)
 
         # TODO:Retrieve requests that have already sent the KV cache.
         finished_sending: set[str] = set()
@@ -571,6 +608,25 @@ class P2pNcclEngine:
         finished_recving: set[str] = set()
 
         return finished_sending or None, finished_recving or None
+
+    @staticmethod
+    def _request_id_from_tensor_id(tensor_id: str) -> str:
+        request_id, _, _ = tensor_id.partition("#")
+        return normalize_request_id(request_id)
+
+    def _cleanup_send_store(self, request_id: str) -> None:
+        if not hasattr(self, "send_store"):
+            return
+
+        tensor_ids = self.send_request_id_to_tensor_ids.pop(request_id, set())
+        if not tensor_ids:
+            return
+
+        with self.send_store_cv:
+            for tensor_id in tensor_ids:
+                tensor = self.send_store.pop(tensor_id, None)
+                if tensor is not None:
+                    self.buffer_size -= tensor.element_size() * tensor.numel()
 
     def ping(self):
         sock = self.context.socket(zmq.DEALER)

--- a/vllm/utils/request_id.py
+++ b/vllm/utils/request_id.py
@@ -1,0 +1,56 @@
+"""Helpers for working with transport-scoped request IDs."""
+
+from functools import lru_cache
+
+_PUBLIC_ID_PREFIXES = (
+    "cmpl-",
+    "chatcmpl-",
+    "generate-tokens-",
+)
+_TRANSPORT_PREFIX = "___prefill_addr_"
+_DECODE_PREFIX = "___decode_addr_"
+
+
+@lru_cache(maxsize=4096)
+def normalize_request_id(request_id: str) -> str:
+    """Return a transport-stable request ID for KV connector lookups.
+
+    The disaggregated prefill proxy injects a transport-aware request ID:
+
+        ___prefill_addr_<host:port>___decode_addr_<host:port>_<hash>
+
+    API layers may wrap that value with a public prefix such as ``cmpl-`` or
+    ``chatcmpl-``, and the engine may append an internal suffix (for example
+    ``-<idx>-<rand>`` or ``-<rand>``). This helper strips those wrappers while
+    leaving unrelated or malformed request IDs unchanged.
+    """
+    if not request_id:
+        return request_id
+
+    candidate = request_id
+    for prefix in _PUBLIC_ID_PREFIXES:
+        if candidate.startswith(prefix):
+            candidate = candidate[len(prefix) :]
+            break
+
+    transport_start = candidate.find(_TRANSPORT_PREFIX)
+    if transport_start == -1:
+        return request_id
+
+    candidate = candidate[transport_start:]
+    decode_start = candidate.find(_DECODE_PREFIX)
+    if decode_start == -1:
+        return request_id
+
+    hash_sep = candidate.find("_", decode_start + len(_DECODE_PREFIX))
+    if hash_sep == -1 or hash_sep == len(candidate) - 1:
+        return request_id
+
+    transport_end = hash_sep + 1
+    while transport_end < len(candidate) and candidate[transport_end].isalnum():
+        transport_end += 1
+
+    if transport_end == hash_sep + 1:
+        return request_id
+
+    return candidate[:transport_end]


### PR DESCRIPTION


## Purpose

Fix a disaggregated prefill hang caused by inconsistent `request_id` usage across the OpenAI-compatible API layer and the P2P NCCL KV transfer path.

### Root cause

In the disaggregated prefill flow, the same `request_id` string was being used for three different purposes:

1. Public API-facing request ID
2. Engine-local request/scheduler ID
3. Cross-node KV transport key

The OpenAI-compatible serving layer wraps IDs such as:

- `___prefill_addr_<ip:port>___decode_addr_<ip:port>_<hash>`

into values like:

- `cmpl-___prefill_addr_<...>___decode_addr_<...>_<hash>-0-<suffix>`
- `chatcmpl-___prefill_addr_<...>___decode_addr_<...>_<hash>-0-<suffix>`

and the engine may append additional local uniqueness suffixes.

This caused the prefill node and decode node to use different raw `request_id` values for the same request. `parse_request_id()` could still extract the remote address, but tensor lookup used exact `tensor_id = request_id + "#" + layer_name`, so the KV cache could not be found during decode. In `GET` mode this resulted in cache misses; in `PUT` / `PUT_ASYNC` flows it could lead to indefinite waiting with no clear signal about the mismatch.

### What this PR changes

This PR adds a short-term, production-safe normalization layer for transport request IDs without changing public OpenAI-compatible response IDs.

#### Main changes

- Add `vllm/utils/request_id.py` with `normalize_request_id(request_id: str) -> str`
- Normalize request IDs at KV send / recv / cleanup boundaries
- Ensure tensor IDs are constructed from the normalized transport ID:
  - `tensor_id = normalized_request_id + "#" + layer_name`
- Add defensive normalization in request-to-tensor bookkeeping
- Improve observability with debug/warning logs for:
  - request ID normalization
  - KV send/recv activity
  - parse failures
  - KV cache misses
  - long waits for missing tensors
- Add regression tests covering normalization, connector behavior, cleanup, and preservation of public API-facing IDs

### Scope

This PR intentionally keeps the fix narrowly scoped and backward compatible.

It does **not** change public API behavior. OpenAI-compatible response IDs such as `cmpl-*` and `chatcmpl-*` remain unchanged.

A larger architectural follow-up would be to introduce a dedicated immutable `transport_req_id` and fully separate transport identity from API-facing and engine-local request IDs. That is out of scope for this patch.

## Test Plan

### Static / local verification

```bash
python -m compileall \
  vllm/utils/request_id.py \
  vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py \
  vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py \
  tests/test_request_id.py \
  tests/v1/kv_connector/unit/test_p2p_request_id_normalization.py \
  tests/entrypoints/openai/completion/test_completion.py
