### PR TITLE
[Perf][GDN] Align TMA usage with upstream FLA

### DIFF
--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -155,8 +155,8 @@ is_nvidia_hopper = is_nvidia and (
 use_cuda_graph = is_nvidia and os.environ.get("FLA_USE_CUDA_GRAPH", "0") == "1"
 is_gather_supported = hasattr(triton.language, "gather")
 is_tma_supported = (
-    (is_nvidia and torch.cuda.get_device_capability(0)[0] >= 9)
-    and os.environ.get("FLA_USE_TMA", "0") == "1"
+    is_nvidia_hopper
+    and os.getenv("FLA_USE_TMA", "0") == "1"
     and (
         hasattr(triton.language, "_experimental_make_tensor_descriptor")
         or hasattr(triton.language, "make_tensor_descriptor")

--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -154,9 +154,13 @@ is_nvidia_hopper = is_nvidia and (
 )
 use_cuda_graph = is_nvidia and os.environ.get("FLA_USE_CUDA_GRAPH", "0") == "1"
 is_gather_supported = hasattr(triton.language, "gather")
-is_tma_supported = (is_nvidia and torch.cuda.get_device_capability(0)[0] >= 9) and (
-    hasattr(triton.language, "_experimental_make_tensor_descriptor")
-    or hasattr(triton.language, "make_tensor_descriptor")
+is_tma_supported = (
+    (is_nvidia and torch.cuda.get_device_capability(0)[0] >= 9)
+    and os.environ.get("FLA_USE_TMA", "0") == "1"
+    and (
+        hasattr(triton.language, "_experimental_make_tensor_descriptor")
+        or hasattr(triton.language, "make_tensor_descriptor")
+    )
 )
 
 


### PR DESCRIPTION
## Purpose

Align `is_tma_supported` in vLLM's GDN kernels with upstream FLA behavior: TMA is now disabled by default and requires `FLA_USE_TMA=1` to enable.

vLLM's copy of FLA GDN kernels was forked before [fla-org/flash-linear-attention#607](https://github.com/fla-org/flash-linear-attention/issues/607) / [2eade97](https://github.com/fla-org/flash-linear-attention/commit/2eade97), so `is_tma_supported` is unconditionally `True` on SM90+ (Hopper/Blackwell). Upstream FLA disabled TMA by default because of Triton compiler issues on Blackwell (SM100+) and made it opt-in via `FLA_USE_TMA=1`.

Without this fix, vLLM's GDN prefill kernels (`solve_tril`) take the TMA code path on B200, which is both slower and diverges from the reference FLA implementation.

## Test Results

Hardware: 8xB200

### Kernel microbenchmark (GDN chunked prefill, FLA vs vLLM)

Tested with the script below across all Qwen3.5 head configurations (TP1..TP8) and sequence lengths (1x2048..1x8192, multi-seq, variable-length).

**Before** (TMA enabled on B200): vLLM is **5-20% slower** than FLA in most configurations (up to 1.21x on TP1 large heads).

**After** (TMA disabled): vLLM matches or beats FLA — majority of configs show `<=1.0x` ratio, worst case ~1.06x on a few edge configs.

### e2e serving benchmark (prefill-only, Qwen3.5-397B TP8)

```
vllm serve nvidia/Qwen3.5-397B-A17B-NVFP4 \
  --port 8000 -tp 1 -pp 1 -dp 8 \
  --enable-expert-parallel --language-model-only \
  --reasoning-parser qwen3 --stream-interval 100
```

```
vllm bench serve \
  --backend vllm --model nvidia/Qwen3.5-397B-A17B-NVFP4 \
  --port 8000 --endpoint /v1/completions \
  --dataset-name random --random-input 8192 --random-output 1 \
  --max-concurrency 128 --num-prompt 128 --ignore-eos --temperature 0.0
```

| Metric | Before | After |
|---|---|---|
| Total token throughput (tok/s) | 166,182 | **171,485** (+3.2%) |
| Mean TTFT (ms) | 3,362 | **3,282** (-2.4%) |
| P99 TTFT (ms) | 6,272 | **5,872** (-6.4%) |

<details>
<summary>Kernel microbenchmark: before fix</summary>

```
GPU: NVIDIA B200
Triton cache: /home/aperevedents/.triton/cache (default, fresh: no)
Comparison: fla.ops.gated_delta_rule.chunk.chunk_gated_delta_rule_fwd
         vs vllm.model_executor.layers.fla.ops.chunk.chunk_gated_delta_rule_fwd
Models: Qwen3.5 family, d=128, dtype=fp16

Heads            Seqlens           h_qk  h_v      FLA (ms)     vLLM (ms)  vLLM/FLA
----------------------------------------------------------------------------------
397B/122B TP8    1x8192               2    8      0.362±0.001      0.384±0.001    1.061x -
397B/122B TP8    1x4096               2    8      0.263±0.001      0.259±0.001    0.986x =
397B/122B TP8    1x2048               2    8      0.204±0.001      0.193±0.000    0.945x +
397B/122B TP8    1024x8               2    8      0.229±0.001      0.202±0.001    0.879x +
397B/122B TP8    2048x4               2    8      0.230±0.001      0.219±0.001    0.950x +
397B/122B TP8    6144+2048            2    8      0.320±0.001      0.326±0.001    1.019x =
397B/122B TP8    4096+4096            2    8      0.275±0.001      0.269±0.001    0.977x +
397B/122B TP8    2048+6144            2    8      0.317±0.001      0.326±0.001    1.029x -
397B/122B TP8    1024+7168            2    8      0.342±0.001      0.351±0.001    1.026x -

397B/122B TP4    1x8192               4   16      0.412±0.001      0.474±0.001    1.150x -
397B/122B TP4    1x4096               4   16      0.277±0.001      0.270±0.001    0.974x +
397B/122B TP4    1x2048               4   16      0.216±0.001      0.202±0.000    0.933x +
397B/122B TP4    1024x8               4   16      0.336±0.001      0.338±0.001    1.006x =
397B/122B TP4    2048x4               4   16      0.327±0.001      0.335±0.000    1.024x -
397B/122B TP4    6144+2048            4   16      0.368±0.001      0.420±0.001    1.140x -
397B/122B TP4    4096+4096            4   16      0.324±0.001      0.367±0.001    1.131x -
397B/122B TP4    2048+6144            4   16      0.367±0.001      0.421±0.001    1.147x -
397B/122B TP4    1024+7168            4   16      0.391±0.001      0.445±0.001    1.138x -

397B/122B TP2    1x8192               8   32      0.591±0.001      0.685±0.001    1.159x -
397B/122B TP2    1x4096               8   32      0.326±0.001      0.372±0.001    1.140x -
397B/122B TP2    1x2048               8   32      0.235±0.001      0.225±0.001    0.955x +
397B/122B TP2    1024x8               8   32      0.595±0.001      0.624±0.001    1.048x -
397B/122B TP2    2048x4               8   32      0.601±0.001      0.618±0.001    1.029x -
397B/122B TP2    6144+2048            8   32      0.592±0.001      0.653±0.001    1.103x -
397B/122B TP2    4096+4096            8   32      0.594±0.001      0.618±0.001    1.040x -
397B/122B TP2    2048+6144            8   32      0.594±0.001      0.684±0.001    1.151x -
397B/122B TP2    1024+7168            8   32      0.596±0.001      0.719±0.001    1.207x -

397B/122B TP1    1x8192              16   64      1.010±0.001      1.197±0.001    1.185x -
397B/122B TP1    1x4096              16   64      0.532±0.001      0.618±0.001    1.160x -
397B/122B TP1    1x2048              16   64      0.300±0.001      0.336±0.001    1.122x -
397B/122B TP1    1024x8              16   64      1.018±0.001      1.180±0.001    1.159x -
397B/122B TP1    2048x4              16   64      1.026±0.001      1.199±0.001    1.169x -
397B/122B TP1    6144+2048           16   64      1.009±0.001      1.191±0.001    1.179x -
397B/122B TP1    4096+4096           16   64      1.013±0.001      1.192±0.001    1.177x -
397B/122B TP1    2048+6144           16   64      1.015±0.001      1.194±0.001    1.176x -
397B/122B TP1    1024+7168           16   64      1.017±0.001      1.195±0.001    1.175x -

35B/9B/4B TP1    1x8192              16   32      0.591±0.001      0.685±0.001    1.159x -
35B/9B/4B TP1    1x4096              16   32      0.326±0.001      0.371±0.001    1.138x -
35B/9B/4B TP1    1x2048              16   32      0.232±0.001      0.222±0.001    0.956x +
35B/9B/4B TP1    1024x8              16   32      0.595±0.001      0.624±0.001    1.048x -
35B/9B/4B TP1    2048x4              16   32      0.601±0.001      0.617±0.001    1.028x -
35B/9B/4B TP1    6144+2048           16   32      0.592±0.001      0.652±0.001    1.102x -
35B/9B/4B TP1    4096+4096           16   32      0.594±0.001      0.618±0.001    1.040x -
35B/9B/4B TP1    2048+6144           16   32      0.594±0.001      0.684±0.001    1.150x -
35B/9B/4B TP1    1024+7168           16   32      0.595±0.001      0.719±0.001    1.208x -

27B TP1          1x8192              16   48      0.835±0.001      0.983±0.001    1.176x -
27B TP1          1x4096              16   48      0.455±0.001      0.519±0.001    1.142x -
27B TP1          1x2048              16   48      0.273±0.001      0.282±0.000    1.030x -
27B TP1          1024x8              16   48      0.802±0.001      0.930±0.001    1.159x -
27B TP1          2048x4              16   48      0.790±0.001      0.920±0.001    1.165x -
27B TP1          6144+2048           16   48      0.778±0.001      0.915±0.001    1.176x -
27B TP1          4096+4096           16   48      0.842±0.001      0.982±0.001    1.166x -
27B TP1          2048+6144           16   48      0.839±0.001      0.983±0.001    1.172x -
27B TP1          1024+7168           16   48      0.849±0.001      0.985±0.001    1.159x -

2B/0.8B TP1      1x8192              16   16      0.412±0.001      0.471±0.001    1.144x -
2B/0.8B TP1      1x4096              16   16      0.277±0.001      0.272±0.001    0.981x =
2B/0.8B TP1      1x2048              16   16      0.216±0.001      0.204±0.000    0.947x +
2B/0.8B TP1      1024x8              16   16      0.334±0.001      0.336±0.001    1.006x =
2B/0.8B TP1      2048x4              16   16      0.328±0.001      0.333±0.001    1.014x =
2B/0.8B TP1      6144+2048           16   16      0.367±0.001      0.419±0.001    1.142x -
2B/0.8B TP1      4096+4096           16   16      0.322±0.001      0.366±0.001    1.134x -
2B/0.8B TP1      2048+6144           16   16      0.366±0.001      0.420±0.001    1.145x -
2B/0.8B TP1      1024+7168           16   16      0.391±0.001      0.447±0.001    1.143x -

Sym h32          1x8192              32   32      0.591±0.001      0.685±0.001    1.159x -
Sym h32          1x4096              32   32      0.325±0.001      0.368±0.000    1.135x -
Sym h32          1x2048              32   32      0.231±0.001      0.222±0.001    0.959x +
Sym h32          1024x8              32   32      0.595±0.001      0.625±0.001    1.049x -
Sym h32          2048x4              32   32      0.601±0.001      0.617±0.001    1.026x -
Sym h32          6144+2048           32   32      0.592±0.001      0.652±0.001    1.102x -
Sym h32          4096+4096           32   32      0.594±0.000      0.618±0.001    1.039x -
Sym h32          2048+6144           32   32      0.594±0.001      0.686±0.001    1.155x -
Sym h32          1024+7168           32   32      0.595±0.001      0.719±0.001    1.209x -
```

</details>

<details>
<summary>Kernel microbenchmark: after fix</summary>

```
GPU: NVIDIA B200
Triton cache: /home/aperevedents/.triton/cache (default, fresh: no)
Comparison: fla.ops.gated_delta_rule.chunk.chunk_gated_delta_rule_fwd
         vs vllm.model_executor.layers.fla.ops.chunk.chunk_gated_delta_rule_fwd
Models: Qwen3.5 family, d=128, dtype=fp16

Heads            Seqlens           h_qk  h_v      FLA (ms)     vLLM (ms)  vLLM/FLA
----------------------------------------------------------------------------------
397B/122B TP8    1x8192               2    8      0.367±0.001      0.381±0.001    1.038x -
397B/122B TP8    1x4096               2    8      0.262±0.001      0.256±0.001    0.976x +
397B/122B TP8    1x2048               2    8      0.203±0.001      0.191±0.000    0.939x +
397B/122B TP8    1024x8               2    8      0.232±0.001      0.195±0.001    0.842x +
397B/122B TP8    2048x4               2    8      0.225±0.001      0.215±0.001    0.959x +
397B/122B TP8    6144+2048            2    8      0.319±0.001      0.320±0.001    1.004x =
397B/122B TP8    4096+4096            2    8      0.273±0.001      0.266±0.001    0.976x +
397B/122B TP8    2048+6144            2    8      0.318±0.001      0.317±0.001    0.995x =
397B/122B TP8    1024+7168            2    8      0.340±0.001      0.347±0.001    1.021x -

397B/122B TP4    1x8192               4   16      0.412±0.001      0.427±0.001    1.037x -
397B/122B TP4    1x4096               4   16      0.283±0.001      0.271±0.001    0.956x +
397B/122B TP4    1x2048               4   16      0.217±0.001      0.200±0.000    0.922x +
397B/122B TP4    1024x8               4   16      0.337±0.001      0.290±0.000    0.859x +
397B/122B TP4    2048x4               4   16      0.329±0.001      0.287±0.001    0.874x +
397B/122B TP4    6144+2048            4   16      0.368±0.001      0.372±0.001    1.011x =
397B/122B TP4    4096+4096            4   16      0.324±0.001      0.322±0.001    0.994x =
397B/122B TP4    2048+6144            4   16      0.367±0.001      0.373±0.001    1.015x =
397B/122B TP4    1024+7168            4   16      0.391±0.001      0.399±0.001    1.020x -

397B/122B TP2    1x8192               8   32      0.590±0.001      0.595±0.001    1.009x =
397B/122B TP2    1x4096               8   32      0.327±0.001      0.324±0.001    0.991x =
397B/122B TP2    1x2048               8   32      0.235±0.001      0.215±0.001    0.915x +
397B/122B TP2    1024x8               8   32      0.595±0.000      0.535±0.001    0.900x +
397B/122B TP2    2048x4               8   32      0.601±0.001      0.528±0.001    0.879x +
397B/122B TP2    6144+2048            8   32      0.592±0.001      0.563±0.001    0.950x +
397B/122B TP2    4096+4096            8   32      0.594±0.001      0.528±0.001    0.889x +
397B/122B TP2    2048+6144            8   32      0.594±0.001      0.596±0.001    1.002x =
397B/122B TP2    1024+7168            8   32      0.596±0.001      0.629±0.001    1.056x -

397B/122B TP1    1x8192              16   64      1.010±0.001      1.011±0.001    1.001x =
397B/122B TP1    1x4096              16   64      0.532±0.001      0.528±0.001    0.992x =
397B/122B TP1    1x2048              16   64      0.299±0.001      0.291±0.001    0.972x +
397B/122B TP1    1024x8              16   64      1.018±0.001      0.994±0.001    0.977x +
397B/122B TP1    2048x4              16   64      1.025±0.001      1.014±0.001    0.989x =
397B/122B TP1    6144+2048           16   64      1.009±0.001      1.005±0.001    0.995x =
397B/122B TP1    4096+4096           16   64      1.013±0.001      1.007±0.001    0.994x =
397B/122B TP1    2048+6144           16   64      1.015±0.001      1.009±0.001    0.994x =
397B/122B TP1    1024+7168           16   64      1.015±0.001      1.010±0.001    0.995x =

35B/9B/4B TP1    1x8192              16   32      0.590±0.001      0.595±0.001    1.007x =
35B/9B/4B TP1    1x4096              16   32      0.324±0.001      0.324±0.001    1.001x =
35B/9B/4B TP1    1x2048              16   32      0.232±0.001      0.218±0.001    0.938x +
35B/9B/4B TP1    1024x8              16   32      0.595±0.001      0.535±0.000    0.898x +
35B/9B/4B TP1    2048x4              16   32      0.600±0.001      0.527±0.001    0.878x +
35B/9B/4B TP1    6144+2048           16   32      0.592±0.001      0.563±0.001    0.951x +
35B/9B/4B TP1    4096+4096           16   32      0.594±0.001      0.528±0.001    0.889x +
35B/9B/4B TP1    2048+6144           16   32      0.594±0.001      0.595±0.001    1.002x =
35B/9B/4B TP1    1024+7168           16   32      0.595±0.001      0.630±0.001    1.058x -

27B TP1          1x8192              16   48      0.836±0.001      0.837±0.001    1.000x =
27B TP1          1x4096              16   48      0.454±0.001      0.449±0.001    0.988x =
27B TP1          1x2048              16   48      0.275±0.001      0.256±0.001    0.932x +
27B TP1          1024x8              16   48      0.801±0.001      0.785±0.001    0.980x +
27B TP1          2048x4              16   48      0.790±0.001      0.776±0.001    0.983x =
27B TP1          6144+2048           16   48      0.778±0.001      0.771±0.001    0.991x =
27B TP1          4096+4096           16   48      0.842±0.001      0.836±0.001    0.993x =
27B TP1          2048+6144           16   48      0.839±0.001      0.838±0.001    0.999x =
27B TP1          1024+7168           16   48      0.850±0.001      0.839±0.001    0.987x =

2B/0.8B TP1      1x8192              16   16      0.414±0.001      0.429±0.001    1.038x -
2B/0.8B TP1      1x4096              16   16      0.278±0.001      0.270±0.001    0.972x +
2B/0.8B TP1      1x2048              16   16      0.217±0.001      0.204±0.000    0.944x +
2B/0.8B TP1      1024x8              16   16      0.336±0.001      0.289±0.001    0.862x +
2B/0.8B TP1      2048x4              16   16      0.341±0.001      0.297±0.001    0.869x +
2B/0.8B TP1      6144+2048           16   16      0.379±0.001      0.384±0.001    1.013x =
2B/0.8B TP1      4096+4096           16   16      0.335±0.001      0.332±0.001    0.993x =
2B/0.8B TP1      2048+6144           16   16      0.383±0.001      0.386±0.001    1.007x =
2B/0.8B TP1      1024+7168           16   16      0.406±0.001      0.413±0.001    1.016x =

Sym h32          1x8192              32   32      0.592±0.001      0.598±0.001    1.009x =
Sym h32          1x4096              32   32      0.337±0.001      0.337±0.001    1.001x =
Sym h32          1x2048              32   32      0.248±0.001      0.217±0.001    0.875x +
Sym h32          1024x8              32   32      0.595±0.001      0.535±0.000    0.900x +
Sym h32          2048x4              32   32      0.601±0.000      0.528±0.001    0.879x +
Sym h32          6144+2048           32   32      0.592±0.001      0.564±0.001    0.953x +
Sym h32          4096+4096           32   32      0.594±0.001      0.528±0.000    0.890x +
Sym h32          2048+6144           32   32      0.594±0.001      0.595±0.001    1.002x =
Sym h32          1024+7168           32   32      0.595±0.001      0.630±0.001    1.059x -
```

</details>

<details>
<summary>Benchmark script: gdn_fla_vs_vllm_bench.py</summary>

```python
"""Benchmark: fla.ops.gated_delta_rule.chunk vs vllm's copy of chunk_gated_delta_rule_fwd.

Use ``--fresh-triton-cache`` to point TRITON_CACHE_DIR at a new empty directory
(under ``~/.cache/gdn_fla_vs_vllm_bench/triton/``) before any kernels compile,
so old autotune state does not skew FLA vs vLLM timings.

``--triton-cache-dir PATH`` sets TRITON_CACHE_DIR explicitly (mkdir if needed);
it overrides ``--fresh-triton-cache``.
"""

import argparse
import os
import sys
import tempfile
import types
import math
from pathlib import Path


def _configure_triton_cache_from_argv():
    """Must run before ``import triton``. Returns True iff ``--fresh-triton-cache`` was used."""
    parser = argparse.ArgumentParser(add_help=False)
    parser.add_argument(
        "--fresh-triton-cache",
        action="store_true",
        help="Use a new empty TRITON_CACHE_DIR under ~/.cache/gdn_fla_vs_vllm_bench/triton/",
    )
    parser.add_argument(
        "--triton-cache-dir",
        type=str,
        default=None,
        metavar="PATH",
        help="Set TRITON_CACHE_DIR to PATH (created if missing). Overrides --fresh-triton-cache.",
    )
    args, rest = parser.parse_known_args()
    sys.argv = [sys.argv[0]] + rest

    if args.triton_cache_dir:
        path = Path(args.triton_cache_dir).expanduser().resolve()
        path.mkdir(parents=True, exist_ok=True)
        os.environ["TRITON_CACHE_DIR"] = str(path)
        return False
    if args.fresh_triton_cache:
        base = Path.home() / ".cache" / "gdn_fla_vs_vllm_bench" / "triton"
        base.mkdir(parents=True, exist_ok=True)
        os.environ["TRITON_CACHE_DIR"] = tempfile.mkdtemp(dir=str(base))
        return True
    return False


_TRITON_CLI_FRESH_CACHE = _configure_triton_cache_from_argv()

import torch
import torch.nn.functional as F
import numpy as np
import triton

# Set up triton allocator for vllm's kernels that need runtime scratch memory
class _ScratchBuffer:
    def __init__(self, ptr):
        self._ptr = ptr
    def data_ptr(self):
        return self._ptr

class _TorchAllocator:
    _cache = {}
    def __call__(self, size, alignment, stream):
        key = (size, alignment)
        if key not in self._cache:
            self._cache[key] = torch.empty(size, dtype=torch.uint8, device="cuda")
        return _ScratchBuffer(self._cache[key].data_ptr())
triton.set_allocator(_TorchAllocator())

# Import FLA (upstream)
from fla.ops.gated_delta_rule.chunk import chunk_gated_delta_rule_fwd as fla_fwd

# Import vLLM copy (with mocked vllm deps)
def _import_vllm_fwd():
    import triton as _triton
    import triton.language as _tl
    try:
        import triton.language.extra.libdevice as _tldevice
    except ImportError:
        _tldevice = _tl

    VLLM_ROOT = str(Path(__file__).resolve().parent)
    VLLM_OPS = f"{VLLM_ROOT}/vllm/model_executor/layers/fla/ops"

    vllm_pkg = types.ModuleType("vllm")
    vllm_pkg.__path__ = [VLLM_ROOT + "/vllm"]
    sys.modules["vllm"] = vllm_pkg

    platforms = types.ModuleType("vllm.platforms")
    class _MockPlatform:
        def is_cuda_alike(self):
            return True
        def num_compute_units(self, device_id=0):
            return torch.cuda.get_device_properties(device_id).multi_processor_count
    platforms.current_platform = _MockPlatform()
    sys.modules["vllm.platforms"] = platforms

    triton_utils = types.ModuleType("vllm.triton_utils")
    triton_utils.triton = _triton
    triton_utils.tl = _tl
    triton_utils.tldevice = _tldevice
    triton_utils.HAS_TRITON = True
    triton_utils.LOG2E = 1.4426950408889634
    triton_utils.LOGE2 = 0.6931471805599453
    sys.modules["vllm.triton_utils"] = triton_utils

    vllm_utils = types.ModuleType("vllm.utils")
    vllm_utils.__path__ = [VLLM_ROOT + "/vllm/utils"]
    sys.modules["vllm.utils"] = vllm_utils

    math_utils = types.ModuleType("vllm.utils.math_utils")
    math_utils.cdiv = lambda a, b: -(a // -b)
    math_utils.next_power_of_2 = lambda n: 1 if n < 1 else 1 << (n - 1).bit_length()
    math_utils.RCP_LN2 = 1.4426950216
    sys.modules["vllm.utils.math_utils"] = math_utils

    platform_utils = types.ModuleType("vllm.utils.platform_utils")
    platform_utils.num_compute_units = lambda dev=0: torch.cuda.get_device_properties(dev).multi_processor_count
    sys.modules["vllm.utils.platform_utils"] = platform_utils

    for name, subpath in [
        ("vllm.model_executor", "vllm/model_executor"),
        ("vllm.model_executor.layers", "vllm/model_executor/layers"),
        ("vllm.model_executor.layers.fla", "vllm/model_executor/layers/fla"),
        ("vllm.model_executor.layers.fla.ops", VLLM_OPS),
    ]:
        m = types.ModuleType(name)
        m.__path__ = [VLLM_ROOT + "/" + subpath if not subpath.startswith("/") else subpath]
        sys.modules[name] = m

    from vllm.model_executor.layers.fla.ops.chunk import chunk_gated_delta_rule_fwd
    return chunk_gated_delta_rule_fwd


vllm_fwd = _import_vllm_fwd()

# Benchmark imports
from flashinfer.testing import bench_gpu_time_with_cupti

# Configs
HEAD_CONFIGS = [
    # (h_qk, h_v, d, label)
    ( 2,  8, 128, "397B/122B TP8"),
    ( 4, 16, 128, "397B/122B TP4"),
    ( 8, 32, 128, "397B/122B TP2"),
    (16, 64, 128, "397B/122B TP1"),
    (16, 32, 128, "35B/9B/4B TP1"),
    (16, 48, 128, "27B TP1"),
    (16, 16, 128, "2B/0.8B TP1"),
    (32, 32, 128, "Sym h32"),
]

SEQ_CONFIGS = [
    ((8192,),                                    "1x8192"),
    ((4096,),                                    "1x4096"),
    ((2048,),                                    "1x2048"),
    (tuple(1024 * (i + 1) for i in range(8)),    "1024x8"),
    ((2048, 2048 * 2, 2048 * 3, 8192),           "2048x4"),
    ((1024 * 6, 8192),                           "6144+2048"),
    ((1024 * 4, 8192),                           "4096+4096"),
    ((1024 * 2, 8192),                           "2048+6144"),
    ((1024 * 1, 8192),                           "1024+7168"),
]


def _make_inputs(endpoints, h_qk, h_v, d):
    """FLA and vLLM both expect q, k, v to share the same head count (H=h_v).
    Only FlashInfer's CUDA kernel supports split h_qk != h_v."""
    device = "cuda"
    dtype = torch.float16
    h = h_v
    BT = 64
    N = len(endpoints)
    T = endpoints[-1]
    cu_seqlens = torch.tensor([0] + list(endpoints), dtype=torch.int32, device=device)
    lens = torch.tensor(
        [endpoints[0]] + [endpoints[i] - endpoints[i - 1] for i in range(1, N)],
        dtype=torch.int32,
    )
    n_chunks = (lens + BT - 1) // BT
    chunk_indices = torch.cat([torch.arange(n) for n in n_chunks.tolist()])
    chunk_indices = torch.stack(
        [chunk_indices.eq(0).cumsum(0) - 1, chunk_indices], 1
    ).to(dtype=torch.int32, device=device)
    chunk_offsets = torch.cat(
        [torch.zeros(1, dtype=torch.int32), n_chunks]
    ).cumsum(-1).to(dtype=torch.int32, device=device)
    q = torch.randn((1, T, h, d), dtype=dtype, device=device)
    k = F.normalize(
        torch.randn(1, T, h, d, dtype=torch.float32, device=device), p=2, dim=-1
    ).to(dtype)
    v = torch.randn((1, T, h_v, d), dtype=dtype, device=device)
    g = F.logsigmoid(torch.rand(1, T, h_v, dtype=torch.float32, device=device))
    beta = torch.rand(1, T, h_v, dtype=torch.float32, device=device).sigmoid()
    h0 = torch.randn((N, h_v, d, d), dtype=torch.float32, device=device)
    scale = d ** -0.5
    return q, k, v, g, beta, h0, cu_seqlens, scale, chunk_indices, chunk_offsets


def bench_fla(endpoints, h_qk, h_v, d):
    q, k, v, g, beta, h0, cu_seqlens, _, chunk_indices, _co = _make_inputs(endpoints, h_qk, h_v, d)
    fn = lambda: fla_fwd(q, k, v, g, beta, None, initial_state=h0,
                         output_final_state=True, cu_seqlens=cu_seqlens,
                         chunk_indices=chunk_indices)
    times = bench_gpu_time_with_cupti(
        fn=fn,
        input_args=(),
        dry_run_time_ms=25,
        repeat_time_ms=100,
        cold_l2_cache=True,
        use_cuda_graph=False,
        sleep_after_run=False,
    )
    torch.cuda.empty_cache()
    med = float(np.median(times))
    se = float(np.std(times) / math.sqrt(len(times)))
    return med, se


def bench_vllm(endpoints, h_qk, h_v, d):
    q, k, v, g, beta, h0, cu_seqlens, scale, chunk_indices, chunk_offsets = _make_inputs(endpoints, h_qk, h_v, d)
    fn = lambda: vllm_fwd(q, k, v, g, beta, scale, initial_state=h0,
                          output_final_state=True, cu_seqlens=cu_seqlens,
                          chunk_indices=chunk_indices, chunk_offsets=chunk_offsets)
    times = bench_gpu_time_with_cupti(
        fn=fn,
        input_args=(),
        dry_run_time_ms=25,
        repeat_time_ms=100,
        cold_l2_cache=True,
        use_cuda_graph=False,
        sleep_after_run=False,
    )
    torch.cuda.empty_cache()
    med = float(np.median(times))
    se = float(np.std(times) / math.sqrt(len(times)))
    return med, se


def main():
    gpu_name = torch.cuda.get_device_name(0)
    print(f"\nGPU: {gpu_name}")
    env_cache = os.environ.get("TRITON_CACHE_DIR")
    if env_cache:
        fresh = "yes" if _TRITON_CLI_FRESH_CACHE else "no"
        print(f"Triton cache: {Path(env_cache).resolve()} (fresh: {fresh})")
    else:
        print(f"Triton cache: {Path.home() / '.triton' / 'cache'} (default, fresh: no)")
    print("Comparison: fla.ops.gated_delta_rule.chunk.chunk_gated_delta_rule_fwd")
    print(
        "         vs vllm.model_executor.layers.fla.ops.chunk.chunk_gated_delta_rule_fwd"
    )
    print(f"Models: Qwen3.5 family, d=128, dtype=fp16")
    print()

    hdr = (f"{'Heads':<15s}  {'Seqlens':<16s}  {'h_qk':>4s} {'h_v':>4s}"
           f"  {'FLA (ms)':>12s}  {'vLLM (ms)':>12s}  {'vLLM/FLA':>8s}")
    print(hdr)
    print("-" * len(hdr))

    for h_qk, h_v, d, h_label in HEAD_CONFIGS:
        for endpoints, s_label in SEQ_CONFIGS:
            fla_med, fla_se = bench_fla(endpoints, h_qk, h_v, d)
            vllm_med, vllm_se = bench_vllm(endpoints, h_qk, h_v, d)
            ratio = vllm_med / fla_med if fla_med > 0 else float("inf")
            marker = "=" if abs(ratio - 1.0) < 0.02 else ("+" if ratio < 1.0 else "-")
            print(
                f"{h_label:<15s}  {s_label:<16s}  {h_qk:>4d} {h_v:>4d}"
                f"  {fla_med:>9.3f}±{fla_se:.3f}"
                f"  {vllm_med:>9.3f}±{vllm_se:.3f}"
                f"  {ratio:>7.3f}x {marker}"
            )
        print()


if __name__ == "__main__":
    main()
```

</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>