### PR TITLE
[BUILD] Enable compile_commands export for Ninja builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -304,11 +304,14 @@ class cmake_build_ext(build_ext):
                 "-DCMAKE_JOB_POOLS:STRING=compile={}".format(num_jobs),
                 "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
             ]
-            src = Path(self.build_temp) / "compile_commands.json"
-            dst = src.parent.parent / src.name
-            if dst.is_symlink() or dst.exists():
-                dst.unlink()
-            dst.symlink_to(src.resolve())
+            try:
+                src = Path(self.build_temp) / "compile_commands.json"
+                dst = src.parent.parent / src.name
+                if dst.is_symlink() or dst.exists():
+                    dst.unlink()
+                dst.symlink_to(src.resolve())
+            except Exception as e:
+                logger.warning("Failed to symlink compile_commands.json: %s", e)
         else:
             # Default build tool to whatever cmake picks.
             build_tool = []

--- a/setup.py
+++ b/setup.py
@@ -305,8 +305,9 @@ class cmake_build_ext(build_ext):
                 "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
             ]
             try:
-                src = Path(self.build_temp) / "compile_commands.json"
-                dst = src.parent.parent / src.name
+                build_temp = ROOT_DIR / self.build_temp
+                src = build_temp / "compile_commands.json"
+                dst = build_temp.parent / src.name
                 if dst.is_symlink() or dst.exists():
                     dst.unlink()
                 dst.symlink_to(src.resolve())

--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,13 @@ class cmake_build_ext(build_ext):
             cmake_args += [
                 "-DCMAKE_JOB_POOL_COMPILE:STRING=compile",
                 "-DCMAKE_JOB_POOLS:STRING=compile={}".format(num_jobs),
+                "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
             ]
+            src = Path(self.build_temp) / "compile_commands.json"
+            dst = src.parent.parent / src.name
+            if dst.is_symlink() or dst.exists():
+                dst.unlink()
+            dst.symlink_to(src.resolve())
         else:
             # Default build tool to whatever cmake picks.
             build_tool = []


### PR DESCRIPTION
Enable `CMAKE_EXPORT_COMPILE_COMMANDS=ON` when configuring with Ninja to improve
clangd indexing. This generates a compile_commands.json file containing the full compilation database,
which enables accurate code navigation, auto-completion, and diagnostics in clangd.

After generating compile_commands.json, move it to the build directory so that clangd can locate it.

What is clangd:
https://clangd.llvm.org/