### PR TITLE
[Helion] Add rotary positional embedding (RoPE) Helion kernels (neox + gptj)

### DIFF
--- a/tests/kernels/helion/test_rotary_embedding.py
+++ b/tests/kernels/helion/test_rotary_embedding.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the Helion rotary embedding kernels.
+
+Structure mirrors tests/kernels/helion/test_silu_mul_fp8.py.
+
+Two levels of correctness testing:
+  1. Against ``RotaryEmbedding.forward_static`` (the vLLM canonical reference).
+  2. Against a pure-PyTorch inline implementation that is independent of
+     vLLM C-extension availability.
+
+NOTE: TestRotaryEmbeddingConfigPicker does NOT require Helion and can run
+on any machine. Correctness and registration tests require Helion + CUDA.
+"""
+
+import regex as re
+
+import pytest
+import torch
+
+from vllm.utils.import_utils import has_helion
+
+_HELION_AVAILABLE = has_helion()
+
+# Config picker is re-implemented here (mirroring the kernel file) so that
+# TestRotaryEmbeddingConfigPicker can run without Helion being installed.
+def _pick_rope_config_for_test(
+    args, config_keys: list[str]
+) -> str | None:
+    if not config_keys:
+        return None
+    _pos, query, _key, _head_size, rotary_dim, _cache = args
+    num_tokens = query.shape[0]
+    parsed: dict[int, list[int]] = {}
+    for k in config_keys:
+        if k == "default":
+            continue
+        m = re.fullmatch(r"rotarydim_(\d+)_numtokens_(\d+)", k)
+        if not m:
+            raise ValueError(
+                f"Malformed config key '{k}', "
+                f"expected format 'rotarydim_{{int}}_numtokens_{{int}}'"
+            )
+        parsed.setdefault(int(m.group(1)), []).append(int(m.group(2)))
+    if not parsed:
+        return "default" if "default" in config_keys else None
+    best_rdim = min(parsed, key=lambda d: abs(d - rotary_dim))
+    avail = sorted(parsed[best_rdim])
+    best_n = next((n for n in avail if n >= num_tokens), avail[-1])
+    return f"rotarydim_{best_rdim}_numtokens_{best_n}"
+
+
+# These are always importable (stubs exist when Helion is unavailable).
+from vllm.kernels.helion.ops.rotary_embedding import (
+    rotary_embedding_baseline,
+    rotary_embedding_gptj,
+    rotary_embedding_neox,
+)
+
+if _HELION_AVAILABLE:
+    from vllm.kernels.helion.config_manager import ConfigManager
+
+
+# ---------------------------------------------------------------------------
+# Helper: skip when no pre-tuned config exists for this GPU
+# ---------------------------------------------------------------------------
+
+def _skip_if_platform_unsupported(kernel_name: str) -> None:
+    """Skip the test if no pre-tuned configs are present for this GPU."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    try:
+        from vllm.kernels.helion.utils import get_canonical_gpu_name
+
+        platform = get_canonical_gpu_name()
+        try:
+            config_manager = ConfigManager.get_instance()
+        except RuntimeError:
+            config_manager = ConfigManager()
+
+        configs = config_manager.get_platform_configs(kernel_name, platform)
+        if not configs:
+            pytest.skip(
+                f"Current GPU platform '{platform}' has no pre-tuned configs "
+                f"for kernel '{kernel_name}'"
+            )
+    except (ImportError, RuntimeError, KeyError):
+        pytest.skip(
+            f"Error detecting platform support for kernel '{kernel_name}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_config_manager():
+    if _HELION_AVAILABLE:
+        from vllm.kernels.helion.config_manager import ConfigManager
+        ConfigManager.reset_instance()
+        ConfigManager()
+    yield
+    if _HELION_AVAILABLE:
+        from vllm.kernels.helion.config_manager import ConfigManager
+        ConfigManager.reset_instance()
+
+
+# ---------------------------------------------------------------------------
+# Pure-PyTorch reference (independent of vLLM C extension)
+# ---------------------------------------------------------------------------
+
+def _rope_pytorch(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    head_size: int,
+    rotary_dim: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox_style: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch RoPE matching ``RotaryEmbedding.forward_static``."""
+    num_tokens = positions.shape[0]
+    rot_half = rotary_dim // 2
+
+    cos_sin = cos_sin_cache.index_select(0, positions)  # [num_tokens, rotary_dim]
+    cos = cos_sin[:, :rot_half]   # [num_tokens, rot_half]
+    sin = cos_sin[:, rot_half:]   # [num_tokens, rot_half]
+
+    def _apply(x_flat: torch.Tensor, n_heads: int) -> torch.Tensor:
+        # x_flat: [num_tokens, n_heads * head_size]
+        x = x_flat.reshape(num_tokens, n_heads, head_size)
+        x_rot = x[:, :, :rotary_dim]   # [num_tokens, n_heads, rotary_dim]
+        x_pass = x[:, :, rotary_dim:]  # unrotated tail
+
+        cos_h = cos.unsqueeze(1).to(x.dtype)  # [num_tokens, 1, rot_half]
+        sin_h = sin.unsqueeze(1).to(x.dtype)
+
+        if is_neox_style:
+            x1 = x_rot[:, :, :rot_half]
+            x2 = x_rot[:, :, rot_half:]
+            x_rot_out = torch.cat(
+                (x1 * cos_h - x2 * sin_h, x2 * cos_h + x1 * sin_h), dim=-1
+            )
+        else:
+            x1 = x_rot[:, :, ::2]
+            x2 = x_rot[:, :, 1::2]
+            x_rot_out = torch.stack(
+                (x1 * cos_h - x2 * sin_h, x2 * cos_h + x1 * sin_h), dim=-1
+            ).flatten(-2)
+
+        x_out = torch.cat((x_rot_out, x_pass), dim=-1)
+        return x_out.reshape_as(x_flat)
+
+    num_q_heads = query.shape[1] // head_size
+    num_kv_heads = key.shape[1] // head_size
+
+    q_out = _apply(query, num_q_heads)
+    k_out = _apply(key, num_kv_heads)
+    return q_out, k_out
+
+
+# ---------------------------------------------------------------------------
+# Config picker tests
+# ---------------------------------------------------------------------------
+
+class TestRotaryEmbeddingConfigPicker:
+    """Tests for pick_rotary_embedding_config() selection logic."""
+
+    def _make_args(
+        self,
+        num_tokens: int,
+        rotary_dim: int,
+        head_size: int = 128,
+        num_q_heads: int = 32,
+        num_kv_heads: int = 8,
+    ) -> tuple:
+        positions = torch.zeros(num_tokens, dtype=torch.int64, device="cpu")
+        query = torch.zeros(num_tokens, num_q_heads * head_size, device="cpu")
+        key = torch.zeros(num_tokens, num_kv_heads * head_size, device="cpu")
+        cos_sin_cache = torch.zeros(2048, rotary_dim, device="cpu")
+        return positions, query, key, head_size, rotary_dim, cos_sin_cache
+
+    def test_exact_match(self):
+        keys = ["rotarydim_128_numtokens_32", "rotarydim_128_numtokens_64"]
+        args = self._make_args(num_tokens=32, rotary_dim=128)
+        assert _pick_rope_config_for_test(args, keys) == "rotarydim_128_numtokens_32"
+
+    def test_ceiling_selection(self):
+        """Smallest num_tokens >= input should be selected."""
+        keys = [
+            "rotarydim_128_numtokens_8",
+            "rotarydim_128_numtokens_32",
+            "rotarydim_128_numtokens_128",
+        ]
+        args = self._make_args(num_tokens=20, rotary_dim=128)
+        assert _pick_rope_config_for_test(args, keys) == "rotarydim_128_numtokens_32"
+
+    def test_fallback_to_largest(self):
+        """When input exceeds all available num_tokens, pick the largest."""
+        keys = [
+            "rotarydim_128_numtokens_8",
+            "rotarydim_128_numtokens_32",
+            "rotarydim_128_numtokens_128",
+        ]
+        args = self._make_args(num_tokens=512, rotary_dim=128)
+        assert _pick_rope_config_for_test(args, keys) == "rotarydim_128_numtokens_128"
+
+    def test_closest_rotary_dim(self):
+        """When exact rotary_dim not found, use closest available."""
+        keys = [
+            "rotarydim_64_numtokens_32",
+            "rotarydim_128_numtokens_32",
+        ]
+        # rotary_dim=100 → closer to 128 (dist=28) than 64 (dist=36) → pick rotarydim_128_numtokens_32
+        args = self._make_args(num_tokens=32, rotary_dim=100)
+        assert _pick_rope_config_for_test(args, keys) == "rotarydim_128_numtokens_32"
+
+    def test_fallback_to_default(self):
+        args = self._make_args(num_tokens=32, rotary_dim=128)
+        assert _pick_rope_config_for_test(args, ["default"]) == "default"
+
+    def test_empty_config_keys(self):
+        args = self._make_args(num_tokens=32, rotary_dim=128)
+        assert _pick_rope_config_for_test(args, []) is None
+
+    def test_malformed_key_raises(self):
+        keys = ["rotarydim_128_badformat_32"]
+        args = self._make_args(num_tokens=32, rotary_dim=128)
+        with pytest.raises(ValueError, match="Malformed config key"):
+            _pick_rope_config_for_test(args, keys)
+
+    def test_default_skipped_when_valid_keys_exist(self):
+        keys = [
+            "default",
+            "rotarydim_128_numtokens_32",
+            "rotarydim_128_numtokens_64",
+        ]
+        args = self._make_args(num_tokens=32, rotary_dim=128)
+        assert _pick_rope_config_for_test(args, keys) == "rotarydim_128_numtokens_32"
+
+
+# ---------------------------------------------------------------------------
+# Correctness tests
+# ---------------------------------------------------------------------------
+
+class TestRotaryEmbeddingNeoxCorrectness:
+    """Compare rotary_embedding_neox against RotaryEmbedding.forward_static."""
+
+    @pytest.mark.parametrize("num_tokens", [1, 8, 32, 128])
+    @pytest.mark.parametrize("rotary_dim", [64, 128])
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_neox_vs_baseline(self, num_tokens, rotary_dim, dtype):
+        _skip_if_platform_unsupported("_helion_rotary_embedding_neox")
+
+        head_size = rotary_dim
+        num_q_heads, num_kv_heads = 32, 8
+
+        positions = torch.randint(0, 512, (num_tokens,), device="cuda")
+        query = torch.randn(num_tokens, num_q_heads * head_size, device="cuda", dtype=dtype)
+        key = torch.randn(num_tokens, num_kv_heads * head_size, device="cuda", dtype=dtype)
+        cos_sin_cache = torch.randn(1024, rotary_dim, device="cuda", dtype=dtype)
+
+        q_ref, k_ref = rotary_embedding_baseline(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache, is_neox_style=True,
+        )
+        q_helion, k_helion = rotary_embedding_neox(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache,
+        )
+
+        assert q_helion.shape == q_ref.shape
+        assert k_helion.shape == k_ref.shape
+
+        rtol, atol = (2e-2, 2e-2) if dtype == torch.bfloat16 else (2e-3, 2e-3)
+        torch.testing.assert_close(
+            q_helion.float(), q_ref.float(), rtol=rtol, atol=atol,
+            msg=f"Query mismatch: tokens={num_tokens}, rotary_dim={rotary_dim}, dtype={dtype}",
+        )
+        torch.testing.assert_close(
+            k_helion.float(), k_ref.float(), rtol=rtol, atol=atol,
+            msg=f"Key mismatch: tokens={num_tokens}, rotary_dim={rotary_dim}, dtype={dtype}",
+        )
+
+    def test_neox_vs_pytorch(self):
+        """Against pure-PyTorch reference (no C extension needed)."""
+        _skip_if_platform_unsupported("_helion_rotary_embedding_neox")
+
+        num_tokens, rotary_dim, head_size = 32, 128, 128
+        num_q_heads, num_kv_heads = 16, 8
+        dtype = torch.bfloat16
+
+        positions = torch.randint(0, 512, (num_tokens,), device="cuda")
+        query = torch.randn(num_tokens, num_q_heads * head_size, device="cuda", dtype=dtype)
+        key = torch.randn(num_tokens, num_kv_heads * head_size, device="cuda", dtype=dtype)
+        cos_sin_cache = torch.randn(1024, rotary_dim, device="cuda", dtype=dtype)
+
+        q_ref, k_ref = _rope_pytorch(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache, is_neox_style=True,
+        )
+        q_helion, k_helion = rotary_embedding_neox(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache,
+        )
+        torch.testing.assert_close(q_helion.float(), q_ref.float(), rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(k_helion.float(), k_ref.float(), rtol=2e-2, atol=2e-2)
+
+    def test_neox_partial_rope(self):
+        """rotary_dim < head_size (partial RoPE): un-rotated tail must be unchanged."""
+        _skip_if_platform_unsupported("_helion_rotary_embedding_neox")
+
+        num_tokens = 16
+        head_size = 128
+        rotary_dim = 64   # partial: rotate only first 64 of 128 dims
+        num_q_heads, num_kv_heads = 8, 4
+        dtype = torch.bfloat16
+
+        positions = torch.randint(0, 512, (num_tokens,), device="cuda")
+        query = torch.randn(num_tokens, num_q_heads * head_size, device="cuda", dtype=dtype)
+        key = torch.randn(num_tokens, num_kv_heads * head_size, device="cuda", dtype=dtype)
+        cos_sin_cache = torch.randn(1024, rotary_dim, device="cuda", dtype=dtype)
+
+        q_ref, k_ref = rotary_embedding_baseline(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache, is_neox_style=True,
+        )
+        q_helion, k_helion = rotary_embedding_neox(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache,
+        )
+        torch.testing.assert_close(q_helion.float(), q_ref.float(), rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(k_helion.float(), k_ref.float(), rtol=2e-2, atol=2e-2)
+
+
+class TestRotaryEmbeddingGptjCorrectness:
+    """Compare rotary_embedding_gptj against RotaryEmbedding.forward_static."""
+
+    @pytest.mark.parametrize("num_tokens", [1, 8, 32, 128])
+    @pytest.mark.parametrize("rotary_dim", [64, 128])
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_gptj_vs_baseline(self, num_tokens, rotary_dim, dtype):
+        _skip_if_platform_unsupported("_helion_rotary_embedding_gptj")
+
+        head_size = rotary_dim
+        num_q_heads, num_kv_heads = 32, 8
+
+        positions = torch.randint(0, 512, (num_tokens,), device="cuda")
+        query = torch.randn(num_tokens, num_q_heads * head_size, device="cuda", dtype=dtype)
+        key = torch.randn(num_tokens, num_kv_heads * head_size, device="cuda", dtype=dtype)
+        cos_sin_cache = torch.randn(1024, rotary_dim, device="cuda", dtype=dtype)
+
+        q_ref, k_ref = rotary_embedding_baseline(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache, is_neox_style=False,
+        )
+        q_helion, k_helion = rotary_embedding_gptj(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache,
+        )
+
+        assert q_helion.shape == q_ref.shape
+        assert k_helion.shape == k_ref.shape
+
+        rtol, atol = (2e-2, 2e-2) if dtype == torch.bfloat16 else (2e-3, 2e-3)
+        torch.testing.assert_close(q_helion.float(), q_ref.float(), rtol=rtol, atol=atol)
+        torch.testing.assert_close(k_helion.float(), k_ref.float(), rtol=rtol, atol=atol)
+
+    def test_gptj_vs_pytorch(self):
+        _skip_if_platform_unsupported("_helion_rotary_embedding_gptj")
+
+        num_tokens, rotary_dim, head_size = 32, 128, 128
+        num_q_heads, num_kv_heads = 16, 8
+        dtype = torch.bfloat16
+
+        positions = torch.randint(0, 512, (num_tokens,), device="cuda")
+        query = torch.randn(num_tokens, num_q_heads * head_size, device="cuda", dtype=dtype)
+        key = torch.randn(num_tokens, num_kv_heads * head_size, device="cuda", dtype=dtype)
+        cos_sin_cache = torch.randn(1024, rotary_dim, device="cuda", dtype=dtype)
+
+        q_ref, k_ref = _rope_pytorch(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache, is_neox_style=False,
+        )
+        q_helion, k_helion = rotary_embedding_gptj(
+            positions, query.clone(), key.clone(),
+            head_size, rotary_dim, cos_sin_cache,
+        )
+        torch.testing.assert_close(q_helion.float(), q_ref.float(), rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(k_helion.float(), k_ref.float(), rtol=2e-2, atol=2e-2)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: kernel registration
+# ---------------------------------------------------------------------------
+
+# Internal names used by @register_kernel (the decorated function names).
+_NEOX_KERNEL_NAME = "_helion_rotary_embedding_neox"
+_GPTJ_KERNEL_NAME = "_helion_rotary_embedding_gptj"
+
+
+class TestRotaryEmbeddingRegistration:
+    def test_both_kernels_registered(self):
+        if not _HELION_AVAILABLE:
+            pytest.skip("Helion not installed")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered = get_registered_kernels()
+        assert _NEOX_KERNEL_NAME in registered, (
+            f"{_NEOX_KERNEL_NAME} was not auto-registered"
+        )
+        assert _GPTJ_KERNEL_NAME in registered, (
+            f"{_GPTJ_KERNEL_NAME} was not auto-registered"
+        )
+
+    def test_kernel_wrappers_have_config_picker(self):
+        if not _HELION_AVAILABLE:
+            pytest.skip("Helion not installed")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered = get_registered_kernels()
+        for name in [_NEOX_KERNEL_NAME, _GPTJ_KERNEL_NAME]:
+            wrapper = registered[name]
+            assert wrapper._config_picker is not None, (
+                f"Kernel '{name}' has no config picker"
+            )
+
+    def test_kernel_wrappers_have_input_generator(self):
+        if not _HELION_AVAILABLE:
+            pytest.skip("Helion not installed")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered = get_registered_kernels()
+        for name in [_NEOX_KERNEL_NAME, _GPTJ_KERNEL_NAME]:
+            wrapper = registered[name]
+            assert wrapper._input_generator is not None, (
+                f"Kernel '{name}' has no input generator"
+            )
+            # Smoke-test: calling get_inputs() on CPU should not crash.
+            inputs = wrapper.get_inputs()
+            assert len(inputs) > 0
+
+    def test_output_is_not_inplace(self):
+        """The Helion kernel must return new tensors (out-of-place)."""
+        _skip_if_platform_unsupported("rotary_embedding_neox")
+
+        num_tokens, rotary_dim, head_size = 8, 128, 128
+        positions = torch.randint(0, 512, (num_tokens,), device="cuda")
+        query = torch.randn(num_tokens, 32 * head_size, device="cuda", dtype=torch.bfloat16)
+        key = torch.randn(num_tokens, 8 * head_size, device="cuda", dtype=torch.bfloat16)
+        cos_sin_cache = torch.randn(1024, rotary_dim, device="cuda", dtype=torch.bfloat16)
+
+        q_before = query.clone()
+        k_before = key.clone()
+
+        q_out, k_out = rotary_embedding_neox(
+            positions, query, key, head_size, rotary_dim, cos_sin_cache
+        )
+
+        # Input tensors must be unchanged (out-of-place).
+        torch.testing.assert_close(query, q_before)
+        torch.testing.assert_close(key, k_before)
+
+        # Output tensors must differ from the input.
+        assert not torch.allclose(q_out, query), "q_out should differ from query"
+        assert not torch.allclose(k_out, key), "k_out should differ from key"

--- a/vllm/ir/ops/__init__.py
+++ b/vllm/ir/ops/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from .layernorm import rms_norm
+from .rotary_embedding import rotary_embedding_gptj, rotary_embedding_neox
 
-__all__ = ["rms_norm"]
+__all__ = ["rms_norm", "rotary_embedding_neox", "rotary_embedding_gptj"]

--- a/vllm/ir/ops/rotary_embedding.py
+++ b/vllm/ir/ops/rotary_embedding.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+from torch import Tensor
+
+from ..op import register_op
+
+
+@register_op
+def rotary_embedding_neox(
+    positions: Tensor,
+    query: Tensor,
+    key: Tensor,
+    head_size: int,
+    rotary_dim: int,
+    cos_sin_cache: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Rotary positional embedding – Neox-style (first-half / second-half split).
+
+    Applies RoPE to the first ``rotary_dim`` dimensions of each attention head::
+
+        cos, sin = cos_sin_cache[pos].chunk(2)   # each [rotary_dim//2]
+        x1, x2  = q[..., :half], q[..., half:]
+        out      = cat(x1*cos - x2*sin,  x2*cos + x1*sin)
+
+    ``cos_sin_cache`` layout (matches ``RotaryEmbedding._compute_cos_sin_cache``)::
+
+        cos_sin_cache[pos, :rotary_dim//2]  = cos values
+        cos_sin_cache[pos, rotary_dim//2:]  = sin values
+
+    Args:
+        positions:      [num_tokens] int64 position indices.
+        query:          [num_tokens, num_q_heads * head_size].
+        key:            [num_tokens, num_kv_heads * head_size].
+        head_size:      Full head dimension.
+        rotary_dim:     Number of head dims to rotate (≤ head_size).
+        cos_sin_cache:  [max_seq_len, rotary_dim] packed cos|sin cache.
+
+    Returns:
+        (query_out, key_out) with RoPE applied (out-of-place).
+    """
+    num_tokens = positions.shape[0]
+    rot_half = rotary_dim // 2
+
+    cos_sin = cos_sin_cache.index_select(0, positions)  # [num_tokens, rotary_dim]
+    cos = cos_sin[:, :rot_half]   # [num_tokens, rot_half]
+    sin = cos_sin[:, rot_half:]   # [num_tokens, rot_half]
+
+    def _apply(x_flat: Tensor, n_heads: int) -> Tensor:
+        x = x_flat.reshape(num_tokens, n_heads, head_size)
+        x_rot = x[:, :, :rotary_dim]
+        x_pass = x[:, :, rotary_dim:]
+        cos_h = cos.unsqueeze(1).to(x.dtype)  # [num_tokens, 1, rot_half]
+        sin_h = sin.unsqueeze(1).to(x.dtype)
+        x1 = x_rot[:, :, :rot_half]
+        x2 = x_rot[:, :, rot_half:]
+        x_rot_out = torch.cat((x1 * cos_h - x2 * sin_h,
+                               x2 * cos_h + x1 * sin_h), dim=-1)
+        return torch.cat((x_rot_out, x_pass), dim=-1).reshape_as(x_flat)
+
+    num_q_heads = query.shape[1] // head_size
+    num_kv_heads = key.shape[1] // head_size
+    return _apply(query, num_q_heads), _apply(key, num_kv_heads)
+
+
+@register_op
+def rotary_embedding_gptj(
+    positions: Tensor,
+    query: Tensor,
+    key: Tensor,
+    head_size: int,
+    rotary_dim: int,
+    cos_sin_cache: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Rotary positional embedding – GPT-J-style (interleaved even/odd).
+
+    Applies RoPE to the first ``rotary_dim`` dimensions of each attention head::
+
+        cos, sin = cos_sin_cache[pos].chunk(2)   # each [rotary_dim//2]
+        x1, x2  = q[..., ::2], q[..., 1::2]
+        out      = stack(x1*cos - x2*sin,  x2*cos + x1*sin).flatten(-2)
+
+    ``cos_sin_cache`` layout is identical to ``rotary_embedding_neox``.
+
+    Args:
+        positions:      [num_tokens] int64 position indices.
+        query:          [num_tokens, num_q_heads * head_size].
+        key:            [num_tokens, num_kv_heads * head_size].
+        head_size:      Full head dimension.
+        rotary_dim:     Number of head dims to rotate (≤ head_size).
+        cos_sin_cache:  [max_seq_len, rotary_dim] packed cos|sin cache.
+
+    Returns:
+        (query_out, key_out) with RoPE applied (out-of-place).
+    """
+    num_tokens = positions.shape[0]
+    rot_half = rotary_dim // 2
+
+    cos_sin = cos_sin_cache.index_select(0, positions)
+    cos = cos_sin[:, :rot_half]
+    sin = cos_sin[:, rot_half:]
+
+    def _apply(x_flat: Tensor, n_heads: int) -> Tensor:
+        x = x_flat.reshape(num_tokens, n_heads, head_size)
+        x_rot = x[:, :, :rotary_dim]
+        x_pass = x[:, :, rotary_dim:]
+        cos_h = cos.unsqueeze(1).to(x.dtype)
+        sin_h = sin.unsqueeze(1).to(x.dtype)
+        x1 = x_rot[:, :, ::2]
+        x2 = x_rot[:, :, 1::2]
+        x_rot_out = torch.stack((x1 * cos_h - x2 * sin_h,
+                                 x2 * cos_h + x1 * sin_h), dim=-1).flatten(-2)
+        return torch.cat((x_rot_out, x_pass), dim=-1).reshape_as(x_flat)
+
+    num_q_heads = query.shape[1] // head_size
+    num_kv_heads = key.shape[1] // head_size
+    return _apply(query, num_q_heads), _apply(key, num_kv_heads)

--- a/vllm/kernels/helion/configs/_helion_rotary_embedding_gptj/nvidia_h800.json
+++ b/vllm/kernels/helion/configs/_helion_rotary_embedding_gptj/nvidia_h800.json
@@ -1,0 +1,1365 @@
+{
+  "rotarydim_64_numtokens_1": {
+    "block_sizes": [
+      1,
+      2
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_2": {
+    "block_sizes": [
+      1,
+      4
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_4": {
+    "block_sizes": [
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_8": {
+    "block_sizes": [
+      1,
+      4
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_64_numtokens_16": {
+    "block_sizes": [
+      1,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_32": {
+    "block_sizes": [
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_64": {
+    "block_sizes": [
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_128": {
+    "block_sizes": [
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_256": {
+    "block_sizes": [
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_512": {
+    "block_sizes": [
+      1,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "reduction_loops": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_1": {
+    "block_sizes": [
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_2": {
+    "block_sizes": [
+      1,
+      2
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_4": {
+    "block_sizes": [
+      1,
+      2
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_8": {
+    "block_sizes": [
+      1,
+      4
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_16": {
+    "block_sizes": [
+      1,
+      4
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_32": {
+    "block_sizes": [
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_64": {
+    "block_sizes": [
+      1,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_128": {
+    "block_sizes": [
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1,
+    "maxnreg": 32
+  },
+  "rotarydim_128_numtokens_256": {
+    "block_sizes": [
+      16,
+      2
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_512": {
+    "block_sizes": [
+      16,
+      4
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  }
+}

--- a/vllm/kernels/helion/configs/_helion_rotary_embedding_neox/nvidia_h800.json
+++ b/vllm/kernels/helion/configs/_helion_rotary_embedding_neox/nvidia_h800.json
@@ -1,0 +1,5727 @@
+{
+  "rotarydim_64_numtokens_1": {
+    "block_sizes": [
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_2": {
+    "block_sizes": [
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_4": {
+    "block_sizes": [
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_8": {
+    "block_sizes": [
+      2,
+      4
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 4
+  },
+  "rotarydim_64_numtokens_16": {
+    "block_sizes": [
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_24": {
+    "block_sizes": [
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_32": {
+    "block_sizes": [
+      1,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_40": {
+    "block_sizes": [
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_48": {
+    "block_sizes": [
+      4,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_56": {
+    "block_sizes": [
+      2,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_64": {
+    "block_sizes": [
+      4,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_72": {
+    "block_sizes": [
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_80": {
+    "block_sizes": [
+      4,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_88": {
+    "block_sizes": [
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_96": {
+    "block_sizes": [
+      2,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_104": {
+    "block_sizes": [
+      32,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_112": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_120": {
+    "block_sizes": [
+      32,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_128": {
+    "block_sizes": [
+      16,
+      32
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_136": {
+    "block_sizes": [
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_144": {
+    "block_sizes": [
+      32,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_152": {
+    "block_sizes": [
+      8,
+      16
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_160": {
+    "block_sizes": [
+      2,
+      32
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_168": {
+    "block_sizes": [
+      2,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      false
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_64_numtokens_176": {
+    "block_sizes": [
+      16,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_184": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_192": {
+    "block_sizes": [
+      8,
+      16
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_200": {
+    "block_sizes": [
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_208": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_216": {
+    "block_sizes": [
+      32,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_224": {
+    "block_sizes": [
+      2,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_232": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "last",
+      "first",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_240": {
+    "block_sizes": [
+      4,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_248": {
+    "block_sizes": [
+      16,
+      32
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_64_numtokens_256": {
+    "block_sizes": [
+      1,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_272": {
+    "block_sizes": [
+      32,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_288": {
+    "block_sizes": [
+      8,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_304": {
+    "block_sizes": [
+      4,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_320": {
+    "block_sizes": [
+      16,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_336": {
+    "block_sizes": [
+      8,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_352": {
+    "block_sizes": [
+      64,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_368": {
+    "block_sizes": [
+      8,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_384": {
+    "block_sizes": [
+      1,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_400": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_64_numtokens_416": {
+    "block_sizes": [
+      4,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_432": {
+    "block_sizes": [
+      32,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "first",
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_448": {
+    "block_sizes": [
+      8,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_464": {
+    "block_sizes": [
+      4,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_480": {
+    "block_sizes": [
+      8,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_496": {
+    "block_sizes": [
+      32,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_64_numtokens_512": {
+    "block_sizes": [
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_128_numtokens_1": {
+    "block_sizes": [
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_2": {
+    "block_sizes": [
+      1,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first",
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_4": {
+    "block_sizes": [
+      1,
+      4
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_8": {
+    "block_sizes": [
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_16": {
+    "block_sizes": [
+      16,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_24": {
+    "block_sizes": [
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_32": {
+    "block_sizes": [
+      4,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_40": {
+    "block_sizes": [
+      4,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_128_numtokens_48": {
+    "block_sizes": [
+      16,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_56": {
+    "block_sizes": [
+      8,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_64": {
+    "block_sizes": [
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_72": {
+    "block_sizes": [
+      16,
+      32
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_128_numtokens_80": {
+    "block_sizes": [
+      2,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_88": {
+    "block_sizes": [
+      16,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "last",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_96": {
+    "block_sizes": [
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_104": {
+    "block_sizes": [
+      4,
+      16
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_112": {
+    "block_sizes": [
+      32,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_120": {
+    "block_sizes": [
+      4,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_128": {
+    "block_sizes": [
+      16,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_136": {
+    "block_sizes": [
+      4,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_144": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_152": {
+    "block_sizes": [
+      4,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_160": {
+    "block_sizes": [
+      2,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_168": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_128_numtokens_176": {
+    "block_sizes": [
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 2
+  },
+  "rotarydim_128_numtokens_184": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_192": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      1
+    ],
+    "range_multi_buffers": [
+      false
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_128_numtokens_200": {
+    "block_sizes": [
+      4,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_208": {
+    "block_sizes": [
+      4,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      1
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_128_numtokens_216": {
+    "block_sizes": [
+      32,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_128_numtokens_224": {
+    "block_sizes": [
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 1
+  },
+  "rotarydim_128_numtokens_256": {
+    "block_sizes": [
+      32,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "rotarydim_128_numtokens_512": {
+    "block_sizes": [
+      8,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "reduction_loops": [
+      null
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [
+      0
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  }
+}

--- a/vllm/kernels/helion/ops/rotary_embedding.py
+++ b/vllm/kernels/helion/ops/rotary_embedding.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Helion kernel implementations for rotary positional embedding (RoPE).
+
+These kernels register as implementations of ``vllm.ir.ops.rotary_embedding_neox``
+and ``vllm.ir.ops.rotary_embedding_gptj`` using the vLLM IR dispatch mechanism.
+
+The semantic contract (signature, cos_sin_cache layout) is defined in
+``vllm/ir/ops/rotary_embedding.py``; this file only provides the optimized
+Helion/Triton-backed implementation.
+
+Kernel config key format: ``"rotarydim_{rotary_dim}_numtokens_{num_tokens}"``
+"""
+
+from typing import Any
+
+import regex as re
+import torch
+from torch import Tensor
+
+from vllm import ir
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+
+logger = init_logger(__name__)
+
+_HELION_AVAILABLE = has_helion()
+_CUDA_ALIKE = current_platform.is_cuda_alike()
+
+if _HELION_AVAILABLE:
+    import helion.language as hl
+    from vllm.kernels.helion.register import register_kernel
+
+
+# ---------------------------------------------------------------------------
+# Config picker (shared by both variants)
+# ---------------------------------------------------------------------------
+
+def _pick_rope_config(
+    args: tuple[Any, ...], config_keys: list[str]
+) -> str | None:
+    """Pick the best pre-tuned config for the given (rotary_dim, num_tokens).
+
+    Config keys follow the format ``"rotarydim_{int}_numtokens_{int}"``.
+    Selection strategy: closest rotary_dim, then ceiling num_tokens.
+    """
+    if not config_keys:
+        return None
+
+    # args = (positions, query, key, head_size, rotary_dim, cos_sin_cache)
+    _pos, query, _key, _head_size, rotary_dim, _cache = args
+    num_tokens = query.shape[0]
+
+    parsed: dict[int, list[int]] = {}
+    for k in config_keys:
+        if k == "default":
+            continue
+        m = re.fullmatch(r"rotarydim_(\d+)_numtokens_(\d+)", k)
+        if not m:
+            raise ValueError(
+                f"Malformed config key '{k}', "
+                f"expected format 'rotarydim_{{int}}_numtokens_{{int}}'"
+            )
+        parsed.setdefault(int(m.group(1)), []).append(int(m.group(2)))
+
+    if not parsed:
+        return "default" if "default" in config_keys else None
+
+    best_rdim = min(parsed, key=lambda d: abs(d - rotary_dim))
+    avail = sorted(parsed[best_rdim])
+    best_n = next((n for n in avail if n >= num_tokens), avail[-1])
+    return f"rotarydim_{best_rdim}_numtokens_{best_n}"
+
+
+# ---------------------------------------------------------------------------
+# Input generator (shared by both variants)
+# ---------------------------------------------------------------------------
+
+def _generate_rope_inputs() -> dict[str, tuple[Any, ...]]:
+    """Representative inputs for autotuning. Covers Llama-3 / DeepSeek shapes.
+
+    We use a sparse set of num_tokens values (powers-of-two plus a few
+    cudagraph capture sizes) rather than every possible batch size.  The
+    optimal tile configuration changes very little between adjacent token
+    counts, so dense sampling would waste autotuning time without improving
+    the selected configs.
+    """
+    rotary_dims = [64, 128]
+    num_q_heads, num_kv_heads = 32, 8
+    # Sparse coverage: small (1-8), medium (16-128), large (256-512).
+    num_tokens_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+    inputs: dict[str, tuple[Any, ...]] = {}
+    for rotary_dim in rotary_dims:
+        head_size = rotary_dim
+        for num_tokens in num_tokens_list:
+            positions = torch.randint(
+                0, 2048, (num_tokens,), device="cuda", dtype=torch.int64
+            )
+            query = torch.randn(
+                num_tokens, num_q_heads * head_size,
+                device="cuda", dtype=torch.bfloat16,
+            )
+            key = torch.randn(
+                num_tokens, num_kv_heads * head_size,
+                device="cuda", dtype=torch.bfloat16,
+            )
+            cos_sin_cache = torch.randn(
+                2048, rotary_dim, device="cuda", dtype=torch.bfloat16,
+            )
+            config_key = f"rotarydim_{rotary_dim}_numtokens_{num_tokens}"
+            inputs[config_key] = (
+                positions, query, key, head_size, rotary_dim, cos_sin_cache,
+            )
+    return inputs
+
+
+# ---------------------------------------------------------------------------
+# Helion kernels (only defined when Helion is available on CUDA)
+# ---------------------------------------------------------------------------
+
+if _HELION_AVAILABLE and _CUDA_ALIKE:
+
+    @register_kernel(
+        config_picker=_pick_rope_config,
+        input_generator=_generate_rope_inputs,
+    )
+    def _helion_rotary_embedding_neox(
+        positions: Tensor,
+        query: Tensor,
+        key: Tensor,
+        head_size: int,
+        rotary_dim: int,
+        cos_sin_cache: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        """Helion/Triton RoPE kernel – Neox-style."""
+        num_tokens = hl.specialize(query.shape[0])
+        num_q_heads = hl.specialize(query.shape[1] // head_size)
+        num_kv_heads = hl.specialize(key.shape[1] // head_size)
+        rot_half = rotary_dim // 2
+
+        # Reshape to 3D outside the tile loop (static shapes only).
+        # Helion requires all in-loop allocations to have compile-time shapes.
+        q_3d = query.view(num_tokens, num_q_heads, head_size)
+        k_3d = key.view(num_tokens, num_kv_heads, head_size)
+        q_out_3d = torch.empty_like(q_3d)
+        k_out_3d = torch.empty_like(k_3d)
+
+        # Copy unrotated tail; slice assign is outside hl.tile which causes a
+        # TensorOperationInWrapper warning but is the only valid approach since
+        # Helion forbids hl.tile inside an `if` block (NestedGridLoop error).
+        # This path is only taken for the rare case where rotary_dim < head_size.
+        if rotary_dim < head_size:
+            q_out_3d[:, :, rotary_dim:] = q_3d[:, :, rotary_dim:]
+            k_out_3d[:, :, rotary_dim:] = k_3d[:, :, rotary_dim:]
+
+        for tile_tok, tile_pair in hl.tile([num_tokens, rot_half]):
+            pos = positions[tile_tok]
+            cos_half = cos_sin_cache[pos, tile_pair]        # [tile_tok, tile_pair]
+            sin_half = cos_sin_cache[pos, tile_pair + rot_half]
+            cos_h = cos_half.unsqueeze(1)                   # [tile_tok, 1, tile_pair]
+            sin_h = sin_half.unsqueeze(1)
+
+            # query: Neox pairs at [tile_pair] and [tile_pair + rot_half]
+            q1 = q_3d[tile_tok, :, tile_pair]
+            q2 = q_3d[tile_tok, :, tile_pair + rot_half]
+            q_out_3d[tile_tok, :, tile_pair] = q1 * cos_h - q2 * sin_h
+            q_out_3d[tile_tok, :, tile_pair + rot_half] = q2 * cos_h + q1 * sin_h
+
+            # key
+            k1 = k_3d[tile_tok, :, tile_pair]
+            k2 = k_3d[tile_tok, :, tile_pair + rot_half]
+            k_out_3d[tile_tok, :, tile_pair] = k1 * cos_h - k2 * sin_h
+            k_out_3d[tile_tok, :, tile_pair + rot_half] = k2 * cos_h + k1 * sin_h
+
+        return q_out_3d.view_as(query), k_out_3d.view_as(key)
+
+    @register_kernel(
+        config_picker=_pick_rope_config,
+        input_generator=_generate_rope_inputs,
+    )
+    def _helion_rotary_embedding_gptj(
+        positions: Tensor,
+        query: Tensor,
+        key: Tensor,
+        head_size: int,
+        rotary_dim: int,
+        cos_sin_cache: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        """Helion/Triton RoPE kernel – GPT-J-style.
+
+        GPT-J uses interleaved (even/odd) pairs: position i maps to head
+        indices (2i, 2i+1).  This requires arithmetic on tile indices
+        (tile_pair * 2) which Helion's TileIndexType does not support.
+
+        Work-around: reshape input to [..., rot_half, 2] (4-D view) so even/odd
+        pairs become the last dim, indexed with plain ints 0/1.  This avoids
+        tile-index arithmetic and strided slices, neither of which Helion
+        supports.
+        """
+        num_tokens = hl.specialize(query.shape[0])
+        num_q_heads = hl.specialize(query.shape[1] // head_size)
+        num_kv_heads = hl.specialize(key.shape[1] // head_size)
+        rot_half = rotary_dim // 2
+
+        # Reshape to 4D so even/odd pairs are the last dim (index 0/1).
+        # Helion does not support tile-index arithmetic (tile*2) or strided
+        # slices, so this 4D view is the only way to express interleaved pairs.
+        # Requires head_size == rotary_dim; when rotary_dim < head_size the
+        # caller is expected to pre-split query/key to the rotary portion and
+        # handle the tail separately (the IR wrapper does this).
+        q_rot4 = query.view(num_tokens, num_q_heads, rot_half, 2)
+        k_rot4 = key.view(num_tokens, num_kv_heads, rot_half, 2)
+        q_out4 = torch.empty_like(q_rot4)
+        k_out4 = torch.empty_like(k_rot4)
+
+        for tile_tok, tile_pair in hl.tile([num_tokens, rot_half]):
+            pos = positions[tile_tok]
+            cos_h = cos_sin_cache[pos, tile_pair]
+            sin_h = cos_sin_cache[pos, tile_pair + rot_half]
+            cos_h2 = cos_h.unsqueeze(1)
+            sin_h2 = sin_h.unsqueeze(1)
+
+            q1 = q_rot4[tile_tok, :, tile_pair, 0]
+            q2 = q_rot4[tile_tok, :, tile_pair, 1]
+            q_out4[tile_tok, :, tile_pair, 0] = q1 * cos_h2 - q2 * sin_h2
+            q_out4[tile_tok, :, tile_pair, 1] = q2 * cos_h2 + q1 * sin_h2
+
+            k1 = k_rot4[tile_tok, :, tile_pair, 0]
+            k2 = k_rot4[tile_tok, :, tile_pair, 1]
+            k_out4[tile_tok, :, tile_pair, 0] = k1 * cos_h2 - k2 * sin_h2
+            k_out4[tile_tok, :, tile_pair, 1] = k2 * cos_h2 + k1 * sin_h2
+
+        return q_out4.view_as(query), k_out4.view_as(key)
+
+    # ------------------------------------------------------------------
+    # Register Helion kernels as vLLM IR implementations
+    # ------------------------------------------------------------------
+
+    @ir.ops.rotary_embedding_neox.register_impl(
+        "helion", supported=_CUDA_ALIKE
+    )
+    def _neox_impl(
+        positions: Tensor,
+        query: Tensor,
+        key: Tensor,
+        head_size: int,
+        rotary_dim: int,
+        cos_sin_cache: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        return _helion_rotary_embedding_neox(
+            positions, query, key, head_size, rotary_dim, cos_sin_cache
+        )
+
+    @ir.ops.rotary_embedding_gptj.register_impl(
+        "helion", supported=_CUDA_ALIKE
+    )
+    def _gptj_impl(
+        positions: Tensor,
+        query: Tensor,
+        key: Tensor,
+        head_size: int,
+        rotary_dim: int,
+        cos_sin_cache: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        return _helion_rotary_embedding_gptj(
+            positions, query, key, head_size, rotary_dim, cos_sin_cache
+        )
+
+    # Public aliases so tests can import them directly.
+    rotary_embedding_neox = _helion_rotary_embedding_neox
+    rotary_embedding_gptj = _helion_rotary_embedding_gptj
+
+else:
+    # Stubs so test imports don't fail when Helion is unavailable.
+    def rotary_embedding_neox(*args, **kwargs):  # type: ignore[misc]
+        raise RuntimeError("rotary_embedding_neox requires Helion to be installed.")
+
+    def rotary_embedding_gptj(*args, **kwargs):  # type: ignore[misc]
+        raise RuntimeError("rotary_embedding_gptj requires Helion to be installed.")
+
+
+def rotary_embedding_baseline(
+    positions: Tensor,
+    query: Tensor,
+    key: Tensor | None,
+    head_size: int,
+    rotary_dim: int,
+    cos_sin_cache: Tensor,
+    is_neox_style: bool,
+) -> tuple[Tensor, Tensor | None]:
+    """Pure-PyTorch reference using ``RotaryEmbedding.forward_static``.
+
+    Used in correctness tests to verify the Helion kernel output.
+    """
+    from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
+
+    return RotaryEmbedding.forward_static(
+        positions=positions,
+        query=query,
+        key=key,
+        head_size=head_size,
+        rotary_dim=rotary_dim,
+        cos_sin_cache=cos_sin_cache,
+        is_neox_style=is_neox_style,
+    )


### PR DESCRIPTION



## Purpose
Add Helion/Triton-backed kernels for rotary positional embedding (RoPE), supporting both Neox-style and GPT-J-style rotation. The kernels register as implementations of the vLLM IR ops introduced in #33825 and are dispatched automatically on CUDA-capable hardware when Helion is installed.

## Test Plan
```
# Autotune (run once on target GPU)
python scripts/autotune_helion_kernels.py --kernels _helion_rotary_embedding_neox _helion_rotary_embedding_gptj

# Unit tests
python -m pytest tests/kernels/helion/test_rotary_embedding.py -v
```
## Test Result
```
cd /home/meiziyuan/vllm && python -m pytest tests/kernels/helion/test_rotary_embedding.py -v 2>&1
======================================================= test session starts =======================================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/home/meiziyuan/vllm/.hypothesis/examples'))
rootdir: /home/meiziyuan/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0, hypothesis-6.130.8, flakefinder-1.1.0, rerunfailures-15.1, shard-0.1.2, xdist-3.6.1, xdoctest-1.0.2
collected 47 items                                                                                                                
Running 47 items in this shard: tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_exact_match, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_ceiling_selection, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_fallback_to_largest, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_closest_rotary_dim, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_fallback_to_default, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_empty_config_keys, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_malformed_key_raises, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_default_skipped_when_valid_keys_exist, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-64-1], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-64-8], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-64-32], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-64-128], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-128-1], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-128-8], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-128-32], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-128-128], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-64-1], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-64-8], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-64-32], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-64-128], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-128-1], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-128-8], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-128-32], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-128-128], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_pytorch, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_partial_rope, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-64-1], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-64-8], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-64-32], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-64-128], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-128-1], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-128-8], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-128-32], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-128-128], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-64-1], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-64-8], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-64-32], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-64-128], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-128-1], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-128-8], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-128-32], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-128-128], tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_pytorch, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingRegistration::test_both_kernels_registered, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingRegistration::test_kernel_wrappers_have_config_picker, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingRegistration::test_kernel_wrappers_have_input_generator, tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingRegistration::test_output_is_not_inplace

tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_exact_match PASSED                     [  2%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_ceiling_selection PASSED               [  4%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_fallback_to_largest PASSED             [  6%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_closest_rotary_dim PASSED              [  8%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_fallback_to_default PASSED             [ 10%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_empty_config_keys PASSED               [ 12%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_malformed_key_raises PASSED            [ 14%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingConfigPicker::test_default_skipped_when_valid_keys_exist PASSED [ 17%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-64-1] PASSED [ 19%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-64-8] PASSED [ 21%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-64-32] PASSED [ 23%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-64-128] PASSED [ 25%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-128-1] PASSED [ 27%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-128-8] PASSED [ 29%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-128-32] PASSED [ 31%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype0-128-128] PASSED [ 34%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-64-1] PASSED [ 36%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-64-8] PASSED [ 38%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-64-32] PASSED [ 40%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-64-128] PASSED [ 42%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-128-1] PASSED [ 44%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-128-8] PASSED [ 46%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-128-32] PASSED [ 48%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_baseline[dtype1-128-128] PASSED [ 51%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_vs_pytorch PASSED              [ 53%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingNeoxCorrectness::test_neox_partial_rope PASSED            [ 55%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-64-1] PASSED [ 57%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-64-8] PASSED [ 59%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-64-32] PASSED [ 61%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-64-128] PASSED [ 63%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-128-1] PASSED [ 65%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-128-8] PASSED [ 68%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-128-32] PASSED [ 70%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype0-128-128] PASSED [ 72%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-64-1] PASSED [ 74%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-64-8] PASSED [ 76%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-64-32] PASSED [ 78%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-64-128] PASSED [ 80%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-128-1] PASSED [ 82%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-128-8] PASSED [ 85%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-128-32] PASSED [ 87%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_baseline[dtype1-128-128] PASSED [ 89%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingGptjCorrectness::test_gptj_vs_pytorch PASSED              [ 91%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingRegistration::test_both_kernels_registered PASSED         [ 93%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingRegistration::test_kernel_wrappers_have_config_picker PASSED [ 95%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingRegistration::test_kernel_wrappers_have_input_generator PASSED [ 97%]
tests/kernels/helion/test_rotary_embedding.py::TestRotaryEmbeddingRegistration::test_output_is_not_inplace SKIPPED (Cur...) [100%]

======================================================== warnings summary =========================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/kernels/helion/test_rotary_embedding.py: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 46 passed, 1 skipped, 16 warnings in 33.45s ===========================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

