### PR TITLE
[Bugfix]: Fix Gemma4ToolParser.__init__() missing `tools` parameter

### DIFF
--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -38,7 +38,7 @@ from vllm.entrypoints.openai.responses.protocol import (
 )
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
-from vllm.tool_parsers.abstract_tool_parser import ToolParser
+from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
 from vllm.tool_parsers.utils import find_common_prefix
 
 logger = init_logger(__name__)
@@ -281,8 +281,8 @@ class Gemma4ToolParser(ToolParser):
     tool parsers.
     """
 
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
+        super().__init__(tokenizer, tools)
 
         if not self.model_tokenizer:
             raise ValueError(


### PR DESCRIPTION
## Purpose

Fix `Gemma4ToolParser.__init__()` to accept the `tools` parameter, matching the base `ToolParser` interface.

Without this fix, enabling tool calling with `--tool-call-parser gemma4` results in:
```
400 Gemma4ToolParser.__init__() takes 2 positional arguments but 3 were given
```

The `tools` parameter was added to the base `ToolParser` class in #38029, but the `Gemma4ToolParser` introduced in #38826 was written against the old signature.

Fixes #38837

## Test Plan

```bash
vllm serve nvidia/Gemma-4-31B-IT-NVFP4 \
    --enable-auto-tool-choice \
    --tool-call-parser gemma4
```

Send a chat completion request with `tools` specified — previously returned 400, now works.

## Test Result

Tested on NVIDIA DGX Spark (GB10, SM 12.1) with `nvidia/Gemma-4-31B-IT-NVFP4`. Tool calls are processed correctly after the fix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.
</details>