### PR TITLE
[fix]: deepseekv31 tool parser: `"` and `}` may arrive in seperate deltas.

### DIFF
--- a/tests/tool_parsers/test_deepseekv31_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv31_tool_parser.py
@@ -3,12 +3,19 @@
 
 import pytest
 
+from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.deepseekv31_tool_parser import (
     DeepSeekV31ToolParser,
 )
 
 MODEL = "deepseek-ai/DeepSeek-V3.1"
+
+TOOL_CALLS_START = "<｜tool▁calls▁begin｜>"
+TOOL_CALLS_END = "<｜tool▁calls▁end｜>"
+TOOL_CALL_START = "<｜tool▁call▁begin｜>"
+TOOL_CALL_END = "<｜tool▁call▁end｜>"
+TOOL_SEP = "<｜tool▁sep｜>"
 
 
 @pytest.fixture(scope="module")
@@ -59,3 +66,46 @@ def test_extract_tool_calls_with_multiple_tools(parser):
 
     # prefix is content
     assert result.content == "some prefix text"
+
+
+def test_streaming_close_brace_with_end_token_but_quote_in_prior_delta(parser):
+    deltas = [
+        TOOL_CALLS_START,
+        TOOL_CALL_START,
+        "get_weather",
+        TOOL_SEP,
+        '{"city": "NYC',
+        '"',  # quote arrives alone
+        "}" + TOOL_CALL_END,  # brace + end token in same delta
+        TOOL_CALLS_END,
+    ]
+    reconstructor = run_tool_extraction_streaming(
+        parser, deltas, assert_one_tool_per_delta=True
+    )
+    assert len(reconstructor.tool_calls) == 1
+    assert reconstructor.tool_calls[0].function.name == "get_weather"
+    args = reconstructor.tool_calls[0].function.arguments
+    # The closing "}" must not be dropped
+    assert args.endswith("}")
+    assert "city" in args
+    assert "NYC" in args
+
+
+def test_streaming_close_brace_alone_with_end_token(parser):
+    deltas = [
+        TOOL_CALLS_START,
+        TOOL_CALL_START,
+        "get_weather",
+        TOOL_SEP,
+        '{"x": 1',
+        "}" + TOOL_CALL_END,  # closing brace + end token
+        TOOL_CALLS_END,
+    ]
+    reconstructor = run_tool_extraction_streaming(
+        parser, deltas, assert_one_tool_per_delta=True
+    )
+    assert len(reconstructor.tool_calls) == 1
+    assert reconstructor.tool_calls[0].function.name == "get_weather"
+    args = reconstructor.tool_calls[0].function.arguments
+    assert args.endswith("}")
+    assert "x" in args

--- a/vllm/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv31_tool_parser.py
@@ -215,10 +215,16 @@ class DeepSeekV31ToolParser(ToolParser):
                         if diff is str
                         else diff
                     )
-                    if '"}' not in delta_text:
+                    # Handle cases where `"` and `}` may arrive in
+                    # separate streaming deltas, so `"}` never appears
+                    # as a substring of a single delta_text.
+                    if "}" in delta_text:
+                        end_loc = delta_text.rindex("}")
+                        diff = delta_text[:end_loc] + "}"
+                    else:
+                        diff = delta_text.rstrip("\n`")
+                    if diff == "":
                         return None
-                    end_loc = delta_text.rindex('"}')
-                    diff = delta_text[:end_loc] + '"}'
                     logger.debug(
                         "Finishing tool and found diff that had not "
                         "been streamed yet: %s",


### PR DESCRIPTION




## Purpose
fix a bug for deepseek v31 tool parser, when `"` and `}` arrive in seperate deltas, tools are not parsed as expect.


## Test Plan
Add unit test in `tests/tool_parsers/test_deepseekv31_tool_parser.py`.


## Test Result
```
tests/tool_parsers/test_deepseekv31_tool_parser.py::test_extract_tool_calls_with_tool PASSED
tests/tool_parsers/test_deepseekv31_tool_parser.py::test_extract_tool_calls_with_multiple_tools PASSED
tests/tool_parsers/test_deepseekv31_tool_parser.py::test_streaming_close_brace_with_end_token_but_quote_in_prior_delta PASSED
tests/tool_parsers/test_deepseekv31_tool_parser.py::test_streaming_close_brace_alone_with_end_token PASSED
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

