### PR TITLE
[P/D][Feature] Support kv_transfer_params for parallel sampling (n>1)

### DIFF
--- a/vllm/entrypoints/generate/base/serving.py
+++ b/vllm/entrypoints/generate/base/serving.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass, field
 from http import HTTPStatus
-from typing import ClassVar, Generic, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar
 
 from fastapi import Request
 from pydantic import ConfigDict
@@ -215,6 +215,28 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
         except ValueError:
             return None
 
+    @staticmethod
+    def _get_remote_prefill_kv_transfer_params(
+        request_id: str,
+        kv_transfer_params: dict[str, Any] | None,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        if not kv_transfer_params:
+            return []
+
+        per_child_params = kv_transfer_params.get("parallel_kv_transfer_params")
+        if isinstance(per_child_params, list):
+            return [
+                # Match ParentRequest child request ids for n > 1.
+                (f"{index}_{request_id}", params)
+                for index, params in enumerate(per_child_params)
+                if params is not None and params.get("do_remote_prefill")
+            ]
+
+        if kv_transfer_params.get("do_remote_prefill"):
+            return [(request_id, kv_transfer_params)]
+
+        return []
+
     async def _with_kv_transfer_rejection_cleanup(
         self,
         awaitable: Awaitable[_T],
@@ -224,8 +246,13 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
         """Wrap a `create_*` coroutine so that, if it raises or returns an
         ErrorResponse (i.e. the request never reached the engine), the KV
         connector is notified to free any pinned remote-prefill blocks."""
-        kv_transfer_params = self.has_kv_connector and request.kv_transfer_params
-        if not kv_transfer_params or not kv_transfer_params.get("do_remote_prefill"):
+        kv_transfer_params = (
+            request.kv_transfer_params if self.has_kv_connector else None
+        )
+        remote_prefill_params = self._get_remote_prefill_kv_transfer_params(
+            request.request_id, kv_transfer_params
+        )
+        if not remote_prefill_params:
             return await awaitable
 
         notify = True
@@ -236,18 +263,20 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
             return result
         finally:
             if notify:
-                try:
-                    await self.engine_client.notify_kv_transfer_request_rejected(
-                        request.request_id,
-                        kv_transfer_params,
-                        data_parallel_rank=self._get_data_parallel_rank(raw_request),
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to notify KV connector about rejected request %s",
-                        request.request_id,
-                        exc_info=True,
-                    )
+                data_parallel_rank = self._get_data_parallel_rank(raw_request)
+                for rejected_request_id, rejected_params in remote_prefill_params:
+                    try:
+                        await self.engine_client.notify_kv_transfer_request_rejected(
+                            rejected_request_id,
+                            rejected_params,
+                            data_parallel_rank=data_parallel_rank,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to notify KV connector about rejected request %s",
+                            rejected_request_id,
+                            exc_info=True,
+                        )
 
     @staticmethod
     def _get_decoded_token(

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -31,6 +31,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     StructuralTagResponseFormat,
     ToolCall,
     UsageInfo,
+    normalize_kv_transfer_params,
     validate_structural_tag_response_format,
     validate_structured_outputs_structural_tag,
 )
@@ -697,6 +698,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
             skip_clone=True,  # Created fresh per request, safe to skip clone
             repetition_detection=self.repetition_detection,
         )
+
+    @model_validator(mode="after")
+    def validate_kv_transfer_params(self) -> "ChatCompletionRequest":
+        self.kv_transfer_params = normalize_kv_transfer_params(
+            self.kv_transfer_params, self.n or 1
+        )
+        return self
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -20,6 +20,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     StreamOptions,
     StructuralTagResponseFormat,
     UsageInfo,
+    normalize_kv_transfer_params,
     validate_structural_tag_response_format,
     validate_structured_outputs_structural_tag,
 )
@@ -378,6 +379,13 @@ class CompletionRequest(OpenAIBaseModel):
             repetition_detection=self.repetition_detection,
             thinking_token_budget=self.thinking_token_budget,
         )
