### PR TITLE
[ROCm] pad intermediate size for certain unquantized moe model gemma4 to use aiter fused moe for alignment 

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -4,7 +4,9 @@
 from enum import Enum
 
 import torch
+import torch.nn.functional as F
 from torch.nn import Module
+from torch.nn.parameter import Parameter
 
 import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
@@ -290,6 +292,60 @@ def select_unquantized_moe_backend(
     )
 
 
+def _maybe_pad_intermediate_for_aiter(
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    moe_config: "FusedMoEConfig",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pad the MoE intermediate dimension to a multiple of 128 for AITER
+    CK GEMM compatibility. Some models (e.g.
+    expert_intermediate_size=704) have intermediate sizes not aligned to
+    CK's device_gemm tile requirements, causing runtime errors like
+    'device_gemm does not support this GEMM problem'.
+
+    Zero-padding is mathematically safe: the extra w1 outputs are zero
+    (from zero-padded weights), activation(0)*0=0 for gated activations
+    (SiLU/GELU), and the extra w2 input columns are also zero.
+    """
+    AITER_MOE_ALIGN = 128
+    inter = w2_weight.shape[-1]  # intermediate_size_per_partition
+    padded_inter = ((inter + AITER_MOE_ALIGN - 1) // AITER_MOE_ALIGN) * AITER_MOE_ALIGN
+    if padded_inter == inter:
+        return w13_weight, w2_weight
+
+    pad_amount = padded_inter - inter
+    logger.info_once(
+        "Padding MoE intermediate dimension from %d to %d for AITER CK GEMM alignment.",
+        inter,
+        padded_inter,
+    )
+
+    # w13: (E, [2*]inter, hidden) -> (E, [2*]padded_inter, hidden)
+    if moe_config.is_act_and_mul:
+        # Split gate and up projections, pad each, recombine so that
+        # the zero-padding sits at the end of each half, not in between.
+        gate, up = w13_weight.data.chunk(2, dim=1)
+        gate = F.pad(gate, (0, 0, 0, pad_amount))
+        up = F.pad(up, (0, 0, 0, pad_amount))
+        w13_padded = torch.cat([gate, up], dim=1).contiguous()
+    else:
+        w13_padded = F.pad(w13_weight.data, (0, 0, 0, pad_amount)).contiguous()
+
+    # w2: (E, hidden, inter) -> (E, hidden, padded_inter)
+    w2_padded = F.pad(w2_weight.data, (0, pad_amount)).contiguous()
+
+    # Update moe_config so downstream kernels compute the correct shapes.
+    if padded_inter != moe_config.intermediate_size_per_partition:
+        moe_config.intermediate_size_per_partition = padded_inter
+
+    torch.accelerator.empty_cache()
+
+    return (
+        Parameter(w13_padded, requires_grad=False),
+        Parameter(w2_padded, requires_grad=False),
+    )
+
+
 def convert_to_unquantized_kernel_format(
     unquantized_backend: UnquantizedMoeBackend,
     layer: Module,
@@ -297,6 +353,9 @@ def convert_to_unquantized_kernel_format(
     w2_weight: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if unquantized_backend == UnquantizedMoeBackend.AITER:
+        w13_weight, w2_weight = _maybe_pad_intermediate_for_aiter(
+            w13_weight, w2_weight, layer.moe_config
+        )
         w13_weight, w2_weight = rocm_aiter_ops.shuffle_weights(w13_weight, w2_weight)
 
     elif unquantized_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS:

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -6,7 +6,6 @@ from collections.abc import Callable
 import torch
 import torch.nn.functional as F
 from torch.nn import Module
-from torch.nn.parameter import Parameter
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -148,58 +147,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
 
         return weight
 
-    @staticmethod
-    def _maybe_pad_intermediate_for_aiter(
-        w13_weight: Parameter,
-        w2_weight: Parameter,
-        is_act_and_mul: bool,
-    ) -> tuple[Parameter, Parameter]:
-        """Pad the MoE intermediate dimension to a multiple of 128 for AITER
-        CK GEMM compatibility. Some models (e.g.
-        expert_intermediate_size=704) have intermediate sizes not aligned to
-        CK's device_gemm tile requirements, causing runtime errors like
-        'device_gemm does not support this GEMM problem'.
-
-        Zero-padding is mathematically safe: the extra w1 outputs are zero
-        (from zero-padded weights), activation(0)*0=0 for gated activations
-        (SiLU/GELU), and the extra w2 input columns are also zero.
-        """
-        AITER_MOE_ALIGN = 128
-        inter = w2_weight.shape[-1]  # intermediate_size_per_partition
-        padded_inter = (
-            (inter + AITER_MOE_ALIGN - 1) // AITER_MOE_ALIGN
-        ) * AITER_MOE_ALIGN
-        if padded_inter == inter:
-            return w13_weight, w2_weight
-
-        pad_amount = padded_inter - inter
-        logger.info_once(
-            "Padding MoE intermediate dimension from %d to %d "
-            "for AITER CK GEMM alignment.",
-            inter,
-            padded_inter,
-        )
-
-        # w13: (E, [2*]inter, hidden) -> (E, [2*]padded_inter, hidden)
-        # F.pad spec: (last_dim_left, last_dim_right, second_last_left, ...)
-        if is_act_and_mul:
-            # Split gate and up projections, pad each, recombine so that
-            # the zero-padding sits at the end of each half, not in between.
-            gate, up = w13_weight.data.chunk(2, dim=1)
-            gate = F.pad(gate, (0, 0, 0, pad_amount))
-            up = F.pad(up, (0, 0, 0, pad_amount))
-            w13_padded = torch.cat([gate, up], dim=1).contiguous()
-        else:
-            w13_padded = F.pad(w13_weight.data, (0, 0, 0, pad_amount)).contiguous()
-
-        # w2: (E, hidden, inter) -> (E, hidden, padded_inter)
-        w2_padded = F.pad(w2_weight.data, (0, pad_amount)).contiguous()
-
-        return (
-            Parameter(w13_padded, requires_grad=False),
-            Parameter(w2_padded, requires_grad=False),
-        )
-
     def _setup_kernel(
         self,
         layer: Module,
@@ -242,20 +189,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         ]:
             # OOT handles internally.
             return
-
-        # Pad intermediate dimension for AITER CK GEMM alignment
-        if self.unquantized_backend == UnquantizedMoeBackend.AITER:
-            w13, w2 = self._maybe_pad_intermediate_for_aiter(
-                layer.w13_weight, layer.w2_weight, self.moe.is_act_and_mul
-            )
-            replace_parameter(layer, "w13_weight", w13)
-            replace_parameter(layer, "w2_weight", w2)
-            torch.accelerator.empty_cache()
-            # Update moe_config so rocm_aiter_fused_experts computes the
-            # correct intermediate_pad = padded - unpadded.
-            padded_inter = w2.shape[-1]  # (E, hidden, padded_inter)
-            if padded_inter != self.moe.intermediate_size_per_partition:
-                self.moe.intermediate_size_per_partition = padded_inter
 
         if self.unquantized_backend == UnquantizedMoeBackend.CPU:
             # CPU stays on the old path — no oracle, no moe_kernel.

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -250,6 +250,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             )
             replace_parameter(layer, "w13_weight", w13)
             replace_parameter(layer, "w2_weight", w2)
+            torch.accelerator.empty_cache()
             # Update moe_config so rocm_aiter_fused_experts computes the
             # correct intermediate_pad = padded - unpadded.
             padded_inter = w2.shape[-1]  # (E, hidden, padded_inter)

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import torch
 import torch.nn.functional as F
 from torch.nn import Module
+from torch.nn.parameter import Parameter
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -147,6 +148,58 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
 
         return weight
 
+    @staticmethod
+    def _maybe_pad_intermediate_for_aiter(
+        w13_weight: Parameter,
+        w2_weight: Parameter,
+        is_act_and_mul: bool,
+    ) -> tuple[Parameter, Parameter]:
+        """Pad the MoE intermediate dimension to a multiple of 128 for AITER
+        CK GEMM compatibility. Some models (e.g.
+        expert_intermediate_size=704) have intermediate sizes not aligned to
+        CK's device_gemm tile requirements, causing runtime errors like
+        'device_gemm does not support this GEMM problem'.
+
+        Zero-padding is mathematically safe: the extra w1 outputs are zero
+        (from zero-padded weights), activation(0)*0=0 for gated activations
+        (SiLU/GELU), and the extra w2 input columns are also zero.
+        """
+        AITER_MOE_ALIGN = 128
+        inter = w2_weight.shape[-1]  # intermediate_size_per_partition
+        padded_inter = (
+            (inter + AITER_MOE_ALIGN - 1) // AITER_MOE_ALIGN
+        ) * AITER_MOE_ALIGN
+        if padded_inter == inter:
+            return w13_weight, w2_weight
+
+        pad_amount = padded_inter - inter
+        logger.info_once(
+            "Padding MoE intermediate dimension from %d to %d "
+            "for AITER CK GEMM alignment.",
+            inter,
+            padded_inter,
+        )
+
+        # w13: (E, [2*]inter, hidden) -> (E, [2*]padded_inter, hidden)
+        # F.pad spec: (last_dim_left, last_dim_right, second_last_left, ...)
+        if is_act_and_mul:
+            # Split gate and up projections, pad each, recombine so that
+            # the zero-padding sits at the end of each half, not in between.
+            gate, up = w13_weight.data.chunk(2, dim=1)
+            gate = F.pad(gate, (0, 0, 0, pad_amount))
+            up = F.pad(up, (0, 0, 0, pad_amount))
+            w13_padded = torch.cat([gate, up], dim=1).contiguous()
+        else:
+            w13_padded = F.pad(w13_weight.data, (0, 0, 0, pad_amount)).contiguous()
+
+        # w2: (E, hidden, inter) -> (E, hidden, padded_inter)
+        w2_padded = F.pad(w2_weight.data, (0, pad_amount)).contiguous()
+
+        return (
+            Parameter(w13_padded, requires_grad=False),
+            Parameter(w2_padded, requires_grad=False),
+        )
+
     def _setup_kernel(
         self,
         layer: Module,
@@ -190,7 +243,20 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             # OOT handles internally.
             return
 
-        elif self.unquantized_backend == UnquantizedMoeBackend.CPU:
+        # Pad intermediate dimension for AITER CK GEMM alignment
+        if self.unquantized_backend == UnquantizedMoeBackend.AITER:
+            w13, w2 = self._maybe_pad_intermediate_for_aiter(
+                layer.w13_weight, layer.w2_weight, self.moe.is_act_and_mul
+            )
+            replace_parameter(layer, "w13_weight", w13)
+            replace_parameter(layer, "w2_weight", w2)
+            # Update moe_config so rocm_aiter_fused_experts computes the
+            # correct intermediate_pad = padded - unpadded.
+            padded_inter = w2.shape[-1]  # (E, hidden, padded_inter)
+            if padded_inter != self.moe.intermediate_size_per_partition:
+                self.moe.intermediate_size_per_partition = padded_inter
+
+        if self.unquantized_backend == UnquantizedMoeBackend.CPU:
             # CPU stays on the old path — no oracle, no moe_kernel.
             from vllm.model_executor.layers.fused_moe import cpu_fused_moe
 

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -190,7 +190,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             # OOT handles internally.
             return
 
-        if self.unquantized_backend == UnquantizedMoeBackend.CPU:
+        elif self.unquantized_backend == UnquantizedMoeBackend.CPU:
             # CPU stays on the old path — no oracle, no moe_kernel.
             from vllm.model_executor.layers.fused_moe import cpu_fused_moe
 


### PR DESCRIPTION



## Purpose
Pad the MoE intermediate dimension to a multiple of 128 for AITER CK GEMM compatibility. Some models (like the gemma4 gemma-4-26B-A4B-it model MoE) have intermediate sizes not aligned to CK's device_gemm tile requirements, causing runtime errors like:
 ```
       'device_gemm does not support this GEMM problem'.
```

## Test Plan
-regression test on gpt-oss-120b model
-test on a MoE model (google gemma-4-26B-A4B-it model ) expert_intermediate_size=704 with environment variable VLLM_ROCM_USE_AITER=1.

## Test Result
No error.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

