### PR TITLE
[BUG] Fix PP for R3

### DIFF
--- a/tests/distributed/test_pp_routed_experts.py
+++ b/tests/distributed/test_pp_routed_experts.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Test that routed expert capture works correctly with pipeline parallelism.
+
+This test creates two LLM instances — one with PP=1 (baseline) and one with
+PP=2 — and asserts that the routed experts returned are identical.
+"""
+
+import numpy as np
+
+from tests.utils import multi_gpu_test
+from vllm import LLM, SamplingParams
+
+MODEL_NAME = "TitanML/tiny-mixtral"
+
+# tiny-mixtral config: 8 local experts, top-2 routing, 2 hidden layers
+NUM_LOCAL_EXPERTS = 8
+NUM_EXPERTS_PER_TOK = 2
+NUM_HIDDEN_LAYERS = 2
+
+PROMPT = "The quick brown fox jumps over the lazy dog"
+MAX_TOKENS = 10
+
+
+def _generate_with_routed_experts(pipeline_parallel_size: int):
+    """Spin up an LLM with the given PP size and return routed_experts."""
+    llm = LLM(
+        model=MODEL_NAME,
+        max_model_len=256,
+        max_num_seqs=32,
+        enforce_eager=True,
+        enable_return_routed_experts=True,
+        pipeline_parallel_size=pipeline_parallel_size,
+        distributed_executor_backend="mp",
+    )
+    outputs = llm.generate(PROMPT, SamplingParams(max_tokens=MAX_TOKENS, temperature=0))
+    del llm
+
+    assert len(outputs) == 1
+    completion = outputs[0].outputs[0]
+    assert completion.routed_experts is not None
+    return completion.routed_experts
+
+
+@multi_gpu_test(num_gpus=2)
+def test_pp2_routed_experts_match_pp1():
+    """PP=2 must return the same routing decisions as PP=1."""
+    experts_pp1 = _generate_with_routed_experts(pipeline_parallel_size=1)
+    experts_pp2 = _generate_with_routed_experts(pipeline_parallel_size=2)
+
+    np.testing.assert_array_equal(
+        experts_pp1,
+        experts_pp2,
+        err_msg=(
+            "Routed experts differ between PP=1 and PP=2. "
+            f"PP=1:\n{experts_pp1}\nPP=2:\n{experts_pp2}"
+        ),
+    )

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -194,12 +194,20 @@ class RoutedExpertsCapturer:
         if self._device_buffer is not None:
             self._device_buffer.zero_()
 
-    def save_captured_experts(self, indices: np.ndarray) -> None:
+    def save_captured_experts(
+        self,
+        indices: np.ndarray,
+        layer_range: tuple[int, int] | None = None,
+    ) -> None:
         """
         Save captured experts from device buffer to shared memory.
 
         Args:
             indices: Array of indices indicating where to store the data.
