### PR TITLE
[Bugfix] Fix MoE routed input transform when using DeepEP LL

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner_base.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner_base.py
@@ -508,6 +508,13 @@ class MoERunnerBase(MoERunner):
         if self.gate is not None:
             router_logits, _ = self.gate(hidden_states)
 
+        assert hidden_states.dtype == self.moe_config.in_dtype, (
+            f"{hidden_states.dtype} == {self.moe_config.in_dtype}"
+        )
+        assert router_logits.dtype == self.moe_config.router_logits_dtype, (
+            f"{router_logits.dtype} == {self.moe_config.router_logits_dtype}"
+        )
+
         with self._sequence_parallel_context():
             return self._forward_impl(
                 layer,


### PR DESCRIPTION
## Purpose

Nemotron-H was not working with the DeepEP LL backend for the following reasons:
1. The final shared experts output for the chunked runner implementation was sized according to the padded hidden states.  It should have been sized to match `shared_experts_input`
2. The router logits type returned by the gate did not match the type in the `FusedMoEConfig` which is used to allocate the temp buffers for the chunked runner.

I've fixed both issues and added some asserts in the runner that make sure the types in `FusedMoEConfig` match the actual runtime data types for hidden states and router logits.

I think some other CI tests will trigger the new asserts so I'll probably have to update the PR with some more fixes.

cc @robertgshaw2-redhat 

## Test Plan

CI
Ran Nemotron-H with DeepEP LL backend.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

