### PR TITLE
[Doc] add Apple Clang 21+ compilation troubleshooting

### DIFF
--- a/docs/getting_started/installation/cpu.apple.inc.md
+++ b/docs/getting_started/installation/cpu.apple.inc.md
@@ -44,6 +44,29 @@ uv pip install -e .
     On macOS the `VLLM_TARGET_DEVICE` is automatically set to `cpu`, which is currently the only supported device.
 
 !!! example "Troubleshooting"
+    ### Apple Clang 21+ Compilation Error
+
+    If the build fails with errors like the following on macOS:
+
+    ```text
+    error: chained comparison 'X < Y <= Z' does not behave the same as 
+    a mathematical expression [-Wparentheses]
+        static_assert(0 < M <= 8);
+    ```
+
+    **Cause:** Apple Clang 21+ treats `-Wparentheses` warnings as errors by default.
+
+    **Solution:** Set the `CXXFLAGS` environment variable before building:
+
+    ```bash
+    export CXXFLAGS="-Wno-parentheses"
+    uv pip install -e .
+    ```
+
+    ---
+
+    ### Missing C++ Headers
+
     If the build fails with errors like the following where standard C++ headers cannot be found, try to remove and reinstall your
     [Command Line Tools for Xcode](https://developer.apple.com/download/all/).
 
@@ -61,6 +84,8 @@ uv pip install -e .
     ```
 
     ---
+
+    ### C++ Standard Compatibility Errors
 
     If the build fails with C++11/C++17 compatibility errors like the following, the issue is that the build system is defaulting to an older C++ standard:
 


### PR DESCRIPTION
 ## Purpose

   This PR adds documentation for a compilation error that occurs on macOS with Apple
 Clang 21+ when building vLLM from source.

   **Problem:**
   - **System:** macOS with Apple Clang 21.0.0 or later
   - **Command:** `uv pip install -e .`
   - **Error:**
 ```

   error: chained comparison 'X < Y <= Z' does not behave the same as
   a mathematical expression [-Wparentheses]
       static_assert(0 < M <= 8);

 ```
   - **Root Cause:** Apple Clang 21+ treats `-Wparentheses` warnings as errors by
 default

   **Solution:**
   Added a troubleshooting section to the Apple Silicon installation guide documenting
 the workaround:
   ```bash
   export CXXFLAGS="-Wno-parentheses"
   uv pip install -e .
 ```

 Related Issues: N/A (first-time reporter)

 Test Plan

 Manual testing on macOS with Apple Clang 21.0.0:

 1. Reproduce the error (before fix):
   ```bash
     # Without CXXFLAGS
     uv pip install -e .
     # Expected: Compilation fails with -Wparentheses error
   ```
 2. Verify the workaround:
   ```bash
     # With CXXFLAGS
     export CXXFLAGS="-Wno-parentheses"
     uv pip install -e .
     # Expected: Build completes successfully
   ```
 3. Documentation verification:
     - Navigate to the modified file:
 docs/getting_started/installation/cpu.apple.inc.md
     - Verify the "Apple Clang 21+ Compilation Error" section is present in
 Troubleshooting
     - Check markdown formatting renders correctly

 Test Result

 Test Environment:
 - macOS Sonoma
 - Apple Clang 21.0.0.21000099
 - Python 3.12.12

 Results:


Test Case | Before | After
-- | -- | --
Default build | ❌ Fails with -Wparentheses error | ✅ N/A (workaround documented)
Build with CXXFLAGS="-Wno-parentheses" | ✅ Builds successfully | ✅ Builds successfully
Documentation clarity | ❌ No guidance | ✅ Clear error message and solution


 The new Troubleshooting section appears under "Building on Apple Silicon" with:
 - Clear error message identification
 - Concise cause explanation
 - Copy-paste ready solution


 Checklist

 - The purpose of the PR is clearly described
 - The test plan is provided with specific commands
 - The test results are documented
 - Documentation updated (this is a documentation PR)
 - No code changes, so no model support or examples need updating
 - No release notes update needed (documentation-only change)


 Additional Notes:

 This PR takes a documentation-first approach. If the community feels a code fix would
 improve user experience (e.g., auto-adding -Wno-parentheses for macOS builds in CMake
 configuration), I'm happy to implement it. Please share your feedback!