### PR TITLE
 [Bugfix] Fix Qwen3.5 LoRA activation for shared expert modules

### DIFF
--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from collections import OrderedDict
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -11,6 +13,7 @@ from torch import nn
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.lora import LoRAConfig
 from vllm.lora.layers import (
+    BaseLayerWithLoRA,
     ColumnParallelLinearWithLoRA,
     MergedColumnParallelLinearWithLoRA,
     RowParallelLinearWithLoRA,
@@ -27,6 +30,13 @@ from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.request import LoRARequest
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager, WorkerLoRAManager
 from vllm.platforms import current_platform
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.models.interfaces import SupportsLoRA
 
 from .utils import create_peft_lora
 
@@ -35,14 +45,61 @@ EMBEDDING_MODULES = {
     "lm_head": "output_embeddings",
 }
 
-DEVICE_TYPE = current_platform.device_type
+
 DEVICES = (
-    [f"{DEVICE_TYPE}:{i}" for i in range(min(torch.accelerator.device_count(), 2))]
+    [f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)]
     if current_platform.is_cuda_alike()
     else ["cpu"]
 )
 
 DEFAULT_DTYPE = torch.get_default_dtype()
+
+
+class DummyLoRAModel(nn.Sequential, SupportsLoRA):
+    pass
+
+
+class DummySharedExpertContainer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self._shared_experts = None
+
+
+class DummySharedExpertModel(nn.Module, SupportsLoRA):
+    pass
+
+
+@pytest.fixture
+def dummy_shared_expert_model(default_vllm_config) -> nn.Module:
+    shared_expert_gate = ReplicatedLinear(16, 1)
+    shared_expert = nn.Sequential(
+        OrderedDict(
+            [
+                ("gate_up_proj", MergedColumnParallelLinear(16, [8, 8])),
+                ("down_proj", RowParallelLinear(8, 16)),
+            ]
+        )
+    )
+    shared_expert.expert_gate = shared_expert_gate
+
+    experts = DummySharedExpertContainer()
+    experts._shared_experts = shared_expert
+
+    mlp = nn.Module()
+    mlp.shared_expert_gate = shared_expert_gate
+    mlp.shared_expert = shared_expert
+    mlp.experts = experts
+
+    layer = nn.Module()
+    layer.mlp = mlp
+
+    model = DummySharedExpertModel()
+    model.layer = layer
+    model.config = MagicMock()
+    model.embedding_modules = {}
+    model.unpadded_vocab_size = 0
+    model.packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+    return model
 
 
 @pytest.mark.parametrize("device", DEVICES)
