### PR TITLE
[EP] Fault tolerance: automatic elastic scale-down on DP engine death

### DIFF
--- a/tests/v1/engine/test_ep_fault_tolerance.py
+++ b/tests/v1/engine/test_ep_fault_tolerance.py
@@ -1,0 +1,1283 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for EP fault tolerance.
+
+These tests validate the fault-tolerance logic without requiring GPUs by
+mocking the heavy infrastructure (engine managers, executors, ZMQ, etc.).
+"""
+
+import asyncio
+import multiprocessing
+import weakref
+from dataclasses import dataclass, field
+from datetime import timedelta
+from threading import Event
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import msgspec.msgpack
+import pytest
+import torch
+
+from vllm.config import ParallelConfig
+from vllm.distributed.elastic_ep.elastic_execute import (
+    ElasticEPScalingExecutor,
+    rebuild_eplb_derived_maps,
+    strip_dead_columns,
+)
+from vllm.distributed.elastic_ep.elastic_state import (
+    ElasticEPScalingState,
+    ScaleDownRemainingEngineState,
+    _BarrierTimeoutError,
+)
+from vllm.distributed.elastic_ep.standby_state import (
+    _build_surviving_rank_tensor,
+)
+from vllm.v1.engine import (
+    EngineCoreRequest,
+    ReconfigureDistributedRequest,
+    ReconfigureRankType,
+)
+from vllm.v1.engine.core_client import (
+    DPLBAsyncMPClient,
+    ElasticScalingCache,
+    MPClient,
+)
+from vllm.v1.engine.utils import CoreEngineActorManager, CoreEngineProcManager
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_parallel_config(**overrides) -> MagicMock:
+    """Create a mock ParallelConfig with sane defaults."""
+    pc = MagicMock(spec=ParallelConfig)
+    pc.enable_elastic_ep = overrides.get("enable_elastic_ep", True)
+    pc.enable_ep_fault_tolerance = overrides.get("enable_ep_fault_tolerance", True)
+    pc.data_parallel_backend = overrides.get("data_parallel_backend", "ray")
+    pc.tensor_parallel_size = overrides.get("tensor_parallel_size", 1)
+    pc.data_parallel_size = overrides.get("data_parallel_size", 4)
+    pc.data_parallel_master_ip = "127.0.0.1"
+    pc.data_parallel_master_port = 29500
+    pc._data_parallel_master_port_list = [29501, 29502, 29503]
+    pc._coord_store_port = 29600
+    return pc
+
+
+def _make_vllm_config(**pc_overrides) -> MagicMock:
+    config = MagicMock()
+    config.parallel_config = _make_parallel_config(**pc_overrides)
+    config.model_config = None
+    return config
+
+
+@dataclass
+class FakeResources:
+    engine_dead: bool = False
+    engine_manager: Any = None
+    coordinator: Any = None
+
+
+@dataclass
+class FakeTCPStore:
+    """Minimal TCP store substitute for barrier tests."""
+
+    _data: dict = field(default_factory=dict)
+
+    def set(self, key: str, value: bytes) -> None:
+        self._data[key] = value
+
+    def get(self, key: str) -> bytes:
+        return self._data.get(key, b"0")
+
+    def check(self, keys: list[str]) -> bool:
+        return all(k in self._data for k in keys)
+
+    def delete_key(self, key: str) -> None:
+        self._data.pop(key, None)
+
+    def add(self, key: str, value: int) -> int:
+        cur = int(self._data.get(key, b"0"))
+        new_val = cur + value
+        self._data[key] = str(new_val).encode()
+        return new_val
+
+    def compare_set(self, key: str, expected: str, value: bytes) -> bytes:
+        cur = self._data.get(key, "")
+        if cur == expected or cur == expected.encode():
+            self._data[key] = value
+        return self._data.get(key, b"")
+
+
+# ===========================================================================
+# 1. CoreEngineProcManager._dp_rank_from_proc_name
+# ===========================================================================
+
+
+class TestDPRankFromProcName:
+    def test_standard_dp_name(self):
+        assert CoreEngineProcManager._dp_rank_from_proc_name("EngineCore_DP0") == 0
+        assert CoreEngineProcManager._dp_rank_from_proc_name("EngineCore_DP3") == 3
+        assert CoreEngineProcManager._dp_rank_from_proc_name("EngineCore_DP15") == 15
+
+    def test_non_dp_name(self):
+        assert CoreEngineProcManager._dp_rank_from_proc_name("EngineCore") == -1
+        assert CoreEngineProcManager._dp_rank_from_proc_name("SomeProcess") == -1
+
+
+# ===========================================================================
+# 2. DPLBAsyncMPClient._is_fault_tolerant
+# ===========================================================================
+
+
+class TestIsFaultTolerant:
+    def _make_client_stub(self, **pc_overrides):
+        """Create a bare DPLBAsyncMPClient instance without running __init__."""
+        client = object.__new__(DPLBAsyncMPClient)
+        client.vllm_config = _make_vllm_config(**pc_overrides)
+        return client
+
+    def test_true_when_flag_enabled(self):
+        client = self._make_client_stub(enable_ep_fault_tolerance=True)
+        assert client._is_fault_tolerant() is True
+
+    def test_false_when_flag_disabled(self):
+        client = self._make_client_stub(enable_ep_fault_tolerance=False)
+        assert client._is_fault_tolerant() is False
+
+
+# ===========================================================================
+# 3. DPLBAsyncMPClient._on_engine_process_died
+# ===========================================================================
+
+
+class TestOnEngineProcessDied:
+    def _make_client_stub(self, dp_size: int = 4, ft_in_progress: bool = False):
+        client = object.__new__(DPLBAsyncMPClient)
+        client.vllm_config = _make_vllm_config(data_parallel_size=dp_size)
+        client.resources = FakeResources()
+        client.core_engines = [i.to_bytes(2, "little") for i in range(dp_size)]
+        client._ft_scaling_in_progress = ft_in_progress
+        client._dead_engine_identities = set()
+        client._ft_event_loop = None
+        client.shutdown = MagicMock()
+        client.reqs_in_flight = {}
+        return client
+
+    def test_returns_false_when_only_one_engine(self):
+        client = self._make_client_stub(dp_size=1)
+        result = client._on_engine_process_died("EngineCore_DP0", 0)
+        assert result is False
+        assert client.resources.engine_dead is True
+        client.shutdown.assert_called_once()
+
+    def test_returns_false_when_scaling_in_progress(self):
+        client = self._make_client_stub(dp_size=4, ft_in_progress=True)
+        result = client._on_engine_process_died("EngineCore_DP2", 2)
+        assert result is False
+        assert client.resources.engine_dead is True
+
+    def test_schedules_scale_down_and_returns_true(self):
+        client = self._make_client_stub(dp_size=4)
+
+        loop = asyncio.new_event_loop()
+        scheduled_coros = []
+        loop.call_soon_threadsafe = lambda fn: scheduled_coros.append(fn)
+        client._ft_event_loop = loop
+
+        result = client._on_engine_process_died("EngineCore_DP2", 2)
+
+        assert result is True
+        assert client._ft_scaling_in_progress is True
+        assert len(scheduled_coros) == 1
+        # Verify dead engine identity is tracked for routing avoidance.
+        expected_identity = (2).to_bytes(2, "little")
+        assert expected_identity in client._dead_engine_identities
+        loop.close()
+
+    def test_duplicate_death_notification_is_ignored(self):
+        """Ray may report the same actor death multiple times. The second
+        notification for the same rank should be a no-op, not trigger a
+        shutdown due to 'scaling already in progress'."""
+        client = self._make_client_stub(dp_size=4)
+
+        loop = asyncio.new_event_loop()
+        scheduled_coros = []
+        loop.call_soon_threadsafe = lambda fn: scheduled_coros.append(fn)
+        client._ft_event_loop = loop
+
+        # First notification — triggers scale-down.
+        result1 = client._on_engine_process_died("EngineCore_DP2", 2)
+        assert result1 is True
+        assert client._ft_scaling_in_progress is True
+
+        # Second notification for the SAME rank — should be ignored.
+        result2 = client._on_engine_process_died("EngineCore_DP2", 2)
+        assert result2 is True  # keep monitoring
+        assert client.resources.engine_dead is False  # NOT shut down
+        assert len(scheduled_coros) == 1  # only one scale-down scheduled
+        client.shutdown.assert_not_called()
+        loop.close()
+
+    def test_returns_false_when_no_event_loop(self):
+        client = self._make_client_stub(dp_size=4)
+        # _ft_event_loop is already None from _make_client_stub
+        assert client._ft_event_loop is None
+        result = client._on_engine_process_died("EngineCore_DP1", 1)
+        assert result is False
+        assert client.resources.engine_dead is True
+
+
+# ===========================================================================
+# 4. DPLBAsyncMPClient._fail_inflight_requests_for_engine
+# ===========================================================================
+
+
+class TestFailInflightRequests:
+    def test_removes_matching_requests(self):
+        client = object.__new__(DPLBAsyncMPClient)
+        engine_0 = (0).to_bytes(2, "little")
+        engine_1 = (1).to_bytes(2, "little")
+        client.reqs_in_flight = {
+            "req-1": engine_0,
+            "req-2": engine_1,
+            "req-3": engine_0,
+            "req-4": engine_1,
+        }
+        client._fail_inflight_requests_for_engine(engine_0)
+        assert "req-1" not in client.reqs_in_flight
+        assert "req-3" not in client.reqs_in_flight
+        assert "req-2" in client.reqs_in_flight
+        assert "req-4" in client.reqs_in_flight
+
+    def test_noop_when_no_matching_requests(self):
+        client = object.__new__(DPLBAsyncMPClient)
+        engine_0 = (0).to_bytes(2, "little")
+        engine_2 = (2).to_bytes(2, "little")
+        client.reqs_in_flight = {"req-1": engine_0}
+        client._fail_inflight_requests_for_engine(engine_2)
+        assert len(client.reqs_in_flight) == 1
+
+    def test_returns_dead_request_ids(self):
+        """Verify that the method returns the IDs it dropped, so callers
+        can propagate errors to waiting clients."""
+        client = object.__new__(DPLBAsyncMPClient)
+        engine_0 = (0).to_bytes(2, "little")
+        engine_1 = (1).to_bytes(2, "little")
+        client.reqs_in_flight = {
+            "req-1": engine_0,
+            "req-2": engine_1,
+            "req-3": engine_0,
+        }
+        dead_ids = client._fail_inflight_requests_for_engine(engine_0)
+        assert set(dead_ids) == {"req-1", "req-3"}
+
+
+# ===========================================================================
+# 4b. register_ft_abort_callback
+# ===========================================================================
+
+
+class TestRegisterFTAbortCallback:
+    def test_registers_and_stores_callback(self):
+        client = object.__new__(DPLBAsyncMPClient)
+        client._ft_abort_callback = None
+
+        callback = MagicMock()
+        client.register_ft_abort_callback(callback)
+        assert client._ft_abort_callback is callback
+
+    def test_callback_is_callable(self):
+        client = object.__new__(DPLBAsyncMPClient)
+        client._ft_abort_callback = None
+
+        called_with = []
+        client.register_ft_abort_callback(lambda ids: called_with.extend(ids))
+        client._ft_abort_callback(["req-1", "req-2"])
+        assert called_with == ["req-1", "req-2"]
+
+
+# ===========================================================================
+# 5. ElasticEPScalingState barrier logic with dead ranks
+# ===========================================================================
+
+
+class TestElasticEPScalingStateBarriers:
+    """Test the barrier and progress logic with dead ranks."""
+
+    def _make_scaling_state(
+        self, dead_dp_ranks: list[int] | None = None, dp_size: int = 4
+    ):
+        """Build a minimal ElasticEPScalingState for testing barriers."""
+        reconfig = ReconfigureDistributedRequest(
+            new_data_parallel_size=dp_size - 1,
+            new_data_parallel_rank=ReconfigureRankType.KEEP_CURRENT_RANK,
+            new_data_parallel_rank_local=ReconfigureRankType.KEEP_CURRENT_RANK,
+            new_data_parallel_master_ip="127.0.0.1",
+            new_data_parallel_master_port=29500,
+            new_data_parallel_master_port_list=[29501],
+            coord_store_port=29600,
+            dead_dp_ranks=dead_dp_ranks or [],
+        )
+
+        fake_dp_group = MagicMock()
+        fake_dp_group.rank.return_value = 0
+        fake_dp_group.size.return_value = dp_size
+
+        fake_store = FakeTCPStore()
+
+        state = object.__new__(ElasticEPScalingState)
+        state.old_dp_group = fake_dp_group
+        state.old_dp_store = fake_store
+        state.new_dp_group = None
+        state.new_dp_store = None
+        state.reconfig_request = reconfig
+        state.dead_dp_ranks = set(dead_dp_ranks or [])
+        state.worker_type = "existing"
+        state.scale_type = "scale_down"
+        state.state = ScaleDownRemainingEngineState.PREPARE
+        state.vllm_config = _make_vllm_config()
+        state.model_executor_ref = MagicMock(return_value=MagicMock())
+        state.engine_core_ref = MagicMock(return_value=MagicMock())
+
+        return state
+
+    @pytest.mark.parametrize(
+        ("dead", "dp_size", "expected_alive", "expected_first_alive"),
+        [
+            ([2], 4, 3, 0),
+            ([], 4, 4, 0),
+            ([0], 4, 3, 1),
+            ([0, 1], 4, 2, 2),
+        ],
+    )
+    def test_alive_group_helpers(
+        self, dead, dp_size, expected_alive, expected_first_alive
+    ):
+        state = self._make_scaling_state(dead_dp_ranks=dead, dp_size=dp_size)
+        assert state._alive_group_size() == expected_alive
+        assert state._first_alive_rank() == expected_first_alive
+
+    def test_tcp_store_barrier_skips_dead_ranks(self):
+        state = self._make_scaling_state(dead_dp_ranks=[2], dp_size=4)
+        store = state.old_dp_store
+
+        # Simulate ranks 0, 1, 3 arriving (rank 2 is dead).
+        for rank in [0, 1, 3]:
+            store.set(f"arrival_test_barrier_{rank}", b"1")
+
+        # Should complete without waiting for rank 2.
+        state._execute_tcp_store_barrier(
+            store,
+            group_rank=0,
+            group_size=4,
+            barrier_id="test_barrier",
+            timeout=None,
+            skip_ranks={2},
+        )
+
+    def test_tcp_store_barrier_times_out_without_alive_rank(self):
+        """Alive ranks 1 and 3 never arrive — barrier should time out."""
+        state = self._make_scaling_state(dead_dp_ranks=[2], dp_size=4)
+        state.old_dp_store.set("arrival_test_barrier_0", b"1")
+
+        with pytest.raises(_BarrierTimeoutError):
+            state._execute_tcp_store_barrier(
+                state.old_dp_store, group_rank=0, group_size=4,
+                barrier_id="test_barrier",
+                timeout=timedelta(seconds=0.1), skip_ranks={2},
+            )
+
+
+# ===========================================================================
+# 7. _synthesize_shutdown_complete_for_dead_ranks
+# ===========================================================================
+
+
+class TestSynthesizeShutdownComplete:
+    def _make_client_stub(
+        self, dp_size: int = 4, dead_dp_ranks: set[int] | None = None
+    ):
+        """Create a DPLBAsyncMPClient stub with eep_scaling_cache set up."""
+        client = object.__new__(DPLBAsyncMPClient)
+        mock_mgr = MagicMock(spec=CoreEngineActorManager)
+        mock_mgr.scale_down_elastic_ep = MagicMock()
+        client.resources = SimpleNamespace(engine_manager=mock_mgr)
+
+        num_removed = len(dead_dp_ranks or set())
+        client.eep_scaling_cache = ElasticScalingCache(
+            existing_core_engines=[i.to_bytes(2, "little") for i in range(dp_size)],
+            num_new_core_engines=-num_removed,
+            pending_notifications={},
+        )
+        return client
+
+    def test_injects_notifications_for_dead_ranks(self):
+        dead = {3}
+        client = self._make_client_stub(dp_size=4, dead_dp_ranks=dead)
+        client._synthesize_shutdown_complete_for_dead_ranks(dead)
+
+        cache = client.eep_scaling_cache
+        # Cache should be cleared after all notifications are resolved.
+        assert cache is None
+
+    def test_partial_notification_does_not_clear_cache(self):
+        # 2 ranks being removed, only 1 dead — cache should remain.
+        client = self._make_client_stub(dp_size=4, dead_dp_ranks={3})
+        client.eep_scaling_cache.num_new_core_engines = -2
+        client._synthesize_shutdown_complete_for_dead_ranks({3})
+        assert client.eep_scaling_cache is not None
+
+
+# ===========================================================================
+# 8. _scale_down_elastic_ep skips dead engines
+# ===========================================================================
+
+
+class TestScaleDownSkipsDeadEngines:
+    def _make_client_stub(self, dp_size: int = 4):
+        client = object.__new__(DPLBAsyncMPClient)
+        client.vllm_config = _make_vllm_config(data_parallel_size=dp_size)
+        client.core_engines = [i.to_bytes(2, "little") for i in range(dp_size)]
+        client.lb_engines = [[0, 0] for _ in range(dp_size)]
+        mock_mgr = MagicMock(spec=CoreEngineActorManager)
+        mock_mgr.remove_run_refs_for_scale_down = MagicMock()
+        mock_mgr.scale_down_elastic_ep = MagicMock()
+        mock_mgr.placement_group_is_local = [True] * dp_size
+        client.resources = SimpleNamespace(engine_manager=mock_mgr)
+        client.eep_scaling_cache = None
+        client.utility_results = {}
+        client._ensure_stats_update_task = MagicMock()
+        client._setup_elastic_ep_reconfig_bootstrap = MagicMock(
+            return_value=("127.0.0.1", 29600)
+        )
+        client._coord_store = MagicMock(port=29600)
+        client._eep_wait_for_setup_switch_complete = AsyncMock()
+        client.first_req_send_socket = MagicMock()
+        client.first_req_send_socket.send = AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_skips_reconfigure_for_dead_rank(self):
+        """Verify that _scale_down_elastic_ep does not send reconfigure
+        messages to dead engines."""
+        client = self._make_client_stub()
+        sent_engines = []
+
+        async def mock_call_utility(method, *args, engine=None):
+            sent_engines.append(engine)
+            return None
+
+        client._call_utility_async = mock_call_utility
+
+        await client._scale_down_elastic_ep(
+            cur_data_parallel_size=4,
+            new_data_parallel_size=3,
+            dead_dp_ranks={3},
+        )
+
+        dead_engine_id = (3).to_bytes(2, "little")
+        assert dead_engine_id not in sent_engines
+        assert len(sent_engines) == 3
+
+
+# ===========================================================================
+# 9. has_unfinished_dp fault_tolerant flag
+# ===========================================================================
+
+
+class TestHasUnfinishedDPFaultTolerant:
+    def test_fault_tolerant_returns_true_on_exception(self):
+        fake_group = MagicMock()
+        with patch(
+            "torch.distributed.all_reduce", side_effect=RuntimeError("gloo timeout")
+        ):
+            result = ParallelConfig.has_unfinished_dp(
+                fake_group, True, fault_tolerant=True
+            )
+        assert result is True
+
+    def test_non_fault_tolerant_raises_on_exception(self):
+        fake_group = MagicMock()
+        with (
+            patch(
+                "torch.distributed.all_reduce", side_effect=RuntimeError("gloo timeout")
+            ),
+            pytest.raises(RuntimeError, match="gloo timeout"),
+        ):
+            ParallelConfig.has_unfinished_dp(fake_group, True, fault_tolerant=False)
+
+    def test_normal_operation_returns_correct_value(self):
+        fake_group = MagicMock()
+
+        def fake_all_reduce(tensor, **kwargs):
+            tensor.fill_(1)
+
+        with patch("torch.distributed.all_reduce", side_effect=fake_all_reduce):
+            result = ParallelConfig.has_unfinished_dp(
+                fake_group, False, fault_tolerant=False
+            )
+        assert result is True
+
+
+# ===========================================================================
+# 10. get_core_engine_for_request skips dead engines
+# ===========================================================================
+
+
+class TestGetCoreEngineSkipsDeadEngines:
+    def _make_client_stub(self, dp_size: int = 4):
+        client = object.__new__(DPLBAsyncMPClient)
+        client.core_engines = [i.to_bytes(2, "little") for i in range(dp_size)]
+        client.lb_engines = [[0, 0] for _ in range(dp_size)]
+        client.eng_start_index = 0
+        client.client_count = 1
+        client._dead_engine_identities = set()
+        client.reqs_in_flight = {}
+        return client
+
+    def _make_request(self, request_id: str = "req-1"):
+        req = MagicMock(spec=EngineCoreRequest)
+        req.request_id = request_id
+        req.data_parallel_rank = None
+        req.pooling_params = None
+        return req
+
+    def test_skips_dead_engine_even_when_cheapest(self):
+        """Dead engine has the lowest score but must be skipped;
+        router should pick the best alive engine instead."""
+        client = self._make_client_stub(dp_size=4)
+        dead_identity = (2).to_bytes(2, "little")
+        client._dead_engine_identities.add(dead_identity)
+        # Engine 2 looks cheapest, but it's dead → engine 1 should win.
+        client.lb_engines = [[10, 10], [1, 1], [0, 0], [10, 10]]
+
+        req = self._make_request()
+        chosen = client.get_core_engine_for_request(req)
+        assert chosen != dead_identity
+        assert chosen == (1).to_bytes(2, "little")
+
+    def test_routes_normally_with_no_dead_engines(self):
+        client = self._make_client_stub(dp_size=4)
+        client.lb_engines = [[10, 10], [0, 0], [5, 5], [5, 5]]
+
+        req = self._make_request()
+        chosen = client.get_core_engine_for_request(req)
+        assert chosen == (1).to_bytes(2, "little")
+
+    def test_records_request_in_flight(self):
+        client = self._make_client_stub(dp_size=2)
+        req = self._make_request("req-42")
+        chosen = client.get_core_engine_for_request(req)
+        assert client.reqs_in_flight["req-42"] == chosen
+
+    def test_explicit_dp_rank_targeting_dead_engine_raises(self):
+        """When request.data_parallel_rank explicitly targets a dead engine,
+        a ValueError is raised so the client can retry on another rank."""
+        client = self._make_client_stub(dp_size=4)
+        client._dead_engine_identities.add((2).to_bytes(2, "little"))
+
+        req = self._make_request()
+        req.data_parallel_rank = 2
+
+        with pytest.raises(ValueError, match="dead"):
+            client.get_core_engine_for_request(req)
+
+
+# ===========================================================================
+# 11. _fault_triggered_scale_down async flow
+# ===========================================================================
+
+
+class TestFaultTriggeredScaleDown:
+    def _make_client_stub(self, dp_size: int = 4):
+        client = object.__new__(DPLBAsyncMPClient)
+        client.vllm_config = _make_vllm_config(data_parallel_size=dp_size)
+        client.core_engines = [i.to_bytes(2, "little") for i in range(dp_size)]
+        client.lb_engines = [[0, 0] for _ in range(dp_size)]
+        client.resources = FakeResources()
+        client._ft_scaling_in_progress = True
+        client._dead_engine_identities = set()
+        client._ft_abort_callback = None
+        client.reqs_in_flight = {
+            "req-on-dead": (2).to_bytes(2, "little"),
+            "req-on-alive": (0).to_bytes(2, "little"),
+        }
+        client.shutdown = MagicMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_success_calls_scale_down_and_clears_state(self):
+        client = self._make_client_stub()
+        client._scale_down_elastic_ep = AsyncMock()
+
+        abort_callback = MagicMock()
+        client._ft_abort_callback = abort_callback
+
+        await client._fault_triggered_scale_down(dead_dp_rank=2)
+
+        # Verify scale-down was called with correct args.
+        client._scale_down_elastic_ep.assert_awaited_once_with(4, 3, dead_dp_ranks={2})
+        # In-flight request on dead engine should be removed.
+        assert "req-on-dead" not in client.reqs_in_flight
+        assert "req-on-alive" in client.reqs_in_flight
+        # Abort callback should have been invoked with the dead request IDs.
+        # In production, AsyncLLM registers output_processor.abort_requests()
+        # here, which sends FinishReason.ABORT to each request's client queue.
+        abort_callback.assert_called_once_with(["req-on-dead"])
+        # State should be cleared in finally block.
+        assert client._ft_scaling_in_progress is False
+        assert len(client._dead_engine_identities) == 0
+        # Should NOT have set engine_dead on success.
+        assert client.resources.engine_dead is False
+
+    @pytest.mark.asyncio
+    async def test_no_callback_does_not_crash(self):
+        """When no abort callback is registered, dead requests are still
+        removed from reqs_in_flight but no abort is propagated."""
+        client = self._make_client_stub()
+        client._scale_down_elastic_ep = AsyncMock()
+
+        await client._fault_triggered_scale_down(dead_dp_rank=2)
+
+        assert "req-on-dead" not in client.reqs_in_flight
+        client._scale_down_elastic_ep.assert_awaited_once()
+        assert client.resources.engine_dead is False
+
+    @pytest.mark.asyncio
+    async def test_failure_sets_engine_dead_and_shuts_down(self):
+        client = self._make_client_stub()
+        client._scale_down_elastic_ep = AsyncMock(
+            side_effect=RuntimeError("scale-down failed")
+        )
+
+        await client._fault_triggered_scale_down(dead_dp_rank=2)
+
+        assert client.resources.engine_dead is True
+        client.shutdown.assert_called_once()
+        # State should still be cleared in finally block.
+        assert client._ft_scaling_in_progress is False
+
+
+# ===========================================================================
+# 12. monitor_engine_liveness_fault_tolerant (CoreEngineProcManager)
+# ===========================================================================
+
+
+class TestMonitorEngineLivenessFaultTolerant:
+    def test_calls_on_engine_died_when_process_exits_nonzero(self):
+        """Simulate a process dying with non-zero exit code."""
+        mgr = object.__new__(CoreEngineProcManager)
+        mgr.manager_stopped = Event()
+
+        # Create a real subprocess that exits with code 1.
+        proc = multiprocessing.Process(target=lambda: exit(1), name="EngineCore_DP2")
+        proc.start()
+        proc.join()  # Wait for it to finish.
+
+        mgr.processes = [proc]
+        died_reports = []
+
+        def on_died(proc_name: str, dp_rank: int) -> bool:
+            died_reports.append((proc_name, dp_rank))
+            return False  # Stop monitoring.
+
+        # shutdown should be called when on_died returns False.
+        mgr.shutdown = MagicMock()
+
+        mgr.monitor_engine_liveness_fault_tolerant(on_died)
+
+        assert len(died_reports) == 1
+        assert died_reports[0] == ("EngineCore_DP2", 2)
+
+    def test_continues_monitoring_when_on_died_returns_true(self):
+        """When on_died returns True, remaining sentinels should be monitored."""
+        mgr = object.__new__(CoreEngineProcManager)
+        mgr.manager_stopped = Event()
+
+        # Two processes: one dies immediately, one exits cleanly.
+        proc1 = multiprocessing.Process(target=lambda: exit(1), name="EngineCore_DP0")
+        proc2 = multiprocessing.Process(target=lambda: exit(0), name="EngineCore_DP1")
+        proc1.start()
+        proc2.start()
+        proc1.join()
+        proc2.join()
+
+        mgr.processes = [proc1, proc2]
+        died_reports = []
+
+        def on_died(proc_name: str, dp_rank: int) -> bool:
+            died_reports.append((proc_name, dp_rank))
+            return True  # Keep monitoring.
+
+        mgr.shutdown = MagicMock()
+        mgr.failed_proc_name = None
+
+        mgr.monitor_engine_liveness_fault_tolerant(on_died)
+
+        # Only the process with non-zero exit should be reported.
+        assert len(died_reports) == 1
+        assert died_reports[0][0] == "EngineCore_DP0"
+
+    def test_skips_report_when_manager_stopped(self):
+        """When the server is shutting down (SIGTERM), manager_stopped is set.
+        Process deaths during shutdown should not trigger fault recovery."""
+        mgr = object.__new__(CoreEngineProcManager)
+        mgr.manager_stopped = Event()
+        mgr.manager_stopped.set()  # Already stopped.
+
+        proc = multiprocessing.Process(target=lambda: exit(1), name="EngineCore_DP0")
+        proc.start()
+        proc.join()
+
+        mgr.processes = [proc]
+        died_reports = []
+
+        def on_died(proc_name: str, dp_rank: int) -> bool:
+            died_reports.append((proc_name, dp_rank))
+            return True
+
+        mgr.shutdown = MagicMock()
+        mgr.monitor_engine_liveness_fault_tolerant(on_died)
+
+        # Should not report because manager_stopped was set.
+        assert len(died_reports) == 0
+
+
+# ===========================================================================
+# 13. enable_ep_fault_tolerance config validation
+# ===========================================================================
+
+
+class TestEPFaultToleranceConfigValidation:
+    def test_requires_elastic_ep(self):
+        with pytest.raises(ValueError, match="enable_elastic_ep=True"):
+            ParallelConfig(
+                enable_ep_fault_tolerance=True,
+                enable_elastic_ep=False,
+                data_parallel_size=2,
+            )
+
+    def test_requires_tp_1(self):
+        with pytest.raises(ValueError, match="tensor_parallel_size=1"):
+            ParallelConfig(
+                enable_ep_fault_tolerance=True,
+                enable_elastic_ep=True,
+                enable_eplb=True,
+                tensor_parallel_size=2,
+                data_parallel_size=2,
+            )
+
+    def test_requires_dp_greater_than_1(self):
+        with pytest.raises(ValueError, match="data_parallel_size > 1"):
+            ParallelConfig(
+                enable_ep_fault_tolerance=True,
+                enable_elastic_ep=True,
+                enable_eplb=True,
+                data_parallel_size=1,
+            )
+
+    def test_valid_config_accepted(self):
+        """dp_size > 1 with elastic EP, EPLB, EP, and TP=1 should succeed."""
+        pc = ParallelConfig(
+            enable_ep_fault_tolerance=True,
+            enable_elastic_ep=True,
+            enable_eplb=True,
+            enable_expert_parallel=True,
+            data_parallel_size=2,
+            tensor_parallel_size=1,
+        )
+        assert pc.enable_ep_fault_tolerance is True
+
+
+# ===========================================================================
+# 14. _first_alive_rank edge case: all ranks dead
+# ===========================================================================
+
+
+class TestFirstAliveRankAllDead:
+    def test_raises_when_all_ranks_dead(self):
+        state = object.__new__(ElasticEPScalingState)
+        fake_dp_group = MagicMock()
+        fake_dp_group.size.return_value = 3
+        state.old_dp_group = fake_dp_group
+        state.dead_dp_ranks = {0, 1, 2}
+
+        with pytest.raises(RuntimeError, match="All ranks are dead"):
+            state._first_alive_rank()
+
+
+# ===========================================================================
+# 15. _synthesize_shutdown_complete: verify engine_manager call
+# ===========================================================================
+
+
+class TestSynthesizeShutdownCompleteVerifySideEffects:
+    def test_calls_engine_manager_scale_down(self):
+        """Verify that scale_down_elastic_ep is called on the engine manager
+        when all expected SHUTDOWN_COMPLETE notifications are present."""
+        client = object.__new__(DPLBAsyncMPClient)
+        mock_mgr = MagicMock(spec=CoreEngineActorManager)
+        client.resources = SimpleNamespace(engine_manager=mock_mgr)
+
+        client.eep_scaling_cache = ElasticScalingCache(
+            existing_core_engines=[i.to_bytes(2, "little") for i in range(4)],
+            num_new_core_engines=-1,
+            pending_notifications={},
+        )
+
+        client._synthesize_shutdown_complete_for_dead_ranks({3})
+
+        # Verify engine_manager was called with correct old/new sizes
+        # and the removed rank set.
+        mock_mgr.scale_down_elastic_ep.assert_called_once_with(
+            4, 3, removed_dp_ranks={3},
+        )
+        # Cache should be cleared.
+        assert client.eep_scaling_cache is None
+
+    def test_does_not_call_engine_manager_when_not_all_notified(self):
+        """When fewer than expected notifications arrive, engine_manager should
+        NOT be called and cache should remain."""
+        client = object.__new__(DPLBAsyncMPClient)
+        mock_mgr = MagicMock(spec=CoreEngineActorManager)
+        client.resources = SimpleNamespace(engine_manager=mock_mgr)
+
+        client.eep_scaling_cache = ElasticScalingCache(
+            existing_core_engines=[i.to_bytes(2, "little") for i in range(4)],
+            num_new_core_engines=-2,  # Expecting 2 shutdowns.
+            pending_notifications={},
+        )
+
+        client._synthesize_shutdown_complete_for_dead_ranks({3})  # Only 1.
+
+        mock_mgr.scale_down_elastic_ep.assert_not_called()
+        assert client.eep_scaling_cache is not None
+
+    def test_noop_when_cache_is_none(self):
+        client = object.__new__(DPLBAsyncMPClient)
+        client.eep_scaling_cache = None
+        # Should not raise.
+        client._synthesize_shutdown_complete_for_dead_ranks({3})
+
+
+# ===========================================================================
+# 16. start_engine_core_monitor dispatch
+# ===========================================================================
+
+
+class TestStartEngineMonitorDispatch:
+    def test_dispatches_to_fault_tolerant_monitor(self):
+        client = object.__new__(MPClient)
+        client.resources = SimpleNamespace(
+            engine_manager=MagicMock(),
+        )
+        client._is_fault_tolerant = MagicMock(return_value=True)
+        client._start_fault_tolerant_monitor = MagicMock()
+        client._start_standard_monitor = MagicMock()
+
+        client.start_engine_core_monitor()
+
+        client._start_fault_tolerant_monitor.assert_called_once()
+        client._start_standard_monitor.assert_not_called()
+
+    def test_dispatches_to_standard_monitor(self):
+        client = object.__new__(MPClient)
+        client.resources = SimpleNamespace(
+            engine_manager=MagicMock(),
+        )
+        client._is_fault_tolerant = MagicMock(return_value=False)
+        client._start_fault_tolerant_monitor = MagicMock()
+        client._start_standard_monitor = MagicMock()
+
+        client.start_engine_core_monitor()
+
+        client._start_standard_monitor.assert_called_once()
+        client._start_fault_tolerant_monitor.assert_not_called()
+
+    def test_noop_when_no_engine_manager(self):
+        client = object.__new__(MPClient)
+        client.resources = SimpleNamespace(engine_manager=None)
+        client._is_fault_tolerant = MagicMock(return_value=True)
+        client._start_fault_tolerant_monitor = MagicMock()
+
+        client.start_engine_core_monitor()
+
+        client._start_fault_tolerant_monitor.assert_not_called()
+
+
+# ===========================================================================
+# 17. Mid-rank death: _scale_down_elastic_ep rank compaction
+# ===========================================================================
+
+
+class TestScaleDownMidRankDeath:
+    """Verify _scale_down_elastic_ep handles both fault-triggered
+    (mid-rank death with compaction) and graceful (highest rank removed)."""
+
+    def _make_client_stub(self, dp_size: int = 4):
+        client = object.__new__(DPLBAsyncMPClient)
+        client.vllm_config = _make_vllm_config(data_parallel_size=dp_size)
+        client.core_engines = [i.to_bytes(2, "little") for i in range(dp_size)]
+        client.lb_engines = [[i, i] for i in range(dp_size)]
+        mock_mgr = MagicMock(spec=CoreEngineActorManager)
+        mock_mgr.remove_run_refs_for_scale_down = MagicMock()
+        mock_mgr.scale_down_elastic_ep = MagicMock()
+        mock_mgr.placement_group_is_local = [True] * dp_size
+        client.resources = SimpleNamespace(engine_manager=mock_mgr)
+        client.eep_scaling_cache = None
+        client.utility_results = {}
+        client._ensure_stats_update_task = MagicMock()
+        client._setup_elastic_ep_reconfig_bootstrap = MagicMock(
+            return_value=("127.0.0.1", 29600)
+        )
+        client._coord_store = MagicMock(port=29600)
+        client._eep_wait_for_setup_switch_complete = AsyncMock()
+        client.first_req_send_socket = MagicMock()
+        client.first_req_send_socket.send = AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_fault_triggered_mid_rank_death(self):
+        """Rank 1 dies from [0,1,2,3]: dead rank removed, survivors get
+        compacted ranks, no alive engine gets SHUTDOWN, coordinator
+        marker includes removed rank."""
+        client = self._make_client_stub(dp_size=4)
+        reconfig_by_engine: dict[bytes, ReconfigureDistributedRequest] = {}
+
+        async def mock_call_utility(method, *args, engine=None):
+            if method == "reinitialize_distributed" and args:
+                reconfig_by_engine[engine] = args[0]
+            return None
+
+        client._call_utility_async = mock_call_utility
+
+        await client._scale_down_elastic_ep(
+            cur_data_parallel_size=4,
+            new_data_parallel_size=3,
+            dead_dp_ranks={1},
+        )
+
+        # core_engines: dead rank removed, not truncated.
+        assert client.core_engines == [
+            r.to_bytes(2, "little") for r in [0, 2, 3]
+        ]
+        # lb_engines: dead entry removed.
+        assert client.lb_engines == [[0, 0], [2, 2], [3, 3]]
+        # No alive engine told to SHUTDOWN; compacted ranks assigned.
+        assert (1).to_bytes(2, "little") not in reconfig_by_engine
+        for engine, req in reconfig_by_engine.items():
+            assert req.new_data_parallel_rank != (
+                ReconfigureRankType.SHUTDOWN_CURRENT_RANK
+            )
+        assert reconfig_by_engine[(0).to_bytes(2, "little")].new_data_parallel_rank == 0
+        assert reconfig_by_engine[(2).to_bytes(2, "little")].new_data_parallel_rank == 1
+        assert reconfig_by_engine[(3).to_bytes(2, "little")].new_data_parallel_rank == 2
+        # Coordinator marker includes removed rank.
+        marker = msgspec.msgpack.decode(
+            client.first_req_send_socket.send.call_args[0][0]
+        )
+        assert marker == ["SCALE_ELASTIC_EP", 3, [1]]
+
+    @pytest.mark.asyncio
+    async def test_graceful_scale_down_unchanged(self):
+        """Graceful (no dead ranks): highest rank gets SHUTDOWN,
+        others keep current rank, core_engines truncated normally."""
+        client = self._make_client_stub(dp_size=4)
+        reconfig_by_engine: dict[bytes, ReconfigureDistributedRequest] = {}
+
+        async def mock_call_utility(method, *args, engine=None):
+            if method == "reinitialize_distributed" and args:
+                reconfig_by_engine[engine] = args[0]
+            return None
+
+        client._call_utility_async = mock_call_utility
+
+        await client._scale_down_elastic_ep(
+            cur_data_parallel_size=4,
+            new_data_parallel_size=3,
+            dead_dp_ranks=None,
+        )
+
+        assert (
+            reconfig_by_engine[(3).to_bytes(2, "little")].new_data_parallel_rank
+            == ReconfigureRankType.SHUTDOWN_CURRENT_RANK
+        )
+        for r in [0, 1, 2]:
+            assert (
+                reconfig_by_engine[r.to_bytes(2, "little")].new_data_parallel_rank
+                == ReconfigureRankType.KEEP_CURRENT_RANK
+            )
+        assert client.core_engines == [
+            i.to_bytes(2, "little") for i in range(3)
+        ]
+
+
+# ===========================================================================
+# 18. _build_surviving_rank_tensor
+# ===========================================================================
+
+
+class TestBuildSurvivingRankTensor:
+    @pytest.mark.parametrize(
+        ("new_dp", "pp", "tp", "dead", "world_ranks",
+         "expected_ranks", "expected_shape"),
+        [
+            # First scale-down: contiguous world ranks
+            (3, 1, 1, {1}, [0, 1, 2, 3], [0, 2, 3], (1, 3, 1, 1)),
+            (2, 1, 1, {0}, [0, 1, 2], [1, 2], (1, 2, 1, 1)),
+            (3, 1, 2, {1}, [0, 1, 2, 3, 4, 5, 6, 7],
+             [0, 1, 4, 5, 6, 7], (1, 3, 1, 2)),
+            # Second scale-down: non-contiguous world ranks
+            (2, 1, 1, {2}, [0, 2, 3], [0, 2], (1, 2, 1, 1)),
+        ],
+    )
+    def test_surviving_ranks(
+        self, new_dp, pp, tp, dead, world_ranks,
+        expected_ranks, expected_shape,
+    ):
+        result = _build_surviving_rank_tensor(
+            new_dp_size=new_dp, pp_size=pp, tp_size=tp,
+            dead_dp_ranks=dead,
+            current_world_ranks=world_ranks,
+        )
+        assert sorted(result.flatten().tolist()) == expected_ranks
+        assert result.shape == expected_shape
+
+
+# ===========================================================================
+# 19. perform_scale_down_eplb_reshuffle rank mapping
+# ===========================================================================
+
+
+class TestScaleDownEPLBReshuffleMapping:
+    """Verify rank_mapping maps dead ranks to -1 and compacts survivors."""
+
+    def _make_executor(self, tp_size: int, dp_size: int):
+        executor = object.__new__(ElasticEPScalingExecutor)
+        worker = MagicMock()
+        worker.vllm_config.parallel_config.tensor_parallel_size = tp_size
+        worker.vllm_config.parallel_config.data_parallel_size = dp_size
+        executor.worker_ref = weakref.ref(worker)
+        executor._worker_strong_ref = worker
+
+        captured = {}
+
+        def mock_reshuffle(rank_mapping=None):
+            captured["rank_mapping"] = rank_mapping
+
+        executor._perform_eplb_reshuffle = mock_reshuffle
+        executor._set_eplb_suppressed = MagicMock()
+        return executor, captured
+
+    @pytest.mark.parametrize(
+        ("tp", "dp", "new_dp", "dead", "expected_mapping"),
+        [
+            # TP=1: rank 1 dies → dead=-1, compact rest.
+            (1, 4, 3, [1], {0: 0, 1: -1, 2: 1, 3: 2}),
+            # TP=1: graceful → highest rank removed.
+            (1, 4, 3, None, {0: 0, 1: 1, 2: 2, 3: -1}),
+            # TP=2: DP rank 1 dies → EP ranks 2,3 dead.
+            (2, 3, 2, [1], {0: 0, 1: 1, 2: -1, 3: -1, 4: 2, 5: 3}),
+        ],
+    )
+    def test_rank_mapping(self, tp, dp, new_dp, dead, expected_mapping):
+        executor, captured = self._make_executor(tp_size=tp, dp_size=dp)
+        executor.perform_scale_down_eplb_reshuffle(
+            new_dp_size=new_dp, dead_dp_ranks=dead
+        )
+        assert captured["rank_mapping"] == expected_mapping
+
+
+# ===========================================================================
+# 20. reassign_missing_experts
+# ===========================================================================
+
+
+class TestReassignMissingExperts:
+    """Verify reassign_missing_experts compacts p2l, replaces missing
+    logical experts with redundant replicas, and rebuilds derived maps."""
+
+    def _make_executor_with_eplb(
+        self,
+        p2l: "torch.Tensor",
+        num_logical: int,
+        tp_size: int,
+        new_ep_size: int,
+        dead_dp_ranks: list[int],
+    ):
+        executor = object.__new__(ElasticEPScalingExecutor)
+        worker = MagicMock()
+        worker.vllm_config.parallel_config.tensor_parallel_size = tp_size
+        executor.worker_ref = weakref.ref(worker)
+        executor._worker_strong_ref = worker
+
+        reconfig = MagicMock()
+        reconfig.dead_dp_ranks = dead_dp_ranks
+        executor.reconfig_request = reconfig
+
+        ep_group = MagicMock()
+        ep_group.rank = 0
+        ep_group.world_size = new_ep_size
+
+        num_moe_layers = p2l.shape[0]
+        state = SimpleNamespace(
+            physical_to_logical_map=p2l.clone(),
+            logical_replica_count=torch.zeros(
+                num_moe_layers, num_logical, dtype=torch.long
+            ),
+            logical_to_physical_map=torch.full(
+                (num_moe_layers, num_logical, 4), -1, dtype=torch.long,
+            ),
+            communicator=MagicMock(),
+        )
+        worker.model_runner.eplb_state = SimpleNamespace(
+            model_states={"h": state},
+        )
+        worker.model_runner.model_config.compute_hash.return_value = "h"
+        worker.model_runner.get_model.return_value = MagicMock(
+            expert_weights=[],
+        )
+
+        return executor, state, ep_group
+
+    _REARRANGE_PATH = (
+        "vllm.distributed.eplb.rebalance_execute"
+        ".rearrange_expert_weights_inplace"
+    )
+    _EP_GROUP_PATH = (
+        "vllm.distributed.elastic_ep.elastic_execute.get_ep_group"
+    )
+
+    def test_compaction_and_missing_expert_replacement(self):
+        """p2l already compacted by _apply_new_config.  Expert 2 was only
+        on the dead rank.  Verifies: expert 2 placed into a redundant
+        slot, derived maps consistent."""
+        # After compaction (rank 1 removed):
+        # rank0=[0,1], rank2=[0,1], rank3=[0,3]
+        # Expert 2 missing.  Expert 0 has 3 replicas.
+        p2l = torch.tensor([[0, 1, 0, 1, 0, 3]])
+        executor, state, ep_group = self._make_executor_with_eplb(
+            p2l=p2l, num_logical=4, tp_size=1,
+            new_ep_size=3, dead_dp_ranks=[1],
+        )
+
+        with (
+            patch(self._EP_GROUP_PATH, return_value=ep_group),
+            patch(self._REARRANGE_PATH),
+        ):
+            executor.reassign_missing_experts()
+
+        final_p2l = state.physical_to_logical_map[0]
+
+        # Still 6 columns (already compacted).
+        assert final_p2l.shape[0] == 6
+        # Expert 2 is now present.
+        assert 2 in final_p2l.tolist()
+        # Expert 0 lost one redundant replica (3 → 2).
+        assert final_p2l.tolist().count(0) == 2
+        # All 4 logical experts covered.
+        assert set(final_p2l.tolist()) == {0, 1, 2, 3}
+        # Derived maps consistent.
+        for lid in range(4):
+            expected = (final_p2l == lid).sum().item()
+            assert state.logical_replica_count[0, lid].item() == expected
+            for r in range(expected):
+                phys = state.logical_to_physical_map[0, lid, r].item()
+                assert phys >= 0
+                assert final_p2l[phys].item() == lid
+
+    def test_no_reassignment_when_all_present(self):
+        """Kill rank 3 — all experts still have replicas on survivors."""
+        # After compaction (rank 3 removed):
+        # rank0=[0,1], rank1=[2,3], rank2=[0,2]
+        p2l = torch.tensor([[0, 1, 2, 3, 0, 2]])
+        executor, state, ep_group = self._make_executor_with_eplb(
+            p2l=p2l, num_logical=4, tp_size=1,
+            new_ep_size=3, dead_dp_ranks=[3],
+        )
+
+        with (
+            patch(self._EP_GROUP_PATH, return_value=ep_group),
+            patch(self._REARRANGE_PATH),
+        ):
+            executor.reassign_missing_experts()
+
+        # All 4 experts present, no eviction needed.
+        assert set(state.physical_to_logical_map[0].tolist()) == {0, 1, 2, 3}
+
+    def test_derived_maps_correct_after_compaction_no_missing(self):
+        """After p2l compaction with no missing experts,
+        rebuild_eplb_derived_maps must produce l2p entries that
+        reference the NEW compacted physical indices, not the old
+        pre-compaction indices.
+
+        This reproduces the bug that caused garbled output:
+        _apply_new_config compacted p2l but didn't rebuild derived
+        maps, so the router used stale slot indices.
+        """
+        # BEFORE compaction (4 ranks, 2 local each = 8 physical):
+        # rank0=[0,1], rank1=[2,3], rank2=[0,2], rank3=[1,3]
+        old_p2l = torch.tensor([[0, 1, 2, 3, 0, 2, 1, 3]])
+        num_logical = 4
+        max_replicas = 4
+
+        # Compact using the real production function.
+        new_p2l = strip_dead_columns(old_p2l, dead_ep_ranks={1}, num_local=2)
+        num_physical = new_p2l.shape[1]  # 6
+
+        # Build an eplb_model_state with stale derived maps (old indices).
+        state = SimpleNamespace(
+            physical_to_logical_map=new_p2l,
+            logical_replica_count=torch.zeros(1, num_logical,
+                                              dtype=torch.long),
+            logical_to_physical_map=torch.full(
+                (1, num_logical, max_replicas), -1, dtype=torch.long,
+            ),
+        )
+
+        # Call the real production function.
+        rebuild_eplb_derived_maps(state)
+
+        # All physical indices in l2p must be valid (< num_physical).
+        for lid in range(num_logical):
+            count = state.logical_replica_count[0, lid].item()
+            assert count >= 1, f"Expert {lid} has 0 replicas"
+            for r in range(count):
+                phys = state.logical_to_physical_map[0, lid, r].item()
+                assert 0 <= phys < num_physical, (
+                    f"Expert {lid} replica {r} points to slot {phys} "
+                    f"but only {num_physical} slots exist"
+                )
+                assert new_p2l[0, phys].item() == lid
+
+    def test_no_donor_drained_to_zero(self):
+        """Multiple missing experts must not drain all replicas from a
+        single donor.  Expert 0 has 3 replicas and 2 experts are
+        missing — naive greedy could evict all copies of expert 0."""
+        # After compaction (rank 1 removed):
+        # rank0=[0,1], rank2=[0,1], rank3=[0,1]
+        # Experts 2 and 3 are missing.  Expert 0 has 3 replicas,
+        # expert 1 has 3 replicas.
+        p2l = torch.tensor([[0, 1, 0, 1, 0, 1]])
+        executor, state, ep_group = self._make_executor_with_eplb(
+            p2l=p2l, num_logical=4, tp_size=1,
+            new_ep_size=3, dead_dp_ranks=[1],
+        )
+
+        with (
+            patch(self._EP_GROUP_PATH, return_value=ep_group),
+            patch(self._REARRANGE_PATH),
+        ):
+            executor.reassign_missing_experts()
+
+        final = state.physical_to_logical_map[0].tolist()
+        # All 4 logical experts must be present.
+        assert set(final) == {0, 1, 2, 3}
+        # No expert should have 0 replicas.
+        for lid in range(4):
+            assert final.count(lid) >= 1, (
+                f"Expert {lid} has 0 replicas: {final}"
+            )

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -188,6 +188,12 @@ class ParallelConfig:
     enable_elastic_ep: bool = False
     """Enable elastic expert parallelism with stateless NCCL groups for DP/EP."""
 
+    enable_ep_fault_tolerance: bool = False
+    """Enable EP fault tolerance.  When a DP engine process dies, the system
+    automatically scales down instead of shutting everything down.  Requires
+    ``enable_elastic_ep=True``, ``data_parallel_backend="ray"``, and
+    ``tensor_parallel_size=1``."""
+
     enable_dbo: bool = False
     """Enable dual batch overlap for the model executor."""
     ubatch_size: int = 0
@@ -573,13 +579,26 @@ class ParallelConfig:
         return self.world_size // self.nnodes_within_dp
 
     @staticmethod
-    def has_unfinished_dp(dp_group: ProcessGroup, has_unfinished: bool) -> bool:
+    def has_unfinished_dp(
+        dp_group: ProcessGroup,
+        has_unfinished: bool,
+        fault_tolerant: bool = False,
+    ) -> bool:
         tensor = torch.tensor([has_unfinished], dtype=torch.int32, device="cpu")
         # dp rank 0: has_unfinished_seqs=True
         # dp rank 1: has_unfinished_seqs=False
         # aggregated: has_unfinished_seqs=True
         # so this is an OR operation, i.e. MAX in integers
-        torch.distributed.all_reduce(tensor, op=ReduceOp.MAX, group=dp_group)
+        try:
+            torch.distributed.all_reduce(tensor, op=ReduceOp.MAX, group=dp_group)
+        except Exception:
+            if not fault_tolerant:
+                raise
+            logger.warning(
+                "DP all-reduce timed out — a peer may be dead. "
+                "Continuing in fault-tolerant mode."
+            )
+            return True
         aggregated_has_unfinished = bool(tensor.item())
         return aggregated_has_unfinished
 
@@ -666,6 +685,17 @@ class ParallelConfig:
                     "or data_parallel_hybrid_lb. Elastic EP relies on a single API "
                     "server and core client to coordinate scale up/down."
                 )
+
+        if self.enable_ep_fault_tolerance:
+            if not self.enable_elastic_ep:
+                raise ValueError("EP fault tolerance requires enable_elastic_ep=True.")
+            if self.tensor_parallel_size > 1:
+                raise ValueError(
+                    "EP fault tolerance requires tensor_parallel_size=1. "
+                    "With TP>1, a dead process would hang the NCCL TP group."
+                )
+            if self.data_parallel_size <= 1:
+                raise ValueError("EP fault tolerance requires data_parallel_size > 1.")
 
         if self.data_parallel_size > 1 or self.data_parallel_size_local == 0:
             # Data parallel was specified in the engine args.

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -146,6 +146,15 @@ class NaiveAll2AllManager(All2AllManagerBase):
     def destroy(self):
         pass
 
+    def abort(self):
+        """Forcefully abort without waiting for peers.
+
+        No NCCL comms in the base class. Subclasses that introduce NCCL
+        communicators must override this to call ncclCommAbort instead of
+        ncclCommDestroy to avoid hanging when a peer rank has died.
+        """
+        pass
+
 
 class AgRsAll2AllManager(All2AllManagerBase):
     """

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -310,6 +310,15 @@ class DeviceCommunicatorBase:
     def destroy(self):
         pass
 
