### PR TITLE
[ROCm][Perf] Add AITER MLA prefill kernel for dense MLA backend

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -464,6 +464,52 @@ def _rocm_aiter_mla_decode_fwd_fake(
     pass
 
 
+def _rocm_aiter_mla_prefill_fwd_impl(
+    q: torch.Tensor,
+    kv_buffer: torch.Tensor,
+    o: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    max_seqlen_qo: int,
+    kv_indptr: torch.Tensor | None = None,
+    kv_indices: torch.Tensor | None = None,
+    kv_last_page_lens: torch.Tensor | None = None,
+    sm_scale: float = 1.0,
+    logit_cap: float = 0.0,
+    num_kv_splits: int | None = None,
+) -> None:
+    from aiter.mla import mla_prefill_fwd
+
+    mla_prefill_fwd(
+        q,
+        kv_buffer.view(-1, 1, 1, q.shape[-1]),
+        o,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_lens,
+        max_seqlen_qo,
+        sm_scale=sm_scale,
+        logit_cap=logit_cap,
+        num_kv_splits=num_kv_splits,
+    )
+
+
+def _rocm_aiter_mla_prefill_fwd_fake(
+    q: torch.Tensor,
+    kv_buffer: torch.Tensor,
+    o: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    max_seqlen_qo: int,
+    kv_indptr: torch.Tensor | None = None,
+    kv_indices: torch.Tensor | None = None,
+    kv_last_page_lens: torch.Tensor | None = None,
+    sm_scale: float = 1.0,
+    logit_cap: float = 0.0,
+    num_kv_splits: int | None = None,
+) -> None:
+    pass
+
+
 def _rocm_aiter_gemm_a8w8_impl(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -1309,6 +1355,13 @@ class rocm_aiter_ops:
             )
 
             direct_register_custom_op(
+                op_name="rocm_aiter_mla_prefill_fwd",
+                op_func=_rocm_aiter_mla_prefill_fwd_impl,
+                mutates_args=["o"],
+                fake_impl=_rocm_aiter_mla_prefill_fwd_fake,
+            )
+
+            direct_register_custom_op(
                 op_name="rocm_aiter_gemm_a8w8",
                 op_func=_rocm_aiter_gemm_a8w8_impl,
                 mutates_args=[],
@@ -1720,6 +1773,34 @@ class rocm_aiter_ops:
             reduce_indptr=reduce_indptr,
             reduce_final_map=reduce_final_map,
             reduce_partial_map=reduce_partial_map,
+        )
+
+    @staticmethod
+    def mla_prefill_fwd(
+        q: torch.Tensor,
+        kv_buffer: torch.Tensor,
+        o: torch.Tensor,
+        sm_scale: float,
+        qo_indptr: torch.Tensor,
+        max_seqlen_qo: int,
+        kv_indptr: torch.Tensor | None = None,
+        kv_indices: torch.Tensor | None = None,
+        kv_last_page_lens: torch.Tensor | None = None,
+        logit_cap: float = 0.0,
+        num_kv_splits: int | None = None,
+    ):
+        torch.ops.vllm.rocm_aiter_mla_prefill_fwd(
+            q,
+            kv_buffer.view(-1, 1, 1, q.shape[-1]),
+            o,
+            qo_indptr,
+            max_seqlen_qo,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_lens,
+            sm_scale=sm_scale,
+            logit_cap=logit_cap,
+            num_kv_splits=num_kv_splits,
         )
 
     @staticmethod

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -9,6 +9,7 @@ import torch
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
+from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonBackend,
     MLACommonDecodeMetadata,
@@ -17,6 +18,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonMetadataBuilder,
     QueryLenSupport,
 )
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backend import (
     AttentionCGSupport,
@@ -25,6 +27,8 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
+
+logger = init_logger(__name__)
 
 
 class AiterMLABackend(MLACommonBackend):
@@ -378,6 +382,146 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         from aiter import flash_attn_varlen_func
 
         self.flash_attn_varlen_func = flash_attn_varlen_func
+        self._absorption_weights_ready = False
+        self._W_UK_T: torch.Tensor | None = None
+        self._W_UV_ctx: torch.Tensor | None = None
+
+    def _ensure_absorption_weights(self) -> None:
+        """Lazily extract W_UK^T and W_UV from kv_b_proj for Q absorption.
+
+        These are the same weights the decode path uses for the MQA approach.
+        We duplicate them here so that the prefill context path can compute
+        attention directly against the paged cache without expanding K/V
+        through kv_b_proj.
+        """
+        if self._absorption_weights_ready:
+            return
+        from vllm.model_executor.layers.quantization.utils.quant_utils import (
+            get_and_maybe_dequant_weights,
+        )
+
+        kv_b_w = get_and_maybe_dequant_weights(
+            self.kv_b_proj, out_dtype=torch.bfloat16
+        ).T.view(
+            self.kv_lora_rank,
+            self.num_heads,
+            self.qk_nope_head_dim + self.v_head_dim,
+        )
+        W_UK = kv_b_w[..., : self.qk_nope_head_dim]
+        W_UV = kv_b_w[..., self.qk_nope_head_dim :]
+        self._W_UK_T = W_UK.permute(1, 2, 0).contiguous()  # [N, P, L]
+        self._W_UV_ctx = W_UV.transpose(0, 1).contiguous()  # [N, L, V]
+        self._absorption_weights_ready = True
+
+    def _compute_prefill_context(
+        self,
+        q: torch.Tensor,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: AiterMLAMetadata,
+        k_scale: torch.Tensor,
+    ):
+        """Use AITER mla_prefill_fwd for context attention.
+
+        Instead of the base class's chunk-by-chunk approach (gather cached KV,
+        expand through kv_b_proj, flash_attn, merge), this computes
+        absorbed-Q attention directly against the paged KV cache in a single
+        assembly kernel call, eliminating the expensive KV expansion.
+        """
+        prefill = attn_metadata.prefill
+        assert prefill is not None
+        ctx = prefill.chunked_context
+        assert ctx is not None
+
+        if prefill.q_data_type == current_platform.fp8_dtype():
+            return super()._compute_prefill_context(
+                q, kv_c_and_k_pe_cache, attn_metadata, k_scale
+            )
+
+        try:
+            from aiter.mla import mla_prefill_fwd
+        except ImportError:
+            return super()._compute_prefill_context(
+                q, kv_c_and_k_pe_cache, attn_metadata, k_scale
+            )
+
+        self._ensure_absorption_weights()
+        assert self._W_UK_T is not None and self._W_UV_ctx is not None
+
+        q_nope = q[..., : self.qk_nope_head_dim]
+        q_pe = q[..., self.qk_nope_head_dim :]
+        T, N, _ = q_nope.shape
+        L = self.kv_lora_rank
+
+        # q_nope: [T, N, P]  W_UK_T: [N, P, L] -> q_absorbed: [T, N, L]
+        q_absorbed = torch.bmm(
+            q_nope.transpose(0, 1), self._W_UK_T
+        ).transpose(0, 1)
+        q_mqa = torch.cat([q_absorbed, q_pe], dim=-1)  # [T, N, L+R]
+
+        iters = len(ctx.seq_tot)
+        batch_size = ctx.cu_seq_lens[0].shape[0] - 1
+        context_lens = torch.zeros(
+            batch_size, dtype=torch.int32, device=q.device
+        )
+        for i in range(iters):
+            cu = ctx.cu_seq_lens[i]
+            context_lens += (cu[1:] - cu[:-1]).int()
+
+        kv_indptr = torch.zeros(
+            batch_size + 1, dtype=torch.int32, device=q.device
+        )
+        torch.cumsum(context_lens, dim=0, out=kv_indptr[1:])
+
+        total_pages = int(kv_indptr[-1].item())
+        if total_pages == 0:
+            output = torch.zeros(
+                T, N, self.v_head_dim, dtype=q.dtype, device=q.device
+            )
+            lse = torch.full(
+                (N, T), float("-inf"), dtype=torch.float32, device=q.device
+            )
+            return output, lse
+
+        page_indices = torch.empty(
+            total_pages, dtype=torch.int32, device=q.device
+        )
+        max_ctx = max(int(context_lens.max().item()), 1)
+        _copy_page_indices_kernel[(batch_size,)](
+            page_indices,
+            prefill.block_table,
+            prefill.block_table.stride(0),
+            kv_indptr,
+            BLOCK_SIZE=triton.next_power_of_2(max_ctx),
+        )
+        kv_last_page_lens = torch.where(
+            context_lens > 0, 1, 0
+        ).int()  # block_size=1
+
+        o_compressed = torch.zeros(
+            T, N, L, dtype=torch.float32, device=q.device
+        )
+        kv_buffer = kv_c_and_k_pe_cache.unsqueeze(2)
+
+        _, attn_lse = mla_prefill_fwd(
+            q_mqa,
+            kv_buffer,
+            o_compressed,
+            prefill.query_start_loc,
+            kv_indptr,
+            page_indices,
+            kv_last_page_lens,
+            prefill.max_query_len,
+            sm_scale=self.scale,
+        )
+
+        output = torch.bmm(
+            o_compressed.to(self._W_UV_ctx.dtype).transpose(0, 1),
+            self._W_UV_ctx,
+        ).transpose(0, 1)
+
+        lse = attn_lse.squeeze(-1).squeeze(1).transpose(0, 1).contiguous()
+
+        return output, lse
 
     def _flash_attn_varlen_diff_headdims(
         self, q, k, v, return_softmax_lse=False, softmax_scale=None, **kwargs


### PR DESCRIPTION
## Summary

Integrate AITER's `mla_prefill_fwd` assembly kernel into vLLM's dense MLA backend (`AiterMLAImpl`), replacing the base class's chunk-by-chunk prefill context path with a single kernel call that avoids expensive KV expansion.

### What this changes

The base class (`MLACommonImpl._compute_prefill_context`) computes context attention by:
1. Gathering cached KV per chunk
2. Expanding through `kv_b_proj` to materialize full K/V heads
3. Running `flash_attn_varlen` per chunk
4. Merging chunk results

This is expensive because `kv_b_proj` expansion materializes `O(context_len * num_heads * head_dim)` intermediate tensors.

The new path instead:
1. **Absorbs Q** through `W_UK^T` (extracted from `kv_b_proj` weights) to produce compressed queries in the latent space `[T, N, L+R]`
2. **Runs `mla_prefill_fwd`** directly against the paged KV cache in a single assembly kernel call — no KV expansion needed
3. **Projects output** through `W_UV` to recover full V dimensions

This eliminates the per-chunk KV expansion loop and replaces it with a single kernel dispatch.

### Fallback behavior

- **FP8 prefill**: Falls back to base class (AITER `mla_prefill_fwd` does not yet accept `q_scale`/`kv_scale`)
- **AITER unavailable**: Falls back to base class via `ImportError` guard

### Part of the GLM-5 on ROCm performance series

This PR is part of a series of optimizations to bring GLM-5 inference on ROCm (MI355X) closer to ATOM performance:

| PR | Description | Status |
|---|---|---|
| #38665 | Dual-stream shared experts + Quark MXFP4 + GLM-5-FP8 weight loading fix | Open |
| #36855 | Sparse MLA head repeat for < 16 heads + FP8 KV cache support | Open |
| **This PR** | MLA prefill kernel integration (eliminates KV expansion) | **New** |

Related upstream:
- [ROCm/aiter#2563](https://github.com/ROCm/aiter/issues/2563) — AITER sparse MLA ZeroDivisionError with < 16 heads
- [ROCm/aiter#2577](https://github.com/ROCm/aiter/pull/2577) — AITER MLA decode nhead < 16 pad-to-16 support

### Context

Reference: [ATOM GLM-5 recipe](https://github.com/ROCm/ATOM/blob/main/recipes/GLM-5.md)

AI assistance (Claude) was used. The submitting human has reviewed all changed lines.

**Not duplicating existing PRs**: No existing vLLM PR integrates `mla_prefill_fwd` for the dense MLA backend.

## Test plan

- [ ] Serve DeepSeek-V3 / GLM-5 on MI355X (TP=8) and verify prefill context path uses AITER kernel (check logs)
- [ ] Compare prefill throughput with and without this change
- [ ] Verify FP8 prefill falls back correctly to base class
- [ ] Verify CUDA path is unaffected (AITER import guard)