+
+    @model_validator(mode="after")
+    def validate_kv_transfer_params(self) -> "CompletionRequest":
+        self.kv_transfer_params = normalize_kv_transfer_params(
+            self.kv_transfer_params, self.n
+        )
+        return self
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -375,3 +375,44 @@ class GenerationError(Exception):
     def __init__(self, message: str = "Internal server error"):
         super().__init__(message)
         self.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+def normalize_kv_transfer_params(
+    kv_transfer_params: dict[str, Any] | None,
+    n: int,
+) -> dict[str, Any] | None:
+    if kv_transfer_params is None:
+        return kv_transfer_params
+
+    per_child_params = kv_transfer_params.get("parallel_kv_transfer_params")
+    if per_child_params is None:
+        return kv_transfer_params
+
+    if not isinstance(per_child_params, list):
+        raise VLLMValidationError(
+            "`kv_transfer_params.parallel_kv_transfer_params` must be a list.",
+            parameter="kv_transfer_params.parallel_kv_transfer_params",
+            value=per_child_params,
+        )
+
+    if len(per_child_params) != n:
+        raise VLLMValidationError(
+            "`kv_transfer_params.parallel_kv_transfer_params` length must match `n`.",
+            parameter="kv_transfer_params.parallel_kv_transfer_params",
+            value=per_child_params,
+        )
+
+    if not all(
+        params is None or isinstance(params, dict) for params in per_child_params
+    ):
+        raise VLLMValidationError(
+            "`kv_transfer_params.parallel_kv_transfer_params` entries "
+            "must be objects or null.",
+            parameter="kv_transfer_params.parallel_kv_transfer_params",
+            value=per_child_params,
+        )
+
+    if n == 1:
+        return per_child_params[0]
+
+    return kv_transfer_params

--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -16,7 +16,11 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.completion.protocol import CompletionRequest
-from vllm.entrypoints.openai.engine.protocol import StreamOptions, UsageInfo
+from vllm.entrypoints.openai.engine.protocol import (
+    StreamOptions,
+    UsageInfo,
+    normalize_kv_transfer_params,
+)
 from vllm.logprobs import Logprob
 from vllm.renderers import TokenizeParams
 from vllm.sampling_params import SamplingParams
@@ -153,6 +157,19 @@ class GenerateRequest(BaseModel):
         instance = handler(data)
         instance._sampling_params_provided_keys = provided
         return instance
+
+    @model_validator(mode="after")
+    def _validate_kv_transfer_params(self) -> "GenerateRequest":
+        self.kv_transfer_params = normalize_kv_transfer_params(
+            self.kv_transfer_params, self.sampling_params.n
+        )
+        if self.kv_transfer_params:
+            extra_args = self.sampling_params.extra_args or {}
+            self.sampling_params.extra_args = {
+                **extra_args,
+                "kv_transfer_params": self.kv_transfer_params,
+            }
+        return self
 
     def is_sampling_param_provided(self, name: str) -> bool:
         """Whether the caller explicitly set ``sampling_params.<name>``.

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import warnings
 from collections.abc import MutableSequence
 from collections.abc import Sequence as GenericSequence
 from dataclasses import dataclass
@@ -35,6 +36,7 @@ class CompletionOutput:
             to stop, None if the completion finished for some other reason
             including encountering the EOS token.
         lora_request: The LoRA request that was used to generate the output.
+        kv_transfer_params: The params for remote K/V transfer.
     """
 
     index: int
@@ -46,6 +48,7 @@ class CompletionOutput:
     finish_reason: str | None = None
     stop_reason: int | str | None = None
     lora_request: LoRARequest | None = None
+    kv_transfer_params: dict[str, Any] | None = None
 
     def finished(self) -> bool:
         return self.finish_reason is not None
@@ -59,7 +62,8 @@ class CompletionOutput:
             f"cumulative_logprob={self.cumulative_logprob}, "
             f"logprobs={self.logprobs}, "
             f"finish_reason={self.finish_reason}, "
-            f"stop_reason={self.stop_reason})"
+            f"stop_reason={self.stop_reason}, "
+            f"kv_transfer_params={self.kv_transfer_params})"
         )
 
 
@@ -103,7 +107,6 @@ class RequestOutput:
         encoder_prompt_token_ids: The token IDs of the encoder prompt.
                                   None if decoder-only.
         num_cached_tokens: The number of tokens with prefix cache hit.
