### PR TITLE
[Bugfix] Gemma 4: Fix bug around invalid JSON diffs during tool usage

### DIFF
--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -678,7 +678,7 @@ class Gemma4ToolParser(ToolParser):
         # tokens arrive. Strip trailing '}', '"', and ']' sequences
         # to get the "safe prefix".
         safe_json = current_args_json
-        while safe_json and safe_json[-1] in ("}", '"', "]"):
+        while safe_json and safe_json[-1] in ("}", '"', "]", "<", "|", "\\", ">"):
             safe_json = safe_json[:-1]
 
         prev_streamed = self.streamed_args_for_tool[self.current_tool_id]


### PR DESCRIPTION
## Purpose

Currently, the parsing logic while streaming does not consider the string delimiter. This leads to incorrect strings and somtimes even invalid json during tool usage in applications such as OpenCode.

## Test Plan

Use of OpenCode connected to the [nvidia/Gemma-4-31B-IT-NVFP4](https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4) model hosted with vllm on an H100.

## Test Result

Before fix:

```
> try to write a simple todo using the tool

> invalid [tool=todowrite, error=Invalid input for tool todowrite: JSON parsing failed: Text: {"todos": [{"content": "<|\Demonstrate todowrite tool usage<|\"|", "priority": "<|\medium<|\"|", "status": "<|\"in_progress<|\"}]}.  Error message: JSON Parse error: Invalid escape character D]
```

After fix:

```
> try to write a simple todo using the tool

> Todos                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
   [•] Demonstrate todowrite tool usage 
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

