### PR TITLE
[ROCm] mi250x decode regression

### DIFF
--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -340,6 +340,30 @@ __device__ inline unsigned int min__(uint32_t a, uint32_t b) {
   return min(a, b);
 }
 
+#if defined(__HIP__GFX9__)
+__device__ inline float wvsplitk_reduce_wave_gfx9(float value) {
+  asm("s_nop 0\n\tv_add_f32 %0, %2, %3 row_shr:8 bound_ctrl:0 "
+      : "=v"(value)
+      : "0"(value), "v"(value), "v"(value));
+  asm("s_nop 0\n\tv_add_f32 %0, %2, %3 row_shr:4 bound_ctrl:0 "
+      : "=v"(value)
+      : "0"(value), "v"(value), "v"(value));
+  asm("s_nop 0\n\tv_add_f32 %0, %2, %3 row_shr:2 bound_ctrl:0 "
+      : "=v"(value)
+      : "0"(value), "v"(value), "v"(value));
+  asm("s_nop 0\n\tv_add_f32 %0, %2, %3 wave_shr:1 bound_ctrl:0"
+      : "=v"(value)
+      : "0"(value), "v"(value), "v"(value));
+  asm("s_nop 0\n\tv_add_f32 %0, %2, %3 row_bcast:15 bound_ctrl:0"
+      : "=v"(value)
+      : "0"(value), "v"(value), "v"(value));
+  asm("s_nop 0\n\tv_add_f32 %0, %2, %3 row_bcast:31 bound_ctrl:0"
+      : "=v"(value)
+      : "0"(value), "v"(value), "v"(value));
+  return value;
+}
+#endif
+
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX1X__)
 // This version targets cases where A[] fits LDS capacity
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
@@ -474,6 +498,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     if constexpr (!use_mfma) {
       for (int n = 0; n < N; n++) {
         for (int y = 0; y < YTILE; y++) {
+#if defined(__HIP__GFX9__)
+          sum[n][y] = wvsplitk_reduce_wave_gfx9(sum[n][y]);
+#else
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x118, 0xf, 0xf,
                                                 1);  // row_shr8
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x114, 0xf, 0xf,
@@ -482,14 +509,8 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                                                 1);  // row_shr2
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x111, 0xf, 0xf,
                                                 1);  // row_shr1
-  #if defined(__HIP__GFX9__)
-          sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x142, 0xf, 0xf,
-                                                1);  // ROW_BCAST15
-          sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x143, 0xf, 0xf,
-                                                1);  // ROW_BCAST31
-  #else
           sum[n][y] += __shfl_xor(sum[n][y], 16);
-  #endif
+#endif
         }
       }
 
@@ -695,6 +716,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     if constexpr (!use_mfma) {
       for (int n = 0; n < N; n++) {
         for (int y = 0; y < YTILE; y++) {
+#if defined(__HIP__GFX9__)
+          sum[n][y] = wvsplitk_reduce_wave_gfx9(sum[n][y]);
+#else
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x118, 0xf, 0xf,
                                                 1);  // row_shr8
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x114, 0xf, 0xf,
@@ -703,14 +727,8 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                                                 1);  // row_shr2
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x111, 0xf, 0xf,
                                                 1);  // row_shr1
-  #if defined(__HIP__GFX9__)
-          sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x142, 0xf, 0xf,
-                                                1);  // ROW_BCAST15
-          sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x143, 0xf, 0xf,
-                                                1);  // ROW_BCAST31
-  #else
           sum[n][y] += __shfl_xor(sum[n][y], 16);
-  #endif
+#endif
         }
       }
 
@@ -1048,6 +1066,9 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     if constexpr (!use_mfma) {
       for (int n = 0; n < N; n++) {
         for (int y = 0; y < YTILE; y++) {
+#if defined(__HIP__GFX9__)
+          sum[n][y] = wvsplitk_reduce_wave_gfx9(sum[n][y]);
+#else
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x118, 0xf, 0xf,
                                                 1);  // row_shr8
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x114, 0xf, 0xf,
@@ -1056,14 +1077,8 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
                                                 1);  // row_shr2
           sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x111, 0xf, 0xf,
                                                 1);  // row_shr1
-  #if defined(__HIP__GFX9__)
-          sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x142, 0xf, 0xf,
-                                                1);  // ROW_BCAST15
-          sum[n][y] += __builtin_amdgcn_mov_dpp(sum[n][y], 0x143, 0xf, 0xf,
-                                                1);  // ROW_BCAST31
-  #else
           sum[n][y] += __shfl_xor(sum[n][y], 16);
