### PR TITLE
[Bugfix] Fix Gemma4 non-streaming reasoning parsing

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -23,7 +23,10 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
-from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.chat_completion.serving import (
+    OpenAIServingChat,
+    _get_reasoning_parser_input_text,
+)
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
     RequestResponseMetadata,
@@ -38,6 +41,7 @@ from vllm.entrypoints.serve.render.serving import OpenAIServingRender
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import TokensPrompt
 from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.reasoning.gemma4_reasoning_parser import Gemma4ReasoningParser
 from vllm.renderers.hf import HfRenderer
 from vllm.renderers.mistral import MistralRenderer
 from vllm.tokenizers import get_tokenizer
@@ -2094,3 +2098,43 @@ class TestCreateRemainingArgsDelta:
         assert tc.type == "function"
         assert tc.function.name is None
         assert tc.function.arguments == '{"data": "value"}'
+
+
+class _Gemma4ReasoningTokenizer:
+    def get_vocab(self) -> dict[str, int]:
+        return {
+            "<|channel>": 100,
+            "<channel|>": 101,
+        }
+
+    def decode(self, ids, skip_special_tokens: bool = False) -> str:
+        if ids != [100, 200, 101, 300]:
+            raise AssertionError(f"unexpected ids: {ids!r}")
+        if skip_special_tokens:
+            return "thought\nThe user is asking...\n2 + 2 = 4"
+        return "<|channel>thought\nThe user is asking...\n<channel|>2 + 2 = 4"
+
+
+def test_gemma4_non_streaming_reasoning_uses_token_ids():
+    tokenizer = _Gemma4ReasoningTokenizer()
+    parser = Gemma4ReasoningParser(tokenizer)
+    output = CompletionOutput(
+        index=0,
+        text="thought\nThe user is asking...\n2 + 2 = 4",
+        token_ids=[100, 200, 101, 300],
+        cumulative_logprob=0.0,
+        logprobs=None,
+    )
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "What is 2+2?"}],
+    )
+
+    parser_input = _get_reasoning_parser_input_text(output, tokenizer, parser)
+    reasoning, content = parser.extract_reasoning(parser_input, request=request)
+
+    assert parser_input == (
+        "<|channel>thought\nThe user is asking...\n<channel|>2 + 2 = 4"
+    )
+    assert reasoning == "The user is asking...\n"
+    assert content == "2 + 2 = 4"

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -84,6 +84,22 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _get_reasoning_parser_input_text(
+    output: CompletionOutput,
+    tokenizer: TokenizerLike,
+    reasoning_parser: ReasoningParser,
+) -> str:
+    """Build non-streaming parser input without losing reasoning markers."""
+    start_token_id = getattr(reasoning_parser, "start_token_id", None)
+    end_token_id = getattr(reasoning_parser, "end_token_id", None)
+    if output.token_ids and (
+        (start_token_id is not None and start_token_id in output.token_ids)
+        or (end_token_id is not None and end_token_id in output.token_ids)
+    ):
+        return tokenizer.decode(output.token_ids, skip_special_tokens=False)
+    return output.text
+
+
 class OpenAIServingChat(OpenAIServing):
     def __init__(
         self,
@@ -1375,8 +1391,13 @@ class OpenAIServingChat(OpenAIServing):
             if reasoning_parser:
                 # If the reasoning parser is enabled,
                 # tool calls are extracted exclusively from the content.
+                parser_input_text = _get_reasoning_parser_input_text(
+                    output,
+                    tokenizer,
+                    reasoning_parser,
+                )
                 reasoning, content = reasoning_parser.extract_reasoning(
-                    output.text, request=request
+                    parser_input_text, request=request
                 )
                 if not request.include_reasoning:
                     reasoning = None


### PR DESCRIPTION
## Purpose

Fixes [#38855](https://github.com/vllm-project/vllm/issues/38855), where Gemma4 non-streaming chat completions fail to populate `reasoning_content` and instead return the thought trace in `content`.

The issue report suggested a parser-side token ID fix, but after inspecting the merged Gemma4 implementation from [#38826](https://github.com/vllm-project/vllm/pull/38826), the Gemma4 parser already inherits `start_token_id` / `end_token_id` support from `BaseThinkingReasoningParser`. The actual failure is in the non-streaming OpenAI chat serving path: it passes `output.text` to the parser after special tokens have already been stripped, so Gemma4 never sees `<|channel>` / `<channel|>` boundaries.

This PR fixes that handoff in `vllm/entrypoints/openai/chat_completion/serving.py` by reconstructing parser input from `output.token_ids` with `skip_special_tokens=False` when the reasoning parser's boundary token IDs are present. This keeps the fix narrow, preserves the existing parser contract, and avoids adding parser-side logic that would need to infer reasoning boundaries from text after the delimiter tokens have already been removed.

## Test Plan

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py -k gemma4_non_streaming_reasoning_uses_token_ids -v
.venv/bin/pre-commit run --files vllm/entrypoints/openai/chat_completion/serving.py tests/entrypoints/openai/chat_completion/test_serving_chat.py
```

## Test Result

Passed:
- Targeted regression test for the new non-streaming Gemma4 behavior in `tests/entrypoints/openai/chat_completion/test_serving_chat.py`
- `pre-commit` on all changed files

The focused regression covers the before/after behavior for this bug:
- Before: `reasoning_content` was `null` and `content` contained the thought trace
- After: reasoning and final content are separated correctly