### PR TITLE
[CI] Fix: pass string cache_dtype in test_register_kv_caches

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -1613,7 +1613,7 @@ def test_register_kv_caches(
                                 )
                             ]
                         ],
-                        cache_dtype=torch.bfloat16,
+                        cache_dtype="bfloat16",
                         device=torch.accelerator.current_device_index(),
                         kernel_block_sizes=[block_size],
                     )


### PR DESCRIPTION
## Summary
- Fix `test_register_kv_caches[TRITON_ATTN-True]` failure related to #38378
- The test passed `torch.bfloat16` (a `torch.dtype` object) as `cache_dtype`, but `allocate_uniform_kv_caches` expects a `CacheDType` string (e.g. `"bfloat16"`)
- This caused `AttributeError: 'torch.dtype' object has no attribute 'startswith'` in `get_kv_quant_mode`

## Test plan
- [x] `pytest tests/v1/kv_connector/unit/test_nixl_connector.py::test_register_kv_caches -k "TRITON_ATTN-True"` passes