### PR TITLE
[KV Offload] Add SLRU eviction policy for CPU offloading cache

### DIFF
--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -13,17 +13,19 @@ from vllm.v1.kv_offload.abstract import (
 from vllm.v1.kv_offload.cpu.policies.abstract import BlockStatus, CachePolicy
 from vllm.v1.kv_offload.cpu.policies.arc import ARCCachePolicy
 from vllm.v1.kv_offload.cpu.policies.lru import LRUCachePolicy
+from vllm.v1.kv_offload.cpu.policies.slru import SLRUCachePolicy
 from vllm.v1.kv_offload.mediums import CPULoadStoreSpec
 
 _CACHE_POLICIES: dict[str, type[CachePolicy]] = {
     "lru": LRUCachePolicy,
     "arc": ARCCachePolicy,
+    "slru": SLRUCachePolicy,
 }
 
 
 class CPUOffloadingManager(OffloadingManager):
     """
-    An OffloadingManager with a pluggable CachePolicy (LRU or ARC).
+    An OffloadingManager with a pluggable CachePolicy (LRU, ARC, or SLRU).
 
     The manager owns all shared logic: ref-counting, event emission,
     block pool management, and the prepare_store/complete_store skeletons.
@@ -35,7 +37,7 @@ class CPUOffloadingManager(OffloadingManager):
         self,
         block_size: int,
         num_blocks: int,
-        cache_policy: Literal["lru", "arc"] = "lru",
+        cache_policy: Literal["lru", "arc", "slru"] = "lru",
         enable_events: bool = False,
     ):
         self.block_size: int = block_size

--- a/vllm/v1/kv_offload/cpu/policies/slru.py
+++ b/vllm/v1/kv_offload/cpu/policies/slru.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Segmented LRU (SLRU) cache policy with ghost set.
+
+Splits the cache into two segments:
+  - **Probation**: new blocks land here. Evicted first.
+  - **Protected**: blocks promoted here after a second access. Evicted last.
+
+A bounded *ghost set* remembers block hashes that were previously in the
+protected segment. When a block with a ghost-hit hash is re-inserted,
+it enters protected directly, skipping probation. This accelerates
+cache recovery after transient pressure spikes (e.g., scale-in events
+that temporarily flush the cache with one-time prefixes).
+
+Compared to ARC (also two-segment + ghost):
+  - ARC ghost hits adjust the T1/T2 *ratio* (advisory).
+  - SLRU ghost hits directly *place* the block in protected (prescriptive).
+  This means SLRU recovers faster after cache pressure because returning
+  hot blocks skip the probation phase entirely.
+"""
+
+from collections import OrderedDict
+from collections.abc import Iterable
+
+from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.kv_offload.cpu.policies.abstract import BlockStatus, CachePolicy
+
+_PROTECTED_RATIO = 0.8
+
+
+class SLRUCachePolicy(CachePolicy):
+    """Segmented LRU with ghost set."""
+
+    def __init__(self, cache_capacity: int):
+        self.cache_capacity = cache_capacity
+        self.max_protected = int(cache_capacity * _PROTECTED_RATIO)
+
+        self.probation: OrderedDict[BlockHash, BlockStatus] = OrderedDict()
+        self.protected: OrderedDict[BlockHash, BlockStatus] = OrderedDict()
+        # Ghost set bounded to cache_capacity (same sizing as ARC ghost lists).
+        self.ghost: OrderedDict[BlockHash, None] = OrderedDict()
+
+    def get(self, block_hash: BlockHash) -> BlockStatus | None:
+        return (self.probation.get(block_hash)
+                or self.protected.get(block_hash))
+
+    def insert(self, block_hash: BlockHash, block: BlockStatus) -> None:
+        if block_hash in self.ghost:
+            del self.ghost[block_hash]
+            self.protected[block_hash] = block
+            self._maybe_demote()
+        else:
+            self.probation[block_hash] = block
+
+    def remove(self, block_hash: BlockHash) -> None:
+        if block_hash in self.probation:
+            del self.probation[block_hash]
+        elif block_hash in self.protected:
+            del self.protected[block_hash]
+
+    def touch(self, block_hashes: Iterable[BlockHash]) -> None:
+        for block_hash in reversed(list(block_hashes)):
+            if block_hash in self.probation:
+                block = self.probation[block_hash]
+                if not block.is_ready:
+                    self.probation.move_to_end(block_hash)
+                else:
+                    del self.probation[block_hash]
+                    self.protected[block_hash] = block
+                    self._maybe_demote()
+
+            elif block_hash in self.protected:
+                self.protected.move_to_end(block_hash)
+
+    def evict(
+        self, n: int, protected: set[BlockHash],
+    ) -> list[tuple[BlockHash, BlockStatus]] | None:
+        if n == 0:
+            return []
+
+        candidates: list[tuple[BlockHash, BlockStatus, bool]] = []
+
+        for block_hash, block in self.probation.items():
+            if block.ref_cnt == 0 and block_hash not in protected:
+                candidates.append((block_hash, block, True))
+                if len(candidates) == n:
+                    break
+
+        if len(candidates) < n:
+            for block_hash, block in self.protected.items():
+                if block.ref_cnt == 0 and block_hash not in protected:
+                    candidates.append((block_hash, block, False))
+                    if len(candidates) == n:
+                        break
+
+        if len(candidates) < n:
+            return None
+
+        result: list[tuple[BlockHash, BlockStatus]] = []
+        for block_hash, block, from_probation in candidates:
+            if from_probation:
+                del self.probation[block_hash]
+            else:
+                del self.protected[block_hash]
+                self.ghost[block_hash] = None
+            result.append((block_hash, block))
+
+        # Trim ghost set once after all insertions.
+        while len(self.ghost) > self.cache_capacity:
+            self.ghost.popitem(last=False)
+
+        return result
+
+    def _maybe_demote(self) -> None:
+        """If protected exceeds capacity, demote LRU entries to probation."""
+        while len(self.protected) > self.max_protected:
+            block_hash, block = self.protected.popitem(last=False)
+            self.probation[block_hash] = block


### PR DESCRIPTION
## Purpose

Add Segmented LRU (SLRU) as a third eviction policy option for the CPU offloading cache, alongside LRU and ARC.

SLRU splits the cache into probation and protected segments. New blocks enter probation; blocks accessed a second time are promoted to protected. Eviction always prefers probation, shielding frequently-reused prefixes from being flushed by one-time traffic.

A bounded *ghost set* remembers hashes of recently evicted protected blocks. When the same prefix re-enters the cache, it skips probation and goes directly to protected. This accelerates cache recovery after transient pressure spikes (e.g., scale-in events that temporarily flood the cache with cold prefixes).

Configured via `eviction_policy` in `kv_connector_extra_config`:

```bash
vllm serve model --kv-offloading-size 32 \
  --kv-connector-extra-config '{"eviction_policy": "slru"}'
```

## Test Plan

```bash
python -c "
from vllm.v1.kv_offload.cpu.policies.slru import SLRUCachePolicy
from vllm.v1.kv_offload.cpu.policies.abstract import BlockStatus
from vllm.v1.core.kv_cache_utils import BlockHash

p = SLRUCachePolicy(cache_capacity=100)
for i in range(10):
    b = BlockStatus(block_id=i); b.ref_cnt = 0
    p.insert(BlockHash(f'b{i}'.encode()), b)
p.touch([BlockHash(f'b{i}'.encode()) for i in range(5)])
print(f'probation={len(p.probation)}, protected={len(p.protected)}')
evicted = p.evict(3, set())
print(f'evicted {len(evicted)} from probation')

from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
mgr = CPUOffloadingManager(block_size=16, num_blocks=100, cache_policy='slru')
print('CPUOffloadingManager with slru: OK')
"
```

## Test Result

```
probation=5, protected=5
evicted 3 from probation
CPUOffloadingManager with slru: OK
```