+            layer_range: Optional (start, end) layer slice to write.  When
+                running with pipeline parallelism each rank should only write
+                the layers it owns to avoid clobbering data from other ranks.
+                If *None*, all layers are written.
         """
         if get_tensor_model_parallel_rank() != 0:
             return
@@ -211,10 +219,16 @@ class RoutedExpertsCapturer:
             raise RuntimeError("Device buffer not initialized.")
 
         num_tokens = len(indices)
-        data = self._device_buffer[:num_tokens, :, :].cpu().numpy()
 
-        with _file_lock(self._lock_file):
-            self._host_buffer_view[indices, :, :] = data
+        if layer_range is not None:
+            ls, le = layer_range
+            data = self._device_buffer[:num_tokens, ls:le, :].cpu().numpy()
+            with _file_lock(self._lock_file):
+                self._host_buffer_view[indices, ls:le, :] = data
+        else:
+            data = self._device_buffer[:num_tokens, :, :].cpu().numpy()
+            with _file_lock(self._lock_file):
+                self._host_buffer_view[indices, :, :] = data
 
     def cleanup(self) -> None:
         """Explicitly clean up shared memory resources."""

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -220,15 +220,15 @@ class RoutedExpertsCapturer:
 
         num_tokens = len(indices)
 
-        if layer_range is not None:
-            ls, le = layer_range
-            data = self._device_buffer[:num_tokens, ls:le, :].cpu().numpy()
-            with _file_lock(self._lock_file):
-                self._host_buffer_view[indices, ls:le, :] = data
-        else:
-            data = self._device_buffer[:num_tokens, :, :].cpu().numpy()
-            with _file_lock(self._lock_file):
-                self._host_buffer_view[indices, :, :] = data
+        ls, le = (
+            layer_range
+            if layer_range is not None
+            else (0, self._device_buffer.shape[1])
+        )
+        data = self._device_buffer[:num_tokens, ls:le, :].cpu().numpy()
+
+        with _file_lock(self._lock_file):
+            self._host_buffer_view[indices, ls:le, :] = data
 
     def cleanup(self) -> None:
         """Explicitly clean up shared memory resources."""

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -431,6 +431,7 @@ class GPUModelRunner(
         # Set to True after init_routed_experts_capturer() completes.
         # Prevents routed experts code from running during profiling/dummy run.
         self.routed_experts_initialized = False
+        self.routed_experts_layer_range: tuple[int, int] | None = None
         self.max_model_len = model_config.max_model_len
 
         # Always set to false after the first forward pass
@@ -4040,6 +4041,14 @@ class GPUModelRunner(
             if not self.broadcast_pp_output:
                 # Common case.
                 if not get_pp_group().is_last_rank:
+                    if self.routed_experts_initialized:
+                        capturer = RoutedExpertsCapturer.get_instance()
+                        if capturer is not None:
+                            capturer.save_captured_experts(
+                                indices=self.slot_mapping,
+                                layer_range=self.routed_experts_layer_range,
+                            )
+
                     # Return the intermediate tensors.
                     assert isinstance(hidden_states, IntermediateTensors)
                     hidden_states.kv_connector_output = kv_connector_output
@@ -4302,7 +4311,10 @@ class GPUModelRunner(
             if self.routed_experts_initialized:
                 capturer = RoutedExpertsCapturer.get_instance()
                 if capturer is not None:
-                    capturer.save_captured_experts(indices=self.slot_mapping)  # noqa
+                    capturer.save_captured_experts(
+                        indices=self.slot_mapping,
+                        layer_range=self.routed_experts_layer_range,
+                    )
                 else:
                     logger.error("RoutedExpertsCapturer not initialized.")
 
@@ -6897,14 +6909,24 @@ class GPUModelRunner(
             BaseRouter,
         )
 
+        bound_layer_ids: list[int] = []
         for module in self.compilation_config.static_forward_context.values():
             if isinstance(module, FusedMoE) and isinstance(module.router, BaseRouter):
                 layer_id = module.layer_id
+                bound_layer_ids.append(layer_id)
 
                 def _capture_fn(topk_ids, _layer_id=layer_id, _capturer=capturer):
                     _capturer.capture(_layer_id, topk_ids)
 
                 module.router.set_capture_fn(_capture_fn)
+
+        if bound_layer_ids:
+            self.routed_experts_layer_range = (
+                min(bound_layer_ids),
+                max(bound_layer_ids) + 1,
+            )
+        else:
+            self.routed_experts_layer_range = None
 
     def may_add_encoder_only_layers_to_kv_cache_config(self) -> None:
         """

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4041,7 +4041,10 @@ class GPUModelRunner(
             if not self.broadcast_pp_output:
                 # Common case.
                 if not get_pp_group().is_last_rank:
-                    if self.routed_experts_initialized and self.routed_experts_layer_range is not None:
+                    if (
+                        self.routed_experts_initialized
+                        and self.routed_experts_layer_range is not None
+                    ):
                         capturer = RoutedExpertsCapturer.get_instance()
                         if capturer is not None:
                             capturer.save_captured_experts(
@@ -4308,7 +4311,10 @@ class GPUModelRunner(
         self.kv_connector_output = None
 
         with record_function_or_nullcontext("gpu_model_runner: ModelRunnerOutput"):
-            if self.routed_experts_initialized:
+            if (
+                self.routed_experts_initialized
+                and self.routed_experts_layer_range is not None
+            ):
                 capturer = RoutedExpertsCapturer.get_instance()
                 if capturer is not None:
                     capturer.save_captured_experts(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4041,7 +4041,7 @@ class GPUModelRunner(
             if not self.broadcast_pp_output:
                 # Common case.
                 if not get_pp_group().is_last_rank:
-                    if self.routed_experts_initialized:
+                    if self.routed_experts_initialized and self.routed_experts_layer_range is not None:
                         capturer = RoutedExpertsCapturer.get_instance()
                         if capturer is not None:
                             capturer.save_captured_experts(


### PR DESCRIPTION



## Purpose
When using PP>1 with R3, only the last pp rank's expert indices are returned. This PR allows all PP ranks to write to the shared buffer so the returned expert indices correspond to all the routed experts of all layers.

## Test Plan
Included unit test comparing PP=1 with PP=2, ensuring the routed experts are the same.

## Test Result
passing
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

