### PR TITLE
[Bugfix] Fix oversized piecewise CUDA graphs for Gemma3n cross-decoder

### DIFF
--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Iterable
+from dataclasses import replace
 
 import torch
 from torch import nn
@@ -944,12 +945,26 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
         self.per_layer_inputs[:num_padded_logits_indices].copy_(
             per_layer_inputs_adjusted[logits_indices_padded]
         )
+
+        # Update the forward context's batch_descriptor so the
+        # cross-decoder's piecewise CUDAGraphWrapper dispatches to a graph
+        # captured at the reduced batch size, not the full batch size.
+        forward_context = get_forward_context()
+        orig_batch_desc = forward_context.batch_descriptor
+        if orig_batch_desc is not None:
+            forward_context.batch_descriptor = replace(
+                orig_batch_desc, num_tokens=num_padded_logits_indices
+            )
+
         cross_decoder_hidden_states = self.cross_decoder(
             positions=self.positions[:num_padded_logits_indices],
             hidden_states=self.hidden_states[:num_padded_logits_indices],
             per_layer_inputs=self.per_layer_inputs[:num_padded_logits_indices],
             **kwargs,
         )
+
+        # Restore the original batch_descriptor
+        forward_context.batch_descriptor = orig_batch_desc
 
         if num_logits_indices is not None:
             assert num_logits_indices > 0


### PR DESCRIPTION
## Purpose

Fix a bug where the cross-decoder's piecewise CUDA graphs are captured and replayed at the full batch size instead of the reduced batch size when `--kv-sharing-fast-prefill` is enabled.

### Root Cause

In `fast_prefill_forward()`, the self-decoder processes the full batch while the cross-decoder only processes decode tokens (reduced batch). However, the `CUDAGraphWrapper` dispatches graphs based on `forward_context.batch_descriptor`, which is set once per forward pass with the full batch's `num_tokens` and never updated between piecewise units. This means the cross-decoder always replays a graph captured at the full batch size, wasting compute on the extra (unused) tokens.

### Fix

Update `forward_context.batch_descriptor.num_tokens` to match the reduced cross-decoder batch size before calling the cross-decoder, then restore it after. This ensures the `CUDAGraphWrapper` dispatches to a graph captured at the correct (smaller) size.

## Test Plan

### Unit tests

```bash
python -m pytest tests/v1/worker/test_gpu_model_runner.py -k "test_init_kv_cache" -v
```

### E2E tests

```bash
python -m pytest tests/v1/e2e/general/test_kv_sharing_fast_prefill.py -v
```

### GSM8K eval (Gemma3n-E4B, 5-shot)

```bash
lm_eval --model vllm --tasks gsm8k --num_fewshot 5 \
  --model_args pretrained=google/gemma-3n-E4B-it,gpu_memory_utilization=0.9,max_model_len=4096,tensor_parallel_size=1,kv_sharing_fast_prefill=True \
  --batch_size auto --apply_chat_template --fewshot_as_multiturn
```

### Serving benchmark

```bash
# Start server
vllm serve google/gemma-3n-E4B-it \
  --port 8434 \
  --disable-log-stats \
  --no-enable-prefix-caching \
  --max-num-seqs 128 \
  --max-model-len 32768 \
  --max-num-batched-tokens 8192 \
  --kv-sharing-fast-prefill \
  --attention-backend TRITON_ATTN

# Run benchmark (after server is ready)
vllm bench serve \
  --backend vllm \
  --ignore-eos \
  --port 8434 \
  --model google/gemma-3n-E4B-it \
  --dataset-name random \
  --max-concurrency 32 \
  --request-rate inf \
  --num-prompts 256 \
  --random-input-len 8192 \
  --random-output-len 150
```

## Test Results

### GSM8K accuracy (Gemma3n-E4B, 5-shot)

No accuracy regression:

|                    | strict-match | flexible-extract |
|--------------------|-------------|-----------------|
| FP=ON (this PR)    | 0.6975      | 0.7741          |
| FP=OFF (baseline)  | 0.6983      | 0.7771          |


### Serving performance (Gemma3n-E4B, 1xH200, input=8192, output=150, n=256)

#### concurrency=8

| Condition          | Throughput  | Mean TTFT | Mean TPOT |
|--------------------|------------|-----------|-----------|
| FP=ON (this PR)    | 3.69 req/s | 586ms     | 10.63ms   |
| FP=ON (unfixed)    | 3.63 req/s | 590ms     | 10.82ms   |
| FP=OFF (baseline)  | 2.97 req/s | 967ms     | 11.56ms   |

#### concurrency=32

| Condition          | Throughput  | Mean TTFT | Mean TPOT  |
|--------------------|------------|-----------|------------|
| FP=ON (this PR)    | 5.67 req/s | 1991ms    | 24.37ms |
| FP=ON (unfixed)    | 5.74 req/s | 1628ms    | 26.36ms |
| FP=OFF (baseline)  | 3.92 req/s | 3288ms    | 32.72ms    |
