### PR TITLE
[Bugfix] Fix Qwen3 </think> leak in streaming with stop sequences

### DIFF
--- a/tests/reasoning/test_qwen3_reasoning_parser.py
+++ b/tests/reasoning/test_qwen3_reasoning_parser.py
@@ -23,6 +23,14 @@ REASONING_MODEL_NAMES = [
 ]
 
 
+class DummyQwen3Tokenizer:
+    def get_vocab(self) -> dict[str, int]:
+        return {
+            "<think>": 1,
+            "</think>": 2,
+        }
+
+
 @pytest.fixture(scope="module", params=REASONING_MODEL_NAMES)
 def qwen3_tokenizer(request):
     return AutoTokenizer.from_pretrained(request.param)
@@ -278,6 +286,55 @@ def test_reasoning_streaming_multi_token_deltas(
 
     assert reconstructor.reasoning == expected_reasoning
     assert (reconstructor.other_content or None) == expected_content
+
+
+def test_reasoning_streaming_delayed_visible_end_token():
+    """Stop buffering can delay visible </think> text to a later chunk."""
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        DummyQwen3Tokenizer()
+    )
+
+    previous_text = ""
+    previous_token_ids: list[int] = []
+
+    first_delta = parser.extract_reasoning_streaming(
+        previous_text=previous_text,
+        current_text="Thinking...",
+        delta_text="Thinking...",
+        previous_token_ids=previous_token_ids,
+        current_token_ids=[100],
+        delta_token_ids=[100],
+    )
+    assert first_delta is not None
+    assert first_delta.reasoning == "Thinking..."
+    assert first_delta.content is None
+
+    previous_text = "Thinking..."
+    previous_token_ids = [100]
+
+    hidden_end_delta = parser.extract_reasoning_streaming(
+        previous_text=previous_text,
+        current_text=previous_text,
+        delta_text="",
+        previous_token_ids=previous_token_ids,
+        current_token_ids=previous_token_ids + [parser.end_token_id],
+        delta_token_ids=[parser.end_token_id],
+    )
+    assert hidden_end_delta is None
+
+    previous_token_ids = previous_token_ids + [parser.end_token_id]
+
+    flushed_delta = parser.extract_reasoning_streaming(
+        previous_text=previous_text,
+        current_text=previous_text + "</think>Hello!",
+        delta_text="</think>Hello!",
+        previous_token_ids=previous_token_ids,
+        current_token_ids=previous_token_ids + [101],
+        delta_token_ids=[101],
+    )
+    assert flushed_delta is not None
+    assert flushed_delta.reasoning is None
+    assert flushed_delta.content == "Hello!"
 
 
 # --- Tests for enable_thinking=False (thinking explicitly disabled) ---

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -120,26 +120,30 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             if start_idx >= 0:
                 delta_text = delta_text[start_idx + len(self.start_token) :]
 
-        if self.end_token_id in delta_token_ids:
-            # End token in this delta: split reasoning from content.
-            end_index = delta_text.find(self.end_token)
-            if end_index >= 0:
-                reasoning = delta_text[:end_index]
-                content = delta_text[end_index + len(self.end_token) :]
-                if not reasoning and not content:
-                    return None
-                return DeltaMessage(
-                    reasoning=reasoning if reasoning else None,
-                    content=content if content else None,
-                )
-            # end_token_id in IDs but not in text (already stripped)
+        # Stop-string buffering can delay the visible text for </think> until a
+        # later chunk, so detect the end marker from text first rather than
+        # relying solely on the token ids from the current delta.
+        end_index = delta_text.find(self.end_token)
+        if end_index >= 0:
+            reasoning = delta_text[:end_index]
+            content = delta_text[end_index + len(self.end_token) :]
+            if not reasoning and not content:
+                return None
+            return DeltaMessage(
+                reasoning=reasoning if reasoning else None,
+                content=content if content else None,
+            )
+
+        if self.end_token_id in delta_token_ids and not delta_text:
+            # End token in IDs but not in visible text yet. Wait for the
+            # detokenizer to flush the buffered text in a later chunk.
             return None
 
         # No end token in this delta.
         if not delta_text:
             # Nothing left after stripping start token.
             return None
-        elif self.end_token_id in previous_token_ids:
+        elif self.end_token_id in previous_token_ids or self.end_token in previous_text:
             # End token already passed: everything is content now.
             return DeltaMessage(content=delta_text)
         else:


### PR DESCRIPTION
## Purpose

Fixes #38789, where `Qwen3ReasoningParser` can leak `</think>` into streamed `content` when stop sequences are enabled.

The failure is caused by a text/token desync in the streaming parser. With stop-string buffering enabled, the `</think>` token ID can be observed in one chunk while the visible `</think>` text is still withheld from `delta_text`. The existing parser logic checked token IDs first, so by the time the buffered text was flushed in a later chunk, the parser could no longer split reasoning and content correctly.

This PR fixes that in `vllm/reasoning/qwen3_reasoning_parser.py` by splitting on the visible `</think>` text first and ignoring chunks where the end token ID is present but the visible end text has not been flushed yet. This keeps the fix narrow, stays within the existing parser contract, and avoids changing detokenizer or serving-layer behavior.

## Test Plan

```bash
.venv/bin/python -m pytest tests/reasoning/test_qwen3_reasoning_parser.py -q -k delayed_visible_end_token
.venv/bin/pre-commit run --files vllm/reasoning/qwen3_reasoning_parser.py tests/reasoning/test_qwen3_reasoning_parser.py
```

## Test Result
Passed:
- Targeted regression test for the delayed-visible-`</think>` streaming case in `tests/reasoning/test_qwen3_reasoning_parser.py`
- `pre-commit` on all changed files

The focused regression covers the before/after behavior for this bug:

- Before: the flushed chunk could emit `</think>` as part of streamed `content`
- After: reasoning and final content are separated correctly when stop buffering delays the visible `</think>` text