-        kv_transfer_params: The params for remote K/V transfer.
     """
 
     def __init__(
@@ -120,6 +123,9 @@ class RequestOutput:
         encoder_prompt_token_ids: list[int] | None = None,
         num_cached_tokens: int | None = None,
         *,
+        # Deprecated compatibility path for callers that still pass request-
+        # level kv_transfer_params. Use CompletionOutput.kv_transfer_params;
+        # it preserves choice-index alignment for parallel sampling.
         kv_transfer_params: dict[str, Any] | None = None,
         # Forward compatibility, code that uses args added in new release can
         # still run with older versions of vLLM without breaking.
@@ -140,13 +146,48 @@ class RequestOutput:
         self.encoder_prompt = encoder_prompt
         self.encoder_prompt_token_ids = encoder_prompt_token_ids
         self.num_cached_tokens = num_cached_tokens
-        self.kv_transfer_params = kv_transfer_params
+        if kv_transfer_params is not None:
+            warnings.warn(
+                "Passing kv_transfer_params to RequestOutput is deprecated. "
+                "Set kv_transfer_params on each CompletionOutput instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self._set_kv_transfer_params(kv_transfer_params)
+
+    @property
+    def kv_transfer_params(self) -> dict[str, Any] | None:
+        if len(self.outputs) == 1:
+            return self.outputs[0].kv_transfer_params
+
+        if len(self.outputs) > 1:
+            params_list: list[dict[str, Any] | None] = [None] * (
+                max(output.index for output in self.outputs) + 1
+            )
+            for output in self.outputs:
+                params_list[output.index] = output.kv_transfer_params
+            if any(params is not None for params in params_list):
+                return {"parallel_kv_transfer_params": params_list}
+        return None
+
+    def _set_kv_transfer_params(self, kv_transfer_params: dict[str, Any]) -> None:
+        if not self.outputs:
+            return
+
+        per_child_params = kv_transfer_params.get("parallel_kv_transfer_params")
+        if isinstance(per_child_params, list):
+            for output in self.outputs:
+                if output.index < len(per_child_params):
+                    output.kv_transfer_params = per_child_params[output.index]
+            return
+
+        if len(self.outputs) == 1:
+            self.outputs[0].kv_transfer_params = kv_transfer_params
 
     def add(self, next_output: "RequestOutput", aggregate: bool) -> None:
         """Merge subsequent RequestOutput into this one"""
 
         self.finished |= next_output.finished
-        self.kv_transfer_params = next_output.kv_transfer_params
 
         for next_completion in next_output.outputs:
             for i, completion in enumerate(self.outputs):
@@ -165,6 +206,9 @@ class RequestOutput:
                         )
                         completion.finish_reason = next_completion.finish_reason
                         completion.stop_reason = next_completion.stop_reason
+                        completion.kv_transfer_params = (
+                            next_completion.kv_transfer_params
+                        )
                     else:
                         # Replace the output with the new one
                         self.outputs[i] = next_completion

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -316,7 +316,9 @@ class RequestState:
                 finished,
             )
 
-        output = self._new_completion_output(new_token_ids, finish_reason, stop_reason)
+        output = self._new_completion_output(
+            new_token_ids, finish_reason, stop_reason, kv_transfer_params
+        )
 
         if self.parent_req is None:
             outputs = [output]
@@ -326,16 +328,13 @@ class RequestState:
                 return None
             external_req_id = self.parent_req.external_req_id
 
-        return self._new_request_output(
-            external_req_id, outputs, finished, kv_transfer_params
-        )
+        return self._new_request_output(external_req_id, outputs, finished)
 
     def _new_request_output(
         self,
         external_req_id: str,
         outputs: list[CompletionOutput] | list[PoolingOutput],
         finished: bool,
-        kv_transfer_params: dict[str, Any] | None = None,
     ) -> RequestOutput | PoolingRequestOutput:
         # If prompt embeds were used, put placeholder prompt token ids
         prompt_token_ids = self.prompt_token_ids
@@ -368,7 +367,6 @@ class RequestState:
             prompt_logprobs=prompt_logprobs,
             outputs=cast(list[CompletionOutput], outputs),
             finished=finished,
-            kv_transfer_params=kv_transfer_params,
             num_cached_tokens=self.num_cached_tokens,
             metrics=self.stats,
         )
@@ -378,6 +376,7 @@ class RequestState:
         token_ids: list[int],
         finish_reason: FinishReason | None,
         stop_reason: int | str | None,
+        kv_transfer_params: dict[str, Any] | None = None,
     ) -> CompletionOutput:
         assert self.detokenizer is not None
         assert self.logprobs_processor is not None
@@ -408,6 +407,7 @@ class RequestState:
             cumulative_logprob=self.logprobs_processor.cumulative_logprob,
             finish_reason=str(finish_reason) if finished else None,
             stop_reason=stop_reason if finished else None,
+            kv_transfer_params=kv_transfer_params,
         )
 
     def _new_pooling_output(self, pooling_output: torch.Tensor) -> PoolingOutput:

--- a/vllm/v1/engine/parallel_sampling.py
+++ b/vllm/v1/engine/parallel_sampling.py
@@ -72,9 +72,31 @@ class ParentRequest:
         # Build child sampling_params
         child_sampling_params = copy(self.sampling_params)
         child_sampling_params.n = 1
+        extra_args = child_sampling_params.extra_args or {}
+        kv_transfer = extra_args.get("kv_transfer_params")
+        per_child_kv_transfer = (
+            kv_transfer.get("parallel_kv_transfer_params")
+            if isinstance(kv_transfer, dict)
+            else None
+        )
+        if per_child_kv_transfer is not None:
+            if not isinstance(per_child_kv_transfer, list):
+                raise ValueError(
+                    "kv_transfer_params.parallel_kv_transfer_params must be a list"
+                )
+            if len(per_child_kv_transfer) != self.sampling_params.n:
+                raise ValueError(
+                    "kv_transfer_params.parallel_kv_transfer_params "
+                    "length must match sampling_params.n"
+                )
+            child_sampling_params.extra_args = {
+                **extra_args,
+                "kv_transfer_params": per_child_kv_transfer[index],
+            }
         if seed is None:
-            # Cache child sampling_params for later reuse
-            self.cached_child_sampling_params = child_sampling_params
+            if per_child_kv_transfer is None:
+                # Cache child sampling_params for later reuse
+                self.cached_child_sampling_params = child_sampling_params
         else:
             # Each child gets a clone with a unique seed
             child_sampling_params.seed = seed + index


### PR DESCRIPTION

Before this PR, P/D (Prefill/Decode) did not support parallel sampling (`n > 1`).

The reason is that when `request.n > 1` (e.g., `request.n = 3`), the Prefill node will split the request into three child requests. These child requests are then processed independently by the EngineCore, resulting in different `request_id`s and `kv_block_id`s. For example:

* `request_id = [0_chatcmpl-87d0ef24-418b, 1_chatcmpl-87d0ef24-418b, 2_chatcmpl-87d0ef24-418b]`
* `kv_block_id = [[1,2,3,4,5,9], [1,2,3,4,5,10], [1,2,3,4,5,11]]`

However, the original design of `kv_transfer_params` only supports transferring the `request_id` and `kv_block_id` for a single request. As a result, the KV blocks for the other child requests are not transferred.

In addition, the Decode stage relies on `request_id` to notify the Prefill stage to release resources. This limitation effectively restricts Prefill to handling only one request, while the remaining child requests cannot be properly processed.

To address this, this PR introduces a backward-compatible change to `kv_transfer_params`. When `request.n > 1`, it allows notifying and handling all child requests instead of just a single one.




## Purpose
Support kv_transfer_params for parallel sampling (n>1)


## Test Plan

```
messages = [{"role": "user", "content": "9.11 and 9.8, which is lower?"}]
response = client.chat.completions.create(
    model="my-model",
    messages=messages,
    stream=stream,
    n=3,
)
for choice in response.choices:
  print(f"Choice {choice.index}:")
  print(choice.message.content)
  print()

```


## Test Result
```
Choice 0:
....
**Answer:**  
9.11 is lower.

Choice 1:
....
**Answer**:  
**9.11 is lower than 9.8.**

Choice 2:
...
4. **Conclusion**:  
   **9.11** is lower than **9.8**.

**Answer**:  
**9.11 is lower than 9.8.**


```
```
ver pid=967379) INFO 04-03 18:42:22 [metrics.py:103] KV Transfer metrics: Num successful transfers=3, Avg xfer time (ms)=3.637, P90 xfer time (ms)=4.696, Avg post time (ms)=0.928, P90 post time (ms)=1.235, Avg MB per transfer=2.25, Throughput (MB/s)=618.642, Avg number of descriptors=72.0

```
---
request.n = 3
```
{
  "id": "chatcmpl-87d0ef24-418b-4224-b436-6f31226848ae",
  "object": "chat.completion",
  "created": 1775208649,
  "model": "my-model",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": null,
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [],
        "reasoning": ""
      },
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "token_ids": null
    },
    {
      "index": 1,
      "message": {
        "role": "assistant",
        "content": null,
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [],
        "reasoning": ""
      },
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "token_ids": null
    },
    {
      "index": 2,
      "message": {
        "role": "assistant",
        "content": null,
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [],
        "reasoning": ""
      },
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "token_ids": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 576,
    "total_tokens": 579,
    "completion_tokens": 3,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null,
  "prompt_token_ids": null,
  "kv_transfer_params": [            # <<<<- all requests and all kv_block_id
    {
      "do_remote_prefill": true,
      "do_remote_decode": false,
      "remote_block_ids": [
        [
          1,
          2,
          3,
          4,
          5,
          6,
          7,
.....
          25,
          26,
          27,
          28,
          29,
          30,
          31,
          32,
          33,
          34,
          35,
          40
        ]
      ],
      "remote_engine_id": "777e6cbd-af31-4305-a3c0-b335bdcc9867",
      "remote_request_id": "0_chatcmpl-87d0ef24-418b-4224-b436-6f31226848ae-b296b0ae",
      "remote_host": "localhost",
      "remote_port": 6700,
      "tp_size": 1
    },
    {
      "do_remote_prefill": true,
      "do_remote_decode": false,
      "remote_block_ids": [
        [
          1,
          2,
          3,
          4,
          5,
          6,
          7,
  .....
          31,
          32,
          33,
          34,
          35,
          41
        ]
      ],
      "remote_engine_id": "777e6cbd-af31-4305-a3c0-b335bdcc9867",
      "remote_request_id": "1_chatcmpl-87d0ef24-418b-4224-b436-6f31226848ae-b296b0ae",
      "remote_host": "localhost",
      "remote_port": 6700,
      "tp_size": 1
    },
    {
      "do_remote_prefill": true,
      "do_remote_decode": false,
      "remote_block_ids": [
        [
          1,
          2,
          3,
          4,
          5,
          6,
.....
          30,
          31,
          32,
          33,
          34,
          35,
          42
        ]
      ],
      "remote_engine_id": "777e6cbd-af31-4305-a3c0-b335bdcc9867",
      "remote_request_id": "2_chatcmpl-87d0ef24-418b-4224-b436-6f31226848ae-b296b0ae",
      "remote_host": "localhost",
      "remote_port": 6700,
      "tp_size": 1
    }
  ]
}

```


request.n = 1
```
{
  "id": "chatcmpl-c757b78f-4258-4022-8ef9-0d9e9712b87c",
  "object": "chat.completion",
  "created": 1775208779,
  "model": "my-model",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": null,
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [],
        "reasoning": ""
      },
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "token_ids": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 576,
    "total_tokens": 577,
    "completion_tokens": 1,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null,
  "prompt_token_ids": null,
  "kv_transfer_params": {           # <<<<- one request and one kv_block_id
    "do_remote_prefill": true,
    "do_remote_decode": false,
    "remote_block_ids": [
      [
        1,
        2,
        3,
        4,
        5,
        6,
        7,
   ....
        31,
        32,
        33,
        34,
        35,
        43
      ]
    ],
    "remote_engine_id": "777e6cbd-af31-4305-a3c0-b335bdcc9867",
    "remote_request_id": "chatcmpl-c757b78f-4258-4022-8ef9-0d9e9712b87c-85f8a2e3",
    "remote_host": "localhost",
    "remote_port": 6700,
    "tp_size": 1
  }
}


```

---






<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

