### PR TITLE
[Transformers v5] Fix Tarsier2Config text_config nesting (#38736)

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -219,28 +219,22 @@ class HFConfigParser(ConfigParserBase):
                 **kwargs,
             )
         else:
+            kwargs = _maybe_update_auto_config_kwargs(kwargs, model_type=model_type)
             if model_type in _CONFIG_REGISTRY:
-                # Register the config class to AutoConfig to ensure it's used
-                # in future calls to `from_pretrained` (e.g. from
-                # AutoTokenizer or AutoProcessor).
+                # Bypass model_type mismatch in config.json by loading via config_class.
                 config_class = _CONFIG_REGISTRY[model_type]
                 config_class.model_type = model_type
                 AutoConfig.register(model_type, config_class, exist_ok=True)
-                # If the on-disk model_type differs from the overridden
-                # one, register under both so AutoConfig.from_pretrained
-                # returns the correct class regardless of what the
-                # checkpoint says
+                # Also register the on-disk model_type for AutoTokenizer/AutoProcessor.
                 if (
                     config_model_type := config_dict.get("model_type")
                 ) and config_model_type != model_type:
-                    config_class.model_type = config_model_type
                     AutoConfig.register(config_model_type, config_class, exist_ok=True)
-                    config_class.model_type = model_type
-                # Now that it is registered, it is not considered remote code anymore
-                trust_remote_code = False
+                loader, trust_remote_code = config_class, False
+            else:
+                loader = AutoConfig
             try:
-                kwargs = _maybe_update_auto_config_kwargs(kwargs, model_type=model_type)
-                config = AutoConfig.from_pretrained(
+                config = loader.from_pretrained(
                     model,
                     trust_remote_code=trust_remote_code,
                     revision=revision,
@@ -252,16 +246,14 @@ class HFConfigParser(ConfigParserBase):
                     not trust_remote_code
                     and "requires you to execute the configuration file" in str(e)
                 ):
-                    err_msg = (
+                    raise RuntimeError(
                         "Failed to load the model config. If the model "
                         "is a custom model not yet available in the "
                         "HuggingFace transformers library, consider setting "
                         "`trust_remote_code=True` in LLM or using the "
                         "`--trust-remote-code` flag in the CLI."
-                    )
-                    raise RuntimeError(err_msg) from e
-                else:
-                    raise e
+                    ) from e
+                raise
         config = _maybe_remap_hf_config_attrs(config)
         return config_dict, config
 
@@ -716,7 +708,7 @@ def get_config(
         except Exception as e:
             error_message = (
                 "Invalid repository ID or local directory specified:"
-                " '{model}'.\nPlease verify the following requirements:\n"
+                f" '{model}'.\nPlease verify the following requirements:\n"
                 "1. Provide a valid Hugging Face repository ID.\n"
                 "2. Specify a local directory that contains a recognized "
                 "configuration file.\n"
@@ -724,7 +716,7 @@ def get_config(
                 "'config.json'.\n"
                 "   - For Mistral models: ensure the presence of a "
                 "'params.json'.\n"
-            ).format(model=model)
+            )
 
             raise ValueError(error_message) from e
 

--- a/vllm/transformers_utils/configs/tarsier2.py
+++ b/vllm/transformers_utils/configs/tarsier2.py
@@ -5,20 +5,20 @@ from transformers import Qwen2VLConfig
 
 class Tarsier2Config(Qwen2VLConfig):
     """
-    Tarsier2's config.json is written such that AutoConfig.from_pretrained will create
-    a deeply nested config consisting of:
+    Config class for Tarsier2 models.
 
-    - LlavaConfig
-      - Qwen2VLConfig
-        - Qwen2VLTextConfig
-        - Qwen2VLVisionConfig
-      - Qwen2VLConfig
-        - Qwen2VLTextConfig
-        - Qwen2VLVisionConfig
+    Tarsier2's config.json reports ``model_type: "llava"``, which causes
+    ``AutoConfig.from_pretrained`` to instantiate ``LlavaConfig`` instead of
+    ``Qwen2VLConfig``. ``LlavaConfig.get_text_config()`` returns a
+    ``Qwen2VLConfig`` sub-object that does not expose ``num_attention_heads``
+    directly (it is delegated to the inner ``Qwen2VLTextConfig``), triggering
+    the ``ValueError`` in ``get_hf_text_config``.
 
-    When it should really just be a single Qwen2VLConfig.
-
-    This class is a hack to stop AutoConfig from creating the nested config structure.
+    Registering this subclass and loading via ``config_class.from_pretrained``
+    (see ``HFConfigParser.parse``) bypasses the ``model_type`` mismatch.
+    ``Qwen2VLConfig.__post_init__`` then correctly converts the flat
+    ``text_config`` dict into a ``Qwen2VLTextConfig`` with all fields intact
+    (``num_attention_heads=28``, ``hidden_size=3584``, etc.).
     """
 
     model_type = "tarsier2"


### PR DESCRIPTION
## Summary

Tarsier2's `config.json` reports `model_type: "llava"`, so `AutoConfig.from_pretrained` instantiates `LlavaConfig` instead of `Qwen2VLConfig`. `LlavaConfig.get_text_config()` returns a `Qwen2VLConfig` sub-object where `num_attention_heads` is on the inner `Qwen2VLTextConfig`, not the outer object, so `hasattr(text_cfg, "num_attention_heads")` is `False` and `get_hf_text_config` raises `ValueError`.

**Root cause:** `AutoConfig.from_pretrained` reads `model_type` from config.json and ignores the registered `Tarsier2Config`. Registering a custom config class is not sufficient when the file reports a different `model_type`.

**Fix:**

1. **`HFConfigParser.parse` (`config.py`):** When `model_type in _CONFIG_REGISTRY`, call `config_class.from_pretrained` directly instead of routing through `AutoConfig.from_pretrained`. The registered class is used regardless of what `model_type` config.json reports.

2. **`Tarsier2Config` (`tarsier2.py`):** Simplified the docstring. The `__post_init__` override was dead code: the `text_config` dict in config.json is flat, so the unwrap condition never fired. `Qwen2VLConfig.__post_init__` converts the flat dict into `Qwen2VLTextConfig` with all fields intact (`num_attention_heads=28`, `hidden_size=3584`, etc.).

## Duplicate Check

No open or merged PRs address #38736. Checked before opening:

```bash
gh pr list --repo vllm-project/vllm --state open --search "Tarsier2"
gh pr list --repo vllm-project/vllm --state open --search "text_config nesting"
gh pr list --repo vllm-project/vllm --state open --search "38736"
```

## Test Plan

```python
from vllm.transformers_utils.config import HFConfigParser
_, cfg = HFConfigParser().parse("omni-research/Tarsier2-Recap-7b", trust_remote_code=False)
assert type(cfg).__name__ == "Tarsier2Config"
assert type(cfg.get_text_config()).__name__ == "Qwen2VLTextConfig"
assert cfg.get_text_config().num_attention_heads == 28
```

All assertions passed.

## Checklist

- [x] Format: `ruff check` / `ruff format` pass
- [x] No new dependencies introduced

AI assistance was used in developing this fix.

Fixes #38736