### PR TITLE
[Transformers v5] Fix tokenizer metadata in quantized LoRA tests

### DIFF
--- a/tests/lora/conftest.py
+++ b/tests/lora/conftest.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+import shutil
 import tempfile
 from collections import OrderedDict
 from unittest.mock import MagicMock
@@ -249,8 +251,24 @@ def qwen3_woofing_lora_files():
 
 
 @pytest.fixture(scope="session")
-def tinyllama_lora_files():
-    return snapshot_download(repo_id="jashing/tinyllama-colorist-lora")
+def tinyllama_lora_files(tmp_path_factory):
+    source_dir = snapshot_download(repo_id="jashing/tinyllama-colorist-lora")
+    patched_dir = tmp_path_factory.mktemp("tinyllama-colorist-lora")
+
+    shutil.copytree(source_dir, patched_dir, dirs_exist_ok=True)
+
+    tokenizer_config_path = patched_dir / "tokenizer_config.json"
+    with open(tokenizer_config_path) as f:
+        tokenizer_config = json.load(f)
+
+    # Transformers v5 no longer tolerates the old TinyLlama tokenizer class
+    # metadata used by this public test checkpoint.
+    tokenizer_config["tokenizer_class"] = "PreTrainedTokenizerFast"
+
+    with open(tokenizer_config_path, "w") as f:
+        json.dump(tokenizer_config, f)
+
+    return str(patched_dir)
 
 
 @pytest.fixture(scope="session")

--- a/tests/lora/test_quant_model.py
+++ b/tests/lora/test_quant_model.py
@@ -143,6 +143,7 @@ def test_quant_model_tp_equality(tinyllama_lora_files, num_gpus_available, model
         quantization=model.quantization,
         trust_remote_code=True,
         enable_chunked_prefill=True,
+        tokenizer=tinyllama_lora_files,
     )
     output_tp1 = do_sample(llm_tp1, tinyllama_lora_files, lora_id=1)
 
@@ -157,7 +158,9 @@ def test_quant_model_tp_equality(tinyllama_lora_files, num_gpus_available, model
         tensor_parallel_size=2,
         gpu_memory_utilization=0.2,  # avoid OOM
         quantization=model.quantization,
+        trust_remote_code=True,
         enable_chunked_prefill=True,
+        tokenizer=tinyllama_lora_files,
     )
     output_tp2 = do_sample(llm_tp2, tinyllama_lora_files, lora_id=1)
 


### PR DESCRIPTION

## Purpose
Fix the Transformers v5 regression in `tests/lora/test_quant_model.py` caused by incorrect `tokenizer_config.json` metadata in the TinyLlama LoRA test checkpoint.

Related Issue: https://github.com/vllm-project/vllm/issues/38386

## Test Plan
```shell
python -m pytest tests/lora/test_quant_model.py::test_quant_model_lora -v
```
## Test Result
Pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