+    def abort(self):
+        """Forcefully abort the communicator without waiting for peers.
+
+        Subclasses that wrap NCCL communicators must override this to
+        call ncclCommAbort instead of ncclCommDestroy to avoid hanging
+        when a peer rank has died.
+        """
+        pass
+
     def prepare_communication_buffer_for_model(self, model: torch.nn.Module) -> None:
         """
         Prepare the communication buffer for the model.

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -112,6 +112,15 @@ class All2AllManagerBase:
     def destroy(self):
         pass
 
+    def abort(self):
+        """Forcefully abort without waiting for peers.
+
+        No NCCL comms in the base class. Subclasses that introduce NCCL
+        communicators must override this to call ncclCommAbort instead of
+        ncclCommDestroy to avoid hanging when a peer rank has died.
+        """
+        pass
+
 
 class DeviceCommunicatorBase:
     """

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -349,6 +349,29 @@ class CudaCommunicator(DeviceCommunicatorBase):
             self.all2all_manager.destroy()
             self.all2all_manager = None  # type: ignore[assignment]
 
+    def abort(self):
+        """Forcefully abort the NCCL communicator via ncclCommAbort.
+
+        Unlike destroy() (which calls ncclCommDestroy and may trigger an
+        implicit ncclCommFinalize collective that hangs when a peer is
+        dead), abort is unconditionally safe in fault scenarios.
+
+        Sub-communicators (fi_ar_comm, all2all_manager) don't wrap NCCL
+        comms today, but we call abort() for consistency so that the
+        fault path stays correct if they ever gain NCCL dependencies.
+        """
+        if self.pynccl_comm is not None:
+            self.pynccl_comm.abort()
+            self.pynccl_comm = None
+        if self.ca_comm is not None:
+            self.ca_comm = None
+        if self.fi_ar_comm is not None:
+            self.fi_ar_comm.abort()
+            self.fi_ar_comm = None
+        if self.all2all_manager is not None:
+            self.all2all_manager.abort()
+            self.all2all_manager = None  # type: ignore[assignment]
+
     def all_gatherv(
         self,
         input_: torch.Tensor | list[torch.Tensor],

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -330,3 +330,12 @@ class FlashInferAllReduce:
     def destroy(self):
         if not self.disabled:
             destroy_fi_ar_workspace()
+
+    def abort(self):
+        """Forcefully abort without waiting for peers.
+
+        No NCCL comms here. If NCCL communicators are ever added, this
+        must call ncclCommAbort instead of ncclCommDestroy to avoid
+        hanging when a peer rank has died.
+        """
+        self.destroy()

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -152,6 +152,19 @@ class PyNcclCommunicator:
             self.available = False
             self.disabled = True
 
+    def abort(self):
+        """Forcefully abort the NCCL communicator via ncclCommAbort.
+
+        Unlike destroy() (which calls ncclCommDestroy and may trigger an
+        implicit ncclCommFinalize collective), abort is safe to call when
+        a peer rank has died and would otherwise cause destroy to hang.
+        """
+        if self.available and not self.disabled:
+            with torch.accelerator.device_index(self.device.index):
+                self.nccl.ncclCommAbort(self.comm)
+            self.available = False
+            self.disabled = True
+
     def all_reduce(
         self,
         in_tensor: torch.Tensor,

--- a/vllm/distributed/device_communicators/pynccl_wrapper.py
+++ b/vllm/distributed/device_communicators/pynccl_wrapper.py
@@ -290,6 +290,8 @@ class NCCLLibrary:
         # it is better not to call it at all.
         # ncclResult_t  ncclCommDestroy(ncclComm_t comm);
         Function("ncclCommDestroy", ncclResult_t, [ncclComm_t]),
+        # ncclResult_t  ncclCommAbort(ncclComm_t comm);
+        Function("ncclCommAbort", ncclResult_t, [ncclComm_t]),
         # ncclResult_t ncclGroupStart();
         Function("ncclGroupStart", ncclResult_t, []),
         # ncclResult_t ncclGroupEnd();
@@ -547,6 +549,9 @@ class NCCLLibrary:
 
     def ncclCommDestroy(self, comm: ncclComm_t) -> None:
         self.NCCL_CHECK(self._funcs["ncclCommDestroy"](comm))
+
+    def ncclCommAbort(self, comm: ncclComm_t) -> None:
+        self.NCCL_CHECK(self._funcs["ncclCommAbort"](comm))
 
     def ncclGroupStart(self) -> None:
         self.NCCL_CHECK(self._funcs["ncclGroupStart"]())

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -4,6 +4,7 @@ import copy
 import gc
 import weakref
 from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -31,6 +32,7 @@ from vllm.distributed.elastic_ep.standby_state import (
 )
 from vllm.distributed.eplb.eplb_communicator import create_eplb_communicator
 from vllm.distributed.parallel_state import (
+    _abort_and_replace_active_groups,
     _replace_active_groups,
     get_eplb_group,
     prepare_communication_buffer_for_model,
@@ -42,7 +44,72 @@ from vllm.v1.engine import ReconfigureDistributedRequest, ReconfigureRankType
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.workspace import lock_workspace, unlock_workspace
 
+if TYPE_CHECKING:
+    from vllm.distributed.eplb.eplb_state import EplbModelState
+
 logger = init_logger(__name__)
+
+
+def dead_dp_to_ep_ranks(
+    dead_dp_ranks: set[int] | list[int],
+    tp_size: int,
+) -> set[int]:
+    """Expand dead DP ranks to the corresponding dead EP ranks."""
+    dead_ep: set[int] = set()
+    for dp_rank in dead_dp_ranks:
+        for tp_offset in range(tp_size):
+            dead_ep.add(dp_rank * tp_size + tp_offset)
+    return dead_ep
+
+
+def strip_dead_columns(
+    p2l: torch.Tensor,
+    dead_ep_ranks: set[int],
+    num_local: int,
+) -> torch.Tensor:
+    """Remove dead EP rank columns from physical_to_logical_map.
+
+    Returns a new contiguous tensor with only the surviving ranks'
+    columns, preserving order.
+    """
+    old_ep_size = p2l.shape[1] // num_local
+    surviving_cols: list[int] = []
+    for ep_r in range(old_ep_size):
+        if ep_r not in dead_ep_ranks:
+            start = ep_r * num_local
+            surviving_cols.extend(range(start, start + num_local))
+    col_idx = torch.tensor(surviving_cols, device=p2l.device)
+    return p2l[:, col_idx].contiguous()
+
+
+def rebuild_eplb_derived_maps(
+    eplb_model_state: "EplbModelState",
+) -> None:
+    """Rebuild logical_to_physical_map and logical_replica_count
+    from physical_to_logical_map.
+
+    Call after any modification to physical_to_logical_map (compaction,
+    reassignment) to keep the derived maps consistent. Modifies the
+    tensors in-place so existing views (held by FusedMoE layers) see
+    the updates.
+    """
+    p2l = eplb_model_state.physical_to_logical_map
+    num_moe_layers, num_physical = p2l.shape
+    eplb_model_state.logical_replica_count.zero_()
+    eplb_model_state.logical_to_physical_map.fill_(-1)
+    for layer_idx in range(num_moe_layers):
+        for phys_idx in range(num_physical):
+            lid = p2l[layer_idx, phys_idx].item()
+            if lid >= 0:
+                c = eplb_model_state.logical_replica_count[
+                    layer_idx, lid
+                ].item()
+                eplb_model_state.logical_to_physical_map[
+                    layer_idx, lid, c
+                ] = phys_idx
+                eplb_model_state.logical_replica_count[
+                    layer_idx, lid
+                ] += 1
 
 
 def batch_transfer_weights(
@@ -173,7 +240,9 @@ class ElasticEPScalingExecutor:
         self._set_eplb_suppressed(True)
 
     def create_standby_groups(
-        self, reconfig_request: ReconfigureDistributedRequest
+        self,
+        reconfig_request: ReconfigureDistributedRequest,
+        dead_dp_ranks: set[int] | None = None,
     ) -> None:
         self.reconfig_request = reconfig_request
         new_dp_size = reconfig_request.new_data_parallel_size
@@ -192,6 +261,7 @@ class ElasticEPScalingExecutor:
                 master_ip=reconfig_request.new_data_parallel_master_ip,
                 coord_store_port=reconfig_request.coord_store_port,
                 enable_eplb=updated_config.parallel_config.enable_eplb,
+                dead_dp_ranks=dead_dp_ranks,
             )
         if new_dp_size > old_dp_size:
             self._set_eplb_suppressed(True)
@@ -282,18 +352,45 @@ class ElasticEPScalingExecutor:
         self._release_cuda_graphs()
         _replace_active_groups(world=None, dp=None, ep=None, eplb=None, node_count=None)
 
+    def abort_and_switch(self) -> None:
+        """Abort old NCCL groups and switch to standby groups.
+
+        Used for fault-triggered scale-down where a peer rank has died
+        and normal collective teardown would hang.  Identical to
+        switch_and_prepare but uses abort instead of destroy.
+        """
+        old_dp_size = get_dp_group().world_size
+        old_ep_size = get_ep_group().world_size
+        logger.debug(
+            "[Elastic EP] abort_and_switch: old EP %d → new EP %d",
+            old_ep_size, old_ep_size - 1,
+        )
+        self._release_cuda_graphs()
+        _abort_and_replace_active_groups(**pop_standby_groups())
+        self._apply_new_config(old_dp_size, old_ep_size)
+
     def switch_and_prepare(self) -> None:
         old_dp_size = get_dp_group().world_size
         old_ep_size = get_ep_group().world_size
-
         self._release_cuda_graphs()
         _replace_active_groups(**pop_standby_groups())
+        self._apply_new_config(old_dp_size, old_ep_size)
 
+    def _apply_new_config(
+        self, old_dp_size: int, old_ep_size: int
+    ) -> None:
+        """Apply reconfigure request to parallel config, MoE modules,
+        EPLB state, and communication buffers after group replacement."""
         parallel_config = self.worker.vllm_config.parallel_config
         reconfig_request = self.reconfig_request
         assert reconfig_request is not None
         new_dp_size = reconfig_request.new_data_parallel_size
         new_ep_size = get_ep_group().world_size
+
+        logger.debug(
+            "[Elastic EP] _apply_new_config: DP %d→%d, EP %d→%d",
+            old_dp_size, new_dp_size, old_ep_size, new_ep_size,
+        )
 
         parallel_config.data_parallel_size = new_dp_size
         if (
@@ -343,6 +440,11 @@ class ElasticEPScalingExecutor:
                 vllm_parallel_config=parallel_config,
             )
             module.moe_config.moe_parallel_config = module.moe_parallel_config
+            # Rebuild _expert_map for the new EP size/rank. Without this,
+            # the map has the old size (e.g. 96 entries for 3 ranks) and
+            # indexing with new expert IDs causes out-of-bounds access.
+            if hasattr(module, 'update_expert_map') and module._expert_map is not None:
+                module.update_expert_map()
 
         # Update EPLB state
         eplb_state = self.worker.model_runner.eplb_state
@@ -393,6 +495,29 @@ class ElasticEPScalingExecutor:
             ]
             eplb_state.num_valid_physical_experts = num_physical_experts
 
+            # Trim physical_to_logical_map to match the new EP size.
+            # For fault-triggered scale-down, dead rank columns are in
+            # the middle — strip them. For graceful, the highest columns
+            # are removed — simple slice works too.
+            dead_dp = set(
+                reconfig_request.dead_dp_ranks
+            ) if reconfig_request.dead_dp_ranks else set()
+            if dead_dp:
+                dead_ep = dead_dp_to_ep_ranks(
+                    dead_dp, get_tp_group().world_size
+                )
+                eplb_model_state.physical_to_logical_map = (
+                    strip_dead_columns(
+                        old_physical_to_logical, dead_ep, num_local_experts
+                    )
+                )
+            else:
+                eplb_model_state.physical_to_logical_map = (
+                    old_physical_to_logical[:, :num_physical_experts]
+                )
+
+            rebuild_eplb_derived_maps(eplb_model_state)
+
         model = self.worker.model_runner.get_model()
         model.expert_weights = []
         with set_current_vllm_config(self.worker.vllm_config):
@@ -413,6 +538,14 @@ class ElasticEPScalingExecutor:
                     module.quant_method = module.quant_method.old_quant_method
                     module.runner = module._init_runner()
             prepare_communication_buffer_for_model(self.worker.model_runner.model)
+
+        logger.debug(
+            "[Elastic EP] _apply_new_config: p2l=%s, "
+            "num_physical=%d, num_redundant=%d",
+            list(eplb_model_state.physical_to_logical_map.shape),
+            num_physical_experts,
+            parallel_config.eplb_config.num_redundant_experts,
+        )
 
         eplb_model_state.communicator = create_eplb_communicator(
             group_coordinator=get_eplb_group(),
@@ -442,6 +575,15 @@ class ElasticEPScalingExecutor:
                 (bt.block_table.gpu.clone(), bt.block_table.cpu.clone())
             )
         multi_block_table.clear()
+
+        # For fault-triggered scale-down, reassign missing experts
+        # BEFORE warmup. The warmup does a real forward pass (for CUDA
+        # graph capture), which will crash if logical experts are missing
+        # from the p2l map (router produces expert IDs that map to -1).
+        reconfig_request = self.reconfig_request
+        if (reconfig_request and reconfig_request.dead_dp_ranks
+                and new_dp_size < old_dp_size):
+            self.reassign_missing_experts()
 
         unlock_workspace()
         self.worker.compile_or_warm_up_model()
@@ -487,16 +629,238 @@ class ElasticEPScalingExecutor:
         self._perform_eplb_reshuffle()
         self._set_eplb_suppressed(False)
 
-    def perform_scale_down_eplb_reshuffle(self, new_dp_size: int) -> None:
+    def reassign_missing_experts(self) -> None:
+        """Reassign logical experts that lost all replicas after a fault.
+
+        After a fault-triggered scale-down, _apply_new_config has already
+        compacted physical_to_logical_map (stripped dead rank columns).
+        This method:
+        1. Identifies which logical experts have zero replicas.
+        2. Replaces the most-redundant replicas with missing experts.
+        3. Rebuilds the derived EPLB maps in-place.
+        4. Transfers actual expert weights via NCCL P2P.
+
+        All tensors are already sized for the new EP topology when this
+        method runs (p2l, expert_load_pass, expert_load_window all have
+        new_ep_size * num_local columns).
+        """
+        eplb_state = self.worker.model_runner.eplb_state
+        if eplb_state is None:
+            return
+
+        model_config = self.worker.model_runner.model_config
+        eplb_model_state = eplb_state.model_states[model_config.compute_hash()]
+        p2l = eplb_model_state.physical_to_logical_map
+        num_moe_layers = p2l.shape[0]
+        num_physical = p2l.shape[1]
+        num_logical = eplb_model_state.logical_replica_count.shape[1]
+
+        ep_group = get_ep_group()
+        ep_rank = ep_group.rank
+        new_ep_size = ep_group.world_size
+
+        # Save the current map — this reflects the true state of expert
+        # weights in GPU memory (before reassignment modifies it).
+        old_p2l = p2l.clone()
+
+        logger.debug(
+            "[Elastic EP] reassign_missing_experts: p2l shape=%s, "
+            "%d logical experts, %d physical slots",
+            list(p2l.shape), num_logical, num_physical,
+        )
+
+        # --- 1 & 2. Identify missing experts and reassign -----------------
+        all_logical = set(range(num_logical))
+        any_reassigned = False
+
+        for layer_idx in range(num_moe_layers):
+            layer_map = p2l[layer_idx]
+
+            replica_count: dict[int, int] = {}
+            global_redundant: list[tuple[int, int]] = []
+            for phys_idx in range(num_physical):
+                lid = layer_map[phys_idx].item()
+                if lid >= 0:
+                    replica_count[lid] = replica_count.get(lid, 0) + 1
+
+            missing = sorted(all_logical - set(replica_count.keys()))
+            if not missing:
+                continue
+
+            any_reassigned = True
+
+            for phys_idx in range(num_physical):
+                lid = layer_map[phys_idx].item()
+                if lid >= 0 and replica_count.get(lid, 0) > 1:
+                    global_redundant.append((replica_count[lid], phys_idx))
+            global_redundant.sort(reverse=True)
+
+            slot_iter = iter(global_redundant)
+            for logical_id in missing:
+                # Find a redundant slot whose donor still has >1 replica.
+                placed = False
+                while True:
+                    candidate = next(slot_iter, None)
+                    if candidate is None:
+                        raise RuntimeError(
+                            f"[Fault Tolerance] Layer {layer_idx}: no "
+                            f"redundant slot available to place missing "
+                            f"logical expert {logical_id}. This should "
+                            f"not happen — the capacity check in "
+                            f"_on_engine_process_died should have "
+                            f"prevented scale-down."
+                        )
+                    _, global_slot = candidate
+                    old_lid = layer_map[global_slot].item()
+                    if replica_count.get(old_lid, 0) > 1:
+                        p2l[layer_idx, global_slot] = logical_id
+                        replica_count[old_lid] -= 1
+                        placed = True
+                        break
+                if not placed:
+                    raise RuntimeError(
+                        f"[Fault Tolerance] Layer {layer_idx}: failed "
+                        f"to place missing logical expert {logical_id}."
+                    )
+
+        if not any_reassigned:
+            if ep_rank == 0:
+                logger.info(
+                    "[Fault Tolerance] All %d logical experts have at "
+                    "least one replica in every layer — no "
+                    "reassignment needed.",
+                    num_logical,
+                )
+            return
+
+        if ep_rank == 0:
+            logger.info(
+                "[Fault Tolerance] Replaced redundant expert slots "
+                "with missing experts across %d layers.",
+                num_moe_layers,
+            )
+
+        # --- 3. Rebuild derived maps in-place --------------------------------
+        rebuild_eplb_derived_maps(eplb_model_state)
+
+        # --- 4. Transfer actual expert weights via NCCL P2P ---------------
+        # old_p2l reflects what's actually in GPU memory (pre-reassignment).
+        # p2l reflects the desired state (post-reassignment).
+        # rearrange_expert_weights_inplace sees the diff and transfers
+        # weights from ranks that hold the needed expert.
+        #
+        # Split experts into two groups:
+        # - reachable: have a surviving replica in old_p2l → NCCL P2P
+        # - unreachable: no surviving replica → reload from disk
+        old_present = set(old_p2l[old_p2l >= 0].tolist())
+        new_required = set(p2l[p2l >= 0].tolist())
+        unreachable = new_required - old_present
+
+        from vllm.distributed.eplb.rebalance_execute import (
+            rearrange_expert_weights_inplace,
+        )
+
+        model = self.worker.model_runner.get_model()
+        ep_group_pg = get_ep_group().device_group
+        rearrange_expert_weights_inplace(
+            old_global_expert_indices=old_p2l,
+            new_global_expert_indices=p2l,
+            expert_weights=model.expert_weights,
+            ep_group=ep_group_pg,
+            communicator=eplb_model_state.communicator,
+        )
+
+        # Reload unreachable experts from disk.
+        if unreachable:
+            if ep_rank == 0:
+                logger.info(
+                    "[Fault Tolerance] Reloading %d experts from disk: %s",
+                    len(unreachable),
+                    sorted(unreachable),
+                )
+            self._reload_expert_weights_from_disk(unreachable)
+
+        if ep_rank == 0:
+            logger.info(
+                "[Fault Tolerance] Expert weight transfer complete. "
+                "%d physical experts across %d EP ranks.",
+                num_physical, new_ep_size,
+            )
+
+    def _reload_expert_weights_from_disk(
+        self, unreachable_experts: set[int]
+    ) -> None:
+        """Reload expert weights from the model checkpoint for experts
+        that have no surviving replica in GPU memory.
+
+        Uses the existing model.load_weights() pipeline. The FusedMoE
+        weight_loader consults logical_to_physical_map (already updated
+        by reassign_missing_experts) to route each expert's weights to
+        the correct reassigned physical slot.
+        """
+        from vllm.model_executor.model_loader.default_loader import (
+            DefaultModelLoader,
+        )
+        from vllm.model_executor.model_loader.ep_weight_filter import (
+            parse_expert_id,
+        )
+
+        model = self.worker.model_runner.get_model()
+        model_config = self.worker.model_runner.model_config
+        load_config = self.worker.vllm_config.load_config
+
+        loader = DefaultModelLoader(load_config)
+        all_weights = loader.get_all_weights(model_config, model)
+        filtered = (
+            (name, tensor)
+            for name, tensor in all_weights
+            if parse_expert_id(name) in unreachable_experts
+        )
+        model.load_weights(filtered)
+
+    def abort_eplb_group_for_dead_ranks(self) -> None:
+        """Abort the EPLB NCCL process group so that pending/future NCCL
+        ops involving dead ranks don't hang indefinitely.  After this call
+        the old EPLB communicator is unusable — a new standby group must be
+        created before any further EPLB operations."""
+        from vllm.distributed.parallel_state import get_eplb_group
+        eplb_group = get_eplb_group()
+        logger.info(
+            "[Elastic EP] Aborting old EPLB process group (rank %d) "
+            "to unblock operations involving dead ranks.",
+            eplb_group.rank,
+        )
+        eplb_group.device_group.abort()
+
+    def perform_scale_down_eplb_reshuffle(
+        self,
+        new_dp_size: int,
+        dead_dp_ranks: list[int] | None = None,
+    ) -> None:
         self._set_eplb_suppressed(True)
         parallel_config = self.worker.vllm_config.parallel_config
         tp_size = parallel_config.tensor_parallel_size
         old_ep_size = parallel_config.data_parallel_size * tp_size
         new_ep_size = new_dp_size * tp_size
-        rank_mapping = {
-            old_ep_rank: old_ep_rank if old_ep_rank < new_ep_size else -1
-            for old_ep_rank in range(old_ep_size)
-        }
+
+        if dead_dp_ranks:
+            # Fault-triggered: map dead ranks' experts to -1, compact
+            # surviving ranks to contiguous 0..new_ep_size-1.
+            dead_ep = dead_dp_to_ep_ranks(dead_dp_ranks, tp_size)
+            rank_mapping = {}
+            new_rank = 0
+            for old_ep_rank in range(old_ep_size):
+                if old_ep_rank in dead_ep:
+                    rank_mapping[old_ep_rank] = -1
+                else:
+                    rank_mapping[old_ep_rank] = new_rank
+                    new_rank += 1
+        else:
+            # Graceful: remove the highest-ranked engines.
+            rank_mapping = {
+                old_ep_rank: old_ep_rank if old_ep_rank < new_ep_size else -1
+                for old_ep_rank in range(old_ep_size)
+            }
         self._perform_eplb_reshuffle(rank_mapping=rank_mapping)
 
     def receive_weights(self) -> None:

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -361,10 +361,6 @@ class ElasticEPScalingExecutor:
         """
         old_dp_size = get_dp_group().world_size
         old_ep_size = get_ep_group().world_size
-        logger.debug(
-            "[Elastic EP] abort_and_switch: old EP %d → new EP %d",
-            old_ep_size, old_ep_size - 1,
-        )
         self._release_cuda_graphs()
         _abort_and_replace_active_groups(**pop_standby_groups())
         self._apply_new_config(old_dp_size, old_ep_size)
@@ -538,14 +534,6 @@ class ElasticEPScalingExecutor:
                     module.quant_method = module.quant_method.old_quant_method
                     module.runner = module._init_runner()
             prepare_communication_buffer_for_model(self.worker.model_runner.model)
-
-        logger.debug(
-            "[Elastic EP] _apply_new_config: p2l=%s, "
-            "num_physical=%d, num_redundant=%d",
-            list(eplb_model_state.physical_to_logical_map.shape),
-            num_physical_experts,
-            parallel_config.eplb_config.num_redundant_experts,
-        )
 
         eplb_model_state.communicator = create_eplb_communicator(
             group_coordinator=get_eplb_group(),

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -358,6 +358,15 @@ class ElasticEPScalingExecutor:
         Used for fault-triggered scale-down where a peer rank has died
         and normal collective teardown would hang.  Identical to
         switch_and_prepare but uses abort instead of destroy.
+
+        TODO: Currently abort() is called here in the recovery path,
+        which requires all surviving ranks to reach this point first.
+        If a worker is stuck in a collective (e.g. all2all mid-forward),
+        it can never reach here — deadlock.  A more robust approach is
+        to call abort() from a separate sentinel thread that monitors
+        rank health independently.  The sentinel would abort the local
+        communicators immediately on death detection, unblocking the
+        main thread's hung collective so it can enter recovery.
         """
         old_dp_size = get_dp_group().world_size
         old_ep_size = get_ep_group().world_size

--- a/vllm/distributed/elastic_ep/elastic_state.py
+++ b/vllm/distributed/elastic_ep/elastic_state.py
@@ -102,6 +102,10 @@ class ElasticEPScalingState:
         self.scale_type = scale_type
         self.reconfig_request = reconfig_request
 
+        self.dead_dp_ranks: set[int] = set()
+        if reconfig_request is not None and reconfig_request.dead_dp_ranks:
+            self.dead_dp_ranks = set(reconfig_request.dead_dp_ranks)
+
         self.state: EngineState
         if scale_type == "scale_up":
             self.state = (
@@ -150,15 +154,25 @@ class ElasticEPScalingState:
         assert self.state == ScaleUpNewEngineState.PREPARE
 
     def _execute_tcp_store_barrier(
-        self, dp_store, group_rank, group_size, barrier_id, timeout=None
+        self,
+        dp_store,
+        group_rank,
+        group_size,
+        barrier_id,
+        timeout=None,
+        skip_ranks: set[int] | None = None,
     ):
+        if skip_ranks is None:
+            skip_ranks = set()
+        expected_count = group_size - len(skip_ranks)
+
         arrival_key = f"arrival_{barrier_id}_{group_rank}"
         dp_store.set(arrival_key, b"1")
 
         start_time = time.time()
         processes_arrived: set[int] = set()
 
-        while len(processes_arrived) < group_size:
+        while len(processes_arrived) < expected_count:
             if (
                 timeout is not None
                 and time.time() - start_time > timeout.total_seconds()
@@ -168,7 +182,7 @@ class ElasticEPScalingState:
                 )
 
             for i in range(group_size):
-                if i in processes_arrived:
+                if i in processes_arrived or i in skip_ranks:
                     continue
 
                 key = f"arrival_{barrier_id}_{i}"
@@ -176,7 +190,7 @@ class ElasticEPScalingState:
                 if present:
                     processes_arrived.add(i)
 
-            if len(processes_arrived) < group_size:
+            if len(processes_arrived) < expected_count:
                 sched_yield()
 
     def _staged_barrier(self, use_new_group: bool, barrier_name: str) -> bool:
@@ -208,21 +222,42 @@ class ElasticEPScalingState:
         # TODO(yongji): figure out appropriate timeout for the barrier
         timeout = None if dp_store.check([sync_key]) else timedelta(seconds=5)
 
+        # When ranks are dead, the gloo-based torch.distributed.barrier
+        # would hang. Use TCP store barrier only for synchronization.
+        has_dead_ranks = len(self.dead_dp_ranks) > 0
+
         try:
             self._execute_tcp_store_barrier(
-                dp_store, group_rank, group_size, barrier_id, timeout=timeout
+                dp_store,
+                group_rank,
+                group_size,
+                barrier_id,
+                timeout=timeout,
+                skip_ranks=self.dead_dp_ranks,
             )
-            torch.distributed.barrier(dp_group)
-            if group_rank == 0:
+            if not has_dead_ranks:
+                torch.distributed.barrier(dp_group)
+
+            alive_rank_0 = self._first_alive_rank()
+            if group_rank == alive_rank_0:
                 dp_store.delete_key(sync_key)
                 for i in range(group_size):
-                    dp_store.delete_key(f"arrival_{barrier_id}_{i}")
+                    if i not in self.dead_dp_ranks:
+                        dp_store.delete_key(f"arrival_{barrier_id}_{i}")
             return True
         except _BarrierTimeoutError as e:
             if timeout is None:
                 raise RuntimeError("Unexpected timeout encountered") from e
             dp_store.compare_set(sync_key, "", b"1")
             return False
+
+    def _first_alive_rank(self) -> int:
+        """Return the lowest-numbered rank that is not dead."""
+        assert self.old_dp_group is not None
+        for i in range(self.old_dp_group.size()):
+            if i not in self.dead_dp_ranks:
+                return i
+        raise RuntimeError("All ranks are dead")
 
     def _progress_existing_engine(self) -> bool:
         state = self.state
@@ -360,11 +395,31 @@ class ElasticEPScalingState:
             assert self.state == ScaleUpNewEngineState.COMPLETE
             return True
 
+    def _alive_group_size(self) -> int:
+        """Number of ranks expected to participate in barriers."""
+        assert self.old_dp_group is not None
+        return self.old_dp_group.size() - len(self.dead_dp_ranks)
+
+    def _abort_eplb_group_for_dead_ranks(self):
+        """Abort the old EPLB NCCL process group so operations involving
+        dead ranks don't hang.  Must be called from the worker via
+        collective_rpc so it runs on every surviving rank."""
+        self.model_executor.collective_rpc(
+            "elastic_ep_execute",
+            args=("abort_eplb_group_for_dead_ranks",),
+        )
+
     def _progress_remaining_engine(self) -> bool:
         state = self.state
         assert self.old_dp_group is not None and self.old_dp_store is not None
 
         if state == ScaleDownRemainingEngineState.PREPARE:
+            if self.dead_dp_ranks:
+                # Abort the old EPLB NCCL process group so that any
+                # pending/future NCCL ops involving the dead rank don't
+                # hang. The standby groups (created later) will provide
+                # a new communicator for the surviving ranks.
+                self._abort_eplb_group_for_dead_ranks()
             self.state = ScaleDownRemainingEngineState.EPLB_RESHUFFLE
             self.old_dp_store.add("eep_barrier_engine_count", 1)
             return True
@@ -372,27 +427,35 @@ class ElasticEPScalingState:
         elif state == ScaleDownRemainingEngineState.EPLB_RESHUFFLE:
             if (
                 int(self.old_dp_store.get("eep_barrier_engine_count"))
-                < self.old_dp_group.size()
+                < self._alive_group_size()
             ):
                 return False
             if not self._staged_barrier(
                 use_new_group=False, barrier_name="eplb_reshuffle"
             ):
                 return False
-            if self.old_dp_group.rank() == 0:
+            alive_rank_0 = self._first_alive_rank()
+            if self.old_dp_group.rank() == alive_rank_0:
                 self.old_dp_store.delete_key("eep_barrier_engine_count")
-            self._eplb_reshuffle_before_scale_down()
+            if self.dead_dp_ranks:
+                # Fault-triggered: old EPLB NCCL group was aborted (dead
+                # rank can't participate). Skip weight reshuffle — experts
+                # on the dead rank are lost. After standby groups are
+                # created the system continues with reduced expert coverage.
+                if self.old_dp_group.rank() == alive_rank_0:
+                    logger.info(
+                        "[Elastic EP] Skipping EPLB reshuffle (fault-"
+                        "triggered, dead ranks: %s)", self.dead_dp_ranks)
+            else:
+                self._eplb_reshuffle_before_scale_down()
             self.state = ScaleDownRemainingEngineState.SWITCH_AND_PREPARE
-            # NOTE(yongji): currently, after EPLB reshuffle
-            # that redistributes experts to remaining workers, workers
-            # to be removed will immediately initiate shutdown;
-            # existing workers can no longer execute forward steps using
-            # the old setup. In the future, we may keep
-            # the removing workers alive a bit longer,
-            # e.g., to drain in-batch requests.
             self._create_standby_groups()
             self._switch_and_prepare()
             self._update_parallel_config()
+            # NOTE: reassign_missing_experts is now called inside
+            # _apply_new_config (before compile_or_warm_up_model) to
+            # avoid crashes during CUDA graph capture when logical
+            # experts are missing from the p2l map.
             self.state = ScaleDownRemainingEngineState.COMPLETE
             return True
 
@@ -412,7 +475,7 @@ class ElasticEPScalingState:
         if state == ScaleDownRemovingEngineState.EPLB_RESHUFFLE:
             if (
                 int(self.old_dp_store.get("eep_barrier_engine_count"))
-                < self.old_dp_group.size()
+                < self._alive_group_size()
             ):
                 return False
             if not self._staged_barrier(
@@ -468,7 +531,12 @@ class ElasticEPScalingState:
             self.new_parallel_config.stateless_init_dp_group(return_store=True)
         )
         self.model_executor.collective_rpc(
-            "elastic_ep_execute", args=("create_standby_groups", self.reconfig_request)
+            "elastic_ep_execute",
+            args=(
+                "create_standby_groups",
+                self.reconfig_request,
+                self.dead_dp_ranks or None,
+            ),
         )
         if self.old_dp_group.rank() == 0:
             logger.info("[Elastic EP] Created standby communication groups")
@@ -503,11 +571,24 @@ class ElasticEPScalingState:
             logger.info("[Elastic EP] Synced KV cache memory size to new workers")
 
     def _switch_and_prepare(self):
-        self.model_executor.collective_rpc(
-            "elastic_ep_execute", args=("switch_and_prepare",)
-        )
-        old_dp_group = self.old_dp_group
-        stateless_destroy_torch_distributed_process_group(old_dp_group)
+        has_dead = len(self.dead_dp_ranks) > 0
+        if has_dead:
+            # Fault-triggered: abort the old groups to avoid NCCL hang.
+            self.model_executor.collective_rpc(
+                "elastic_ep_execute", args=("abort_and_switch",)
+            )
+            from vllm.distributed.utils import (
+                stateless_abort_torch_distributed_process_group,
+            )
+            old_dp_group = self.old_dp_group
+            stateless_abort_torch_distributed_process_group(old_dp_group)
+        else:
+            self.model_executor.collective_rpc(
+                "elastic_ep_execute", args=("switch_and_prepare",)
+            )
+            old_dp_group = self.old_dp_group
+            stateless_destroy_torch_distributed_process_group(old_dp_group)
+
         assert self.new_dp_group is not None
         new_dp_group = self.new_dp_group
         self.engine_core.dp_group = new_dp_group
@@ -542,6 +623,18 @@ class ElasticEPScalingState:
         if self.new_dp_group.rank() == 0:
             logger.info("[Elastic EP] EPLB reshuffle completed")
 
+    def _reload_missing_experts(self):
+        """Reload logical experts that lost all replicas due to a fault."""
+        self.model_executor.collective_rpc(
+            "elastic_ep_execute",
+            args=("reassign_missing_experts",),
+        )
+        assert self.new_dp_group is not None
+        if self.new_dp_group.rank() == 0:
+            logger.info(
+                "[Elastic EP] Missing expert reload completed"
+            )
+
     def _eplb_reshuffle_before_scale_down(self):
         assert self.reconfig_request is not None and self.old_dp_group is not None
         self.model_executor.collective_rpc(
@@ -549,6 +642,7 @@ class ElasticEPScalingState:
             args=(
                 "perform_scale_down_eplb_reshuffle",
                 self.reconfig_request.new_data_parallel_size,
+                self.reconfig_request.dead_dp_ranks or None,
             ),
         )
         if self.old_dp_group.rank() == 0:

--- a/vllm/distributed/elastic_ep/elastic_state.py
+++ b/vllm/distributed/elastic_ep/elastic_state.py
@@ -437,25 +437,20 @@ class ElasticEPScalingState:
             alive_rank_0 = self._first_alive_rank()
             if self.old_dp_group.rank() == alive_rank_0:
                 self.old_dp_store.delete_key("eep_barrier_engine_count")
+
             if self.dead_dp_ranks:
-                # Fault-triggered: old EPLB NCCL group was aborted (dead
-                # rank can't participate). Skip weight reshuffle — experts
-                # on the dead rank are lost. After standby groups are
-                # created the system continues with reduced expert coverage.
                 if self.old_dp_group.rank() == alive_rank_0:
                     logger.info(
                         "[Elastic EP] Skipping EPLB reshuffle (fault-"
                         "triggered, dead ranks: %s)", self.dead_dp_ranks)
             else:
                 self._eplb_reshuffle_before_scale_down()
+
             self.state = ScaleDownRemainingEngineState.SWITCH_AND_PREPARE
             self._create_standby_groups()
             self._switch_and_prepare()
             self._update_parallel_config()
-            # NOTE: reassign_missing_experts is now called inside
-            # _apply_new_config (before compile_or_warm_up_model) to
-            # avoid crashes during CUDA graph capture when logical
-            # experts are missing from the p2l map.
+
             self.state = ScaleDownRemainingEngineState.COMPLETE
             return True
 

--- a/vllm/distributed/elastic_ep/standby_state.py
+++ b/vllm/distributed/elastic_ep/standby_state.py
@@ -34,6 +34,37 @@ def get_standby_world_group() -> StatelessGroupCoordinator | None:
     return _STANDBY_WORLD
 
 
+def _build_surviving_rank_tensor(
+    new_dp_size: int,
+    pp_size: int,
+    tp_size: int,
+    dead_dp_ranks: set[int],
+    current_world_ranks: list[int] | None = None,
+) -> torch.Tensor:
+    """Build a rank tensor containing only the surviving world ranks.
+
+    Returns a tensor of shape (*, new_dp_size, pp_size, tp_size) with the
+    actual world-rank values of the surviving engines, preserving the
+    original ordering and skipping dead DP ranks.
+
+    Args:
+        current_world_ranks: The actual world ranks of the current group.
+            If None, fetched from get_world_group().ranks. After previous
+            scale-downs these may be non-contiguous (e.g. [0, 2, 3]).
+    """
+    old_dp_size = new_dp_size + len(dead_dp_ranks)
+    if current_world_ranks is None:
+        current_world_ranks = get_world_group().ranks
+    full = torch.tensor(current_world_ranks).reshape(
+        -1, old_dp_size, pp_size, tp_size
+    )
+    surviving_dp_indices = [
+        i for i in range(old_dp_size) if i not in dead_dp_ranks
+    ]
+    assert len(surviving_dp_indices) == new_dp_size
+    return full[:, surviving_dp_indices, :, :]
+
+
 def create_standby_groups(
     new_dp_size: int,
     new_world_size_across_dp: int,
@@ -41,6 +72,7 @@ def create_standby_groups(
     coord_store_port: int,
     enable_eplb: bool = True,
     backend: str | None = None,
+    dead_dp_ranks: set[int] | None = None,
 ) -> None:
     global \
         _STANDBY_WORLD, \
@@ -51,14 +83,31 @@ def create_standby_groups(
 
     from vllm.distributed.utils import get_cached_tcp_store_client
 
-    assert new_world_size_across_dp == torch.distributed.get_world_size() * new_dp_size
     world_group = get_world_group()
     assert isinstance(world_group, StatelessGroupCoordinator)
     backend = backend or world_group.backend
 
     coord_store = get_cached_tcp_store_client(master_ip, coord_store_port)
 
-    standby_world_ranks = [list(range(new_world_size_across_dp))]
+    tp_size = get_tp_group().world_size
+    pp_size = get_pp_group().world_size
+
+    if dead_dp_ranks:
+        # Fault-triggered: surviving world ranks are non-contiguous.
+        all_ranks = _build_surviving_rank_tensor(
+            new_dp_size, pp_size, tp_size, dead_dp_ranks
+        )
+        surviving_world_ranks = sorted(all_ranks.flatten().tolist())
+    else:
+        assert new_world_size_across_dp == (
+            torch.distributed.get_world_size() * new_dp_size
+        )
+        all_ranks = torch.arange(new_world_size_across_dp).reshape(
+            -1, new_dp_size, pp_size, tp_size
+        )
+        surviving_world_ranks = list(range(new_world_size_across_dp))
+
+    standby_world_ranks = [surviving_world_ranks]
     _STANDBY_WORLD = _init_stateless_group(
         standby_world_ranks,
         "world",
@@ -69,12 +118,6 @@ def create_standby_groups(
     )
     _STANDBY_WORLD_NODE_COUNT = _node_count(_STANDBY_WORLD.tcp_store_group)
 
-    tp_size = get_tp_group().world_size
-    pp_size = get_pp_group().world_size
-
-    all_ranks = torch.arange(new_world_size_across_dp).reshape(
-        -1, new_dp_size, pp_size, tp_size
-    )
     standby_dp_ranks = all_ranks.transpose(1, 3).reshape(-1, new_dp_size).unbind(0)
     standby_dp_ranks = [x.tolist() for x in standby_dp_ranks]
     _STANDBY_DP = _init_stateless_group(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1213,6 +1213,72 @@ def _replace_active_groups(
     _NODE_COUNT = node_count
 
 
+def _abort_and_replace_active_groups(
+    *,
+    world: GroupCoordinator | None,
+    dp: GroupCoordinator | None,
+    ep: GroupCoordinator | None,
+    eplb: GroupCoordinator | None,
+    node_count: int | None,
+) -> None:
+    """Abort the current DP/EP/WORLD/EPLB groups and replace them.
+
+    Unlike _replace_active_groups, this uses abort() instead of destroy()
+    to avoid hanging when a peer rank has died.
+    """
+    global _WORLD, _DP, _EP, _EPLB, _NODE_COUNT
+    for group in (_DP, _EP, _WORLD, _EPLB):
+        if group is not None:
+            # Abort underlying ProcessGroups to unblock pending NCCL/Gloo
+            # ops involving dead ranks.  Wrapped in try/except because the
+            # group may have already been aborted (e.g. EPLB group aborted
+            # early to unblock barriers).
+            try:
+                if hasattr(group, "device_group") and group.device_group:
+                    group.device_group.abort()
+            except Exception:
+                logger.warning(
+                    "[Fault Tolerance] Failed to abort device_group",
+                    exc_info=True,
+                )
+            try:
+                if hasattr(group, "cpu_group") and group.cpu_group:
+                    group.cpu_group.abort()
+            except Exception:
+                logger.warning(
+                    "[Fault Tolerance] Failed to abort cpu_group",
+                    exc_info=True,
+                )
+            # Destroy device communicator last — this is a local cleanup
+            # that doesn't require peer coordination.
+            try:
+                if (hasattr(group, "device_communicator")
+                        and group.device_communicator):
+                    group.device_communicator.destroy()
+            except Exception:
+                logger.warning(
+                    "[Fault Tolerance] Failed to destroy "
+                    "device_communicator",
+                    exc_info=True,
+                )
+    # Synchronize to surface any async CUDA errors from the aborts
+    # immediately, rather than having them appear later during
+    # unrelated operations (per NCCL team recommendation).
+    try:
+        import torch
+        torch.cuda.synchronize()
+    except Exception:
+        logger.warning(
+            "[Fault Tolerance] CUDA sync after abort raised an error",
+            exc_info=True,
+        )
+    _WORLD = world
+    _DP = dp
+    _EP = ep
+    _EPLB = eplb
+    _NODE_COUNT = node_count
+
+
 _TP: GroupCoordinator | None = None
 
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1249,15 +1249,16 @@ def _abort_and_replace_active_groups(
                     "[Fault Tolerance] Failed to abort cpu_group",
                     exc_info=True,
                 )
-            # Destroy device communicator last — this is a local cleanup
-            # that doesn't require peer coordination.
+            # Abort device communicator last — uses ncclCommAbort
+            # (not ncclCommDestroy) to avoid triggering an implicit
+            # ncclCommFinalize collective that would hang.
             try:
                 if (hasattr(group, "device_communicator")
                         and group.device_communicator):
-                    group.device_communicator.destroy()
+                    group.device_communicator.abort()
             except Exception:
                 logger.warning(
-                    "[Fault Tolerance] Failed to destroy "
+                    "[Fault Tolerance] Failed to abort "
                     "device_communicator",
                     exc_info=True,
                 )

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1225,6 +1225,12 @@ def _abort_and_replace_active_groups(
 
     Unlike _replace_active_groups, this uses abort() instead of destroy()
     to avoid hanging when a peer rank has died.
+
+    TODO: This is called from the main worker thread during recovery,
+    which means the worker must not be stuck in a collective to reach
+    here.  For robustness, abort() should be callable from a sentinel
+    thread so that workers stuck in mid-forward collectives can be
+    unblocked immediately on fault detection.
     """
     global _WORLD, _DP, _EP, _EPLB, _NODE_COUNT
     for group in (_DP, _EP, _WORLD, _EPLB):

--- a/vllm/distributed/stateless_coordinator.py
+++ b/vllm/distributed/stateless_coordinator.py
@@ -192,6 +192,23 @@ class StatelessGroupCoordinator(GroupCoordinator):
         if self.cpu_group:
             stateless_destroy_torch_distributed_process_group(self.cpu_group)
 
+    def abort(self):
+        """Abort all underlying process groups without waiting for peers.
+
+        Use instead of destroy() when a peer rank in this group has died
+        and normal collective teardown would hang.
+        """
+        from vllm.distributed.utils import (
+            stateless_abort_torch_distributed_process_group,
+        )
+
+        if self.device_communicator:
+            self.device_communicator.destroy()
+        if self.device_group:
+            stateless_abort_torch_distributed_process_group(self.device_group)
+        if self.cpu_group:
+            stateless_abort_torch_distributed_process_group(self.cpu_group)
+
     def size(self) -> int:
         """Return the world size of this group."""
         return self.world_size

--- a/vllm/distributed/stateless_coordinator.py
+++ b/vllm/distributed/stateless_coordinator.py
@@ -203,7 +203,7 @@ class StatelessGroupCoordinator(GroupCoordinator):
         )
 
         if self.device_communicator:
-            self.device_communicator.destroy()
+            self.device_communicator.abort()
         if self.device_group:
             stateless_abort_torch_distributed_process_group(self.device_group)
         if self.cpu_group:

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -633,6 +633,18 @@ def stateless_destroy_torch_distributed_process_group(pg: ProcessGroup) -> None:
     _unregister_process_group(pg.group_name)
 
 
+def stateless_abort_torch_distributed_process_group(pg: ProcessGroup) -> None:
+    """Abort a process group without waiting for pending operations.
+
+    Unlike destroy (which calls shutdown and may block if a peer is dead),
+    abort forces the underlying communicator to release immediately.
+    Use this when a rank in the group has died and normal teardown would hang.
+    Works with any backend (NCCL, Gloo, etc.).
+    """
+    pg.abort()
+    _unregister_process_group(pg.group_name)
+
+
 def get_worker_rank_suffix(global_rank: int | None = None) -> str:
     """Generate a descriptive rank suffix for worker identification.
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -434,6 +434,7 @@ class EngineArgs:
     moe_backend: MoEBackend = KernelConfig.moe_backend
     all2all_backend: All2AllBackend = ParallelConfig.all2all_backend
     enable_elastic_ep: bool = ParallelConfig.enable_elastic_ep
+    enable_ep_fault_tolerance: bool = ParallelConfig.enable_ep_fault_tolerance
     enable_dbo: bool = ParallelConfig.enable_dbo
     ubatch_size: int = ParallelConfig.ubatch_size
     dbo_decode_token_threshold: int = ParallelConfig.dbo_decode_token_threshold
@@ -944,6 +945,10 @@ class EngineArgs:
         )
         parallel_group.add_argument(
             "--enable-elastic-ep", **parallel_kwargs["enable_elastic_ep"]
+        )
+        parallel_group.add_argument(
+            "--enable-ep-fault-tolerance",
+            **parallel_kwargs["enable_ep_fault_tolerance"],
         )
         parallel_group.add_argument(
             "--dbo-decode-token-threshold",
@@ -1790,6 +1795,7 @@ class EngineArgs:
             enable_ep_weight_filter=self.enable_ep_weight_filter,
             all2all_backend=self.all2all_backend,
             enable_elastic_ep=self.enable_elastic_ep,
+            enable_ep_fault_tolerance=self.enable_ep_fault_tolerance,
             enable_dbo=self.enable_dbo,
             ubatch_size=self.ubatch_size,
             dbo_decode_token_threshold=self.dbo_decode_token_threshold,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1096,7 +1096,31 @@ class FusedMoE(CustomOp):
 
         quant_method_name = self.quant_method.__class__.__name__
         global_expert_id = expert_id
-        expert_id = self._map_global_expert_id_to_local_expert_id(global_expert_id)
+
+        # When EPLB is active, the logical-to-physical mapping may differ
+        # from the static EP partition in expert_map.  Use l2p to find
+        # the local physical slot for this logical expert.
+        eplb = getattr(self, "eplb_state", None)
+        if (
+            eplb is not None
+            and getattr(eplb, "logical_to_physical_map", None) is not None
+            and global_expert_id < eplb.logical_to_physical_map.shape[0]
+        ):
+            l2p = eplb.logical_to_physical_map
+            replica_count = eplb.logical_replica_count
+            num_replicas = replica_count[global_expert_id].item()
+            local_start = self.ep_rank * self.local_num_experts
+            local_end = local_start + self.local_num_experts
+            expert_id = -1
+            for r in range(num_replicas):
+                phys = l2p[global_expert_id, r].item()
+                if local_start <= phys < local_end:
+                    expert_id = phys - local_start
+                    break
+        else:
+            expert_id = self._map_global_expert_id_to_local_expert_id(
+                global_expert_id
+            )
 
         use_global_sf = (
             getattr(self.quant_method, "use_global_sf", False)

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -238,6 +238,7 @@ class ReconfigureDistributedRequest(msgspec.Struct):
     new_data_parallel_master_port: int
     new_data_parallel_master_port_list: list[int]
     coord_store_port: int
+    dead_dp_ranks: list[int] = []
 
 
 class ReconfigureRankType(enum.IntEnum):

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -160,6 +160,12 @@ class AsyncLLM(EngineClient):
             client_index=client_index,
         )
 
+        if hasattr(self.engine_core, "register_ft_abort_callback"):
+            output_processor = self.output_processor
+            self.engine_core.register_ft_abort_callback(
+                lambda req_ids: output_processor.abort_requests(req_ids, internal=True)
+            )
+
         # Loggers.
         self.logger_manager: StatLoggerManager | None = None
         if self.log_stats:

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -312,11 +312,14 @@ class DPCoordinatorProc:
                     decoded = msgspec.msgpack.decode(buffer)
                     if (
                         isinstance(decoded, (list, tuple))
-                        and len(decoded) == 2
+                        and len(decoded) >= 2
                         and decoded[0] == "SCALE_ELASTIC_EP"
                     ):
-                        # Handle scale up notification
                         new_engine_count = decoded[1]
+                        removed_ranks = (
+                            set(decoded[2]) if len(decoded) >= 3
+                            else set()
+                        )
                         current_count = len(self.engines)
                         if new_engine_count > current_count:
                             for _ in range(new_engine_count - current_count):
@@ -335,6 +338,19 @@ class DPCoordinatorProc:
                                 "DPCoordinator scaled up from %s to %s engines",
                                 current_count,
                                 new_engine_count,
+                            )
+                        elif removed_ranks:
+                            # Remove specific engine entries (fault-triggered).
+                            self.engines = [
+                                e for i, e in enumerate(self.engines)
+                                if i not in removed_ranks
+                            ]
+                            logger.info(
+                                "DPCoordinator scaled down from %s to %s "
+                                "engines (removed ranks: %s)",
+                                current_count,
+                                new_engine_count,
+                                sorted(removed_ranks),
                             )
                         else:
                             self.engines = self.engines[:new_engine_count]

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1755,7 +1755,10 @@ class DPEngineCoreProc(EngineCoreProc):
         if self.step_counter % 32 != 0:
             return True
 
-        return ParallelConfig.has_unfinished_dp(self.dp_group, local_unfinished)
+        fault_tolerant = self.vllm_config.parallel_config.enable_ep_fault_tolerance
+        return ParallelConfig.has_unfinished_dp(
+            self.dp_group, local_unfinished, fault_tolerant=fault_tolerant
+        )
 
     def reinitialize_distributed(
         self, reconfig_request: ReconfigureDistributedRequest

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -636,6 +636,10 @@ class MPClient(EngineCoreClient):
     def dp_engines_running(self) -> bool:
         return self.engines_running
 
+    def _is_fault_tolerant(self) -> bool:
+        """Whether this client supports single-engine fault tolerance."""
+        return False
+
     def start_engine_core_monitor(self):
         """Start a monitor thread for engine core processes."""
         engine_manager = self.resources.engine_manager
@@ -645,8 +649,12 @@ class MPClient(EngineCoreClient):
 
         self_ref = weakref.ref(self)
 
-        # Monitor engine core process liveness. If any die unexpectedly,
-        # marks the engine as dead, and shuts down the client.
+        if self._is_fault_tolerant():
+            self._start_fault_tolerant_monitor(engine_manager, self_ref)
+        else:
+            self._start_standard_monitor(engine_manager, self_ref)
+
+    def _start_standard_monitor(self, engine_manager, self_ref):
         def monitor_engine_cores():
             engine_manager.monitor_engine_liveness()
             _self = self_ref()
@@ -654,13 +662,38 @@ class MPClient(EngineCoreClient):
                 return
             _self.resources.engine_dead = True
             _self.shutdown()
-            # Note: For MPClient, we don't have a failure callback mechanism
-            # like MultiprocExecutor, but we set engine_dead flag which will
-            # cause subsequent operations to raise EngineDeadError
 
         Thread(
             target=monitor_engine_cores, daemon=True, name="MPClientEngineMonitor"
         ).start()
+
+    def _start_fault_tolerant_monitor(self, engine_manager, self_ref):
+        def on_engine_died(proc_name: str, dp_rank: int) -> bool:
+            _self = self_ref()
+            if not _self or not _self._finalizer.alive or _self.resources.engine_dead:
+                return False
+            return _self._on_engine_process_died(proc_name, dp_rank)
+
+        def monitor_engine_cores_ft():
+            engine_manager.monitor_engine_liveness_fault_tolerant(on_engine_died)
+            _self = self_ref()
+            if not _self or not _self._finalizer.alive or _self.resources.engine_dead:
+                return
+            _self.resources.engine_dead = True
+            _self.shutdown()
+
+        Thread(
+            target=monitor_engine_cores_ft,
+            daemon=True,
+            name="MPClientFTEngineMonitor",
+        ).start()
+
+    def _on_engine_process_died(self, proc_name: str, dp_rank: int) -> bool:
+        """Handle a single engine process death. Returns True to keep
+        monitoring, False to stop. Default: stop everything."""
+        self.resources.engine_dead = True
+        self.shutdown()
+        return False
 
 
 def _process_utility_output(
@@ -1189,12 +1222,14 @@ class DPAsyncMPClient(AsyncMPClient):
                         decoded = msgspec.msgpack.decode(buf)
                         if (
                             isinstance(decoded, (list, tuple))
-                            and len(decoded) == 2
+                            and len(decoded) >= 2
                             and decoded[0] == "SCALE_ELASTIC_EP"
                         ):
-                            # Extract new engine count from the decoded message
                             new_engine_count = decoded[1]
-                            # Update engine_ranks_managed and count_slice
+                            removed_ranks = (
+                                set(decoded[2]) if len(decoded) >= 3
+                                else set()
+                            )
                             parallel_config = self.vllm_config.parallel_config
                             dp_size = parallel_config.data_parallel_size
                             dp_rank = parallel_config.data_parallel_rank
@@ -1215,11 +1250,18 @@ class DPAsyncMPClient(AsyncMPClient):
                                         new_engine_count - len(self.lb_engines)
                                     )
                                 ]
+                            elif removed_ranks:
+                                self.lb_engines = [
+                                    lb
+                                    for i, lb in enumerate(self.lb_engines)
+                                    if i not in removed_ranks
+                                ]
                             else:
                                 self.lb_engines = self.lb_engines[:new_engine_count]
-                            # Send scale up notification to coordinator
+                            # Forward to coordinator (include removed ranks).
                             scale_msg = msgspec.msgpack.encode(
-                                ("SCALE_ELASTIC_EP", new_engine_count)
+                                ("SCALE_ELASTIC_EP", new_engine_count,
+                                 sorted(removed_ranks))
                             )
                             await socket.send(scale_msg)
                             continue
@@ -1267,6 +1309,10 @@ class DPAsyncMPClient(AsyncMPClient):
 
     async def add_request_async(self, request: EngineCoreRequest) -> None:
         self._ensure_stats_update_task()
+
+        # Lazily capture the event loop for the FT monitor thread.
+        if hasattr(self, '_ft_event_loop') and self._ft_event_loop is None:
+            self._ft_event_loop = asyncio.get_running_loop()
 
         request.current_wave = self.current_wave
         request.client_index = self.client_index
@@ -1319,6 +1365,229 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             len(self.core_engines) * self.client_index
         ) // client_count
 
+        # Fault tolerance state.
+        self._ft_scaling_in_progress = False
+        self._dead_engine_identities: set[EngineIdentity] = set()
+        self._ft_abort_callback: Callable[[list[str]], None] | None = None
+        # Capture the event loop for scheduling async scale-down from
+        # the monitor thread. May be None if __init__ runs outside an
+        # async context; updated lazily when add_request_async is called.
+        try:
+            self._ft_event_loop: asyncio.AbstractEventLoop | None = (
+                asyncio.get_running_loop()
+            )
+        except RuntimeError:
+            self._ft_event_loop = None
+
+    # ------------------------------------------------------------------
+    # Fault-tolerant engine monitoring
+    # ------------------------------------------------------------------
+
+    def _is_fault_tolerant(self) -> bool:
+        pc = self.vllm_config.parallel_config
+        return pc.enable_ep_fault_tolerance
+
+    def _on_engine_process_died(self, proc_name: str, dp_rank: int) -> bool:
+        """Handle a single DP engine death without killing the whole server.
+
+        Called from the monitor thread.  Schedules the async scale-down on
+        the event loop.  Returns True to keep monitoring surviving engines.
+        """
+        # Deduplicate: Ray may report the same actor death multiple times.
+        dead_identity = dp_rank.to_bytes(2, "little")
+        if dead_identity in self._dead_engine_identities:
+            logger.warning(
+                "[Fault Tolerance] Engine %s (dp_rank=%d) death already "
+                "handled. Ignoring duplicate notification.",
+                proc_name,
+                dp_rank,
+            )
+            return True
+
+        # Track the dead rank immediately so all downstream checks
+        # can derive surviving count from _dead_engine_identities.
+        self._dead_engine_identities.add(dead_identity)
+
+        cur_dp_size = len(self.core_engines)
+
+        if cur_dp_size <= 1:
+            logger.error(
+                "[Fault Tolerance] Engine %s (dp_rank=%d) died and no "
+                "surviving engines remain. Shutting down.",
+                proc_name,
+                dp_rank,
+            )
+            self.resources.engine_dead = True
+            self.shutdown()
+            return False
+
+        # Check whether the surviving GPUs have enough physical expert
+        # slots to cover all logical experts.  Each GPU holds a fixed
+        # number of local experts; if the surviving pool drops below
+        # the number of logical experts, recovery is impossible.
+        # Derive surviving count from actual state in case multiple 
+        # ranks died between checks.
+        pc = self.vllm_config.parallel_config
+        tp_size = pc.tensor_parallel_size
+        model_config = getattr(self.vllm_config, "model_config", None)
+        if model_config is not None and model_config.is_moe:
+            num_logical_experts = model_config.get_num_experts()
+            num_surviving = cur_dp_size - len(self._dead_engine_identities)
+            surviving_ep_size = num_surviving * tp_size
+            cur_ep_size = cur_dp_size * tp_size
+            num_local_physical = (
+                (num_logical_experts + pc.eplb_config.num_redundant_experts)
+                // cur_ep_size
+            )
+            new_total_physical = surviving_ep_size * num_local_physical
+            if new_total_physical < num_logical_experts:
+                logger.error(
+                    "[Fault Tolerance] Engine %s (dp_rank=%d) died. "
+                    "%d surviving GPUs have %d physical expert slots "
+                    "but %d logical experts require coverage. Cannot "
+                    "recover — shutting down.",
+                    proc_name,
+                    dp_rank,
+                    num_surviving,
+                    new_total_physical,
+                    num_logical_experts,
+                )
+                self.resources.engine_dead = True
+                self.shutdown()
+                return False
+
+        if self._ft_scaling_in_progress:
+            logger.error(
+                "[Fault Tolerance] Engine %s (dp_rank=%d) died while "
+                "a fault-triggered scale-down is already in progress. "
+                "Shutting down.",
+                proc_name,
+                dp_rank,
+            )
+            self.resources.engine_dead = True
+            self.shutdown()
+            return False
+
+        logger.warning(
+            "[Fault Tolerance] Engine %s (dp_rank=%d) died. "
+            "Initiating automatic scale-down from %d to %d engines.",
+            proc_name,
+            dp_rank,
+            cur_dp_size,
+            cur_dp_size - 1,
+        )
+
+        self._ft_scaling_in_progress = True
+
+        loop = self._ft_event_loop
+        if loop is None or loop.is_closed():
+            logger.error(
+                "[Fault Tolerance] No event loop available to schedule "
+                "fault-triggered scale-down. Shutting down."
+            )
+            self.resources.engine_dead = True
+            self.shutdown()
+            return False
+
+        loop.call_soon_threadsafe(
+            lambda: asyncio.ensure_future(self._fault_triggered_scale_down(dp_rank))
+        )
+
+        return True
+
+    async def _fault_triggered_scale_down(self, dead_dp_rank: int) -> None:
+        """Scale down after a DP engine process died unexpectedly.
+
+        Args:
+            dead_dp_rank: The ORIGINAL dp_rank from the process name.
+                After previous scale-downs, this may differ from the
+                current list index in core_engines.
+        """
+        try:
+            # Translate original dp_rank → current list index.
+            # After previous scale-downs with rank compaction, the
+            # original rank number may not match the list position.
+            dead_engine_identity = dead_dp_rank.to_bytes(2, "little")
+            try:
+                dead_index = self.core_engines.index(dead_engine_identity)
+            except ValueError:
+                logger.warning(
+                    "[Fault Tolerance] Engine dp_rank=%d (identity=%s) "
+                    "not found in core_engines. Already removed?",
+                    dead_dp_rank, dead_engine_identity,
+                )
+                return
+
+            cur_dp_size = len(self.core_engines)
+            new_dp_size = cur_dp_size - 1
+
+            logger.info(
+                "[Fault Tolerance] Starting fault-triggered scale-down: "
+                "original_dp_rank=%d, current_index=%d, %d -> %d engines.",
+                dead_dp_rank,
+                dead_index,
+                cur_dp_size,
+                new_dp_size,
+            )
+
+            dead_req_ids = self._fail_inflight_requests_for_engine(dead_engine_identity)
+            if dead_req_ids and self._ft_abort_callback is not None:
+                self._ft_abort_callback(dead_req_ids)
+
+            await self._scale_down_elastic_ep(
+                cur_dp_size,
+                new_dp_size,
+                dead_dp_ranks={dead_index},
+            )
+
+            logger.info(
+                "[Fault Tolerance] Fault-triggered scale-down complete. "
+                "Now running with %d engines.",
+                new_dp_size,
+            )
+        except Exception:
+            logger.exception(
+                "[Fault Tolerance] Fault-triggered scale-down failed. Shutting down."
+            )
+            self.resources.engine_dead = True
+            self.shutdown()
+        finally:
+            self._ft_scaling_in_progress = False
+            self._dead_engine_identities.clear()
+
+    def _fail_inflight_requests_for_engine(
+        self, dead_engine: EngineIdentity
+    ) -> list[str]:
+        """Remove in-flight requests that were assigned to a dead engine.
+
+        Returns the list of dropped request IDs so callers can propagate
+        errors to waiting clients (e.g. via OutputProcessor.abort_requests).
+        """
+        dead_req_ids = [
+            req_id
+            for req_id, engine in self.reqs_in_flight.items()
+            if engine == dead_engine
+        ]
+        for req_id in dead_req_ids:
+            self.reqs_in_flight.pop(req_id, None)
+        if dead_req_ids:
+            logger.warning(
+                "[Fault Tolerance] Dropped %d in-flight requests that "
+                "were assigned to the dead engine.",
+                len(dead_req_ids),
+            )
+        return dead_req_ids
+
+    def register_ft_abort_callback(self, callback: Callable[[list[str]], None]) -> None:
+        """Register a callback to abort requests when an engine dies.
+
+        AsyncLLM sets this so that dead-engine requests go through the
+        proper OutputProcessor.abort_requests() path (LoRA cleanup,
+        pooling handling, parent/child tracking) rather than pushing
+        synthetic EngineCoreOutput objects through the inference pipeline.
+        """
+        self._ft_abort_callback = callback
+
     def get_core_engine_for_request(self, request: EngineCoreRequest) -> EngineIdentity:
         # Engines are in rank order.
         if (eng_index := request.data_parallel_rank) is None and (
@@ -1327,6 +1596,7 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             )
         ) is None:
             current_counts = self.lb_engines
+            dead = self._dead_engine_identities
             # TODO use P2C alg for larger DP sizes
             num_engines = len(current_counts)
             min_score = sys.maxsize
@@ -1335,6 +1605,8 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
                 # Start from client_index to help with balancing when engines
                 # are empty.
                 idx = (self.eng_start_index + i) % num_engines
+                if dead and self.core_engines[idx] in dead:
+                    continue
                 waiting, running = current_counts[idx]
                 score = waiting * 4 + running
                 if score < min_score:
@@ -1345,6 +1617,11 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             current_counts[eng_index][0] += self.client_count
 
         chosen_engine = self.core_engines[eng_index]
+        if self._dead_engine_identities and chosen_engine in self._dead_engine_identities:
+            raise ValueError(
+                f"Request targets DP rank {eng_index} which is dead. "
+                "Retry without specifying data_parallel_rank."
+            )
         # Record which engine is chosen for this request, to handle aborts.
         self.reqs_in_flight[request.request_id] = chosen_engine
         return chosen_engine
@@ -1408,8 +1685,14 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
                 assert cache.num_new_core_engines < 0
                 old_dp_size = len(cache.existing_core_engines)
                 new_dp_size = old_dp_size + cache.num_new_core_engines
+                # Collect the ranks that were removed (dead or gracefully
+                # shut down) so the actor manager removes the right entries.
+                removed_ranks = cache.pending_notifications.get(
+                    notification_type, set()
+                )
                 self.resources.engine_manager.scale_down_elastic_ep(
-                    old_dp_size, new_dp_size
+                    old_dp_size, new_dp_size,
+                    removed_dp_ranks=removed_ranks,
                 )
             else:
                 await asyncio.gather(
@@ -1604,10 +1887,22 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         )
 
     async def _scale_down_elastic_ep(
-        self, cur_data_parallel_size: int, new_data_parallel_size: int
+        self,
+        cur_data_parallel_size: int,
+        new_data_parallel_size: int,
+        dead_dp_ranks: set[int] | None = None,
     ) -> None:
         """Scale down the data parallel size by shutting down and
-        reconfiguring existing engine cores."""
+        reconfiguring existing engine cores.
+
+        Args:
+            dead_dp_ranks: DP ranks that are already dead (fault-triggered).
+                Reconfigure messages are skipped for these ranks, and the
+                elastic EP state machine on surviving ranks will use
+                fault-tolerant barriers that don't wait for them.
+        """
+        if dead_dp_ranks is None:
+            dead_dp_ranks = set()
         cur_data_parallel_size = len(self.core_engines)
 
         self.eep_scaling_cache = ElasticScalingCache(
@@ -1619,11 +1914,39 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         parallel_config = self.vllm_config.parallel_config
         ip, coord_store_port = self._setup_elastic_ep_reconfig_bootstrap()
 
-        removed_dp_size = cur_data_parallel_size - new_data_parallel_size
+        # For graceful scale-down, the highest-ranked engines are removed.
+        # For fault-triggered scale-down, the dead engines are removed.
+        if dead_dp_ranks:
+            ranks_to_remove = dead_dp_ranks
+        else:
+            ranks_to_remove = set(
+                range(new_data_parallel_size, cur_data_parallel_size)
+            )
+
+        # Compute rank compaction: surviving ranks get new contiguous IDs.
+        surviving_ranks = [
+            r for r in range(cur_data_parallel_size) if r not in ranks_to_remove
+        ]
+        new_rank_map = {old: new for new, old in enumerate(surviving_ranks)}
+
         assert isinstance(self.resources.engine_manager, CoreEngineActorManager)
-        self.resources.engine_manager.remove_run_refs_for_scale_down(removed_dp_size)
+
+        # Count how many removed engines are local BEFORE lists are modified.
+        mgr = self.resources.engine_manager
+        self._local_engines_removed = sum(
+            1 for r in ranks_to_remove
+            if r < len(mgr.placement_group_is_local)
+            and mgr.placement_group_is_local[r]
+        )
+
+        mgr.remove_run_refs_for_scale_down(
+            len(ranks_to_remove), ranks_to_remove=ranks_to_remove,
+        )
         reconfig_futures = []
         for cur_dp_rank, engine in enumerate(self.core_engines):
+            if cur_dp_rank in dead_dp_ranks:
+                continue
+
             reconfig_request = ReconfigureDistributedRequest(
                 new_data_parallel_size=new_data_parallel_size,
                 new_data_parallel_rank=ReconfigureRankType.KEEP_CURRENT_RANK,
@@ -1632,35 +1955,94 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
                 new_data_parallel_master_port=parallel_config.data_parallel_master_port,
                 new_data_parallel_master_port_list=parallel_config._data_parallel_master_port_list,
                 coord_store_port=coord_store_port,
+                dead_dp_ranks=list(dead_dp_ranks),
             )
-            if cur_dp_rank >= new_data_parallel_size:
+            if cur_dp_rank in ranks_to_remove:
                 reconfig_request.new_data_parallel_rank = (
                     ReconfigureRankType.SHUTDOWN_CURRENT_RANK
                 )
+            elif dead_dp_ranks:
+                # Fault-triggered: assign compacted rank so surviving
+                # engines form a contiguous group 0..N-1.
+                reconfig_request.new_data_parallel_rank = new_rank_map[
+                    cur_dp_rank
+                ]
             coro = self._call_utility_async(
                 "reinitialize_distributed", reconfig_request, engine=engine
             )
             reconfig_futures.append(asyncio.create_task(coro))
 
-        # NOTE(yongji): Immediately stop sending requests to the removing engines.
-        self.core_engines = self.core_engines[:new_data_parallel_size]
-        self.lb_engines = self.lb_engines[:new_data_parallel_size]
+        # Immediately stop sending requests to the removed engines.
+        # Look up actual identities from current core_engines list
+        # (indices may differ from original rank numbers after previous
+        # scale-downs).
+        dead_identities = {
+            self.core_engines[i] for i in ranks_to_remove
+            if i < len(self.core_engines)
+        }
+        self.core_engines = [
+            e for e in self.core_engines if e not in dead_identities
+        ]
+        self.lb_engines = [
+            lb
+            for i, lb in enumerate(self.lb_engines)
+            if i not in ranks_to_remove
+        ]
         wait_future = self._eep_wait_for_setup_switch_complete()
 
         await asyncio.gather(*reconfig_futures)
 
+        if dead_dp_ranks:
+            # The dead engines can't send SHUTDOWN_COMPLETE, so we
+            # simulate it to unblock the notification handling.
+            self._synthesize_shutdown_complete_for_dead_ranks(dead_dp_ranks)
+
         self.vllm_config.parallel_config.data_parallel_size = new_data_parallel_size
+        local_removed = getattr(self, "_local_engines_removed", 0)
+        if local_removed > 0:
+            self.vllm_config.parallel_config.data_parallel_size_local -= (
+                local_removed
+            )
         self._ensure_stats_update_task()
         scale_down_marker = msgspec.msgpack.encode(
-            ("SCALE_ELASTIC_EP", new_data_parallel_size)
+            ("SCALE_ELASTIC_EP", new_data_parallel_size,
+             sorted(ranks_to_remove))
         )
         await self.first_req_send_socket.send(scale_down_marker)
 
-        # NOTE(yongji): Unlike scaling up,
-        # here we don't actually need to wait for the setup switch to complete.
-        # We may want to remove it in the future.
         await wait_future
         logger.info(
             "[Elastic EP] Scale down completed, new data parallel size: %s",
             new_data_parallel_size,
         )
+
+    def _synthesize_shutdown_complete_for_dead_ranks(
+        self, dead_dp_ranks: set[int]
+    ) -> None:
+        """Inject synthetic SHUTDOWN_COMPLETE notifications for dead ranks
+        so the notification handler doesn't wait forever."""
+        cache = self.eep_scaling_cache
+        if cache is None:
+            return
+
+        notification_type = EEPNotificationType.SHUTDOWN_COMPLETE
+        if notification_type not in cache.pending_notifications:
+            cache.pending_notifications[notification_type] = set()
+        for dp_rank in dead_dp_ranks:
+            cache.pending_notifications[notification_type].add(dp_rank)
+
+        if len(cache.pending_notifications[notification_type]) >= abs(
+            cache.num_new_core_engines
+        ):
+            assert isinstance(self.resources.engine_manager, CoreEngineActorManager)
+            old_dp_size = len(cache.existing_core_engines)
+            new_dp_size = old_dp_size + cache.num_new_core_engines
+            removed_ranks = cache.pending_notifications.get(
+                notification_type, set()
+            )
+            self.resources.engine_manager.scale_down_elastic_ep(
+                old_dp_size, new_dp_size,
+                removed_dp_ranks=removed_ranks,
+            )
+            cache.pending_notifications[notification_type] = set()
+            self.eep_scaling_cache = None

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1368,6 +1368,7 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         # Fault tolerance state.
         self._ft_scaling_in_progress = False
         self._dead_engine_identities: set[EngineIdentity] = set()
+        self._initial_dp_size = len(self.core_engines)
         self._ft_abort_callback: Callable[[list[str]], None] | None = None
         # Capture the event loop for scheduling async scale-down from
         # the monitor thread. May be None if __init__ runs outside an
@@ -1434,10 +1435,13 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             num_logical_experts = model_config.get_num_experts()
             num_surviving = cur_dp_size - len(self._dead_engine_identities)
             surviving_ep_size = num_surviving * tp_size
-            cur_ep_size = cur_dp_size * tp_size
+            # Per-GPU physical slots are fixed at startup and never change.
+            # Use the initial EP size to compute them, not the current
+            # (already-shrunk) EP size.
+            initial_ep_size = self._initial_dp_size * tp_size
             num_local_physical = (
                 (num_logical_experts + pc.eplb_config.num_redundant_experts)
-                // cur_ep_size
+                // initial_ep_size
             )
             new_total_physical = surviving_ep_size * num_local_physical
             if new_total_physical < num_logical_experts:

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -182,6 +182,44 @@ class CoreEngineProcManager:
 
         self.shutdown()
 
+    def monitor_engine_liveness_fault_tolerant(
+        self,
+        on_engine_died: Callable[[str, int], bool],
+    ) -> None:
+        """Monitor engine liveness, reporting individual failures.
+
+        Args:
+            on_engine_died: Called with (proc_name, dp_rank) when a process
+                dies unexpectedly. Return True to continue monitoring
+                surviving engines, False to stop.
+        """
+        sentinel_to_proc = {proc.sentinel: proc for proc in self.processes}
+        sentinels = set(sentinel_to_proc.keys())
+
+        while sentinels and not self.manager_stopped.is_set():
+            died_sentinels = connection.wait(sentinels, timeout=1)
+
+            for sentinel in died_sentinels:
+                sentinels.discard(cast(int, sentinel))
+                proc = sentinel_to_proc.pop(cast(int, sentinel))
+                exitcode = proc.exitcode or 0
+                if exitcode != 0 and not self.manager_stopped.is_set():
+                    self.failed_proc_name = proc.name
+                    dp_rank = self._dp_rank_from_proc_name(proc.name)
+                    should_continue = on_engine_died(proc.name, dp_rank)
+                    if not should_continue:
+                        self.shutdown()
+                        return
+
+        self.shutdown()
+
+    @staticmethod
+    def _dp_rank_from_proc_name(name: str) -> int:
+        prefix = "EngineCore_DP"
+        if name.startswith(prefix):
+            return int(name[len(prefix) :])
+        return -1
+
     def sentinels(self) -> list:
         return [proc.sentinel for proc in self.processes]
 
@@ -419,10 +457,13 @@ class CoreEngineActorManager:
         ray.get(refs)
         self.run_refs = []
         self.actor_run_ref_dict = dict()
-        for actor in self.local_engine_actors + self.remote_engine_actors:
+        self.run_ref_to_dp_rank: dict = {}
+        all_actors = self.local_engine_actors + self.remote_engine_actors
+        for dp_rank_idx, actor in enumerate(all_actors):
             ref = actor.run.remote()
             self.run_refs.append(ref)
             self.actor_run_ref_dict[actor] = ref
+            self.run_ref_to_dp_rank[ref] = dp_rank_idx
 
     @staticmethod
     def create_dp_placement_groups(
@@ -814,9 +855,29 @@ class CoreEngineActorManager:
                 new_local_engines
             )
 
+    def _actor_at_rank(self, dp_rank: int):
+        """Return the actor at the given DP rank."""
+        is_local = self.placement_group_is_local[dp_rank]
+        if is_local:
+            local_idx = sum(
+                1 for i in range(dp_rank)
+                if self.placement_group_is_local[i]
+            )
+            return self.local_engine_actors[local_idx]
+        else:
+            remote_idx = sum(
+                1 for i in range(dp_rank)
+                if not self.placement_group_is_local[i]
+            )
+            return self.remote_engine_actors[remote_idx]
+
     def scale_down_elastic_ep(
-        self, cur_data_parallel_size: int, new_data_parallel_size: int
-    ) -> None:
+        self,
+        cur_data_parallel_size: int,
+        new_data_parallel_size: int,
+        removed_dp_ranks: set[int] | None = None,
+    ) -> int:
+        """Remove engines for scale-down. Returns count of local engines removed."""
         import ray
 
         assert cur_data_parallel_size > new_data_parallel_size, (
@@ -824,30 +885,63 @@ class CoreEngineActorManager:
             f"than new_data_parallel_size {new_data_parallel_size} "
             "for scale down"
         )
-        for _ in range(cur_data_parallel_size - new_data_parallel_size):
-            pg = self.created_placement_groups.pop()
-            is_local = self.placement_group_is_local.pop()
-            if is_local:
-                self.local_engine_actors.pop()
-            else:
-                self.remote_engine_actors.pop()
-            ray.util.remove_placement_group(pg)
+        if removed_dp_ranks is None:
+            removed_dp_ranks = set(
+                range(new_data_parallel_size, cur_data_parallel_size)
+            )
 
-    def remove_run_refs_for_scale_down(self, removed_dp_size: int) -> None:
+        local_removed = 0
+        # Remove in reverse order so indices remain valid.
+        for rank in sorted(removed_dp_ranks, reverse=True):
+            pg = self.created_placement_groups.pop(rank)
+            is_local = self.placement_group_is_local.pop(rank)
+            if is_local:
+                local_removed += 1
+                local_idx = sum(
+                    1 for i in range(rank)
+                    if self.placement_group_is_local[i]
+                )
+                self.local_engine_actors.pop(local_idx)
+            else:
+                remote_idx = sum(
+                    1 for i in range(rank)
+                    if not self.placement_group_is_local[i]
+                )
+                self.remote_engine_actors.pop(remote_idx)
+            ray.util.remove_placement_group(pg)
+        return local_removed
+
+    def remove_run_refs_for_scale_down(
+        self,
+        removed_dp_size: int,
+        ranks_to_remove: set[int] | None = None,
+    ) -> None:
         if removed_dp_size <= 0:
             return
-        flags = self.placement_group_is_local[-removed_dp_size:]
-        li = len(self.local_engine_actors) - 1
-        ri = len(self.remote_engine_actors) - 1
-        for is_local in reversed(flags):
-            if is_local:
-                actor = self.local_engine_actors[li]
-                li -= 1
-            else:
-                actor = self.remote_engine_actors[ri]
-                ri -= 1
-            ref = self.actor_run_ref_dict.pop(actor)
-            self.run_refs.remove(ref)
+
+        if ranks_to_remove is None:
+            # Default: remove from the end (graceful scale-down).
+            flags = self.placement_group_is_local[-removed_dp_size:]
+            li = len(self.local_engine_actors) - 1
+            ri = len(self.remote_engine_actors) - 1
+            for is_local in reversed(flags):
+                if is_local:
+                    actor = self.local_engine_actors[li]
+                    li -= 1
+                else:
+                    actor = self.remote_engine_actors[ri]
+                    ri -= 1
+                ref = self.actor_run_ref_dict.pop(actor)
+                self.run_refs.remove(ref)
+                self.run_ref_to_dp_rank.pop(ref, None)
+        else:
+            # Fault-triggered: remove specific ranks.
+            for rank in sorted(ranks_to_remove, reverse=True):
+                actor = self._actor_at_rank(rank)
+                ref = self.actor_run_ref_dict.pop(actor, None)
+                if ref is not None:
+                    self.run_refs.remove(ref)
+                    self.run_ref_to_dp_rank.pop(ref, None)
 
     def get_run_refs(self):
         return self.run_refs
@@ -879,6 +973,46 @@ class CoreEngineActorManager:
 
             if unexpected_failure:
                 break
+
+        self.shutdown()
+
+    def monitor_engine_liveness_fault_tolerant(
+        self,
+        on_engine_died: Callable[[str, int], bool],
+    ) -> None:
+        """Monitor engine liveness, reporting individual failures.
+
+        Args:
+            on_engine_died: Called with (actor_name, dp_rank) when an actor
+                dies unexpectedly. Return True to continue monitoring
+                surviving engines, False to stop.
+        """
+        import ray
+
+        while not self.manager_stopped.is_set():
+            actor_run_refs = list(self.get_run_refs())
+            if not actor_run_refs:
+                logger.info(
+                    "There are no actors to monitor currently. "
+                    "The monitoring function is about to terminate."
+                )
+                break
+            actor_done_refs, _ = ray.wait(actor_run_refs, timeout=5)
+            for actor_ref in actor_done_refs:
+                if self.manager_stopped.is_set():
+                    break
+                if actor_ref not in self.get_run_refs():
+                    continue
+                try:
+                    ray.get(actor_ref)
+                except ray.exceptions.RayActorError:
+                    actor_name = f"Actor {actor_ref}"
+                    self.failed_proc_name = actor_name
+                    dp_rank = self.run_ref_to_dp_rank.get(actor_ref, -1)
+                    should_continue = on_engine_died(actor_name, dp_rank)
+                    if not should_continue:
+                        self.shutdown()
+                        return
 
         self.shutdown()
 


### PR DESCRIPTION
## What problem does this solve?

When running large MoE models (like DeepSeek) with Expert Parallelism across multiple GPUs, if **any single GPU worker crashes**, the entire serving cluster goes down. This means one bad GPU can take out your whole deployment.

This PR adds **automatic fault tolerance**: when a GPU worker dies, the system detects it, redistributes the work across surviving GPUs, and resumes serving — all without operator intervention or downtime beyond the recovery window (~25 seconds).

**Important:** This PR has **no dependency on FT EP kernels** (e.g., DeepEP low-latency with fault masking, NIXL EP) **or FT Torch collectives**. It works with the default `allgather_reducescatter` NCCL backend using standard NCCL operations.

## How it works (plain English)

**Background context:** In Expert Parallelism (EP), a large MoE model's experts are split across multiple GPUs. Each GPU holds a subset of experts. With EPLB (Expert-Parallel Load Balancing), some experts are intentionally duplicated across GPUs for redundancy.

**When a GPU worker dies, here's what happens:**

1. **Detection** — A monitor thread watches all GPU worker processes. When one dies, it identifies which worker and deduplicates notifications (Ray may report the same death multiple times).

2. **Feasibility check** — Before attempting recovery, verify that the remaining GPUs have enough expert slots to cover all the model's logical experts. If not, shut down gracefully.

3. **Cleanup** — Abort the old communication groups (NCCL) that included the dead worker — otherwise surviving workers would hang waiting for the dead one. Fail any in-flight requests that were assigned to the dead worker.

4. **Reconfiguration** — Create new communication groups with only the surviving workers. This uses a two-staged barrier to handle the timing issue where some workers may be mid-computation when the fault is detected.

5. **Expert recovery** — This is the core logic:
   - Remove the dead worker's columns from the expert assignment table (`strip_dead_columns`)
   - Find which experts lost **all** their copies (no surviving replica)
   - Find which experts still have **extra** copies (redundant replicas)
   - Reassign the lost experts into those redundant slots (`reassign_missing_experts`)
   - For experts that still have a copy somewhere: transfer weights between GPUs via direct GPU-to-GPU communication (NCCL P2P)
   - For experts where **every copy was on the dead GPU** (no surviving replica anywhere): reload those expert weights from the original model checkpoint on disk
   - **Note:** The post-fault expert reassignment is **not load-balanced**. It only ensures every logical expert has at least 1 physical replica by stealing from the most-redundant slots. Future EPLB rebalancing cycles will optimize the placement for load.

6. **Resume** — Re-capture CUDA graphs with the new configuration and resume normal inference.

## Example: what it looks like in practice

### Case 1: All experts have a surviving replica (common with high redundancy)

When enough redundant experts are configured, the dead worker's experts likely still have copies on other GPUs. Recovery only needs GPU-to-GPU weight transfer — no disk I/O.

```
# GPU worker 1 crashes
[Fault Tolerance] Engine (dp_rank=1) died. Initiating scale-down from 4 to 3 engines.
[Fault Tolerance] All 64 logical experts have at least one replica — no reassignment needed.
[Fault Tolerance] Scale-down complete. Now running with 3 engines.

POST /v1/completions → 200 OK   (still serving!)
```

### Case 2: Some experts have no surviving replica (requires disk reload)

With lower redundancy or after multiple failures, some experts may only have existed on the dead GPU. These must be reloaded from the model checkpoint on disk.

```
# GPU worker 2 crashes (was the only holder of experts 42, 57)
[Fault Tolerance] Engine (dp_rank=2) died. Initiating scale-down from 3 to 2 engines.
[Fault Tolerance] 2 missing experts detected — reassigning to redundant slots.
[Fault Tolerance] Reloading 2 unreachable experts from disk checkpoint.
[Fault Tolerance] Scale-down complete. Now running with 2 engines.

POST /v1/completions → 200 OK   (still serving!)
```

## Why fault-triggered scale-down needs custom logic

This PR **reuses the existing elastic scale-down path**. The only differences vs normal (graceful) scale-down are handling a dead GPU that (1) cannot join NCCL collectives and (2) cannot participate in the pre-scale-down EPLB weight reshuffle.

In normal (graceful) elastic EP scale-down, the removing engine is **alive and cooperates**. In fault-triggered scale-down, it's **already dead**. Every distributed operation requires all group members to participate — when one is dead, it hangs forever. This PR replaces each cooperative step with a non-cooperative alternative:

| Step | Normal | Fault-triggered | Why |
|------|--------|----------------|-----|
| **NCCL teardown** | `destroy()` (orderly, all ranks) | `abort()` (unilateral, no waiting) | `destroy()` hangs waiting for dead rank |
| **Gloo barrier** | `torch.distributed.barrier()` after TCP store sync | Skipped — TCP store barrier only | Gloo requires all ranks |
| **Barrier count** | `old_dp_group.size()` | `_alive_group_size()` | Dead rank won't write arrival key |
| **Barrier cleanup** | Rank 0 deletes keys | `_first_alive_rank()` deletes keys | Rank 0 may be dead |
| **EPLB weight transfer** | NCCL P2P between all ranks (pre-scale-down reshuffle) | Skipped; post-hoc reassignment via `reassign_missing_experts()` + disk reload fallback. **Not load-balanced** — only ensures at least 1 replica per expert. | Dead rank can't send/recv |
| **SHUTDOWN_COMPLETE** | Removing engine sends after reshuffle | `_synthesize_shutdown_complete_for_dead_ranks()` injects it | Dead engine can't notify |
| **Standby group ranks** | Contiguous `[0..N-1]` | Non-contiguous world ranks (e.g. `[0,2,3]`), compacted to contiguous `rank_in_group` for NCCL; ZMQ keeps original world rank | Surviving ranks keep identity for socket routing |
| **Expert map** | `_expert_map` stays valid (rank identity unchanged, highest ranks removed) | Must call `update_expert_map()` — middle-rank removal changes `ep_rank` for compacted ranks, making the old map invalid | Rank compaction changes `ep_rank` for some surviving ranks |
| **Client routing** | Trim `core_engines` after completion | `_dead_engine_identities` blocks routing immediately; abort callback sends `FinishReason.ABORT` to in-flight requests | Requests on dead engine would hang |
| **Reconfigure** | Sent to all engines | Skip dead engine | Would timeout |

## Recovery timing breakdown

All steps run **sequentially** on each worker. Workers run in **parallel** across GPUs via `collective_rpc`.

From real E2E runs (4 to 3 scale-down, DeepSeek-V2-Lite, 4xA100):

| Step | Time | % |
|------|------|---|
| Abort NCCL groups | 2.0s | 8% |
| Create standby groups | 1.8s | 7% |
| MoE reconfig + expert reassign | 0.25s | 1% |
| **CUDA graph recapture (51 captures)** | **21.7s** | **83%** |
| **Total** | **~26s** | |

The bottleneck is CUDA graph recapture: 51 captures at vLLM's default batch sizes [1..512]. Large batches (256-512) take ~1.1s each due to MoE all2all traffic; small batches (1-248) take ~0.2s each.

Expert reassignment time depends on whether disk reload is needed:
- **No disk reload** (redundant replicas cover lost experts): 0.04s
- **Disk reload** (tail-rank death, total replica loss): 3.81s

## Usage

```bash
python -m vllm.entrypoints.openai.api_server \
    --model deepseek-ai/DeepSeek-V2-Lite \
    --data-parallel-size 4 \
    --data-parallel-backend ray \
    --enable-expert-parallel \
    --enable-elastic-ep \
    --enable-eplb \
    --eplb-config '{"num_redundant_experts": 64}' \
    --enable-ep-fault-tolerance
```

**Requirements:**
- `--data-parallel-backend ray` (multiprocessing backend not yet supported)
- `--tensor-parallel-size 1` (TP>1 not yet supported)
- `--enable-elastic-ep` must be on (fault tolerance builds on elastic EP infrastructure)
- `--enable-eplb` with `num_redundant_experts > 0` (redundancy enables expert recovery without always hitting disk)
- No dependency on FT EP kernels or FT Torch collectives

## Files changed

| File | What it does |
|------|-------------|
| `vllm/config/parallel.py` | New `--enable-ep-fault-tolerance` flag and validation |
| `vllm/v1/engine/core_client.py` | Detect worker death, orchestrate scale-down, clean up in-flight requests |
| `vllm/v1/engine/utils.py` | Worker process health monitoring |
| `vllm/distributed/elastic_ep/elastic_state.py` | State machine for coordinating reconfiguration across workers |
| `vllm/distributed/elastic_ep/elastic_execute.py` | Expert reassignment, weight transfer, and disk reload logic |
| `vllm/distributed/elastic_ep/standby_state.py` | Create new communication groups with only surviving workers |
| `tests/v1/engine/test_ep_fault_tolerance.py` | ~1300 lines of unit tests |

## Test plan

### Unit tests (`tests/v1/engine/test_ep_fault_tolerance.py`)
- [x] Parse DP rank from process name
- [x] Config flag validation
- [x] Fault detection and deduplication
- [x] In-flight request cleanup on worker death
- [x] Abort callback registration
- [x] Two-staged barrier with timeout handling
- [x] Rank compaction after scale-down
- [x] Expert reassignment (missing to redundant slots)
- [x] Expert assignment table compaction
- [x] Surviving rank computation
- [x] Worker liveness monitoring

### E2E fault injection (Kubernetes, 4xA100)

Model: `deepseek-ai/DeepSeek-V2-Lite`, DP=4, TP=1, 64 redundant experts

**Run 1: kill 1, 1, 1 (no disk reload)**

| Stage | Action | Total | Reassign | Result |
|-------|--------|-------|----------|--------|
| 0 | Startup 4 workers | — | — | Inference works |
| 1 | Kill rank 1 (4 to 3) | 26.3s | 0.04s | Inference works |
| 2 | Kill rank 1 (3 to 2) | 24.3s | 0.03s | Inference works |
| 3 | Kill rank 1 (2 to 1) | — | — | ep_size=1 not supported |

**Run 2: kill 1, 2, 1 (disk reload triggered at stage 2)**

| Stage | Action | Total | Reassign | Result |
|-------|--------|-------|----------|--------|
| 0 | Startup 4 workers | — | — | Inference works |
| 1 | Kill rank 1 (4 to 3) | 26.7s | 0.04s | Inference works |
| 2 | Kill rank 2 (3 to 2) | 27.4s | 3.81s (disk) | Inference works |
| 3 | Kill rank 1 (2 to 1) | — | — | ep_size=1 not supported |

Run 2 stage 2: tail-rank death causes total replica loss for some experts, triggering disk reload (3.81s).

### Known limitations
- Requires `tensor_parallel_size=1` (TP>1 support is future work)
- Requires Ray backend (`data_parallel_backend="ray"`)
- Scale-up (adding workers back after recovery) not yet implemented
- Post-fault expert reassignment is not load-balanced (only ensures at least 1 replica per expert; future EPLB cycles will optimize)
- 2 to 1 scale-down not supported (FusedMoE requires ep_size >= 2)

---

> AI assistance was used in developing this PR.
> Verified no existing open PR addresses EP fault tolerance.