@@ -642,6 +699,124 @@ def test_worker_adapter_manager(
 
 
 @pytest.mark.parametrize("device", DEVICES)
+def test_shared_expert_alias_activation(
+    default_vllm_config, dist_init, dummy_shared_expert_model, device
+):
+    model = dummy_shared_expert_model
+    manager = LoRAModelManager(
+        model,
+        1,
+        1,
+        1,
+        LoRAConfig(
+            max_lora_rank=8, max_cpu_loras=1, max_loras=1, lora_dtype=DEFAULT_DTYPE
+        ),
+        device=device,
+    )
+
+    loras = {
+        "layer.mlp.shared_expert_gate": LoRALayerWeights(
+            "layer.mlp.shared_expert_gate",
+            8,
+            16,
+            torch.rand([8, 16], device=device),
+            torch.rand([1, 8], device=device),
+        ),
+        "layer.mlp.shared_expert.gate_proj": LoRALayerWeights(
+            "layer.mlp.shared_expert.gate_proj",
+            8,
+            16,
+            torch.rand([8, 16], device=device),
+            torch.rand([8, 8], device=device),
+        ),
+        "layer.mlp.shared_expert.up_proj": LoRALayerWeights(
+            "layer.mlp.shared_expert.up_proj",
+            8,
+            16,
+            torch.rand([8, 16], device=device),
+            torch.rand([8, 8], device=device),
+        ),
+        "layer.mlp.shared_expert.down_proj": LoRALayerWeights(
+            "layer.mlp.shared_expert.down_proj",
+            8,
+            16,
+            torch.rand([8, 8], device=device),
+            torch.rand([16, 8], device=device),
+        ),
+    }
+    lora_model = LoRAModel(1, 8, loras)
+
+    assert manager.add_adapter(lora_model)
+    assert manager.activate_adapter(1)
+
+    shared_expert = manager.model.layer.mlp.shared_expert
+    assert isinstance(shared_expert.gate_up_proj, MergedColumnParallelLinearWithLoRA)
+    assert isinstance(shared_expert.down_proj, RowParallelLinearWithLoRA)
+    assert isinstance(shared_expert.expert_gate, BaseLayerWithLoRA)
+
+    assert torch.count_nonzero(shared_expert.gate_up_proj.lora_a_stacked[0]).item() > 0
+    assert torch.count_nonzero(shared_expert.gate_up_proj.lora_a_stacked[1]).item() > 0
+    assert torch.count_nonzero(shared_expert.gate_up_proj.lora_b_stacked[0]).item() > 0
+    assert torch.count_nonzero(shared_expert.gate_up_proj.lora_b_stacked[1]).item() > 0
+    assert torch.count_nonzero(shared_expert.down_proj.lora_a_stacked[0]).item() > 0
+    assert torch.count_nonzero(shared_expert.down_proj.lora_b_stacked[0]).item() > 0
+    assert torch.count_nonzero(shared_expert.expert_gate.lora_a_stacked[0]).item() > 0
+    assert torch.count_nonzero(shared_expert.expert_gate.lora_b_stacked[0]).item() > 0
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_shared_expert_gate_alias_updated_after_lora_replacement(
+    default_vllm_config, dist_init, dummy_shared_expert_model, device
+):
+    """Regression test for the Qwen3.5 shared-expert alias bug.
+
+    After LoRA module replacement, ``shared_expert.expert_gate`` must point to
+    the same live LoRA-wrapped object as ``mlp.shared_expert_gate``.
+
+    Before the fix in ``LoRAModelManager._create_lora_modules``, the gate was
+    replaced under the ``mlp.shared_expert_gate`` path but the alias reference
+    ``shared_expert.expert_gate`` was never updated.  This caused the LoRA to
+    be invisible to the forward path that uses the alias.
+
+    PR before: FAIL — ``shared_expert.expert_gate`` remains the original base
+               ``ReplicatedLinear``, so the assert below raises.
+    PR after:  PASS — ``_create_lora_modules`` explicitly re-points the alias
+               at the new LoRA wrapper.
+    """
+    model = dummy_shared_expert_model
+    LoRAModelManager(
+        model,
+        1,
+        1,
+        1,
+        LoRAConfig(
+            max_lora_rank=8, max_cpu_loras=1, max_loras=1, lora_dtype=DEFAULT_DTYPE
+        ),
+        device=device,
+    )
+
+    mlp = model.layer.mlp
+    shared_expert_gate_wrapper = mlp.shared_expert_gate
+    expert_gate_alias = mlp.shared_expert.expert_gate
+
+    # Both must be LoRA wrappers after replacement.
+    assert isinstance(shared_expert_gate_wrapper, BaseLayerWithLoRA), (
+        "mlp.shared_expert_gate was not replaced with a LoRA wrapper"
+    )
+    assert isinstance(expert_gate_alias, BaseLayerWithLoRA), (
+        "shared_expert.expert_gate is not a LoRA wrapper — alias was not updated"
+    )
+
+    # Critical: they must be the SAME live object.
+    # Without the fix, expert_gate still points at the original ReplicatedLinear
+    # while shared_expert_gate points at the new wrapper — they are different.
+    assert expert_gate_alias is shared_expert_gate_wrapper, (
+        "shared_expert.expert_gate and mlp.shared_expert_gate are different "
+        "objects — the alias was not updated after LoRA replacement"
+    )
+
+
+@pytest.mark.parametrize("device", DEVICES)
 def test_packed_loras(default_vllm_config, dist_init, dummy_model_gate_up, device):
     model = dummy_model_gate_up
     model_lora = create_packed_lora(
@@ -900,3 +1075,4 @@ def test_load_adapter_warns_on_target_modules_restriction(
         assert found, (
             f"Expected warning about target_modules restriction, got: {warning_args}"
         )
+

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -45,9 +45,9 @@ EMBEDDING_MODULES = {
     "lm_head": "output_embeddings",
 }
 
-
+DEVICE_TYPE = current_platform.device_type
 DEVICES = (
-    [f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)]
+    [f"{DEVICE_TYPE}:{i}" for i in range(min(torch.accelerator.device_count(), 2))]
     if current_platform.is_cuda_alike()
     else ["cpu"]
 )

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
 import math
 from collections.abc import Callable
 from typing import TypeVar
@@ -271,9 +270,9 @@ class LoRAModelManager:
             return False
         first_free_slot = next(
             (
-                (i, lora_id)
-                for i, lora_id in enumerate(self.lora_index_to_id)
-                if lora_id is None
+                (i, active_lora_id)
+                for i, active_lora_id in enumerate(self.lora_index_to_id)
+                if active_lora_id is None
             ),
             None,
         )
@@ -286,7 +285,12 @@ class LoRAModelManager:
             "Activating LoRA. int id: %d, slot index: %d", lora_model.id, index
         )
         self.lora_index_to_id[index] = lora_model.id
+
+        seen_live_modules: set[BaseLayerWithLoRA] = set()
         for module_name, module in self.modules.items():
+            if module in seen_live_modules:
+                continue
+            seen_live_modules.add(module)
             module_lora = self._get_lora_layer_weights(lora_model, module_name)
             if not module_lora:
                 module.reset_lora(index)
@@ -360,9 +364,14 @@ class LoRAModelManager:
             #  - given an input 'x' return ''
             return module_name.rpartition(".")[0]
 
+        seen_modules: set[nn.Module] = set()
         for module_name, module in self.model.named_modules(remove_duplicate=False):
             if isinstance(module, PPMissingLayer):
                 continue
+
+            if module in seen_modules:
+                continue
+            seen_modules.add(module)
 
             if not self._match_target_modules(module_name):
                 continue
@@ -411,6 +420,20 @@ class LoRAModelManager:
                     self.model.config,
                 ),
             )
