### PR TITLE
[Bugfix][Frontend] Fix Gemma4 streaming HTML duplication after tool calls

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -531,3 +531,64 @@ class TestStreamingExtraction:
         assert "<|" not in args_text, (
             f"Partial delimiter leaked into JSON: {args_text!r}"
         )
+
+    def test_streaming_does_not_duplicate_plain_text_after_tool_call(
+        self, parser, mock_request, monkeypatch
+    ):
+        """Buffered plain text after a tool call must not corrupt current_text."""
+        captured_current_texts: list[str] = []
+        original_extract_streaming = parser._extract_streaming
+
+        def wrapped_extract_streaming(previous_text, current_text, delta_text):
+            captured_current_texts.append(current_text)
+            return original_extract_streaming(previous_text, current_text, delta_text)
+
+        monkeypatch.setattr(parser, "_extract_streaming", wrapped_extract_streaming)
+
+        chunks = [
+            "<|tool_call>",
+            "call:get_weather{",
+            'location:<|"|>Paris<|"|>}',
+            "<tool_call|><",
+            "div>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        content_parts = [
+            delta.content for delta, _ in results if delta is not None and delta.content
+        ]
+        assert "".join(content_parts) == "<div>"
+        assert captured_current_texts[-1].endswith("<tool_call|><div>")
+        assert not captured_current_texts[-1].endswith("<tool_call|><<div>")
+
+    def test_streaming_html_argument_does_not_duplicate_tag_prefixes(
+        self, parser, mock_request
+    ):
+        """HTML content inside tool arguments must not be duplicated."""
+        chunks = [
+            "<|tool_call>",
+            "call:write_file{",
+            'path:<|"|>index.html<|"|>,',
+            'content:<|"|><!DOCTYPE html>\n<',
+            'html lang="zh-CN">\n<',
+            'head>\n    <',
+            'meta charset="UTF-8">\n    <',
+            'meta name="viewport" content="width=device-width">\n',
+            '<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+        assert args_text
+
+        parsed_args = json.loads(args_text)
+        assert parsed_args["path"] == "index.html"
+        assert (
+            parsed_args["content"]
+            == "<!DOCTYPE html>\n"
+            '<html lang="zh-CN">\n'
+            "<head>\n"
+            '    <meta charset="UTF-8">\n'
+            '    <meta name="viewport" content="width=device-width">\n'
+        )

--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -571,7 +571,7 @@ class TestStreamingExtraction:
             'path:<|"|>index.html<|"|>,',
             'content:<|"|><!DOCTYPE html>\n<',
             'html lang="zh-CN">\n<',
-            'head>\n    <',
+            "head>\n    <",
             'meta charset="UTF-8">\n    <',
             'meta name="viewport" content="width=device-width">\n',
             '<|"|>}',
@@ -585,8 +585,7 @@ class TestStreamingExtraction:
         parsed_args = json.loads(args_text)
         assert parsed_args["path"] == "index.html"
         assert (
-            parsed_args["content"]
-            == "<!DOCTYPE html>\n"
+            parsed_args["content"] == "<!DOCTYPE html>\n"
             '<html lang="zh-CN">\n'
             "<head>\n"
             '    <meta charset="UTF-8">\n'

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -436,8 +436,10 @@ class Gemma4ToolParser(ToolParser):
     ) -> DeltaMessage | None:
         # Buffer delta text to handle multi-token special sequences
         delta_text = self._buffer_delta_text(delta_text)
-        # Reconstruct current_text after buffering to stay in sync
-        current_text = previous_text + delta_text
+        # Keep current_text from the upstream stream state. The buffered delta
+        # is only for emission, and must not be stitched back into the
+        # accumulated model text or normal content like "<div>" can be
+        # duplicated into "<<div>" when a tool call just ended.
 
         # If no tool call token seen yet, emit as content
         if self.tool_call_start_token not in current_text:


### PR DESCRIPTION
## Summary

Fix a Gemma4 streaming bug where buffered deltas are stitched back into `current_text`, which can corrupt normal text after or inside tool calls.

This showed up most clearly with HTML content in tool arguments such as `write_file(content=...)`, where tags like `<html>` and `<meta>` could be streamed into malformed output such as `<<htmlhtml` or `<<metameta`.

Fixes #38910.

## Root cause

`Gemma4ToolParser.extract_tool_calls_streaming()` buffered `delta_text` to avoid leaking partial special tokens and then rebuilt `current_text` using:

```python
current_text = previous_text + delta_text
```

That mixes buffered output state with the original accumulated model text. When a buffered `<` is replayed into `current_text`, the parser can produce invalid intermediate states like `<<div>`, `<<html`, and `<<meta`. Those bad intermediate states then interact with the argument diff logic and can duplicate tag names in the final streamed tool arguments.

## Fix

Keep `current_text` from the upstream streaming state and use buffered `delta_text` only for emission. Do not reconstruct `current_text` from the buffered delta.

## Tests

Why this is not duplicating an existing PR:
- I searched open PRs/issues for Gemma4 streaming duplication/buffering regressions and did not find an existing open PR covering this fix.

Validation run:
- Targeted parser verification via `uv run --no-project python -`
- Verified standard Gemma4 streaming tool-call argument parsing still produces valid JSON
- Verified a regression case for plain text after a tool call keeps `<div>` intact instead of producing `<<div>` internally
- Verified a regression case for HTML content inside tool arguments keeps `<html>` / `<meta>` intact instead of producing duplicated prefixes such as `<<htmlhtml` or `<<metameta`

Note:
- I also added regression coverage in `tests/tool_parsers/test_gemma4_tool_parser.py`.
- I did not run the full pytest target in this workspace because the local test environment is not fully bootstrapped here.

## AI disclosure

This PR includes AI-assisted code generation and analysis. I reviewed the changes, reproduced the bug path, and validated the fix myself.
