### PR TITLE
fix(gptq): auto-detect v1/v2 zero-point format from actual weights

### DIFF
--- a/vllm/model_executor/layers/quantization/gptq.py
+++ b/vllm/model_executor/layers/quantization/gptq.py
@@ -239,7 +239,18 @@ class GPTQLinearMethod(LinearMethodBase):
         self.quant_config = quant_config
 
         # GPTQ v1 and v2 format deals with zero points differently
-        self.use_v2_format = quant_config.checkpoint_format == "gptq_v2"
+        # GPTQ v1 stores zero_point - 1 (e.g., 7 for symmetric 4-bit),
+        # and the kernel adds +1 during dequantization.
+        # GPTQ v2 stores the actual zero_point (e.g., 8 for symmetric 4-bit),
+        # and the kernel uses it directly.
+        # Some quantizers (e.g., GPTQModel v5+) set checkpoint_format="gptq"
+        # but store v2-style zeros. Auto-detect from actual zero values
+        # in process_weights_after_loading() if not explicitly set.
+        if quant_config.checkpoint_format == "gptq_v2":
+            self.use_v2_format = True
+        else:
+            # Will be auto-detected after weights are loaded
+            self.use_v2_format = None
 
     def create_weights(
         self,
@@ -355,6 +366,19 @@ class GPTQLinearMethod(LinearMethodBase):
         layer.exllama_state = exllama_state
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Auto-detect v1/v2 format from actual zero-point values
+        # if not explicitly set via checkpoint_format
+        if self.use_v2_format is None:
+            qzeros = layer.qzeros.data
+            if qzeros.numel() > 0:
+                # Extract first zero-point value
+                first_packed = qzeros.view(-1)[0].item()
+                first_zero = first_packed & ((1 << self.quant_config.weight_bits) - 1)
+                expected_v2_zero = 1 << (self.quant_config.weight_bits - 1)  # e.g., 8 for 4-bit
+                self.use_v2_format = (first_zero == expected_v2_zero)
+            else:
+                self.use_v2_format = False
+
         # for torch.compile
         layer.qzeros = Parameter(layer.qzeros.data, requires_grad=False)
         layer.qweight = Parameter(layer.qweight.data, requires_grad=False)


### PR DESCRIPTION
## Summary
- Auto-detect GPTQ v1/v2 zero-point format from actual weight values instead of relying solely on `checkpoint_format` field
- Fixes incorrect dequantization for models that store v2-style zeros without setting `checkpoint_format="gptq_v2"`
- 1 file changed, 25 insertions, 1 deletion

## Problem
Some GPTQ quantizers (e.g., GPTQModel v5+) produce checkpoints with `checkpoint_format="gptq"` but store **v2-style** zero points (actual zero value, e.g., 8 for symmetric 4-bit). vLLM only recognizes the explicit `"gptq_v2"` string as v2 format.

This causes a zero-point off-by-one error in `gptq_gemm`:
- **v1**: `dequant = (w_int - (stored_zero + 1)) * scale` → expects stored_zero=7
- **v2**: `dequant = (w_int - stored_zero) * scale` → expects stored_zero=8

When a v2 model (zeros=8) is treated as v1, every weight is offset by `scale`, which accumulates through 64 layers and produces garbage output.

### Reproduction
```bash
# Qwen/Qwen3.5-27B-GPTQ-Int4 has zeros=8 but checkpoint_format="gptq" (not "gptq_v2")
# Without this fix: model outputs all token-0 ("!!!...")
# With this fix: correct output
```

## Fix
After weights are loaded, inspect the actual stored zero-point value:
- For symmetric 4-bit: v2 stores `8` (2^3), v1 stores `7` (2^3 - 1)
- This detection is robust regardless of the `checkpoint_format` metadata field

Falls back to `False` (v1) if `checkpoint_format="gptq_v2"` is not set and zeros cannot be inspected.

## Test plan
- [x] `Qwen/Qwen3.5-27B-GPTQ-Int4` (zeros=8): auto-detected as v2, correct output
- [x] `codgician/...GPTQ-int4` (zeros=7): auto-detected as v1, correct output  
- [x] Explicit `checkpoint_format="gptq_v2"`: still works (bypasses auto-detection)
- [x] No regression for standard GPTQ models
