### PR TITLE
[Bugfix][LoRA] Fix missing in_proj_z in Qwen3_5ForConditionalGenerati…

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -620,6 +620,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
             self.packed_modules_mapping = {k: list(v) for k, v in base.items()}
             self.packed_modules_mapping.pop("in_proj_qkvz", None)
             self.packed_modules_mapping["in_proj_qkv"] = ["in_proj_qkv"]
+            self.packed_modules_mapping["in_proj_z"] = ["in_proj_z"]
 
     def embed_input_ids(
         self,


### PR DESCRIPTION
## Purpose

Fix missing `in_proj_z` entry in `Qwen3_5ForConditionalGeneration.update_packed_mapping()` when LoRA is enabled.

When LoRA is enabled, GDN layers use separate `in_proj_qkv` and `in_proj_z` projections instead of the merged `in_proj_qkvz`. The `update_packed_mapping()` method correctly removes `in_proj_qkvz` and adds `in_proj_qkv`, but was missing the `in_proj_z` entry. This causes `slice_lora_b` to raise `IndexError: list index out of range` when loading LoRA adapters under tensor parallelism (TP > 1).

Note that `Qwen3_5ForCausalLMBase.__init__` already handles this correctly — only the `update_packed_mapping()` method (used by `Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration`) was missing the line.

### Why this is not duplicating an existing PR

- PR #36069 works around the symptom by adding bounds-checking in `MergedColumnParallelLinearWithLoRA.set_lora()`, but does not fix the root cause in the model mapping.
- PR #36603 identifies this root cause in a comment but does not fix it.
- PR #37114 addresses a different LoRA issue (expert base_layer loading).
- This PR fixes the root cause directly with a one-line addition.

## Test Plan

```bash
ruff check vllm/model_executor/models/qwen3_5.py
ruff format --check vllm/model_executor/models/qwen3_5.py
```

## Test Results

```
All checks passed!
1 file already formatted
```

## AI Assistance

AI assistance (Claude) was used to search for duplicate PRs, run linters, and draft this PR description. The change itself was authored by the submitter.

---

Essential Elements of an Effective PR Description Checklist:
- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [x] Not duplicating an existing PR
- [x] AI assistance disclosure