+            # Qwen3.5 MoE keeps the same shared expert under both
+            # `mlp.shared_expert.*` and `mlp.experts._shared_experts.*`.
+            # Mark the replacement wrapper as seen so the alias path does not
+            # reprocess the same live module and accidentally reset its LoRA.
+            seen_modules.add(new_module)
+
+            if module_name.endswith(".shared_expert_gate"):
+                parent_module_name = _parent_module(module_name)
+                parent_module = self.model.get_submodule(parent_module_name)
+                shared_expert = getattr(parent_module, "shared_expert", None)
+                if shared_expert is not None and getattr(
+                    shared_expert, "expert_gate", None
+                ) is module:
+                    shared_expert.expert_gate = new_module
 
             # (yard1): TODO make this more robust
             if "lm_head" in module_name:

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -270,9 +270,9 @@ class LoRAModelManager:
             return False
         first_free_slot = next(
             (
-                (i, active_lora_id)
-                for i, active_lora_id in enumerate(self.lora_index_to_id)
-                if active_lora_id is None
+                (i, lora_id)
+                for i, lora_id in enumerate(self.lora_index_to_id)
+                if lora_id is None
             ),
             None,
         )

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -94,6 +94,7 @@ from .qwen3_vl import (
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
+    WeightsMapper,
     _merge_multimodal_embeddings,
     extract_layer_index,
     is_pp_missing_parameter,
@@ -449,6 +450,12 @@ class Qwen3_5ForCausalLMBase(
     SupportsLoRA,
     SupportsPP,
 ):
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "model.",
+        }
+    )
+
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -543,7 +550,7 @@ class Qwen3_5ForCausalLMBase(
             self,
             skip_prefixes=["mtp."],
         )
-        return loader.load_weights(weights)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 
 class Qwen3_5ForCausalLM(Qwen3_5ForCausalLMBase):

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -94,7 +94,6 @@ from .qwen3_vl import (
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
-    WeightsMapper,
     _merge_multimodal_embeddings,
     extract_layer_index,
     is_pp_missing_parameter,
@@ -450,12 +449,6 @@ class Qwen3_5ForCausalLMBase(
     SupportsLoRA,
     SupportsPP,
 ):
-    hf_to_vllm_mapper = WeightsMapper(
-        orig_to_new_prefix={
-            "model.language_model.": "model.",
-        }
-    )
-
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -550,7 +543,7 @@ class Qwen3_5ForCausalLMBase(
             self,
             skip_prefixes=["mtp."],
         )
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        return loader.load_weights(weights)
 
 
 class Qwen3_5ForCausalLM(Qwen3_5ForCausalLMBase):


### PR DESCRIPTION
## Summary
- Fix Qwen3.5 MoE shared-expert LoRA activation: `shared_expert.expert_gate` alias was not updated after `shared_expert_gate` replacement
- Deduplicate module processing in `_create_lora_modules` and `activate_adapter` using object-reference sets instead of `id()`-based tracking (per reviewer feedback)
- Add two regression tests: one for LoRA buffer non-zero activation, one identity test that directly proves the alias fix

## Root cause

Qwen3.5 MoE keeps the same shared-expert module object under two path aliases:
- `mlp.shared_expert_gate` (outer MoE block)
- `shared_expert.expert_gate` (alias set during model construction)

`LoRAModelManager` replaced `mlp.shared_expert_gate` with a LoRA wrapper but never updated `shared_expert.expert_gate`, so the forward path continued using the original base `ReplicatedLinear`. Additionally, `named_modules(remove_duplicate=False)` caused alias paths to be processed twice, allowing a second traversal to reset LoRA buffers populated by the first.

## Fix

1. After replacing `shared_expert_gate`, explicitly re-point `shared_expert.expert_gate` at the new LoRA wrapper
2. Deduplicate module iteration by tracking visited modules as object references (not `id()`)

## Test plan — local results (NVIDIA RTX 4090, CUDA 12.x)

### Regression test: `test_shared_expert_gate_alias_updated_after_lora_replacement`

This test directly captures the fix: after LoRA module replacement, `shared_expert.expert_gate` **must** be the same live object as `mlp.shared_expert_gate`.

| Version | Result | Key failure message |
|---------|--------|---------------------|
| **Before this PR** | ❌ FAIL | `AssertionError: shared_expert.expert_gate is not a LoRA wrapper — alias was not updated` (it remained the original `ReplicatedLinear`) |
| **After this PR** | ✅ PASS | |

```bash
.venv/bin/python -m pytest tests/lora/test_lora_manager.py -v \
  -k test_shared_expert_gate_alias_updated_after_lora_replacement
Existing regression test: test_shared_expert_alias_activation
Validates that LoRA buffers for all shared-expert modules are non-zero after activation.


.venv/bin/python -m pytest tests/lora/test_lora_manager.py -v \
  -k shared_expert_alias_activation
Both tests pass on this PR.