### PR TITLE
[ROCm] Support unlimited sequence lengths via multi-pass reduction

### DIFF
--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -59,17 +59,578 @@ enum class MFMAType {
   Fp4 = 2,
 };
 
-// Forward declaration of merge kernel - defined here so it's available to all architectures
-template <typename scalar_t, typename OUTT, int HEAD_SIZE>
+
+// ============================================================================
+// Arch-independent helpers and free reduce kernel.
+// These are used by all architectures (GFX9/GFX11/GFX12) and must be defined
+// before the arch-specific blocks.
+// ============================================================================
+
+using bit8_t = uint8_t;
+
+template <typename T>
+__device__ __forceinline__ float to_float(const T& inp) {
+  if constexpr (std::is_same<T, _Float16>::value) {
+    return (float)inp;
+  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
+    return __bfloat162float(inp);
+  } else {
+    static_assert(false, "unsupported 16b dtype");
+  }
+}
+
+template <typename T>
+__device__ __forceinline__ T from_float(const float& inp) {
+  if constexpr (std::is_same<T, _Float16>::value) {
+    return (_Float16)inp;
+  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
+    return __float2bfloat16(inp);
+  } else {
+    static_assert(false, "unsupported 16b dtype");
+  }
+}
+
+// Grid: (num_heads, num_seqs).
+// "Free" reduce kernel: runtime head_size (no HEAD_SIZE/NUM_THREADS template params)
+template <typename scalar_t, typename OUTT,
+          int PARTITION_SIZE, int NPAR_LOOPS>
+__global__
+__launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
+    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
+    const float* __restrict__ exp_sums,    // [num_seqs, num_heads, max_num_partitions]
+    const float* __restrict__ max_logits,  // [num_seqs, num_heads, max_num_partitions]
+    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads, max_num_partitions, head_size]
+    const int* __restrict__ seq_lens,      // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset,
+    int head_size) {
+  const auto num_heads = gridDim.x;
+  const auto head_idx = blockIdx.x;
+  const auto seq_idx = blockIdx.y;
+
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
+    return;
+  }
+
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr2 = temp_dst + query_start_off * num_heads * head_size +
+                             static_cast<int64_t>(head_idx) * head_size;
+      if (threadIdx.x < head_size)
+        temp_out_ptr2[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
+  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
+  const auto warpid = threadIdx.x / WARP_SIZE;
+
+  __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
+  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
+
+  if (warpid == 0) {
+    const float* max_logits_ptr = max_logits + partition_offset +
+                                  seq_idx * num_heads * max_num_partitions +
+                                  head_idx * max_num_partitions;
+
+    int valid_partition[NPAR_LOOPS];
+    float reg_max_logit[NPAR_LOOPS];
+    const int last_valid_partition = num_partitions - 1;
+
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const auto partition_no = i * WARP_SIZE + threadIdx.x;
+      valid_partition[i] =
+          (partition_no < num_partitions) ? partition_no : last_valid_partition;
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
+    }
+    float max_logit = reg_max_logit[0];
+  #pragma unroll
+    for (int i = 1; i < NPAR_LOOPS; i++) {
+      max_logit = fmaxf(max_logit, reg_max_logit[i]);
+    }
+  #pragma unroll
+    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
+    }
+
+    const float* exp_sums_ptr2 = exp_sums + partition_offset +
+                                seq_idx * num_heads * max_num_partitions +
+                                head_idx * max_num_partitions;
+
+    float rescaled_exp_sum[NPAR_LOOPS];
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      rescaled_exp_sum[i] = exp_sums_ptr2[valid_partition[i]];
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const auto partition_no = i * WARP_SIZE + threadIdx.x;
+      rescaled_exp_sum[i] *= (partition_no < num_partitions)
+                                 ? expf(reg_max_logit[i] - max_logit)
+                                 : 0.0f;
+    }
+    float global_exp_sum = rescaled_exp_sum[0];
+  #pragma unroll
+    for (int i = 1; i < NPAR_LOOPS; i++) {
+      global_exp_sum += rescaled_exp_sum[i];
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const auto partition_no = i * WARP_SIZE + threadIdx.x;
+      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
+    }
+  #pragma unroll
+    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+      global_exp_sum += __shfl_xor(global_exp_sum, mask);
+    }
+    if (threadIdx.x == 0) {
+      shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
+    }
+  }
+
+  const scalar_t* tmp_out_ptr =
+      tmp_out + seq_idx * num_heads * max_num_partitions * head_size +
+      head_idx * max_num_partitions * head_size +
+      static_cast<int64_t>(partition_offset) * head_size + threadIdx.x;
+  constexpr int MAX_NPAR = 64;
+  scalar_t tmps[MAX_NPAR];
+  const float dzero = 0.0f;
+  #pragma unroll
+  for (int j = 0; j < MAX_NPAR; j++) {
+    tmps[j] = from_float<scalar_t>(dzero);
+  }
+  const int last_partition_offset = (num_partitions - 1) * head_size;
+  const int num_partition_offset = (num_partitions) * head_size;
+  int idx = 0;
+
+  constexpr int JCHUNK = 16;
+
+  for (int p = 0; p < JCHUNK; p++) {
+    const int j = p * head_size;
+    const int lastj_offset =
+        (j < num_partition_offset) ? j : last_partition_offset;
+    tmps[idx] = tmp_out_ptr[lastj_offset];
+    idx++;
+  }
+  __syncthreads();
+
+  if (num_partitions > JCHUNK) {
+    for (int p = JCHUNK; p < 2 * JCHUNK && p < MAX_NPAR; p++) {
+      const int j = p * head_size;
+      const int lastj_offset =
+          (j < num_partition_offset) ? j : last_partition_offset;
+      tmps[idx] = tmp_out_ptr[lastj_offset];
+      idx++;
+    }
+    if (num_partitions > 2 * JCHUNK) {
+      for (int p = 2 * JCHUNK; p < MAX_NPAR; p++) {
+        const int j = p * head_size;
+        const int lastj_offset =
+            (j < num_partition_offset) ? j : last_partition_offset;
+        tmps[idx] = tmp_out_ptr[lastj_offset];
+        idx++;
+      }
+    }
+  }
+
+  // Aggregate tmp_out to out
+  float acc = 0.0f;
+  for (int j = 0; j < JCHUNK; j++) {
+    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+  }
+  if (num_partitions > JCHUNK) {
+    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
+      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+    }
+    if (num_partitions > 2 * JCHUNK) {
+      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
+        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+      }
+    }
+  }
+
+  for (int p = 1; p < NPAR_LOOPS; p++) {
+    if (num_partitions > p * MAX_NPAR) {
+      idx = 0;
+      for (int pp = 0; pp < MAX_NPAR; pp++) {
+        const int j = (p * MAX_NPAR + pp) * head_size;
+        const int lastj_offset =
+            (j < num_partition_offset) ? j : last_partition_offset;
+        tmps[idx] = tmp_out_ptr[lastj_offset];
+        idx++;
+      }
+      for (int j = 0; j < MAX_NPAR; j++) {
+        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
+      }
+    }
+  }
+
+  const float inv_global_exp_sum =
+      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
+  const float out_scale =
+      (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+
+  const int64_t query_start_off = static_cast<int64_t>(
+      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+  OUTT* out_ptr = out + query_start_off * num_heads * head_size +
+                  static_cast<int64_t>(head_idx) * head_size;
+
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr2 = temp_dst + query_start_off * num_heads * head_size +
+                           static_cast<int64_t>(head_idx) * head_size;
+    temp_out_ptr2[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
+  } else {
+    acc *= inv_global_exp_sum;
+    acc *= out_scale;
+    if constexpr (std::is_same<OUTT, bit8_t>::value) {
+      out_ptr[threadIdx.x] =
+          __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                                 vllm::fp8::fp8_type::__default_interpret);
+    } else {
+      out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    }
+  }
+}
+
+// Merge kernel: combines float4 (acc, exp_sum, max_logit, 0) outputs from multiple
+// reduction passes using numerically-stable log-sum-exp across passes.
+// Defined once for all architectures.
+template <typename scalar_t, typename OUTT>
 __global__ void paged_attention_merge_reduce_kernel(
-    OUTT* __restrict__ out,
-    const scalar_t* __restrict__ tmp_out,
-    const int64_t temp_base_offset,
-    const int* __restrict__ seq_lens,
-    const int* __restrict__ query_start_loc_ptr,
+    OUTT* __restrict__ out,           // [num_seqs, num_heads, head_size]
+    const scalar_t* __restrict__ tmp_out, // base pointer
+    const int64_t temp_base_offset,   // byte offset from tmp_out to float4 temp buffer
+    const int* __restrict__ seq_lens, // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr, // [num_seqs+1] or nullptr
     const int num_passes,
     const int num_heads,
-    const float* __restrict__ fp8_out_scale_ptr);
+    const float* __restrict__ fp8_out_scale_ptr,
+    int head_size) {
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX11__) || defined(__HIP__GFX12__)
+  const auto head_idx = blockIdx.x;
+  const auto seq_idx = blockIdx.y;
+
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
+    return;
+  }
+
+  const float4* temps = reinterpret_cast<const float4*>(
+      reinterpret_cast<const char*>(tmp_out) + temp_base_offset);
+
+  const int num_seqs = gridDim.y;
+  const int64_t per_pass_stride = (int64_t)num_seqs * num_heads * head_size;
+  const int64_t seq_head_offset = (int64_t)seq_idx * num_heads * head_size +
+                                  (int64_t)head_idx * head_size + threadIdx.x;
+
+  float true_max_logit = -FLT_MAX;
+  for (int pass = 0; pass < num_passes; ++pass) {
+    true_max_logit = fmaxf(true_max_logit,
+                           temps[(int64_t)pass * per_pass_stride + seq_head_offset].z);
+  }
+
+  float acc = 0.0f;
+  float global_exp_sum = 0.0f;
+  for (int pass = 0; pass < num_passes; ++pass) {
+    const float4 temp = temps[(int64_t)pass * per_pass_stride + seq_head_offset];
+    const float correction = expf(temp.z - true_max_logit);
+    acc            += temp.x * correction;
+    global_exp_sum += temp.y * correction;
+  }
+
+  const int64_t query_start_off = static_cast<int64_t>(
+      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+  OUTT* out_ptr = out + query_start_off * num_heads * head_size +
+                  static_cast<int64_t>(head_idx) * head_size;
+
+  const float inv_global_exp_sum = __fdividef(1.0f, global_exp_sum + 1e-6f);
+  const float out_scale = (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+  acc *= inv_global_exp_sum;
+  acc *= out_scale;
+
+  // fp8 output supported on GFX9 (MI300) and GFX12 (RDNA4); GFX11 support TBD
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
+  if constexpr (std::is_same<OUTT, bit8_t>::value) {
+    out_ptr[threadIdx.x] =
+        __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                               vllm::fp8::fp8_type::__default_interpret);
+  } else {
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+  }
+#else
+  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+#endif
+#endif
+}
+
+// Grid: (num_heads, num_seqs).
+// Single definition for all architectures. GFX9 (MI300) supports MAX_NPAR=64;
+// GFX11/GFX12 use MAX_NPAR=32. fp8 output is supported on GFX9 and GFX12.
+template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
+          int PARTITION_SIZE, int NPAR_LOOPS>
+__global__
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
+    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
+    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
+                                           // max_num_partitions]
+    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
+                                           // max_num_partitions]
+    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
+                                           // max_num_partitions, head_size]
+    const int* __restrict__ seq_lens,      // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX11__) || defined(__HIP__GFX12__)
+  const auto num_heads = gridDim.x;
+  const auto head_idx = blockIdx.x;
+  const auto seq_idx = blockIdx.y;
+
+  // NOTE queries with sequence len > 1 are prefills and taken care by another
+  // kernel.
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
+    return;
+  }
+
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
+    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
+      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
+  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
+  const int warpid = threadIdx.x / WARP_SIZE;
+
+  __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
+  // max num partitions supported is warp_size * NPAR_LOOPS
+  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
+
+  if (warpid == 0) {
+    const float* max_logits_ptr = max_logits + partition_offset +
+                                  seq_idx * num_heads * max_num_partitions +
+                                  head_idx * max_num_partitions;
+
+    // valid partition is the last valid partition in case threadid > num
+    // partitions
+    int valid_partition[NPAR_LOOPS];
+    float reg_max_logit[NPAR_LOOPS];
+    const int last_valid_partition = num_partitions - 1;
+
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const int partition_no = i * WARP_SIZE + threadIdx.x;
+      valid_partition[i] =
+          (partition_no < num_partitions) ? partition_no : last_valid_partition;
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
+    }
+    float max_logit = reg_max_logit[0];
+  #pragma unroll
+    for (int i = 1; i < NPAR_LOOPS; i++) {
+      max_logit = fmaxf(max_logit, reg_max_logit[i]);
+    }
+
+  #pragma unroll
+    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
+    }
+
+    const float* exp_sums_ptr = exp_sums + partition_offset +
+                                seq_idx * num_heads * max_num_partitions +
+                                head_idx * max_num_partitions;
+
+    float rescaled_exp_sum[NPAR_LOOPS];
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      rescaled_exp_sum[i] = exp_sums_ptr[valid_partition[i]];
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const int partition_no = i * WARP_SIZE + threadIdx.x;
+      rescaled_exp_sum[i] *= (partition_no < num_partitions)
+                                 ? expf(reg_max_logit[i] - max_logit)
+                                 : 0.0f;
+    }
+    float global_exp_sum = rescaled_exp_sum[0];
+  #pragma unroll
+    for (int i = 1; i < NPAR_LOOPS; i++) {
+      global_exp_sum += rescaled_exp_sum[i];
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const int partition_no = i * WARP_SIZE + threadIdx.x;
+      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
+    }
+
+  #pragma unroll
+    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+      global_exp_sum += __shfl_xor(global_exp_sum, mask);
+    }
+    if (threadIdx.x == 0) {
+      shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
+    }
+  }  // warpid == 0
+  const scalar_t* tmp_out_ptr =
+      tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
+      head_idx * max_num_partitions * HEAD_SIZE +
+      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
+#if defined(__HIP__GFX9__)
+  constexpr int MAX_NPAR = 64;
+#else
+  constexpr int MAX_NPAR = 32;
+#endif
+  scalar_t tmps[MAX_NPAR];
+  const float dzero = 0.0f;
+  #pragma unroll
+  for (int j = 0; j < MAX_NPAR; j++) {
+    tmps[j] = from_float<scalar_t>(dzero);
+  }
+  const int last_partition_offset = (num_partitions - 1) * HEAD_SIZE;
+  const int num_partition_offset = (num_partitions)*HEAD_SIZE;
+  int idx = 0;
+
+  constexpr int JCHUNK = 16;
+
+  #pragma unroll
+  for (int j = 0; j < JCHUNK * HEAD_SIZE; j += HEAD_SIZE) {
+    // lastj is last valid partition
+    const int lastj_offset =
+        (j < num_partition_offset) ? j : last_partition_offset;
+    tmps[idx] = tmp_out_ptr[lastj_offset];
+    idx++;
+  }
+  __syncthreads();
+
+  if (num_partitions > JCHUNK) {
+  #pragma unroll
+    for (int j = JCHUNK * HEAD_SIZE; j < 2 * JCHUNK * HEAD_SIZE;
+         j += HEAD_SIZE) {
+      const int lastj_offset =
+          (j < num_partition_offset) ? j : last_partition_offset;
+      tmps[idx] = tmp_out_ptr[lastj_offset];
+      idx++;
+    }
+
+    if (num_partitions > 2 * JCHUNK) {
+  #pragma unroll
+      for (int j = 2 * JCHUNK * HEAD_SIZE; j < MAX_NPAR * HEAD_SIZE;
+           j += HEAD_SIZE) {
+        const int lastj_offset =
+            (j < num_partition_offset) ? j : last_partition_offset;
+        tmps[idx] = tmp_out_ptr[lastj_offset];
+        idx++;
+      }
+    }
+  }  // num_partitions > JCHUNK
+
+  // Aggregate tmp_out to out.
+  float acc = 0.0f;
+  #pragma unroll
+  for (int j = 0; j < JCHUNK; j++) {
+    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+  }
+  if (num_partitions > JCHUNK) {
+  #pragma unroll
+    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
+      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+    }
+    if (num_partitions > 2 * JCHUNK) {
+  #pragma unroll
+      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
+        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+      }
+    }
+  }
+
+  for (int p = 1; p < NPAR_LOOPS; p++) {
+    if (num_partitions > p * MAX_NPAR) {
+      idx = 0;
+  #pragma unroll
+      for (int j = p * MAX_NPAR * HEAD_SIZE; j < (p + 1) * MAX_NPAR * HEAD_SIZE;
+           j += HEAD_SIZE) {
+        // lastj is last valid partition
+        const int lastj_offset =
+            (j < num_partition_offset) ? j : last_partition_offset;
+        tmps[idx] = tmp_out_ptr[lastj_offset];
+        idx++;
+      }
+
+  #pragma unroll
+      for (int j = 0; j < MAX_NPAR; j++) {
+        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
+      }
+    }
+  }
+
+  const float inv_global_exp_sum =
+      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
+
+  const int64_t query_start_off = static_cast<int64_t>(
+      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
+                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
+
+  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
+  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
+    temp_out_ptr[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
+    return;
+  } else {
+    acc *= inv_global_exp_sum;
+    acc *= (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+    // fp8 output supported on GFX9 (MI300) and GFX12 (RDNA4); GFX11 support TBD
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
+    if constexpr (std::is_same<OUTT, bit8_t>::value) {
+      out_ptr[threadIdx.x] =
+          __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                                 vllm::fp8::fp8_type::__default_interpret);
+    } else {
+      out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    }
+#else
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+#endif
+  }
+#endif
+}
 
 #if defined(__HIP__GFX9__)
 
@@ -96,7 +657,6 @@ typedef struct _B16x8 {
 
 using _B8x8 = uint2;
 using _B8x4 = int32_t;  // used in builtins
-using bit8_t = uint8_t;
 
 typedef struct _B8x16 {
   _B8x8 xy[2];
@@ -144,28 +704,6 @@ __device__ __forceinline__ floatx4 gcn_mfma16x16x32_instr(const long& inpA,
                                                       cbid, blgp);
   } else {
     static_assert(false, "unsupported 8b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ float to_float(const T& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (float)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __bfloat162float(inp);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ T from_float(const float& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (_Float16)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __float2bfloat16(inp);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
   }
 }
 
@@ -1425,242 +1963,682 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   }  // warpid == 0
 }
 
-// Grid: (num_heads, num_seqs).
-template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
-          int PARTITION_SIZE, int NPAR_LOOPS>
+
+// ============================================================================
+// "Free" kernels: runtime block_size and head_size (no template specialization)
+// Supports head_size up to 256 and arbitrary block_size >= 16.
+// ============================================================================
+
+// Helper: KV register storage that is either a union (shared registers) or
+// separate arrays, selected at compile time by SHARED_KV.
+// NWARPS == TLOOP == VTLOOP; VTLANELOOP == DIVIDE_ROUND_UP(16, 16/sizeof(cache_t)).
+template <bool SHARED_KV, int NWARPS, int VTLANELOOP>
+struct KVRegs {
+  // Default (SHARED_KV=false): separate Klocal + Vlocal, 256 VGPRs at head=256.
+  _B16x8 Klocal[NWARPS][8];
+  _B16x8 Vlocal[NWARPS][4][VTLANELOOP];
+};
+template <int NWARPS, int VTLANELOOP>
+struct KVRegs<true, NWARPS, VTLANELOOP> {
+  // Union: Klocal and Vlocal share the same 128 VGPRs (valid when lifetimes
+  // don't overlap — Klocal is dead before Vlocal is first written).
+  union {
+    _B16x8 Klocal[NWARPS][8];
+    _B16x8 Vlocal[NWARPS][4][VTLANELOOP];
+  };
+};
+
+// grid (num_seqs, num_partitions, num_kv_heads)
+// block (256)
+// clang-format off
+template <typename scalar_t, typename cache_t,
+          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
+          int NUM_THREADS, bool ALIBI_ENABLED, MFMAType MFMA_TYPE,
+          bool SHARED_KV = false>
 __global__
-__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
-    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
-    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
-                                           // max_num_partitions, head_size]
-    const int* __restrict__ seq_lens,      // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
-    const int partition_offset) {
-  const auto num_heads = gridDim.x;
-  const auto head_idx = blockIdx.x;
-  const auto seq_idx = blockIdx.y;
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel(
+    const scalar_t* __restrict__ q,         // [num_seqs, num_heads, head_size]
+    const cache_t* __restrict__ k_cache,    // [num_blocks, num_kv_heads, head_size/x, block_size, x]
+    const cache_t* __restrict__ v_cache,    // [num_blocks, num_kv_heads, head_size, block_size]
+    const int num_kv_heads,
+    const float scale,
+    const int* __restrict__ block_tables,   // [num_seqs, max_num_blocks_per_seq]
+    const int* __restrict__ seq_lens,       // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr,   // [num_seqs]
+    const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes, // [num_heads]
+    const int q_stride,
+    const int kv_block_stride,
+    const int kv_head_stride,
+    float* __restrict__ exp_sums,           // [num_seqs, num_heads, max_num_partitions]
+    float* __restrict__ max_logits,         // [num_seqs, num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,             // [num_seqs, num_heads, max_num_partitions, head_size]
+    OUTT* __restrict__ final_out,           // [num_seqs, num_heads, head_size]
+    int max_ctx_blocks, const float* k_scale, const float* v_scale,
+    int block_size, int head_size, int gqa_ratio) {
+  // clang-format on
 
-  // NOTE queries with sequence len > 1 are prefills and taken care by another
-  // kernel.
-  if (query_start_loc_ptr != nullptr &&
-      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
-    return;
-  }
-
-  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
-  if (seq_len <= 0) {
-    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
-    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
-    if constexpr (std::is_same<OUTT, float4>::value) {
-      const int64_t query_start_off = static_cast<int64_t>(
-          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-      float4* temp_dst = reinterpret_cast<float4*>(
-          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
-      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
-    }
-    return;
-  }
-  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
+  constexpr int NWARPS = NUM_THREADS / WARP_SIZE;
   const auto warpid = threadIdx.x / WARP_SIZE;
+  const auto laneid = threadIdx.x % WARP_SIZE;
+  const int lane4id = laneid % 4;
+  const int lane16id = laneid % 16;
+  const int rowid = laneid / 16;
 
-  __shared__ float shared_global_exp_sum;
-  __shared__ float shared_max_logit;
-  // max num partitions supported is warp_size * NPAR_LOOPS
-  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
-
-  if (warpid == 0) {
-    const float* max_logits_ptr = max_logits + partition_offset +
-                                  seq_idx * num_heads * max_num_partitions +
-                                  head_idx * max_num_partitions;
-
-    // valid partition is the last valid partition in case threadid > num
-    // partitions
-    int valid_partition[NPAR_LOOPS];
-    float reg_max_logit[NPAR_LOOPS];
-    const int last_valid_partition = num_partitions - 1;
-
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const auto partition_no = i * WARP_SIZE + threadIdx.x;
-      valid_partition[i] =
-          (partition_no < num_partitions) ? partition_no : last_valid_partition;
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
-    }
-    float max_logit = reg_max_logit[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      max_logit = fmaxf(max_logit, reg_max_logit[i]);
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
-    }
-
-    const float* exp_sums_ptr = exp_sums + partition_offset +
-                                seq_idx * num_heads * max_num_partitions +
-                                head_idx * max_num_partitions;
-
-    float rescaled_exp_sum[NPAR_LOOPS];
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      rescaled_exp_sum[i] = exp_sums_ptr[valid_partition[i]];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const auto partition_no = i * WARP_SIZE + threadIdx.x;
-      rescaled_exp_sum[i] *= (partition_no < num_partitions)
-                                 ? expf(reg_max_logit[i] - max_logit)
-                                 : 0.0f;
-    }
-    float global_exp_sum = rescaled_exp_sum[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      global_exp_sum += rescaled_exp_sum[i];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const auto partition_no = i * WARP_SIZE + threadIdx.x;
-      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      global_exp_sum += __shfl_xor(global_exp_sum, mask);
-    }
-    if (threadIdx.x == 0) {
-      shared_global_exp_sum = global_exp_sum;
-      shared_max_logit = max_logit;
-    }
-  }  // warpid == 0
-  const scalar_t* tmp_out_ptr =
-      tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE +
-      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
-  constexpr int MAX_NPAR = 64;
-  scalar_t tmps[MAX_NPAR];
-  const float dzero = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < MAX_NPAR; j++) {
-    tmps[j] = from_float<scalar_t>(dzero);
-  }
-  const int last_partition_offset = (num_partitions - 1) * HEAD_SIZE;
-  const int num_partition_offset = (num_partitions)*HEAD_SIZE;
-  int idx = 0;
-
-  constexpr int JCHUNK = 16;
-
-  #pragma unroll
-  for (int j = 0; j < JCHUNK * HEAD_SIZE; j += HEAD_SIZE) {
-    // lastj is last valid partition
-    const int lastj_offset =
-        (j < num_partition_offset) ? j : last_partition_offset;
-    tmps[idx] = tmp_out_ptr[lastj_offset];
-    idx++;
-  }
-  __syncthreads();
-
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK * HEAD_SIZE; j < 2 * JCHUNK * HEAD_SIZE;
-         j += HEAD_SIZE) {
-      const int lastj_offset =
-          (j < num_partition_offset) ? j : last_partition_offset;
-      tmps[idx] = tmp_out_ptr[lastj_offset];
-      idx++;
-    }
-
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK * HEAD_SIZE; j < MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-    }
-  }  // num_partitions > JCHUNK
-
-  // Aggregate tmp_out to out.
-  float acc = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < JCHUNK; j++) {
-    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-  }
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
-      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-    }
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-      }
-    }
+  const auto seq_idx = blockIdx.x;
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx]) != 1) {
+    return;
   }
 
-  for (int p = 1; p < NPAR_LOOPS; p++) {
-    if (num_partitions > p * MAX_NPAR) {
-      idx = 0;
-  #pragma unroll
-      for (int j = p * MAX_NPAR * HEAD_SIZE; j < (p + 1) * MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        // lastj is last valid partition
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-
-  #pragma unroll
-      for (int j = 0; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
-      }
-    }
+  const auto partition_idx = blockIdx.y;
+  constexpr int T_PAR_SIZE = 256;
+  const auto max_num_partitions = gridDim.y;
+  const int seq_len = seq_lens[seq_idx];
+  const int partition_start_token_idx = partition_idx * T_PAR_SIZE;
+  if (partition_start_token_idx >= seq_len) {
+    return;
   }
 
-  const float inv_global_exp_sum =
-      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
-  const float out_scale =
-      (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+  constexpr int ROWS_PER_WARP = WARP_SIZE / 16;
+  constexpr int CONTIGUOUS_KV_ELEMS_16B_LOAD = 16 / sizeof(cache_t);
+  constexpr int QKHE_PER_FETCH = CONTIGUOUS_KV_ELEMS_16B_LOAD * ROWS_PER_WARP;
+  constexpr int QK_SIZE_RATIO = sizeof(scalar_t) / sizeof(cache_t);
+  const int qkheloop = head_size / QKHE_PER_FETCH;
+  // Dynamic shared memory: layout [max(NWARPS,qkheloop)][4][16][4] of _B16x4 (8 bytes).
+  // Size is computed in the launch macro and passed as the third <<<>>> argument.
+  // Aliased as a 4D array pointer so all existing indexing syntax is preserved.
+  extern __shared__ _B16x4 shared_logits_flat[];
+  _B16x4 (*shared_logits)[4][16][4] =
+      reinterpret_cast<_B16x4(*)[4][16][4]>(shared_logits_flat);
 
+  constexpr int MAX_QKHELOOP = 8;  // register array bound; increase for head_size > 256
+
+  // Register arrays: use max sizes, loop with runtime bounds
+  _B16x8 Qlocal[MAX_QKHELOOP][QK_SIZE_RATIO];
+
+  constexpr int CONTIGUOUS_SCALAR_ELEMS_16B = 16 / sizeof(scalar_t);
+  constexpr int TOKENS_PER_WARP = T_PAR_SIZE / NWARPS;
+  constexpr int TLOOP = TOKENS_PER_WARP / 16;
+
+  const auto wg_start_head_idx = blockIdx.z * gqa_ratio;
+  const auto wg_start_kv_head_idx = blockIdx.z;
+  const auto total_num_heads = gridDim.z * gqa_ratio;
+
+  const int num_seq_blocks = DIVIDE_ROUND_UP(seq_len, block_size);
+  const int last_seq_block = num_seq_blocks - 1;
+  const int* block_table_seq = block_tables + seq_idx * max_num_blocks_per_seq;
+
+  int kphysical_block_number[TLOOP];
+#if defined(__HIP__FP8MFMA__)
+  float q_max = 0;
+  float q_scale = 1.0;
+#endif
+
+  // fetch k physical block numbers (runtime block_size)
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int klocal_token_idx =
+        TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int kglobal_token_idx = partition_start_token_idx + klocal_token_idx;
+    const int kblock_idx = (kglobal_token_idx < seq_len)
+                               ? kglobal_token_idx / block_size
+                               : last_seq_block;
+    kphysical_block_number[token_depth] = block_table_seq[kblock_idx];
+  }
+
+  // fetch Q in shared across warps and then write to registers
+  const int local_qhead_idx = 4 * warpid + rowid;
+  const int global_qhead_idx = wg_start_head_idx + local_qhead_idx;
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
-                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
+  const scalar_t* q_ptr =
+      q + query_start_off * q_stride + global_qhead_idx * head_size;
 
-  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
-  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
-  if constexpr (std::is_same<OUTT, float4>::value) {
-    float4* temp_dst = reinterpret_cast<float4*>(
-        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
-    temp_out_ptr[threadIdx.x] =
-        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
-  } else {
-    acc *= inv_global_exp_sum;
-    acc *= out_scale;
-    if constexpr (std::is_same<OUTT, bit8_t>::value) {
-      out_ptr[threadIdx.x] =
-          __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
-                                 vllm::fp8::fp8_type::__default_interpret);
+  const int qhead_element = lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
+  if ((local_qhead_idx < gqa_ratio) && (qhead_element < head_size)) {
+    const scalar_t* q_fetch_ptr = q_ptr + qhead_element;
+    const _B16x8* q_fetch_ptr_16B =
+        reinterpret_cast<const _B16x8*>(q_fetch_ptr);
+    _B16x8 tmp = *q_fetch_ptr_16B;
+    if constexpr (KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto) {
+      const int offset1 = lane16id / 4;
+      shared_logits[offset1][lane4id][local_qhead_idx][0] = tmp.xy[0];
+      shared_logits[offset1][lane4id][local_qhead_idx][1] = tmp.xy[1];
     } else {
-      out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+      for (int i = 0; i < 2; i++) {
+        const int head_elem = lane16id * 2 + i;
+        const int offset3 = head_elem % 4;
+        const int offset2 = (head_elem / 4) % 4;
+        const int offset1 = head_elem / 4 / 4;
+        shared_logits[offset1][offset2][local_qhead_idx][offset3] = tmp.xy[i];
+      }
+    }
+  }
+
+  // For head_size > 128: need second pass to fetch remaining Q elements
+  // First pass covered lane16id 0-15 → elements 0..127
+  // Second pass covers elements 128..head_size-1
+  if (head_size > 128) {
+    __syncthreads();
+    // Read first half of Q into registers
+    for (int qkhe_depth = 0; qkhe_depth < 4; qkhe_depth++) {
+      for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+        for (int i = 0; i < 2; i++) {
+          Qlocal[qkhe_depth][qkratio].xy[i] =
+              shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio]
+                           [2 * qkratio + i];
+#if defined(__HIP__FP8MFMA__)
+          if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto &&
+                        MFMA_TYPE == MFMAType::Fp8) {
+            scalar_t* qptr =
+                reinterpret_cast<scalar_t*>(&Qlocal[qkhe_depth][qkratio].xy[i]);
+            for (int k = 0; k < 4; k++)
+              q_max = fmax(fabs(to_float<scalar_t>(qptr[k])), q_max);
+          }
+#endif
+        }
+      }
+    }
+    __syncthreads();
+
+    // Second Q fetch: elements 128..255
+    const int qhead_element2 = 128 + lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
+    if ((local_qhead_idx < gqa_ratio) && (qhead_element2 < head_size)) {
+      const scalar_t* q_fetch_ptr2 = q_ptr + qhead_element2;
+      const _B16x8* q_fetch_ptr_16B2 =
+          reinterpret_cast<const _B16x8*>(q_fetch_ptr2);
+      _B16x8 tmp2 = *q_fetch_ptr_16B2;
+      if constexpr (KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto) {
+        const int offset1 = lane16id / 4;
+        shared_logits[offset1][lane4id][local_qhead_idx][0] = tmp2.xy[0];
+        shared_logits[offset1][lane4id][local_qhead_idx][1] = tmp2.xy[1];
+      } else {
+        for (int i = 0; i < 2; i++) {
+          const int head_elem = lane16id * 2 + i;
+          const int offset3 = head_elem % 4;
+          const int offset2 = (head_elem / 4) % 4;
+          const int offset1 = head_elem / 4 / 4;
+          shared_logits[offset1][offset2][local_qhead_idx][offset3] = tmp2.xy[i];
+        }
+      }
+    }
+    __syncthreads();
+
+    // Read second half of Q into registers (qkhe_depth 4..7)
+    for (int qkhe_depth = 4; qkhe_depth < qkheloop; qkhe_depth++) {
+      for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+        for (int i = 0; i < 2; i++) {
+          Qlocal[qkhe_depth][qkratio].xy[i] =
+              shared_logits[qkhe_depth - 4][rowid][lane16id % gqa_ratio]
+                           [2 * qkratio + i];
+#if defined(__HIP__FP8MFMA__)
+          if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto &&
+                        MFMA_TYPE == MFMAType::Fp8) {
+            scalar_t* qptr =
+                reinterpret_cast<scalar_t*>(&Qlocal[qkhe_depth][qkratio].xy[i]);
+            for (int k = 0; k < 4; k++)
+              q_max = fmax(fabs(to_float<scalar_t>(qptr[k])), q_max);
+          }
+#endif
+        }
+      }
+    }
+  } else {
+    // head_size <= 128: single pass (original path)
+    __syncthreads();
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+        for (int i = 0; i < 2; i++) {
+          Qlocal[qkhe_depth][qkratio].xy[i] =
+              shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio]
+                           [2 * qkratio + i];
+#if defined(__HIP__FP8MFMA__)
+          if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto &&
+                        MFMA_TYPE == MFMAType::Fp8) {
+            scalar_t* qptr =
+                reinterpret_cast<scalar_t*>(&Qlocal[qkhe_depth][qkratio].xy[i]);
+            for (int k = 0; k < 4; k++)
+              q_max = fmax(fabs(to_float<scalar_t>(qptr[k])), q_max);
+          }
+#endif
+        }
+      }
+    }
+  }
+
+  constexpr int KX = 16 / sizeof(cache_t);
+  const cache_t* k_ptr = k_cache + wg_start_kv_head_idx * kv_head_stride;
+  const int row_head_elem = rowid * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+
+  // V-related constants (runtime head_size for vheloop)
+  constexpr int VTOKENS_PER_LANE = TOKENS_PER_WARP / ROWS_PER_WARP;
+  constexpr int VBLOCKS_PER_LANE = 1;  // assumes block_size >= 16
+  constexpr int VTLOOP = NWARPS;
+  constexpr int VTLANELOOP = DIVIDE_ROUND_UP(
+      VTOKENS_PER_LANE, CONTIGUOUS_KV_ELEMS_16B_LOAD);
+  const int vheloop = head_size / 16 / NWARPS;
+  constexpr int MAX_VHELOOP = 4;  // supports head_size up to 256
+
+
+  KVRegs<SHARED_KV, NWARPS, VTLANELOOP> _kv;
+  auto& Klocal = _kv.Klocal;
+  auto& Vlocal = _kv.Vlocal;
+
+  // fetch K values (runtime block_size for block offset)
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int64_t kblock_number =
+        static_cast<int64_t>(kphysical_block_number[token_depth]);
+    const cache_t* k_ptr2 = k_ptr + kblock_number * kv_block_stride;
+    const int klocal_token_idx =
+        TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int kphysical_block_offset = klocal_token_idx % block_size;
+    const cache_t* k_ptr3 = k_ptr2 + kphysical_block_offset * KX;
+
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      const int head_elem = row_head_elem + qkhe_depth * QKHE_PER_FETCH;
+      const int offset1 = head_elem / KX;
+      const int offset2 = head_elem % KX;
+      const cache_t* k_fetch_ptr =
+          k_ptr3 + offset1 * block_size * KX + offset2;
+      const _B16x8* k_fetch_ptr_16B =
+          reinterpret_cast<const _B16x8*>(k_fetch_ptr);
+      Klocal[token_depth][qkhe_depth] = *k_fetch_ptr_16B;
+    }
+  }
+
+  float alibi_slope;
+  if constexpr (ALIBI_ENABLED) {
+    const int alibi_head_idx = wg_start_head_idx + lane16id;
+    alibi_slope = (lane16id < gqa_ratio) ? alibi_slopes[alibi_head_idx] : 0.f;
+  }
+
+  int vphysical_block_number[VTLOOP][VBLOCKS_PER_LANE];
+
+  // fetch v physical block numbers (runtime block_size)
+  for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+    for (int vblock_depth = 0; vblock_depth < VBLOCKS_PER_LANE;
+         vblock_depth++) {
+      const int vlocal_token_idx =
+          vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
+          rowid * VTOKENS_PER_LANE + vblock_depth * block_size;
+      const int vglobal_token_idx =
+          partition_start_token_idx + vlocal_token_idx;
+      const int vblock_idx = (vglobal_token_idx < seq_len)
+                                 ? vglobal_token_idx / block_size
+                                 : last_seq_block;
+      vphysical_block_number[vtoken_depth][vblock_depth] =
+          block_table_seq[vblock_idx];
+    }
+  }
+
+
+  const cache_t* v_ptr = v_cache + wg_start_kv_head_idx * kv_head_stride +
+                         ((rowid * VTOKENS_PER_LANE) % block_size);
+
+  auto fetchV = [&]() {
+    // fetch V values (runtime head_size for vheloop, runtime block_size for addressing)
+    for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+      const int vhead_elem = vhe_depth * NWARPS * 16 + warpid * 16 + lane16id;
+      const cache_t* v_ptr2 = v_ptr + vhead_elem * block_size;
+
+      for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+        for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+          const int vblock_depth = 0;
+          const int64_t vblock_number = static_cast<int64_t>(
+              vphysical_block_number[vtoken_depth][vblock_depth]);
+          const cache_t* v_ptr3 = v_ptr2 + (vblock_number * kv_block_stride);
+          const cache_t* v_fetch_ptr =
+              v_ptr3 + vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+          const _B16x8* v_fetch_ptr_16B =
+              reinterpret_cast<const _B16x8*>(v_fetch_ptr);
+          Vlocal[vtoken_depth][vhe_depth][vfetch_depth] = *v_fetch_ptr_16B;
+        }
+      }
+    }
+  };
+  if constexpr (!SHARED_KV) fetchV();
+
+  // calculate post qk mfma scale
+  float scale2 = scale;
+  if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto) {
+    scale2 *= *k_scale;
+#if defined(__HIP__FP8MFMA__)
+    q_max = warpReduceMax(q_max);
+    constexpr float FP8_E4M3_SCALE_TARGET = 224.0f;
+    if constexpr (MFMA_TYPE == MFMAType::Fp8) {
+      q_scale = q_max > 0 ? FP8_E4M3_SCALE_TARGET / q_max : 1.0f;
+      scale2 /= q_scale;
+    }
+#endif
+  }
+
+  floatx4 d_out[TLOOP];
+  // QK MFMA (runtime qkheloop)
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    d_out[token_depth] = {0};
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      if constexpr (KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto) {
+        for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+          for (int i = 0; i < 2; i++) {
+            d_out[token_depth] = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                Klocal[token_depth][qkhe_depth].xy[i],
+                Qlocal[qkhe_depth][qkratio].xy[i], d_out[token_depth]);
+          }
+        }
+      } else {
+        auto Ktmp = Klocal[token_depth][qkhe_depth];
+        _B8x16 Ktmp8x16 = *reinterpret_cast<_B8x16*>(&Ktmp);
+        for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+          if constexpr (MFMA_TYPE == MFMAType::F16) {
+            _B8x8 Ktmp8x8 = Ktmp8x16.xy[qkratio];
+            _B16x8 Klocaltmp = convert_b8x8_custom<scalar_t>(Ktmp8x8);
+            for (int i = 0; i < 2; i++) {
+              d_out[token_depth] = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                  Klocaltmp.xy[i], Qlocal[qkhe_depth][qkratio].xy[i],
+                  d_out[token_depth]);
+            }
+          } else {
+#if defined(__HIP__FP8MFMA__)
+            _T8x8 Ktmp8x8, Qtmp8x8;
+            Ktmp8x8.b8x8 = Ktmp8x16.xy[qkratio];
+            for (int n = 0; n < 2; n++) {
+              scalar_t* qptr = reinterpret_cast<scalar_t*>(
+                  &Qlocal[qkhe_depth][qkratio].xy[n]);
+              Qtmp8x8.b16x4[n * 2] =
+                  vllm::fp8::scaled_vec_conversion<uint16_t, float2>(
+                      make_float2(to_float<scalar_t>(qptr[0]),
+                                  to_float<scalar_t>(qptr[1])),
+                      q_scale);
+              Qtmp8x8.b16x4[n * 2 + 1] =
+                  vllm::fp8::scaled_vec_conversion<uint16_t, float2>(
+                      make_float2(to_float<scalar_t>(qptr[2]),
+                                  to_float<scalar_t>(qptr[3])),
+                      q_scale);
+            }
+            d_out[token_depth] =
+                gcn_mfma16x16x32_instr<__hip_fp8_e4m3, 0, 0, 0>(
+                    Ktmp8x8.i64, Qtmp8x8.i64, d_out[token_depth]);
+#else
+            UNREACHABLE_CODE
+#endif
+          }
+        }
+      }
+    }
+    d_out[token_depth] *= scale2;
+  }
+
+  if constexpr (SHARED_KV) fetchV();
+
+  const int qkout_token_idx =
+      partition_start_token_idx + TOKENS_PER_WARP * warpid + rowid * 4;
+
+  if constexpr (ALIBI_ENABLED) {
+    for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+      const int local_token_idx = qkout_token_idx + token_depth * 16;
+      const int alibi_offset = local_token_idx - seq_len + 1;
+      for (int i = 0; i < 4; i++) {
+        d_out[token_depth][i] += alibi_slope * (alibi_offset + i);
+      }
+    }
+  }
+
+  // Online softmax: calculate qk_max and exp_sum per warp
+  float qk_max = -FLT_MAX;
+  float exp_sum = 0.0f;
+
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int local_token_idx = qkout_token_idx + token_depth * 16;
+    for (int i = 0; i < 4; i++) {
+      const float tmp =
+          (local_token_idx + i < seq_len) ? d_out[token_depth][i] : -FLT_MAX;
+      qk_max = fmaxf(qk_max, tmp);
+    }
+  }
+
+  for (int mask = WARP_SIZE / 2; mask >= 16; mask /= 2) {
+    qk_max = fmaxf(qk_max, __shfl_xor(qk_max, mask));
+  }
+
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int local_token_idx = qkout_token_idx + token_depth * 16;
+    for (int i = 0; i < 4; i++) {
+      const float tmp = (local_token_idx + i < seq_len)
+                            ? __expf(d_out[token_depth][i] - qk_max)
+                            : 0.0f;
+      d_out[token_depth][i] = tmp;
+      exp_sum += tmp;
+    }
+  }
+
+  for (int mask = WARP_SIZE / 2; mask >= 16; mask /= 2) {
+    exp_sum += __shfl_xor(exp_sum, mask);
+  }
+
+  __syncthreads();
+
+  float* shared_mem = reinterpret_cast<float*>(shared_logits);
+  if (laneid < 16) {
+    const int qk_max_offset = warpid * 16 + lane16id;
+    shared_mem[qk_max_offset] = qk_max;
+    const int exp_sum_offset = NWARPS * 16 + qk_max_offset;
+    shared_mem[exp_sum_offset] = exp_sum;
+  }
+
+  __syncthreads();
+
+  // Partition-level qk_max and exp_sum
+  float partition_qk_max = -FLT_MAX;
+  float warp_qk_max_exp[NWARPS];
+  float partition_exp_sum = 0.0f;
+
+  for (int w = 0; w < NWARPS; w++) {
+    warp_qk_max_exp[w] = shared_mem[w * 16 + lane16id];
+    partition_qk_max = fmaxf(partition_qk_max, warp_qk_max_exp[w]);
+  }
+
+  for (int w = 0; w < NWARPS; w++) {
+    warp_qk_max_exp[w] = __expf(warp_qk_max_exp[w] - partition_qk_max);
+    partition_exp_sum +=
+        shared_mem[NWARPS * 16 + w * 16 + lane16id] * warp_qk_max_exp[w];
+  }
+
+  const float inv_sum_scale =
+      __fdividef(1.f, partition_exp_sum + 1e-6f) * warp_qk_max_exp[warpid];
+
+  __syncthreads();
+
+  constexpr bool LOGITS_RTZ_CONVERSION = false;
+#if defined(__HIP__FP8MFMA__)
+  int rowid_8x8 = rowid / 2;
+  int offset = rowid % 2;
+#endif
+
+  // Write logits to shared mem
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    d_out[token_depth] *= inv_sum_scale;
+    if constexpr (MFMA_TYPE != MFMAType::Fp8) {
+      if constexpr (LOGITS_RTZ_CONVERSION) {
+        shared_logits[warpid][token_depth][lane16id][rowid] =
+            from_floatx4_rtz<scalar_t>(d_out[token_depth]);
+      } else {
+        shared_logits[warpid][token_depth][lane16id][rowid] =
+            from_floatx4<scalar_t>(d_out[token_depth]);
+      }
+    } else {
+#if defined(__HIP__FP8MFMA__)
+      _T8x8& logits_8x8 = *reinterpret_cast<_T8x8*>(
+          &shared_logits[warpid][token_depth][lane16id][rowid_8x8]);
+      logits_8x8.b16x4[offset * 2] = __builtin_amdgcn_cvt_pk_fp8_f32(
+          d_out[token_depth][0], d_out[token_depth][1], 0, false);
+      logits_8x8.b16x4[offset * 2 + 1] = __builtin_amdgcn_cvt_pk_fp8_f32(
+          d_out[token_depth][2], d_out[token_depth][3], 0, false);
+#else
+      UNREACHABLE_CODE
+#endif
+    }
+  }
+
+  // Write partition max_logits and exp_sum
+  if (threadIdx.x < gqa_ratio) {
+    const int qhead_idx = lane16id;
+    const int64_t poffset = static_cast<int64_t>(seq_idx) *
+                                static_cast<int64_t>(total_num_heads) *
+                                static_cast<int64_t>(max_num_partitions) +
+                            (static_cast<int64_t>(wg_start_head_idx) +
+                             static_cast<int64_t>(qhead_idx)) *
+                                static_cast<int64_t>(max_num_partitions) +
+                            static_cast<int64_t>(partition_idx);
+    max_logits[poffset] = partition_qk_max;
+    exp_sums[poffset] = partition_exp_sum;
+  }
+
+  __syncthreads();
+
+  constexpr int ELEMS8_ELEMS4_RATIO = 8 / 4;
+  constexpr int ELEMS16_ELEMS8_RATIO = 16 / 8;
+
+  _B16x4 outelems[MAX_VHELOOP];
+  // Softmax-V MFMA (runtime vheloop)
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    floatx4 tmp_out = {0};
+
+    for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+      if constexpr (KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto) {
+        for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+          for (int i = 0; i < ELEMS8_ELEMS4_RATIO; i++) {
+            const int off = rowid * VTLANELOOP * ELEMS8_ELEMS4_RATIO +
+                            vfetch_depth * ELEMS8_ELEMS4_RATIO + i;
+            const int offset1 = off % ROWS_PER_WARP;
+            const int offset2 = off / ROWS_PER_WARP;
+            tmp_out = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                Vlocal[vtoken_depth][vhe_depth][vfetch_depth].xy[i],
+                shared_logits[vtoken_depth][offset2][lane16id][offset1],
+                tmp_out);
+          }
+        }
+      } else {
+        for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+          _B16x8 Vtmp = Vlocal[vtoken_depth][vhe_depth][vfetch_depth];
+          _B8x16 Vtmp8x16 = *reinterpret_cast<_B8x16*>(&Vtmp);
+          for (int j = 0; j < ELEMS16_ELEMS8_RATIO; j++) {
+            _B8x8 Vtmp8x8 = Vtmp8x16.xy[j];
+            if constexpr (MFMA_TYPE == MFMAType::F16) {
+              _B16x8 Vlocaltmp = convert_b8x8_custom<scalar_t>(Vtmp8x8);
+              for (int i = 0; i < ELEMS8_ELEMS4_RATIO; i++) {
+                const int off =
+                    rowid * ELEMS16_ELEMS8_RATIO * ELEMS8_ELEMS4_RATIO +
+                    j * ELEMS8_ELEMS4_RATIO + i;
+                const int offset1 = off % ROWS_PER_WARP;
+                const int offset2 = off / ROWS_PER_WARP;
+                tmp_out = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                    Vlocaltmp.xy[i],
+                    shared_logits[vtoken_depth][offset2][lane16id][offset1],
+                    tmp_out);
+              }
+            } else {
+#if defined(__HIP__FP8MFMA__)
+              for (int i = 0; i < ELEMS8_ELEMS4_RATIO / 2; i++) {
+                const int off =
+                    rowid * ELEMS16_ELEMS8_RATIO * ELEMS8_ELEMS4_RATIO +
+                    j * ELEMS8_ELEMS4_RATIO + i;
+                const int offset1 = (off % ROWS_PER_WARP) / 2;
+                const int offset2 = off / ROWS_PER_WARP;
+                tmp_out = gcn_mfma16x16x32_instr<__hip_fp8_e4m3, 0, 0, 0>(
+                    reinterpret_cast<_T8x8*>(&Vtmp8x8)->i64,
+                    reinterpret_cast<_T8x8*>(
+                        &shared_logits[vtoken_depth][offset2][lane16id]
+                                      [offset1])
+                        ->i64,
+                    tmp_out);
+              }
+#else
+              UNREACHABLE_CODE
+#endif
+            }
+          }
+        }
+      }
+    }
+    if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto) {
+      tmp_out *= *v_scale;
+    }
+    outelems[vhe_depth] = from_floatx4<scalar_t>(tmp_out);
+  }
+
+  __syncthreads();
+
+  // Store SV output to shared mem
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    shared_logits[warpid][vhe_depth][lane16id][rowid] = outelems[vhe_depth];
+  }
+
+  __syncthreads();
+
+  const int64_t hsz_maxp_mult =
+      static_cast<int64_t>(head_size * max_num_partitions);
+  // Write to tmp_out with coalesced writes (runtime head_size)
+  if (warpid == 0) {
+    _B16x8 vout[4];
+    const int head_elem_idx = lane16id * 8;
+    if (head_elem_idx < head_size) {
+      for (int h = 0; h < 4; h++) {
+        const int local_head_idx = 4 * h + rowid;
+        if (local_head_idx >= gqa_ratio) break;
+        const int off1 = (head_elem_idx / 16) % NWARPS;
+        const int off2 = head_elem_idx / 16 / NWARPS;
+        const int off3 = (head_elem_idx / 4) % 4;
+        for (int i = 0; i < 2; i++) {
+          vout[h].xy[i] =
+              shared_logits[off1][off2][local_head_idx][off3 + i];
+        }
+      }
+
+      scalar_t* out_ptr = out + seq_idx * total_num_heads * hsz_maxp_mult +
+                          partition_idx * head_size;
+      for (int h = 0; h < 4; h++) {
+        const int local_head_idx = 4 * h + rowid;
+        if (local_head_idx < gqa_ratio) {
+          const int64_t out_head_idx =
+              static_cast<int64_t>(wg_start_head_idx + local_head_idx);
+          scalar_t* out_ptr2 = out_ptr + out_head_idx * hsz_maxp_mult;
+          scalar_t* out_ptr3 = out_ptr2 + head_elem_idx;
+          _B16x8* out_ptr_B16x8 = reinterpret_cast<_B16x8*>(out_ptr3);
+          *out_ptr_B16x8 = vout[h];
+        }
+      }
+    }
+
+    // For head_size > 128: second write pass for elements 128..head_size-1
+    if (head_size > 128) {
+      const int head_elem_idx2 = 128 + lane16id * 8;
+      if (head_elem_idx2 < head_size) {
+        for (int h = 0; h < 4; h++) {
+          const int local_head_idx = 4 * h + rowid;
+          if (local_head_idx >= gqa_ratio) break;
+          const int off1 = ((head_elem_idx2) / 16) % NWARPS;
+          const int off2 = (head_elem_idx2) / 16 / NWARPS;
+          const int off3 = ((head_elem_idx2) / 4) % 4;
+          for (int i = 0; i < 2; i++) {
+            vout[h].xy[i] =
+                shared_logits[off1][off2][local_head_idx][off3 + i];
+          }
+        }
+
+        for (int h = 0; h < 4; h++) {
+          const int local_head_idx = 4 * h + rowid;
+          if (local_head_idx < gqa_ratio) {
+            const int64_t out_head_idx =
+                static_cast<int64_t>(wg_start_head_idx + local_head_idx);
+            scalar_t* out_ptr2 = out + seq_idx * total_num_heads * hsz_maxp_mult +
+                                partition_idx * head_size +
+                                out_head_idx * hsz_maxp_mult;
+            scalar_t* out_ptr3 = out_ptr2 + head_elem_idx2;
+            _B16x8* out_ptr_B16x8 = reinterpret_cast<_B16x8*>(out_ptr3);
+            *out_ptr_B16x8 = vout[h];
+          }
+        }
+      }
     }
   }
 }
@@ -1689,7 +2667,6 @@ union b16x16_u {
 typedef b16x16_u _B16x16;
 
 using _B8x8 = uint2;
-using bit8_t = uint8_t;
 
 typedef struct _B8x16 {
   _B8x8 xy[2];
@@ -1703,28 +2680,6 @@ __device__ __forceinline__ floatx8 gcn_wmma16x16x16_instr(const bit16x16& inpA,
     return __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(inpA, inpB, inpC);
   } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
     return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(inpA, inpB, inpC);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ float to_float(const T& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (float)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __bfloat162float(inp);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ T from_float(const float& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (_Float16)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __float2bfloat16(inp);
   } else {
     static_assert(false, "unsupported 16b dtype");
   }
@@ -2225,236 +3180,25 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   UNREACHABLE_CODE
 }
 
-// Grid: (num_heads, num_seqs).
-template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
-          int PARTITION_SIZE, int NPAR_LOOPS>
+
+// GFX11 stubs for "free" kernels (not supported on Navi)
+template <typename scalar_t, typename cache_t,
+          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
+          int NUM_THREADS, bool ALIBI_ENABLED, MFMAType MFMA_TYPE,
+          bool SHARED_KV = false>
 __global__
-__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
-    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
-    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
-                                           // max_num_partitions, head_size]
-    const int* __restrict__ seq_lens,      // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
-    const int partition_offset) {
-  const auto num_heads = gridDim.x;
-  const auto head_idx = blockIdx.x;
-  const auto seq_idx = blockIdx.y;
-
-  // NOTE queries with sequence len > 1 are prefills and taken care by another
-  // kernel.
-  if (query_start_loc_ptr != nullptr &&
-      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
-    return;
-  }
-
-  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
-  if (seq_len <= 0) {
-    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
-    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
-    if constexpr (std::is_same<OUTT, float4>::value) {
-      const int64_t query_start_off = static_cast<int64_t>(
-          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-      float4* temp_dst = reinterpret_cast<float4*>(
-          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
-      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
-    }
-    return;
-  }
-  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
-  const int warpid = threadIdx.x / WARP_SIZE;
-
-  __shared__ float shared_global_exp_sum;
-  __shared__ float shared_max_logit;
-  // max num partitions supported is warp_size * NPAR_LOOPS
-  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
-
-  if (warpid == 0) {
-    const float* max_logits_ptr = max_logits + partition_offset +
-                                  seq_idx * num_heads * max_num_partitions +
-                                  head_idx * max_num_partitions;
-
-    // valid partition is the last valid partition in case threadid > num
-    // partitions
-    int valid_partition[NPAR_LOOPS];
-    float reg_max_logit[NPAR_LOOPS];
-    const int last_valid_partition = num_partitions - 1;
-
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      valid_partition[i] =
-          (partition_no < num_partitions) ? partition_no : last_valid_partition;
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
-    }
-    float max_logit = reg_max_logit[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      max_logit = fmaxf(max_logit, reg_max_logit[i]);
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
-    }
-
-    const float* exp_sums_ptr = exp_sums + partition_offset +
-                                seq_idx * num_heads * max_num_partitions +
-                                head_idx * max_num_partitions;
-
-    float rescaled_exp_sum[NPAR_LOOPS];
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      rescaled_exp_sum[i] = exp_sums_ptr[valid_partition[i]];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      rescaled_exp_sum[i] *= (partition_no < num_partitions)
-                                 ? expf(reg_max_logit[i] - max_logit)
-                                 : 0.0f;
-    }
-    float global_exp_sum = rescaled_exp_sum[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      global_exp_sum += rescaled_exp_sum[i];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      global_exp_sum += __shfl_xor(global_exp_sum, mask);
-    }
-    if (threadIdx.x == 0) {
-      shared_global_exp_sum = global_exp_sum;
-      shared_max_logit = max_logit;
-    }
-  }  // warpid == 0
-  const scalar_t* tmp_out_ptr =
-      tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE +
-      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
-  constexpr int MAX_NPAR = 32;
-  scalar_t tmps[MAX_NPAR];
-  const float dzero = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < MAX_NPAR; j++) {
-    tmps[j] = from_float<scalar_t>(dzero);
-  }
-  const int last_partition_offset = (num_partitions - 1) * HEAD_SIZE;
-  const int num_partition_offset = (num_partitions)*HEAD_SIZE;
-  int idx = 0;
-
-  constexpr int JCHUNK = 16;
-
-  #pragma unroll
-  for (int j = 0; j < JCHUNK * HEAD_SIZE; j += HEAD_SIZE) {
-    // lastj is last valid partition
-    const int lastj_offset =
-        (j < num_partition_offset) ? j : last_partition_offset;
-    tmps[idx] = tmp_out_ptr[lastj_offset];
-    idx++;
-  }
-  __syncthreads();
-
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK * HEAD_SIZE; j < 2 * JCHUNK * HEAD_SIZE;
-         j += HEAD_SIZE) {
-      const int lastj_offset =
-          (j < num_partition_offset) ? j : last_partition_offset;
-      tmps[idx] = tmp_out_ptr[lastj_offset];
-      idx++;
-    }
-
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK * HEAD_SIZE; j < MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-    }
-  }  // num_partitions > JCHUNK
-
-  // Aggregate tmp_out to out.
-  float acc = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < JCHUNK; j++) {
-    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-  }
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
-      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-    }
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-      }
-    }
-  }
-
-  for (int p = 1; p < NPAR_LOOPS; p++) {
-    if (num_partitions > p * MAX_NPAR) {
-      idx = 0;
-  #pragma unroll
-      for (int j = p * MAX_NPAR * HEAD_SIZE; j < (p + 1) * MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        // lastj is last valid partition
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-
-  #pragma unroll
-      for (int j = 0; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
-      }
-    }
-  }
-
-  const float inv_global_exp_sum =
-      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
-
-  const int64_t query_start_off = static_cast<int64_t>(
-      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
-                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
-
-  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
-  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
-  if constexpr (std::is_same<OUTT, float4>::value) {
-    float4* temp_dst = reinterpret_cast<float4*>(
-        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
-    temp_out_ptr[threadIdx.x] =
-        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
-    return;
-  } else {
-    acc *= inv_global_exp_sum;
-    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
-  }
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel(
+    const scalar_t* __restrict__ q, const cache_t* __restrict__ k_cache,
+    const cache_t* __restrict__ v_cache, const int num_kv_heads, const float scale,
+    const int* __restrict__ block_tables, const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc_ptr, const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes, const int q_stride,
+    const int kv_block_stride, const int kv_head_stride,
+    float* __restrict__ exp_sums, float* __restrict__ max_logits,
+    scalar_t* __restrict__ out, OUTT* __restrict__ final_out,
+    int max_ctx_blocks, const float* k_scale, const float* v_scale,
+    int block_size, int head_size, int gqa_ratio) {
+  UNREACHABLE_CODE
 }
 
 #elif defined(__GFX12__)
@@ -2473,7 +3217,6 @@ union b16x8_u {
 typedef b16x8_u _B16x8;
 
 using _B8x8 = uint2;
-using bit8_t = uint8_t;
 
 typedef struct _B8x16 {
   _B8x8 xy[2];
@@ -2493,17 +3236,6 @@ __device__ __forceinline__ floatx8 gcn_wmma16x16x16_instr(const bit16x8& inpA,
 }
 
 template <typename T>
-__device__ __forceinline__ float to_float(const T& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (float)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __bfloat162float(inp);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
 __device__ __forceinline__ float to_float_b16(const bit16_t& inp) {
   union tmpcvt {
     bit16_t u;
@@ -2515,17 +3247,6 @@ __device__ __forceinline__ float to_float_b16(const bit16_t& inp) {
     return (float)t16.f;
   } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
     return __bfloat162float(t16.b);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ T from_float(const float& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (_Float16)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __float2bfloat16(inp);
   } else {
     static_assert(false, "unsupported 16b dtype");
   }
@@ -2991,235 +3712,352 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   UNREACHABLE_CODE
 }
 
-// Grid: (num_heads, num_seqs).
-template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
-          int PARTITION_SIZE, int NPAR_LOOPS>
-__global__
-__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
-    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
-    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
-                                           // max_num_partitions, head_size]
-    const int* __restrict__ seq_lens,      // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
-    const int partition_offset) {
-  const auto num_heads = gridDim.x;
-  const auto head_idx = blockIdx.x;
-  const auto seq_idx = blockIdx.y;
 
-  // NOTE queries with sequence len > 1 are prefills and taken care by another
-  // kernel.
+// GFX12 free QKV kernel: runtime block_size, head_size, gqa_ratio.
+// Warp layout: WARP_SIZE=32, NWARPS=8, ROWS_PER_WARP=2, TLOOP=2, QKHE_PER_FETCH=16.
+// Reuses the same static shared memory layout as the non-free GFX12 kernel.
+// Supports head_size in {64, 128, 192, 256} with V-fetch bound guard for partial warps.
+// clang-format off
+template <typename scalar_t, typename cache_t,
+          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
+          int NUM_THREADS, bool ALIBI_ENABLED, MFMAType MFMA_TYPE,
+          bool SHARED_KV = false>
+__global__
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel(
+    const scalar_t* __restrict__ q, const cache_t* __restrict__ k_cache,
+    const cache_t* __restrict__ v_cache, const int num_kv_heads, const float scale,
+    const int* __restrict__ block_tables, const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc_ptr, const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes, const int q_stride,
+    const int kv_block_stride, const int kv_head_stride,
+    float* __restrict__ exp_sums, float* __restrict__ max_logits,
+    scalar_t* __restrict__ out, OUTT* __restrict__ final_out,
+    int max_ctx_blocks, const float* k_scale, const float* v_scale,
+    int block_size, int head_size, int gqa_ratio) {
+  // clang-format on
+  constexpr int NWARPS = NUM_THREADS / WARP_SIZE;  // 8
+  const int warpid = threadIdx.x / WARP_SIZE;
+  const int laneid = threadIdx.x % WARP_SIZE;
+  const int lane2id = laneid % 2;
+  const int lane16id = laneid % 16;
+  const int rowid = laneid / 16;
+
+  const int seq_idx = blockIdx.x;
   if (query_start_loc_ptr != nullptr &&
       (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
     return;
   }
-
-  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
-  if (seq_len <= 0) {
-    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
-    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
-    if constexpr (std::is_same<OUTT, float4>::value) {
-      const int64_t query_start_off = static_cast<int64_t>(
-          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-      float4* temp_dst = reinterpret_cast<float4*>(
-          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
-      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
-    }
+  const int partition_idx = blockIdx.y;
+  constexpr int T_PAR_SIZE = 256;
+  const int max_num_partitions = gridDim.y;
+  const int seq_len = seq_lens[seq_idx];
+  const int partition_start_token_idx = partition_idx * T_PAR_SIZE;
+  if (partition_start_token_idx >= seq_len) {
     return;
   }
-  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
-  const int warpid = threadIdx.x / WARP_SIZE;
 
-  __shared__ float shared_global_exp_sum;
-  __shared__ float shared_max_logit;
-  // max num partitions supported is warp_size * NPAR_LOOPS
-  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
+  constexpr int ROWS_PER_WARP = WARP_SIZE / 16;  // 2
+  constexpr int CONTIGUOUS_KV_ELEMS_16B_LOAD = 16 / sizeof(cache_t);
+  constexpr int QKHE_PER_FETCH = CONTIGUOUS_KV_ELEMS_16B_LOAD * ROWS_PER_WARP;  // 16
+  constexpr int CONTIGUOUS_SCALAR_ELEMS_16B = 16 / sizeof(scalar_t);
+  const int qkheloop = head_size / QKHE_PER_FETCH;
 
-  if (warpid == 0) {
-    const float* max_logits_ptr = max_logits + partition_offset +
-                                  seq_idx * num_heads * max_num_partitions +
-                                  head_idx * max_num_partitions;
+  constexpr int MAX_QKHELOOP = 16;   // supports head_size up to 256
+  constexpr int MAX_GQA_RATIO2 = 8;  // supports gqa_ratio up to 16
 
-    // valid partition is the last valid partition in case threadid > num
-    // partitions
-    int valid_partition[NPAR_LOOPS];
-    float reg_max_logit[NPAR_LOOPS];
-    const int last_valid_partition = num_partitions - 1;
+  // Same static shared memory layout as the GFX12 non-free kernel.
+  // Also repurposed as float scratch during qk_max/exp_sum reduction.
+  __shared__ _B16x8 shared_logits[NWARPS][2][16][2];
 
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      valid_partition[i] =
-          (partition_no < num_partitions) ? partition_no : last_valid_partition;
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
-    }
-    float max_logit = reg_max_logit[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      max_logit = fmaxf(max_logit, reg_max_logit[i]);
-    }
+  constexpr int TOKENS_PER_WARP = T_PAR_SIZE / NWARPS;  // 32
+  constexpr int TLOOP = TOKENS_PER_WARP / 16;           // 2
 
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
-    }
+  const int wg_start_head_idx = blockIdx.z * gqa_ratio;
+  const int wg_start_kv_head_idx = blockIdx.z;
+  const int total_num_heads = gridDim.z * gqa_ratio;
 
-    const float* exp_sums_ptr = exp_sums + partition_offset +
-                                seq_idx * num_heads * max_num_partitions +
-                                head_idx * max_num_partitions;
-
-    float rescaled_exp_sum[NPAR_LOOPS];
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      rescaled_exp_sum[i] = exp_sums_ptr[valid_partition[i]];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      rescaled_exp_sum[i] *= (partition_no < num_partitions)
-                                 ? expf(reg_max_logit[i] - max_logit)
-                                 : 0.0f;
-    }
-    float global_exp_sum = rescaled_exp_sum[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      global_exp_sum += rescaled_exp_sum[i];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      global_exp_sum += __shfl_xor(global_exp_sum, mask);
-    }
-    if (threadIdx.x == 0) {
-      shared_global_exp_sum = global_exp_sum;
-      shared_max_logit = max_logit;
-    }
-  }  // warpid == 0
-  const scalar_t* tmp_out_ptr =
-      tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE +
-      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
-  constexpr int MAX_NPAR = 32;
-  scalar_t tmps[MAX_NPAR];
-  const float dzero = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < MAX_NPAR; j++) {
-    tmps[j] = from_float<scalar_t>(dzero);
-  }
-  const int last_partition_offset = (num_partitions - 1) * HEAD_SIZE;
-  const int num_partition_offset = (num_partitions)*HEAD_SIZE;
-  int idx = 0;
-
-  constexpr int JCHUNK = 16;
-
-  #pragma unroll
-  for (int j = 0; j < JCHUNK * HEAD_SIZE; j += HEAD_SIZE) {
-    // lastj is last valid partition
-    const int lastj_offset =
-        (j < num_partition_offset) ? j : last_partition_offset;
-    tmps[idx] = tmp_out_ptr[lastj_offset];
-    idx++;
-  }
-  __syncthreads();
-
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK * HEAD_SIZE; j < 2 * JCHUNK * HEAD_SIZE;
-         j += HEAD_SIZE) {
-      const int lastj_offset =
-          (j < num_partition_offset) ? j : last_partition_offset;
-      tmps[idx] = tmp_out_ptr[lastj_offset];
-      idx++;
-    }
-
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK * HEAD_SIZE; j < MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-    }
-  }  // num_partitions > JCHUNK
-
-  // Aggregate tmp_out to out.
-  float acc = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < JCHUNK; j++) {
-    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-  }
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
-      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-    }
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-      }
-    }
-  }
-
-  for (int p = 1; p < NPAR_LOOPS; p++) {
-    if (num_partitions > p * MAX_NPAR) {
-      idx = 0;
-  #pragma unroll
-      for (int j = p * MAX_NPAR * HEAD_SIZE; j < (p + 1) * MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        // lastj is last valid partition
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-
-  #pragma unroll
-      for (int j = 0; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
-      }
-    }
-  }
-
-  const float inv_global_exp_sum =
-      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
+  const int num_seq_blocks = DIVIDE_ROUND_UP(seq_len, block_size);
+  const int last_seq_block = num_seq_blocks - 1;
+  const int* block_table_seq = block_tables + seq_idx * max_num_blocks_per_seq;
 
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
-                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
 
-  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
-  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
-  if constexpr (std::is_same<OUTT, float4>::value) {
-    float4* temp_dst = reinterpret_cast<float4*>(
-        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
-    temp_out_ptr[threadIdx.x] =
-        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
-    return;
+  // --- Q loading via shared memory (handles any gqa_ratio 1..16) ---
+  // Each (warpid, rowid) pair owns one Q head (local_qhead_idx = 2*warpid + rowid).
+  // Each lane16id loads 16 bytes of that head; offset1 routes to the correct qkhe_depth slot.
+  const int local_qhead_idx = 2 * warpid + rowid;
+  const int global_qhead_idx = wg_start_head_idx + local_qhead_idx;
+  const scalar_t* q_ptr = q + query_start_off * q_stride + global_qhead_idx * head_size;
+  const int qhead_element = lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
+
+  _B16x8 Qlocal[MAX_QKHELOOP];
+
+  if ((local_qhead_idx < gqa_ratio) && (qhead_element < head_size)) {
+    const _B16x8* q_fetch_ptr_16B = reinterpret_cast<const _B16x8*>(q_ptr + qhead_element);
+    _B16x8 tmp = *q_fetch_ptr_16B;
+    const int offset1 = lane16id / 2;  // maps 16 lanes to 8 qkhe_depth slots
+    shared_logits[offset1][lane2id][local_qhead_idx][0] = tmp;
+  }
+
+  if (head_size > 128) {
+    __syncthreads();
+    // Read first half of Q (head elements 0..127) into registers
+    for (int qkhe_depth = 0; qkhe_depth < 8; qkhe_depth++) {
+      Qlocal[qkhe_depth] = shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio][0];
+    }
+    __syncthreads();
+    // Second pass: load head elements 128..head_size-1 into the same shared slots
+    const int qhead_element2 = 128 + lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
+    if ((local_qhead_idx < gqa_ratio) && (qhead_element2 < head_size)) {
+      const _B16x8* q_fetch_ptr_16B2 = reinterpret_cast<const _B16x8*>(q_ptr + qhead_element2);
+      _B16x8 tmp2 = *q_fetch_ptr_16B2;
+      const int offset1 = lane16id / 2;
+      shared_logits[offset1][lane2id][local_qhead_idx][0] = tmp2;
+    }
+    __syncthreads();
+    // Read second half of Q (qkhe_depth 8..qkheloop-1) into registers
+    for (int qkhe_depth = 8; qkhe_depth < qkheloop; qkhe_depth++) {
+      Qlocal[qkhe_depth] = shared_logits[qkhe_depth - 8][rowid][lane16id % gqa_ratio][0];
+    }
   } else {
-    acc *= inv_global_exp_sum;
-    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    __syncthreads();
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      Qlocal[qkhe_depth] = shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio][0];
+    }
+  }
+
+  // --- K physical block numbers and fetch ---
+  int kphysical_block_number[TLOOP];
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int klocal_token_idx = TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int kglobal_token_idx = partition_start_token_idx + klocal_token_idx;
+    const int kblock_idx = (kglobal_token_idx < seq_len)
+                               ? kglobal_token_idx / block_size
+                               : last_seq_block;
+    kphysical_block_number[token_depth] = block_table_seq[kblock_idx];
+  }
+
+  constexpr int KX = 16 / sizeof(cache_t);
+  const cache_t* k_ptr = k_cache + wg_start_kv_head_idx * kv_head_stride;
+  const int row_head_elem = rowid * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+
+  _B16x8 Klocal[TLOOP][MAX_QKHELOOP];
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int64_t kblock_number = static_cast<int64_t>(kphysical_block_number[token_depth]);
+    const cache_t* k_ptr2 = k_ptr + kblock_number * kv_block_stride;
+    const int klocal_token_idx = TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int kphysical_block_offset = klocal_token_idx % block_size;
+    const cache_t* k_ptr3 = k_ptr2 + kphysical_block_offset * KX;
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      const int head_elem = row_head_elem + qkhe_depth * QKHE_PER_FETCH;
+      const int offset1 = head_elem / KX;
+      const int offset2 = head_elem % KX;
+      const cache_t* k_fetch_ptr = k_ptr3 + offset1 * block_size * KX + offset2;
+      Klocal[token_depth][qkhe_depth] = *reinterpret_cast<const _B16x8*>(k_fetch_ptr);
+    }
+  }
+
+  // --- V block numbers and fetch ---
+  constexpr int VTOKENS_PER_LANE = TOKENS_PER_WARP / ROWS_PER_WARP;  // 16
+  constexpr int VBLOCKS_PER_LANE = 1;  // assumes block_size >= 16
+  constexpr int VTLOOP = NWARPS;       // 8
+  constexpr int VTLANELOOP = DIVIDE_ROUND_UP(VTOKENS_PER_LANE, CONTIGUOUS_KV_ELEMS_16B_LOAD);  // 2
+  const int vheloop = DIVIDE_ROUND_UP(head_size / 16, NWARPS);
+  constexpr int MAX_VHELOOP = 2;  // supports head_size up to 256
+
+  int vphysical_block_number[VTLOOP][VBLOCKS_PER_LANE];
+  for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+    for (int vblock_depth = 0; vblock_depth < VBLOCKS_PER_LANE; vblock_depth++) {
+      const int vlocal_token_idx =
+          vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
+          rowid * VTOKENS_PER_LANE + vblock_depth * block_size;
+      const int vglobal_token_idx = partition_start_token_idx + vlocal_token_idx;
+      const int vblock_idx = (vglobal_token_idx < seq_len)
+                                 ? vglobal_token_idx / block_size
+                                 : last_seq_block;
+      vphysical_block_number[vtoken_depth][vblock_depth] = block_table_seq[vblock_idx];
+    }
+  }
+
+  _B16x8 Vlocal[VTLOOP][MAX_VHELOOP][VTLANELOOP] = {};  // zero-init: guard below may skip some
+  // v_ptr base: no intra-block offset here; computed per vtoken_depth below
+  const cache_t* v_ptr = v_cache + wg_start_kv_head_idx * kv_head_stride;
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    const int vhead_elem = vhe_depth * NWARPS * 16 + warpid * 16 + lane16id;
+    if (vhead_elem >= head_size) continue;  // partial last vheloop (e.g. head_size=64)
+    const cache_t* v_ptr2 = v_ptr + vhead_elem * block_size;
+    for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+      // intra-block token offset varies with vtoken_depth for block_size > TOKENS_PER_WARP
+      const int vlocal_tok_in_block =
+          (partition_start_token_idx +
+           vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
+           rowid * VTOKENS_PER_LANE) % block_size;
+      for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+        const int vblock_depth = 0;
+        const int64_t vblock_number =
+            static_cast<int64_t>(vphysical_block_number[vtoken_depth][vblock_depth]);
+        const cache_t* v_ptr3 = v_ptr2 + vblock_number * kv_block_stride;
+        const cache_t* v_fetch_ptr =
+            v_ptr3 + vlocal_tok_in_block + vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+        Vlocal[vtoken_depth][vhe_depth][vfetch_depth] = *reinterpret_cast<const _B16x8*>(v_fetch_ptr);
+      }
+    }
+  }
+
+  // --- QK WMMA ---
+  floatx8 dout[TLOOP];
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    dout[token_depth] = {0};
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      dout[token_depth] = gcn_wmma16x16x16_instr<scalar_t, 0, 0, 0>(
+          Klocal[token_depth][qkhe_depth].u16x8, Qlocal[qkhe_depth].u16x8,
+          dout[token_depth]);
+    }
+    dout[token_depth] *= scale;
+  }
+
+  // --- Softmax: per-warp qk_max and exp_sum, then partition-wide reduction ---
+  float qk_max = -FLT_MAX;
+  float exp_sum = 0.0f;
+  const int qkout_token_idx =
+      partition_start_token_idx + TOKENS_PER_WARP * warpid + rowid * 8;
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int local_token_idx = qkout_token_idx + token_depth * 16;
+    for (int i = 0; i < 8; i++) {
+      const float tmp = (local_token_idx + i < seq_len) ? dout[token_depth][i] : -FLT_MAX;
+      qk_max = fmaxf(qk_max, tmp);
+    }
+  }
+  qk_max = fmaxf(qk_max, __shfl_xor(qk_max, 16));
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int local_token_idx = qkout_token_idx + token_depth * 16;
+    for (int i = 0; i < 8; i++) {
+      const float tmp = (local_token_idx + i < seq_len)
+                            ? __expf(dout[token_depth][i] - qk_max)
+                            : 0.0f;
+      dout[token_depth][i] = tmp;
+      exp_sum += tmp;
+    }
+  }
+  exp_sum += __shfl_xor(exp_sum, 16);
+
+  __syncthreads();
+  // Reuse shared_logits as float scratch for cross-warp qk_max/exp_sum exchange
+  float* shared_mem = reinterpret_cast<float*>(shared_logits);
+  if (laneid < 16) {
+    shared_mem[warpid * 16 + lane16id] = qk_max;
+    shared_mem[NWARPS * 16 + warpid * 16 + lane16id] = exp_sum;
+  }
+  __syncthreads();
+
+  float partition_qk_max = -FLT_MAX;
+  float warp_qk_max_exp[NWARPS];
+  float partition_exp_sum = 0.0f;
+  for (int w = 0; w < NWARPS; w++) {
+    warp_qk_max_exp[w] = shared_mem[w * 16 + lane16id];
+    partition_qk_max = fmaxf(partition_qk_max, warp_qk_max_exp[w]);
+  }
+  for (int w = 0; w < NWARPS; w++) {
+    warp_qk_max_exp[w] = __expf(warp_qk_max_exp[w] - partition_qk_max);
+    partition_exp_sum += shared_mem[NWARPS * 16 + w * 16 + lane16id] * warp_qk_max_exp[w];
+  }
+  const float inv_sum_scale =
+      __fdividef(1.f, partition_exp_sum + 1e-6f) * warp_qk_max_exp[warpid];
+
+  __syncthreads();
+  // Write scaled logits to shared memory for V WMMA
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    dout[token_depth] *= inv_sum_scale;
+    shared_logits[warpid][token_depth][lane16id][rowid] =
+        from_floatx8<scalar_t>(dout[token_depth]);
+  }
+
+  // Write partition max_logits and exp_sum (one thread per Q head)
+  if (threadIdx.x < gqa_ratio) {
+    const int qhead_idx = lane16id;
+    const int offset = seq_idx * total_num_heads * max_num_partitions +
+                       (wg_start_head_idx + qhead_idx) * max_num_partitions +
+                       partition_idx;
+    max_logits[offset] = partition_qk_max;
+    exp_sums[offset] = partition_exp_sum;
+  }
+
+  __syncthreads();
+
+  // --- Softmax-V WMMA ---
+  _B16x8 outelems[MAX_VHELOOP];
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    floatx8 tmp_out = {0};
+    for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+      for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+        const int offset = rowid * VTLANELOOP + vfetch_depth;
+        const int offset1 = offset % ROWS_PER_WARP;
+        const int offset2 = offset / ROWS_PER_WARP;
+        tmp_out = gcn_wmma16x16x16_instr<scalar_t, 0, 0, 0>(
+            Vlocal[vtoken_depth][vhe_depth][vfetch_depth].u16x8,
+            shared_logits[vtoken_depth][offset2][lane16id][offset1].u16x8,
+            tmp_out);
+      }
+    }
+    outelems[vhe_depth] = from_floatx8<scalar_t>(tmp_out);
+  }
+
+  __syncthreads();
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    shared_logits[warpid][vhe_depth][lane16id][rowid] = outelems[vhe_depth];
+  }
+  __syncthreads();
+
+  // --- Write final output (warp 0 only, coalesced across head elements) ---
+  if (warpid == 0) {
+    _B16x8 vout[MAX_GQA_RATIO2];
+    const int64_t hsz_maxp_mult = static_cast<int64_t>(head_size * max_num_partitions);
+    const int head_elem_idx = lane16id * 8;
+    if (head_elem_idx < head_size) {
+      for (int h = 0; h < MAX_GQA_RATIO2; h++) {
+        const int local_head_idx = 2 * h + rowid;
+        if (local_head_idx >= gqa_ratio) break;
+        const int offset1 = (head_elem_idx / 16) % NWARPS;
+        const int offset2 = head_elem_idx / 16 / NWARPS;
+        const int offset3 = (head_elem_idx / 8) % 2;
+        vout[h] = shared_logits[offset1][offset2][local_head_idx][offset3];
+      }
+      scalar_t* out_ptr = out + seq_idx * total_num_heads * hsz_maxp_mult +
+                          partition_idx * head_size;
+      for (int h = 0; h < MAX_GQA_RATIO2; h++) {
+        const int local_head_idx = 2 * h + rowid;
+        if (local_head_idx >= gqa_ratio) break;
+        const int64_t out_head_idx =
+            static_cast<int64_t>(wg_start_head_idx + local_head_idx);
+        scalar_t* out_ptr3 = out_ptr + out_head_idx * hsz_maxp_mult + head_elem_idx;
+        *reinterpret_cast<_B16x8*>(out_ptr3) = vout[h];
+      }
+    }
+    // For head_size > 128: second pass for head elements 128..head_size-1
+    if (head_size > 128) {
+      const int head_elem_idx2 = 128 + lane16id * 8;
+      if (head_elem_idx2 < head_size) {
+        for (int h = 0; h < MAX_GQA_RATIO2; h++) {
+          const int local_head_idx = 2 * h + rowid;
+          if (local_head_idx >= gqa_ratio) break;
+          const int offset1 = (head_elem_idx2 / 16) % NWARPS;
+          const int offset2 = head_elem_idx2 / 16 / NWARPS;
+          const int offset3 = (head_elem_idx2 / 8) % 2;
+          vout[h] = shared_logits[offset1][offset2][local_head_idx][offset3];
+        }
+        scalar_t* out_ptr = out + seq_idx * total_num_heads * hsz_maxp_mult +
+                            partition_idx * head_size;
+        for (int h = 0; h < MAX_GQA_RATIO2; h++) {
+          const int local_head_idx = 2 * h + rowid;
+          if (local_head_idx >= gqa_ratio) break;
+          const int64_t out_head_idx =
+              static_cast<int64_t>(wg_start_head_idx + local_head_idx);
+          scalar_t* out_ptr3 = out_ptr + out_head_idx * hsz_maxp_mult + head_elem_idx2;
+          *reinterpret_cast<_B16x8*>(out_ptr3) = vout[h];
+        }
+      }
+    }
   }
 }
 
@@ -3280,61 +4118,93 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   UNREACHABLE_CODE
 }
 
-// Grid: (num_heads, num_seqs).
-template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
-          int PARTITION_SIZE, int NPAR_LOOPS>
+// #else stub for free QKV kernel
+template <typename scalar_t, typename cache_t,
+          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
+          int NUM_THREADS, bool ALIBI_ENABLED, MFMAType MFMA_TYPE,
+          bool SHARED_KV = false>
 __global__
-__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
-    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
-    const float* __restrict__ exp_sums,    // [num_seqs, num_heads, max_num_partitions]
-    const float* __restrict__ max_logits,  // [num_seqs, num_heads, max_num_partitions]
-    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads, max_num_partitions, head_size]
-    const int* __restrict__ seq_lens,  // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
-    const int partition_offset) {
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel(
+    const scalar_t* __restrict__ q, const cache_t* __restrict__ k_cache,
+    const cache_t* __restrict__ v_cache, const int num_kv_heads, const float scale,
+    const int* __restrict__ block_tables, const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc_ptr, const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes, const int q_stride,
+    const int kv_block_stride, const int kv_head_stride,
+    float* __restrict__ exp_sums, float* __restrict__ max_logits,
+    scalar_t* __restrict__ out, OUTT* __restrict__ final_out,
+    int max_ctx_blocks, const float* k_scale, const float* v_scale,
+    int block_size, int head_size, int gqa_ratio) {
   UNREACHABLE_CODE
 }
 // clang-format on
 
 #endif
 
-#define LAUNCH_CUSTOM_ATTENTION_MFMA16(GQA_RATIO)                              \
-  paged_attention_ll4mi_QKV_mfma16_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,  \
-                                          HEAD_SIZE, NTHR, ALIBI_ENABLED,      \
-                                          GQA_RATIO, MFMA_TYPE>                \
-      <<<grid, block, 0, stream>>>(                                            \
-          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,      \
-          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                 \
-          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride, \
-          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,  \
+#define LAUNCH_CUSTOM_ATTENTION_MFMA16_FREE()                                        \
+  {                                                                                  \
+  /* Dynamic smem: [max(NWARPS, qkheloop)][4][16][4] * 8 bytes per _B16x4 */        \
+  const int _qkhe_per_fetch = (16 / (int)sizeof(KVT)) * (WARP_SIZE / 16);           \
+  const int _qkheloop = head_size / _qkhe_per_fetch;                                \
+  const int _sdim0 = MAX((int)(NTHR / WARP_SIZE), _qkheloop);                       \
+  const size_t _smem_bytes = (size_t)_sdim0 * 4 * 16 * 4 * 8;                      \
+  paged_attention_ll4mi_QKV_mfma16_free_kernel<T, KVT, KV_DTYPE, OUTT,              \
+                                               NTHR, ALIBI_ENABLED,                 \
+                                               MFMA_TYPE, SHARED_KV>                \
+      <<<grid, block, _smem_bytes, stream>>>(                                       \
+          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,           \
+          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                      \
+          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride,      \
+          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,       \
+          max_ctx_blocks, k_scale_ptr, v_scale_ptr,                                 \
+          block_size, head_size, gqa_ratio);                                         \
+  }
+
+#define LAUNCH_CUSTOM_ATTENTION_MFMA16(GQA_RATIO)                                   \
+  paged_attention_ll4mi_QKV_mfma16_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,       \
+                                          HEAD_SIZE, NTHR, ALIBI_ENABLED,            \
+                                          GQA_RATIO, MFMA_TYPE>                      \
+      <<<grid, block, 0, stream>>>(                                                  \
+          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,            \
+          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                       \
+          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride,       \
+          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,        \
           max_ctx_blocks, k_scale_ptr, v_scale_ptr);
 
-#define LAUNCH_CUSTOM_ATTENTION_MFMA4(GQA_RATIO)                               \
-  paged_attention_ll4mi_QKV_mfma4_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,   \
-                                         HEAD_SIZE, NTHR, ALIBI_ENABLED,       \
-                                         GQA_RATIO>                            \
-      <<<grid, block, 0, stream>>>(                                            \
-          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,      \
-          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                 \
-          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride, \
-          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,  \
+#define LAUNCH_CUSTOM_ATTENTION_MFMA4(GQA_RATIO)                                    \
+  paged_attention_ll4mi_QKV_mfma4_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,        \
+                                         HEAD_SIZE, NTHR, ALIBI_ENABLED,             \
+                                         GQA_RATIO>                                  \
+      <<<grid, block, 0, stream>>>(                                                  \
+          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,            \
+          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                       \
+          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride,       \
+          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,        \
           max_ctx_blocks, k_scale_ptr, v_scale_ptr);
 
-#define LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, DST, OUT_TYPE,             \
-                                     TEMP_OFFSET, PART_OFFSET)              \
-  paged_attention_ll4mi_reduce_kernel<T, OUT_TYPE, HEAD_SIZE, HEAD_SIZE,    \
-                                      PARTITION_SIZE, NPAR_LOOPS>           \
-      <<<reduce_grid, reduce_block, 0, stream>>>(                           \
-          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,   \
-          tmp_out_ptr, seq_lens_ptr,                                        \
-          query_start_loc_ptr, max_num_partitions, fp8_out_scale_ptr,       \
-          seq_len_offset, TEMP_OFFSET, PART_OFFSET);
+#define LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, DST, OUT_TYPE,                    \
+                                      TEMP_OFFSET, PART_OFFSET)                     \
+  paged_attention_ll4mi_reduce_kernel<T, OUT_TYPE, HEAD_SIZE, HEAD_SIZE,             \
+                                      PARTITION_SIZE, NPAR_LOOPS>                   \
+      <<<reduce_grid, reduce_block, 0, stream>>>(                                   \
+          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,            \
+          tmp_out_ptr, seq_lens_ptr, query_start_loc_ptr, max_num_partitions,        \
+          fp8_out_scale_ptr, seq_len_offset, TEMP_OFFSET, PART_OFFSET);
 
-#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                 \
+#define LAUNCH_CUSTOM_REDUCTION_INNER_FREE(NPAR_LOOPS, DST, OUT_TYPE,               \
+                                           TEMP_OFFSET, PART_OFFSET)                \
+  paged_attention_ll4mi_reduce_free_kernel<T, OUT_TYPE,                              \
+                                           PARTITION_SIZE, NPAR_LOOPS>              \
+      <<<reduce_grid, reduce_block, 0, stream>>>(                                   \
+          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,            \
+          tmp_out_ptr, seq_lens_ptr, query_start_loc_ptr, max_num_partitions,        \
+          fp8_out_scale_ptr, seq_len_offset, TEMP_OFFSET, PART_OFFSET, head_size);
+
+#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                          \
   LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, out_ptr, OUTT, 0, 0)
+
+#define LAUNCH_CUSTOM_REDUCTION_FREE(NPAR_LOOPS)                                     \
+  LAUNCH_CUSTOM_REDUCTION_INNER_FREE(NPAR_LOOPS, out_ptr, OUTT, 0, 0)
 
 template <typename T, typename KVT, vllm::Fp8KVCacheDataType KV_DTYPE,
           int BLOCK_SIZE, int HEAD_SIZE, typename OUTT, int PARTITION_SIZE_OLD,
@@ -3527,11 +4397,160 @@ void paged_attention_custom_launcher(
   // This ensures numerical stability when merging attention weights from multiple passes.
   if (npar_loops > 8) {
     const int num_passes = (npar_loops + 7) / 8;
-    paged_attention_merge_reduce_kernel<T, OUTT, HEAD_SIZE>
+    paged_attention_merge_reduce_kernel<T, OUTT>
         <<<reduce_grid, reduce_block, 0, stream>>>(
             out_ptr, tmp_out_ptr, temp_base_offset,
             seq_lens_ptr, query_start_loc_ptr, num_passes,
-            num_heads, fp8_out_scale_ptr);
+            num_heads, fp8_out_scale_ptr,
+            head_size);
+  }
+}
+
+
+template <typename T, typename KVT, vllm::Fp8KVCacheDataType KV_DTYPE,
+          typename OUTT, int PARTITION_SIZE_OLD,
+          bool ALIBI_ENABLED, MFMAType MFMA_TYPE>
+void paged_attention_fully_custom_launcher(
+    torch::Tensor& out, torch::Tensor& exp_sums, torch::Tensor& max_logits,
+    torch::Tensor& tmp_out, torch::Tensor& query, torch::Tensor& key_cache,
+    torch::Tensor& value_cache, const int num_kv_heads, float scale,
+    torch::Tensor& block_tables, torch::Tensor& seq_lens,
+    const std::optional<torch::Tensor>& query_start_loc, int max_seq_len,
+    const std::optional<torch::Tensor>& alibi_slopes, torch::Tensor& k_scale,
+    torch::Tensor& v_scale, const std::optional<torch::Tensor>& fp8_out_scale,
+    int block_size, int head_size) {
+  int num_seqs = block_tables.size(0);
+  int num_heads = query.size(1);
+  assert ( head_size == query.size(2) );
+  int max_num_blocks_per_seq = block_tables.size(1);
+  int q_stride = query.stride(0);
+  int kv_block_stride = key_cache.stride(0);
+  int kv_head_stride = key_cache.stride(1);
+
+  // NOTE: query start location is optional for V0 decode should not be used.
+  // If batch contains mix of prefills and decode, prefills should be skipped.
+  const int* query_start_loc_ptr =
+      query_start_loc
+          ? reinterpret_cast<const int*>(query_start_loc.value().data_ptr())
+          : nullptr;
+
+  // NOTE: alibi_slopes is optional.
+  const float* alibi_slopes_ptr =
+      alibi_slopes
+          ? reinterpret_cast<const float*>(alibi_slopes.value().data_ptr())
+          : nullptr;
+
+  float* exp_sums_ptr = reinterpret_cast<float*>(exp_sums.data_ptr());
+  float* max_logits_ptr = reinterpret_cast<float*>(max_logits.data_ptr());
+  T* tmp_out_ptr = reinterpret_cast<T*>(tmp_out.data_ptr());
+  T* query_ptr = reinterpret_cast<T*>(query.data_ptr());
+  KVT* key_cache_ptr = reinterpret_cast<KVT*>(key_cache.data_ptr());
+  KVT* value_cache_ptr = reinterpret_cast<KVT*>(value_cache.data_ptr());
+  int* block_tables_ptr = block_tables.data_ptr<int>();
+  int* seq_lens_ptr = seq_lens.data_ptr<int>();
+  const float* k_scale_ptr = reinterpret_cast<const float*>(k_scale.data_ptr());
+  const float* v_scale_ptr = reinterpret_cast<const float*>(v_scale.data_ptr());
+  // NOTE: fp8_out_scale is optional.
+  const auto fp8_out_scale_ptr =
+      fp8_out_scale
+          ? static_cast<const float*>(fp8_out_scale.value().data_ptr())
+          : nullptr;
+  OUTT* out_ptr = reinterpret_cast<OUTT*>(out.data_ptr());
+
+  const int max_ctx_blocks = DIVIDE_ROUND_UP(max_seq_len, block_size);
+
+  // partition size is fixed at 256 since both mfma4 and mfma16 kernels support
+  // it mfma4 kernel also supports partition size 512
+  constexpr int PARTITION_SIZE = 256;
+  const int max_num_partitions = DIVIDE_ROUND_UP(max_seq_len, PARTITION_SIZE);
+  const int gqa_ratio = num_heads / num_kv_heads;
+  assert(num_heads % num_kv_heads == 0);
+
+  constexpr int NTHR = 256;
+  dim3 grid(num_seqs, max_num_partitions, num_kv_heads);
+  dim3 block(NTHR);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  constexpr bool SHARED_KV = false;  // set true to use union Klocal/Vlocal (saves ~128 VGPRs)
+  LAUNCH_CUSTOM_ATTENTION_MFMA16_FREE();
+
+  dim3 reduce_grid(num_heads, num_seqs);
+  dim3 reduce_block(head_size);
+  const int npar_loops = DIVIDE_ROUND_UP(max_num_partitions, WARP_SIZE);
+  int seq_len_offset = 0;
+  // reduction kernel supports upto 8 NPAR_loops * 64 (warp_size) * 256
+  // (partition size) = 128K context length
+
+  // Byte offset from tmp_out to the float4 multi-pass buffer.
+  // The buffer lives at the end of tmp_out, after max_num_partitions partition slices.
+  // Python allocates extra partitions in tmp_out: extra = max_passes * sizeof(float4)/sizeof(T).
+  const int64_t temp_base_offset =
+      (int64_t)num_seqs * num_heads * max_num_partitions * head_size * sizeof(T);
+
+  switch (npar_loops) {
+    case 1:
+      LAUNCH_CUSTOM_REDUCTION_FREE(1);
+      break;
+    case 2:
+      LAUNCH_CUSTOM_REDUCTION_FREE(2);
+      break;
+    case 3:
+      LAUNCH_CUSTOM_REDUCTION_FREE(3);
+      break;
+    case 4:
+      LAUNCH_CUSTOM_REDUCTION_FREE(4);
+      break;
+    case 5:
+      LAUNCH_CUSTOM_REDUCTION_FREE(5);
+      break;
+    case 6:
+      LAUNCH_CUSTOM_REDUCTION_FREE(6);
+      break;
+    case 7:
+      LAUNCH_CUSTOM_REDUCTION_FREE(7);
+      break;
+    case 8:
+      LAUNCH_CUSTOM_REDUCTION_FREE(8);
+      break;
+    default:
+      // For npar_loops > 8, perform multiple reductions with 8 loops each.
+      // GFX9 hardware has a hard limit of 8 npar_loops per reduction kernel.
+      // This corresponds to processing 8 * WARP_SIZE (512) partitions per pass.
+      // For sequences longer than 128K tokens (which require ~512 partitions at 256-tok/partition),
+      // we split the work into multiple passes:
+      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for intermediate results
+      //   - A final merge kernel combines these using log-sum-exp for numerical stability
+      //   - This allows unlimited sequence length via multiple passes
+      if (npar_loops > 8) {
+        const int num_passes = (npar_loops + 7) / 8;
+        const int partitions_per_pass = 8 * WARP_SIZE;  // 8 npar_loops * 64 warp_size
+        for (int pass = 0; pass < num_passes; ++pass) {
+          const int part_offset = pass * partitions_per_pass;
+          const int64_t pass_temp_offset = temp_base_offset +
+              pass * (int64_t)num_seqs * num_heads * head_size * sizeof(float4);
+          LAUNCH_CUSTOM_REDUCTION_INNER_FREE(8, out_ptr, float4,
+                                        pass_temp_offset, part_offset);
+          seq_len_offset += 8 * PARTITION_SIZE * 64;
+        }
+      } else {
+        TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      }
+      break;
+  }
+
+  // If we did multi-pass reductions, merge the results using log-sum-exp.
+  // The multi-pass reductions produced float4 outputs per pass.
+  // This merge kernel combines them into the final output using the stable log-sum-exp formula:
+  //   result = value_1 + exp_sum_1 * (value_2 / exp_sum_1 + ...)
+  // This ensures numerical stability when merging attention weights from multiple passes.
+  if (npar_loops > 8) {
+    const int num_passes = (npar_loops + 7) / 8;
+    paged_attention_merge_reduce_kernel<T, OUTT>
+        <<<reduce_grid, reduce_block, 0, stream>>>(
+            out_ptr, tmp_out_ptr, temp_base_offset,
+            seq_lens_ptr, query_start_loc_ptr, num_passes,
+            num_heads, fp8_out_scale_ptr, head_size);
   }
 }
 
@@ -3740,11 +4759,12 @@ void paged_attention_custom_launcher_navi(
   // This ensures numerical stability when merging attention weights from multiple passes.
   if (npar_loops > 16) {
     const int num_passes = (npar_loops + 15) / 16;
-    paged_attention_merge_reduce_kernel<T, OUTT, HEAD_SIZE>
+    paged_attention_merge_reduce_kernel<T, OUTT>
         <<<reduce_grid, reduce_block, 0, stream>>>(
             out_ptr, tmp_out_ptr, temp_base_offset,
             seq_lens_ptr, query_start_loc_ptr, num_passes,
-            num_heads, fp8_out_scale_ptr);
+            num_heads, fp8_out_scale_ptr,
+            head_size);
   }
 }
 
@@ -3764,6 +4784,16 @@ void paged_attention_custom_launcher_navi(
         num_kv_heads, scale, block_tables, seq_lens, query_start_loc,       \
         max_seq_len, alibi_slopes, k_scale, v_scale);                       \
   }
+
+#define CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE)                  \
+  TORCH_CHECK(!fp8_out_scale, "free launcher does not support fp8_out");             \
+  paged_attention_fully_custom_launcher<T, KVT, KV_DTYPE,                           \
+                                       T, 256, false, MFMA_TYPE>(                   \
+      out, exp_sums, max_logits, tmp_out, query, key_cache, value_cache,             \
+      num_kv_heads, scale, block_tables, seq_lens, query_start_loc,                 \
+      max_seq_len, alibi_slopes, k_scale, v_scale, fp8_out_scale,                   \
+      block_size, head_size);
+
 
 #define CALL_CUSTOM_LAUNCHER_ALIBI(T, KVT, KV_DTYPE, BLK_SIZE, HEAD_SIZE,    \
                                    OUTT, PSIZE, MFMA_TYPE)                   \
@@ -3805,7 +4835,7 @@ void paged_attention_custom_launcher_navi(
       CALL_CUSTOM_LAUNCHER_OUT(T, KVT, KV_DTYPE, 32, HEAD_SIZE, MFMA_TYPE); \
       break;                                                                \
     default:                                                                \
-      TORCH_CHECK(false, "Unsupported block size: ", block_size);           \
+      CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE); \
       break;                                                                \
   }
 
@@ -3818,90 +4848,9 @@ void paged_attention_custom_launcher_navi(
       CALL_CUSTOM_LAUNCHER_BLK(T, KVT, KV_DTYPE, 128, MFMA_TYPE);  \
       break;                                                       \
     default:                                                       \
-      TORCH_CHECK(false, "Unsupported head size: ", head_size);    \
+      CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE);  \
       break;                                                       \
   }
-
-// Merge kernel implementation: combines multiple float4 (acc, exp_sum, max_logit, 0) outputs
-// using numerically stable log-sum-exp across passes. Defined outside architecture blocks.
-// temps layout: [num_passes][num_seqs * num_heads * HEAD_SIZE] float4 elements
-template <typename scalar_t, typename OUTT, int HEAD_SIZE>
-__global__ void paged_attention_merge_reduce_kernel(
-    OUTT* __restrict__ out,           // [num_seqs, num_heads, head_size]
-    const scalar_t* __restrict__ tmp_out, // base pointer (same as reduce kernel receives)
-    const int64_t temp_base_offset,   // byte offset from tmp_out to float4 temp buffer
-    const int* __restrict__ seq_lens, // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr, // [num_seqs+1] or nullptr
-    const int num_passes,
-    const int num_heads,
-    const float* __restrict__ fp8_out_scale_ptr) {
-#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
-  const auto head_idx = blockIdx.x;
-  const auto seq_idx = blockIdx.y;
-
-  // NOTE queries with sequence len > 1 are prefills and taken care by another kernel.
-  if (query_start_loc_ptr != nullptr &&
-      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
-    return;
-  }
-
-  // Reconstruct temps pointer from tmp_out + byte offset (CUDA graph safe).
-  const float4* temps = reinterpret_cast<const float4*>(
-      reinterpret_cast<const char*>(tmp_out) + temp_base_offset);
-
-  // Each element of temps is float4(acc, exp_sum, max_logit, 0).
-  // acc and exp_sum are relative to max_logit (that pass's global max).
-  // To correctly merge, re-scale each pass to the true global max across all passes.
-  // temps layout: [num_passes][num_seqs * num_heads * HEAD_SIZE] float4 elements.
-  const int num_seqs = gridDim.y;
-  const int64_t per_pass_stride = (int64_t)num_seqs * num_heads * HEAD_SIZE;
-  const int64_t seq_head_offset = (int64_t)seq_idx * num_heads * HEAD_SIZE +
-                                  (int64_t)head_idx * HEAD_SIZE + threadIdx.x;
-
-  // Pass 1: find the true global max logit across all passes
-  float true_max_logit = -FLT_MAX;
-  for (int pass = 0; pass < num_passes; ++pass) {
-    const int64_t idx = (int64_t)pass * per_pass_stride + seq_head_offset;
-    // max_logit is per (seq, head), same for all threadIdx.x — but we read it per element;
-    // they are identical across threadIdx.x for the same (pass, seq, head), so no issue.
-    true_max_logit = fmaxf(true_max_logit, temps[idx].z);
-  }
-
-  // Pass 2: accumulate with correction for different pass max_logits
-  float acc = 0.0f;
-  float global_exp_sum = 0.0f;
-  for (int pass = 0; pass < num_passes; ++pass) {
-    const int64_t idx = (int64_t)pass * per_pass_stride + seq_head_offset;
-    const float4 temp = temps[idx];
-    const float correction = expf(temp.z - true_max_logit);
-    acc           += temp.x * correction;
-    global_exp_sum += temp.y * correction;
-  }
-
-  const int64_t query_start_off = static_cast<int64_t>(
-      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
-                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
-
-  // Normalize and write output
-  const float inv_global_exp_sum = __fdividef(1.0f, global_exp_sum + 1e-6f);
-  const float out_scale = (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
-  acc *= inv_global_exp_sum;
-  acc *= out_scale;
-
-#ifdef __HIP__GFX9__
-  if constexpr (std::is_same<OUTT, bit8_t>::value) {
-    out_ptr[threadIdx.x] =
-        __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
-                               vllm::fp8::fp8_type::__default_interpret);
-  } else {
-    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
-  }
-#else
-  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
-#endif
-#endif
-}
 
 bool is_navi_gpu() {
   static bool is_cached = false;

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -59,6 +59,18 @@ enum class MFMAType {
   Fp4 = 2,
 };
 
+// Forward declaration of merge kernel - defined here so it's available to all architectures
+template <typename scalar_t, typename OUTT, int HEAD_SIZE>
+__global__ void paged_attention_merge_reduce_kernel(
+    OUTT* __restrict__ out,
+    const scalar_t* __restrict__ tmp_out,
+    const int64_t temp_base_offset,
+    const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc_ptr,
+    const int num_passes,
+    const int num_heads,
+    const float* __restrict__ fp8_out_scale_ptr);
+
 #if defined(__HIP__GFX9__)
 
   #define GCN_MFMA_INSTR1 __builtin_amdgcn_mfma_f32_16x16x4f32
@@ -1427,7 +1439,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
                                            // max_num_partitions, head_size]
     const int* __restrict__ seq_lens,      // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr) {
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
   const auto num_heads = gridDim.x;
   const auto head_idx = blockIdx.x;
   const auto seq_idx = blockIdx.y;
@@ -1439,16 +1454,31 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     return;
   }
 
-  const int seq_len = seq_lens[seq_idx];
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
+    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
+      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
   const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
   const auto warpid = threadIdx.x / WARP_SIZE;
 
   __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
   // max num partitions supported is warp_size * NPAR_LOOPS
   __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
 
   if (warpid == 0) {
-    const float* max_logits_ptr = max_logits +
+    const float* max_logits_ptr = max_logits + partition_offset +
                                   seq_idx * num_heads * max_num_partitions +
                                   head_idx * max_num_partitions;
 
@@ -1479,7 +1509,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
       max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
     }
 
-    const float* exp_sums_ptr = exp_sums +
+    const float* exp_sums_ptr = exp_sums + partition_offset +
                                 seq_idx * num_heads * max_num_partitions +
                                 head_idx * max_num_partitions;
 
@@ -1512,11 +1542,13 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     }
     if (threadIdx.x == 0) {
       shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
     }
   }  // warpid == 0
   const scalar_t* tmp_out_ptr =
       tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE + threadIdx.x;
+      head_idx * max_num_partitions * HEAD_SIZE +
+      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
   constexpr int MAX_NPAR = 64;
   scalar_t tmps[MAX_NPAR];
   const float dzero = 0.0f;
@@ -1605,18 +1637,31 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
       __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
   const float out_scale =
       (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
-  acc *= inv_global_exp_sum;
-  acc *= out_scale;
+
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
   OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
                   static_cast<int64_t>(head_idx) * HEAD_SIZE;
-  if constexpr (std::is_same<OUTT, bit8_t>::value) {
-    out_ptr[threadIdx.x] =
-        __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
-                               vllm::fp8::fp8_type::__default_interpret);
+
+  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
+  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
+    temp_out_ptr[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
   } else {
-    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    acc *= inv_global_exp_sum;
+    acc *= out_scale;
+    if constexpr (std::is_same<OUTT, bit8_t>::value) {
+      out_ptr[threadIdx.x] =
+          __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                                 vllm::fp8::fp8_type::__default_interpret);
+    } else {
+      out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    }
   }
 }
 
@@ -2194,7 +2239,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
                                            // max_num_partitions, head_size]
     const int* __restrict__ seq_lens,      // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr) {
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
   const auto num_heads = gridDim.x;
   const auto head_idx = blockIdx.x;
   const auto seq_idx = blockIdx.y;
@@ -2206,16 +2254,31 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     return;
   }
 
-  const int seq_len = seq_lens[seq_idx];
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
+    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
+      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
   const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
   const int warpid = threadIdx.x / WARP_SIZE;
 
   __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
   // max num partitions supported is warp_size * NPAR_LOOPS
   __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
 
   if (warpid == 0) {
-    const float* max_logits_ptr = max_logits +
+    const float* max_logits_ptr = max_logits + partition_offset +
                                   seq_idx * num_heads * max_num_partitions +
                                   head_idx * max_num_partitions;
 
@@ -2246,7 +2309,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
       max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
     }
 
-    const float* exp_sums_ptr = exp_sums +
+    const float* exp_sums_ptr = exp_sums + partition_offset +
                                 seq_idx * num_heads * max_num_partitions +
                                 head_idx * max_num_partitions;
 
@@ -2279,11 +2342,13 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     }
     if (threadIdx.x == 0) {
       shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
     }
   }  // warpid == 0
   const scalar_t* tmp_out_ptr =
       tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE + threadIdx.x;
+      head_idx * max_num_partitions * HEAD_SIZE +
+      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
   constexpr int MAX_NPAR = 32;
   scalar_t tmps[MAX_NPAR];
   const float dzero = 0.0f;
@@ -2370,13 +2435,26 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
 
   const float inv_global_exp_sum =
       __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
-  acc *= inv_global_exp_sum;
 
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
   OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
                   static_cast<int64_t>(head_idx) * HEAD_SIZE;
-  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+
+  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
+  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
+    temp_out_ptr[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
+    return;
+  } else {
+    acc *= inv_global_exp_sum;
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+  }
 }
 
 #elif defined(__GFX12__)
@@ -2927,7 +3005,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
                                            // max_num_partitions, head_size]
     const int* __restrict__ seq_lens,      // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr) {
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
   const auto num_heads = gridDim.x;
   const auto head_idx = blockIdx.x;
   const auto seq_idx = blockIdx.y;
@@ -2939,16 +3020,31 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     return;
   }
 
-  const int seq_len = seq_lens[seq_idx];
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
+    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
+      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
   const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
   const int warpid = threadIdx.x / WARP_SIZE;
 
   __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
   // max num partitions supported is warp_size * NPAR_LOOPS
   __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
 
   if (warpid == 0) {
-    const float* max_logits_ptr = max_logits +
+    const float* max_logits_ptr = max_logits + partition_offset +
                                   seq_idx * num_heads * max_num_partitions +
                                   head_idx * max_num_partitions;
 
@@ -2979,7 +3075,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
       max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
     }
 
-    const float* exp_sums_ptr = exp_sums +
+    const float* exp_sums_ptr = exp_sums + partition_offset +
                                 seq_idx * num_heads * max_num_partitions +
                                 head_idx * max_num_partitions;
 
@@ -3012,11 +3108,13 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     }
     if (threadIdx.x == 0) {
       shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
     }
   }  // warpid == 0
   const scalar_t* tmp_out_ptr =
       tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE + threadIdx.x;
+      head_idx * max_num_partitions * HEAD_SIZE +
+      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
   constexpr int MAX_NPAR = 32;
   scalar_t tmps[MAX_NPAR];
   const float dzero = 0.0f;
@@ -3103,13 +3201,26 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
 
   const float inv_global_exp_sum =
       __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
-  acc *= inv_global_exp_sum;
 
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
   OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
                   static_cast<int64_t>(head_idx) * HEAD_SIZE;
-  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+
+  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
+  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
+    temp_out_ptr[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
+    return;
+  } else {
+    acc *= inv_global_exp_sum;
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+  }
 }
 
 #else
@@ -3180,7 +3291,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads, max_num_partitions, head_size]
     const int* __restrict__ seq_lens,  // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr) {
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
   UNREACHABLE_CODE
 }
 // clang-format on
@@ -3209,12 +3323,18 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
           kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,  \
           max_ctx_blocks, k_scale_ptr, v_scale_ptr);
 
-#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                 \
-  paged_attention_ll4mi_reduce_kernel<T, OUTT, HEAD_SIZE, HEAD_SIZE,        \
+#define LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, DST, OUT_TYPE,             \
+                                     TEMP_OFFSET, PART_OFFSET)              \
+  paged_attention_ll4mi_reduce_kernel<T, OUT_TYPE, HEAD_SIZE, HEAD_SIZE,    \
                                       PARTITION_SIZE, NPAR_LOOPS>           \
       <<<reduce_grid, reduce_block, 0, stream>>>(                           \
-          out_ptr, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, seq_lens_ptr, \
-          query_start_loc_ptr, max_num_partitions, fp8_out_scale_ptr);
+          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,   \
+          tmp_out_ptr, seq_lens_ptr,                                        \
+          query_start_loc_ptr, max_num_partitions, fp8_out_scale_ptr,       \
+          seq_len_offset, TEMP_OFFSET, PART_OFFSET);
+
+#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                 \
+  LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, out_ptr, OUTT, 0, 0)
 
 template <typename T, typename KVT, vllm::Fp8KVCacheDataType KV_DTYPE,
           int BLOCK_SIZE, int HEAD_SIZE, typename OUTT, int PARTITION_SIZE_OLD,
@@ -3339,8 +3459,16 @@ void paged_attention_custom_launcher(
   dim3 reduce_grid(num_heads, num_seqs);
   dim3 reduce_block(head_size);
   const int npar_loops = DIVIDE_ROUND_UP(max_num_partitions, WARP_SIZE);
+  int seq_len_offset = 0;
   // reduction kernel supports upto 8 NPAR_loops * 64 (warp_size) * 256
   // (partition size) = 128K context length
+
+  // Byte offset from tmp_out to the float4 multi-pass buffer.
+  // The buffer lives at the end of tmp_out, after max_num_partitions partition slices.
+  // Python allocates extra partitions in tmp_out: extra = max_passes * sizeof(float4)/sizeof(T).
+  const int64_t temp_base_offset =
+      (int64_t)num_seqs * num_heads * max_num_partitions * head_size * sizeof(T);
+
   switch (npar_loops) {
     case 1:
       LAUNCH_CUSTOM_REDUCTION(1);
@@ -3367,8 +3495,43 @@ void paged_attention_custom_launcher(
       LAUNCH_CUSTOM_REDUCTION(8);
       break;
     default:
-      TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      // For npar_loops > 8, perform multiple reductions with 8 loops each.
+      // GFX9 hardware has a hard limit of 8 npar_loops per reduction kernel.
+      // This corresponds to processing 8 * WARP_SIZE (512) partitions per pass.
+      // For sequences longer than 128K tokens (which require ~512 partitions at 256-tok/partition),
+      // we split the work into multiple passes:
+      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for intermediate results
+      //   - A final merge kernel combines these using log-sum-exp for numerical stability
+      //   - This allows unlimited sequence length via multiple passes
+      if (npar_loops > 8) {
+        const int num_passes = (npar_loops + 7) / 8;
+        const int partitions_per_pass = 8 * WARP_SIZE;  // 8 npar_loops * 64 warp_size
+        for (int pass = 0; pass < num_passes; ++pass) {
+          const int part_offset = pass * partitions_per_pass;
+          const int64_t pass_temp_offset = temp_base_offset +
+              pass * (int64_t)num_seqs * num_heads * head_size * sizeof(float4);
+          LAUNCH_CUSTOM_REDUCTION_INNER(8, out_ptr, float4,
+                                        pass_temp_offset, part_offset);
+          seq_len_offset += 8 * PARTITION_SIZE * 64;
+        }
+      } else {
+        TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      }
       break;
+  }
+
+  // If we did multi-pass reductions, merge the results using log-sum-exp.
+  // The multi-pass reductions produced float4 outputs per pass.
+  // This merge kernel combines them into the final output using the stable log-sum-exp formula:
+  //   result = value_1 + exp_sum_1 * (value_2 / exp_sum_1 + ...)
+  // This ensures numerical stability when merging attention weights from multiple passes.
+  if (npar_loops > 8) {
+    const int num_passes = (npar_loops + 7) / 8;
+    paged_attention_merge_reduce_kernel<T, OUTT, HEAD_SIZE>
+        <<<reduce_grid, reduce_block, 0, stream>>>(
+            out_ptr, tmp_out_ptr, temp_base_offset,
+            seq_lens_ptr, query_start_loc_ptr, num_passes,
+            num_heads, fp8_out_scale_ptr);
   }
 }
 
@@ -3429,6 +3592,7 @@ void paged_attention_custom_launcher_navi(
   dim3 block(NTHR);
   const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int seq_len_offset = 0;
 
   switch (gqa_ratio) {
     case 1:
@@ -3488,8 +3652,12 @@ void paged_attention_custom_launcher_navi(
   dim3 reduce_block(head_size);
   const int warp_size = 32;
   const int npar_loops = DIVIDE_ROUND_UP(max_num_partitions, warp_size);
-  // reduction kernel supports upto 16 NPAR_loops * 32 (warp_size) * 256
-  // (partition size) = 128K context length
+  // Byte offset from tmp_out to the float4 multi-pass buffer.
+  // The buffer lives at the end of tmp_out, after max_num_partitions partition slices.
+  // Python allocates extra partitions in tmp_out: extra = max_passes * sizeof(float4)/sizeof(T).
+  const int64_t temp_base_offset =
+      (int64_t)num_seqs * num_heads * max_num_partitions * head_size * sizeof(T);
+
   switch (npar_loops) {
     case 1:
       LAUNCH_CUSTOM_REDUCTION(1);
@@ -3540,8 +3708,43 @@ void paged_attention_custom_launcher_navi(
       LAUNCH_CUSTOM_REDUCTION(16);
       break;
     default:
-      TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      // For npar_loops > 16, perform multiple reductions with 16 loops each.
+      // RDNA (GFX12) hardware has a limit of 16 npar_loops per reduction kernel.
+      // This corresponds to processing 16 * warp_size (512) partitions per pass.
+      // For sequences longer than 128K tokens (which require ~512 partitions at 256-tok/partition),
+      // we split the work into multiple passes:
+      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for intermediate results
+      //   - A final merge kernel combines these using log-sum-exp for numerical stability
+      //   - This allows unlimited sequence length via multiple passes
+      if (npar_loops > 16) {
+        const int num_passes = (npar_loops + 15) / 16;
+        const int partitions_per_pass = 16 * warp_size;  // 16 npar_loops * 32 warp_size
+        for (int pass = 0; pass < num_passes; ++pass) {
+          const int part_offset = pass * partitions_per_pass;
+          const int64_t pass_temp_offset = temp_base_offset +
+              pass * (int64_t)num_seqs * num_heads * head_size * sizeof(float4);
+          LAUNCH_CUSTOM_REDUCTION_INNER(16, out_ptr, float4,
+                                        pass_temp_offset, part_offset);
+          seq_len_offset += 16 * PARTITION_SIZE * 32;
+        }
+      } else {
+        TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      }
       break;
+  }
+
+  // If we did multi-pass reductions, merge the results using log-sum-exp.
+  // The multi-pass reductions produced float4 outputs per pass.
+  // This merge kernel combines them into the final output using the stable log-sum-exp formula:
+  //   result = value_1 + exp_sum_1 * (value_2 / exp_sum_1 + ...)
+  // This ensures numerical stability when merging attention weights from multiple passes.
+  if (npar_loops > 16) {
+    const int num_passes = (npar_loops + 15) / 16;
+    paged_attention_merge_reduce_kernel<T, OUTT, HEAD_SIZE>
+        <<<reduce_grid, reduce_block, 0, stream>>>(
+            out_ptr, tmp_out_ptr, temp_base_offset,
+            seq_lens_ptr, query_start_loc_ptr, num_passes,
+            num_heads, fp8_out_scale_ptr);
   }
 }
 
@@ -3618,6 +3821,87 @@ void paged_attention_custom_launcher_navi(
       TORCH_CHECK(false, "Unsupported head size: ", head_size);    \
       break;                                                       \
   }
+
+// Merge kernel implementation: combines multiple float4 (acc, exp_sum, max_logit, 0) outputs
+// using numerically stable log-sum-exp across passes. Defined outside architecture blocks.
+// temps layout: [num_passes][num_seqs * num_heads * HEAD_SIZE] float4 elements
+template <typename scalar_t, typename OUTT, int HEAD_SIZE>
+__global__ void paged_attention_merge_reduce_kernel(
+    OUTT* __restrict__ out,           // [num_seqs, num_heads, head_size]
+    const scalar_t* __restrict__ tmp_out, // base pointer (same as reduce kernel receives)
+    const int64_t temp_base_offset,   // byte offset from tmp_out to float4 temp buffer
+    const int* __restrict__ seq_lens, // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr, // [num_seqs+1] or nullptr
+    const int num_passes,
+    const int num_heads,
+    const float* __restrict__ fp8_out_scale_ptr) {
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
+  const auto head_idx = blockIdx.x;
+  const auto seq_idx = blockIdx.y;
+
+  // NOTE queries with sequence len > 1 are prefills and taken care by another kernel.
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
+    return;
+  }
+
+  // Reconstruct temps pointer from tmp_out + byte offset (CUDA graph safe).
+  const float4* temps = reinterpret_cast<const float4*>(
+      reinterpret_cast<const char*>(tmp_out) + temp_base_offset);
+
+  // Each element of temps is float4(acc, exp_sum, max_logit, 0).
+  // acc and exp_sum are relative to max_logit (that pass's global max).
+  // To correctly merge, re-scale each pass to the true global max across all passes.
+  // temps layout: [num_passes][num_seqs * num_heads * HEAD_SIZE] float4 elements.
+  const int num_seqs = gridDim.y;
+  const int64_t per_pass_stride = (int64_t)num_seqs * num_heads * HEAD_SIZE;
+  const int64_t seq_head_offset = (int64_t)seq_idx * num_heads * HEAD_SIZE +
+                                  (int64_t)head_idx * HEAD_SIZE + threadIdx.x;
+
+  // Pass 1: find the true global max logit across all passes
+  float true_max_logit = -FLT_MAX;
+  for (int pass = 0; pass < num_passes; ++pass) {
+    const int64_t idx = (int64_t)pass * per_pass_stride + seq_head_offset;
+    // max_logit is per (seq, head), same for all threadIdx.x — but we read it per element;
+    // they are identical across threadIdx.x for the same (pass, seq, head), so no issue.
+    true_max_logit = fmaxf(true_max_logit, temps[idx].z);
+  }
+
+  // Pass 2: accumulate with correction for different pass max_logits
+  float acc = 0.0f;
+  float global_exp_sum = 0.0f;
+  for (int pass = 0; pass < num_passes; ++pass) {
+    const int64_t idx = (int64_t)pass * per_pass_stride + seq_head_offset;
+    const float4 temp = temps[idx];
+    const float correction = expf(temp.z - true_max_logit);
+    acc           += temp.x * correction;
+    global_exp_sum += temp.y * correction;
+  }
+
+  const int64_t query_start_off = static_cast<int64_t>(
+      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
+                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
+
+  // Normalize and write output
+  const float inv_global_exp_sum = __fdividef(1.0f, global_exp_sum + 1e-6f);
+  const float out_scale = (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+  acc *= inv_global_exp_sum;
+  acc *= out_scale;
+
+#ifdef __HIP__GFX9__
+  if constexpr (std::is_same<OUTT, bit8_t>::value) {
+    out_ptr[threadIdx.x] =
+        __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                               vllm::fp8::fp8_type::__default_interpret);
+  } else {
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+  }
+#else
+  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+#endif
+#endif
+}
 
 bool is_navi_gpu() {
   static bool is_cached = false;

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -2467,6 +2467,17 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
           const _B16x8* v_fetch_ptr_16B =
               reinterpret_cast<const _B16x8*>(v_fetch_ptr);
           Vlocal[vtoken_depth][vhe_depth][vfetch_depth] = *v_fetch_ptr_16B;
+          // Slots past seq_len in the final block are never written and may
+          // hold NaN; score masking alone does not help, since 0 * NaN = NaN.
+          if (partition_start_token_idx + T_PAR_SIZE > seq_len) {
+            const int vglobal_fetch_start =
+                partition_start_token_idx + vlocal_token_idx +
+                vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+            Vlocal[vtoken_depth][vhe_depth][vfetch_depth] =
+                mask_v_cache_padding<cache_t>(
+                    Vlocal[vtoken_depth][vhe_depth][vfetch_depth],
+                    vglobal_fetch_start, seq_len);
+          }
         }
       }
     }
@@ -4147,6 +4158,19 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
             vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
         Vlocal[vtoken_depth][vhe_depth][vfetch_depth] =
             *reinterpret_cast<const _B16x8*>(v_fetch_ptr);
+        // Slots past seq_len in the final block are never written and may hold
+        // NaN; score masking alone does not help, since 0 * NaN = NaN.
+        if (partition_start_token_idx + T_PAR_SIZE > seq_len) {
+          const int vglobal_fetch_start =
+              partition_start_token_idx +
+              vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
+              rowid * VTOKENS_PER_LANE +
+              vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+          Vlocal[vtoken_depth][vhe_depth][vfetch_depth] =
+              mask_v_cache_padding<cache_t>(
+                  Vlocal[vtoken_depth][vhe_depth][vfetch_depth],
+                  vglobal_fetch_start, seq_len);
+        }
       }
     }
   }

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -90,6 +90,18 @@ __device__ __forceinline__ Vec mask_v_cache_padding(Vec values,
   return values;
 }
 
+// Forward declaration of merge kernel - defined here so it's available to all architectures
+template <typename scalar_t, typename OUTT, int HEAD_SIZE>
+__global__ void paged_attention_merge_reduce_kernel(
+    OUTT* __restrict__ out,
+    const scalar_t* __restrict__ tmp_out,
+    const int64_t temp_base_offset,
+    const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc_ptr,
+    const int num_passes,
+    const int num_heads,
+    const float* __restrict__ fp8_out_scale_ptr);
+
 #if defined(__HIP__GFX9__)
 
   #define GCN_MFMA_INSTR1 __builtin_amdgcn_mfma_f32_16x16x4f32
@@ -1556,7 +1568,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
                                            // max_num_partitions, head_size]
     const int* __restrict__ seq_lens,      // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr) {
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
   const auto num_heads = gridDim.x;
   const auto head_idx = blockIdx.x;
   const auto seq_idx = blockIdx.y;
@@ -1568,16 +1583,31 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     return;
   }
 
-  const int seq_len = seq_lens[seq_idx];
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
+    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
+      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
   const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
   const auto warpid = threadIdx.x / WARP_SIZE;
 
   __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
   // max num partitions supported is warp_size * NPAR_LOOPS
   __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
 
   if (warpid == 0) {
-    const float* max_logits_ptr = max_logits +
+    const float* max_logits_ptr = max_logits + partition_offset +
                                   seq_idx * num_heads * max_num_partitions +
                                   head_idx * max_num_partitions;
 
@@ -1608,7 +1638,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
       max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
     }
 
-    const float* exp_sums_ptr = exp_sums +
+    const float* exp_sums_ptr = exp_sums + partition_offset +
                                 seq_idx * num_heads * max_num_partitions +
                                 head_idx * max_num_partitions;
 
@@ -1641,11 +1671,13 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     }
     if (threadIdx.x == 0) {
       shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
     }
   }  // warpid == 0
   const scalar_t* tmp_out_ptr =
       tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE + threadIdx.x;
+      head_idx * max_num_partitions * HEAD_SIZE +
+      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
   constexpr int MAX_NPAR = 64;
   scalar_t tmps[MAX_NPAR];
   const float dzero = 0.0f;
@@ -1734,18 +1766,31 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
       __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
   const float out_scale =
       (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
-  acc *= inv_global_exp_sum;
-  acc *= out_scale;
+
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
   OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
                   static_cast<int64_t>(head_idx) * HEAD_SIZE;
-  if constexpr (std::is_same<OUTT, bit8_t>::value) {
-    out_ptr[threadIdx.x] =
-        __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
-                               vllm::fp8::fp8_type::__default_interpret);
+
+  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
+  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
+    temp_out_ptr[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
   } else {
-    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    acc *= inv_global_exp_sum;
+    acc *= out_scale;
+    if constexpr (std::is_same<OUTT, bit8_t>::value) {
+      out_ptr[threadIdx.x] =
+          __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                                 vllm::fp8::fp8_type::__default_interpret);
+    } else {
+      out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    }
   }
 }
 
@@ -2341,7 +2386,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
                                            // max_num_partitions, head_size]
     const int* __restrict__ seq_lens,      // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr) {
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
   const auto num_heads = gridDim.x;
   const auto head_idx = blockIdx.x;
   const auto seq_idx = blockIdx.y;
@@ -2353,16 +2401,31 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     return;
   }
 
-  const int seq_len = seq_lens[seq_idx];
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
+    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
+      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
   const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
   const int warpid = threadIdx.x / WARP_SIZE;
 
   __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
   // max num partitions supported is warp_size * NPAR_LOOPS
   __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
 
   if (warpid == 0) {
-    const float* max_logits_ptr = max_logits +
+    const float* max_logits_ptr = max_logits + partition_offset +
                                   seq_idx * num_heads * max_num_partitions +
                                   head_idx * max_num_partitions;
 
@@ -2393,7 +2456,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
       max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
     }
 
-    const float* exp_sums_ptr = exp_sums +
+    const float* exp_sums_ptr = exp_sums + partition_offset +
                                 seq_idx * num_heads * max_num_partitions +
                                 head_idx * max_num_partitions;
 
@@ -2426,11 +2489,13 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     }
     if (threadIdx.x == 0) {
       shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
     }
   }  // warpid == 0
   const scalar_t* tmp_out_ptr =
       tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE + threadIdx.x;
+      head_idx * max_num_partitions * HEAD_SIZE +
+      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
   constexpr int MAX_NPAR = 32;
   scalar_t tmps[MAX_NPAR];
   const float dzero = 0.0f;
@@ -2517,13 +2582,26 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
 
   const float inv_global_exp_sum =
       __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
-  acc *= inv_global_exp_sum;
 
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
   OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
                   static_cast<int64_t>(head_idx) * HEAD_SIZE;
-  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+
+  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
+  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
+    temp_out_ptr[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
+    return;
+  } else {
+    acc *= inv_global_exp_sum;
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+  }
 }
 
 #elif defined(__GFX12__)
@@ -3103,7 +3181,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
                                            // max_num_partitions, head_size]
     const int* __restrict__ seq_lens,      // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr) {
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
   const auto num_heads = gridDim.x;
   const auto head_idx = blockIdx.x;
   const auto seq_idx = blockIdx.y;
@@ -3115,16 +3196,31 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     return;
   }
 
-  const int seq_len = seq_lens[seq_idx];
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
+    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
+      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
   const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
   const int warpid = threadIdx.x / WARP_SIZE;
 
   __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
   // max num partitions supported is warp_size * NPAR_LOOPS
   __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
 
   if (warpid == 0) {
-    const float* max_logits_ptr = max_logits +
+    const float* max_logits_ptr = max_logits + partition_offset +
                                   seq_idx * num_heads * max_num_partitions +
                                   head_idx * max_num_partitions;
 
@@ -3155,7 +3251,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
       max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
     }
 
-    const float* exp_sums_ptr = exp_sums +
+    const float* exp_sums_ptr = exp_sums + partition_offset +
                                 seq_idx * num_heads * max_num_partitions +
                                 head_idx * max_num_partitions;
 
@@ -3188,11 +3284,13 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     }
     if (threadIdx.x == 0) {
       shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
     }
   }  // warpid == 0
   const scalar_t* tmp_out_ptr =
       tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE + threadIdx.x;
+      head_idx * max_num_partitions * HEAD_SIZE +
+      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
   constexpr int MAX_NPAR = 32;
   scalar_t tmps[MAX_NPAR];
   const float dzero = 0.0f;
@@ -3279,13 +3377,26 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
 
   const float inv_global_exp_sum =
       __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
-  acc *= inv_global_exp_sum;
 
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
   OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
                   static_cast<int64_t>(head_idx) * HEAD_SIZE;
-  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+
+  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
+  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
+    temp_out_ptr[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
+    return;
+  } else {
+    acc *= inv_global_exp_sum;
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+  }
 }
 
 #else
@@ -3356,7 +3467,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads, max_num_partitions, head_size]
     const int* __restrict__ seq_lens,  // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr) {
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
   UNREACHABLE_CODE
 }
 // clang-format on
@@ -3385,12 +3499,18 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
           kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,  \
           max_ctx_blocks, k_scale_ptr, v_scale_ptr);
 
-#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                 \
-  paged_attention_ll4mi_reduce_kernel<T, OUTT, HEAD_SIZE, HEAD_SIZE,        \
+#define LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, DST, OUT_TYPE,             \
+                                     TEMP_OFFSET, PART_OFFSET)              \
+  paged_attention_ll4mi_reduce_kernel<T, OUT_TYPE, HEAD_SIZE, HEAD_SIZE,    \
                                       PARTITION_SIZE, NPAR_LOOPS>           \
       <<<reduce_grid, reduce_block, 0, stream>>>(                           \
-          out_ptr, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, seq_lens_ptr, \
-          query_start_loc_ptr, max_num_partitions, fp8_out_scale_ptr);
+          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,   \
+          tmp_out_ptr, seq_lens_ptr,                                        \
+          query_start_loc_ptr, max_num_partitions, fp8_out_scale_ptr,       \
+          seq_len_offset, TEMP_OFFSET, PART_OFFSET);
+
+#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                 \
+  LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, out_ptr, OUTT, 0, 0)
 
 template <typename T, typename KVT, vllm::Fp8KVCacheDataType KV_DTYPE,
           int BLOCK_SIZE, int HEAD_SIZE, typename OUTT, int PARTITION_SIZE_OLD,
@@ -3515,8 +3635,16 @@ void paged_attention_custom_launcher(
   dim3 reduce_grid(num_heads, num_seqs);
   dim3 reduce_block(head_size);
   const int npar_loops = DIVIDE_ROUND_UP(max_num_partitions, WARP_SIZE);
+  int seq_len_offset = 0;
   // reduction kernel supports upto 8 NPAR_loops * 64 (warp_size) * 256
   // (partition size) = 128K context length
+
+  // Byte offset from tmp_out to the float4 multi-pass buffer.
+  // The buffer lives at the end of tmp_out, after max_num_partitions partition slices.
+  // Python allocates extra partitions in tmp_out: extra = max_passes * sizeof(float4)/sizeof(T).
+  const int64_t temp_base_offset =
+      (int64_t)num_seqs * num_heads * max_num_partitions * head_size * sizeof(T);
+
   switch (npar_loops) {
     case 1:
       LAUNCH_CUSTOM_REDUCTION(1);
@@ -3543,8 +3671,43 @@ void paged_attention_custom_launcher(
       LAUNCH_CUSTOM_REDUCTION(8);
       break;
     default:
-      TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      // For npar_loops > 8, perform multiple reductions with 8 loops each.
+      // GFX9 hardware has a hard limit of 8 npar_loops per reduction kernel.
+      // This corresponds to processing 8 * WARP_SIZE (512) partitions per pass.
+      // For sequences longer than 128K tokens (which require ~512 partitions at 256-tok/partition),
+      // we split the work into multiple passes:
+      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for intermediate results
+      //   - A final merge kernel combines these using log-sum-exp for numerical stability
+      //   - This allows unlimited sequence length via multiple passes
+      if (npar_loops > 8) {
+        const int num_passes = (npar_loops + 7) / 8;
+        const int partitions_per_pass = 8 * WARP_SIZE;  // 8 npar_loops * 64 warp_size
+        for (int pass = 0; pass < num_passes; ++pass) {
+          const int part_offset = pass * partitions_per_pass;
+          const int64_t pass_temp_offset = temp_base_offset +
+              pass * (int64_t)num_seqs * num_heads * head_size * sizeof(float4);
+          LAUNCH_CUSTOM_REDUCTION_INNER(8, out_ptr, float4,
+                                        pass_temp_offset, part_offset);
+          seq_len_offset += 8 * PARTITION_SIZE * 64;
+        }
+      } else {
+        TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      }
       break;
+  }
+
+  // If we did multi-pass reductions, merge the results using log-sum-exp.
+  // The multi-pass reductions produced float4 outputs per pass.
+  // This merge kernel combines them into the final output using the stable log-sum-exp formula:
+  //   result = value_1 + exp_sum_1 * (value_2 / exp_sum_1 + ...)
+  // This ensures numerical stability when merging attention weights from multiple passes.
+  if (npar_loops > 8) {
+    const int num_passes = (npar_loops + 7) / 8;
+    paged_attention_merge_reduce_kernel<T, OUTT, HEAD_SIZE>
+        <<<reduce_grid, reduce_block, 0, stream>>>(
+            out_ptr, tmp_out_ptr, temp_base_offset,
+            seq_lens_ptr, query_start_loc_ptr, num_passes,
+            num_heads, fp8_out_scale_ptr);
   }
 }
 
@@ -3605,6 +3768,7 @@ void paged_attention_custom_launcher_navi(
   dim3 block(NTHR);
   const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  int seq_len_offset = 0;
 
   switch (gqa_ratio) {
     case 1:
@@ -3664,8 +3828,12 @@ void paged_attention_custom_launcher_navi(
   dim3 reduce_block(head_size);
   const int warp_size = 32;
   const int npar_loops = DIVIDE_ROUND_UP(max_num_partitions, warp_size);
-  // reduction kernel supports upto 16 NPAR_loops * 32 (warp_size) * 256
-  // (partition size) = 128K context length
+  // Byte offset from tmp_out to the float4 multi-pass buffer.
+  // The buffer lives at the end of tmp_out, after max_num_partitions partition slices.
+  // Python allocates extra partitions in tmp_out: extra = max_passes * sizeof(float4)/sizeof(T).
+  const int64_t temp_base_offset =
+      (int64_t)num_seqs * num_heads * max_num_partitions * head_size * sizeof(T);
+
   switch (npar_loops) {
     case 1:
       LAUNCH_CUSTOM_REDUCTION(1);
@@ -3716,8 +3884,43 @@ void paged_attention_custom_launcher_navi(
       LAUNCH_CUSTOM_REDUCTION(16);
       break;
     default:
-      TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      // For npar_loops > 16, perform multiple reductions with 16 loops each.
+      // RDNA (GFX12) hardware has a limit of 16 npar_loops per reduction kernel.
+      // This corresponds to processing 16 * warp_size (512) partitions per pass.
+      // For sequences longer than 128K tokens (which require ~512 partitions at 256-tok/partition),
+      // we split the work into multiple passes:
+      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for intermediate results
+      //   - A final merge kernel combines these using log-sum-exp for numerical stability
+      //   - This allows unlimited sequence length via multiple passes
+      if (npar_loops > 16) {
+        const int num_passes = (npar_loops + 15) / 16;
+        const int partitions_per_pass = 16 * warp_size;  // 16 npar_loops * 32 warp_size
+        for (int pass = 0; pass < num_passes; ++pass) {
+          const int part_offset = pass * partitions_per_pass;
+          const int64_t pass_temp_offset = temp_base_offset +
+              pass * (int64_t)num_seqs * num_heads * head_size * sizeof(float4);
+          LAUNCH_CUSTOM_REDUCTION_INNER(16, out_ptr, float4,
+                                        pass_temp_offset, part_offset);
+          seq_len_offset += 16 * PARTITION_SIZE * 32;
+        }
+      } else {
+        TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      }
       break;
+  }
+
+  // If we did multi-pass reductions, merge the results using log-sum-exp.
+  // The multi-pass reductions produced float4 outputs per pass.
+  // This merge kernel combines them into the final output using the stable log-sum-exp formula:
+  //   result = value_1 + exp_sum_1 * (value_2 / exp_sum_1 + ...)
+  // This ensures numerical stability when merging attention weights from multiple passes.
+  if (npar_loops > 16) {
+    const int num_passes = (npar_loops + 15) / 16;
+    paged_attention_merge_reduce_kernel<T, OUTT, HEAD_SIZE>
+        <<<reduce_grid, reduce_block, 0, stream>>>(
+            out_ptr, tmp_out_ptr, temp_base_offset,
+            seq_lens_ptr, query_start_loc_ptr, num_passes,
+            num_heads, fp8_out_scale_ptr);
   }
 }
 
@@ -3794,6 +3997,87 @@ void paged_attention_custom_launcher_navi(
       TORCH_CHECK(false, "Unsupported head size: ", head_size);    \
       break;                                                       \
   }
+
+// Merge kernel implementation: combines multiple float4 (acc, exp_sum, max_logit, 0) outputs
+// using numerically stable log-sum-exp across passes. Defined outside architecture blocks.
+// temps layout: [num_passes][num_seqs * num_heads * HEAD_SIZE] float4 elements
+template <typename scalar_t, typename OUTT, int HEAD_SIZE>
+__global__ void paged_attention_merge_reduce_kernel(
+    OUTT* __restrict__ out,           // [num_seqs, num_heads, head_size]
+    const scalar_t* __restrict__ tmp_out, // base pointer (same as reduce kernel receives)
+    const int64_t temp_base_offset,   // byte offset from tmp_out to float4 temp buffer
+    const int* __restrict__ seq_lens, // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr, // [num_seqs+1] or nullptr
+    const int num_passes,
+    const int num_heads,
+    const float* __restrict__ fp8_out_scale_ptr) {
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
+  const auto head_idx = blockIdx.x;
+  const auto seq_idx = blockIdx.y;
+
+  // NOTE queries with sequence len > 1 are prefills and taken care by another kernel.
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
+    return;
+  }
+
+  // Reconstruct temps pointer from tmp_out + byte offset (CUDA graph safe).
+  const float4* temps = reinterpret_cast<const float4*>(
+      reinterpret_cast<const char*>(tmp_out) + temp_base_offset);
+
+  // Each element of temps is float4(acc, exp_sum, max_logit, 0).
+  // acc and exp_sum are relative to max_logit (that pass's global max).
+  // To correctly merge, re-scale each pass to the true global max across all passes.
+  // temps layout: [num_passes][num_seqs * num_heads * HEAD_SIZE] float4 elements.
+  const int num_seqs = gridDim.y;
+  const int64_t per_pass_stride = (int64_t)num_seqs * num_heads * HEAD_SIZE;
+  const int64_t seq_head_offset = (int64_t)seq_idx * num_heads * HEAD_SIZE +
+                                  (int64_t)head_idx * HEAD_SIZE + threadIdx.x;
+
+  // Pass 1: find the true global max logit across all passes
+  float true_max_logit = -FLT_MAX;
+  for (int pass = 0; pass < num_passes; ++pass) {
+    const int64_t idx = (int64_t)pass * per_pass_stride + seq_head_offset;
+    // max_logit is per (seq, head), same for all threadIdx.x — but we read it per element;
+    // they are identical across threadIdx.x for the same (pass, seq, head), so no issue.
+    true_max_logit = fmaxf(true_max_logit, temps[idx].z);
+  }
+
+  // Pass 2: accumulate with correction for different pass max_logits
+  float acc = 0.0f;
+  float global_exp_sum = 0.0f;
+  for (int pass = 0; pass < num_passes; ++pass) {
+    const int64_t idx = (int64_t)pass * per_pass_stride + seq_head_offset;
+    const float4 temp = temps[idx];
+    const float correction = expf(temp.z - true_max_logit);
+    acc           += temp.x * correction;
+    global_exp_sum += temp.y * correction;
+  }
+
+  const int64_t query_start_off = static_cast<int64_t>(
+      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
+                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
+
+  // Normalize and write output
+  const float inv_global_exp_sum = __fdividef(1.0f, global_exp_sum + 1e-6f);
+  const float out_scale = (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+  acc *= inv_global_exp_sum;
+  acc *= out_scale;
+
+#ifdef __HIP__GFX9__
+  if constexpr (std::is_same<OUTT, bit8_t>::value) {
+    out_ptr[threadIdx.x] =
+        __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                               vllm::fp8::fp8_type::__default_interpret);
+  } else {
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+  }
+#else
+  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+#endif
+#endif
+}
 
 bool is_navi_gpu() {
   static bool is_cached = false;

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -121,22 +121,22 @@ __device__ __forceinline__ T from_float(const float& inp) {
 }
 
 // Grid: (num_heads, num_seqs).
-// "Free" reduce kernel: runtime head_size (no HEAD_SIZE/NUM_THREADS template params)
-template <typename scalar_t, typename OUTT,
-          int PARTITION_SIZE, int NPAR_LOOPS>
-__global__
-__launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
+// "Free" reduce kernel: runtime head_size (no HEAD_SIZE/NUM_THREADS template
+// params)
+template <typename scalar_t, typename OUTT, int PARTITION_SIZE, int NPAR_LOOPS>
+__global__ __launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
     OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
-    const float* __restrict__ exp_sums,    // [num_seqs, num_heads, max_num_partitions]
-    const float* __restrict__ max_logits,  // [num_seqs, num_heads, max_num_partitions]
-    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads, max_num_partitions, head_size]
+    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
+                                           // max_num_partitions]
+    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
+                                           // max_num_partitions]
+    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
+                                           // max_num_partitions, head_size]
     const int* __restrict__ seq_lens,      // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
     const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
-    const int partition_offset,
-    int head_size) {
+    const int seq_len_offset, const int64_t temp_offset,
+    const int partition_offset, int head_size) {
   const auto num_heads = gridDim.x;
   const auto head_idx = blockIdx.x;
   const auto seq_idx = blockIdx.y;
@@ -152,9 +152,11 @@ __launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
       const int64_t query_start_off = static_cast<int64_t>(
           query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
       float4* temp_dst = reinterpret_cast<float4*>(
-          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-      float4* temp_out_ptr2 = temp_dst + query_start_off * num_heads * head_size +
-                             static_cast<int64_t>(head_idx) * head_size;
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) +
+          temp_offset);
+      float4* temp_out_ptr2 = temp_dst +
+                              query_start_off * num_heads * head_size +
+                              static_cast<int64_t>(head_idx) * head_size;
       if (threadIdx.x < head_size)
         temp_out_ptr2[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
     }
@@ -176,36 +178,36 @@ __launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
     float reg_max_logit[NPAR_LOOPS];
     const int last_valid_partition = num_partitions - 1;
 
-  #pragma unroll
+#pragma unroll
     for (int i = 0; i < NPAR_LOOPS; i++) {
       const auto partition_no = i * WARP_SIZE + threadIdx.x;
       valid_partition[i] =
           (partition_no < num_partitions) ? partition_no : last_valid_partition;
     }
-  #pragma unroll
+#pragma unroll
     for (int i = 0; i < NPAR_LOOPS; i++) {
       reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
     }
     float max_logit = reg_max_logit[0];
-  #pragma unroll
+#pragma unroll
     for (int i = 1; i < NPAR_LOOPS; i++) {
       max_logit = fmaxf(max_logit, reg_max_logit[i]);
     }
-  #pragma unroll
+#pragma unroll
     for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
       max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
     }
 
     const float* exp_sums_ptr2 = exp_sums + partition_offset +
-                                seq_idx * num_heads * max_num_partitions +
-                                head_idx * max_num_partitions;
+                                 seq_idx * num_heads * max_num_partitions +
+                                 head_idx * max_num_partitions;
 
     float rescaled_exp_sum[NPAR_LOOPS];
-  #pragma unroll
+#pragma unroll
     for (int i = 0; i < NPAR_LOOPS; i++) {
       rescaled_exp_sum[i] = exp_sums_ptr2[valid_partition[i]];
     }
-  #pragma unroll
+#pragma unroll
     for (int i = 0; i < NPAR_LOOPS; i++) {
       const auto partition_no = i * WARP_SIZE + threadIdx.x;
       rescaled_exp_sum[i] *= (partition_no < num_partitions)
@@ -213,16 +215,16 @@ __launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
                                  : 0.0f;
     }
     float global_exp_sum = rescaled_exp_sum[0];
-  #pragma unroll
+#pragma unroll
     for (int i = 1; i < NPAR_LOOPS; i++) {
       global_exp_sum += rescaled_exp_sum[i];
     }
-  #pragma unroll
+#pragma unroll
     for (int i = 0; i < NPAR_LOOPS; i++) {
       const auto partition_no = i * WARP_SIZE + threadIdx.x;
       shared_exp_sums[partition_no] = rescaled_exp_sum[i];
     }
-  #pragma unroll
+#pragma unroll
     for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
       global_exp_sum += __shfl_xor(global_exp_sum, mask);
     }
@@ -246,12 +248,12 @@ __launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
   constexpr int MAX_NPAR = 64;
   scalar_t tmps[MAX_NPAR];
   const float dzero = 0.0f;
-  #pragma unroll
+#pragma unroll
   for (int j = 0; j < MAX_NPAR; j++) {
     tmps[j] = from_float<scalar_t>(dzero);
   }
   const int last_partition_offset = (num_partitions - 1) * head_size;
-  const int num_partition_offset = (num_partitions) * head_size;
+  const int num_partition_offset = (num_partitions)*head_size;
   int idx = 0;
 
   constexpr int JCHUNK = 16;
@@ -334,7 +336,7 @@ __launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
     float4* temp_dst = reinterpret_cast<float4*>(
         reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
     float4* temp_out_ptr2 = temp_dst + query_start_off * num_heads * head_size +
-                           static_cast<int64_t>(head_idx) * head_size;
+                            static_cast<int64_t>(head_idx) * head_size;
     temp_out_ptr2[threadIdx.x] =
         make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
   } else {
@@ -350,20 +352,19 @@ __launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
   }
 }
 
-// Merge kernel: combines float4 (acc, exp_sum, max_logit, 0) outputs from multiple
-// reduction passes using numerically-stable log-sum-exp across passes.
+// Merge kernel: combines float4 (acc, exp_sum, max_logit, 0) outputs from
+// multiple reduction passes using numerically-stable log-sum-exp across passes.
 // Defined once for all architectures.
 template <typename scalar_t, typename OUTT>
 __global__ void paged_attention_merge_reduce_kernel(
-    OUTT* __restrict__ out,           // [num_seqs, num_heads, head_size]
-    const scalar_t* __restrict__ tmp_out, // base pointer
-    const int64_t temp_base_offset,   // byte offset from tmp_out to float4 temp buffer
-    const int* __restrict__ seq_lens, // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr, // [num_seqs+1] or nullptr
-    const int num_passes,
-    const int num_heads,
-    const float* __restrict__ fp8_out_scale_ptr,
-    int head_size) {
+    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
+    const scalar_t* __restrict__ tmp_out,  // base pointer
+    const int64_t
+        temp_base_offset,  // byte offset from tmp_out to float4 temp buffer
+    const int* __restrict__ seq_lens,             // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr,  // [num_seqs+1] or nullptr
+    const int num_passes, const int num_heads,
+    const float* __restrict__ fp8_out_scale_ptr, int head_size) {
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX11__) || defined(__HIP__GFX12__)
   const auto head_idx = blockIdx.x;
   const auto seq_idx = blockIdx.y;
@@ -383,16 +384,18 @@ __global__ void paged_attention_merge_reduce_kernel(
 
   float true_max_logit = -FLT_MAX;
   for (int pass = 0; pass < num_passes; ++pass) {
-    true_max_logit = fmaxf(true_max_logit,
-                           temps[(int64_t)pass * per_pass_stride + seq_head_offset].z);
+    true_max_logit =
+        fmaxf(true_max_logit,
+              temps[(int64_t)pass * per_pass_stride + seq_head_offset].z);
   }
 
   float acc = 0.0f;
   float global_exp_sum = 0.0f;
   for (int pass = 0; pass < num_passes; ++pass) {
-    const float4 temp = temps[(int64_t)pass * per_pass_stride + seq_head_offset];
+    const float4 temp =
+        temps[(int64_t)pass * per_pass_stride + seq_head_offset];
     const float correction = expf(temp.z - true_max_logit);
-    acc            += temp.x * correction;
+    acc += temp.x * correction;
     global_exp_sum += temp.y * correction;
   }
 
@@ -402,12 +405,13 @@ __global__ void paged_attention_merge_reduce_kernel(
                   static_cast<int64_t>(head_idx) * head_size;
 
   const float inv_global_exp_sum = __fdividef(1.0f, global_exp_sum + 1e-6f);
-  const float out_scale = (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+  const float out_scale =
+      (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
   acc *= inv_global_exp_sum;
   acc *= out_scale;
 
   // fp8 output supported on GFX9 (MI300) and GFX12 (RDNA4); GFX11 support TBD
-#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
+  #if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
   if constexpr (std::is_same<OUTT, bit8_t>::value) {
     out_ptr[threadIdx.x] =
         __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
@@ -415,9 +419,9 @@ __global__ void paged_attention_merge_reduce_kernel(
   } else {
     out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
   }
-#else
+  #else
   out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
-#endif
+  #endif
 #endif
 }
 
@@ -438,8 +442,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     const int* __restrict__ seq_lens,      // [num_seqs]
     const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
     const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
+    const int seq_len_offset, const int64_t temp_offset,
     const int partition_offset) {
 #if defined(__HIP__GFX9__) || defined(__HIP__GFX11__) || defined(__HIP__GFX12__)
   const auto num_heads = gridDim.x;
@@ -456,13 +459,16 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
   const int seq_len = seq_lens[seq_idx] - seq_len_offset;
   if (seq_len <= 0) {
     // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
-    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
+    // element so the merge kernel correctly ignores this pass via
+    // exp(-FLT_MAX)≈0.
     if constexpr (std::is_same<OUTT, float4>::value) {
       const int64_t query_start_off = static_cast<int64_t>(
           query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
       float4* temp_dst = reinterpret_cast<float4*>(
-          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) +
+          temp_offset);
+      float4* temp_out_ptr = temp_dst +
+                             query_start_off * num_heads * HEAD_SIZE +
                              static_cast<int64_t>(head_idx) * HEAD_SIZE;
       temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
     }
@@ -548,11 +554,11 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
       tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
       head_idx * max_num_partitions * HEAD_SIZE +
       static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
-#if defined(__HIP__GFX9__)
+  #if defined(__HIP__GFX9__)
   constexpr int MAX_NPAR = 64;
-#else
+  #else
   constexpr int MAX_NPAR = 32;
-#endif
+  #endif
   scalar_t tmps[MAX_NPAR];
   const float dzero = 0.0f;
   #pragma unroll
@@ -644,8 +650,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
   OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
                   static_cast<int64_t>(head_idx) * HEAD_SIZE;
 
-  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
-  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
+  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple
+  // reductions. Use temp_offset from tmp_out instead of 'out' to avoid derived
+  // pointers in CUDA graphs.
   if constexpr (std::is_same<OUTT, float4>::value) {
     float4* temp_dst = reinterpret_cast<float4*>(
         reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
@@ -658,7 +665,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     acc *= inv_global_exp_sum;
     acc *= (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
     // fp8 output supported on GFX9 (MI300) and GFX12 (RDNA4); GFX11 support TBD
-#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
+  #if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
     if constexpr (std::is_same<OUTT, bit8_t>::value) {
       out_ptr[threadIdx.x] =
           __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
@@ -666,9 +673,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
     } else {
       out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
     }
-#else
+  #else
     out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
-#endif
+  #endif
   }
 #endif
 }
@@ -2102,7 +2109,6 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   }  // warpid == 0
 }
 
-
 // ============================================================================
 // "Free" kernels: runtime block_size and head_size (no template specialization)
 // Supports head_size up to 256 and arbitrary block_size >= 16.
@@ -2110,7 +2116,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
 
 // Helper: KV register storage that is either a union (shared registers) or
 // separate arrays, selected at compile time by SHARED_KV.
-// NWARPS == TLOOP == VTLOOP; VTLANELOOP == DIVIDE_ROUND_UP(16, 16/sizeof(cache_t)).
+// NWARPS == TLOOP == VTLOOP; VTLANELOOP == DIVIDE_ROUND_UP(16,
+// 16/sizeof(cache_t)).
 template <bool SHARED_KV, int NWARPS, int VTLANELOOP>
 struct KVRegs {
   // Default (SHARED_KV=false): separate Klocal + Vlocal, 256 VGPRs at head=256.
@@ -2184,14 +2191,16 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   constexpr int QKHE_PER_FETCH = CONTIGUOUS_KV_ELEMS_16B_LOAD * ROWS_PER_WARP;
   constexpr int QK_SIZE_RATIO = sizeof(scalar_t) / sizeof(cache_t);
   const int qkheloop = head_size / QKHE_PER_FETCH;
-  // Dynamic shared memory: layout [max(NWARPS,qkheloop)][4][16][4] of _B16x4 (8 bytes).
-  // Size is computed in the launch macro and passed as the third <<<>>> argument.
-  // Aliased as a 4D array pointer so all existing indexing syntax is preserved.
+  // Dynamic shared memory: layout [max(NWARPS,qkheloop)][4][16][4] of _B16x4 (8
+  // bytes). Size is computed in the launch macro and passed as the third <<<>>>
+  // argument. Aliased as a 4D array pointer so all existing indexing syntax is
+  // preserved.
   extern __shared__ _B16x4 shared_logits_flat[];
-  _B16x4 (*shared_logits)[4][16][4] =
+  _B16x4(*shared_logits)[4][16][4] =
       reinterpret_cast<_B16x4(*)[4][16][4]>(shared_logits_flat);
 
-  constexpr int MAX_QKHELOOP = 8;  // register array bound; increase for head_size > 256
+  constexpr int MAX_QKHELOOP =
+      8;  // register array bound; increase for head_size > 256
 
   // Register arrays: use max sizes, loop with runtime bounds
   _B16x8 Qlocal[MAX_QKHELOOP][QK_SIZE_RATIO];
@@ -2209,10 +2218,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   const int* block_table_seq = block_tables + seq_idx * max_num_blocks_per_seq;
 
   int kphysical_block_number[TLOOP];
-#if defined(__HIP__FP8MFMA__)
+  #if defined(__HIP__FP8MFMA__)
   float q_max = 0;
   float q_scale = 1.0;
-#endif
+  #endif
 
   // fetch k physical block numbers (runtime block_size)
   for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
@@ -2266,7 +2275,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
           Qlocal[qkhe_depth][qkratio].xy[i] =
               shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio]
                            [2 * qkratio + i];
-#if defined(__HIP__FP8MFMA__)
+  #if defined(__HIP__FP8MFMA__)
           if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto &&
                         MFMA_TYPE == MFMAType::Fp8) {
             scalar_t* qptr =
@@ -2274,7 +2283,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
             for (int k = 0; k < 4; k++)
               q_max = fmax(fabs(to_float<scalar_t>(qptr[k])), q_max);
           }
-#endif
+  #endif
         }
       }
     }
@@ -2297,7 +2306,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
           const int offset3 = head_elem % 4;
           const int offset2 = (head_elem / 4) % 4;
           const int offset1 = head_elem / 4 / 4;
-          shared_logits[offset1][offset2][local_qhead_idx][offset3] = tmp2.xy[i];
+          shared_logits[offset1][offset2][local_qhead_idx][offset3] =
+              tmp2.xy[i];
         }
       }
     }
@@ -2310,7 +2320,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
           Qlocal[qkhe_depth][qkratio].xy[i] =
               shared_logits[qkhe_depth - 4][rowid][lane16id % gqa_ratio]
                            [2 * qkratio + i];
-#if defined(__HIP__FP8MFMA__)
+  #if defined(__HIP__FP8MFMA__)
           if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto &&
                         MFMA_TYPE == MFMAType::Fp8) {
             scalar_t* qptr =
@@ -2318,7 +2328,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
             for (int k = 0; k < 4; k++)
               q_max = fmax(fabs(to_float<scalar_t>(qptr[k])), q_max);
           }
-#endif
+  #endif
         }
       }
     }
@@ -2331,7 +2341,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
           Qlocal[qkhe_depth][qkratio].xy[i] =
               shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio]
                            [2 * qkratio + i];
-#if defined(__HIP__FP8MFMA__)
+  #if defined(__HIP__FP8MFMA__)
           if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto &&
                         MFMA_TYPE == MFMAType::Fp8) {
             scalar_t* qptr =
@@ -2339,7 +2349,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
             for (int k = 0; k < 4; k++)
               q_max = fmax(fabs(to_float<scalar_t>(qptr[k])), q_max);
           }
-#endif
+  #endif
         }
       }
     }
@@ -2353,13 +2363,12 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   constexpr int VTOKENS_PER_LANE = TOKENS_PER_WARP / ROWS_PER_WARP;
   constexpr int VBLOCKS_PER_LANE = 1;  // assumes block_size >= 16
   constexpr int VTLOOP = NWARPS;
-  constexpr int VTLANELOOP = DIVIDE_ROUND_UP(
-      VTOKENS_PER_LANE, CONTIGUOUS_KV_ELEMS_16B_LOAD);
+  constexpr int VTLANELOOP =
+      DIVIDE_ROUND_UP(VTOKENS_PER_LANE, CONTIGUOUS_KV_ELEMS_16B_LOAD);
   // Round up: a head_size that is not a multiple of NWARPS*16 still has a
   // partial last iteration, whose out-of-range lanes are masked in fetchV.
   const int vheloop = DIVIDE_ROUND_UP(head_size / 16, NWARPS);
   constexpr int MAX_VHELOOP = 4;  // supports head_size up to 256
-
 
   KVRegs<SHARED_KV, NWARPS, VTLANELOOP> _kv;
   auto& Klocal = _kv.Klocal;
@@ -2383,8 +2392,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
       const int head_elem = row_head_elem + qkhe_depth * QKHE_PER_FETCH;
       const int offset1 = head_elem / KX;
       const int offset2 = head_elem % KX;
-      const cache_t* k_fetch_ptr =
-          k_ptr3 + offset1 * block_size * KX + offset2;
+      const cache_t* k_fetch_ptr = k_ptr3 + offset1 * block_size * KX + offset2;
       const _B16x8* k_fetch_ptr_16B =
           reinterpret_cast<const _B16x8*>(k_fetch_ptr);
       Klocal[token_depth][qkhe_depth] = *k_fetch_ptr_16B;
@@ -2421,7 +2429,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   const cache_t* v_ptr = v_cache + wg_start_kv_head_idx * kv_head_stride;
 
   auto fetchV = [&]() {
-    // fetch V values (runtime head_size for vheloop, runtime block_size for addressing)
+    // fetch V values (runtime head_size for vheloop, runtime block_size for
+    // addressing)
     for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
       const int vhead_elem = vhe_depth * NWARPS * 16 + warpid * 16 + lane16id;
       if (vhead_elem >= head_size) {
@@ -2468,14 +2477,14 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   float scale2 = scale;
   if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto) {
     scale2 *= *k_scale;
-#if defined(__HIP__FP8MFMA__)
+  #if defined(__HIP__FP8MFMA__)
     q_max = warpReduceMax(q_max);
     constexpr float FP8_E4M3_SCALE_TARGET = 224.0f;
     if constexpr (MFMA_TYPE == MFMAType::Fp8) {
       q_scale = q_max > 0 ? FP8_E4M3_SCALE_TARGET / q_max : 1.0f;
       scale2 /= q_scale;
     }
-#endif
+  #endif
   }
 
   floatx4 d_out[TLOOP];
@@ -2504,7 +2513,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
                   d_out[token_depth]);
             }
           } else {
-#if defined(__HIP__FP8MFMA__)
+  #if defined(__HIP__FP8MFMA__)
             _T8x8 Ktmp8x8, Qtmp8x8;
             Ktmp8x8.b8x8 = Ktmp8x16.xy[qkratio];
             for (int n = 0; n < 2; n++) {
@@ -2524,9 +2533,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
             d_out[token_depth] =
                 gcn_mfma16x16x32_instr<__hip_fp8_e4m3, 0, 0, 0>(
                     Ktmp8x8.i64, Qtmp8x8.i64, d_out[token_depth]);
-#else
+  #else
             UNREACHABLE_CODE
-#endif
+  #endif
           }
         }
       }
@@ -2615,10 +2624,10 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   __syncthreads();
 
   constexpr bool LOGITS_RTZ_CONVERSION = false;
-#if defined(__HIP__FP8MFMA__)
+  #if defined(__HIP__FP8MFMA__)
   int rowid_8x8 = rowid / 2;
   int offset = rowid % 2;
-#endif
+  #endif
 
   // Write logits to shared mem
   for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
@@ -2632,16 +2641,16 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
             from_floatx4<scalar_t>(d_out[token_depth]);
       }
     } else {
-#if defined(__HIP__FP8MFMA__)
+  #if defined(__HIP__FP8MFMA__)
       _T8x8& logits_8x8 = *reinterpret_cast<_T8x8*>(
           &shared_logits[warpid][token_depth][lane16id][rowid_8x8]);
       logits_8x8.b16x4[offset * 2] = __builtin_amdgcn_cvt_pk_fp8_f32(
           d_out[token_depth][0], d_out[token_depth][1], 0, false);
       logits_8x8.b16x4[offset * 2 + 1] = __builtin_amdgcn_cvt_pk_fp8_f32(
           d_out[token_depth][2], d_out[token_depth][3], 0, false);
-#else
+  #else
       UNREACHABLE_CODE
-#endif
+  #endif
     }
   }
 
@@ -2703,7 +2712,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
                     tmp_out);
               }
             } else {
-#if defined(__HIP__FP8MFMA__)
+  #if defined(__HIP__FP8MFMA__)
               for (int i = 0; i < ELEMS8_ELEMS4_RATIO / 2; i++) {
                 const int off =
                     rowid * ELEMS16_ELEMS8_RATIO * ELEMS8_ELEMS4_RATIO +
@@ -2718,9 +2727,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
                         ->i64,
                     tmp_out);
               }
-#else
+  #else
               UNREACHABLE_CODE
-#endif
+  #endif
             }
           }
         }
@@ -2755,8 +2764,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
         const int off2 = head_elem_idx / 16 / NWARPS;
         const int off3 = (head_elem_idx / 4) % 4;
         for (int i = 0; i < 2; i++) {
-          vout[h].xy[i] =
-              shared_logits[off1][off2][local_head_idx][off3 + i];
+          vout[h].xy[i] = shared_logits[off1][off2][local_head_idx][off3 + i];
         }
       }
 
@@ -2786,8 +2794,7 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
           const int off2 = (head_elem_idx2) / 16 / NWARPS;
           const int off3 = ((head_elem_idx2) / 4) % 4;
           for (int i = 0; i < 2; i++) {
-            vout[h].xy[i] =
-                shared_logits[off1][off2][local_head_idx][off3 + i];
+            vout[h].xy[i] = shared_logits[off1][off2][local_head_idx][off3 + i];
           }
         }
 
@@ -2796,9 +2803,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
           if (local_head_idx < gqa_ratio) {
             const int64_t out_head_idx =
                 static_cast<int64_t>(wg_start_head_idx + local_head_idx);
-            scalar_t* out_ptr2 = out + seq_idx * total_num_heads * hsz_maxp_mult +
-                                partition_idx * head_size +
-                                out_head_idx * hsz_maxp_mult;
+            scalar_t* out_ptr2 =
+                out + seq_idx * total_num_heads * hsz_maxp_mult +
+                partition_idx * head_size + out_head_idx * hsz_maxp_mult;
             scalar_t* out_ptr3 = out_ptr2 + head_elem_idx2;
             _B16x8* out_ptr_B16x8 = reinterpret_cast<_B16x8*>(out_ptr3);
             *out_ptr_B16x8 = vout[h];
@@ -3364,20 +3371,19 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   UNREACHABLE_CODE
 }
 
-
 // GFX11 stubs for "free" kernels (not supported on Navi)
 template <typename scalar_t, typename cache_t,
-          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
-          int NUM_THREADS, bool ALIBI_ENABLED, MFMAType MFMA_TYPE,
-          bool SHARED_KV = false>
+          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT, int NUM_THREADS,
+          bool ALIBI_ENABLED, MFMAType MFMA_TYPE, bool SHARED_KV = false>
 __global__
 __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel(
     const scalar_t* __restrict__ q, const cache_t* __restrict__ k_cache,
-    const cache_t* __restrict__ v_cache, const int num_kv_heads, const float scale,
-    const int* __restrict__ block_tables, const int* __restrict__ seq_lens,
-    const int* __restrict__ query_start_loc_ptr, const int max_num_blocks_per_seq,
-    const float* __restrict__ alibi_slopes, const int q_stride,
-    const int kv_block_stride, const int kv_head_stride,
+    const cache_t* __restrict__ v_cache, const int num_kv_heads,
+    const float scale, const int* __restrict__ block_tables,
+    const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc_ptr,
+    const int max_num_blocks_per_seq, const float* __restrict__ alibi_slopes,
+    const int q_stride, const int kv_block_stride, const int kv_head_stride,
     float* __restrict__ exp_sums, float* __restrict__ max_logits,
     scalar_t* __restrict__ out, OUTT* __restrict__ final_out,
     int max_ctx_blocks, const float* k_scale, const float* v_scale,
@@ -3925,11 +3931,11 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   UNREACHABLE_CODE
 }
 
-
 // GFX12 free QKV kernel: runtime block_size, head_size, gqa_ratio.
-// Warp layout: WARP_SIZE=32, NWARPS=8, ROWS_PER_WARP=2, TLOOP=2, QKHE_PER_FETCH=16.
-// Reuses the same static shared memory layout as the non-free GFX12 kernel.
-// Supports head_size in {64, 128, 192, 256} with V-fetch bound guard for partial warps.
+// Warp layout: WARP_SIZE=32, NWARPS=8, ROWS_PER_WARP=2, TLOOP=2,
+// QKHE_PER_FETCH=16. Reuses the same static shared memory layout as the
+// non-free GFX12 kernel. Supports head_size in {64, 128, 192, 256} with V-fetch
+// bound guard for partial warps.
 // clang-format off
 template <typename scalar_t, typename cache_t,
           vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
@@ -3971,7 +3977,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
 
   constexpr int ROWS_PER_WARP = WARP_SIZE / 16;  // 2
   constexpr int CONTIGUOUS_KV_ELEMS_16B_LOAD = 16 / sizeof(cache_t);
-  constexpr int QKHE_PER_FETCH = CONTIGUOUS_KV_ELEMS_16B_LOAD * ROWS_PER_WARP;  // 16
+  constexpr int QKHE_PER_FETCH =
+      CONTIGUOUS_KV_ELEMS_16B_LOAD * ROWS_PER_WARP;  // 16
   constexpr int CONTIGUOUS_SCALAR_ELEMS_16B = 16 / sizeof(scalar_t);
   const int qkheloop = head_size / QKHE_PER_FETCH;
 
@@ -3997,17 +4004,20 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
 
   // --- Q loading via shared memory (handles any gqa_ratio 1..16) ---
-  // Each (warpid, rowid) pair owns one Q head (local_qhead_idx = 2*warpid + rowid).
-  // Each lane16id loads 16 bytes of that head; offset1 routes to the correct qkhe_depth slot.
+  // Each (warpid, rowid) pair owns one Q head (local_qhead_idx = 2*warpid +
+  // rowid). Each lane16id loads 16 bytes of that head; offset1 routes to the
+  // correct qkhe_depth slot.
   const int local_qhead_idx = 2 * warpid + rowid;
   const int global_qhead_idx = wg_start_head_idx + local_qhead_idx;
-  const scalar_t* q_ptr = q + query_start_off * q_stride + global_qhead_idx * head_size;
+  const scalar_t* q_ptr =
+      q + query_start_off * q_stride + global_qhead_idx * head_size;
   const int qhead_element = lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
 
   _B16x8 Qlocal[MAX_QKHELOOP];
 
   if ((local_qhead_idx < gqa_ratio) && (qhead_element < head_size)) {
-    const _B16x8* q_fetch_ptr_16B = reinterpret_cast<const _B16x8*>(q_ptr + qhead_element);
+    const _B16x8* q_fetch_ptr_16B =
+        reinterpret_cast<const _B16x8*>(q_ptr + qhead_element);
     _B16x8 tmp = *q_fetch_ptr_16B;
     const int offset1 = lane16id / 2;  // maps 16 lanes to 8 qkhe_depth slots
     shared_logits[offset1][lane2id][local_qhead_idx][0] = tmp;
@@ -4017,13 +4027,16 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
     __syncthreads();
     // Read first half of Q (head elements 0..127) into registers
     for (int qkhe_depth = 0; qkhe_depth < 8; qkhe_depth++) {
-      Qlocal[qkhe_depth] = shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio][0];
+      Qlocal[qkhe_depth] =
+          shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio][0];
     }
     __syncthreads();
-    // Second pass: load head elements 128..head_size-1 into the same shared slots
+    // Second pass: load head elements 128..head_size-1 into the same shared
+    // slots
     const int qhead_element2 = 128 + lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
     if ((local_qhead_idx < gqa_ratio) && (qhead_element2 < head_size)) {
-      const _B16x8* q_fetch_ptr_16B2 = reinterpret_cast<const _B16x8*>(q_ptr + qhead_element2);
+      const _B16x8* q_fetch_ptr_16B2 =
+          reinterpret_cast<const _B16x8*>(q_ptr + qhead_element2);
       _B16x8 tmp2 = *q_fetch_ptr_16B2;
       const int offset1 = lane16id / 2;
       shared_logits[offset1][lane2id][local_qhead_idx][0] = tmp2;
@@ -4031,19 +4044,22 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
     __syncthreads();
     // Read second half of Q (qkhe_depth 8..qkheloop-1) into registers
     for (int qkhe_depth = 8; qkhe_depth < qkheloop; qkhe_depth++) {
-      Qlocal[qkhe_depth] = shared_logits[qkhe_depth - 8][rowid][lane16id % gqa_ratio][0];
+      Qlocal[qkhe_depth] =
+          shared_logits[qkhe_depth - 8][rowid][lane16id % gqa_ratio][0];
     }
   } else {
     __syncthreads();
     for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
-      Qlocal[qkhe_depth] = shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio][0];
+      Qlocal[qkhe_depth] =
+          shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio][0];
     }
   }
 
   // --- K physical block numbers and fetch ---
   int kphysical_block_number[TLOOP];
   for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
-    const int klocal_token_idx = TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int klocal_token_idx =
+        TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
     const int kglobal_token_idx = partition_start_token_idx + klocal_token_idx;
     const int kblock_idx = (kglobal_token_idx < seq_len)
                                ? kglobal_token_idx / block_size
@@ -4057,9 +4073,11 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
 
   _B16x8 Klocal[TLOOP][MAX_QKHELOOP];
   for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
-    const int64_t kblock_number = static_cast<int64_t>(kphysical_block_number[token_depth]);
+    const int64_t kblock_number =
+        static_cast<int64_t>(kphysical_block_number[token_depth]);
     const cache_t* k_ptr2 = k_ptr + kblock_number * kv_block_stride;
-    const int klocal_token_idx = TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int klocal_token_idx =
+        TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
     // Same as the GFX9 free kernel: derive the slot from the global token
     // index. The V path below already does. No-op where block_size divides
     // T_PAR_SIZE, i.e. everywhere this kernel is correct today.
@@ -4071,7 +4089,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
       const int offset1 = head_elem / KX;
       const int offset2 = head_elem % KX;
       const cache_t* k_fetch_ptr = k_ptr3 + offset1 * block_size * KX + offset2;
-      Klocal[token_depth][qkhe_depth] = *reinterpret_cast<const _B16x8*>(k_fetch_ptr);
+      Klocal[token_depth][qkhe_depth] =
+          *reinterpret_cast<const _B16x8*>(k_fetch_ptr);
     }
   }
 
@@ -4079,45 +4098,55 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   constexpr int VTOKENS_PER_LANE = TOKENS_PER_WARP / ROWS_PER_WARP;  // 16
   constexpr int VBLOCKS_PER_LANE = 1;  // assumes block_size >= 16
   constexpr int VTLOOP = NWARPS;       // 8
-  constexpr int VTLANELOOP = DIVIDE_ROUND_UP(VTOKENS_PER_LANE, CONTIGUOUS_KV_ELEMS_16B_LOAD);  // 2
+  constexpr int VTLANELOOP =
+      DIVIDE_ROUND_UP(VTOKENS_PER_LANE, CONTIGUOUS_KV_ELEMS_16B_LOAD);  // 2
   const int vheloop = DIVIDE_ROUND_UP(head_size / 16, NWARPS);
   constexpr int MAX_VHELOOP = 2;  // supports head_size up to 256
 
   int vphysical_block_number[VTLOOP][VBLOCKS_PER_LANE];
   for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
-    for (int vblock_depth = 0; vblock_depth < VBLOCKS_PER_LANE; vblock_depth++) {
+    for (int vblock_depth = 0; vblock_depth < VBLOCKS_PER_LANE;
+         vblock_depth++) {
       const int vlocal_token_idx =
           vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
           rowid * VTOKENS_PER_LANE + vblock_depth * block_size;
-      const int vglobal_token_idx = partition_start_token_idx + vlocal_token_idx;
+      const int vglobal_token_idx =
+          partition_start_token_idx + vlocal_token_idx;
       const int vblock_idx = (vglobal_token_idx < seq_len)
                                  ? vglobal_token_idx / block_size
                                  : last_seq_block;
-      vphysical_block_number[vtoken_depth][vblock_depth] = block_table_seq[vblock_idx];
+      vphysical_block_number[vtoken_depth][vblock_depth] =
+          block_table_seq[vblock_idx];
     }
   }
 
-  _B16x8 Vlocal[VTLOOP][MAX_VHELOOP][VTLANELOOP] = {};  // zero-init: guard below may skip some
+  _B16x8 Vlocal[VTLOOP][MAX_VHELOOP][VTLANELOOP] =
+      {};  // zero-init: guard below may skip some
   // v_ptr base: no intra-block offset here; computed per vtoken_depth below
   const cache_t* v_ptr = v_cache + wg_start_kv_head_idx * kv_head_stride;
   for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
     const int vhead_elem = vhe_depth * NWARPS * 16 + warpid * 16 + lane16id;
-    if (vhead_elem >= head_size) continue;  // partial last vheloop (e.g. head_size=64)
+    if (vhead_elem >= head_size)
+      continue;  // partial last vheloop (e.g. head_size=64)
     const cache_t* v_ptr2 = v_ptr + vhead_elem * block_size;
     for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
-      // intra-block token offset varies with vtoken_depth for block_size > TOKENS_PER_WARP
+      // intra-block token offset varies with vtoken_depth for block_size >
+      // TOKENS_PER_WARP
       const int vlocal_tok_in_block =
           (partition_start_token_idx +
            vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
-           rowid * VTOKENS_PER_LANE) % block_size;
+           rowid * VTOKENS_PER_LANE) %
+          block_size;
       for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
         const int vblock_depth = 0;
-        const int64_t vblock_number =
-            static_cast<int64_t>(vphysical_block_number[vtoken_depth][vblock_depth]);
+        const int64_t vblock_number = static_cast<int64_t>(
+            vphysical_block_number[vtoken_depth][vblock_depth]);
         const cache_t* v_ptr3 = v_ptr2 + vblock_number * kv_block_stride;
         const cache_t* v_fetch_ptr =
-            v_ptr3 + vlocal_tok_in_block + vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
-        Vlocal[vtoken_depth][vhe_depth][vfetch_depth] = *reinterpret_cast<const _B16x8*>(v_fetch_ptr);
+            v_ptr3 + vlocal_tok_in_block +
+            vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+        Vlocal[vtoken_depth][vhe_depth][vfetch_depth] =
+            *reinterpret_cast<const _B16x8*>(v_fetch_ptr);
       }
     }
   }
@@ -4142,7 +4171,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
     const int local_token_idx = qkout_token_idx + token_depth * 16;
     for (int i = 0; i < 8; i++) {
-      const float tmp = (local_token_idx + i < seq_len) ? dout[token_depth][i] : -FLT_MAX;
+      const float tmp =
+          (local_token_idx + i < seq_len) ? dout[token_depth][i] : -FLT_MAX;
       qk_max = fmaxf(qk_max, tmp);
     }
   }
@@ -4177,7 +4207,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   }
   for (int w = 0; w < NWARPS; w++) {
     warp_qk_max_exp[w] = __expf(warp_qk_max_exp[w] - partition_qk_max);
-    partition_exp_sum += shared_mem[NWARPS * 16 + w * 16 + lane16id] * warp_qk_max_exp[w];
+    partition_exp_sum +=
+        shared_mem[NWARPS * 16 + w * 16 + lane16id] * warp_qk_max_exp[w];
   }
   const float inv_sum_scale =
       __fdividef(1.f, partition_exp_sum + 1e-6f) * warp_qk_max_exp[warpid];
@@ -4229,7 +4260,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   // --- Write final output (warp 0 only, coalesced across head elements) ---
   if (warpid == 0) {
     _B16x8 vout[MAX_GQA_RATIO2];
-    const int64_t hsz_maxp_mult = static_cast<int64_t>(head_size * max_num_partitions);
+    const int64_t hsz_maxp_mult =
+        static_cast<int64_t>(head_size * max_num_partitions);
     const int head_elem_idx = lane16id * 8;
     if (head_elem_idx < head_size) {
       for (int h = 0; h < MAX_GQA_RATIO2; h++) {
@@ -4247,7 +4279,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
         if (local_head_idx >= gqa_ratio) break;
         const int64_t out_head_idx =
             static_cast<int64_t>(wg_start_head_idx + local_head_idx);
-        scalar_t* out_ptr3 = out_ptr + out_head_idx * hsz_maxp_mult + head_elem_idx;
+        scalar_t* out_ptr3 =
+            out_ptr + out_head_idx * hsz_maxp_mult + head_elem_idx;
         *reinterpret_cast<_B16x8*>(out_ptr3) = vout[h];
       }
     }
@@ -4270,7 +4303,8 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
           if (local_head_idx >= gqa_ratio) break;
           const int64_t out_head_idx =
               static_cast<int64_t>(wg_start_head_idx + local_head_idx);
-          scalar_t* out_ptr3 = out_ptr + out_head_idx * hsz_maxp_mult + head_elem_idx2;
+          scalar_t* out_ptr3 =
+              out_ptr + out_head_idx * hsz_maxp_mult + head_elem_idx2;
           *reinterpret_cast<_B16x8*>(out_ptr3) = vout[h];
         }
       }
@@ -4358,69 +4392,69 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
 
 #endif
 
-#define LAUNCH_CUSTOM_ATTENTION_MFMA16_FREE()                                        \
-  {                                                                                  \
-  /* Dynamic smem: [max(NWARPS, qkheloop)][4][16][4] * 8 bytes per _B16x4 */        \
-  const int _qkhe_per_fetch = (16 / (int)sizeof(KVT)) * (WARP_SIZE / 16);           \
-  const int _qkheloop = head_size / _qkhe_per_fetch;                                \
-  const int _sdim0 = MAX((int)(NTHR / WARP_SIZE), _qkheloop);                       \
-  const size_t _smem_bytes = (size_t)_sdim0 * 4 * 16 * 4 * 8;                      \
-  paged_attention_ll4mi_QKV_mfma16_free_kernel<T, KVT, KV_DTYPE, OUTT,              \
-                                               NTHR, ALIBI_ENABLED,                 \
-                                               MFMA_TYPE, SHARED_KV>                \
-      <<<grid, block, _smem_bytes, stream>>>(                                       \
-          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,           \
-          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                      \
-          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride,      \
-          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,       \
-          max_ctx_blocks, k_scale_ptr, v_scale_ptr,                                 \
-          block_size, head_size, gqa_ratio);                                         \
+#define LAUNCH_CUSTOM_ATTENTION_MFMA16_FREE()                                  \
+  {                                                                            \
+    /* Dynamic smem: [max(NWARPS, qkheloop)][4][16][4] * 8 bytes per _B16x4 */ \
+    const int _qkhe_per_fetch = (16 / (int)sizeof(KVT)) * (WARP_SIZE / 16);    \
+    const int _qkheloop = head_size / _qkhe_per_fetch;                         \
+    const int _sdim0 = MAX((int)(NTHR / WARP_SIZE), _qkheloop);                \
+    const size_t _smem_bytes = (size_t)_sdim0 * 4 * 16 * 4 * 8;                \
+    paged_attention_ll4mi_QKV_mfma16_free_kernel<                              \
+        T, KVT, KV_DTYPE, OUTT, NTHR, ALIBI_ENABLED, MFMA_TYPE, SHARED_KV>     \
+        <<<grid, block, _smem_bytes, stream>>>(                                \
+            query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,    \
+            block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,               \
+            max_num_blocks_per_seq, alibi_slopes_ptr, q_stride,                \
+            kv_block_stride, kv_head_stride, exp_sums_ptr, max_logits_ptr,     \
+            tmp_out_ptr, out_ptr, max_ctx_blocks, k_scale_ptr, v_scale_ptr,    \
+            block_size, head_size, gqa_ratio);                                 \
   }
 
-#define LAUNCH_CUSTOM_ATTENTION_MFMA16(GQA_RATIO)                                   \
-  paged_attention_ll4mi_QKV_mfma16_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,       \
-                                          HEAD_SIZE, NTHR, ALIBI_ENABLED,            \
-                                          GQA_RATIO, MFMA_TYPE>                      \
-      <<<grid, block, 0, stream>>>(                                                  \
-          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,            \
-          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                       \
-          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride,       \
-          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,        \
+#define LAUNCH_CUSTOM_ATTENTION_MFMA16(GQA_RATIO)                              \
+  paged_attention_ll4mi_QKV_mfma16_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,  \
+                                          HEAD_SIZE, NTHR, ALIBI_ENABLED,      \
+                                          GQA_RATIO, MFMA_TYPE>                \
+      <<<grid, block, 0, stream>>>(                                            \
+          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,      \
+          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                 \
+          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride, \
+          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,  \
           max_ctx_blocks, k_scale_ptr, v_scale_ptr);
 
-#define LAUNCH_CUSTOM_ATTENTION_MFMA4(GQA_RATIO)                                    \
-  paged_attention_ll4mi_QKV_mfma4_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,        \
-                                         HEAD_SIZE, NTHR, ALIBI_ENABLED,             \
-                                         GQA_RATIO>                                  \
-      <<<grid, block, 0, stream>>>(                                                  \
-          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,            \
-          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                       \
-          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride,       \
-          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,        \
+#define LAUNCH_CUSTOM_ATTENTION_MFMA4(GQA_RATIO)                               \
+  paged_attention_ll4mi_QKV_mfma4_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,   \
+                                         HEAD_SIZE, NTHR, ALIBI_ENABLED,       \
+                                         GQA_RATIO>                            \
+      <<<grid, block, 0, stream>>>(                                            \
+          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,      \
+          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                 \
+          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride, \
+          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,  \
           max_ctx_blocks, k_scale_ptr, v_scale_ptr);
 
-#define LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, DST, OUT_TYPE,                    \
-                                      TEMP_OFFSET, PART_OFFSET)                     \
-  paged_attention_ll4mi_reduce_kernel<T, OUT_TYPE, HEAD_SIZE, HEAD_SIZE,             \
-                                      PARTITION_SIZE, NPAR_LOOPS>                   \
-      <<<reduce_grid, reduce_block, 0, stream>>>(                                   \
-          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,            \
-          tmp_out_ptr, seq_lens_ptr, query_start_loc_ptr, max_num_partitions,        \
+#define LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, DST, OUT_TYPE, TEMP_OFFSET, \
+                                      PART_OFFSET)                            \
+  paged_attention_ll4mi_reduce_kernel<T, OUT_TYPE, HEAD_SIZE, HEAD_SIZE,      \
+                                      PARTITION_SIZE, NPAR_LOOPS>             \
+      <<<reduce_grid, reduce_block, 0, stream>>>(                             \
+          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,     \
+          tmp_out_ptr, seq_lens_ptr, query_start_loc_ptr, max_num_partitions, \
           fp8_out_scale_ptr, seq_len_offset, TEMP_OFFSET, PART_OFFSET);
 
-#define LAUNCH_CUSTOM_REDUCTION_INNER_FREE(NPAR_LOOPS, DST, OUT_TYPE,               \
-                                           TEMP_OFFSET, PART_OFFSET)                \
-  paged_attention_ll4mi_reduce_free_kernel<T, OUT_TYPE,                              \
-                                           PARTITION_SIZE, NPAR_LOOPS>              \
-      <<<reduce_grid, reduce_block, 0, stream>>>(                                   \
-          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,            \
-          tmp_out_ptr, seq_lens_ptr, query_start_loc_ptr, max_num_partitions,        \
-          fp8_out_scale_ptr, seq_len_offset, TEMP_OFFSET, PART_OFFSET, head_size);
+#define LAUNCH_CUSTOM_REDUCTION_INNER_FREE(NPAR_LOOPS, DST, OUT_TYPE,         \
+                                           TEMP_OFFSET, PART_OFFSET)          \
+  paged_attention_ll4mi_reduce_free_kernel<T, OUT_TYPE, PARTITION_SIZE,       \
+                                           NPAR_LOOPS>                        \
+      <<<reduce_grid, reduce_block, 0, stream>>>(                             \
+          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,     \
+          tmp_out_ptr, seq_lens_ptr, query_start_loc_ptr, max_num_partitions, \
+          fp8_out_scale_ptr, seq_len_offset, TEMP_OFFSET, PART_OFFSET,        \
+          head_size);
 
-#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                          \
+#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS) \
   LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, out_ptr, OUTT, 0, 0)
 
-#define LAUNCH_CUSTOM_REDUCTION_FREE(NPAR_LOOPS)                                     \
+#define LAUNCH_CUSTOM_REDUCTION_FREE(NPAR_LOOPS) \
   LAUNCH_CUSTOM_REDUCTION_INNER_FREE(NPAR_LOOPS, out_ptr, OUTT, 0, 0)
 
 template <typename T, typename KVT, vllm::Fp8KVCacheDataType KV_DTYPE,
@@ -4551,10 +4585,11 @@ void paged_attention_custom_launcher(
   // (partition size) = 128K context length
 
   // Byte offset from tmp_out to the float4 multi-pass buffer.
-  // The buffer lives at the end of tmp_out, after max_num_partitions partition slices.
-  // Python allocates extra partitions in tmp_out: extra = max_passes * sizeof(float4)/sizeof(T).
-  const int64_t temp_base_offset =
-      (int64_t)num_seqs * num_heads * max_num_partitions * head_size * sizeof(T);
+  // The buffer lives at the end of tmp_out, after max_num_partitions partition
+  // slices. Python allocates extra partitions in tmp_out: extra = max_passes *
+  // sizeof(float4)/sizeof(T).
+  const int64_t temp_base_offset = (int64_t)num_seqs * num_heads *
+                                   max_num_partitions * head_size * sizeof(T);
 
   switch (npar_loops) {
     case 1:
@@ -4585,20 +4620,24 @@ void paged_attention_custom_launcher(
       // For npar_loops > 8, perform multiple reductions with 8 loops each.
       // GFX9 hardware has a hard limit of 8 npar_loops per reduction kernel.
       // This corresponds to processing 8 * WARP_SIZE (512) partitions per pass.
-      // For sequences longer than 128K tokens (which require ~512 partitions at 256-tok/partition),
-      // we split the work into multiple passes:
-      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for intermediate results
-      //   - A final merge kernel combines these using log-sum-exp for numerical stability
+      // For sequences longer than 128K tokens (which require ~512 partitions at
+      // 256-tok/partition), we split the work into multiple passes:
+      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for
+      //   intermediate results
+      //   - A final merge kernel combines these using log-sum-exp for numerical
+      //   stability
       //   - This allows unlimited sequence length via multiple passes
       if (npar_loops > 8) {
         const int num_passes = (npar_loops + 7) / 8;
-        const int partitions_per_pass = 8 * WARP_SIZE;  // 8 npar_loops * 64 warp_size
+        const int partitions_per_pass =
+            8 * WARP_SIZE;  // 8 npar_loops * 64 warp_size
         for (int pass = 0; pass < num_passes; ++pass) {
           const int part_offset = pass * partitions_per_pass;
-          const int64_t pass_temp_offset = temp_base_offset +
+          const int64_t pass_temp_offset =
+              temp_base_offset +
               pass * (int64_t)num_seqs * num_heads * head_size * sizeof(float4);
-          LAUNCH_CUSTOM_REDUCTION_INNER(8, out_ptr, float4,
-                                        pass_temp_offset, part_offset);
+          LAUNCH_CUSTOM_REDUCTION_INNER(8, out_ptr, float4, pass_temp_offset,
+                                        part_offset);
           seq_len_offset += 8 * PARTITION_SIZE * 64;
         }
       } else {
@@ -4609,24 +4648,24 @@ void paged_attention_custom_launcher(
 
   // If we did multi-pass reductions, merge the results using log-sum-exp.
   // The multi-pass reductions produced float4 outputs per pass.
-  // This merge kernel combines them into the final output using the stable log-sum-exp formula:
+  // This merge kernel combines them into the final output using the stable
+  // log-sum-exp formula:
   //   result = value_1 + exp_sum_1 * (value_2 / exp_sum_1 + ...)
-  // This ensures numerical stability when merging attention weights from multiple passes.
+  // This ensures numerical stability when merging attention weights from
+  // multiple passes.
   if (npar_loops > 8) {
     const int num_passes = (npar_loops + 7) / 8;
     paged_attention_merge_reduce_kernel<T, OUTT>
         <<<reduce_grid, reduce_block, 0, stream>>>(
-            out_ptr, tmp_out_ptr, temp_base_offset,
-            seq_lens_ptr, query_start_loc_ptr, num_passes,
-            num_heads, fp8_out_scale_ptr,
+            out_ptr, tmp_out_ptr, temp_base_offset, seq_lens_ptr,
+            query_start_loc_ptr, num_passes, num_heads, fp8_out_scale_ptr,
             head_size);
   }
 }
 
-
 template <typename T, typename KVT, vllm::Fp8KVCacheDataType KV_DTYPE,
-          typename OUTT, int PARTITION_SIZE_OLD,
-          bool ALIBI_ENABLED, MFMAType MFMA_TYPE>
+          typename OUTT, int PARTITION_SIZE_OLD, bool ALIBI_ENABLED,
+          MFMAType MFMA_TYPE>
 void paged_attention_fully_custom_launcher(
     torch::Tensor& out, torch::Tensor& exp_sums, torch::Tensor& max_logits,
     torch::Tensor& tmp_out, torch::Tensor& query, torch::Tensor& key_cache,
@@ -4638,7 +4677,7 @@ void paged_attention_fully_custom_launcher(
     int block_size, int head_size) {
   int num_seqs = block_tables.size(0);
   int num_heads = query.size(1);
-  assert ( head_size == query.size(2) );
+  assert(head_size == query.size(2));
   int max_num_blocks_per_seq = block_tables.size(1);
   int q_stride = query.stride(0);
   int kv_block_stride = key_cache.stride(0);
@@ -4689,7 +4728,8 @@ void paged_attention_fully_custom_launcher(
   const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  constexpr bool SHARED_KV = false;  // set true to use union Klocal/Vlocal (saves ~128 VGPRs)
+  constexpr bool SHARED_KV =
+      false;  // set true to use union Klocal/Vlocal (saves ~128 VGPRs)
   LAUNCH_CUSTOM_ATTENTION_MFMA16_FREE();
 
   dim3 reduce_grid(num_heads, num_seqs);
@@ -4702,10 +4742,11 @@ void paged_attention_fully_custom_launcher(
   // (partition size) = 128K context length
 
   // Byte offset from tmp_out to the float4 multi-pass buffer.
-  // The buffer lives at the end of tmp_out, after max_num_partitions partition slices.
-  // Python allocates extra partitions in tmp_out: extra = max_passes * sizeof(float4)/sizeof(T).
-  const int64_t temp_base_offset =
-      (int64_t)num_seqs * num_heads * max_num_partitions * head_size * sizeof(T);
+  // The buffer lives at the end of tmp_out, after max_num_partitions partition
+  // slices. Python allocates extra partitions in tmp_out: extra = max_passes *
+  // sizeof(float4)/sizeof(T).
+  const int64_t temp_base_offset = (int64_t)num_seqs * num_heads *
+                                   max_num_partitions * head_size * sizeof(T);
 
   switch (npar_loops) {
     case 1:
@@ -4736,20 +4777,24 @@ void paged_attention_fully_custom_launcher(
       // For npar_loops > 8, perform multiple reductions with 8 loops each.
       // GFX9 hardware has a hard limit of 8 npar_loops per reduction kernel.
       // This corresponds to processing 8 * WARP_SIZE (512) partitions per pass.
-      // For sequences longer than 128K tokens (which require ~512 partitions at 256-tok/partition),
-      // we split the work into multiple passes:
-      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for intermediate results
-      //   - A final merge kernel combines these using log-sum-exp for numerical stability
+      // For sequences longer than 128K tokens (which require ~512 partitions at
+      // 256-tok/partition), we split the work into multiple passes:
+      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for
+      //   intermediate results
+      //   - A final merge kernel combines these using log-sum-exp for numerical
+      //   stability
       //   - This allows unlimited sequence length via multiple passes
       if (npar_loops > 8) {
         const int num_passes = (npar_loops + 7) / 8;
-        const int partitions_per_pass = 8 * WARP_SIZE;  // 8 npar_loops * 64 warp_size
+        const int partitions_per_pass =
+            8 * WARP_SIZE;  // 8 npar_loops * 64 warp_size
         for (int pass = 0; pass < num_passes; ++pass) {
           const int part_offset = pass * partitions_per_pass;
-          const int64_t pass_temp_offset = temp_base_offset +
+          const int64_t pass_temp_offset =
+              temp_base_offset +
               pass * (int64_t)num_seqs * num_heads * head_size * sizeof(float4);
           LAUNCH_CUSTOM_REDUCTION_INNER_FREE(8, out_ptr, float4,
-                                        pass_temp_offset, part_offset);
+                                             pass_temp_offset, part_offset);
           seq_len_offset += 8 * PARTITION_SIZE * 64;
         }
       } else {
@@ -4760,16 +4805,18 @@ void paged_attention_fully_custom_launcher(
 
   // If we did multi-pass reductions, merge the results using log-sum-exp.
   // The multi-pass reductions produced float4 outputs per pass.
-  // This merge kernel combines them into the final output using the stable log-sum-exp formula:
+  // This merge kernel combines them into the final output using the stable
+  // log-sum-exp formula:
   //   result = value_1 + exp_sum_1 * (value_2 / exp_sum_1 + ...)
-  // This ensures numerical stability when merging attention weights from multiple passes.
+  // This ensures numerical stability when merging attention weights from
+  // multiple passes.
   if (npar_loops > 8) {
     const int num_passes = (npar_loops + 7) / 8;
     paged_attention_merge_reduce_kernel<T, OUTT>
         <<<reduce_grid, reduce_block, 0, stream>>>(
-            out_ptr, tmp_out_ptr, temp_base_offset,
-            seq_lens_ptr, query_start_loc_ptr, num_passes,
-            num_heads, fp8_out_scale_ptr, head_size);
+            out_ptr, tmp_out_ptr, temp_base_offset, seq_lens_ptr,
+            query_start_loc_ptr, num_passes, num_heads, fp8_out_scale_ptr,
+            head_size);
   }
 }
 
@@ -4891,10 +4938,11 @@ void paged_attention_custom_launcher_navi(
   const int warp_size = 32;
   const int npar_loops = DIVIDE_ROUND_UP(max_num_partitions, warp_size);
   // Byte offset from tmp_out to the float4 multi-pass buffer.
-  // The buffer lives at the end of tmp_out, after max_num_partitions partition slices.
-  // Python allocates extra partitions in tmp_out: extra = max_passes * sizeof(float4)/sizeof(T).
-  const int64_t temp_base_offset =
-      (int64_t)num_seqs * num_heads * max_num_partitions * head_size * sizeof(T);
+  // The buffer lives at the end of tmp_out, after max_num_partitions partition
+  // slices. Python allocates extra partitions in tmp_out: extra = max_passes *
+  // sizeof(float4)/sizeof(T).
+  const int64_t temp_base_offset = (int64_t)num_seqs * num_heads *
+                                   max_num_partitions * head_size * sizeof(T);
 
   switch (npar_loops) {
     case 1:
@@ -4947,22 +4995,27 @@ void paged_attention_custom_launcher_navi(
       break;
     default:
       // For npar_loops > 16, perform multiple reductions with 16 loops each.
-      // RDNA (GFX12) hardware has a limit of 16 npar_loops per reduction kernel.
-      // This corresponds to processing 16 * warp_size (512) partitions per pass.
-      // For sequences longer than 128K tokens (which require ~512 partitions at 256-tok/partition),
-      // we split the work into multiple passes:
-      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for intermediate results
-      //   - A final merge kernel combines these using log-sum-exp for numerical stability
+      // RDNA (GFX12) hardware has a limit of 16 npar_loops per reduction
+      // kernel. This corresponds to processing 16 * warp_size (512) partitions
+      // per pass. For sequences longer than 128K tokens (which require ~512
+      // partitions at 256-tok/partition), we split the work into multiple
+      // passes:
+      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for
+      //   intermediate results
+      //   - A final merge kernel combines these using log-sum-exp for numerical
+      //   stability
       //   - This allows unlimited sequence length via multiple passes
       if (npar_loops > 16) {
         const int num_passes = (npar_loops + 15) / 16;
-        const int partitions_per_pass = 16 * warp_size;  // 16 npar_loops * 32 warp_size
+        const int partitions_per_pass =
+            16 * warp_size;  // 16 npar_loops * 32 warp_size
         for (int pass = 0; pass < num_passes; ++pass) {
           const int part_offset = pass * partitions_per_pass;
-          const int64_t pass_temp_offset = temp_base_offset +
+          const int64_t pass_temp_offset =
+              temp_base_offset +
               pass * (int64_t)num_seqs * num_heads * head_size * sizeof(float4);
-          LAUNCH_CUSTOM_REDUCTION_INNER(16, out_ptr, float4,
-                                        pass_temp_offset, part_offset);
+          LAUNCH_CUSTOM_REDUCTION_INNER(16, out_ptr, float4, pass_temp_offset,
+                                        part_offset);
           seq_len_offset += 16 * PARTITION_SIZE * 32;
         }
       } else {
@@ -4973,16 +5026,17 @@ void paged_attention_custom_launcher_navi(
 
   // If we did multi-pass reductions, merge the results using log-sum-exp.
   // The multi-pass reductions produced float4 outputs per pass.
-  // This merge kernel combines them into the final output using the stable log-sum-exp formula:
+  // This merge kernel combines them into the final output using the stable
+  // log-sum-exp formula:
   //   result = value_1 + exp_sum_1 * (value_2 / exp_sum_1 + ...)
-  // This ensures numerical stability when merging attention weights from multiple passes.
+  // This ensures numerical stability when merging attention weights from
+  // multiple passes.
   if (npar_loops > 16) {
     const int num_passes = (npar_loops + 15) / 16;
     paged_attention_merge_reduce_kernel<T, OUTT>
         <<<reduce_grid, reduce_block, 0, stream>>>(
-            out_ptr, tmp_out_ptr, temp_base_offset,
-            seq_lens_ptr, query_start_loc_ptr, num_passes,
-            num_heads, fp8_out_scale_ptr,
+            out_ptr, tmp_out_ptr, temp_base_offset, seq_lens_ptr,
+            query_start_loc_ptr, num_passes, num_heads, fp8_out_scale_ptr,
             head_size);
   }
 }
@@ -5004,15 +5058,14 @@ void paged_attention_custom_launcher_navi(
         max_seq_len, alibi_slopes, k_scale, v_scale);                       \
   }
 
-#define CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE)                  \
-  TORCH_CHECK(!fp8_out_scale, "free launcher does not support fp8_out");             \
-  paged_attention_fully_custom_launcher<T, KVT, KV_DTYPE,                           \
-                                       T, 256, false, MFMA_TYPE>(                   \
-      out, exp_sums, max_logits, tmp_out, query, key_cache, value_cache,             \
-      num_kv_heads, scale, block_tables, seq_lens, query_start_loc,                 \
-      max_seq_len, alibi_slopes, k_scale, v_scale, fp8_out_scale,                   \
-      block_size, head_size);
-
+#define CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE)            \
+  TORCH_CHECK(!fp8_out_scale, "free launcher does not support fp8_out");      \
+  paged_attention_fully_custom_launcher<T, KVT, KV_DTYPE, T, 256, false,      \
+                                        MFMA_TYPE>(                           \
+      out, exp_sums, max_logits, tmp_out, query, key_cache, value_cache,      \
+      num_kv_heads, scale, block_tables, seq_lens, query_start_loc,           \
+      max_seq_len, alibi_slopes, k_scale, v_scale, fp8_out_scale, block_size, \
+      head_size);
 
 #define CALL_CUSTOM_LAUNCHER_ALIBI(T, KVT, KV_DTYPE, BLK_SIZE, HEAD_SIZE,    \
                                    OUTT, PSIZE, MFMA_TYPE)                   \
@@ -5054,7 +5107,7 @@ void paged_attention_custom_launcher_navi(
       CALL_CUSTOM_LAUNCHER_OUT(T, KVT, KV_DTYPE, 32, HEAD_SIZE, MFMA_TYPE); \
       break;                                                                \
     default:                                                                \
-      CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE); \
+      CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE);           \
       break;                                                                \
   }
 

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -232,10 +232,17 @@ __launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
     }
   }
 
+  // The block is launched at least one warp wide so the partition reduction
+  // above always has a full warp, which for head_size < WARP_SIZE is more
+  // threads than there are head elements. The surplus lanes must still reach
+  // the __syncthreads below, so they redundantly accumulate element 0 and drop
+  // the result at the store rather than reading past this head's slice.
+  const bool helem_active = threadIdx.x < static_cast<unsigned>(head_size);
+  const unsigned helem = helem_active ? threadIdx.x : 0u;
   const scalar_t* tmp_out_ptr =
       tmp_out + seq_idx * num_heads * max_num_partitions * head_size +
       head_idx * max_num_partitions * head_size +
-      static_cast<int64_t>(partition_offset) * head_size + threadIdx.x;
+      static_cast<int64_t>(partition_offset) * head_size + helem;
   constexpr int MAX_NPAR = 64;
   scalar_t tmps[MAX_NPAR];
   const float dzero = 0.0f;
@@ -318,6 +325,10 @@ __launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
   OUTT* out_ptr = out + query_start_off * num_heads * head_size +
                   static_cast<int64_t>(head_idx) * head_size;
+
+  if (!helem_active) {
+    return;
+  }
 
   if constexpr (std::is_same<OUTT, float4>::value) {
     float4* temp_dst = reinterpret_cast<float4*>(
@@ -2344,7 +2355,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
   constexpr int VTLOOP = NWARPS;
   constexpr int VTLANELOOP = DIVIDE_ROUND_UP(
       VTOKENS_PER_LANE, CONTIGUOUS_KV_ELEMS_16B_LOAD);
-  const int vheloop = head_size / 16 / NWARPS;
+  // Round up: a head_size that is not a multiple of NWARPS*16 still has a
+  // partial last iteration, whose out-of-range lanes are masked in fetchV.
+  const int vheloop = DIVIDE_ROUND_UP(head_size / 16, NWARPS);
   constexpr int MAX_VHELOOP = 4;  // supports head_size up to 256
 
 
@@ -2359,7 +2372,11 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
     const cache_t* k_ptr2 = k_ptr + kblock_number * kv_block_stride;
     const int klocal_token_idx =
         TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
-    const int kphysical_block_offset = klocal_token_idx % block_size;
+    // Slot within the block must come from the global token index:
+    // partition_start_token_idx is congruent to 0 mod block_size only when
+    // block_size divides T_PAR_SIZE.
+    const int kphysical_block_offset =
+        (partition_start_token_idx + klocal_token_idx) % block_size;
     const cache_t* k_ptr3 = k_ptr2 + kphysical_block_offset * KX;
 
     for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
@@ -2399,22 +2416,43 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
     }
   }
 
-
-  const cache_t* v_ptr = v_cache + wg_start_kv_head_idx * kv_head_stride +
-                         ((rowid * VTOKENS_PER_LANE) % block_size);
+  // The intra-block slot offset depends on vtoken_depth and the partition base,
+  // so it cannot be hoisted here; it is computed in the fetch loop below.
+  const cache_t* v_ptr = v_cache + wg_start_kv_head_idx * kv_head_stride;
 
   auto fetchV = [&]() {
     // fetch V values (runtime head_size for vheloop, runtime block_size for addressing)
     for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
       const int vhead_elem = vhe_depth * NWARPS * 16 + warpid * 16 + lane16id;
+      if (vhead_elem >= head_size) {
+        // Partial last iteration: reading V here would run past this head's
+        // slice. Zero so the SV MFMA below consumes defined values; the
+        // resulting outelems are never read back by the tmp_out writeback,
+        // which is itself guarded on head_elem_idx < head_size.
+        for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+          for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP;
+               vfetch_depth++) {
+            Vlocal[vtoken_depth][vhe_depth][vfetch_depth] = _B16x8{};
+          }
+        }
+        continue;
+      }
       const cache_t* v_ptr2 = v_ptr + vhead_elem * block_size;
 
       for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+        // block_size is a multiple of VTOKENS_PER_LANE (16), so a lane's 16
+        // consecutive tokens never straddle a block boundary.
+        const int vlocal_token_idx =
+            vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
+            rowid * VTOKENS_PER_LANE;
+        const int vphysical_block_offset =
+            (partition_start_token_idx + vlocal_token_idx) % block_size;
         for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
           const int vblock_depth = 0;
           const int64_t vblock_number = static_cast<int64_t>(
               vphysical_block_number[vtoken_depth][vblock_depth]);
-          const cache_t* v_ptr3 = v_ptr2 + (vblock_number * kv_block_stride);
+          const cache_t* v_ptr3 = v_ptr2 + (vblock_number * kv_block_stride) +
+                                  vphysical_block_offset;
           const cache_t* v_fetch_ptr =
               v_ptr3 + vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
           const _B16x8* v_fetch_ptr_16B =
@@ -4022,7 +4060,11 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel
     const int64_t kblock_number = static_cast<int64_t>(kphysical_block_number[token_depth]);
     const cache_t* k_ptr2 = k_ptr + kblock_number * kv_block_stride;
     const int klocal_token_idx = TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
-    const int kphysical_block_offset = klocal_token_idx % block_size;
+    // Same as the GFX9 free kernel: derive the slot from the global token
+    // index. The V path below already does. No-op where block_size divides
+    // T_PAR_SIZE, i.e. everywhere this kernel is correct today.
+    const int kphysical_block_offset =
+        (partition_start_token_idx + klocal_token_idx) % block_size;
     const cache_t* k_ptr3 = k_ptr2 + kphysical_block_offset * KX;
     for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
       const int head_elem = row_head_elem + qkhe_depth * QKHE_PER_FETCH;
@@ -4651,7 +4693,9 @@ void paged_attention_fully_custom_launcher(
   LAUNCH_CUSTOM_ATTENTION_MFMA16_FREE();
 
   dim3 reduce_grid(num_heads, num_seqs);
-  dim3 reduce_block(head_size);
+  // At least one full warp: the reduction's partition sweep is warp-wide, so a
+  // head_size below WARP_SIZE would silently drop partitions past head_size.
+  dim3 reduce_block(std::max(head_size, WARP_SIZE));
   const int npar_loops = DIVIDE_ROUND_UP(max_num_partitions, WARP_SIZE);
   int seq_len_offset = 0;
   // reduction kernel supports upto 8 NPAR_loops * 64 (warp_size) * 256

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -90,17 +90,577 @@ __device__ __forceinline__ Vec mask_v_cache_padding(Vec values,
   return values;
 }
 
-// Forward declaration of merge kernel - defined here so it's available to all architectures
-template <typename scalar_t, typename OUTT, int HEAD_SIZE>
+// ============================================================================
+// Arch-independent helpers and free reduce kernel.
+// These are used by all architectures (GFX9/GFX11/GFX12) and must be defined
+// before the arch-specific blocks.
+// ============================================================================
+
+using bit8_t = uint8_t;
+
+template <typename T>
+__device__ __forceinline__ float to_float(const T& inp) {
+  if constexpr (std::is_same<T, _Float16>::value) {
+    return (float)inp;
+  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
+    return __bfloat162float(inp);
+  } else {
+    static_assert(false, "unsupported 16b dtype");
+  }
+}
+
+template <typename T>
+__device__ __forceinline__ T from_float(const float& inp) {
+  if constexpr (std::is_same<T, _Float16>::value) {
+    return (_Float16)inp;
+  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
+    return __float2bfloat16(inp);
+  } else {
+    static_assert(false, "unsupported 16b dtype");
+  }
+}
+
+// Grid: (num_heads, num_seqs).
+// "Free" reduce kernel: runtime head_size (no HEAD_SIZE/NUM_THREADS template params)
+template <typename scalar_t, typename OUTT,
+          int PARTITION_SIZE, int NPAR_LOOPS>
+__global__
+__launch_bounds__(256) void paged_attention_ll4mi_reduce_free_kernel(
+    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
+    const float* __restrict__ exp_sums,    // [num_seqs, num_heads, max_num_partitions]
+    const float* __restrict__ max_logits,  // [num_seqs, num_heads, max_num_partitions]
+    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads, max_num_partitions, head_size]
+    const int* __restrict__ seq_lens,      // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset,
+    int head_size) {
+  const auto num_heads = gridDim.x;
+  const auto head_idx = blockIdx.x;
+  const auto seq_idx = blockIdx.y;
+
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
+    return;
+  }
+
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr2 = temp_dst + query_start_off * num_heads * head_size +
+                             static_cast<int64_t>(head_idx) * head_size;
+      if (threadIdx.x < head_size)
+        temp_out_ptr2[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
+  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
+  const auto warpid = threadIdx.x / WARP_SIZE;
+
+  __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
+  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
+
+  if (warpid == 0) {
+    const float* max_logits_ptr = max_logits + partition_offset +
+                                  seq_idx * num_heads * max_num_partitions +
+                                  head_idx * max_num_partitions;
+
+    int valid_partition[NPAR_LOOPS];
+    float reg_max_logit[NPAR_LOOPS];
+    const int last_valid_partition = num_partitions - 1;
+
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const auto partition_no = i * WARP_SIZE + threadIdx.x;
+      valid_partition[i] =
+          (partition_no < num_partitions) ? partition_no : last_valid_partition;
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
+    }
+    float max_logit = reg_max_logit[0];
+  #pragma unroll
+    for (int i = 1; i < NPAR_LOOPS; i++) {
+      max_logit = fmaxf(max_logit, reg_max_logit[i]);
+    }
+  #pragma unroll
+    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
+    }
+
+    const float* exp_sums_ptr2 = exp_sums + partition_offset +
+                                seq_idx * num_heads * max_num_partitions +
+                                head_idx * max_num_partitions;
+
+    float rescaled_exp_sum[NPAR_LOOPS];
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      rescaled_exp_sum[i] = exp_sums_ptr2[valid_partition[i]];
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const auto partition_no = i * WARP_SIZE + threadIdx.x;
+      rescaled_exp_sum[i] *= (partition_no < num_partitions)
+                                 ? expf(reg_max_logit[i] - max_logit)
+                                 : 0.0f;
+    }
+    float global_exp_sum = rescaled_exp_sum[0];
+  #pragma unroll
+    for (int i = 1; i < NPAR_LOOPS; i++) {
+      global_exp_sum += rescaled_exp_sum[i];
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const auto partition_no = i * WARP_SIZE + threadIdx.x;
+      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
+    }
+  #pragma unroll
+    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+      global_exp_sum += __shfl_xor(global_exp_sum, mask);
+    }
+    if (threadIdx.x == 0) {
+      shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
+    }
+  }
+
+  const scalar_t* tmp_out_ptr =
+      tmp_out + seq_idx * num_heads * max_num_partitions * head_size +
+      head_idx * max_num_partitions * head_size +
+      static_cast<int64_t>(partition_offset) * head_size + threadIdx.x;
+  constexpr int MAX_NPAR = 64;
+  scalar_t tmps[MAX_NPAR];
+  const float dzero = 0.0f;
+  #pragma unroll
+  for (int j = 0; j < MAX_NPAR; j++) {
+    tmps[j] = from_float<scalar_t>(dzero);
+  }
+  const int last_partition_offset = (num_partitions - 1) * head_size;
+  const int num_partition_offset = (num_partitions) * head_size;
+  int idx = 0;
+
+  constexpr int JCHUNK = 16;
+
+  for (int p = 0; p < JCHUNK; p++) {
+    const int j = p * head_size;
+    const int lastj_offset =
+        (j < num_partition_offset) ? j : last_partition_offset;
+    tmps[idx] = tmp_out_ptr[lastj_offset];
+    idx++;
+  }
+  __syncthreads();
+
+  if (num_partitions > JCHUNK) {
+    for (int p = JCHUNK; p < 2 * JCHUNK && p < MAX_NPAR; p++) {
+      const int j = p * head_size;
+      const int lastj_offset =
+          (j < num_partition_offset) ? j : last_partition_offset;
+      tmps[idx] = tmp_out_ptr[lastj_offset];
+      idx++;
+    }
+    if (num_partitions > 2 * JCHUNK) {
+      for (int p = 2 * JCHUNK; p < MAX_NPAR; p++) {
+        const int j = p * head_size;
+        const int lastj_offset =
+            (j < num_partition_offset) ? j : last_partition_offset;
+        tmps[idx] = tmp_out_ptr[lastj_offset];
+        idx++;
+      }
+    }
+  }
+
+  // Aggregate tmp_out to out
+  float acc = 0.0f;
+  for (int j = 0; j < JCHUNK; j++) {
+    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+  }
+  if (num_partitions > JCHUNK) {
+    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
+      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+    }
+    if (num_partitions > 2 * JCHUNK) {
+      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
+        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+      }
+    }
+  }
+
+  for (int p = 1; p < NPAR_LOOPS; p++) {
+    if (num_partitions > p * MAX_NPAR) {
+      idx = 0;
+      for (int pp = 0; pp < MAX_NPAR; pp++) {
+        const int j = (p * MAX_NPAR + pp) * head_size;
+        const int lastj_offset =
+            (j < num_partition_offset) ? j : last_partition_offset;
+        tmps[idx] = tmp_out_ptr[lastj_offset];
+        idx++;
+      }
+      for (int j = 0; j < MAX_NPAR; j++) {
+        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
+      }
+    }
+  }
+
+  const float inv_global_exp_sum =
+      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
+  const float out_scale =
+      (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+
+  const int64_t query_start_off = static_cast<int64_t>(
+      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+  OUTT* out_ptr = out + query_start_off * num_heads * head_size +
+                  static_cast<int64_t>(head_idx) * head_size;
+
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr2 = temp_dst + query_start_off * num_heads * head_size +
+                           static_cast<int64_t>(head_idx) * head_size;
+    temp_out_ptr2[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
+  } else {
+    acc *= inv_global_exp_sum;
+    acc *= out_scale;
+    if constexpr (std::is_same<OUTT, bit8_t>::value) {
+      out_ptr[threadIdx.x] =
+          __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                                 vllm::fp8::fp8_type::__default_interpret);
+    } else {
+      out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    }
+  }
+}
+
+// Merge kernel: combines float4 (acc, exp_sum, max_logit, 0) outputs from multiple
+// reduction passes using numerically-stable log-sum-exp across passes.
+// Defined once for all architectures.
+template <typename scalar_t, typename OUTT>
 __global__ void paged_attention_merge_reduce_kernel(
-    OUTT* __restrict__ out,
-    const scalar_t* __restrict__ tmp_out,
-    const int64_t temp_base_offset,
-    const int* __restrict__ seq_lens,
-    const int* __restrict__ query_start_loc_ptr,
+    OUTT* __restrict__ out,           // [num_seqs, num_heads, head_size]
+    const scalar_t* __restrict__ tmp_out, // base pointer
+    const int64_t temp_base_offset,   // byte offset from tmp_out to float4 temp buffer
+    const int* __restrict__ seq_lens, // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr, // [num_seqs+1] or nullptr
     const int num_passes,
     const int num_heads,
-    const float* __restrict__ fp8_out_scale_ptr);
+    const float* __restrict__ fp8_out_scale_ptr,
+    int head_size) {
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX11__) || defined(__HIP__GFX12__)
+  const auto head_idx = blockIdx.x;
+  const auto seq_idx = blockIdx.y;
+
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
+    return;
+  }
+
+  const float4* temps = reinterpret_cast<const float4*>(
+      reinterpret_cast<const char*>(tmp_out) + temp_base_offset);
+
+  const int num_seqs = gridDim.y;
+  const int64_t per_pass_stride = (int64_t)num_seqs * num_heads * head_size;
+  const int64_t seq_head_offset = (int64_t)seq_idx * num_heads * head_size +
+                                  (int64_t)head_idx * head_size + threadIdx.x;
+
+  float true_max_logit = -FLT_MAX;
+  for (int pass = 0; pass < num_passes; ++pass) {
+    true_max_logit = fmaxf(true_max_logit,
+                           temps[(int64_t)pass * per_pass_stride + seq_head_offset].z);
+  }
+
+  float acc = 0.0f;
+  float global_exp_sum = 0.0f;
+  for (int pass = 0; pass < num_passes; ++pass) {
+    const float4 temp = temps[(int64_t)pass * per_pass_stride + seq_head_offset];
+    const float correction = expf(temp.z - true_max_logit);
+    acc            += temp.x * correction;
+    global_exp_sum += temp.y * correction;
+  }
+
+  const int64_t query_start_off = static_cast<int64_t>(
+      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+  OUTT* out_ptr = out + query_start_off * num_heads * head_size +
+                  static_cast<int64_t>(head_idx) * head_size;
+
+  const float inv_global_exp_sum = __fdividef(1.0f, global_exp_sum + 1e-6f);
+  const float out_scale = (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+  acc *= inv_global_exp_sum;
+  acc *= out_scale;
+
+  // fp8 output supported on GFX9 (MI300) and GFX12 (RDNA4); GFX11 support TBD
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
+  if constexpr (std::is_same<OUTT, bit8_t>::value) {
+    out_ptr[threadIdx.x] =
+        __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                               vllm::fp8::fp8_type::__default_interpret);
+  } else {
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+  }
+#else
+  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+#endif
+#endif
+}
+
+// Grid: (num_heads, num_seqs).
+// Single definition for all architectures. GFX9 (MI300) supports MAX_NPAR=64;
+// GFX11/GFX12 use MAX_NPAR=32. fp8 output is supported on GFX9 and GFX12.
+template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
+          int PARTITION_SIZE, int NPAR_LOOPS>
+__global__
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
+    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
+    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
+                                           // max_num_partitions]
+    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
+                                           // max_num_partitions]
+    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
+                                           // max_num_partitions, head_size]
+    const int* __restrict__ seq_lens,      // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
+    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
+    const int seq_len_offset,
+    const int64_t temp_offset,
+    const int partition_offset) {
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX11__) || defined(__HIP__GFX12__)
+  const auto num_heads = gridDim.x;
+  const auto head_idx = blockIdx.x;
+  const auto seq_idx = blockIdx.y;
+
+  // NOTE queries with sequence len > 1 are prefills and taken care by another
+  // kernel.
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
+    return;
+  }
+
+  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
+  if (seq_len <= 0) {
+    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
+    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
+    if constexpr (std::is_same<OUTT, float4>::value) {
+      const int64_t query_start_off = static_cast<int64_t>(
+          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+      float4* temp_dst = reinterpret_cast<float4*>(
+          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
+      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
+    }
+    return;
+  }
+  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
+  const int warpid = threadIdx.x / WARP_SIZE;
+
+  __shared__ float shared_global_exp_sum;
+  __shared__ float shared_max_logit;
+  // max num partitions supported is warp_size * NPAR_LOOPS
+  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
+
+  if (warpid == 0) {
+    const float* max_logits_ptr = max_logits + partition_offset +
+                                  seq_idx * num_heads * max_num_partitions +
+                                  head_idx * max_num_partitions;
+
+    // valid partition is the last valid partition in case threadid > num
+    // partitions
+    int valid_partition[NPAR_LOOPS];
+    float reg_max_logit[NPAR_LOOPS];
+    const int last_valid_partition = num_partitions - 1;
+
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const int partition_no = i * WARP_SIZE + threadIdx.x;
+      valid_partition[i] =
+          (partition_no < num_partitions) ? partition_no : last_valid_partition;
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
+    }
+    float max_logit = reg_max_logit[0];
+  #pragma unroll
+    for (int i = 1; i < NPAR_LOOPS; i++) {
+      max_logit = fmaxf(max_logit, reg_max_logit[i]);
+    }
+
+  #pragma unroll
+    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
+    }
+
+    const float* exp_sums_ptr = exp_sums + partition_offset +
+                                seq_idx * num_heads * max_num_partitions +
+                                head_idx * max_num_partitions;
+
+    float rescaled_exp_sum[NPAR_LOOPS];
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      rescaled_exp_sum[i] = exp_sums_ptr[valid_partition[i]];
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const int partition_no = i * WARP_SIZE + threadIdx.x;
+      rescaled_exp_sum[i] *= (partition_no < num_partitions)
+                                 ? expf(reg_max_logit[i] - max_logit)
+                                 : 0.0f;
+    }
+    float global_exp_sum = rescaled_exp_sum[0];
+  #pragma unroll
+    for (int i = 1; i < NPAR_LOOPS; i++) {
+      global_exp_sum += rescaled_exp_sum[i];
+    }
+  #pragma unroll
+    for (int i = 0; i < NPAR_LOOPS; i++) {
+      const int partition_no = i * WARP_SIZE + threadIdx.x;
+      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
+    }
+
+  #pragma unroll
+    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
+      global_exp_sum += __shfl_xor(global_exp_sum, mask);
+    }
+    if (threadIdx.x == 0) {
+      shared_global_exp_sum = global_exp_sum;
+      shared_max_logit = max_logit;
+    }
+  }  // warpid == 0
+  const scalar_t* tmp_out_ptr =
+      tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
+      head_idx * max_num_partitions * HEAD_SIZE +
+      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
+#if defined(__HIP__GFX9__)
+  constexpr int MAX_NPAR = 64;
+#else
+  constexpr int MAX_NPAR = 32;
+#endif
+  scalar_t tmps[MAX_NPAR];
+  const float dzero = 0.0f;
+  #pragma unroll
+  for (int j = 0; j < MAX_NPAR; j++) {
+    tmps[j] = from_float<scalar_t>(dzero);
+  }
+  const int last_partition_offset = (num_partitions - 1) * HEAD_SIZE;
+  const int num_partition_offset = (num_partitions)*HEAD_SIZE;
+  int idx = 0;
+
+  constexpr int JCHUNK = 16;
+
+  #pragma unroll
+  for (int j = 0; j < JCHUNK * HEAD_SIZE; j += HEAD_SIZE) {
+    // lastj is last valid partition
+    const int lastj_offset =
+        (j < num_partition_offset) ? j : last_partition_offset;
+    tmps[idx] = tmp_out_ptr[lastj_offset];
+    idx++;
+  }
+  __syncthreads();
+
+  if (num_partitions > JCHUNK) {
+  #pragma unroll
+    for (int j = JCHUNK * HEAD_SIZE; j < 2 * JCHUNK * HEAD_SIZE;
+         j += HEAD_SIZE) {
+      const int lastj_offset =
+          (j < num_partition_offset) ? j : last_partition_offset;
+      tmps[idx] = tmp_out_ptr[lastj_offset];
+      idx++;
+    }
+
+    if (num_partitions > 2 * JCHUNK) {
+  #pragma unroll
+      for (int j = 2 * JCHUNK * HEAD_SIZE; j < MAX_NPAR * HEAD_SIZE;
+           j += HEAD_SIZE) {
+        const int lastj_offset =
+            (j < num_partition_offset) ? j : last_partition_offset;
+        tmps[idx] = tmp_out_ptr[lastj_offset];
+        idx++;
+      }
+    }
+  }  // num_partitions > JCHUNK
+
+  // Aggregate tmp_out to out.
+  float acc = 0.0f;
+  #pragma unroll
+  for (int j = 0; j < JCHUNK; j++) {
+    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+  }
+  if (num_partitions > JCHUNK) {
+  #pragma unroll
+    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
+      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+    }
+    if (num_partitions > 2 * JCHUNK) {
+  #pragma unroll
+      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
+        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+      }
+    }
+  }
+
+  for (int p = 1; p < NPAR_LOOPS; p++) {
+    if (num_partitions > p * MAX_NPAR) {
+      idx = 0;
+  #pragma unroll
+      for (int j = p * MAX_NPAR * HEAD_SIZE; j < (p + 1) * MAX_NPAR * HEAD_SIZE;
+           j += HEAD_SIZE) {
+        // lastj is last valid partition
+        const int lastj_offset =
+            (j < num_partition_offset) ? j : last_partition_offset;
+        tmps[idx] = tmp_out_ptr[lastj_offset];
+        idx++;
+      }
+
+  #pragma unroll
+      for (int j = 0; j < MAX_NPAR; j++) {
+        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
+      }
+    }
+  }
+
+  const float inv_global_exp_sum =
+      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
+
+  const int64_t query_start_off = static_cast<int64_t>(
+      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
+  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
+                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
+
+  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
+  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
+  if constexpr (std::is_same<OUTT, float4>::value) {
+    float4* temp_dst = reinterpret_cast<float4*>(
+        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
+    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
+                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
+    temp_out_ptr[threadIdx.x] =
+        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
+    return;
+  } else {
+    acc *= inv_global_exp_sum;
+    acc *= (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+    // fp8 output supported on GFX9 (MI300) and GFX12 (RDNA4); GFX11 support TBD
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
+    if constexpr (std::is_same<OUTT, bit8_t>::value) {
+      out_ptr[threadIdx.x] =
+          __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
+                                 vllm::fp8::fp8_type::__default_interpret);
+    } else {
+      out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    }
+#else
+    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+#endif
+  }
+#endif
+}
 
 #if defined(__HIP__GFX9__)
 
@@ -151,7 +711,6 @@ mask_8b_v_cache_boundary(uint2 values, const int valid_bytes) {
 
 using _B8x8 = uint2;
 using _B8x4 = int32_t;  // used in builtins
-using bit8_t = uint8_t;
 
 typedef struct _B8x16 {
   _B8x8 xy[2];
@@ -199,28 +758,6 @@ __device__ __forceinline__ floatx4 gcn_mfma16x16x32_instr(const long& inpA,
                                                       cbid, blgp);
   } else {
     static_assert(false, "unsupported 8b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ float to_float(const T& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (float)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __bfloat162float(inp);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ T from_float(const float& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (_Float16)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __float2bfloat16(inp);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
   }
 }
 
@@ -1554,242 +2091,682 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   }  // warpid == 0
 }
 
-// Grid: (num_heads, num_seqs).
-template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
-          int PARTITION_SIZE, int NPAR_LOOPS>
+
+// ============================================================================
+// "Free" kernels: runtime block_size and head_size (no template specialization)
+// Supports head_size up to 256 and arbitrary block_size >= 16.
+// ============================================================================
+
+// Helper: KV register storage that is either a union (shared registers) or
+// separate arrays, selected at compile time by SHARED_KV.
+// NWARPS == TLOOP == VTLOOP; VTLANELOOP == DIVIDE_ROUND_UP(16, 16/sizeof(cache_t)).
+template <bool SHARED_KV, int NWARPS, int VTLANELOOP>
+struct KVRegs {
+  // Default (SHARED_KV=false): separate Klocal + Vlocal, 256 VGPRs at head=256.
+  _B16x8 Klocal[NWARPS][8];
+  _B16x8 Vlocal[NWARPS][4][VTLANELOOP];
+};
+template <int NWARPS, int VTLANELOOP>
+struct KVRegs<true, NWARPS, VTLANELOOP> {
+  // Union: Klocal and Vlocal share the same 128 VGPRs (valid when lifetimes
+  // don't overlap — Klocal is dead before Vlocal is first written).
+  union {
+    _B16x8 Klocal[NWARPS][8];
+    _B16x8 Vlocal[NWARPS][4][VTLANELOOP];
+  };
+};
+
+// grid (num_seqs, num_partitions, num_kv_heads)
+// block (256)
+// clang-format off
+template <typename scalar_t, typename cache_t,
+          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
+          int NUM_THREADS, bool ALIBI_ENABLED, MFMAType MFMA_TYPE,
+          bool SHARED_KV = false>
 __global__
-__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
-    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
-    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
-                                           // max_num_partitions, head_size]
-    const int* __restrict__ seq_lens,      // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
-    const int partition_offset) {
-  const auto num_heads = gridDim.x;
-  const auto head_idx = blockIdx.x;
-  const auto seq_idx = blockIdx.y;
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel(
+    const scalar_t* __restrict__ q,         // [num_seqs, num_heads, head_size]
+    const cache_t* __restrict__ k_cache,    // [num_blocks, num_kv_heads, head_size/x, block_size, x]
+    const cache_t* __restrict__ v_cache,    // [num_blocks, num_kv_heads, head_size, block_size]
+    const int num_kv_heads,
+    const float scale,
+    const int* __restrict__ block_tables,   // [num_seqs, max_num_blocks_per_seq]
+    const int* __restrict__ seq_lens,       // [num_seqs]
+    const int* __restrict__ query_start_loc_ptr,   // [num_seqs]
+    const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes, // [num_heads]
+    const int q_stride,
+    const int kv_block_stride,
+    const int kv_head_stride,
+    float* __restrict__ exp_sums,           // [num_seqs, num_heads, max_num_partitions]
+    float* __restrict__ max_logits,         // [num_seqs, num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,             // [num_seqs, num_heads, max_num_partitions, head_size]
+    OUTT* __restrict__ final_out,           // [num_seqs, num_heads, head_size]
+    int max_ctx_blocks, const float* k_scale, const float* v_scale,
+    int block_size, int head_size, int gqa_ratio) {
+  // clang-format on
 
-  // NOTE queries with sequence len > 1 are prefills and taken care by another
-  // kernel.
-  if (query_start_loc_ptr != nullptr &&
-      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
-    return;
-  }
-
-  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
-  if (seq_len <= 0) {
-    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
-    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
-    if constexpr (std::is_same<OUTT, float4>::value) {
-      const int64_t query_start_off = static_cast<int64_t>(
-          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-      float4* temp_dst = reinterpret_cast<float4*>(
-          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
-      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
-    }
-    return;
-  }
-  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
+  constexpr int NWARPS = NUM_THREADS / WARP_SIZE;
   const auto warpid = threadIdx.x / WARP_SIZE;
+  const auto laneid = threadIdx.x % WARP_SIZE;
+  const int lane4id = laneid % 4;
+  const int lane16id = laneid % 16;
+  const int rowid = laneid / 16;
 
-  __shared__ float shared_global_exp_sum;
-  __shared__ float shared_max_logit;
-  // max num partitions supported is warp_size * NPAR_LOOPS
-  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
-
-  if (warpid == 0) {
-    const float* max_logits_ptr = max_logits + partition_offset +
-                                  seq_idx * num_heads * max_num_partitions +
-                                  head_idx * max_num_partitions;
-
-    // valid partition is the last valid partition in case threadid > num
-    // partitions
-    int valid_partition[NPAR_LOOPS];
-    float reg_max_logit[NPAR_LOOPS];
-    const int last_valid_partition = num_partitions - 1;
-
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const auto partition_no = i * WARP_SIZE + threadIdx.x;
-      valid_partition[i] =
-          (partition_no < num_partitions) ? partition_no : last_valid_partition;
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
-    }
-    float max_logit = reg_max_logit[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      max_logit = fmaxf(max_logit, reg_max_logit[i]);
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
-    }
-
-    const float* exp_sums_ptr = exp_sums + partition_offset +
-                                seq_idx * num_heads * max_num_partitions +
-                                head_idx * max_num_partitions;
-
-    float rescaled_exp_sum[NPAR_LOOPS];
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      rescaled_exp_sum[i] = exp_sums_ptr[valid_partition[i]];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const auto partition_no = i * WARP_SIZE + threadIdx.x;
-      rescaled_exp_sum[i] *= (partition_no < num_partitions)
-                                 ? expf(reg_max_logit[i] - max_logit)
-                                 : 0.0f;
-    }
-    float global_exp_sum = rescaled_exp_sum[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      global_exp_sum += rescaled_exp_sum[i];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const auto partition_no = i * WARP_SIZE + threadIdx.x;
-      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      global_exp_sum += __shfl_xor(global_exp_sum, mask);
-    }
-    if (threadIdx.x == 0) {
-      shared_global_exp_sum = global_exp_sum;
-      shared_max_logit = max_logit;
-    }
-  }  // warpid == 0
-  const scalar_t* tmp_out_ptr =
-      tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE +
-      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
-  constexpr int MAX_NPAR = 64;
-  scalar_t tmps[MAX_NPAR];
-  const float dzero = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < MAX_NPAR; j++) {
-    tmps[j] = from_float<scalar_t>(dzero);
-  }
-  const int last_partition_offset = (num_partitions - 1) * HEAD_SIZE;
-  const int num_partition_offset = (num_partitions)*HEAD_SIZE;
-  int idx = 0;
-
-  constexpr int JCHUNK = 16;
-
-  #pragma unroll
-  for (int j = 0; j < JCHUNK * HEAD_SIZE; j += HEAD_SIZE) {
-    // lastj is last valid partition
-    const int lastj_offset =
-        (j < num_partition_offset) ? j : last_partition_offset;
-    tmps[idx] = tmp_out_ptr[lastj_offset];
-    idx++;
-  }
-  __syncthreads();
-
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK * HEAD_SIZE; j < 2 * JCHUNK * HEAD_SIZE;
-         j += HEAD_SIZE) {
-      const int lastj_offset =
-          (j < num_partition_offset) ? j : last_partition_offset;
-      tmps[idx] = tmp_out_ptr[lastj_offset];
-      idx++;
-    }
-
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK * HEAD_SIZE; j < MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-    }
-  }  // num_partitions > JCHUNK
-
-  // Aggregate tmp_out to out.
-  float acc = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < JCHUNK; j++) {
-    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-  }
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
-      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-    }
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-      }
-    }
+  const auto seq_idx = blockIdx.x;
+  if (query_start_loc_ptr != nullptr &&
+      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx]) != 1) {
+    return;
   }
 
-  for (int p = 1; p < NPAR_LOOPS; p++) {
-    if (num_partitions > p * MAX_NPAR) {
-      idx = 0;
-  #pragma unroll
-      for (int j = p * MAX_NPAR * HEAD_SIZE; j < (p + 1) * MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        // lastj is last valid partition
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-
-  #pragma unroll
-      for (int j = 0; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
-      }
-    }
+  const auto partition_idx = blockIdx.y;
+  constexpr int T_PAR_SIZE = 256;
+  const auto max_num_partitions = gridDim.y;
+  const int seq_len = seq_lens[seq_idx];
+  const int partition_start_token_idx = partition_idx * T_PAR_SIZE;
+  if (partition_start_token_idx >= seq_len) {
+    return;
   }
 
-  const float inv_global_exp_sum =
-      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
-  const float out_scale =
-      (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+  constexpr int ROWS_PER_WARP = WARP_SIZE / 16;
+  constexpr int CONTIGUOUS_KV_ELEMS_16B_LOAD = 16 / sizeof(cache_t);
+  constexpr int QKHE_PER_FETCH = CONTIGUOUS_KV_ELEMS_16B_LOAD * ROWS_PER_WARP;
+  constexpr int QK_SIZE_RATIO = sizeof(scalar_t) / sizeof(cache_t);
+  const int qkheloop = head_size / QKHE_PER_FETCH;
+  // Dynamic shared memory: layout [max(NWARPS,qkheloop)][4][16][4] of _B16x4 (8 bytes).
+  // Size is computed in the launch macro and passed as the third <<<>>> argument.
+  // Aliased as a 4D array pointer so all existing indexing syntax is preserved.
+  extern __shared__ _B16x4 shared_logits_flat[];
+  _B16x4 (*shared_logits)[4][16][4] =
+      reinterpret_cast<_B16x4(*)[4][16][4]>(shared_logits_flat);
 
+  constexpr int MAX_QKHELOOP = 8;  // register array bound; increase for head_size > 256
+
+  // Register arrays: use max sizes, loop with runtime bounds
+  _B16x8 Qlocal[MAX_QKHELOOP][QK_SIZE_RATIO];
+
+  constexpr int CONTIGUOUS_SCALAR_ELEMS_16B = 16 / sizeof(scalar_t);
+  constexpr int TOKENS_PER_WARP = T_PAR_SIZE / NWARPS;
+  constexpr int TLOOP = TOKENS_PER_WARP / 16;
+
+  const auto wg_start_head_idx = blockIdx.z * gqa_ratio;
+  const auto wg_start_kv_head_idx = blockIdx.z;
+  const auto total_num_heads = gridDim.z * gqa_ratio;
+
+  const int num_seq_blocks = DIVIDE_ROUND_UP(seq_len, block_size);
+  const int last_seq_block = num_seq_blocks - 1;
+  const int* block_table_seq = block_tables + seq_idx * max_num_blocks_per_seq;
+
+  int kphysical_block_number[TLOOP];
+#if defined(__HIP__FP8MFMA__)
+  float q_max = 0;
+  float q_scale = 1.0;
+#endif
+
+  // fetch k physical block numbers (runtime block_size)
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int klocal_token_idx =
+        TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int kglobal_token_idx = partition_start_token_idx + klocal_token_idx;
+    const int kblock_idx = (kglobal_token_idx < seq_len)
+                               ? kglobal_token_idx / block_size
+                               : last_seq_block;
+    kphysical_block_number[token_depth] = block_table_seq[kblock_idx];
+  }
+
+  // fetch Q in shared across warps and then write to registers
+  const int local_qhead_idx = 4 * warpid + rowid;
+  const int global_qhead_idx = wg_start_head_idx + local_qhead_idx;
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
-                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
+  const scalar_t* q_ptr =
+      q + query_start_off * q_stride + global_qhead_idx * head_size;
 
-  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
-  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
-  if constexpr (std::is_same<OUTT, float4>::value) {
-    float4* temp_dst = reinterpret_cast<float4*>(
-        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
-    temp_out_ptr[threadIdx.x] =
-        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
-  } else {
-    acc *= inv_global_exp_sum;
-    acc *= out_scale;
-    if constexpr (std::is_same<OUTT, bit8_t>::value) {
-      out_ptr[threadIdx.x] =
-          __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
-                                 vllm::fp8::fp8_type::__default_interpret);
+  const int qhead_element = lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
+  if ((local_qhead_idx < gqa_ratio) && (qhead_element < head_size)) {
+    const scalar_t* q_fetch_ptr = q_ptr + qhead_element;
+    const _B16x8* q_fetch_ptr_16B =
+        reinterpret_cast<const _B16x8*>(q_fetch_ptr);
+    _B16x8 tmp = *q_fetch_ptr_16B;
+    if constexpr (KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto) {
+      const int offset1 = lane16id / 4;
+      shared_logits[offset1][lane4id][local_qhead_idx][0] = tmp.xy[0];
+      shared_logits[offset1][lane4id][local_qhead_idx][1] = tmp.xy[1];
     } else {
-      out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+      for (int i = 0; i < 2; i++) {
+        const int head_elem = lane16id * 2 + i;
+        const int offset3 = head_elem % 4;
+        const int offset2 = (head_elem / 4) % 4;
+        const int offset1 = head_elem / 4 / 4;
+        shared_logits[offset1][offset2][local_qhead_idx][offset3] = tmp.xy[i];
+      }
+    }
+  }
+
+  // For head_size > 128: need second pass to fetch remaining Q elements
+  // First pass covered lane16id 0-15 → elements 0..127
+  // Second pass covers elements 128..head_size-1
+  if (head_size > 128) {
+    __syncthreads();
+    // Read first half of Q into registers
+    for (int qkhe_depth = 0; qkhe_depth < 4; qkhe_depth++) {
+      for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+        for (int i = 0; i < 2; i++) {
+          Qlocal[qkhe_depth][qkratio].xy[i] =
+              shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio]
+                           [2 * qkratio + i];
+#if defined(__HIP__FP8MFMA__)
+          if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto &&
+                        MFMA_TYPE == MFMAType::Fp8) {
+            scalar_t* qptr =
+                reinterpret_cast<scalar_t*>(&Qlocal[qkhe_depth][qkratio].xy[i]);
+            for (int k = 0; k < 4; k++)
+              q_max = fmax(fabs(to_float<scalar_t>(qptr[k])), q_max);
+          }
+#endif
+        }
+      }
+    }
+    __syncthreads();
+
+    // Second Q fetch: elements 128..255
+    const int qhead_element2 = 128 + lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
+    if ((local_qhead_idx < gqa_ratio) && (qhead_element2 < head_size)) {
+      const scalar_t* q_fetch_ptr2 = q_ptr + qhead_element2;
+      const _B16x8* q_fetch_ptr_16B2 =
+          reinterpret_cast<const _B16x8*>(q_fetch_ptr2);
+      _B16x8 tmp2 = *q_fetch_ptr_16B2;
+      if constexpr (KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto) {
+        const int offset1 = lane16id / 4;
+        shared_logits[offset1][lane4id][local_qhead_idx][0] = tmp2.xy[0];
+        shared_logits[offset1][lane4id][local_qhead_idx][1] = tmp2.xy[1];
+      } else {
+        for (int i = 0; i < 2; i++) {
+          const int head_elem = lane16id * 2 + i;
+          const int offset3 = head_elem % 4;
+          const int offset2 = (head_elem / 4) % 4;
+          const int offset1 = head_elem / 4 / 4;
+          shared_logits[offset1][offset2][local_qhead_idx][offset3] = tmp2.xy[i];
+        }
+      }
+    }
+    __syncthreads();
+
+    // Read second half of Q into registers (qkhe_depth 4..7)
+    for (int qkhe_depth = 4; qkhe_depth < qkheloop; qkhe_depth++) {
+      for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+        for (int i = 0; i < 2; i++) {
+          Qlocal[qkhe_depth][qkratio].xy[i] =
+              shared_logits[qkhe_depth - 4][rowid][lane16id % gqa_ratio]
+                           [2 * qkratio + i];
+#if defined(__HIP__FP8MFMA__)
+          if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto &&
+                        MFMA_TYPE == MFMAType::Fp8) {
+            scalar_t* qptr =
+                reinterpret_cast<scalar_t*>(&Qlocal[qkhe_depth][qkratio].xy[i]);
+            for (int k = 0; k < 4; k++)
+              q_max = fmax(fabs(to_float<scalar_t>(qptr[k])), q_max);
+          }
+#endif
+        }
+      }
+    }
+  } else {
+    // head_size <= 128: single pass (original path)
+    __syncthreads();
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+        for (int i = 0; i < 2; i++) {
+          Qlocal[qkhe_depth][qkratio].xy[i] =
+              shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio]
+                           [2 * qkratio + i];
+#if defined(__HIP__FP8MFMA__)
+          if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto &&
+                        MFMA_TYPE == MFMAType::Fp8) {
+            scalar_t* qptr =
+                reinterpret_cast<scalar_t*>(&Qlocal[qkhe_depth][qkratio].xy[i]);
+            for (int k = 0; k < 4; k++)
+              q_max = fmax(fabs(to_float<scalar_t>(qptr[k])), q_max);
+          }
+#endif
+        }
+      }
+    }
+  }
+
+  constexpr int KX = 16 / sizeof(cache_t);
+  const cache_t* k_ptr = k_cache + wg_start_kv_head_idx * kv_head_stride;
+  const int row_head_elem = rowid * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+
+  // V-related constants (runtime head_size for vheloop)
+  constexpr int VTOKENS_PER_LANE = TOKENS_PER_WARP / ROWS_PER_WARP;
+  constexpr int VBLOCKS_PER_LANE = 1;  // assumes block_size >= 16
+  constexpr int VTLOOP = NWARPS;
+  constexpr int VTLANELOOP = DIVIDE_ROUND_UP(
+      VTOKENS_PER_LANE, CONTIGUOUS_KV_ELEMS_16B_LOAD);
+  const int vheloop = head_size / 16 / NWARPS;
+  constexpr int MAX_VHELOOP = 4;  // supports head_size up to 256
+
+
+  KVRegs<SHARED_KV, NWARPS, VTLANELOOP> _kv;
+  auto& Klocal = _kv.Klocal;
+  auto& Vlocal = _kv.Vlocal;
+
+  // fetch K values (runtime block_size for block offset)
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int64_t kblock_number =
+        static_cast<int64_t>(kphysical_block_number[token_depth]);
+    const cache_t* k_ptr2 = k_ptr + kblock_number * kv_block_stride;
+    const int klocal_token_idx =
+        TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int kphysical_block_offset = klocal_token_idx % block_size;
+    const cache_t* k_ptr3 = k_ptr2 + kphysical_block_offset * KX;
+
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      const int head_elem = row_head_elem + qkhe_depth * QKHE_PER_FETCH;
+      const int offset1 = head_elem / KX;
+      const int offset2 = head_elem % KX;
+      const cache_t* k_fetch_ptr =
+          k_ptr3 + offset1 * block_size * KX + offset2;
+      const _B16x8* k_fetch_ptr_16B =
+          reinterpret_cast<const _B16x8*>(k_fetch_ptr);
+      Klocal[token_depth][qkhe_depth] = *k_fetch_ptr_16B;
+    }
+  }
+
+  float alibi_slope;
+  if constexpr (ALIBI_ENABLED) {
+    const int alibi_head_idx = wg_start_head_idx + lane16id;
+    alibi_slope = (lane16id < gqa_ratio) ? alibi_slopes[alibi_head_idx] : 0.f;
+  }
+
+  int vphysical_block_number[VTLOOP][VBLOCKS_PER_LANE];
+
+  // fetch v physical block numbers (runtime block_size)
+  for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+    for (int vblock_depth = 0; vblock_depth < VBLOCKS_PER_LANE;
+         vblock_depth++) {
+      const int vlocal_token_idx =
+          vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
+          rowid * VTOKENS_PER_LANE + vblock_depth * block_size;
+      const int vglobal_token_idx =
+          partition_start_token_idx + vlocal_token_idx;
+      const int vblock_idx = (vglobal_token_idx < seq_len)
+                                 ? vglobal_token_idx / block_size
+                                 : last_seq_block;
+      vphysical_block_number[vtoken_depth][vblock_depth] =
+          block_table_seq[vblock_idx];
+    }
+  }
+
+
+  const cache_t* v_ptr = v_cache + wg_start_kv_head_idx * kv_head_stride +
+                         ((rowid * VTOKENS_PER_LANE) % block_size);
+
+  auto fetchV = [&]() {
+    // fetch V values (runtime head_size for vheloop, runtime block_size for addressing)
+    for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+      const int vhead_elem = vhe_depth * NWARPS * 16 + warpid * 16 + lane16id;
+      const cache_t* v_ptr2 = v_ptr + vhead_elem * block_size;
+
+      for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+        for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+          const int vblock_depth = 0;
+          const int64_t vblock_number = static_cast<int64_t>(
+              vphysical_block_number[vtoken_depth][vblock_depth]);
+          const cache_t* v_ptr3 = v_ptr2 + (vblock_number * kv_block_stride);
+          const cache_t* v_fetch_ptr =
+              v_ptr3 + vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+          const _B16x8* v_fetch_ptr_16B =
+              reinterpret_cast<const _B16x8*>(v_fetch_ptr);
+          Vlocal[vtoken_depth][vhe_depth][vfetch_depth] = *v_fetch_ptr_16B;
+        }
+      }
+    }
+  };
+  if constexpr (!SHARED_KV) fetchV();
+
+  // calculate post qk mfma scale
+  float scale2 = scale;
+  if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto) {
+    scale2 *= *k_scale;
+#if defined(__HIP__FP8MFMA__)
+    q_max = warpReduceMax(q_max);
+    constexpr float FP8_E4M3_SCALE_TARGET = 224.0f;
+    if constexpr (MFMA_TYPE == MFMAType::Fp8) {
+      q_scale = q_max > 0 ? FP8_E4M3_SCALE_TARGET / q_max : 1.0f;
+      scale2 /= q_scale;
+    }
+#endif
+  }
+
+  floatx4 d_out[TLOOP];
+  // QK MFMA (runtime qkheloop)
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    d_out[token_depth] = {0};
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      if constexpr (KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto) {
+        for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+          for (int i = 0; i < 2; i++) {
+            d_out[token_depth] = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                Klocal[token_depth][qkhe_depth].xy[i],
+                Qlocal[qkhe_depth][qkratio].xy[i], d_out[token_depth]);
+          }
+        }
+      } else {
+        auto Ktmp = Klocal[token_depth][qkhe_depth];
+        _B8x16 Ktmp8x16 = *reinterpret_cast<_B8x16*>(&Ktmp);
+        for (int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++) {
+          if constexpr (MFMA_TYPE == MFMAType::F16) {
+            _B8x8 Ktmp8x8 = Ktmp8x16.xy[qkratio];
+            _B16x8 Klocaltmp = convert_b8x8_custom<scalar_t>(Ktmp8x8);
+            for (int i = 0; i < 2; i++) {
+              d_out[token_depth] = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                  Klocaltmp.xy[i], Qlocal[qkhe_depth][qkratio].xy[i],
+                  d_out[token_depth]);
+            }
+          } else {
+#if defined(__HIP__FP8MFMA__)
+            _T8x8 Ktmp8x8, Qtmp8x8;
+            Ktmp8x8.b8x8 = Ktmp8x16.xy[qkratio];
+            for (int n = 0; n < 2; n++) {
+              scalar_t* qptr = reinterpret_cast<scalar_t*>(
+                  &Qlocal[qkhe_depth][qkratio].xy[n]);
+              Qtmp8x8.b16x4[n * 2] =
+                  vllm::fp8::scaled_vec_conversion<uint16_t, float2>(
+                      make_float2(to_float<scalar_t>(qptr[0]),
+                                  to_float<scalar_t>(qptr[1])),
+                      q_scale);
+              Qtmp8x8.b16x4[n * 2 + 1] =
+                  vllm::fp8::scaled_vec_conversion<uint16_t, float2>(
+                      make_float2(to_float<scalar_t>(qptr[2]),
+                                  to_float<scalar_t>(qptr[3])),
+                      q_scale);
+            }
+            d_out[token_depth] =
+                gcn_mfma16x16x32_instr<__hip_fp8_e4m3, 0, 0, 0>(
+                    Ktmp8x8.i64, Qtmp8x8.i64, d_out[token_depth]);
+#else
+            UNREACHABLE_CODE
+#endif
+          }
+        }
+      }
+    }
+    d_out[token_depth] *= scale2;
+  }
+
+  if constexpr (SHARED_KV) fetchV();
+
+  const int qkout_token_idx =
+      partition_start_token_idx + TOKENS_PER_WARP * warpid + rowid * 4;
+
+  if constexpr (ALIBI_ENABLED) {
+    for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+      const int local_token_idx = qkout_token_idx + token_depth * 16;
+      const int alibi_offset = local_token_idx - seq_len + 1;
+      for (int i = 0; i < 4; i++) {
+        d_out[token_depth][i] += alibi_slope * (alibi_offset + i);
+      }
+    }
+  }
+
+  // Online softmax: calculate qk_max and exp_sum per warp
+  float qk_max = -FLT_MAX;
+  float exp_sum = 0.0f;
+
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int local_token_idx = qkout_token_idx + token_depth * 16;
+    for (int i = 0; i < 4; i++) {
+      const float tmp =
+          (local_token_idx + i < seq_len) ? d_out[token_depth][i] : -FLT_MAX;
+      qk_max = fmaxf(qk_max, tmp);
+    }
+  }
+
+  for (int mask = WARP_SIZE / 2; mask >= 16; mask /= 2) {
+    qk_max = fmaxf(qk_max, __shfl_xor(qk_max, mask));
+  }
+
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int local_token_idx = qkout_token_idx + token_depth * 16;
+    for (int i = 0; i < 4; i++) {
+      const float tmp = (local_token_idx + i < seq_len)
+                            ? __expf(d_out[token_depth][i] - qk_max)
+                            : 0.0f;
+      d_out[token_depth][i] = tmp;
+      exp_sum += tmp;
+    }
+  }
+
+  for (int mask = WARP_SIZE / 2; mask >= 16; mask /= 2) {
+    exp_sum += __shfl_xor(exp_sum, mask);
+  }
+
+  __syncthreads();
+
+  float* shared_mem = reinterpret_cast<float*>(shared_logits);
+  if (laneid < 16) {
+    const int qk_max_offset = warpid * 16 + lane16id;
+    shared_mem[qk_max_offset] = qk_max;
+    const int exp_sum_offset = NWARPS * 16 + qk_max_offset;
+    shared_mem[exp_sum_offset] = exp_sum;
+  }
+
+  __syncthreads();
+
+  // Partition-level qk_max and exp_sum
+  float partition_qk_max = -FLT_MAX;
+  float warp_qk_max_exp[NWARPS];
+  float partition_exp_sum = 0.0f;
+
+  for (int w = 0; w < NWARPS; w++) {
+    warp_qk_max_exp[w] = shared_mem[w * 16 + lane16id];
+    partition_qk_max = fmaxf(partition_qk_max, warp_qk_max_exp[w]);
+  }
+
+  for (int w = 0; w < NWARPS; w++) {
+    warp_qk_max_exp[w] = __expf(warp_qk_max_exp[w] - partition_qk_max);
+    partition_exp_sum +=
+        shared_mem[NWARPS * 16 + w * 16 + lane16id] * warp_qk_max_exp[w];
+  }
+
+  const float inv_sum_scale =
+      __fdividef(1.f, partition_exp_sum + 1e-6f) * warp_qk_max_exp[warpid];
+
+  __syncthreads();
+
+  constexpr bool LOGITS_RTZ_CONVERSION = false;
+#if defined(__HIP__FP8MFMA__)
+  int rowid_8x8 = rowid / 2;
+  int offset = rowid % 2;
+#endif
+
+  // Write logits to shared mem
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    d_out[token_depth] *= inv_sum_scale;
+    if constexpr (MFMA_TYPE != MFMAType::Fp8) {
+      if constexpr (LOGITS_RTZ_CONVERSION) {
+        shared_logits[warpid][token_depth][lane16id][rowid] =
+            from_floatx4_rtz<scalar_t>(d_out[token_depth]);
+      } else {
+        shared_logits[warpid][token_depth][lane16id][rowid] =
+            from_floatx4<scalar_t>(d_out[token_depth]);
+      }
+    } else {
+#if defined(__HIP__FP8MFMA__)
+      _T8x8& logits_8x8 = *reinterpret_cast<_T8x8*>(
+          &shared_logits[warpid][token_depth][lane16id][rowid_8x8]);
+      logits_8x8.b16x4[offset * 2] = __builtin_amdgcn_cvt_pk_fp8_f32(
+          d_out[token_depth][0], d_out[token_depth][1], 0, false);
+      logits_8x8.b16x4[offset * 2 + 1] = __builtin_amdgcn_cvt_pk_fp8_f32(
+          d_out[token_depth][2], d_out[token_depth][3], 0, false);
+#else
+      UNREACHABLE_CODE
+#endif
+    }
+  }
+
+  // Write partition max_logits and exp_sum
+  if (threadIdx.x < gqa_ratio) {
+    const int qhead_idx = lane16id;
+    const int64_t poffset = static_cast<int64_t>(seq_idx) *
+                                static_cast<int64_t>(total_num_heads) *
+                                static_cast<int64_t>(max_num_partitions) +
+                            (static_cast<int64_t>(wg_start_head_idx) +
+                             static_cast<int64_t>(qhead_idx)) *
+                                static_cast<int64_t>(max_num_partitions) +
+                            static_cast<int64_t>(partition_idx);
+    max_logits[poffset] = partition_qk_max;
+    exp_sums[poffset] = partition_exp_sum;
+  }
+
+  __syncthreads();
+
+  constexpr int ELEMS8_ELEMS4_RATIO = 8 / 4;
+  constexpr int ELEMS16_ELEMS8_RATIO = 16 / 8;
+
+  _B16x4 outelems[MAX_VHELOOP];
+  // Softmax-V MFMA (runtime vheloop)
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    floatx4 tmp_out = {0};
+
+    for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+      if constexpr (KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto) {
+        for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+          for (int i = 0; i < ELEMS8_ELEMS4_RATIO; i++) {
+            const int off = rowid * VTLANELOOP * ELEMS8_ELEMS4_RATIO +
+                            vfetch_depth * ELEMS8_ELEMS4_RATIO + i;
+            const int offset1 = off % ROWS_PER_WARP;
+            const int offset2 = off / ROWS_PER_WARP;
+            tmp_out = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                Vlocal[vtoken_depth][vhe_depth][vfetch_depth].xy[i],
+                shared_logits[vtoken_depth][offset2][lane16id][offset1],
+                tmp_out);
+          }
+        }
+      } else {
+        for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+          _B16x8 Vtmp = Vlocal[vtoken_depth][vhe_depth][vfetch_depth];
+          _B8x16 Vtmp8x16 = *reinterpret_cast<_B8x16*>(&Vtmp);
+          for (int j = 0; j < ELEMS16_ELEMS8_RATIO; j++) {
+            _B8x8 Vtmp8x8 = Vtmp8x16.xy[j];
+            if constexpr (MFMA_TYPE == MFMAType::F16) {
+              _B16x8 Vlocaltmp = convert_b8x8_custom<scalar_t>(Vtmp8x8);
+              for (int i = 0; i < ELEMS8_ELEMS4_RATIO; i++) {
+                const int off =
+                    rowid * ELEMS16_ELEMS8_RATIO * ELEMS8_ELEMS4_RATIO +
+                    j * ELEMS8_ELEMS4_RATIO + i;
+                const int offset1 = off % ROWS_PER_WARP;
+                const int offset2 = off / ROWS_PER_WARP;
+                tmp_out = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                    Vlocaltmp.xy[i],
+                    shared_logits[vtoken_depth][offset2][lane16id][offset1],
+                    tmp_out);
+              }
+            } else {
+#if defined(__HIP__FP8MFMA__)
+              for (int i = 0; i < ELEMS8_ELEMS4_RATIO / 2; i++) {
+                const int off =
+                    rowid * ELEMS16_ELEMS8_RATIO * ELEMS8_ELEMS4_RATIO +
+                    j * ELEMS8_ELEMS4_RATIO + i;
+                const int offset1 = (off % ROWS_PER_WARP) / 2;
+                const int offset2 = off / ROWS_PER_WARP;
+                tmp_out = gcn_mfma16x16x32_instr<__hip_fp8_e4m3, 0, 0, 0>(
+                    reinterpret_cast<_T8x8*>(&Vtmp8x8)->i64,
+                    reinterpret_cast<_T8x8*>(
+                        &shared_logits[vtoken_depth][offset2][lane16id]
+                                      [offset1])
+                        ->i64,
+                    tmp_out);
+              }
+#else
+              UNREACHABLE_CODE
+#endif
+            }
+          }
+        }
+      }
+    }
+    if constexpr (KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto) {
+      tmp_out *= *v_scale;
+    }
+    outelems[vhe_depth] = from_floatx4<scalar_t>(tmp_out);
+  }
+
+  __syncthreads();
+
+  // Store SV output to shared mem
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    shared_logits[warpid][vhe_depth][lane16id][rowid] = outelems[vhe_depth];
+  }
+
+  __syncthreads();
+
+  const int64_t hsz_maxp_mult =
+      static_cast<int64_t>(head_size * max_num_partitions);
+  // Write to tmp_out with coalesced writes (runtime head_size)
+  if (warpid == 0) {
+    _B16x8 vout[4];
+    const int head_elem_idx = lane16id * 8;
+    if (head_elem_idx < head_size) {
+      for (int h = 0; h < 4; h++) {
+        const int local_head_idx = 4 * h + rowid;
+        if (local_head_idx >= gqa_ratio) break;
+        const int off1 = (head_elem_idx / 16) % NWARPS;
+        const int off2 = head_elem_idx / 16 / NWARPS;
+        const int off3 = (head_elem_idx / 4) % 4;
+        for (int i = 0; i < 2; i++) {
+          vout[h].xy[i] =
+              shared_logits[off1][off2][local_head_idx][off3 + i];
+        }
+      }
+
+      scalar_t* out_ptr = out + seq_idx * total_num_heads * hsz_maxp_mult +
+                          partition_idx * head_size;
+      for (int h = 0; h < 4; h++) {
+        const int local_head_idx = 4 * h + rowid;
+        if (local_head_idx < gqa_ratio) {
+          const int64_t out_head_idx =
+              static_cast<int64_t>(wg_start_head_idx + local_head_idx);
+          scalar_t* out_ptr2 = out_ptr + out_head_idx * hsz_maxp_mult;
+          scalar_t* out_ptr3 = out_ptr2 + head_elem_idx;
+          _B16x8* out_ptr_B16x8 = reinterpret_cast<_B16x8*>(out_ptr3);
+          *out_ptr_B16x8 = vout[h];
+        }
+      }
+    }
+
+    // For head_size > 128: second write pass for elements 128..head_size-1
+    if (head_size > 128) {
+      const int head_elem_idx2 = 128 + lane16id * 8;
+      if (head_elem_idx2 < head_size) {
+        for (int h = 0; h < 4; h++) {
+          const int local_head_idx = 4 * h + rowid;
+          if (local_head_idx >= gqa_ratio) break;
+          const int off1 = ((head_elem_idx2) / 16) % NWARPS;
+          const int off2 = (head_elem_idx2) / 16 / NWARPS;
+          const int off3 = ((head_elem_idx2) / 4) % 4;
+          for (int i = 0; i < 2; i++) {
+            vout[h].xy[i] =
+                shared_logits[off1][off2][local_head_idx][off3 + i];
+          }
+        }
+
+        for (int h = 0; h < 4; h++) {
+          const int local_head_idx = 4 * h + rowid;
+          if (local_head_idx < gqa_ratio) {
+            const int64_t out_head_idx =
+                static_cast<int64_t>(wg_start_head_idx + local_head_idx);
+            scalar_t* out_ptr2 = out + seq_idx * total_num_heads * hsz_maxp_mult +
+                                partition_idx * head_size +
+                                out_head_idx * hsz_maxp_mult;
+            scalar_t* out_ptr3 = out_ptr2 + head_elem_idx2;
+            _B16x8* out_ptr_B16x8 = reinterpret_cast<_B16x8*>(out_ptr3);
+            *out_ptr_B16x8 = vout[h];
+          }
+        }
+      }
     }
   }
 }
@@ -1818,7 +2795,6 @@ union b16x16_u {
 typedef b16x16_u _B16x16;
 
 using _B8x8 = uint2;
-using bit8_t = uint8_t;
 
 typedef struct _B8x16 {
   _B8x8 xy[2];
@@ -1832,28 +2808,6 @@ __device__ __forceinline__ floatx8 gcn_wmma16x16x16_instr(const bit16x16& inpA,
     return __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(inpA, inpB, inpC);
   } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
     return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(inpA, inpB, inpC);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ float to_float(const T& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (float)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __bfloat162float(inp);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ T from_float(const float& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (_Float16)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __float2bfloat16(inp);
   } else {
     static_assert(false, "unsupported 16b dtype");
   }
@@ -2372,236 +3326,25 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   UNREACHABLE_CODE
 }
 
-// Grid: (num_heads, num_seqs).
-template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
-          int PARTITION_SIZE, int NPAR_LOOPS>
+
+// GFX11 stubs for "free" kernels (not supported on Navi)
+template <typename scalar_t, typename cache_t,
+          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
+          int NUM_THREADS, bool ALIBI_ENABLED, MFMAType MFMA_TYPE,
+          bool SHARED_KV = false>
 __global__
-__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
-    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
-    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
-                                           // max_num_partitions, head_size]
-    const int* __restrict__ seq_lens,      // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
-    const int partition_offset) {
-  const auto num_heads = gridDim.x;
-  const auto head_idx = blockIdx.x;
-  const auto seq_idx = blockIdx.y;
-
-  // NOTE queries with sequence len > 1 are prefills and taken care by another
-  // kernel.
-  if (query_start_loc_ptr != nullptr &&
-      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
-    return;
-  }
-
-  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
-  if (seq_len <= 0) {
-    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
-    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
-    if constexpr (std::is_same<OUTT, float4>::value) {
-      const int64_t query_start_off = static_cast<int64_t>(
-          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-      float4* temp_dst = reinterpret_cast<float4*>(
-          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
-      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
-    }
-    return;
-  }
-  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
-  const int warpid = threadIdx.x / WARP_SIZE;
-
-  __shared__ float shared_global_exp_sum;
-  __shared__ float shared_max_logit;
-  // max num partitions supported is warp_size * NPAR_LOOPS
-  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
-
-  if (warpid == 0) {
-    const float* max_logits_ptr = max_logits + partition_offset +
-                                  seq_idx * num_heads * max_num_partitions +
-                                  head_idx * max_num_partitions;
-
-    // valid partition is the last valid partition in case threadid > num
-    // partitions
-    int valid_partition[NPAR_LOOPS];
-    float reg_max_logit[NPAR_LOOPS];
-    const int last_valid_partition = num_partitions - 1;
-
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      valid_partition[i] =
-          (partition_no < num_partitions) ? partition_no : last_valid_partition;
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
-    }
-    float max_logit = reg_max_logit[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      max_logit = fmaxf(max_logit, reg_max_logit[i]);
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
-    }
-
-    const float* exp_sums_ptr = exp_sums + partition_offset +
-                                seq_idx * num_heads * max_num_partitions +
-                                head_idx * max_num_partitions;
-
-    float rescaled_exp_sum[NPAR_LOOPS];
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      rescaled_exp_sum[i] = exp_sums_ptr[valid_partition[i]];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      rescaled_exp_sum[i] *= (partition_no < num_partitions)
-                                 ? expf(reg_max_logit[i] - max_logit)
-                                 : 0.0f;
-    }
-    float global_exp_sum = rescaled_exp_sum[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      global_exp_sum += rescaled_exp_sum[i];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      global_exp_sum += __shfl_xor(global_exp_sum, mask);
-    }
-    if (threadIdx.x == 0) {
-      shared_global_exp_sum = global_exp_sum;
-      shared_max_logit = max_logit;
-    }
-  }  // warpid == 0
-  const scalar_t* tmp_out_ptr =
-      tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE +
-      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
-  constexpr int MAX_NPAR = 32;
-  scalar_t tmps[MAX_NPAR];
-  const float dzero = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < MAX_NPAR; j++) {
-    tmps[j] = from_float<scalar_t>(dzero);
-  }
-  const int last_partition_offset = (num_partitions - 1) * HEAD_SIZE;
-  const int num_partition_offset = (num_partitions)*HEAD_SIZE;
-  int idx = 0;
-
-  constexpr int JCHUNK = 16;
-
-  #pragma unroll
-  for (int j = 0; j < JCHUNK * HEAD_SIZE; j += HEAD_SIZE) {
-    // lastj is last valid partition
-    const int lastj_offset =
-        (j < num_partition_offset) ? j : last_partition_offset;
-    tmps[idx] = tmp_out_ptr[lastj_offset];
-    idx++;
-  }
-  __syncthreads();
-
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK * HEAD_SIZE; j < 2 * JCHUNK * HEAD_SIZE;
-         j += HEAD_SIZE) {
-      const int lastj_offset =
-          (j < num_partition_offset) ? j : last_partition_offset;
-      tmps[idx] = tmp_out_ptr[lastj_offset];
-      idx++;
-    }
-
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK * HEAD_SIZE; j < MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-    }
-  }  // num_partitions > JCHUNK
-
-  // Aggregate tmp_out to out.
-  float acc = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < JCHUNK; j++) {
-    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-  }
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
-      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-    }
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-      }
-    }
-  }
-
-  for (int p = 1; p < NPAR_LOOPS; p++) {
-    if (num_partitions > p * MAX_NPAR) {
-      idx = 0;
-  #pragma unroll
-      for (int j = p * MAX_NPAR * HEAD_SIZE; j < (p + 1) * MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        // lastj is last valid partition
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-
-  #pragma unroll
-      for (int j = 0; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
-      }
-    }
-  }
-
-  const float inv_global_exp_sum =
-      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
-
-  const int64_t query_start_off = static_cast<int64_t>(
-      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
-                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
-
-  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
-  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
-  if constexpr (std::is_same<OUTT, float4>::value) {
-    float4* temp_dst = reinterpret_cast<float4*>(
-        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
-    temp_out_ptr[threadIdx.x] =
-        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
-    return;
-  } else {
-    acc *= inv_global_exp_sum;
-    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
-  }
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel(
+    const scalar_t* __restrict__ q, const cache_t* __restrict__ k_cache,
+    const cache_t* __restrict__ v_cache, const int num_kv_heads, const float scale,
+    const int* __restrict__ block_tables, const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc_ptr, const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes, const int q_stride,
+    const int kv_block_stride, const int kv_head_stride,
+    float* __restrict__ exp_sums, float* __restrict__ max_logits,
+    scalar_t* __restrict__ out, OUTT* __restrict__ final_out,
+    int max_ctx_blocks, const float* k_scale, const float* v_scale,
+    int block_size, int head_size, int gqa_ratio) {
+  UNREACHABLE_CODE
 }
 
 #elif defined(__GFX12__)
@@ -2620,7 +3363,6 @@ union b16x8_u {
 typedef b16x8_u _B16x8;
 
 using _B8x8 = uint2;
-using bit8_t = uint8_t;
 
 typedef struct _B8x16 {
   _B8x8 xy[2];
@@ -2651,17 +3393,6 @@ __device__ __forceinline__ floatx8 gcn_wmma16x16x16_instr(const bit16x8& inpA,
 }
 
 template <typename T>
-__device__ __forceinline__ float to_float(const T& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (float)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __bfloat162float(inp);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
 __device__ __forceinline__ float to_float_b16(const bit16_t& inp) {
   union tmpcvt {
     bit16_t u;
@@ -2673,17 +3404,6 @@ __device__ __forceinline__ float to_float_b16(const bit16_t& inp) {
     return (float)t16.f;
   } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
     return __bfloat162float(t16.b);
-  } else {
-    static_assert(false, "unsupported 16b dtype");
-  }
-}
-
-template <typename T>
-__device__ __forceinline__ T from_float(const float& inp) {
-  if constexpr (std::is_same<T, _Float16>::value) {
-    return (_Float16)inp;
-  } else if constexpr (std::is_same<T, __hip_bfloat16>::value) {
-    return __float2bfloat16(inp);
   } else {
     static_assert(false, "unsupported 16b dtype");
   }
@@ -3167,235 +3887,352 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   UNREACHABLE_CODE
 }
 
-// Grid: (num_heads, num_seqs).
-template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
-          int PARTITION_SIZE, int NPAR_LOOPS>
-__global__
-__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
-    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
-    const float* __restrict__ exp_sums,    // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const float* __restrict__ max_logits,  // [num_seqs, num_heads,
-                                           // max_num_partitions]
-    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads,
-                                           // max_num_partitions, head_size]
-    const int* __restrict__ seq_lens,      // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
-    const int partition_offset) {
-  const auto num_heads = gridDim.x;
-  const auto head_idx = blockIdx.x;
-  const auto seq_idx = blockIdx.y;
 
-  // NOTE queries with sequence len > 1 are prefills and taken care by another
-  // kernel.
+// GFX12 free QKV kernel: runtime block_size, head_size, gqa_ratio.
+// Warp layout: WARP_SIZE=32, NWARPS=8, ROWS_PER_WARP=2, TLOOP=2, QKHE_PER_FETCH=16.
+// Reuses the same static shared memory layout as the non-free GFX12 kernel.
+// Supports head_size in {64, 128, 192, 256} with V-fetch bound guard for partial warps.
+// clang-format off
+template <typename scalar_t, typename cache_t,
+          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
+          int NUM_THREADS, bool ALIBI_ENABLED, MFMAType MFMA_TYPE,
+          bool SHARED_KV = false>
+__global__
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel(
+    const scalar_t* __restrict__ q, const cache_t* __restrict__ k_cache,
+    const cache_t* __restrict__ v_cache, const int num_kv_heads, const float scale,
+    const int* __restrict__ block_tables, const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc_ptr, const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes, const int q_stride,
+    const int kv_block_stride, const int kv_head_stride,
+    float* __restrict__ exp_sums, float* __restrict__ max_logits,
+    scalar_t* __restrict__ out, OUTT* __restrict__ final_out,
+    int max_ctx_blocks, const float* k_scale, const float* v_scale,
+    int block_size, int head_size, int gqa_ratio) {
+  // clang-format on
+  constexpr int NWARPS = NUM_THREADS / WARP_SIZE;  // 8
+  const int warpid = threadIdx.x / WARP_SIZE;
+  const int laneid = threadIdx.x % WARP_SIZE;
+  const int lane2id = laneid % 2;
+  const int lane16id = laneid % 16;
+  const int rowid = laneid / 16;
+
+  const int seq_idx = blockIdx.x;
   if (query_start_loc_ptr != nullptr &&
       (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
     return;
   }
-
-  const int seq_len = seq_lens[seq_idx] - seq_len_offset;
-  if (seq_len <= 0) {
-    // No work for this pass. In multi-pass mode (OUTT==float4), write a neutral
-    // element so the merge kernel correctly ignores this pass via exp(-FLT_MAX)≈0.
-    if constexpr (std::is_same<OUTT, float4>::value) {
-      const int64_t query_start_off = static_cast<int64_t>(
-          query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-      float4* temp_dst = reinterpret_cast<float4*>(
-          reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-      float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                             static_cast<int64_t>(head_idx) * HEAD_SIZE;
-      temp_out_ptr[threadIdx.x] = make_float4(0.f, 0.f, -FLT_MAX, 0.f);
-    }
+  const int partition_idx = blockIdx.y;
+  constexpr int T_PAR_SIZE = 256;
+  const int max_num_partitions = gridDim.y;
+  const int seq_len = seq_lens[seq_idx];
+  const int partition_start_token_idx = partition_idx * T_PAR_SIZE;
+  if (partition_start_token_idx >= seq_len) {
     return;
   }
-  const int num_partitions = DIVIDE_ROUND_UP(seq_len, PARTITION_SIZE);
-  const int warpid = threadIdx.x / WARP_SIZE;
 
-  __shared__ float shared_global_exp_sum;
-  __shared__ float shared_max_logit;
-  // max num partitions supported is warp_size * NPAR_LOOPS
-  __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
+  constexpr int ROWS_PER_WARP = WARP_SIZE / 16;  // 2
+  constexpr int CONTIGUOUS_KV_ELEMS_16B_LOAD = 16 / sizeof(cache_t);
+  constexpr int QKHE_PER_FETCH = CONTIGUOUS_KV_ELEMS_16B_LOAD * ROWS_PER_WARP;  // 16
+  constexpr int CONTIGUOUS_SCALAR_ELEMS_16B = 16 / sizeof(scalar_t);
+  const int qkheloop = head_size / QKHE_PER_FETCH;
 
-  if (warpid == 0) {
-    const float* max_logits_ptr = max_logits + partition_offset +
-                                  seq_idx * num_heads * max_num_partitions +
-                                  head_idx * max_num_partitions;
+  constexpr int MAX_QKHELOOP = 16;   // supports head_size up to 256
+  constexpr int MAX_GQA_RATIO2 = 8;  // supports gqa_ratio up to 16
 
-    // valid partition is the last valid partition in case threadid > num
-    // partitions
-    int valid_partition[NPAR_LOOPS];
-    float reg_max_logit[NPAR_LOOPS];
-    const int last_valid_partition = num_partitions - 1;
+  // Same static shared memory layout as the GFX12 non-free kernel.
+  // Also repurposed as float scratch during qk_max/exp_sum reduction.
+  __shared__ _B16x8 shared_logits[NWARPS][2][16][2];
 
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      valid_partition[i] =
-          (partition_no < num_partitions) ? partition_no : last_valid_partition;
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
-    }
-    float max_logit = reg_max_logit[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      max_logit = fmaxf(max_logit, reg_max_logit[i]);
-    }
+  constexpr int TOKENS_PER_WARP = T_PAR_SIZE / NWARPS;  // 32
+  constexpr int TLOOP = TOKENS_PER_WARP / 16;           // 2
 
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
-    }
+  const int wg_start_head_idx = blockIdx.z * gqa_ratio;
+  const int wg_start_kv_head_idx = blockIdx.z;
+  const int total_num_heads = gridDim.z * gqa_ratio;
 
-    const float* exp_sums_ptr = exp_sums + partition_offset +
-                                seq_idx * num_heads * max_num_partitions +
-                                head_idx * max_num_partitions;
-
-    float rescaled_exp_sum[NPAR_LOOPS];
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      rescaled_exp_sum[i] = exp_sums_ptr[valid_partition[i]];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      rescaled_exp_sum[i] *= (partition_no < num_partitions)
-                                 ? expf(reg_max_logit[i] - max_logit)
-                                 : 0.0f;
-    }
-    float global_exp_sum = rescaled_exp_sum[0];
-  #pragma unroll
-    for (int i = 1; i < NPAR_LOOPS; i++) {
-      global_exp_sum += rescaled_exp_sum[i];
-    }
-  #pragma unroll
-    for (int i = 0; i < NPAR_LOOPS; i++) {
-      const int partition_no = i * WARP_SIZE + threadIdx.x;
-      shared_exp_sums[partition_no] = rescaled_exp_sum[i];
-    }
-
-  #pragma unroll
-    for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
-      global_exp_sum += __shfl_xor(global_exp_sum, mask);
-    }
-    if (threadIdx.x == 0) {
-      shared_global_exp_sum = global_exp_sum;
-      shared_max_logit = max_logit;
-    }
-  }  // warpid == 0
-  const scalar_t* tmp_out_ptr =
-      tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
-      head_idx * max_num_partitions * HEAD_SIZE +
-      static_cast<int64_t>(partition_offset) * HEAD_SIZE + threadIdx.x;
-  constexpr int MAX_NPAR = 32;
-  scalar_t tmps[MAX_NPAR];
-  const float dzero = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < MAX_NPAR; j++) {
-    tmps[j] = from_float<scalar_t>(dzero);
-  }
-  const int last_partition_offset = (num_partitions - 1) * HEAD_SIZE;
-  const int num_partition_offset = (num_partitions)*HEAD_SIZE;
-  int idx = 0;
-
-  constexpr int JCHUNK = 16;
-
-  #pragma unroll
-  for (int j = 0; j < JCHUNK * HEAD_SIZE; j += HEAD_SIZE) {
-    // lastj is last valid partition
-    const int lastj_offset =
-        (j < num_partition_offset) ? j : last_partition_offset;
-    tmps[idx] = tmp_out_ptr[lastj_offset];
-    idx++;
-  }
-  __syncthreads();
-
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK * HEAD_SIZE; j < 2 * JCHUNK * HEAD_SIZE;
-         j += HEAD_SIZE) {
-      const int lastj_offset =
-          (j < num_partition_offset) ? j : last_partition_offset;
-      tmps[idx] = tmp_out_ptr[lastj_offset];
-      idx++;
-    }
-
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK * HEAD_SIZE; j < MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-    }
-  }  // num_partitions > JCHUNK
-
-  // Aggregate tmp_out to out.
-  float acc = 0.0f;
-  #pragma unroll
-  for (int j = 0; j < JCHUNK; j++) {
-    acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-  }
-  if (num_partitions > JCHUNK) {
-  #pragma unroll
-    for (int j = JCHUNK; j < 2 * JCHUNK; j++) {
-      acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-    }
-    if (num_partitions > 2 * JCHUNK) {
-  #pragma unroll
-      for (int j = 2 * JCHUNK; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
-      }
-    }
-  }
-
-  for (int p = 1; p < NPAR_LOOPS; p++) {
-    if (num_partitions > p * MAX_NPAR) {
-      idx = 0;
-  #pragma unroll
-      for (int j = p * MAX_NPAR * HEAD_SIZE; j < (p + 1) * MAX_NPAR * HEAD_SIZE;
-           j += HEAD_SIZE) {
-        // lastj is last valid partition
-        const int lastj_offset =
-            (j < num_partition_offset) ? j : last_partition_offset;
-        tmps[idx] = tmp_out_ptr[lastj_offset];
-        idx++;
-      }
-
-  #pragma unroll
-      for (int j = 0; j < MAX_NPAR; j++) {
-        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
-      }
-    }
-  }
-
-  const float inv_global_exp_sum =
-      __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
+  const int num_seq_blocks = DIVIDE_ROUND_UP(seq_len, block_size);
+  const int last_seq_block = num_seq_blocks - 1;
+  const int* block_table_seq = block_tables + seq_idx * max_num_blocks_per_seq;
 
   const int64_t query_start_off = static_cast<int64_t>(
       query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
-                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
 
-  // If OUTT is float4, output (acc, exp_sum, max_logit, 0) for merging multiple reductions.
-  // Use temp_offset from tmp_out instead of 'out' to avoid derived pointers in CUDA graphs.
-  if constexpr (std::is_same<OUTT, float4>::value) {
-    float4* temp_dst = reinterpret_cast<float4*>(
-        reinterpret_cast<char*>(const_cast<scalar_t*>(tmp_out)) + temp_offset);
-    float4* temp_out_ptr = temp_dst + query_start_off * num_heads * HEAD_SIZE +
-                           static_cast<int64_t>(head_idx) * HEAD_SIZE;
-    temp_out_ptr[threadIdx.x] =
-        make_float4(acc, shared_global_exp_sum, shared_max_logit, 0.f);
-    return;
+  // --- Q loading via shared memory (handles any gqa_ratio 1..16) ---
+  // Each (warpid, rowid) pair owns one Q head (local_qhead_idx = 2*warpid + rowid).
+  // Each lane16id loads 16 bytes of that head; offset1 routes to the correct qkhe_depth slot.
+  const int local_qhead_idx = 2 * warpid + rowid;
+  const int global_qhead_idx = wg_start_head_idx + local_qhead_idx;
+  const scalar_t* q_ptr = q + query_start_off * q_stride + global_qhead_idx * head_size;
+  const int qhead_element = lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
+
+  _B16x8 Qlocal[MAX_QKHELOOP];
+
+  if ((local_qhead_idx < gqa_ratio) && (qhead_element < head_size)) {
+    const _B16x8* q_fetch_ptr_16B = reinterpret_cast<const _B16x8*>(q_ptr + qhead_element);
+    _B16x8 tmp = *q_fetch_ptr_16B;
+    const int offset1 = lane16id / 2;  // maps 16 lanes to 8 qkhe_depth slots
+    shared_logits[offset1][lane2id][local_qhead_idx][0] = tmp;
+  }
+
+  if (head_size > 128) {
+    __syncthreads();
+    // Read first half of Q (head elements 0..127) into registers
+    for (int qkhe_depth = 0; qkhe_depth < 8; qkhe_depth++) {
+      Qlocal[qkhe_depth] = shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio][0];
+    }
+    __syncthreads();
+    // Second pass: load head elements 128..head_size-1 into the same shared slots
+    const int qhead_element2 = 128 + lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
+    if ((local_qhead_idx < gqa_ratio) && (qhead_element2 < head_size)) {
+      const _B16x8* q_fetch_ptr_16B2 = reinterpret_cast<const _B16x8*>(q_ptr + qhead_element2);
+      _B16x8 tmp2 = *q_fetch_ptr_16B2;
+      const int offset1 = lane16id / 2;
+      shared_logits[offset1][lane2id][local_qhead_idx][0] = tmp2;
+    }
+    __syncthreads();
+    // Read second half of Q (qkhe_depth 8..qkheloop-1) into registers
+    for (int qkhe_depth = 8; qkhe_depth < qkheloop; qkhe_depth++) {
+      Qlocal[qkhe_depth] = shared_logits[qkhe_depth - 8][rowid][lane16id % gqa_ratio][0];
+    }
   } else {
-    acc *= inv_global_exp_sum;
-    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    __syncthreads();
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      Qlocal[qkhe_depth] = shared_logits[qkhe_depth][rowid][lane16id % gqa_ratio][0];
+    }
+  }
+
+  // --- K physical block numbers and fetch ---
+  int kphysical_block_number[TLOOP];
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int klocal_token_idx = TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int kglobal_token_idx = partition_start_token_idx + klocal_token_idx;
+    const int kblock_idx = (kglobal_token_idx < seq_len)
+                               ? kglobal_token_idx / block_size
+                               : last_seq_block;
+    kphysical_block_number[token_depth] = block_table_seq[kblock_idx];
+  }
+
+  constexpr int KX = 16 / sizeof(cache_t);
+  const cache_t* k_ptr = k_cache + wg_start_kv_head_idx * kv_head_stride;
+  const int row_head_elem = rowid * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+
+  _B16x8 Klocal[TLOOP][MAX_QKHELOOP];
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int64_t kblock_number = static_cast<int64_t>(kphysical_block_number[token_depth]);
+    const cache_t* k_ptr2 = k_ptr + kblock_number * kv_block_stride;
+    const int klocal_token_idx = TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+    const int kphysical_block_offset = klocal_token_idx % block_size;
+    const cache_t* k_ptr3 = k_ptr2 + kphysical_block_offset * KX;
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      const int head_elem = row_head_elem + qkhe_depth * QKHE_PER_FETCH;
+      const int offset1 = head_elem / KX;
+      const int offset2 = head_elem % KX;
+      const cache_t* k_fetch_ptr = k_ptr3 + offset1 * block_size * KX + offset2;
+      Klocal[token_depth][qkhe_depth] = *reinterpret_cast<const _B16x8*>(k_fetch_ptr);
+    }
+  }
+
+  // --- V block numbers and fetch ---
+  constexpr int VTOKENS_PER_LANE = TOKENS_PER_WARP / ROWS_PER_WARP;  // 16
+  constexpr int VBLOCKS_PER_LANE = 1;  // assumes block_size >= 16
+  constexpr int VTLOOP = NWARPS;       // 8
+  constexpr int VTLANELOOP = DIVIDE_ROUND_UP(VTOKENS_PER_LANE, CONTIGUOUS_KV_ELEMS_16B_LOAD);  // 2
+  const int vheloop = DIVIDE_ROUND_UP(head_size / 16, NWARPS);
+  constexpr int MAX_VHELOOP = 2;  // supports head_size up to 256
+
+  int vphysical_block_number[VTLOOP][VBLOCKS_PER_LANE];
+  for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+    for (int vblock_depth = 0; vblock_depth < VBLOCKS_PER_LANE; vblock_depth++) {
+      const int vlocal_token_idx =
+          vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
+          rowid * VTOKENS_PER_LANE + vblock_depth * block_size;
+      const int vglobal_token_idx = partition_start_token_idx + vlocal_token_idx;
+      const int vblock_idx = (vglobal_token_idx < seq_len)
+                                 ? vglobal_token_idx / block_size
+                                 : last_seq_block;
+      vphysical_block_number[vtoken_depth][vblock_depth] = block_table_seq[vblock_idx];
+    }
+  }
+
+  _B16x8 Vlocal[VTLOOP][MAX_VHELOOP][VTLANELOOP] = {};  // zero-init: guard below may skip some
+  // v_ptr base: no intra-block offset here; computed per vtoken_depth below
+  const cache_t* v_ptr = v_cache + wg_start_kv_head_idx * kv_head_stride;
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    const int vhead_elem = vhe_depth * NWARPS * 16 + warpid * 16 + lane16id;
+    if (vhead_elem >= head_size) continue;  // partial last vheloop (e.g. head_size=64)
+    const cache_t* v_ptr2 = v_ptr + vhead_elem * block_size;
+    for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+      // intra-block token offset varies with vtoken_depth for block_size > TOKENS_PER_WARP
+      const int vlocal_tok_in_block =
+          (partition_start_token_idx +
+           vtoken_depth * VTOKENS_PER_LANE * ROWS_PER_WARP +
+           rowid * VTOKENS_PER_LANE) % block_size;
+      for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+        const int vblock_depth = 0;
+        const int64_t vblock_number =
+            static_cast<int64_t>(vphysical_block_number[vtoken_depth][vblock_depth]);
+        const cache_t* v_ptr3 = v_ptr2 + vblock_number * kv_block_stride;
+        const cache_t* v_fetch_ptr =
+            v_ptr3 + vlocal_tok_in_block + vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+        Vlocal[vtoken_depth][vhe_depth][vfetch_depth] = *reinterpret_cast<const _B16x8*>(v_fetch_ptr);
+      }
+    }
+  }
+
+  // --- QK WMMA ---
+  floatx8 dout[TLOOP];
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    dout[token_depth] = {0};
+    for (int qkhe_depth = 0; qkhe_depth < qkheloop; qkhe_depth++) {
+      dout[token_depth] = gcn_wmma16x16x16_instr<scalar_t, 0, 0, 0>(
+          Klocal[token_depth][qkhe_depth].u16x8, Qlocal[qkhe_depth].u16x8,
+          dout[token_depth]);
+    }
+    dout[token_depth] *= scale;
+  }
+
+  // --- Softmax: per-warp qk_max and exp_sum, then partition-wide reduction ---
+  float qk_max = -FLT_MAX;
+  float exp_sum = 0.0f;
+  const int qkout_token_idx =
+      partition_start_token_idx + TOKENS_PER_WARP * warpid + rowid * 8;
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int local_token_idx = qkout_token_idx + token_depth * 16;
+    for (int i = 0; i < 8; i++) {
+      const float tmp = (local_token_idx + i < seq_len) ? dout[token_depth][i] : -FLT_MAX;
+      qk_max = fmaxf(qk_max, tmp);
+    }
+  }
+  qk_max = fmaxf(qk_max, __shfl_xor(qk_max, 16));
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    const int local_token_idx = qkout_token_idx + token_depth * 16;
+    for (int i = 0; i < 8; i++) {
+      const float tmp = (local_token_idx + i < seq_len)
+                            ? __expf(dout[token_depth][i] - qk_max)
+                            : 0.0f;
+      dout[token_depth][i] = tmp;
+      exp_sum += tmp;
+    }
+  }
+  exp_sum += __shfl_xor(exp_sum, 16);
+
+  __syncthreads();
+  // Reuse shared_logits as float scratch for cross-warp qk_max/exp_sum exchange
+  float* shared_mem = reinterpret_cast<float*>(shared_logits);
+  if (laneid < 16) {
+    shared_mem[warpid * 16 + lane16id] = qk_max;
+    shared_mem[NWARPS * 16 + warpid * 16 + lane16id] = exp_sum;
+  }
+  __syncthreads();
+
+  float partition_qk_max = -FLT_MAX;
+  float warp_qk_max_exp[NWARPS];
+  float partition_exp_sum = 0.0f;
+  for (int w = 0; w < NWARPS; w++) {
+    warp_qk_max_exp[w] = shared_mem[w * 16 + lane16id];
+    partition_qk_max = fmaxf(partition_qk_max, warp_qk_max_exp[w]);
+  }
+  for (int w = 0; w < NWARPS; w++) {
+    warp_qk_max_exp[w] = __expf(warp_qk_max_exp[w] - partition_qk_max);
+    partition_exp_sum += shared_mem[NWARPS * 16 + w * 16 + lane16id] * warp_qk_max_exp[w];
+  }
+  const float inv_sum_scale =
+      __fdividef(1.f, partition_exp_sum + 1e-6f) * warp_qk_max_exp[warpid];
+
+  __syncthreads();
+  // Write scaled logits to shared memory for V WMMA
+  for (int token_depth = 0; token_depth < TLOOP; token_depth++) {
+    dout[token_depth] *= inv_sum_scale;
+    shared_logits[warpid][token_depth][lane16id][rowid] =
+        from_floatx8<scalar_t>(dout[token_depth]);
+  }
+
+  // Write partition max_logits and exp_sum (one thread per Q head)
+  if (threadIdx.x < gqa_ratio) {
+    const int qhead_idx = lane16id;
+    const int offset = seq_idx * total_num_heads * max_num_partitions +
+                       (wg_start_head_idx + qhead_idx) * max_num_partitions +
+                       partition_idx;
+    max_logits[offset] = partition_qk_max;
+    exp_sums[offset] = partition_exp_sum;
+  }
+
+  __syncthreads();
+
+  // --- Softmax-V WMMA ---
+  _B16x8 outelems[MAX_VHELOOP];
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    floatx8 tmp_out = {0};
+    for (int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++) {
+      for (int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++) {
+        const int offset = rowid * VTLANELOOP + vfetch_depth;
+        const int offset1 = offset % ROWS_PER_WARP;
+        const int offset2 = offset / ROWS_PER_WARP;
+        tmp_out = gcn_wmma16x16x16_instr<scalar_t, 0, 0, 0>(
+            Vlocal[vtoken_depth][vhe_depth][vfetch_depth].u16x8,
+            shared_logits[vtoken_depth][offset2][lane16id][offset1].u16x8,
+            tmp_out);
+      }
+    }
+    outelems[vhe_depth] = from_floatx8<scalar_t>(tmp_out);
+  }
+
+  __syncthreads();
+  for (int vhe_depth = 0; vhe_depth < vheloop; vhe_depth++) {
+    shared_logits[warpid][vhe_depth][lane16id][rowid] = outelems[vhe_depth];
+  }
+  __syncthreads();
+
+  // --- Write final output (warp 0 only, coalesced across head elements) ---
+  if (warpid == 0) {
+    _B16x8 vout[MAX_GQA_RATIO2];
+    const int64_t hsz_maxp_mult = static_cast<int64_t>(head_size * max_num_partitions);
+    const int head_elem_idx = lane16id * 8;
+    if (head_elem_idx < head_size) {
+      for (int h = 0; h < MAX_GQA_RATIO2; h++) {
+        const int local_head_idx = 2 * h + rowid;
+        if (local_head_idx >= gqa_ratio) break;
+        const int offset1 = (head_elem_idx / 16) % NWARPS;
+        const int offset2 = head_elem_idx / 16 / NWARPS;
+        const int offset3 = (head_elem_idx / 8) % 2;
+        vout[h] = shared_logits[offset1][offset2][local_head_idx][offset3];
+      }
+      scalar_t* out_ptr = out + seq_idx * total_num_heads * hsz_maxp_mult +
+                          partition_idx * head_size;
+      for (int h = 0; h < MAX_GQA_RATIO2; h++) {
+        const int local_head_idx = 2 * h + rowid;
+        if (local_head_idx >= gqa_ratio) break;
+        const int64_t out_head_idx =
+            static_cast<int64_t>(wg_start_head_idx + local_head_idx);
+        scalar_t* out_ptr3 = out_ptr + out_head_idx * hsz_maxp_mult + head_elem_idx;
+        *reinterpret_cast<_B16x8*>(out_ptr3) = vout[h];
+      }
+    }
+    // For head_size > 128: second pass for head elements 128..head_size-1
+    if (head_size > 128) {
+      const int head_elem_idx2 = 128 + lane16id * 8;
+      if (head_elem_idx2 < head_size) {
+        for (int h = 0; h < MAX_GQA_RATIO2; h++) {
+          const int local_head_idx = 2 * h + rowid;
+          if (local_head_idx >= gqa_ratio) break;
+          const int offset1 = (head_elem_idx2 / 16) % NWARPS;
+          const int offset2 = head_elem_idx2 / 16 / NWARPS;
+          const int offset3 = (head_elem_idx2 / 8) % 2;
+          vout[h] = shared_logits[offset1][offset2][local_head_idx][offset3];
+        }
+        scalar_t* out_ptr = out + seq_idx * total_num_heads * hsz_maxp_mult +
+                            partition_idx * head_size;
+        for (int h = 0; h < MAX_GQA_RATIO2; h++) {
+          const int local_head_idx = 2 * h + rowid;
+          if (local_head_idx >= gqa_ratio) break;
+          const int64_t out_head_idx =
+              static_cast<int64_t>(wg_start_head_idx + local_head_idx);
+          scalar_t* out_ptr3 = out_ptr + out_head_idx * hsz_maxp_mult + head_elem_idx2;
+          *reinterpret_cast<_B16x8*>(out_ptr3) = vout[h];
+        }
+      }
+    }
   }
 }
 
@@ -3456,61 +4293,93 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
   UNREACHABLE_CODE
 }
 
-// Grid: (num_heads, num_seqs).
-template <typename scalar_t, typename OUTT, int HEAD_SIZE, int NUM_THREADS,
-          int PARTITION_SIZE, int NPAR_LOOPS>
+// #else stub for free QKV kernel
+template <typename scalar_t, typename cache_t,
+          vllm::Fp8KVCacheDataType KV_DTYPE, typename OUTT,
+          int NUM_THREADS, bool ALIBI_ENABLED, MFMAType MFMA_TYPE,
+          bool SHARED_KV = false>
 __global__
-__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
-    OUTT* __restrict__ out,                // [num_seqs, num_heads, head_size]
-    const float* __restrict__ exp_sums,    // [num_seqs, num_heads, max_num_partitions]
-    const float* __restrict__ max_logits,  // [num_seqs, num_heads, max_num_partitions]
-    const scalar_t* __restrict__ tmp_out,  // [num_seqs, num_heads, max_num_partitions, head_size]
-    const int* __restrict__ seq_lens,  // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr,  // [num_seqs]
-    const int max_num_partitions, const float* __restrict__ fp8_out_scale_ptr,
-    const int seq_len_offset,
-    const int64_t temp_offset,
-    const int partition_offset) {
+__launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_free_kernel(
+    const scalar_t* __restrict__ q, const cache_t* __restrict__ k_cache,
+    const cache_t* __restrict__ v_cache, const int num_kv_heads, const float scale,
+    const int* __restrict__ block_tables, const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc_ptr, const int max_num_blocks_per_seq,
+    const float* __restrict__ alibi_slopes, const int q_stride,
+    const int kv_block_stride, const int kv_head_stride,
+    float* __restrict__ exp_sums, float* __restrict__ max_logits,
+    scalar_t* __restrict__ out, OUTT* __restrict__ final_out,
+    int max_ctx_blocks, const float* k_scale, const float* v_scale,
+    int block_size, int head_size, int gqa_ratio) {
   UNREACHABLE_CODE
 }
 // clang-format on
 
 #endif
 
-#define LAUNCH_CUSTOM_ATTENTION_MFMA16(GQA_RATIO)                              \
-  paged_attention_ll4mi_QKV_mfma16_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,  \
-                                          HEAD_SIZE, NTHR, ALIBI_ENABLED,      \
-                                          GQA_RATIO, MFMA_TYPE>                \
-      <<<grid, block, 0, stream>>>(                                            \
-          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,      \
-          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                 \
-          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride, \
-          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,  \
+#define LAUNCH_CUSTOM_ATTENTION_MFMA16_FREE()                                        \
+  {                                                                                  \
+  /* Dynamic smem: [max(NWARPS, qkheloop)][4][16][4] * 8 bytes per _B16x4 */        \
+  const int _qkhe_per_fetch = (16 / (int)sizeof(KVT)) * (WARP_SIZE / 16);           \
+  const int _qkheloop = head_size / _qkhe_per_fetch;                                \
+  const int _sdim0 = MAX((int)(NTHR / WARP_SIZE), _qkheloop);                       \
+  const size_t _smem_bytes = (size_t)_sdim0 * 4 * 16 * 4 * 8;                      \
+  paged_attention_ll4mi_QKV_mfma16_free_kernel<T, KVT, KV_DTYPE, OUTT,              \
+                                               NTHR, ALIBI_ENABLED,                 \
+                                               MFMA_TYPE, SHARED_KV>                \
+      <<<grid, block, _smem_bytes, stream>>>(                                       \
+          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,           \
+          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                      \
+          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride,      \
+          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,       \
+          max_ctx_blocks, k_scale_ptr, v_scale_ptr,                                 \
+          block_size, head_size, gqa_ratio);                                         \
+  }
+
+#define LAUNCH_CUSTOM_ATTENTION_MFMA16(GQA_RATIO)                                   \
+  paged_attention_ll4mi_QKV_mfma16_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,       \
+                                          HEAD_SIZE, NTHR, ALIBI_ENABLED,            \
+                                          GQA_RATIO, MFMA_TYPE>                      \
+      <<<grid, block, 0, stream>>>(                                                  \
+          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,            \
+          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                       \
+          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride,       \
+          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,        \
           max_ctx_blocks, k_scale_ptr, v_scale_ptr);
 
-#define LAUNCH_CUSTOM_ATTENTION_MFMA4(GQA_RATIO)                               \
-  paged_attention_ll4mi_QKV_mfma4_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,   \
-                                         HEAD_SIZE, NTHR, ALIBI_ENABLED,       \
-                                         GQA_RATIO>                            \
-      <<<grid, block, 0, stream>>>(                                            \
-          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,      \
-          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                 \
-          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride, \
-          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,  \
+#define LAUNCH_CUSTOM_ATTENTION_MFMA4(GQA_RATIO)                                    \
+  paged_attention_ll4mi_QKV_mfma4_kernel<T, KVT, KV_DTYPE, OUTT, BLOCK_SIZE,        \
+                                         HEAD_SIZE, NTHR, ALIBI_ENABLED,             \
+                                         GQA_RATIO>                                  \
+      <<<grid, block, 0, stream>>>(                                                  \
+          query_ptr, key_cache_ptr, value_cache_ptr, num_kv_heads, scale,            \
+          block_tables_ptr, seq_lens_ptr, query_start_loc_ptr,                       \
+          max_num_blocks_per_seq, alibi_slopes_ptr, q_stride, kv_block_stride,       \
+          kv_head_stride, exp_sums_ptr, max_logits_ptr, tmp_out_ptr, out_ptr,        \
           max_ctx_blocks, k_scale_ptr, v_scale_ptr);
 
-#define LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, DST, OUT_TYPE,             \
-                                     TEMP_OFFSET, PART_OFFSET)              \
-  paged_attention_ll4mi_reduce_kernel<T, OUT_TYPE, HEAD_SIZE, HEAD_SIZE,    \
-                                      PARTITION_SIZE, NPAR_LOOPS>           \
-      <<<reduce_grid, reduce_block, 0, stream>>>(                           \
-          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,   \
-          tmp_out_ptr, seq_lens_ptr,                                        \
-          query_start_loc_ptr, max_num_partitions, fp8_out_scale_ptr,       \
-          seq_len_offset, TEMP_OFFSET, PART_OFFSET);
+#define LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, DST, OUT_TYPE,                    \
+                                      TEMP_OFFSET, PART_OFFSET)                     \
+  paged_attention_ll4mi_reduce_kernel<T, OUT_TYPE, HEAD_SIZE, HEAD_SIZE,             \
+                                      PARTITION_SIZE, NPAR_LOOPS>                   \
+      <<<reduce_grid, reduce_block, 0, stream>>>(                                   \
+          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,            \
+          tmp_out_ptr, seq_lens_ptr, query_start_loc_ptr, max_num_partitions,        \
+          fp8_out_scale_ptr, seq_len_offset, TEMP_OFFSET, PART_OFFSET);
 
-#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                 \
+#define LAUNCH_CUSTOM_REDUCTION_INNER_FREE(NPAR_LOOPS, DST, OUT_TYPE,               \
+                                           TEMP_OFFSET, PART_OFFSET)                \
+  paged_attention_ll4mi_reduce_free_kernel<T, OUT_TYPE,                              \
+                                           PARTITION_SIZE, NPAR_LOOPS>              \
+      <<<reduce_grid, reduce_block, 0, stream>>>(                                   \
+          reinterpret_cast<OUT_TYPE*>(DST), exp_sums_ptr, max_logits_ptr,            \
+          tmp_out_ptr, seq_lens_ptr, query_start_loc_ptr, max_num_partitions,        \
+          fp8_out_scale_ptr, seq_len_offset, TEMP_OFFSET, PART_OFFSET, head_size);
+
+#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                          \
   LAUNCH_CUSTOM_REDUCTION_INNER(NPAR_LOOPS, out_ptr, OUTT, 0, 0)
+
+#define LAUNCH_CUSTOM_REDUCTION_FREE(NPAR_LOOPS)                                     \
+  LAUNCH_CUSTOM_REDUCTION_INNER_FREE(NPAR_LOOPS, out_ptr, OUTT, 0, 0)
 
 template <typename T, typename KVT, vllm::Fp8KVCacheDataType KV_DTYPE,
           int BLOCK_SIZE, int HEAD_SIZE, typename OUTT, int PARTITION_SIZE_OLD,
@@ -3703,11 +4572,160 @@ void paged_attention_custom_launcher(
   // This ensures numerical stability when merging attention weights from multiple passes.
   if (npar_loops > 8) {
     const int num_passes = (npar_loops + 7) / 8;
-    paged_attention_merge_reduce_kernel<T, OUTT, HEAD_SIZE>
+    paged_attention_merge_reduce_kernel<T, OUTT>
         <<<reduce_grid, reduce_block, 0, stream>>>(
             out_ptr, tmp_out_ptr, temp_base_offset,
             seq_lens_ptr, query_start_loc_ptr, num_passes,
-            num_heads, fp8_out_scale_ptr);
+            num_heads, fp8_out_scale_ptr,
+            head_size);
+  }
+}
+
+
+template <typename T, typename KVT, vllm::Fp8KVCacheDataType KV_DTYPE,
+          typename OUTT, int PARTITION_SIZE_OLD,
+          bool ALIBI_ENABLED, MFMAType MFMA_TYPE>
+void paged_attention_fully_custom_launcher(
+    torch::Tensor& out, torch::Tensor& exp_sums, torch::Tensor& max_logits,
+    torch::Tensor& tmp_out, torch::Tensor& query, torch::Tensor& key_cache,
+    torch::Tensor& value_cache, const int num_kv_heads, float scale,
+    torch::Tensor& block_tables, torch::Tensor& seq_lens,
+    const std::optional<torch::Tensor>& query_start_loc, int max_seq_len,
+    const std::optional<torch::Tensor>& alibi_slopes, torch::Tensor& k_scale,
+    torch::Tensor& v_scale, const std::optional<torch::Tensor>& fp8_out_scale,
+    int block_size, int head_size) {
+  int num_seqs = block_tables.size(0);
+  int num_heads = query.size(1);
+  assert ( head_size == query.size(2) );
+  int max_num_blocks_per_seq = block_tables.size(1);
+  int q_stride = query.stride(0);
+  int kv_block_stride = key_cache.stride(0);
+  int kv_head_stride = key_cache.stride(1);
+
+  // NOTE: query start location is optional for V0 decode should not be used.
+  // If batch contains mix of prefills and decode, prefills should be skipped.
+  const int* query_start_loc_ptr =
+      query_start_loc
+          ? reinterpret_cast<const int*>(query_start_loc.value().data_ptr())
+          : nullptr;
+
+  // NOTE: alibi_slopes is optional.
+  const float* alibi_slopes_ptr =
+      alibi_slopes
+          ? reinterpret_cast<const float*>(alibi_slopes.value().data_ptr())
+          : nullptr;
+
+  float* exp_sums_ptr = reinterpret_cast<float*>(exp_sums.data_ptr());
+  float* max_logits_ptr = reinterpret_cast<float*>(max_logits.data_ptr());
+  T* tmp_out_ptr = reinterpret_cast<T*>(tmp_out.data_ptr());
+  T* query_ptr = reinterpret_cast<T*>(query.data_ptr());
+  KVT* key_cache_ptr = reinterpret_cast<KVT*>(key_cache.data_ptr());
+  KVT* value_cache_ptr = reinterpret_cast<KVT*>(value_cache.data_ptr());
+  int* block_tables_ptr = block_tables.data_ptr<int>();
+  int* seq_lens_ptr = seq_lens.data_ptr<int>();
+  const float* k_scale_ptr = reinterpret_cast<const float*>(k_scale.data_ptr());
+  const float* v_scale_ptr = reinterpret_cast<const float*>(v_scale.data_ptr());
+  // NOTE: fp8_out_scale is optional.
+  const auto fp8_out_scale_ptr =
+      fp8_out_scale
+          ? static_cast<const float*>(fp8_out_scale.value().data_ptr())
+          : nullptr;
+  OUTT* out_ptr = reinterpret_cast<OUTT*>(out.data_ptr());
+
+  const int max_ctx_blocks = DIVIDE_ROUND_UP(max_seq_len, block_size);
+
+  // partition size is fixed at 256 since both mfma4 and mfma16 kernels support
+  // it mfma4 kernel also supports partition size 512
+  constexpr int PARTITION_SIZE = 256;
+  const int max_num_partitions = DIVIDE_ROUND_UP(max_seq_len, PARTITION_SIZE);
+  const int gqa_ratio = num_heads / num_kv_heads;
+  assert(num_heads % num_kv_heads == 0);
+
+  constexpr int NTHR = 256;
+  dim3 grid(num_seqs, max_num_partitions, num_kv_heads);
+  dim3 block(NTHR);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  constexpr bool SHARED_KV = false;  // set true to use union Klocal/Vlocal (saves ~128 VGPRs)
+  LAUNCH_CUSTOM_ATTENTION_MFMA16_FREE();
+
+  dim3 reduce_grid(num_heads, num_seqs);
+  dim3 reduce_block(head_size);
+  const int npar_loops = DIVIDE_ROUND_UP(max_num_partitions, WARP_SIZE);
+  int seq_len_offset = 0;
+  // reduction kernel supports upto 8 NPAR_loops * 64 (warp_size) * 256
+  // (partition size) = 128K context length
+
+  // Byte offset from tmp_out to the float4 multi-pass buffer.
+  // The buffer lives at the end of tmp_out, after max_num_partitions partition slices.
+  // Python allocates extra partitions in tmp_out: extra = max_passes * sizeof(float4)/sizeof(T).
+  const int64_t temp_base_offset =
+      (int64_t)num_seqs * num_heads * max_num_partitions * head_size * sizeof(T);
+
+  switch (npar_loops) {
+    case 1:
+      LAUNCH_CUSTOM_REDUCTION_FREE(1);
+      break;
+    case 2:
+      LAUNCH_CUSTOM_REDUCTION_FREE(2);
+      break;
+    case 3:
+      LAUNCH_CUSTOM_REDUCTION_FREE(3);
+      break;
+    case 4:
+      LAUNCH_CUSTOM_REDUCTION_FREE(4);
+      break;
+    case 5:
+      LAUNCH_CUSTOM_REDUCTION_FREE(5);
+      break;
+    case 6:
+      LAUNCH_CUSTOM_REDUCTION_FREE(6);
+      break;
+    case 7:
+      LAUNCH_CUSTOM_REDUCTION_FREE(7);
+      break;
+    case 8:
+      LAUNCH_CUSTOM_REDUCTION_FREE(8);
+      break;
+    default:
+      // For npar_loops > 8, perform multiple reductions with 8 loops each.
+      // GFX9 hardware has a hard limit of 8 npar_loops per reduction kernel.
+      // This corresponds to processing 8 * WARP_SIZE (512) partitions per pass.
+      // For sequences longer than 128K tokens (which require ~512 partitions at 256-tok/partition),
+      // we split the work into multiple passes:
+      //   - Each pass outputs float4 (value, exp_sum, max_logit, pad) for intermediate results
+      //   - A final merge kernel combines these using log-sum-exp for numerical stability
+      //   - This allows unlimited sequence length via multiple passes
+      if (npar_loops > 8) {
+        const int num_passes = (npar_loops + 7) / 8;
+        const int partitions_per_pass = 8 * WARP_SIZE;  // 8 npar_loops * 64 warp_size
+        for (int pass = 0; pass < num_passes; ++pass) {
+          const int part_offset = pass * partitions_per_pass;
+          const int64_t pass_temp_offset = temp_base_offset +
+              pass * (int64_t)num_seqs * num_heads * head_size * sizeof(float4);
+          LAUNCH_CUSTOM_REDUCTION_INNER_FREE(8, out_ptr, float4,
+                                        pass_temp_offset, part_offset);
+          seq_len_offset += 8 * PARTITION_SIZE * 64;
+        }
+      } else {
+        TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops);
+      }
+      break;
+  }
+
+  // If we did multi-pass reductions, merge the results using log-sum-exp.
+  // The multi-pass reductions produced float4 outputs per pass.
+  // This merge kernel combines them into the final output using the stable log-sum-exp formula:
+  //   result = value_1 + exp_sum_1 * (value_2 / exp_sum_1 + ...)
+  // This ensures numerical stability when merging attention weights from multiple passes.
+  if (npar_loops > 8) {
+    const int num_passes = (npar_loops + 7) / 8;
+    paged_attention_merge_reduce_kernel<T, OUTT>
+        <<<reduce_grid, reduce_block, 0, stream>>>(
+            out_ptr, tmp_out_ptr, temp_base_offset,
+            seq_lens_ptr, query_start_loc_ptr, num_passes,
+            num_heads, fp8_out_scale_ptr, head_size);
   }
 }
 
@@ -3916,11 +4934,12 @@ void paged_attention_custom_launcher_navi(
   // This ensures numerical stability when merging attention weights from multiple passes.
   if (npar_loops > 16) {
     const int num_passes = (npar_loops + 15) / 16;
-    paged_attention_merge_reduce_kernel<T, OUTT, HEAD_SIZE>
+    paged_attention_merge_reduce_kernel<T, OUTT>
         <<<reduce_grid, reduce_block, 0, stream>>>(
             out_ptr, tmp_out_ptr, temp_base_offset,
             seq_lens_ptr, query_start_loc_ptr, num_passes,
-            num_heads, fp8_out_scale_ptr);
+            num_heads, fp8_out_scale_ptr,
+            head_size);
   }
 }
 
@@ -3940,6 +4959,16 @@ void paged_attention_custom_launcher_navi(
         num_kv_heads, scale, block_tables, seq_lens, query_start_loc,       \
         max_seq_len, alibi_slopes, k_scale, v_scale);                       \
   }
+
+#define CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE)                  \
+  TORCH_CHECK(!fp8_out_scale, "free launcher does not support fp8_out");             \
+  paged_attention_fully_custom_launcher<T, KVT, KV_DTYPE,                           \
+                                       T, 256, false, MFMA_TYPE>(                   \
+      out, exp_sums, max_logits, tmp_out, query, key_cache, value_cache,             \
+      num_kv_heads, scale, block_tables, seq_lens, query_start_loc,                 \
+      max_seq_len, alibi_slopes, k_scale, v_scale, fp8_out_scale,                   \
+      block_size, head_size);
+
 
 #define CALL_CUSTOM_LAUNCHER_ALIBI(T, KVT, KV_DTYPE, BLK_SIZE, HEAD_SIZE,    \
                                    OUTT, PSIZE, MFMA_TYPE)                   \
@@ -3981,7 +5010,7 @@ void paged_attention_custom_launcher_navi(
       CALL_CUSTOM_LAUNCHER_OUT(T, KVT, KV_DTYPE, 32, HEAD_SIZE, MFMA_TYPE); \
       break;                                                                \
     default:                                                                \
-      TORCH_CHECK(false, "Unsupported block size: ", block_size);           \
+      CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE); \
       break;                                                                \
   }
 
@@ -3994,90 +5023,9 @@ void paged_attention_custom_launcher_navi(
       CALL_CUSTOM_LAUNCHER_BLK(T, KVT, KV_DTYPE, 128, MFMA_TYPE);  \
       break;                                                       \
     default:                                                       \
-      TORCH_CHECK(false, "Unsupported head size: ", head_size);    \
+      CALL_CUSTOM_LAUNCHER_OUT_FREE(T, KVT, KV_DTYPE, MFMA_TYPE);  \
       break;                                                       \
   }
-
-// Merge kernel implementation: combines multiple float4 (acc, exp_sum, max_logit, 0) outputs
-// using numerically stable log-sum-exp across passes. Defined outside architecture blocks.
-// temps layout: [num_passes][num_seqs * num_heads * HEAD_SIZE] float4 elements
-template <typename scalar_t, typename OUTT, int HEAD_SIZE>
-__global__ void paged_attention_merge_reduce_kernel(
-    OUTT* __restrict__ out,           // [num_seqs, num_heads, head_size]
-    const scalar_t* __restrict__ tmp_out, // base pointer (same as reduce kernel receives)
-    const int64_t temp_base_offset,   // byte offset from tmp_out to float4 temp buffer
-    const int* __restrict__ seq_lens, // [num_seqs]
-    const int* __restrict__ query_start_loc_ptr, // [num_seqs+1] or nullptr
-    const int num_passes,
-    const int num_heads,
-    const float* __restrict__ fp8_out_scale_ptr) {
-#if defined(__HIP__GFX9__) || defined(__HIP__GFX12__)
-  const auto head_idx = blockIdx.x;
-  const auto seq_idx = blockIdx.y;
-
-  // NOTE queries with sequence len > 1 are prefills and taken care by another kernel.
-  if (query_start_loc_ptr != nullptr &&
-      (query_start_loc_ptr[seq_idx + 1] - query_start_loc_ptr[seq_idx] != 1)) {
-    return;
-  }
-
-  // Reconstruct temps pointer from tmp_out + byte offset (CUDA graph safe).
-  const float4* temps = reinterpret_cast<const float4*>(
-      reinterpret_cast<const char*>(tmp_out) + temp_base_offset);
-
-  // Each element of temps is float4(acc, exp_sum, max_logit, 0).
-  // acc and exp_sum are relative to max_logit (that pass's global max).
-  // To correctly merge, re-scale each pass to the true global max across all passes.
-  // temps layout: [num_passes][num_seqs * num_heads * HEAD_SIZE] float4 elements.
-  const int num_seqs = gridDim.y;
-  const int64_t per_pass_stride = (int64_t)num_seqs * num_heads * HEAD_SIZE;
-  const int64_t seq_head_offset = (int64_t)seq_idx * num_heads * HEAD_SIZE +
-                                  (int64_t)head_idx * HEAD_SIZE + threadIdx.x;
-
-  // Pass 1: find the true global max logit across all passes
-  float true_max_logit = -FLT_MAX;
-  for (int pass = 0; pass < num_passes; ++pass) {
-    const int64_t idx = (int64_t)pass * per_pass_stride + seq_head_offset;
-    // max_logit is per (seq, head), same for all threadIdx.x — but we read it per element;
-    // they are identical across threadIdx.x for the same (pass, seq, head), so no issue.
-    true_max_logit = fmaxf(true_max_logit, temps[idx].z);
-  }
-
-  // Pass 2: accumulate with correction for different pass max_logits
-  float acc = 0.0f;
-  float global_exp_sum = 0.0f;
-  for (int pass = 0; pass < num_passes; ++pass) {
-    const int64_t idx = (int64_t)pass * per_pass_stride + seq_head_offset;
-    const float4 temp = temps[idx];
-    const float correction = expf(temp.z - true_max_logit);
-    acc           += temp.x * correction;
-    global_exp_sum += temp.y * correction;
-  }
-
-  const int64_t query_start_off = static_cast<int64_t>(
-      query_start_loc_ptr ? query_start_loc_ptr[seq_idx] : seq_idx);
-  OUTT* out_ptr = out + query_start_off * num_heads * HEAD_SIZE +
-                  static_cast<int64_t>(head_idx) * HEAD_SIZE;
-
-  // Normalize and write output
-  const float inv_global_exp_sum = __fdividef(1.0f, global_exp_sum + 1e-6f);
-  const float out_scale = (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
-  acc *= inv_global_exp_sum;
-  acc *= out_scale;
-
-#ifdef __HIP__GFX9__
-  if constexpr (std::is_same<OUTT, bit8_t>::value) {
-    out_ptr[threadIdx.x] =
-        __hip_cvt_float_to_fp8(acc, vllm::fp8::fp8_type::__default_saturation,
-                               vllm::fp8::fp8_type::__default_interpret);
-  } else {
-    out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
-  }
-#else
-  out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
-#endif
-#endif
-}
 
 bool is_navi_gpu() {
   static bool is_cached = false;

--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -11,6 +11,7 @@ from tests.kernels.utils import opcheck
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.attention import Attention, MMEncoderAttention
 from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx12x
 from vllm.utils.mem_utils import get_max_shared_memory_bytes
 from vllm.utils.torch_utils import set_random_seed
 
@@ -549,12 +550,12 @@ def test_paged_attention_multipass_rocm(
     device: str,
 ) -> None:
     """Test multi-pass reduction with seq_len > 128K."""
-    if current_platform.is_navi() and head_size != 128:
-        pytest.skip("Navi only supports head_size=128")
+    if current_platform.is_navi() and not on_gfx12x() and head_size != 128:
+        pytest.skip("GFX11 only supports head_size=128")
 
     gqa_ratio = num_heads[0] // num_heads[1]
-    if current_platform.is_navi() and not (3 <= gqa_ratio <= 16):
-        pytest.skip("Navi requires 3 <= gqa_ratio <= 16")
+    if current_platform.is_navi() and not on_gfx12x() and not (3 <= gqa_ratio <= 16):
+        pytest.skip("GFX11 requires 3 <= gqa_ratio <= 16")
 
     _run_multipass_attention(
         kv_cache_factory, head_size, num_heads, dtype, device,
@@ -583,13 +584,256 @@ def test_paged_attention_multipass_short_seq_rocm(
     float4 sentinels for unused passes.
     """
     gqa_ratio = num_heads[0] // num_heads[1]
-    if current_platform.is_navi() and not (3 <= gqa_ratio <= 16):
-        pytest.skip("Navi requires 3 <= gqa_ratio <= 16")
+    if current_platform.is_navi() and not on_gfx12x() and not (3 <= gqa_ratio <= 16):
+        pytest.skip("GFX11 requires 3 <= gqa_ratio <= 16")
 
     _run_multipass_attention(
         kv_cache_factory, head_size, num_heads, dtype, device,
         seq_len=100,
         max_seq_len=MULTIPASS_SEQ_LEN + 131072,
+    )
+
+
+# ============================================================================
+# ROCm "free" kernel tests (GFX9 and GFX12)
+#
+# paged_attention_ll4mi_QKV_mfma16_free_kernel is dispatched when:
+#   (a) head_size ∉ {64, 128}  (CALL_CUSTOM_LAUNCHER_BLK_HEAD default branch)
+#   (b) block_size ∉ {16, 32} for head_size ∈ {64, 128}  (CALL_CUSTOM_LAUNCHER_BLK default)
+# GFX11 has no free kernel; GFX9 and GFX12 both do.
+# ============================================================================
+
+# (num_query_heads, num_kv_heads): gqa_ratio=16.
+_FREE_KERNEL_HEADS = (16, 1)
+_FREE_KERNEL_SKIP = pytest.mark.skipif(
+    not current_platform.is_rocm() or
+    (current_platform.is_navi() and not on_gfx12x()),
+    reason="ROCm free-kernel (GFX9 or GFX12 only)",
+)
+
+
+def _run_rocm_free_attention(
+    kv_cache_factory,
+    *,
+    head_size: int,
+    block_size: int,
+    num_seqs: int,
+    max_seq_len: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    num_blocks: int = NUM_BLOCKS,
+) -> None:
+    """Allocate KV cache, run paged_attention_rocm, compare to reference."""
+    num_query_heads, num_kv_heads = _FREE_KERNEL_HEADS
+    set_random_seed(seed)
+    torch.set_default_device(device)
+    scale = float(1.0 / (head_size**0.5))
+
+    query = torch.empty(num_seqs, num_query_heads, head_size, dtype=dtype)
+    query.uniform_(-scale, scale)
+
+    seq_lens_list = [random.randint(1, max_seq_len) for _ in range(num_seqs)]
+    seq_lens_list[-1] = max_seq_len
+    seq_lens = torch.tensor(seq_lens_list, dtype=torch.int)
+
+    max_num_blocks_per_seq = (max_seq_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int,
+    )
+
+    key_caches, value_caches = kv_cache_factory(
+        num_blocks, block_size, 1, num_kv_heads, head_size,
+        "auto", dtype, seed, device,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+    k_scale = v_scale = torch.tensor(1.0, dtype=torch.float32, device=device)
+
+    partition_size = 256
+    num_partitions = (max_seq_len + partition_size - 1) // partition_size
+    output = torch.empty_like(query)
+    tmp_output = torch.empty(
+        size=(num_seqs, num_query_heads, num_partitions, head_size), dtype=dtype,
+    )
+    exp_sums = torch.empty(
+        size=(num_seqs, num_query_heads, num_partitions), dtype=torch.float32,
+    )
+    max_logits = torch.empty_like(exp_sums)
+
+    ops.paged_attention_rocm(
+        output, exp_sums, max_logits, tmp_output,
+        query, key_cache, value_cache, num_kv_heads, scale,
+        block_tables, seq_lens, None, block_size, max_seq_len,
+        None, "auto", k_scale, v_scale,
+    )
+
+    ref_output = torch.empty_like(query)
+    ref_single_query_cached_kv_attention(
+        ref_output, query, num_query_heads // num_kv_heads,
+        key_cache, value_cache, block_tables, seq_lens, scale, None,
+    )
+
+    atol = get_default_atol(output)
+    rtol = get_default_rtol(output)
+    torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol)
+
+
+@_FREE_KERNEL_SKIP
+@pytest.mark.parametrize("num_seqs", [1, 7])
+@pytest.mark.parametrize("block_size", [16, 32])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_rocm_free_head256(
+    kv_cache_factory,
+    num_seqs: int,
+    block_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    """Free kernel: head_size=256 with standard block_sizes (16, 32).
+
+    Hits the default branch of CALL_CUSTOM_LAUNCHER_BLK_HEAD because
+    head_size=256 is not a template specialisation.
+    """
+    _run_rocm_free_attention(
+        kv_cache_factory,
+        head_size=256, block_size=block_size, num_seqs=num_seqs,
+        max_seq_len=4096, dtype=dtype, seed=seed, device=device,
+    )
+
+
+@_FREE_KERNEL_SKIP
+@pytest.mark.parametrize("num_seqs", [1, 7])
+@pytest.mark.parametrize("head_size", [64, 128])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_rocm_free_nonstandard_blocksize(
+    kv_cache_factory,
+    num_seqs: int,
+    head_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    """Free kernel: head_size ∈ {64,128} but block_size=64 (not 16 or 32).
+
+    Hits the default branch of CALL_CUSTOM_LAUNCHER_BLK, so the templated
+    HEAD_SIZE is known but block_size is treated as a runtime parameter.
+    """
+    _run_rocm_free_attention(
+        kv_cache_factory,
+        head_size=head_size, block_size=64, num_seqs=num_seqs,
+        max_seq_len=4096, dtype=dtype, seed=seed, device=device,
+    )
+
+
+@_FREE_KERNEL_SKIP
+@pytest.mark.parametrize("num_seqs", [1, 3])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_rocm_free_qwen35(
+    kv_cache_factory,
+    num_seqs: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    """Free kernel: Qwen3.5 use case — head_size=256, block_size=2096.
+
+    block_size=2096 arises from vLLM's hybrid-model block alignment when
+    Mamba SSM states use float32 (mamba_ssm_dtype='float32').  Both the
+    head_size and block_size switches fall through to the free kernel.
+    Uses a small num_blocks to keep GPU memory consumption manageable.
+    """
+    block_size = 2096
+    max_seq_len = block_size * 3  # 3 blocks worth of tokens
+    num_blocks = num_seqs * 4     # headroom above the 3 needed blocks
+    _run_rocm_free_attention(
+        kv_cache_factory,
+        head_size=256, block_size=block_size, num_seqs=num_seqs,
+        max_seq_len=max_seq_len, dtype=dtype, seed=seed, device=device,
+        num_blocks=num_blocks,
+    )
+
+
+# Broad parametrized sweep: (head_size, block_size) pairs that trigger the
+# free kernel, with varying sequence counts, lengths, and dtypes.
+#
+# Trigger conditions (either OR both):
+#   • head_size ∉ {64, 128}  — non-standard head size
+#   • block_size ∉ {16, 32}  — non-standard block size
+#
+# Sequence-length cases:
+#   • "short"  — fits in one reduction partition (≤256 tokens)
+#   • "medium" — a handful of partitions
+#   • "long"   — many partitions (stress-tests NPAR_LOOPS accumulation)
+_FREE_KERNEL_CASES = [
+    # (head_size, block_size, num_seqs, max_seq_len)
+    # ── non-standard head_size, standard block_size ────────────────────────
+    (32,  16,  1,   256),   # short, head_size<64
+    (32,  32,  4,  2048),   # medium
+    (32,  16,  7, 16384),   # long
+    (96,  16,  1,   256),
+    (96,  32,  4,  2048),
+    (160, 16,  1,   256),
+    (160, 32,  4,  2048),
+    (256, 16,  1,   256),   # single partition
+    (256, 16,  4,  4096),
+    (256, 32,  7,  8192),
+    (256, 16,  2, 32768),   # 128 partitions
+    # ── standard head_size, non-standard block_size ────────────────────────
+    (64,  64,  1,   256),
+    (64,  64,  4,  4096),
+    (64, 128,  4,  2048),
+    (128,  64, 1,   256),
+    (128,  64, 4,  4096),
+    (128, 128, 4,  2048),
+    (128, 128, 7,  8192),
+    # ── both non-standard ──────────────────────────────────────────────────
+    (32,   64, 4,  2048),
+    (256,  64, 4,  4096),
+    (256, 128, 4,  2048),
+    (96,  64,  4,  2048),
+    # ── large block_size (Qwen3.5 / hybrid-model alignment) ───────────────
+    (256, 512,  2,  3 * 512),
+    (256, 1024, 2,  3 * 1024),
+    (128, 512,  2,  3 * 512),
+    (256, 2096, 1,  32768), # Qwen3.5-122B
+]
+
+
+@_FREE_KERNEL_SKIP
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize(
+    "head_size,block_size,num_seqs,max_seq_len", _FREE_KERNEL_CASES,
+)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_rocm_free(
+    kv_cache_factory,
+    head_size: int,
+    block_size: int,
+    num_seqs: int,
+    max_seq_len: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    """Free kernel: broad parametrized sweep over head/block/seq/dtype combos."""
+    # Ensure num_blocks is large enough for the random block_tables.
+    # Each seq needs ceil(max_seq_len / block_size) blocks; add 25% headroom.
+    min_blocks = num_seqs * ((max_seq_len + block_size - 1) // block_size)
+    num_blocks = max(NUM_BLOCKS, min_blocks * 5 // 4)
+    _run_rocm_free_attention(
+        kv_cache_factory,
+        head_size=head_size, block_size=block_size,
+        num_seqs=num_seqs, max_seq_len=max_seq_len,
+        dtype=dtype, seed=seed, device=device,
+        num_blocks=num_blocks,
     )
 
 

--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -407,6 +407,192 @@ def test_paged_attention(
     torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol)
 
 
+# Multi-pass reduction is triggered when npar_loops exceeds the
+# per-architecture limit (8 for GFX9, 16 for GFX12), i.e.
+# max_num_partitions > 512 → max_seq_len > 131072 tokens.
+MULTIPASS_SEQ_LEN = 131072 + 16384
+MULTIPASS_NUM_BLOCKS = (
+    (MULTIPASS_SEQ_LEN + 16 - 1) // 16 + 64
+)
+
+
+def _run_multipass_attention(
+    kv_cache_factory,
+    head_size: int,
+    num_heads: tuple[int, int],
+    dtype: torch.dtype,
+    device: str,
+    seq_len: int,
+    max_seq_len: int,
+) -> None:
+    """Run multi-pass paged attention and compare to reference."""
+    num_query_heads, num_kv_heads = num_heads
+    num_seqs = 1
+    block_size = 16
+
+    set_random_seed(0)
+    torch.set_default_device(device)
+    scale = float(1.0 / (head_size**0.5))
+
+    query = torch.empty(
+        num_seqs, num_query_heads, head_size, dtype=dtype,
+    )
+    query.uniform_(-scale, scale)
+
+    seq_lens = torch.tensor([seq_len], dtype=torch.int)
+
+    max_num_blocks_per_seq = (
+        (max_seq_len + block_size - 1) // block_size
+    )
+    num_blocks = max_num_blocks_per_seq + 64
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq),
+        dtype=torch.int,
+    )
+
+    key_caches, value_caches = kv_cache_factory(
+        num_blocks,
+        block_size,
+        1,
+        num_kv_heads,
+        head_size,
+        "auto",
+        dtype,
+        0,
+        device,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+    k_scale = v_scale = torch.tensor(
+        1.0, dtype=torch.float32, device=device,
+    )
+
+    partition_size = 256
+    num_partitions = (
+        (max_seq_len + partition_size - 1) // partition_size
+    )
+    max_passes = (num_partitions + 511) // 512
+    float4_bytes = 16
+    elem_bytes = query.element_size()
+    extra_per_pass = (
+        1 + (float4_bytes + elem_bytes - 1) // elem_bytes
+    )
+    partition_dim = (
+        num_partitions + max_passes * extra_per_pass
+    )
+
+    output = torch.empty_like(query)
+    tmp_output = torch.empty(
+        size=(
+            num_seqs, num_query_heads,
+            partition_dim, head_size,
+        ),
+        dtype=dtype,
+    )
+    exp_sums = torch.empty(
+        size=(num_seqs, num_query_heads, num_partitions),
+        dtype=torch.float32,
+    )
+    max_logits = torch.empty_like(exp_sums)
+
+    ops.paged_attention_rocm(
+        output,
+        exp_sums,
+        max_logits,
+        tmp_output,
+        query,
+        key_cache,
+        value_cache,
+        num_kv_heads,
+        scale,
+        block_tables,
+        seq_lens,
+        None,
+        block_size,
+        max_seq_len,
+        None,  # alibi_slopes
+        "auto",
+        k_scale,
+        v_scale,
+    )
+
+    ref_output = torch.empty_like(query)
+    ref_single_query_cached_kv_attention(
+        ref_output,
+        query,
+        num_query_heads // num_kv_heads,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        None,  # alibi_slopes
+    )
+
+    atol = get_default_atol(output)
+    rtol = get_default_rtol(output)
+    torch.testing.assert_close(
+        output, ref_output, atol=atol, rtol=rtol,
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(),
+                    reason="ROCm multi-pass reduction only")
+@pytest.mark.parametrize("head_size", [64, 128])
+@pytest.mark.parametrize("num_heads", [(32, 8)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_multipass_rocm(
+    kv_cache_factory,
+    head_size: int,
+    num_heads: tuple[int, int],
+    dtype: torch.dtype,
+    device: str,
+) -> None:
+    """Test multi-pass reduction with seq_len > 128K."""
+    if current_platform.is_navi() and head_size != 128:
+        pytest.skip("Navi only supports head_size=128")
+
+    gqa_ratio = num_heads[0] // num_heads[1]
+    if current_platform.is_navi() and not (3 <= gqa_ratio <= 16):
+        pytest.skip("Navi requires 3 <= gqa_ratio <= 16")
+
+    _run_multipass_attention(
+        kv_cache_factory, head_size, num_heads, dtype, device,
+        seq_len=MULTIPASS_SEQ_LEN,
+        max_seq_len=MULTIPASS_SEQ_LEN,
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(),
+                    reason="ROCm multi-pass reduction only")
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("num_heads", [(32, 8)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_multipass_short_seq_rocm(
+    kv_cache_factory,
+    head_size: int,
+    num_heads: tuple[int, int],
+    dtype: torch.dtype,
+    device: str,
+) -> None:
+    """Test multi-pass with short seq through buffers sized for long.
+
+    Simulates CUDA graph replay: graph captured with max_seq_len=262144
+    but replayed with seq_len=100. The early-exit path must write neutral
+    float4 sentinels for unused passes.
+    """
+    gqa_ratio = num_heads[0] // num_heads[1]
+    if current_platform.is_navi() and not (3 <= gqa_ratio <= 16):
+        pytest.skip("Navi requires 3 <= gqa_ratio <= 16")
+
+    _run_multipass_attention(
+        kv_cache_factory, head_size, num_heads, dtype, device,
+        seq_len=100,
+        max_seq_len=MULTIPASS_SEQ_LEN + 131072,
+    )
+
+
 def ref_multi_query_kv_attention(
     cu_seq_lens: list[int],
     query: torch.Tensor,

--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -314,9 +314,7 @@ def test_paged_attention(
 # per-architecture limit (8 for GFX9, 16 for GFX12), i.e.
 # max_num_partitions > 512 → max_seq_len > 131072 tokens.
 MULTIPASS_SEQ_LEN = 131072 + 16384
-MULTIPASS_NUM_BLOCKS = (
-    (MULTIPASS_SEQ_LEN + 16 - 1) // 16 + 64
-)
+MULTIPASS_NUM_BLOCKS = (MULTIPASS_SEQ_LEN + 16 - 1) // 16 + 64
 
 
 def _run_multipass_attention(
@@ -338,18 +336,21 @@ def _run_multipass_attention(
     scale = float(1.0 / (head_size**0.5))
 
     query = torch.empty(
-        num_seqs, num_query_heads, head_size, dtype=dtype,
+        num_seqs,
+        num_query_heads,
+        head_size,
+        dtype=dtype,
     )
     query.uniform_(-scale, scale)
 
     seq_lens = torch.tensor([seq_len], dtype=torch.int)
 
-    max_num_blocks_per_seq = (
-        (max_seq_len + block_size - 1) // block_size
-    )
+    max_num_blocks_per_seq = (max_seq_len + block_size - 1) // block_size
     num_blocks = max_num_blocks_per_seq + 64
     block_tables = torch.randint(
-        0, num_blocks, (num_seqs, max_num_blocks_per_seq),
+        0,
+        num_blocks,
+        (num_seqs, max_num_blocks_per_seq),
         dtype=torch.int,
     )
 
@@ -366,28 +367,26 @@ def _run_multipass_attention(
     )
     key_cache, value_cache = key_caches[0], value_caches[0]
     k_scale = v_scale = torch.tensor(
-        1.0, dtype=torch.float32, device=device,
+        1.0,
+        dtype=torch.float32,
+        device=device,
     )
 
     partition_size = 256
-    num_partitions = (
-        (max_seq_len + partition_size - 1) // partition_size
-    )
+    num_partitions = (max_seq_len + partition_size - 1) // partition_size
     max_passes = (num_partitions + 511) // 512
     float4_bytes = 16
     elem_bytes = query.element_size()
-    extra_per_pass = (
-        1 + (float4_bytes + elem_bytes - 1) // elem_bytes
-    )
-    partition_dim = (
-        num_partitions + max_passes * extra_per_pass
-    )
+    extra_per_pass = 1 + (float4_bytes + elem_bytes - 1) // elem_bytes
+    partition_dim = num_partitions + max_passes * extra_per_pass
 
     output = torch.empty_like(query)
     tmp_output = torch.empty(
         size=(
-            num_seqs, num_query_heads,
-            partition_dim, head_size,
+            num_seqs,
+            num_query_heads,
+            partition_dim,
+            head_size,
         ),
         dtype=dtype,
     )
@@ -434,12 +433,16 @@ def _run_multipass_attention(
     atol = get_default_atol(output)
     rtol = get_default_rtol(output)
     torch.testing.assert_close(
-        output, ref_output, atol=atol, rtol=rtol,
+        output,
+        ref_output,
+        atol=atol,
+        rtol=rtol,
     )
 
 
-@pytest.mark.skipif(not current_platform.is_rocm(),
-                    reason="ROCm multi-pass reduction only")
+@pytest.mark.skipif(
+    not current_platform.is_rocm(), reason="ROCm multi-pass reduction only"
+)
 @pytest.mark.parametrize("head_size", [64, 128])
 @pytest.mark.parametrize("num_heads", [(32, 8)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
@@ -460,14 +463,19 @@ def test_paged_attention_multipass_rocm(
         pytest.skip("GFX11 requires 3 <= gqa_ratio <= 16")
 
     _run_multipass_attention(
-        kv_cache_factory, head_size, num_heads, dtype, device,
+        kv_cache_factory,
+        head_size,
+        num_heads,
+        dtype,
+        device,
         seq_len=MULTIPASS_SEQ_LEN,
         max_seq_len=MULTIPASS_SEQ_LEN,
     )
 
 
-@pytest.mark.skipif(not current_platform.is_rocm(),
-                    reason="ROCm multi-pass reduction only")
+@pytest.mark.skipif(
+    not current_platform.is_rocm(), reason="ROCm multi-pass reduction only"
+)
 @pytest.mark.parametrize("head_size", [128])
 @pytest.mark.parametrize("num_heads", [(32, 8)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
@@ -490,7 +498,11 @@ def test_paged_attention_multipass_short_seq_rocm(
         pytest.skip("GFX11 requires 3 <= gqa_ratio <= 16")
 
     _run_multipass_attention(
-        kv_cache_factory, head_size, num_heads, dtype, device,
+        kv_cache_factory,
+        head_size,
+        num_heads,
+        dtype,
+        device,
         seq_len=100,
         max_seq_len=MULTIPASS_SEQ_LEN + 131072,
     )
@@ -501,15 +513,15 @@ def test_paged_attention_multipass_short_seq_rocm(
 #
 # paged_attention_ll4mi_QKV_mfma16_free_kernel is dispatched when:
 #   (a) head_size ∉ {64, 128}  (CALL_CUSTOM_LAUNCHER_BLK_HEAD default branch)
-#   (b) block_size ∉ {16, 32} for head_size ∈ {64, 128}  (CALL_CUSTOM_LAUNCHER_BLK default)
+#   (b) block_size ∉ {16, 32} for head_size ∈ {64, 128}
+#       (CALL_CUSTOM_LAUNCHER_BLK default branch)
 # GFX11 has no free kernel; GFX9 and GFX12 both do.
 # ============================================================================
 
 # (num_query_heads, num_kv_heads): gqa_ratio=16.
 _FREE_KERNEL_HEADS = (16, 1)
 _FREE_KERNEL_SKIP = pytest.mark.skipif(
-    not current_platform.is_rocm() or
-    (current_platform.is_navi() and not on_gfx12x()),
+    not current_platform.is_rocm() or (current_platform.is_navi() and not on_gfx12x()),
     reason="ROCm free-kernel (GFX9 or GFX12 only)",
 )
 
@@ -541,12 +553,22 @@ def _run_rocm_free_attention(
 
     max_num_blocks_per_seq = (max_seq_len + block_size - 1) // block_size
     block_tables = torch.randint(
-        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int,
+        0,
+        num_blocks,
+        (num_seqs, max_num_blocks_per_seq),
+        dtype=torch.int,
     )
 
     key_caches, value_caches = kv_cache_factory(
-        num_blocks, block_size, 1, num_kv_heads, head_size,
-        "auto", dtype, seed, device,
+        num_blocks,
+        block_size,
+        1,
+        num_kv_heads,
+        head_size,
+        "auto",
+        dtype,
+        seed,
+        device,
     )
     key_cache, value_cache = key_caches[0], value_caches[0]
     k_scale = v_scale = torch.tensor(1.0, dtype=torch.float32, device=device)
@@ -555,24 +577,47 @@ def _run_rocm_free_attention(
     num_partitions = (max_seq_len + partition_size - 1) // partition_size
     output = torch.empty_like(query)
     tmp_output = torch.empty(
-        size=(num_seqs, num_query_heads, num_partitions, head_size), dtype=dtype,
+        size=(num_seqs, num_query_heads, num_partitions, head_size),
+        dtype=dtype,
     )
     exp_sums = torch.empty(
-        size=(num_seqs, num_query_heads, num_partitions), dtype=torch.float32,
+        size=(num_seqs, num_query_heads, num_partitions),
+        dtype=torch.float32,
     )
     max_logits = torch.empty_like(exp_sums)
 
     ops.paged_attention_rocm(
-        output, exp_sums, max_logits, tmp_output,
-        query, key_cache, value_cache, num_kv_heads, scale,
-        block_tables, seq_lens, None, block_size, max_seq_len,
-        None, "auto", k_scale, v_scale,
+        output,
+        exp_sums,
+        max_logits,
+        tmp_output,
+        query,
+        key_cache,
+        value_cache,
+        num_kv_heads,
+        scale,
+        block_tables,
+        seq_lens,
+        None,
+        block_size,
+        max_seq_len,
+        None,
+        "auto",
+        k_scale,
+        v_scale,
     )
 
     ref_output = torch.empty_like(query)
     ref_single_query_cached_kv_attention(
-        ref_output, query, num_query_heads // num_kv_heads,
-        key_cache, value_cache, block_tables, seq_lens, scale, None,
+        ref_output,
+        query,
+        num_query_heads // num_kv_heads,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        None,
     )
 
     atol = get_default_atol(output)
@@ -601,8 +646,13 @@ def test_paged_attention_rocm_free_head256(
     """
     _run_rocm_free_attention(
         kv_cache_factory,
-        head_size=256, block_size=block_size, num_seqs=num_seqs,
-        max_seq_len=4096, dtype=dtype, seed=seed, device=device,
+        head_size=256,
+        block_size=block_size,
+        num_seqs=num_seqs,
+        max_seq_len=4096,
+        dtype=dtype,
+        seed=seed,
+        device=device,
     )
 
 
@@ -627,8 +677,13 @@ def test_paged_attention_rocm_free_nonstandard_blocksize(
     """
     _run_rocm_free_attention(
         kv_cache_factory,
-        head_size=head_size, block_size=64, num_seqs=num_seqs,
-        max_seq_len=4096, dtype=dtype, seed=seed, device=device,
+        head_size=head_size,
+        block_size=64,
+        num_seqs=num_seqs,
+        max_seq_len=4096,
+        dtype=dtype,
+        seed=seed,
+        device=device,
     )
 
 
@@ -653,11 +708,16 @@ def test_paged_attention_rocm_free_qwen35(
     """
     block_size = 2096
     max_seq_len = block_size * 3  # 3 blocks worth of tokens
-    num_blocks = num_seqs * 4     # headroom above the 3 needed blocks
+    num_blocks = num_seqs * 4  # headroom above the 3 needed blocks
     _run_rocm_free_attention(
         kv_cache_factory,
-        head_size=256, block_size=block_size, num_seqs=num_seqs,
-        max_seq_len=max_seq_len, dtype=dtype, seed=seed, device=device,
+        head_size=256,
+        block_size=block_size,
+        num_seqs=num_seqs,
+        max_seq_len=max_seq_len,
+        dtype=dtype,
+        seed=seed,
+        device=device,
         num_blocks=num_blocks,
     )
 
@@ -676,42 +736,43 @@ def test_paged_attention_rocm_free_qwen35(
 _FREE_KERNEL_CASES = [
     # (head_size, block_size, num_seqs, max_seq_len)
     # ── non-standard head_size, standard block_size ────────────────────────
-    (32,  16,  1,   256),   # short, head_size<64
-    (32,  32,  4,  2048),   # medium
-    (32,  16,  7, 16384),   # long
-    (96,  16,  1,   256),
-    (96,  32,  4,  2048),
-    (160, 16,  1,   256),
-    (160, 32,  4,  2048),
-    (256, 16,  1,   256),   # single partition
-    (256, 16,  4,  4096),
-    (256, 32,  7,  8192),
-    (256, 16,  2, 32768),   # 128 partitions
+    (32, 16, 1, 256),  # short, head_size<64
+    (32, 32, 4, 2048),  # medium
+    (32, 16, 7, 16384),  # long
+    (96, 16, 1, 256),
+    (96, 32, 4, 2048),
+    (160, 16, 1, 256),
+    (160, 32, 4, 2048),
+    (256, 16, 1, 256),  # single partition
+    (256, 16, 4, 4096),
+    (256, 32, 7, 8192),
+    (256, 16, 2, 32768),  # 128 partitions
     # ── standard head_size, non-standard block_size ────────────────────────
-    (64,  64,  1,   256),
-    (64,  64,  4,  4096),
-    (64, 128,  4,  2048),
-    (128,  64, 1,   256),
-    (128,  64, 4,  4096),
-    (128, 128, 4,  2048),
-    (128, 128, 7,  8192),
+    (64, 64, 1, 256),
+    (64, 64, 4, 4096),
+    (64, 128, 4, 2048),
+    (128, 64, 1, 256),
+    (128, 64, 4, 4096),
+    (128, 128, 4, 2048),
+    (128, 128, 7, 8192),
     # ── both non-standard ──────────────────────────────────────────────────
-    (32,   64, 4,  2048),
-    (256,  64, 4,  4096),
-    (256, 128, 4,  2048),
-    (96,  64,  4,  2048),
+    (32, 64, 4, 2048),
+    (256, 64, 4, 4096),
+    (256, 128, 4, 2048),
+    (96, 64, 4, 2048),
     # ── large block_size (Qwen3.5 / hybrid-model alignment) ───────────────
-    (256, 512,  2,  3 * 512),
-    (256, 1024, 2,  3 * 1024),
-    (128, 512,  2,  3 * 512),
-    (256, 2096, 1,  32768), # Qwen3.5-122B
+    (256, 512, 2, 3 * 512),
+    (256, 1024, 2, 3 * 1024),
+    (128, 512, 2, 3 * 512),
+    (256, 2096, 1, 32768),  # Qwen3.5-122B
 ]
 
 
 @_FREE_KERNEL_SKIP
 @pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
 @pytest.mark.parametrize(
-    "head_size,block_size,num_seqs,max_seq_len", _FREE_KERNEL_CASES,
+    "head_size,block_size,num_seqs,max_seq_len",
+    _FREE_KERNEL_CASES,
 )
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
@@ -732,9 +793,13 @@ def test_paged_attention_rocm_free(
     num_blocks = max(NUM_BLOCKS, min_blocks * 5 // 4)
     _run_rocm_free_attention(
         kv_cache_factory,
-        head_size=head_size, block_size=block_size,
-        num_seqs=num_seqs, max_seq_len=max_seq_len,
-        dtype=dtype, seed=seed, device=device,
+        head_size=head_size,
+        block_size=block_size,
+        num_seqs=num_seqs,
+        max_seq_len=max_seq_len,
+        dtype=dtype,
+        seed=seed,
+        device=device,
         num_blocks=num_blocks,
     )
 

--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -11,6 +11,7 @@ from tests.kernels.utils import opcheck
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.attention import Attention, MMEncoderAttention
 from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx12x
 from vllm.utils.mem_utils import get_max_shared_memory_bytes
 from vllm.utils.torch_utils import set_random_seed
 
@@ -451,12 +452,12 @@ def test_paged_attention_multipass_rocm(
     device: str,
 ) -> None:
     """Test multi-pass reduction with seq_len > 128K."""
-    if current_platform.is_navi() and head_size != 128:
-        pytest.skip("Navi only supports head_size=128")
+    if current_platform.is_navi() and not on_gfx12x() and head_size != 128:
+        pytest.skip("GFX11 only supports head_size=128")
 
     gqa_ratio = num_heads[0] // num_heads[1]
-    if current_platform.is_navi() and not (3 <= gqa_ratio <= 16):
-        pytest.skip("Navi requires 3 <= gqa_ratio <= 16")
+    if current_platform.is_navi() and not on_gfx12x() and not (3 <= gqa_ratio <= 16):
+        pytest.skip("GFX11 requires 3 <= gqa_ratio <= 16")
 
     _run_multipass_attention(
         kv_cache_factory, head_size, num_heads, dtype, device,
@@ -485,13 +486,256 @@ def test_paged_attention_multipass_short_seq_rocm(
     float4 sentinels for unused passes.
     """
     gqa_ratio = num_heads[0] // num_heads[1]
-    if current_platform.is_navi() and not (3 <= gqa_ratio <= 16):
-        pytest.skip("Navi requires 3 <= gqa_ratio <= 16")
+    if current_platform.is_navi() and not on_gfx12x() and not (3 <= gqa_ratio <= 16):
+        pytest.skip("GFX11 requires 3 <= gqa_ratio <= 16")
 
     _run_multipass_attention(
         kv_cache_factory, head_size, num_heads, dtype, device,
         seq_len=100,
         max_seq_len=MULTIPASS_SEQ_LEN + 131072,
+    )
+
+
+# ============================================================================
+# ROCm "free" kernel tests (GFX9 and GFX12)
+#
+# paged_attention_ll4mi_QKV_mfma16_free_kernel is dispatched when:
+#   (a) head_size ∉ {64, 128}  (CALL_CUSTOM_LAUNCHER_BLK_HEAD default branch)
+#   (b) block_size ∉ {16, 32} for head_size ∈ {64, 128}  (CALL_CUSTOM_LAUNCHER_BLK default)
+# GFX11 has no free kernel; GFX9 and GFX12 both do.
+# ============================================================================
+
+# (num_query_heads, num_kv_heads): gqa_ratio=16.
+_FREE_KERNEL_HEADS = (16, 1)
+_FREE_KERNEL_SKIP = pytest.mark.skipif(
+    not current_platform.is_rocm() or
+    (current_platform.is_navi() and not on_gfx12x()),
+    reason="ROCm free-kernel (GFX9 or GFX12 only)",
+)
+
+
+def _run_rocm_free_attention(
+    kv_cache_factory,
+    *,
+    head_size: int,
+    block_size: int,
+    num_seqs: int,
+    max_seq_len: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    num_blocks: int = NUM_BLOCKS,
+) -> None:
+    """Allocate KV cache, run paged_attention_rocm, compare to reference."""
+    num_query_heads, num_kv_heads = _FREE_KERNEL_HEADS
+    set_random_seed(seed)
+    torch.set_default_device(device)
+    scale = float(1.0 / (head_size**0.5))
+
+    query = torch.empty(num_seqs, num_query_heads, head_size, dtype=dtype)
+    query.uniform_(-scale, scale)
+
+    seq_lens_list = [random.randint(1, max_seq_len) for _ in range(num_seqs)]
+    seq_lens_list[-1] = max_seq_len
+    seq_lens = torch.tensor(seq_lens_list, dtype=torch.int)
+
+    max_num_blocks_per_seq = (max_seq_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int,
+    )
+
+    key_caches, value_caches = kv_cache_factory(
+        num_blocks, block_size, 1, num_kv_heads, head_size,
+        "auto", dtype, seed, device,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+    k_scale = v_scale = torch.tensor(1.0, dtype=torch.float32, device=device)
+
+    partition_size = 256
+    num_partitions = (max_seq_len + partition_size - 1) // partition_size
+    output = torch.empty_like(query)
+    tmp_output = torch.empty(
+        size=(num_seqs, num_query_heads, num_partitions, head_size), dtype=dtype,
+    )
+    exp_sums = torch.empty(
+        size=(num_seqs, num_query_heads, num_partitions), dtype=torch.float32,
+    )
+    max_logits = torch.empty_like(exp_sums)
+
+    ops.paged_attention_rocm(
+        output, exp_sums, max_logits, tmp_output,
+        query, key_cache, value_cache, num_kv_heads, scale,
+        block_tables, seq_lens, None, block_size, max_seq_len,
+        None, "auto", k_scale, v_scale,
+    )
+
+    ref_output = torch.empty_like(query)
+    ref_single_query_cached_kv_attention(
+        ref_output, query, num_query_heads // num_kv_heads,
+        key_cache, value_cache, block_tables, seq_lens, scale, None,
+    )
+
+    atol = get_default_atol(output)
+    rtol = get_default_rtol(output)
+    torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol)
+
+
+@_FREE_KERNEL_SKIP
+@pytest.mark.parametrize("num_seqs", [1, 7])
+@pytest.mark.parametrize("block_size", [16, 32])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_rocm_free_head256(
+    kv_cache_factory,
+    num_seqs: int,
+    block_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    """Free kernel: head_size=256 with standard block_sizes (16, 32).
+
+    Hits the default branch of CALL_CUSTOM_LAUNCHER_BLK_HEAD because
+    head_size=256 is not a template specialisation.
+    """
+    _run_rocm_free_attention(
+        kv_cache_factory,
+        head_size=256, block_size=block_size, num_seqs=num_seqs,
+        max_seq_len=4096, dtype=dtype, seed=seed, device=device,
+    )
+
+
+@_FREE_KERNEL_SKIP
+@pytest.mark.parametrize("num_seqs", [1, 7])
+@pytest.mark.parametrize("head_size", [64, 128])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_rocm_free_nonstandard_blocksize(
+    kv_cache_factory,
+    num_seqs: int,
+    head_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    """Free kernel: head_size ∈ {64,128} but block_size=64 (not 16 or 32).
+
+    Hits the default branch of CALL_CUSTOM_LAUNCHER_BLK, so the templated
+    HEAD_SIZE is known but block_size is treated as a runtime parameter.
+    """
+    _run_rocm_free_attention(
+        kv_cache_factory,
+        head_size=head_size, block_size=64, num_seqs=num_seqs,
+        max_seq_len=4096, dtype=dtype, seed=seed, device=device,
+    )
+
+
+@_FREE_KERNEL_SKIP
+@pytest.mark.parametrize("num_seqs", [1, 3])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_rocm_free_qwen35(
+    kv_cache_factory,
+    num_seqs: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    """Free kernel: Qwen3.5 use case — head_size=256, block_size=2096.
+
+    block_size=2096 arises from vLLM's hybrid-model block alignment when
+    Mamba SSM states use float32 (mamba_ssm_dtype='float32').  Both the
+    head_size and block_size switches fall through to the free kernel.
+    Uses a small num_blocks to keep GPU memory consumption manageable.
+    """
+    block_size = 2096
+    max_seq_len = block_size * 3  # 3 blocks worth of tokens
+    num_blocks = num_seqs * 4     # headroom above the 3 needed blocks
+    _run_rocm_free_attention(
+        kv_cache_factory,
+        head_size=256, block_size=block_size, num_seqs=num_seqs,
+        max_seq_len=max_seq_len, dtype=dtype, seed=seed, device=device,
+        num_blocks=num_blocks,
+    )
+
+
+# Broad parametrized sweep: (head_size, block_size) pairs that trigger the
+# free kernel, with varying sequence counts, lengths, and dtypes.
+#
+# Trigger conditions (either OR both):
+#   • head_size ∉ {64, 128}  — non-standard head size
+#   • block_size ∉ {16, 32}  — non-standard block size
+#
+# Sequence-length cases:
+#   • "short"  — fits in one reduction partition (≤256 tokens)
+#   • "medium" — a handful of partitions
+#   • "long"   — many partitions (stress-tests NPAR_LOOPS accumulation)
+_FREE_KERNEL_CASES = [
+    # (head_size, block_size, num_seqs, max_seq_len)
+    # ── non-standard head_size, standard block_size ────────────────────────
+    (32,  16,  1,   256),   # short, head_size<64
+    (32,  32,  4,  2048),   # medium
+    (32,  16,  7, 16384),   # long
+    (96,  16,  1,   256),
+    (96,  32,  4,  2048),
+    (160, 16,  1,   256),
+    (160, 32,  4,  2048),
+    (256, 16,  1,   256),   # single partition
+    (256, 16,  4,  4096),
+    (256, 32,  7,  8192),
+    (256, 16,  2, 32768),   # 128 partitions
+    # ── standard head_size, non-standard block_size ────────────────────────
+    (64,  64,  1,   256),
+    (64,  64,  4,  4096),
+    (64, 128,  4,  2048),
+    (128,  64, 1,   256),
+    (128,  64, 4,  4096),
+    (128, 128, 4,  2048),
+    (128, 128, 7,  8192),
+    # ── both non-standard ──────────────────────────────────────────────────
+    (32,   64, 4,  2048),
+    (256,  64, 4,  4096),
+    (256, 128, 4,  2048),
+    (96,  64,  4,  2048),
+    # ── large block_size (Qwen3.5 / hybrid-model alignment) ───────────────
+    (256, 512,  2,  3 * 512),
+    (256, 1024, 2,  3 * 1024),
+    (128, 512,  2,  3 * 512),
+    (256, 2096, 1,  32768), # Qwen3.5-122B
+]
+
+
+@_FREE_KERNEL_SKIP
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@pytest.mark.parametrize(
+    "head_size,block_size,num_seqs,max_seq_len", _FREE_KERNEL_CASES,
+)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_rocm_free(
+    kv_cache_factory,
+    head_size: int,
+    block_size: int,
+    num_seqs: int,
+    max_seq_len: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+) -> None:
+    """Free kernel: broad parametrized sweep over head/block/seq/dtype combos."""
+    # Ensure num_blocks is large enough for the random block_tables.
+    # Each seq needs ceil(max_seq_len / block_size) blocks; add 25% headroom.
+    min_blocks = num_seqs * ((max_seq_len + block_size - 1) // block_size)
+    num_blocks = max(NUM_BLOCKS, min_blocks * 5 // 4)
+    _run_rocm_free_attention(
+        kv_cache_factory,
+        head_size=head_size, block_size=block_size,
+        num_seqs=num_seqs, max_seq_len=max_seq_len,
+        dtype=dtype, seed=seed, device=device,
+        num_blocks=num_blocks,
     )
 
 

--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -309,6 +309,192 @@ def test_paged_attention(
     torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol)
 
 
+# Multi-pass reduction is triggered when npar_loops exceeds the
+# per-architecture limit (8 for GFX9, 16 for GFX12), i.e.
+# max_num_partitions > 512 → max_seq_len > 131072 tokens.
+MULTIPASS_SEQ_LEN = 131072 + 16384
+MULTIPASS_NUM_BLOCKS = (
+    (MULTIPASS_SEQ_LEN + 16 - 1) // 16 + 64
+)
+
+
+def _run_multipass_attention(
+    kv_cache_factory,
+    head_size: int,
+    num_heads: tuple[int, int],
+    dtype: torch.dtype,
+    device: str,
+    seq_len: int,
+    max_seq_len: int,
+) -> None:
+    """Run multi-pass paged attention and compare to reference."""
+    num_query_heads, num_kv_heads = num_heads
+    num_seqs = 1
+    block_size = 16
+
+    set_random_seed(0)
+    torch.set_default_device(device)
+    scale = float(1.0 / (head_size**0.5))
+
+    query = torch.empty(
+        num_seqs, num_query_heads, head_size, dtype=dtype,
+    )
+    query.uniform_(-scale, scale)
+
+    seq_lens = torch.tensor([seq_len], dtype=torch.int)
+
+    max_num_blocks_per_seq = (
+        (max_seq_len + block_size - 1) // block_size
+    )
+    num_blocks = max_num_blocks_per_seq + 64
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq),
+        dtype=torch.int,
+    )
+
+    key_caches, value_caches = kv_cache_factory(
+        num_blocks,
+        block_size,
+        1,
+        num_kv_heads,
+        head_size,
+        "auto",
+        dtype,
+        0,
+        device,
+    )
+    key_cache, value_cache = key_caches[0], value_caches[0]
+    k_scale = v_scale = torch.tensor(
+        1.0, dtype=torch.float32, device=device,
+    )
+
+    partition_size = 256
+    num_partitions = (
+        (max_seq_len + partition_size - 1) // partition_size
+    )
+    max_passes = (num_partitions + 511) // 512
+    float4_bytes = 16
+    elem_bytes = query.element_size()
+    extra_per_pass = (
+        1 + (float4_bytes + elem_bytes - 1) // elem_bytes
+    )
+    partition_dim = (
+        num_partitions + max_passes * extra_per_pass
+    )
+
+    output = torch.empty_like(query)
+    tmp_output = torch.empty(
+        size=(
+            num_seqs, num_query_heads,
+            partition_dim, head_size,
+        ),
+        dtype=dtype,
+    )
+    exp_sums = torch.empty(
+        size=(num_seqs, num_query_heads, num_partitions),
+        dtype=torch.float32,
+    )
+    max_logits = torch.empty_like(exp_sums)
+
+    ops.paged_attention_rocm(
+        output,
+        exp_sums,
+        max_logits,
+        tmp_output,
+        query,
+        key_cache,
+        value_cache,
+        num_kv_heads,
+        scale,
+        block_tables,
+        seq_lens,
+        None,
+        block_size,
+        max_seq_len,
+        None,  # alibi_slopes
+        "auto",
+        k_scale,
+        v_scale,
+    )
+
+    ref_output = torch.empty_like(query)
+    ref_single_query_cached_kv_attention(
+        ref_output,
+        query,
+        num_query_heads // num_kv_heads,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        None,  # alibi_slopes
+    )
+
+    atol = get_default_atol(output)
+    rtol = get_default_rtol(output)
+    torch.testing.assert_close(
+        output, ref_output, atol=atol, rtol=rtol,
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(),
+                    reason="ROCm multi-pass reduction only")
+@pytest.mark.parametrize("head_size", [64, 128])
+@pytest.mark.parametrize("num_heads", [(32, 8)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_multipass_rocm(
+    kv_cache_factory,
+    head_size: int,
+    num_heads: tuple[int, int],
+    dtype: torch.dtype,
+    device: str,
+) -> None:
+    """Test multi-pass reduction with seq_len > 128K."""
+    if current_platform.is_navi() and head_size != 128:
+        pytest.skip("Navi only supports head_size=128")
+
+    gqa_ratio = num_heads[0] // num_heads[1]
+    if current_platform.is_navi() and not (3 <= gqa_ratio <= 16):
+        pytest.skip("Navi requires 3 <= gqa_ratio <= 16")
+
+    _run_multipass_attention(
+        kv_cache_factory, head_size, num_heads, dtype, device,
+        seq_len=MULTIPASS_SEQ_LEN,
+        max_seq_len=MULTIPASS_SEQ_LEN,
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(),
+                    reason="ROCm multi-pass reduction only")
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("num_heads", [(32, 8)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_paged_attention_multipass_short_seq_rocm(
+    kv_cache_factory,
+    head_size: int,
+    num_heads: tuple[int, int],
+    dtype: torch.dtype,
+    device: str,
+) -> None:
+    """Test multi-pass with short seq through buffers sized for long.
+
+    Simulates CUDA graph replay: graph captured with max_seq_len=262144
+    but replayed with seq_len=100. The early-exit path must write neutral
+    float4 sentinels for unused passes.
+    """
+    gqa_ratio = num_heads[0] // num_heads[1]
+    if current_platform.is_navi() and not (3 <= gqa_ratio <= 16):
+        pytest.skip("Navi requires 3 <= gqa_ratio <= 16")
+
+    _run_multipass_attention(
+        kv_cache_factory, head_size, num_heads, dtype, device,
+        seq_len=100,
+        max_seq_len=MULTIPASS_SEQ_LEN + 131072,
+    )
+
+
 def ref_multi_query_kv_attention(
     cu_seq_lens: list[int],
     query: torch.Tensor,

--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -553,11 +553,15 @@ def _run_rocm_free_attention(
 
     max_num_blocks_per_seq = (max_seq_len + block_size - 1) // block_size
     block_tables = torch.randint(
-        0,
+        num_seqs,
         num_blocks,
         (num_seqs, max_num_blocks_per_seq),
         dtype=torch.int,
     )
+    # Give each sequence a private last block so its padding can be poisoned
+    # below without touching another sequence's valid tokens.
+    for seq_idx, seq_len in enumerate(seq_lens_list):
+        block_tables[seq_idx][(seq_len - 1) // block_size] = seq_idx
 
     key_caches, value_caches = kv_cache_factory(
         num_blocks,
@@ -572,6 +576,14 @@ def _run_rocm_free_attention(
     )
     key_cache, value_cache = key_caches[0], value_caches[0]
     k_scale = v_scale = torch.tensor(1.0, dtype=torch.float32, device=device)
+
+    # Slots past seq_len are never written in real serving, so poison them:
+    # the kernel must mask them, since 0 * NaN = NaN would poison the output.
+    for seq_idx, seq_len in enumerate(seq_lens_list):
+        padding_start = seq_len % block_size
+        if padding_start:
+            last_block_idx = block_tables[seq_idx][seq_len // block_size]
+            value_cache[last_block_idx, :, :, padding_start:] = torch.nan
 
     partition_size = 256
     num_partitions = (max_seq_len + partition_size - 1) // partition_size

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -356,17 +356,32 @@ def use_rocm_custom_paged_attention(
 ) -> bool:
     # custom paged attn always supported on V0. On V1, requires sliding window
     # disabled due to observed numerical discrepancy.
+    # The free kernel (runtime head_size/block_size) handles any combination not
+    # covered by the template-specialized non-free kernels.
     if _ON_GFX9:
+        # Non-free kernel: head_size in {64,128} and block_size in {16,32}.
+        # Free kernel: any head_size in {64,128,192,256} and any block_size.
         return (
             (sliding_window == 0 or sliding_window == (-1, -1))
             and (qtype == torch.half or qtype == torch.bfloat16)
-            and (head_size == 64 or head_size == 128)
-            and (block_size == 16 or block_size == 32)
+            and head_size in (64, 128, 192, 256)
             and (gqa_ratio >= 1 and gqa_ratio <= 16)
             and sinks is None
         )
-
+    elif _ON_GFX12X:
+        # Non-free kernel: head_size=128 and block_size=16.
+        # Free kernel: any head_size in {64,128,192,256} and any block_size.
+        return (
+            (sliding_window == 0 or sliding_window == (-1, -1))
+            and (qtype == torch.half or qtype == torch.bfloat16)
+            and head_size in (64, 128, 192, 256)
+            and (gqa_ratio >= 1 and gqa_ratio <= 16)
+            and alibi_slopes is None
+            and kv_cache_dtype == "auto"
+            and sinks is None
+        )
     else:
+        # GFX11: only the template-specialized non-free kernel (head_size=128, block_size=16).
         return (
             _ON_GFX1X
             and (sliding_window == 0 or sliding_window == (-1, -1))

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -363,7 +363,6 @@ def use_rocm_custom_paged_attention(
             and (head_size == 64 or head_size == 128)
             and (block_size == 16 or block_size == 32)
             and (gqa_ratio >= 1 and gqa_ratio <= 16)
-            and max_seq_len <= 128 * 1024
             and sinks is None
         )
 
@@ -375,7 +374,6 @@ def use_rocm_custom_paged_attention(
             and head_size == 128
             and block_size == 16
             and (gqa_ratio >= 3 and gqa_ratio <= 16)
-            and max_seq_len <= 128 * 1024
             and alibi_slopes is None
             and kv_cache_dtype == "auto"
             and sinks is None

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -403,7 +403,6 @@ def use_rocm_custom_paged_attention(
             and (head_size == 64 or head_size == 128)
             and (block_size == 16 or block_size == 32)
             and (gqa_ratio >= 1 and gqa_ratio <= 16)
-            and max_seq_len <= 128 * 1024
             and sinks is None
         )
 
@@ -415,7 +414,6 @@ def use_rocm_custom_paged_attention(
             and head_size == 128
             and block_size == 16
             and (gqa_ratio >= 3 and gqa_ratio <= 16)
-            and max_seq_len <= 128 * 1024
             and alibi_slopes is None
             and kv_cache_dtype == "auto"
             and sinks is None

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -394,6 +394,28 @@ def use_rocm_custom_paged_attention(
     alibi_slopes: torch.Tensor | None = None,
     sinks: torch.Tensor | None = None,
 ) -> bool:
+    """Whether the ROCm custom paged-attention op can serve this configuration.
+
+    Callers fall back to the Triton paged-attention path when this returns
+    False. Two families of kernel sit behind the op: template-specialized
+    "non-free" kernels for a fixed head_size/block_size, and a "free" kernel
+    that takes both at runtime and covers everything else.
+
+    Args:
+        qtype: Query dtype. Only float16 and bfloat16 are supported.
+        head_size: Attention head dimension.
+        block_size: KV-cache page size in tokens.
+        gqa_ratio: Query heads per KV head.
+        max_seq_len: Longest sequence in the batch.
+        sliding_window: Sliding-window size; must be disabled (0 or (-1, -1)),
+            as the custom kernels do not apply the window mask.
+        kv_cache_dtype: KV-cache dtype, e.g. "auto" or "fp8".
+        alibi_slopes: Per-head ALiBi slopes, or None.
+        sinks: Attention sinks, unsupported by the custom kernels.
+
+    Returns:
+        True if the custom op can handle this configuration on this GPU.
+    """
     # custom paged attn always supported on V0. On V1, requires sliding window
     # disabled due to observed numerical discrepancy.
     # The free kernel (runtime head_size/block_size) handles any combination not
@@ -408,7 +430,13 @@ def use_rocm_custom_paged_attention(
             and (gqa_ratio >= 1 and gqa_ratio <= 16)
             and sinks is None
         )
-    elif _ON_GFX12X:
+    elif on_gfx12x():
+        # gfx1250 is excluded here and below: _ON_GFX12X/_ON_GFX1X both include
+        # it, but is_navi_gpu() routes it to the navi launcher, whose __GFX12__
+        # kernels all go through gcn_wmma16x16x16_instr -- and that is a
+        # __builtin_trap() on gfx1250, which provides only the K=32 WMMA
+        # (v_wmma_f32_16x16x32_f16), not the K=16 variant gfx1200/1201 have.
+        # Route gfx1250 to Triton until the kernels grow a K=32 path.
         # Non-free kernel: head_size=128 and block_size=16.
         # Free kernel: any head_size in {64,128,192,256} and any block_size.
         return (
@@ -421,9 +449,10 @@ def use_rocm_custom_paged_attention(
             and sinks is None
         )
     else:
-        # GFX11: only the template-specialized non-free kernel (head_size=128, block_size=16).
+        # GFX11: only the template-specialized non-free kernel
+        # (head_size=128, block_size=16).
         return (
-            _ON_GFX1X
+            on_gfx1x()
             and (sliding_window == 0 or sliding_window == (-1, -1))
             and (qtype == torch.half or qtype == torch.bfloat16)
             and head_size == 128

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -396,17 +396,32 @@ def use_rocm_custom_paged_attention(
 ) -> bool:
     # custom paged attn always supported on V0. On V1, requires sliding window
     # disabled due to observed numerical discrepancy.
-    if on_cdna():
+    # The free kernel (runtime head_size/block_size) handles any combination not
+    # covered by the template-specialized non-free kernels.
+    if _ON_GFX9:
+        # Non-free kernel: head_size in {64,128} and block_size in {16,32}.
+        # Free kernel: any head_size in {64,128,192,256} and any block_size.
         return (
             (sliding_window == 0 or sliding_window == (-1, -1))
             and (qtype == torch.half or qtype == torch.bfloat16)
-            and (head_size == 64 or head_size == 128)
-            and (block_size == 16 or block_size == 32)
+            and head_size in (64, 128, 192, 256)
             and (gqa_ratio >= 1 and gqa_ratio <= 16)
             and sinks is None
         )
-
+    elif _ON_GFX12X:
+        # Non-free kernel: head_size=128 and block_size=16.
+        # Free kernel: any head_size in {64,128,192,256} and any block_size.
+        return (
+            (sliding_window == 0 or sliding_window == (-1, -1))
+            and (qtype == torch.half or qtype == torch.bfloat16)
+            and head_size in (64, 128, 192, 256)
+            and (gqa_ratio >= 1 and gqa_ratio <= 16)
+            and alibi_slopes is None
+            and kv_cache_dtype == "auto"
+            and sinks is None
+        )
     else:
+        # GFX11: only the template-specialized non-free kernel (head_size=128, block_size=16).
         return (
             _ON_GFX1X
             and (sliding_window == 0 or sliding_window == (-1, -1))

--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -367,12 +367,15 @@ def chunked_prefill_paged_decode(
         alibi_slopes,
         sinks,
     )
+    # Force Triton for stride-padded hybrid layouts: they use
+    # reshape_and_cache_flash during cache update, so decode must stay on the
+    # matching stride-aware path. (The custom op now handles non-power-of-2
+    # block sizes like Qwen3's 544, so block size no longer forces Triton.)
     has_native_layout = has_native_kv_cache_layout(key_cache, value_cache)
-    # Force Triton for non-standard blocks like Qwen3's 544 and for
-    # stride-padded hybrid layouts. The latter use reshape_and_cache_flash
-    # during cache update, so keep decode on the matching stride-aware path.
+    # Still needed below to size the Triton block (non-pow2 blocks use 32); it
+    # no longer gates use_custom (the custom op now handles free block sizes).
     is_pow2 = block_size > 0 and (block_size & (block_size - 1) == 0)
-    if not is_pow2 or not has_native_layout:
+    if not has_native_layout:
         use_custom = False
 
     if use_custom:
@@ -380,7 +383,6 @@ def chunked_prefill_paged_decode(
         max_num_partitions = (
             max_seq_len + _PARTITION_SIZE_ROCM - 1
         ) // _PARTITION_SIZE_ROCM
-        assert _PARTITION_SIZE_ROCM % block_size == 0
         total_num_seq = block_table.shape[0]
         # Extra space for multi-pass float4 reduction buffer.
         # The float4 buffer starts at byte offset

--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -382,8 +382,26 @@ def chunked_prefill_paged_decode(
         ) // _PARTITION_SIZE_ROCM
         assert _PARTITION_SIZE_ROCM % block_size == 0
         total_num_seq = block_table.shape[0]
+        # Extra space for multi-pass float4 reduction buffer.
+        # The float4 buffer starts at byte offset
+        # num_seqs * num_heads * max_num_partitions * head_size * elem_size
+        # which must be 16-byte aligned (sizeof(float4)).
+        assert (head_size * query.element_size()) % 16 == 0, (
+            f"head_size * element_size must be float4-aligned, "
+            f"got {head_size} * {query.element_size()}"
+        )
+        max_passes = (max_num_partitions + 511) // 512
+        float4_bytes = 16
+        elem_bytes = query.element_size()
+        extra_per_pass = (
+            1 + (float4_bytes + elem_bytes - 1) // elem_bytes
+        )
+        padded_partitions = (
+            max_num_partitions + max_passes * extra_per_pass
+        )
         tmp_output = torch.empty(
-            size=(total_num_seq, num_query_heads, max_num_partitions, head_size),
+            size=(total_num_seq, num_query_heads,
+                  padded_partitions, head_size),
             dtype=query.dtype,
             device=output.device,
         )

--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -381,12 +381,15 @@ def chunked_prefill_paged_decode(
         alibi_slopes,
         sinks,
     )
+    # Force Triton for stride-padded hybrid layouts: they use
+    # reshape_and_cache_flash during cache update, so decode must stay on the
+    # matching stride-aware path. (The custom op now handles non-power-of-2
+    # block sizes like Qwen3's 544, so block size no longer forces Triton.)
     has_native_layout = has_native_kv_cache_layout(key_cache, value_cache)
-    # Force Triton for non-standard blocks like Qwen3's 544 and for
-    # stride-padded hybrid layouts. The latter use reshape_and_cache_flash
-    # during cache update, so keep decode on the matching stride-aware path.
+    # Still needed below to size the Triton block (non-pow2 blocks use 32); it
+    # no longer gates use_custom (the custom op now handles free block sizes).
     is_pow2 = block_size > 0 and (block_size & (block_size - 1) == 0)
-    if not is_pow2 or not has_native_layout:
+    if not has_native_layout:
         use_custom = False
 
     if use_custom:
@@ -394,7 +397,6 @@ def chunked_prefill_paged_decode(
         max_num_partitions = (
             max_seq_len + _PARTITION_SIZE_ROCM - 1
         ) // _PARTITION_SIZE_ROCM
-        assert _PARTITION_SIZE_ROCM % block_size == 0
         total_num_seq = block_table.shape[0]
         # Extra space for multi-pass float4 reduction buffer.
         # The float4 buffer starts at byte offset

--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -306,6 +306,39 @@ def chunked_prefill_paged_decode(
     is_block_table_ptr: bool = False,
     causal: bool = True,
 ):
+    """Run chunked prefill and paged decode over a mixed batch.
+
+    Prefill sequences go through the Triton chunked-prefill kernel; single-token
+    decode sequences go through paged attention, using the ROCm custom op where
+    `use_rocm_custom_paged_attention` allows it and the Triton paged-decode
+    kernel otherwise. Results are written into `output` in place.
+
+    Args:
+        query: Packed queries for the whole batch, [num_tokens, num_heads,
+            head_size].
+        key: Keys for the current forward pass.
+        value: Values for the current forward pass.
+        output: Destination tensor, written in place.
+        kv_cache_dtype: KV-cache dtype, e.g. "auto" or "fp8".
+        key_cache: Paged key cache.
+        value_cache: Paged value cache.
+        block_table: Per-sequence page table, or a pointer tensor when
+            `is_block_table_ptr` is set.
+        query_start_loc: Cumulative query offsets, length num_seqs + 1.
+        seq_lens: Total context length per sequence.
+        max_seq_len: Longest context length in the batch.
+        max_query_len: Longest query length in the batch; 1 means decode-only.
+        k_scale: Key dequantization scale for quantized KV caches.
+        v_scale: Value dequantization scale for quantized KV caches.
+        alibi_slopes: Per-head ALiBi slopes, or None.
+        sliding_window: Sliding-window size; None or <= 0 disables it.
+        sm_scale: Softmax scale; defaults to 1/sqrt(head_size).
+        output_scale: Output quantization scale, or None.
+        sinks: Optional per-head attention sinks.
+        is_block_table_ptr: Whether `block_table` holds row pointers rather
+            than page ids.
+        causal: Whether to apply the causal mask during prefill.
+    """
     if sm_scale is None:
         sm_scale = 1.0 / (query.shape[2] ** 0.5)
 
@@ -409,15 +442,10 @@ def chunked_prefill_paged_decode(
         max_passes = (max_num_partitions + 511) // 512
         float4_bytes = 16
         elem_bytes = query.element_size()
-        extra_per_pass = (
-            1 + (float4_bytes + elem_bytes - 1) // elem_bytes
-        )
-        padded_partitions = (
-            max_num_partitions + max_passes * extra_per_pass
-        )
+        extra_per_pass = 1 + (float4_bytes + elem_bytes - 1) // elem_bytes
+        padded_partitions = max_num_partitions + max_passes * extra_per_pass
         tmp_output = torch.empty(
-            size=(total_num_seq, num_query_heads,
-                  padded_partitions, head_size),
+            size=(total_num_seq, num_query_heads, padded_partitions, head_size),
             dtype=query.dtype,
             device=output.device,
         )

--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -396,8 +396,26 @@ def chunked_prefill_paged_decode(
         ) // _PARTITION_SIZE_ROCM
         assert _PARTITION_SIZE_ROCM % block_size == 0
         total_num_seq = block_table.shape[0]
+        # Extra space for multi-pass float4 reduction buffer.
+        # The float4 buffer starts at byte offset
+        # num_seqs * num_heads * max_num_partitions * head_size * elem_size
+        # which must be 16-byte aligned (sizeof(float4)).
+        assert (head_size * query.element_size()) % 16 == 0, (
+            f"head_size * element_size must be float4-aligned, "
+            f"got {head_size} * {query.element_size()}"
+        )
+        max_passes = (max_num_partitions + 511) // 512
+        float4_bytes = 16
+        elem_bytes = query.element_size()
+        extra_per_pass = (
+            1 + (float4_bytes + elem_bytes - 1) // elem_bytes
+        )
+        padded_partitions = (
+            max_num_partitions + max_passes * extra_per_pass
+        )
         tmp_output = torch.empty(
-            size=(total_num_seq, num_query_heads, max_num_partitions, head_size),
+            size=(total_num_seq, num_query_heads,
+                  padded_partitions, head_size),
             dtype=query.dtype,
             device=output.device,
         )


### PR DESCRIPTION
At present, on ROCm for certain models including GLM-4.7, vLLM has a choice between two attention implementations from vllm/v1/attention/ops/chunked_prefill_paged_decode.py. One is a very slow reference Triton kernel and the other is a  hand-coded op. The custom op only supports context length up to 131072 tokens, which means that, unless vLLM is set to eager mode, it'll only be used if max_seq_len is <131072 (otherwise, since actual context length is unknown at graph capture time, it defaults to Triton for all context lengths).

This patch drops the 131072 token cap and adds a multi-pass mode to support  unlimited max_seq_len. It also adds unit tests to cover this scenario.

This results in a drastic increase in token generation throughput on ROCm for GLM-4.7 for max_seq_len>131072.

Throughput, token/s, 4x MI325x (2026/Sep/09)
Context | max_model_len | PR - throughput | Baseline - throughput
-- | -- | -- | --
65536 | 75536 | 55.05 | 55.08
100000 | 110000 | 50.21 | 50.09
150000 | 160000 | 42.66 | 0.47

The PR also includes the fix for correctness issue reported by @davetha below.

---
Disclosure: AI (Claude Opus 5) was used to implement and test the PR.