### PR TITLE
[Model] support Gemma 4

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -46,6 +46,8 @@ If the printed type starts with `Transformers...` then it's using the Transforme
 
 If a model has a vLLM implementation but you would prefer to use the Transformers implementation via the Transformers modeling backend, set `model_impl="transformers"` for [offline inference](../serving/offline_inference.md) or `--model-impl transformers` for the [online serving](../serving/openai_compatible_server.md).
 
+Recent multimodal architectures such as `google/gemma-4-31B-it` and `google/gemma-4-26B-A4B-it` are served through this backend rather than a native vLLM model implementation, and require `transformers>=5.5.0`.
+
 !!! note
     For vision-language models, if you are loading with `dtype="auto"`, vLLM loads the whole model with config's `dtype` if it exists. In contrast the native Transformers will respect the `dtype` attribute of each backbone in the model. That might cause a slight difference in performance.
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.56.0, < 5
+transformers >= 4.56.0, < 5.6, !=5.0.*, !=5.1.*, !=5.2.*, !=5.3.*, !=5.4.*
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -39,8 +39,8 @@ opencv-python-headless >= 4.13.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.11 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test
-transformers==4.57.5
-tokenizers==0.22.0
+transformers==5.5.0
+tokenizers==0.22.2
 schemathesis>=3.39.15 # Required for openai schema test.
 # quantization
 bitsandbytes==0.49.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -244,7 +244,6 @@ filelock==3.16.1
     #   huggingface-hub
     #   ray
     #   torch
-    #   transformers
     #   virtualenv
 fiona==1.10.1
     # via torchgeo
@@ -327,7 +326,7 @@ h5py==3.13.0
     # via terratorch
 harfile==0.3.0
     # via schemathesis
-hf-xet==1.1.7
+hf-xet==1.4.3
     # via huggingface-hub
 hiredis==3.0.0
     # via tensorizer
@@ -341,9 +340,10 @@ httpx==0.27.2
     # via
     #   -r requirements/test.in
     #   diffusers
+    #   huggingface-hub
     #   perceptron
     #   schemathesis
-huggingface-hub==0.36.2
+huggingface-hub==1.8.0
     # via
     #   accelerate
     #   datasets
@@ -977,7 +977,7 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.9.11
+regex==2026.3.32
     # via
     #   diffusers
     #   nltk
@@ -997,7 +997,6 @@ requests==2.32.3
     #   google-api-core
     #   google-cloud-storage
     #   gpt-oss
-    #   huggingface-hub
     #   lightly
     #   lm-eval
     #   mistral-common
@@ -1010,7 +1009,6 @@ requests==2.32.3
     #   starlette-testclient
     #   tacoreader
     #   tiktoken
-    #   transformers
     #   wandb
 resampy==0.4.3
     # via -r requirements/test.in
@@ -1211,7 +1209,7 @@ timm==1.0.17
     #   segmentation-models-pytorch
     #   terratorch
     #   torchgeo
-tokenizers==0.22.0
+tokenizers==0.22.2
     # via
     #   -c requirements/common.txt
     #   -r requirements/test.in
@@ -1288,7 +1286,7 @@ tqdm==4.67.3
     #   tacoreader
     #   terratorch
     #   transformers
-transformers==4.57.5
+transformers==5.5.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test.in
@@ -1310,7 +1308,9 @@ typepy==1.3.2
 typer==0.15.2
     # via
     #   fastsafetensors
+    #   huggingface-hub
     #   perceptron
+    #   transformers
 types-python-dateutil==2.9.0.20241206
     # via arrow
 typeshed-client==2.8.2

