### PR TITLE
[Bugfix][MoE] Fix 6-8% decode regression: prefer multi-stream shared expert overlap

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -110,12 +110,10 @@ class SharedExperts:
         self,
         hidden_states: torch.Tensor,
     ) -> SharedExpertsOrder:
-        if self._has_external_experts and not self._use_dp_chunking:
-            return SharedExpertsOrder.EXTERNAL
-
         if self._quant_method.mk_owns_shared_expert:
             return SharedExpertsOrder.MK_INTERNAL_OVERLAPPED
 
+        # Prefer multi-stream overlap when aux stream is available
         should_run_shared_in_aux_stream = (
             current_platform.is_cuda()
             and not self._use_dp_chunking
@@ -126,8 +124,11 @@ class SharedExperts:
 
         if should_run_shared_in_aux_stream:
             return SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
-        else:
-            return SharedExpertsOrder.NO_OVERLAP
+
+        if self._has_external_experts and not self._use_dp_chunking:
+            return SharedExpertsOrder.EXTERNAL
+
+        return SharedExpertsOrder.NO_OVERLAP
 
     def maybe_sync_shared_experts_stream(
         self,

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -93,27 +93,29 @@ class SharedExperts:
                 )
 
     @property
-    def _has_external_experts(self) -> bool:
+    def _use_external_experts(self) -> bool:
+        if self._use_dp_chunking:
+            return False
+
         # Disable shared expert overlap if:
         #   - we are using eplb with non-default backend, because of correctness issues
         #   - we are using flashinfer with DP, since there nothing to gain
         backend = self._moe_config.moe_parallel_config.all2all_backend
-        return not (
-            (
-                self._moe_config.moe_parallel_config.enable_eplb
-                and backend != "allgather_reducescatter"
-            )
-            or self._moe_config.moe_parallel_config.use_fi_nvl_two_sided_kernels
-        )
+        return (
+            self._moe_config.moe_parallel_config.enable_eplb
+            and backend != "allgather_reducescatter"
+        ) or self._moe_config.moe_parallel_config.use_fi_nvl_two_sided_kernels
 
     def _determine_shared_experts_order(
         self,
         hidden_states: torch.Tensor,
     ) -> SharedExpertsOrder:
+        if self._use_external_experts:
+            return SharedExpertsOrder.EXTERNAL
+
         if self._quant_method.mk_owns_shared_expert:
             return SharedExpertsOrder.MK_INTERNAL_OVERLAPPED
 
-        # Prefer multi-stream overlap when aux stream is available
         should_run_shared_in_aux_stream = (
             current_platform.is_cuda()
             and not self._use_dp_chunking
@@ -124,11 +126,8 @@ class SharedExperts:
 
         if should_run_shared_in_aux_stream:
             return SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
-
-        if self._has_external_experts and not self._use_dp_chunking:
-            return SharedExpertsOrder.EXTERNAL
-
-        return SharedExpertsOrder.NO_OVERLAP
+        else:
+            return SharedExpertsOrder.NO_OVERLAP
 
     def maybe_sync_shared_experts_stream(
         self,


### PR DESCRIPTION
** NOTE (rob): this regression does not impact any official vLLM release **

## Summary

Fix **6-8% decode throughput regression** on MoE models with TP-only configurations (no EP/EPLB), introduced by #35153.

### Root cause

In `SharedExperts._determine_shared_experts_order()`, the `_has_external_experts` check is evaluated **before** the aux-stream overlap check. For TP-only configs, `_has_external_experts` returns `True` (neither EPLB nor flashinfer two-sided kernels are active), so `EXTERNAL` is selected unconditionally. The `MULTI_STREAM_OVERLAPPED` path is never reached, even when an aux CUDA stream is available.

- **EXTERNAL**: shared experts run sequentially **before** routed experts on the main stream
- **MULTI_STREAM_OVERLAPPED**: shared experts run **in parallel** on an aux stream (what 0.18.x did)

### Fix

Reorder the checks: evaluate `MULTI_STREAM_OVERLAPPED` first (when aux stream is available), fall back to `EXTERNAL` only when it's not.

### Benchmark (GLM-5 MoE, 8×RTX PRO 6000 Blackwell, TP=8, C=1, no MTP)

| ctx | Before (EXTERNAL) | After (MULTI_STREAM) | Improvement |
|-----|-------------------|---------------------|-------------|
| 0   | 36.8 tok/s        | **41.8 tok/s**      | **+14%**    |
| 16k | 34.8 tok/s        | **37.8 tok/s**      | **+9%**     |
| 32k | 33.8 tok/s        | **36.8 tok/s**      | **+9%**     |

After the fix, vLLM 0.19.1 is faster than 0.18.1 and matches SGLang (same cutlass MoE backend, no custom allreduce):

| ctx | vLLM 0.19.1 fixed | vLLM 0.18.1 | SGLang (cutlass MoE, no custom AR) |
|-----|-------------------|-------------|-------------------------------------|
| 0   | **41.8**          | 39.8        | 42.6                                |
| 16k | **37.8**          | 37.7        | 37.7                                |
| 32k | **36.8**          | 35.8        | 36.3                                |

cc @bnellnm — this regression was introduced in #35153. The `_has_external_experts` early return prevents aux-stream overlap for all TP-only deployments. Affects any MoE model (DeepSeek-V3, GLM-5, etc.) on multi-GPU TP without EP.

Related: https://github.com/vllm-project/vllm/issues/37113

## Test plan

- [x] Benchmarked GLM-5 TP=8 decode throughput before/after
- [x] Verified FLASHINFER_MLA + FLASHINFER_CUTLASS MoE backends unchanged
- [x] Compared against vLLM 0.18.1 and SGLang baselines
- [ ] Run existing MoE tests to verify no correctness regression