### PR TITLE
[Superseded] MLA kv_cache_dtype compatibility mapping

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -364,6 +364,10 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
 
         # Initialize KV cache quantization attributes
+        # C++ concat_and_cache_mla only understands "auto" and "fp8" variants;
+        # map bfloat16/float16 to "auto" so the op dispatches correctly.
+        if kv_cache_dtype in ("bfloat16", "float16"):
+            kv_cache_dtype = "auto"
         self.kv_cache_dtype = kv_cache_dtype
         self.calculate_kv_scales = calculate_kv_scales
         _init_kv_cache_quant(self, quant_config, prefix)

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -863,12 +863,16 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
             return
         from vllm import _custom_ops as ops
 
+        # C++ op only understands "auto" and "fp8" variants
+        effective_dtype = kv_cache_dtype
+        if kv_cache_dtype in ('bfloat16', 'float16'):
+            effective_dtype = 'auto'
         ops.concat_and_cache_mla(
             kv_c_normed,
             k_pe.squeeze(1),
             kv_cache,
             slot_mapping.flatten(),
-            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_dtype=effective_dtype,
             scale=k_scale,
         )
 
@@ -930,12 +934,16 @@ class SparseMLAAttentionImpl(AttentionImplBase[T], Generic[T]):
             return
         from vllm import _custom_ops as ops
 
+        # C++ op only understands "auto" and "fp8" variants
+        effective_dtype = kv_cache_dtype
+        if kv_cache_dtype in ('bfloat16', 'float16'):
+            effective_dtype = 'auto'
         ops.concat_and_cache_mla(
             kv_c_normed,
             k_pe.squeeze(1),
             kv_cache,
             slot_mapping.flatten(),
-            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_dtype=effective_dtype,
             scale=k_scale,
         )
 


### PR DESCRIPTION
Superseded by #39635 and tracked in #37113.

This standalone compatibility PR is no longer the canonical path.