### PR TITLE
[Core] Re-enable Inductor pre-grad passes in standalone compile (torch>=2.12)

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -345,9 +345,9 @@ class InductorStandaloneAdaptor(CompilerInterface):
         # Inductor's pre-grad passes don't do anything for vLLM.
         # The pre-grad passes get run even on cache-hit and negatively impact
         # vllm cold compile times by O(1s)
-        # Can remove this after the following issue gets fixed
+        # Fixed upstream in PyTorch 2.12:
         # https://github.com/pytorch/pytorch/issues/174502
-        if envs.VLLM_ENABLE_PREGRAD_PASSES:
+        if is_torch_equal_or_newer("2.12.0.dev") or envs.VLLM_ENABLE_PREGRAD_PASSES:
             pregrad_ctx: Any = contextlib.nullcontext()
         else:
             pregrad_ctx = patch(


### PR DESCRIPTION
## Purpose

Re-enable Inductor pre-grad passes in vLLM's standalone compile path.
PyTorch 2.12+ no longer runs pre-grad passes before the cache lookup
(`pre_grad_pass_timing = "default"`), so the monkey-patch that bypassed
`_recursive_pre_grad_passes` is no longer needed. Removing it re-enables
pre-grad passes, including any custom passes registered via PyTorch's
pass infrastructure, with no impact on compile time.

## Test Plan

Benchmark cold compile time of one query on
`LLM(model="meta-llama/Meta-Llama-3-70B-Instruct", tensor_parallel_size=4)`,
comparing this change against its parent commit under both PyTorch 2.12+
and older PyTorch behavior (simulated via `pre_grad_pass_timing = "early"`).

## Test Result

Cold compile time (meta-llama/Meta-Llama-3-70B-Instruct, TP=4):

|  | Before this change | With this change |
|---|---|---|
| **Pre-PyTorch 2.12** (simulated via `pre_grad_pass_timing = "early"`) | 41.5s ± 0.9s, median 41.6s (n=80) | 41.4s ± 1.0s, median 41.4s (n=80) |
| **PyTorch 2.12+** (`pre_grad_pass_timing = "default"`) | 41.0s ± 0.1s, median 41.0s (n=4) | 41.3s ± 0.5s, median 41.4s (n=4) |

No compile time regression in either configuration.