-  #endif
+#endif
         }
       }
 

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -239,9 +239,12 @@ def test_rocm_wvsplitk_kernel(
 
 
 @pytest.mark.parametrize("n,k,m", GEMMA_3_1B_DECODE_FACTORS)
+@pytest.mark.parametrize("padded_weight", [False, True])
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 @torch.inference_mode()
-def test_rocm_unquantized_gemm_gemma_decode_regression_mi250x(n, k, m):
+def test_rocm_unquantized_gemm_gemma_decode_regression_mi250x(
+    n, k, m, padded_weight
+):
     if not on_gfx9() or on_gfx942() or on_gfx950():
         pytest.skip("only meant for MI250X/gfx90a")
 
@@ -250,6 +253,8 @@ def test_rocm_unquantized_gemm_gemma_decode_regression_mi250x(n, k, m):
     a = a / math.sqrt(k)
     b = ((torch.rand(m, k, dtype=torch.bfloat16, device="cuda") * 2) - 1)
     b = b / math.sqrt(k)
+    if padded_weight:
+        b = pad_fp8(b)
 
     ref_out = torch.nn.functional.linear(a, b, None)
     out = rocm_unquantized_gemm_impl(a, b, None)

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -109,8 +109,8 @@ NKM_FACTORS_WVSPLITK_FP8 = [
 
 SEEDS = [0]
 
-GEMMA_3_1B_DECODE_FACTORS = [
-    # Gemma-3-1B MLP projection during decode on MI250X/gfx90a.
+MI250X_DECODE_REGRESSION_FACTORS = [
+    # Representative decode shape on MI250X/gfx90a.
     # n is the flattened token count, so n <= 4 takes the ROCm wvSplitK path.
     (1, 1152, 6912),
 ]
@@ -238,11 +238,11 @@ def test_rocm_wvsplitk_kernel(
     torch.testing.assert_close(out, ref_out, atol=atol, rtol=1e-2)
 
 
-@pytest.mark.parametrize("n,k,m", GEMMA_3_1B_DECODE_FACTORS)
+@pytest.mark.parametrize("n,k,m", MI250X_DECODE_REGRESSION_FACTORS)
 @pytest.mark.parametrize("padded_weight", [False, True])
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 @torch.inference_mode()
-def test_rocm_unquantized_gemm_gemma_decode_regression_mi250x(
+def test_rocm_unquantized_gemm_decode_regression_mi250x(
     n, k, m, padded_weight
 ):
     if not on_gfx9() or on_gfx942() or on_gfx950():

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -8,7 +8,8 @@ import torch
 import vllm._custom_ops as ops
 from tests.kernels.quant_utils import ref_dynamic_per_tensor_fp8_quant
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import on_gfx950
+from vllm.platforms.rocm import on_gfx9, on_gfx942, on_gfx950
+from vllm.model_executor.layers.utils import rocm_unquantized_gemm_impl
 from vllm.utils.platform_utils import num_compute_units
 
 DTYPES = [torch.bfloat16, torch.float16]
@@ -107,6 +108,12 @@ NKM_FACTORS_WVSPLITK_FP8 = [
 ]
 
 SEEDS = [0]
+
+GEMMA_3_1B_DECODE_FACTORS = [
+    # Gemma-3-1B MLP projection during decode on MI250X/gfx90a.
+    # n is the flattened token count, so n <= 4 takes the ROCm wvSplitK path.
+    (1, 1152, 6912),
+]
 
 
 def pad_fp8(weight):
@@ -229,6 +236,25 @@ def test_rocm_wvsplitk_kernel(
     # Accumulation error in fp16 GEMM scales with sqrt(K)
     atol = torch.finfo(dtype).eps * math.sqrt(k)
     torch.testing.assert_close(out, ref_out, atol=atol, rtol=1e-2)
+
+
+@pytest.mark.parametrize("n,k,m", GEMMA_3_1B_DECODE_FACTORS)
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+@torch.inference_mode()
+def test_rocm_unquantized_gemm_gemma_decode_regression_mi250x(n, k, m):
+    if not on_gfx9() or on_gfx942() or on_gfx950():
+        pytest.skip("only meant for MI250X/gfx90a")
+
+    torch.manual_seed(0)
+    a = ((torch.rand(n, k, dtype=torch.bfloat16, device="cuda") * 2) - 1)
+    a = a / math.sqrt(k)
+    b = ((torch.rand(m, k, dtype=torch.bfloat16, device="cuda") * 2) - 1)
+    b = b / math.sqrt(k)
+
+    ref_out = torch.nn.functional.linear(a, b, None)
+    out = rocm_unquantized_gemm_impl(a, b, None)
+
+    torch.testing.assert_close(out, ref_out, atol=1e-3, rtol=1e-2)
 
 
 @pytest.mark.parametrize("xnorm", [False, True])


### PR DESCRIPTION



## Purpose

This PR fixes a ROCm `wvSplitK` regression on gfx9 that shows up on MI250X decode workloads.

In practice, this was causing numerically wrong outputs in the decode path and could lead to obviously bad generations. The fix restores the correct reduction behavior in the gfx9 non-MFMA path and adds a regression test for the decode shape that was failing.

The new test covers both contiguous and padded weight layouts.

I only have MI250X/gfx90a hardware available, so that is the only runtime environment I validated this on.

## Test Plan

Run the new regression test:

```bash
python -m pytest -q tests/kernels/quantization/test_rocm_skinny_gemms.py -k decode_regression_mi250x
 ```

Run an end-to-end serving smoke test on MI250X using a known-good model and the existing long-generation harness.

## Test Result

Before this change:

- the MI250X decode path produced incorrect outputs for the failing shape
- long-form generation could degrade into garbage output

After this change:

$ python -m pytest -q tests/kernels/quantization/test_rocm_skinny_gemms.py -k decode_regression_mi250x
2 passed, 11040 deselected, 2 warnings in 60.61s

The end-to-end smoke test also completed successfully on MI250X, with all 8 prompts passing and no garbage-output cases detected.

I have not validated this on MI300/MI350 or newer AMD hardware, since I do not currently have access to those systems.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. (Not needed)
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0). (Not needed)
</details>