--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import transformers
+from packaging.version import Version
+
+from vllm.multimodal import MULTIMODAL_REGISTRY
+
+from ....conftest import ImageTestAssets
+from ...utils import build_model_context
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+GEMMA4_MIN_TRANSFORMERS_VERSION = Version("5.5.0")
+GEMMA4_REQUIRED_SYMBOLS = (
+    "Gemma4Config",
+    "Gemma4ForConditionalGeneration",
+    "Gemma4Processor",
+)
+GEMMA4_MODELS = [
+    (
+        "google/gemma-4-31B-it",
+        "TransformersMultiModalForCausalLM",
+    ),
+    (
+        "google/gemma-4-26B-A4B-it",
+        "TransformersMultiModalMoEForCausalLM",
+    ),
+]
+
+
+def _check_gemma4_transformers_version() -> None:
+    installed = Version(Version(transformers.__version__).base_version)
+    if installed < GEMMA4_MIN_TRANSFORMERS_VERSION:
+        pytest.skip(
+            "Gemma 4 requires transformers "
+            f">={GEMMA4_MIN_TRANSFORMERS_VERSION}, got {installed}"
+        )
+
+    missing_symbols = [
+        name for name in GEMMA4_REQUIRED_SYMBOLS if not hasattr(transformers, name)
+    ]
+    if missing_symbols:
+        pytest.skip(
+            "Installed transformers build does not expose Gemma 4 classes: "
+            + ", ".join(missing_symbols)
+        )
+
+
+@pytest.mark.parametrize(("model_id", "expected_arch"), GEMMA4_MODELS)
+def test_gemma4_uses_transformers_backend(
+    model_id: str,
+    expected_arch: str,
+) -> None:
+    _check_gemma4_transformers_version()
+
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 1},
+    )
+
+    assert ctx.model_config.architecture == expected_arch
+    assert ctx.model_config.using_transformers_backend()
+
+
+@pytest.mark.parametrize("model_id", [model_id for model_id, _ in GEMMA4_MODELS])
+def test_gemma4_processor_emits_image_placeholders(
+    image_assets: ImageTestAssets,
+    model_id: str,
+) -> None:
+    _check_gemma4_transformers_version()
+
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+    hf_processor = processor.info.get_hf_processor()
+
+    processed_inputs = processor(
+        hf_processor.image_token,
+        mm_items=processor.info.parse_mm_data({"image": [image_assets[0].pil_image]}),
+        hf_processor_mm_kwargs={},
+    )
+
+    image_token_id = processor.info.get_tokenizer().convert_tokens_to_ids(
+        hf_processor.image_token
+    )
+    image_token_count = processed_inputs["prompt_token_ids"].count(image_token_id)
+
+    assert image_token_count > 0
+    assert "image" in processed_inputs["mm_placeholders"]
+    assert processed_inputs["mm_placeholders"]["image"][0].length == image_token_count

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1334,12 +1334,17 @@ _TRANSFORMERS_BACKEND_MODELS = {
     "TransformersForCausalLM": _HfExamplesInfo(
         "hmellor/Ilama-3.2-1B", trust_remote_code=True
     ),
-    "TransformersMultiModalForCausalLM": _HfExamplesInfo("BAAI/Emu3-Chat-hf"),
+    "TransformersMultiModalForCausalLM": _HfExamplesInfo(
+        "BAAI/Emu3-Chat-hf",
+        extras={"gemma4-31b-it": "google/gemma-4-31B-it"},
+    ),
     "TransformersMoEForCausalLM": _HfExamplesInfo(
         "allenai/OLMoE-1B-7B-0924", min_transformers_version="5.0.0"
     ),
     "TransformersMultiModalMoEForCausalLM": _HfExamplesInfo(
-        "Qwen/Qwen3-VL-30B-A3B-Instruct", min_transformers_version="5.0.0"
+        "Qwen/Qwen3-VL-30B-A3B-Instruct",
+        extras={"gemma4-26b-a4b-it": "google/gemma-4-26B-A4B-it"},
+        min_transformers_version="5.0.0",
     ),
     "TransformersMoEEmbeddingModel": _HfExamplesInfo(
         "Qwen/Qwen3-30B-A3B", min_transformers_version="5.0.0"


### PR DESCRIPTION
## Summary
- enable `google/gemma-4-31B-it` and `google/gemma-4-26B-A4B-it` through vLLM's existing Transformers multimodal/MoE backend path
- widen vLLM's Transformers dependency range to admit the first Gemma4-capable stable release line and update test pins accordingly
- add focused regression tests and docs for the Gemma 4 backend path

## Scope
- this PR does **not** add a native Gemma 4 vLLM implementation
- this PR enables Gemma 4 through the existing Transformers backend
- scope is **image-input serving** for the two validated models above

## Why this is needed
- stable `transformers==4.57.5` cannot load Gemma 4 even with `trust_remote_code=True`
- official `transformers==5.5.0` can load Gemma 4 configs directly
- current vLLM runtime already resolves these models correctly once a Gemma4-capable Transformers build is installed

## Duplicate-work check
- searched open PRs/issues for `gemma 4`, `gemma-4`, `gemma-4-31b-it`, and `gemma-4-26b-a4b-it`
- found no open PR or issue specifically enabling serving support for these two models in vLLM

## Tests
- `.venv/bin/python -m pytest tests/models/multimodal/processing/test_gemma4.py -q`
- `.venv/bin/python - <<'PY' ... AutoConfig.from_pretrained('google/gemma-4-31B-it') ... PY`
  - verified `transformers==4.57.5` fails even with `trust_remote_code=True`
  - verified `transformers==5.5.0` succeeds
- `.venv/bin/python - <<'PY' ... ModelConfig(model=...) ... PY`
  - verified
    - `google/gemma-4-31B-it` -> `TransformersMultiModalForCausalLM`
    - `google/gemma-4-26B-A4B-it` -> `TransformersMultiModalMoEForCausalLM`
- `.venv/bin/pre-commit run --files requirements/common.txt requirements/test.in requirements/test.txt tests/models/multimodal/processing/test_gemma4.py tests/models/registry.py docs/models/supported_models.md`

## AI assistance
This PR was prepared with AI assistance. I reviewed the duplicate-work check, dependency/runtime reasoning, code changes, and local verification results before updating the PR.