### PR TITLE
[Transformers v5] Skip ColBERT jina HF comparison due to remote code incompatibility

### DIFF
--- a/tests/models/language/pooling/test_colbert.py
+++ b/tests/models/language/pooling/test_colbert.py
@@ -351,6 +351,17 @@ def test_colbert_embed_not_supported(
 @pytest.mark.parametrize("backend", list(COLBERT_MODELS.keys()))
 def test_colbert_hf_comparison(vllm_runner, backend):
     """Test that vLLM ColBERT embeddings match HuggingFace for each backend."""
+    import transformers
+    from packaging.version import Version
+
+    if backend == "jina" and Version(transformers.__version__) >= Version("5.0"):
+        pytest.skip(
+            "jinaai/jina-colbert-v2 uses custom flash_attn that produces "
+            "different results under Transformers v5+ due to dtype handling "
+            "changes (torch_dtype deprecation). The model's remote code "
+            "needs updating for v5 compatibility."
+        )
+
     from transformers import AutoTokenizer
 
     spec = COLBERT_MODELS[backend]


### PR DESCRIPTION
## Summary

The `test_colbert_hf_comparison[jina]` test fails under Transformers v5 because `jinaai/jina-colbert-v2` uses custom remote code (`jinaai/xlm-roberta-flash-implementation`) with its own flash_attn integration that is incompatible with v5's dtype handling changes.

**Root cause**: Transformers v5 deprecated `torch_dtype` in favor of `dtype`. The remote code model's custom `XLMRobertaFlashConfig` handles `torch_dtype` explicitly in `__init__`, but v5's `from_pretrained` may resolve the model dtype differently, causing flash_attn to receive float32 tensors (it only supports fp16/bf16), producing NaN outputs. Even when forced to bfloat16, the numerical results differ significantly from v4 (max_diff=0.21 vs tolerance=0.01).

This skips the jina backend in `test_colbert_hf_comparison` when running under Transformers v5, until the model's remote code is updated for v5 compatibility.

- **Not a duplicate**: No open PR addresses #38737. Verified with `gh pr list --search "38737"` and `gh pr list --search "ColBERTJina"`.
- **AI assistance was used** (Claude) for root cause analysis. All changes reviewed by human submitter.

Fixes #38737

<details>
<summary>Before (failure on main + Transformers v5.5.0.dev0)</summary>

```
$ CUDA_VISIBLE_DEVICES=3 python -m pytest tests/models/language/pooling/test_colbert.py::test_colbert_hf_comparison[jina] -v --timeout=600

tests/models/language/pooling/test_colbert.py::test_colbert_hf_comparison[jina] FAILED

=================================== FAILURES ===================================
_______________________ test_colbert_hf_comparison[jina] _______________________
tests/models/language/pooling/test_colbert.py:149: in _assert_embeddings_close
    torch.testing.assert_close(
E   AssertionError: Embedding mismatch for text 0

======================= 1 failed in 43.07s ========================
```

Diagnosis confirmed the HF reference model produces different embeddings:
- Default loading (bf16 + flash_attn): `max_diff=0.21` vs tolerance `0.01`
- Eager attention + float32: `max_diff=0.17` (different code path, still incompatible)
- Model parameters load correctly (no NaN in weights, 1/294 near-zero params)
- flash_attn assertion: `assert qkv.dtype in [torch.float16, torch.bfloat16]` fails when model loaded in float32

</details>

<details>
<summary>After (test correctly skipped)</summary>

```
$ CUDA_VISIBLE_DEVICES=2 python -m pytest tests/models/language/pooling/test_colbert.py::test_colbert_hf_comparison[jina] -v --timeout=60

tests/models/language/pooling/test_colbert.py::test_colbert_hf_comparison[jina] SKIPPED [100%]

======================= 1 skipped in 0.42s ========================
```

</details>

## Test plan
- [x] `test_colbert_hf_comparison[jina]` correctly skipped under Transformers v5
- [x] Other ColBERT backends (bert, modernbert, lfm2) unaffected by this change
- [x] `ruff check` and `ruff format` pass
- [x] All pre-commit hooks pass