### PR TITLE
[Frontend] Add /v1/files upload endpoint for multimodal inputs (#38531)

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -780,6 +780,98 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
 
 Works with common video formats like MP4 when using OpenCV backends.
 
+#### Uploading Local Media Files
+
+When a multimodal file lives on the client (not the server) and is too large
+to base64-encode into a JSON payload, you can upload it once via the
+`/v1/files` endpoint and reference it in subsequent chat completions with
+the `vllm-file://<id>` URL scheme.
+
+This avoids the two existing pain points for large local media:
+
+- Base64 data URLs inflate the payload ~33% and can exceed shell `ARG_MAX`
+  for videos over ~8 MB.
+- `file://` URLs require the file to already exist on the **server** machine
+  and the server to have been launched with `--allowed-local-media-path`.
+
+The endpoint is **off by default**. Launch the server with
+`--enable-file-uploads` to expose it:
+
+```bash
+vllm serve allenai/Molmo2-8B \
+  --trust-remote-code --max-model-len 6144 \
+  --enable-file-uploads \
+  --file-upload-max-size-mb 128
+```
+
+**Upload a local video and reference it in a chat completion:**
+
+??? code
+
+    ```python
+    from openai import OpenAI
+
+    client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+    # 1. Upload the file once
+    with open("clip.mp4", "rb") as f:
+        uploaded = client.files.create(file=f, purpose="vision")
+
+    # 2. Reference it via vllm-file:// in any number of chat completions
+    response = client.chat.completions.create(
+        model="allenai/Molmo2-8B",
+        messages=[{
+            "role": "user",
+            "content": [
+                {"type": "video_url",
+                 "video_url": {"url": f"vllm-file://{uploaded.id}"}},
+                {"type": "text",
+                 "text": "Describe what happens in this video."},
+            ],
+        }],
+        max_completion_tokens=150,
+    )
+
+    print(response.choices[0].message.content)
+
+    # 3. Clean up (files also expire after --file-upload-ttl-seconds)
+    client.files.delete(uploaded.id)
+    ```
+
+**Or with curl:**
+
+??? code
+
+    ```bash
+    # Upload
+    FILE_ID=$(curl -s http://localhost:8000/v1/files \
+      -F "file=@clip.mp4" \
+      -F "purpose=vision" | jq -r .id)
+
+    # Reference in chat completion
+    curl -s http://localhost:8000/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"model\": \"allenai/Molmo2-8B\",
+        \"messages\": [{
+          \"role\": \"user\",
+          \"content\": [
+            {\"type\": \"video_url\", \"video_url\": {\"url\": \"vllm-file://$FILE_ID\"}},
+            {\"type\": \"text\", \"text\": \"Describe this video.\"}
+          ]
+        }]
+      }"
+    ```
+
+The same endpoint accepts images, audio, and video (within the supported
+media allowlist). Files are scoped per-server by default, automatically
+expire after a configurable TTL (default 1 hour), and are capped by both
+per-file and total-disk quotas.
+
+See [Files API](../serving/openai_compatible_server.md#files-api) for the
+full endpoint reference, all `--file-upload-*` flags, and deployment
+patterns for gateway-fronted servers.
+
 #### Custom RGBA Background Color
 
 To use a custom background color for RGBA images, pass the `rgba_background_color` parameter via `--media-io-kwargs`:

--- a/docs/serving/openai_compatible_server.md
+++ b/docs/serving/openai_compatible_server.md
@@ -61,6 +61,9 @@ We currently support the following OpenAI APIs:
     - Only applicable to [Automatic Speech Recognition (ASR) models](../models/supported_models.md#transcription).
 - [Realtime API](#realtime-api) (`/v1/realtime`)
     - Only applicable to [Automatic Speech Recognition (ASR) models](../models/supported_models.md#transcription).
+- [Files API](#files-api) (`/v1/files`)
+    - Opt-in (requires `--enable-file-uploads`).
+    - Lets clients upload multimodal files once and reference them in chat completions via the `vllm-file://<id>` URL scheme.
 
 In addition, we have the following custom APIs:
 
@@ -458,6 +461,87 @@ Audio must be sent as base64-encoded PCM16 audio at 16kHz sample rate, mono chan
 
 - [openai_realtime_client.py](https://github.com/vllm-project/vllm/tree/main/examples/online_serving/openai_realtime_client.py) - Upload and transcribe an audio file
 - [openai_realtime_microphone_client.py](https://github.com/vllm-project/vllm/tree/main/examples/online_serving/openai_realtime_microphone_client.py) - Gradio demo for live microphone transcription
+
+### Files API
+
+The Files API is opt-in and lets clients upload multimodal files once
+via multipart form and reference them in subsequent chat completions via
+the `vllm-file://<id>` URL scheme — an alternative to inline base64
+data URLs (which inflate payloads and can exceed shell `ARG_MAX` for
+videos) and to `file://` (which requires the file to live on the
+server machine).
+
+Launch the server with `--enable-file-uploads` to expose the endpoint.
+When disabled (the default), all `/v1/files*` paths return 404.
+
+#### Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/v1/files` | Upload one file (`multipart/form-data`: `file`, `purpose`). Returns a `File` object. |
+| `GET` | `/v1/files` | List files. Returns 404 if `--file-upload-disable-listing` is set. |
+| `GET` | `/v1/files/{file_id}` | Retrieve one file's metadata. |
+| `GET` | `/v1/files/{file_id}/content` | Stream the raw bytes (`StreamingResponse`). |
+| `DELETE` | `/v1/files/{file_id}` | Remove metadata and on-disk bytes. |
+
+The response shape matches OpenAI's Files API:
+
+```json
+{
+  "id": "file-<32 hex>",
+  "object": "file",
+  "bytes": 18432100,
+  "created_at": 1743800000,
+  "expires_at": 1743803600,
+  "filename": "clip.mp4",
+  "purpose": "vision",
+  "status": "processed"
+}
+```
+
+Supported `purpose` values: `"vision"` and `"user_data"`. Other values
+(including the OpenAI-specific `"assistants"`, `"batch"`,
+`"fine-tune"`) are rejected with 400.
+
+#### Configuration
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--enable-file-uploads` | `false` | Master on/off switch. |
+| `--file-upload-dir` | `$TMPDIR/vllm-uploads-<pid>` | Where bytes live on disk (cleared on startup). |
+| `--file-upload-ttl-seconds` | `3600` | Expiry after last access. `-1` disables time-based expiry. |
+| `--file-upload-max-size-mb` | `512` | Per-file size cap. Enforced mid-stream. |
+| `--file-upload-max-total-gb` | `5` | Total disk quota. LRU evicts oldest. |
+| `--file-upload-max-concurrent` | `4` | Max in-flight upload operations. |
+| `--file-upload-scope-header` | `""` | If set, a request header whose value scopes uploaded files. |
+| `--file-upload-disable-listing` | `false` | Remove `GET /v1/files` (capability-only deployments). |
+
+#### Deployment Patterns for Gateway-Fronted Servers
+
+When vLLM sits behind an auth proxy that serves multiple callers, set
+`--file-upload-scope-header <NAME>` to the header your gateway already
+populates. Uploaded files are tagged with the header value and scope
+mismatches return 404 (capability non-disclosure). Missing scope
+header → 400.
+
+| Deployment | Header | Notes |
+| --- | --- | --- |
+| Direct OpenAI SDK client | `OpenAI-Project` | SDK auto-sends from `OPENAI_PROJECT_ID` env or `project=...` client param. |
+| Apigee gateway | `OpenAI-Project` (via AssignMessage policy) or custom `X-Consumer-ID` | One-line policy, no client changes. |
+| Kong gateway | `X-Consumer-ID` | Kong populates natively on authenticated routes. |
+| Envoy / oauth2-proxy | `X-Auth-Request-User` | JWT `sub` claim extracted by oauth2-proxy, forwarded via ext_authz. |
+
+#### Security
+
+- **Off by default.** No behavior change unless `--enable-file-uploads` is set.
+- **128-bit capability handles.** File IDs are `file-<32 hex>` (128 bits of `os.urandom`). Possession implies authority.
+- **MIME allowlist via magic-byte sniffing.** Uploads are classified from the file head; only `video/*`, `image/*`, `audio/*` pass. The client `Content-Type` is advisory.
+- **Path confinement.** On-disk filenames are `sha256(random)`. The client `filename` is stripped of path components and control chars, capped at 255 bytes, and used only as metadata.
+- **Streaming size enforcement.** Uploads exceeding `--file-upload-max-size-mb` are rejected mid-stream — no memory spike.
+- **Audit log.** Every file operation emits one INFO-level JSON line with `op`, `file_id`, `bytes`, `scope`, `client_host`, `request_id`, `ts` (plus `reason` on rejection). Suitable for Splunk/Datadog ingestion.
+- **Non-persistent across restarts.** The upload directory is cleared on server startup.
+
+See the [user guide](../features/multimodal_inputs.md#uploading-local-media-files) for end-to-end examples.
 
 ### Tokenizer API
 

--- a/examples/online_serving/openai_file_upload_client.py
+++ b/examples/online_serving/openai_file_upload_client.py
@@ -1,18 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""An example showing how to upload a local multimodal file via the
-/v1/files endpoint and reference it in a chat completion with the
-`vllm-file://<id>` URL scheme.
+"""End-to-end example for the /v1/files upload endpoint.
+
+Demonstrates the full lifecycle: upload a local multimodal file, list
+and retrieve its metadata, reference it in multiple chat completions
+via the `vllm-file://<id>` URL scheme, then delete. The "upload once,
+reuse across turns" pattern is the whole point of the feature — inline
+data URLs would re-transmit the bytes on every turn.
 
 Launch the vLLM server with file uploads enabled:
 
-    vllm serve allenai/Molmo2-8B \
-        --trust-remote-code --max-model-len 6144 \
+    vllm serve allenai/Molmo2-8B \\
+        --trust-remote-code --max-model-len 6144 \\
         --enable-file-uploads --file-upload-max-size-mb 128
 
-Then run this script against a local video/image/audio file:
+Then run this script against a local video / image / audio file:
 
     python openai_file_upload_client.py path/to/clip.mp4
+    python openai_file_upload_client.py photo.jpg "What breed is this dog?"
+    python openai_file_upload_client.py speech.mp3
 
 This avoids the two pain points of inline multimodal inputs:
 
@@ -25,7 +31,9 @@ This avoids the two pain points of inline multimodal inputs:
 
 from __future__ import annotations
 
+import mimetypes
 import sys
+from pathlib import Path
 
 from openai import OpenAI
 from utils import get_first_model
@@ -35,19 +43,56 @@ openai_api_base = "http://localhost:8000/v1"
 
 client = OpenAI(api_key=openai_api_key, base_url=openai_api_base)
 
+# Map sniffed/guessed MIME type prefix to the chat-completion content
+# type the server expects. vLLM's multimodal loaders dispatch on this
+# key to select the right decoder.
+_CONTENT_TYPE_BY_PREFIX: dict[str, tuple[str, str]] = {
+    "video/": ("video_url", "video_url"),
+    "image/": ("image_url", "image_url"),
+    "audio/": ("input_audio", "audio_url"),
+}
 
-def run(path: str) -> None:
-    model = get_first_model(client)
+# Default prompts per modality (overridden by a CLI arg if provided).
+_DEFAULT_PROMPTS: dict[str, tuple[str, str]] = {
+    "video/": (
+        "Describe what happens in this clip in 2-3 sentences.",
+        "What is the emotional tone of the scene?",
+    ),
+    "image/": (
+        "Describe this image in one sentence.",
+        "What colors dominate the composition?",
+    ),
+    "audio/": (
+        "Transcribe the audio.",
+        "What is the speaker's tone?",
+    ),
+}
 
-    # 1. Upload the local file once. The server streams it to disk and
-    #    returns a 128-bit capability handle.
-    with open(path, "rb") as f:
-        uploaded = client.files.create(file=f, purpose="vision")
-    print(f"uploaded:  {uploaded.id}  ({uploaded.bytes} bytes)")
 
-    # 2. Reference it by id in any number of chat completions using
-    #    the `vllm-file://<id>` URL scheme. The same file can be used
-    #    across multiple turns without re-uploading.
+def _detect_modality(path: Path) -> str:
+    """Guess the content-type prefix (video/, image/, audio/) from the
+    file extension. The server runs its own magic-byte sniffer and
+    ignores the client-side guess, but we need the right chat-message
+    content key to send the URL under."""
+    mime, _ = mimetypes.guess_type(path.name)
+    if mime is None:
+        raise SystemExit(
+            f"error: could not infer media type from extension {path.suffix!r}. "
+            "Supported: video/image/audio files."
+        )
+    for prefix in _CONTENT_TYPE_BY_PREFIX:
+        if mime.startswith(prefix):
+            return prefix
+    raise SystemExit(
+        f"error: MIME type {mime!r} is not in the supported media allowlist "
+        "(video/*, image/*, audio/*)."
+    )
+
+
+def _ask(model: str, prefix: str, file_id: str, prompt: str) -> str:
+    """Send a single chat-completion request referencing the uploaded
+    file, and return the model's text response."""
+    content_type, url_key = _CONTENT_TYPE_BY_PREFIX[prefix]
     response = client.chat.completions.create(
         model=model,
         messages=[
@@ -55,32 +100,73 @@ def run(path: str) -> None:
                 "role": "user",
                 "content": [
                     {
-                        "type": "video_url",
-                        "video_url": {"url": f"vllm-file://{uploaded.id}"},
+                        "type": content_type,
+                        url_key: {"url": f"vllm-file://{file_id}"},
                     },
-                    {
-                        "type": "text",
-                        "text": "Describe what happens in this clip in 2-3 sentences.",
-                    },
+                    {"type": "text", "text": prompt},
                 ],
             }
         ],
         max_completion_tokens=150,
     )
-    print(f"response:  {response.choices[0].message.content}")
+    return response.choices[0].message.content or ""
 
-    # 3. Clean up. Files also auto-expire after
-    #    --file-upload-ttl-seconds (default 1h) and are quota-bounded
-    #    by --file-upload-max-total-gb (default 5 GB, LRU eviction).
-    client.files.delete(uploaded.id)
-    print(f"deleted:   {uploaded.id}")
+
+def run(path: Path, custom_prompt: str | None) -> None:
+    model = get_first_model(client)
+    prefix = _detect_modality(path)
+
+    # 1. Upload the local file once. The server streams it to disk and
+    #    returns a 128-bit capability handle (file-<32 hex>).
+    with open(path, "rb") as f:
+        uploaded = client.files.create(file=f, purpose="vision")
+    print(f"uploaded:  {uploaded.id} ({uploaded.bytes} bytes, {path.name})")
+
+    try:
+        # 2. List files to confirm it's discoverable (also demonstrates
+        #    the GET /v1/files endpoint).
+        listing = client.files.list()
+        ours = next((f for f in listing.data if f.id == uploaded.id), None)
+        assert ours is not None, "uploaded file missing from listing"
+        print(f"listed:    1 of {len(listing.data)} visible files")
+
+        # 3. Retrieve metadata (demonstrates GET /v1/files/{id}).
+        meta = client.files.retrieve(uploaded.id)
+        print(
+            f"metadata:  purpose={meta.purpose} status={meta.status} "
+            f"expires_at={meta.expires_at}"
+        )
+
+        # 4. Reference by id in MULTIPLE chat completions. Same file,
+        #    no re-upload. This is the reason /v1/files exists.
+        prompts = (custom_prompt,) if custom_prompt else _DEFAULT_PROMPTS[prefix]
+        for i, prompt in enumerate(prompts, start=1):
+            answer = _ask(model, prefix, uploaded.id, prompt)
+            print(f"\nturn {i}:")
+            print(f"  prompt:  {prompt}")
+            print(f"  answer:  {answer}")
+    finally:
+        # 5. Clean up. Files also auto-expire after
+        #    --file-upload-ttl-seconds (default 1h) and are quota-
+        #    bounded by --file-upload-max-total-gb (default 5 GB, LRU
+        #    eviction). Explicit delete returns the capability immediately.
+        client.files.delete(uploaded.id)
+        print(f"\ndeleted:   {uploaded.id}")
 
 
 def main() -> None:
-    if len(sys.argv) != 2:
-        print(f"usage: {sys.argv[0]} <path-to-media-file>", file=sys.stderr)
+    if len(sys.argv) < 2 or len(sys.argv) > 3:
+        print(
+            f"usage: {sys.argv[0]} <path-to-media-file> [custom-prompt]",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    run(sys.argv[1])
+    path = Path(sys.argv[1])
+    if not path.is_file():
+        print(f"error: {path} is not a file", file=sys.stderr)
+        sys.exit(1)
+    custom_prompt = sys.argv[2] if len(sys.argv) == 3 else None
+    run(path, custom_prompt)
 
 
 if __name__ == "__main__":

--- a/examples/online_serving/openai_file_upload_client.py
+++ b/examples/online_serving/openai_file_upload_client.py
@@ -113,8 +113,11 @@ def _ask(model: str, prefix: str, file_id: str, prompt: str) -> str:
 
 
 def run(path: Path, custom_prompt: str | None) -> None:
-    model = get_first_model(client)
+    # Validate modality before connecting to the server — unsupported
+    # file types fail fast with a clear error, without waiting on a
+    # network round-trip.
     prefix = _detect_modality(path)
+    model = get_first_model(client)
 
     # 1. Upload the local file once. The server streams it to disk and
     #    returns a 128-bit capability handle (file-<32 hex>).

--- a/examples/online_serving/openai_file_upload_client.py
+++ b/examples/online_serving/openai_file_upload_client.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""An example showing how to upload a local multimodal file via the
+/v1/files endpoint and reference it in a chat completion with the
+`vllm-file://<id>` URL scheme.
+
+Launch the vLLM server with file uploads enabled:
+
+    vllm serve allenai/Molmo2-8B \
+        --trust-remote-code --max-model-len 6144 \
+        --enable-file-uploads --file-upload-max-size-mb 128
+
+Then run this script against a local video/image/audio file:
+
+    python openai_file_upload_client.py path/to/clip.mp4
+
+This avoids the two pain points of inline multimodal inputs:
+
+- Base64 data URLs inflate payloads ~33% and can exceed shell ARG_MAX
+  for videos over ~8 MB.
+- `file://` URLs require `--allowed-local-media-path` AND the file to
+  live on the server machine (useless when client and server are on
+  different hosts).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from openai import OpenAI
+from utils import get_first_model
+
+openai_api_key = "EMPTY"
+openai_api_base = "http://localhost:8000/v1"
+
+client = OpenAI(api_key=openai_api_key, base_url=openai_api_base)
+
+
+def run(path: str) -> None:
+    model = get_first_model(client)
+
+    # 1. Upload the local file once. The server streams it to disk and
+    #    returns a 128-bit capability handle.
+    with open(path, "rb") as f:
+        uploaded = client.files.create(file=f, purpose="vision")
+    print(f"uploaded:  {uploaded.id}  ({uploaded.bytes} bytes)")
+
+    # 2. Reference it by id in any number of chat completions using
+    #    the `vllm-file://<id>` URL scheme. The same file can be used
+    #    across multiple turns without re-uploading.
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": f"vllm-file://{uploaded.id}"},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Describe what happens in this clip in 2-3 sentences.",
+                    },
+                ],
+            }
+        ],
+        max_completion_tokens=150,
+    )
+    print(f"response:  {response.choices[0].message.content}")
+
+    # 3. Clean up. Files also auto-expire after
+    #    --file-upload-ttl-seconds (default 1h) and are quota-bounded
+    #    by --file-upload-max-total-gb (default 5 GB, LRU eviction).
+    client.files.delete(uploaded.id)
+    print(f"deleted:   {uploaded.id}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <path-to-media-file>", file=sys.stderr)
+        sys.exit(1)
+    run(sys.argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/entrypoints/openai/files/__init__.py
+++ b/tests/entrypoints/openai/files/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/entrypoints/openai/files/test_api_router.py
+++ b/tests/entrypoints/openai/files/test_api_router.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm.config import FileUploadConfig
+from vllm.entrypoints.openai.files.api_router import attach_router
+from vllm.entrypoints.openai.files.serving import OpenAIServingFiles
+from vllm.entrypoints.openai.files.store import FileUploadStore
+
+# Shared test fixtures (real magic bytes so the MIME sniffer passes).
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 512
+_MP4 = b"\x00\x00\x00\x20ftypisom" + b"\x00" * 2048
+_TEXT = b"this is not a media file at all" + b"\x00" * 32
+
+
+def _app_with_store(tmp_path, **config_overrides) -> FastAPI:
+    defaults = {
+        "enabled": True,
+        "dir": str(tmp_path / "uploads"),
+        "ttl_seconds": 3600,
+        "max_size_mb": 1,
+        "max_total_gb": 1,
+        "max_concurrent": 4,
+        "scope_header": "",
+        "disable_listing": False,
+    }
+    defaults.update(config_overrides)
+    config = FileUploadConfig(**defaults)
+    store = FileUploadStore(config)
+    app = FastAPI()
+    app.state.openai_serving_files = OpenAIServingFiles(store, config)
+    attach_router(app)
+    return app
+
+
+def _png_upload(name: str = "cat.png") -> dict:
+    return {"file": (name, io.BytesIO(_PNG), "image/png")}
+
+
+# ---------------------------------------------------------------------------
+# happy path: upload → list → get → download → delete
+# ---------------------------------------------------------------------------
+
+
+def test_full_round_trip(tmp_path):
+    client = TestClient(_app_with_store(tmp_path))
+
+    # POST
+    r = client.post("/v1/files", files=_png_upload(), data={"purpose": "vision"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    file_id = body["id"]
+    assert file_id.startswith("file-")
+    assert body["filename"] == "cat.png"
+    assert body["purpose"] == "vision"
+    assert body["bytes"] == len(_PNG)
+    assert body["object"] == "file"
+
+    # GET list
+    r = client.get("/v1/files")
+    assert r.status_code == 200
+    assert r.json()["object"] == "list"
+    assert len(r.json()["data"]) == 1
+
+    # GET single
+    r = client.get(f"/v1/files/{file_id}")
+    assert r.status_code == 200
+    assert r.json()["id"] == file_id
+
+    # GET content
+    r = client.get(f"/v1/files/{file_id}/content")
+    assert r.status_code == 200
+    assert r.content == _PNG
+    assert r.headers["content-type"].startswith("image/png")
+
+    # DELETE
+    r = client.delete(f"/v1/files/{file_id}")
+    assert r.status_code == 200
+    assert r.json()["deleted"] is True
+
+    # GET now 404
+    assert client.get(f"/v1/files/{file_id}").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# purpose + size validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_purpose", ["assistants", "fine-tune", "batch", "VISION"])
+def test_rejects_unsupported_purpose(tmp_path, bad_purpose):
+    client = TestClient(_app_with_store(tmp_path))
+    r = client.post("/v1/files", files=_png_upload(), data={"purpose": bad_purpose})
+    assert r.status_code == 400
+    assert "purpose" in r.json()["error"]["message"]
+
+
+def test_default_purpose_is_user_data(tmp_path):
+    """Purpose defaults to user_data when unset (matches OpenAI SDK default)."""
+    client = TestClient(_app_with_store(tmp_path))
+    r = client.post("/v1/files", files=_png_upload())
+    assert r.status_code == 200
+    assert r.json()["purpose"] == "user_data"
+
+
+def test_concurrency_limit_returns_503(tmp_path):
+    """When `max_concurrent` uploads are already in flight, the store
+    rejects with `ConcurrencyLimitExceeded` and the serving layer maps
+    that to 503 (documented back-pressure contract)."""
+    app = _app_with_store(tmp_path, max_concurrent=1)
+    client = TestClient(app)
+    # Saturate the semaphore manually — simulates a slow upload still in
+    # flight when a second client arrives.
+    store = app.state.openai_serving_files._store  # noqa: SLF001
+    # Consume the only slot without releasing. Using sync access here
+    # because asyncio.Semaphore is consumable from any context.
+    store._upload_semaphore._value = 0  # noqa: SLF001
+    r = client.post("/v1/files", files=_png_upload(), data={"purpose": "vision"})
+    assert r.status_code == 503
+    assert "max_concurrent" in r.json()["error"]["message"]
+
+
+def test_oversize_upload_returns_413(tmp_path):
+    client = TestClient(_app_with_store(tmp_path, max_size_mb=1))
+    big = io.BytesIO(_PNG + b"\x00" * (2 * 1024 * 1024))
+    r = client.post(
+        "/v1/files",
+        files={"file": ("big.png", big, "image/png")},
+        data={"purpose": "vision"},
+    )
+    assert r.status_code == 413
+
+
+def test_non_media_upload_returns_400(tmp_path):
+    client = TestClient(_app_with_store(tmp_path))
+    r = client.post(
+        "/v1/files",
+        files={"file": ("note.txt", io.BytesIO(_TEXT), "text/plain")},
+        data={"purpose": "user_data"},
+    )
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# list disablement
+# ---------------------------------------------------------------------------
+
+
+def test_disable_listing_returns_404_on_GET_v1_files(tmp_path):
+    client = TestClient(_app_with_store(tmp_path, disable_listing=True))
+    # Upload first so there's something to (not) list.
+    client.post("/v1/files", files=_png_upload(), data={"purpose": "vision"})
+
+    r = client.get("/v1/files")
+    assert r.status_code == 404
+    assert "disabled" in r.json()["error"]["message"].lower()
+
+
+def test_disable_listing_does_not_affect_individual_ops(tmp_path):
+    client = TestClient(_app_with_store(tmp_path, disable_listing=True))
+    r = client.post("/v1/files", files=_png_upload(), data={"purpose": "vision"})
+    assert r.status_code == 200
+    file_id = r.json()["id"]
+    assert client.get(f"/v1/files/{file_id}").status_code == 200
+    assert client.get(f"/v1/files/{file_id}/content").status_code == 200
+    assert client.delete(f"/v1/files/{file_id}").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# scope header enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_scope_header_missing_returns_400(tmp_path):
+    client = TestClient(_app_with_store(tmp_path, scope_header="OpenAI-Project"))
+    r = client.post("/v1/files", files=_png_upload(), data={"purpose": "vision"})
+    assert r.status_code == 400
+    assert "OpenAI-Project" in r.json()["error"]["message"]
+
+
+def test_scope_header_present_attaches_scope(tmp_path):
+    client = TestClient(_app_with_store(tmp_path, scope_header="OpenAI-Project"))
+    r = client.post(
+        "/v1/files",
+        files=_png_upload(),
+        data={"purpose": "vision"},
+        headers={"OpenAI-Project": "team-alpha"},
+    )
+    assert r.status_code == 200
+    file_id = r.json()["id"]
+
+    # Same scope: visible.
+    r = client.get(f"/v1/files/{file_id}", headers={"OpenAI-Project": "team-alpha"})
+    assert r.status_code == 200
+
+    # Different scope: 404 (capability non-disclosure).
+    r = client.get(f"/v1/files/{file_id}", headers={"OpenAI-Project": "team-bravo"})
+    assert r.status_code == 404
+
+
+def test_scope_header_mismatch_returns_404_not_403(tmp_path):
+    """Capability non-disclosure: wrong-scope callers must not be able
+    to distinguish 'file exists but you cannot see it' from 'file does
+    not exist'."""
+    client = TestClient(_app_with_store(tmp_path, scope_header="OpenAI-Project"))
+    # Upload as team-alpha.
+    r = client.post(
+        "/v1/files",
+        files=_png_upload(),
+        data={"purpose": "vision"},
+        headers={"OpenAI-Project": "team-alpha"},
+    )
+    file_id = r.json()["id"]
+
+    # team-bravo sees 404 (not 403).
+    r = client.get(f"/v1/files/{file_id}", headers={"OpenAI-Project": "team-bravo"})
+    assert r.status_code == 404
+
+    # team-bravo attempting delete also 404.
+    r = client.delete(f"/v1/files/{file_id}", headers={"OpenAI-Project": "team-bravo"})
+    assert r.status_code == 404
+
+
+def test_list_scope_filtered(tmp_path):
+    client = TestClient(_app_with_store(tmp_path, scope_header="OpenAI-Project"))
+    client.post(
+        "/v1/files",
+        files=_png_upload("a.png"),
+        data={"purpose": "vision"},
+        headers={"OpenAI-Project": "alpha"},
+    )
+    client.post(
+        "/v1/files",
+        files=_png_upload("b.png"),
+        data={"purpose": "vision"},
+        headers={"OpenAI-Project": "bravo"},
+    )
+    r = client.get("/v1/files", headers={"OpenAI-Project": "alpha"})
+    data = r.json()["data"]
+    assert len(data) == 1
+    assert data[0]["filename"] == "a.png"
+
+
+# ---------------------------------------------------------------------------
+# audit log includes request_id when provided as X-Request-Id header
+# ---------------------------------------------------------------------------
+
+
+def test_request_id_propagates_to_audit_log(tmp_path):
+    store_logger = logging.getLogger("vllm.entrypoints.openai.files.store")
+    captured: list[logging.LogRecord] = []
+
+    class _H(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
+    h = _H(level=logging.INFO)
+    store_logger.addHandler(h)
+    try:
+        client = TestClient(_app_with_store(tmp_path))
+        r = client.post(
+            "/v1/files",
+            files=_png_upload(),
+            data={"purpose": "vision"},
+            headers={"X-Request-Id": "req-7"},
+        )
+        assert r.status_code == 200
+    finally:
+        store_logger.removeHandler(h)
+
+    import json
+
+    req_ids = [
+        json.loads(rec.getMessage()).get("request_id")
+        for rec in captured
+        if rec.getMessage().startswith("{")
+    ]
+    assert "req-7" in req_ids
+
+
+# ---------------------------------------------------------------------------
+# feature-off: router not attached → 404
+# ---------------------------------------------------------------------------
+
+
+def test_feature_off_router_not_attached(tmp_path):
+    """When the feature is disabled, the router is not attached and all
+    /v1/files* paths return 404 (FastAPI default for unknown routes)."""
+    config = FileUploadConfig(enabled=False)
+    app = FastAPI()
+    # Intentionally do NOT attach the router or set app.state.
+    client = TestClient(app)
+    assert client.post("/v1/files", files=_png_upload()).status_code == 404
+    assert client.get("/v1/files").status_code == 404
+    assert client.delete("/v1/files/file-abc").status_code == 404
+    _ = config  # silence flake; demonstrates the disabled-state contract

--- a/tests/entrypoints/openai/files/test_config.py
+++ b/tests/entrypoints/openai/files/test_config.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.config import FileUploadConfig
+
+
+def test_defaults_are_off_and_conservative():
+    c = FileUploadConfig()
+    assert c.enabled is False
+    assert c.dir == ""
+    assert c.ttl_seconds == 3600
+    assert c.max_size_mb == 512
+    assert c.max_total_gb == 5
+    assert c.max_concurrent == 4
+    assert c.scope_header == ""
+    assert c.disable_listing is False
+
+
+def test_custom_values_accepted():
+    c = FileUploadConfig(
+        enabled=True,
+        dir="/tmp/vllm-uploads",
+        ttl_seconds=-1,
+        max_size_mb=1024,
+        max_total_gb=20,
+        max_concurrent=8,
+        scope_header="OpenAI-Project",
+        disable_listing=True,
+    )
+    assert c.enabled is True
+    assert c.ttl_seconds == -1
+    assert c.scope_header == "OpenAI-Project"
+    assert c.disable_listing is True
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("max_size_mb", 0),
+        ("max_size_mb", -1),
+        ("max_total_gb", 0),
+        ("max_total_gb", -5),
+        ("max_concurrent", 0),
+        ("max_concurrent", -1),
+    ],
+)
+def test_rejects_non_positive_sizes(field, value):
+    with pytest.raises(ValidationError):
+        FileUploadConfig(**{field: value})
+
+
+def test_ttl_seconds_allows_negative_sentinel():
+    """`-1` is the explicit 'disable time-based expiry' sentinel. Any negative
+    value other than -1 is still accepted (no validator), but only -1 is
+    documented. We intentionally do not restrict to {-1, >=0} at the config
+    layer — the sweeper treats any value < 0 as disabled."""
+    c = FileUploadConfig(ttl_seconds=-1)
+    assert c.ttl_seconds == -1
+    c2 = FileUploadConfig(ttl_seconds=0)
+    assert c2.ttl_seconds == 0
+
+
+def test_rejects_extra_fields():
+    """@config forbids extra fields — surfaces typos at config-load time."""
+    with pytest.raises(ValidationError):
+        FileUploadConfig(enable=True)  # typo: missing 'd'

--- a/tests/entrypoints/openai/files/test_media_connector_integration.py
+++ b/tests/entrypoints/openai/files/test_media_connector_integration.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end: upload a file via the store, then resolve it via
+MediaConnector's vllm-file:// scheme handler — the path a chat-completion
+takes during multimodal resolution."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from vllm.config import FileUploadConfig
+from vllm.entrypoints.openai.files.store import (
+    FileUploadStore,
+    get_store,
+    register_store,
+)
+from vllm.multimodal.media import MediaConnector
+
+# Minimal PNG-shaped payload.
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 1024
+
+
+async def _stream(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+class _BytesMediaIO:
+    """Minimal MediaIO stand-in so we don't have to spin up the real
+    image/video decoders just to test URL dispatch."""
+
+    def load_bytes(self, data: bytes) -> bytes:
+        return data
+
+
+@pytest.fixture
+def _store(tmp_path):
+    config = FileUploadConfig(
+        enabled=True, dir=str(tmp_path / "uploads"), max_size_mb=1
+    )
+    store = FileUploadStore(config)
+    register_store(store)
+    yield store
+    register_store(None)
+
+
+@pytest.mark.asyncio
+async def test_vllm_file_scheme_resolves_to_stored_bytes(_store):
+    rec = await _store.create_file(
+        stream=_stream(_PNG), filename="cat.png", purpose="vision", scope=None
+    )
+    connector = MediaConnector()
+    result = connector.load_from_url(f"vllm-file://{rec.id}", _BytesMediaIO())
+    assert result == _PNG
+
+
+@pytest.mark.asyncio
+async def test_vllm_file_scheme_ignores_scope_on_resolution(_store):
+    """Capability-based: a file uploaded under scope A can be resolved
+    by the chat-completion path regardless of scope. The 128-bit ID is
+    the access control here (documented trust model)."""
+    rec = await _store.create_file(
+        stream=_stream(_PNG),
+        filename="a.png",
+        purpose="vision",
+        scope="team-alpha",
+    )
+    connector = MediaConnector()
+    result = connector.load_from_url(f"vllm-file://{rec.id}", _BytesMediaIO())
+    assert result == _PNG
+
+
+def test_vllm_file_scheme_raises_when_store_not_registered(tmp_path):
+    register_store(None)  # ensure cleared
+    connector = MediaConnector()
+    with pytest.raises(RuntimeError, match="enable-file-uploads"):
+        connector.load_from_url("vllm-file://file-" + "0" * 32, _BytesMediaIO())
+
+
+@pytest.mark.asyncio
+async def test_vllm_file_scheme_unknown_id_raises(_store):
+    connector = MediaConnector()
+    with pytest.raises(ValueError, match="Unknown vllm-file id"):
+        connector.load_from_url("vllm-file://file-" + "0" * 32, _BytesMediaIO())
+
+
+@pytest.mark.asyncio
+async def test_vllm_file_async_path(_store):
+    rec = await _store.create_file(
+        stream=_stream(_PNG), filename="c.png", purpose="vision", scope=None
+    )
+    connector = MediaConnector()
+    result = await connector.load_from_url_async(
+        f"vllm-file://{rec.id}", _BytesMediaIO()
+    )
+    assert result == _PNG
+
+
+@pytest.mark.asyncio
+async def test_vllm_file_resolution_touches_atime(_store):
+    import time
+
+    rec = await _store.create_file(
+        stream=_stream(_PNG), filename="d.png", purpose="vision", scope=None
+    )
+    original = rec.last_accessed
+    time.sleep(0.02)
+    connector = MediaConnector()
+    connector.load_from_url(f"vllm-file://{rec.id}", _BytesMediaIO())
+    assert rec.last_accessed > original
+
+
+def test_register_store_and_get_store_roundtrip(tmp_path):
+    assert get_store() is None
+    config = FileUploadConfig(enabled=True, dir=str(tmp_path / "u"))
+    store = FileUploadStore(config)
+    register_store(store)
+    try:
+        assert get_store() is store
+    finally:
+        register_store(None)
+    assert get_store() is None

--- a/tests/entrypoints/openai/files/test_mime.py
+++ b/tests/entrypoints/openai/files/test_mime.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.openai.files import mime
+from vllm.entrypoints.openai.files.mime import (
+    SNIFF_HEAD_BYTES,
+    _sniff_inline,
+    is_allowed_mime,
+    sniff_mime,
+)
+
+# Short valid signatures for each supported format. These are real magic
+# bytes truncated to the minimum required; the sniffer never reads past
+# SNIFF_HEAD_BYTES so padding isn't necessary.
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+_JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 8
+_GIF87 = b"GIF87a" + b"\x00" * 10
+_GIF89 = b"GIF89a" + b"\x00" * 10
+_WEBP = b"RIFF\x00\x00\x00\x00WEBPVP8 "
+_WAV = b"RIFF\x00\x00\x00\x00WAVEfmt "
+_WEBM = b"\x1a\x45\xdf\xa3" + b"\x00" * 12
+_MP3_ID3 = b"ID3\x04\x00" + b"\x00" * 11
+_MP3_SYNC = b"\xff\xfb\x90\x00" + b"\x00" * 12
+_MP4_ISOM = b"\x00\x00\x00\x20ftypisom" + b"\x00" * 4
+_MP4_MP42 = b"\x00\x00\x00\x20ftypmp42" + b"\x00" * 4
+_MP4_M4V = b"\x00\x00\x00\x20ftypM4V " + b"\x00" * 4
+_M4A = b"\x00\x00\x00\x20ftypM4A " + b"\x00" * 4
+_MOV = b"\x00\x00\x00\x20ftypqt  " + b"\x00" * 4
+_MP4_UNKNOWN_BRAND = b"\x00\x00\x00\x20ftypXXXX" + b"\x00" * 4
+
+
+@pytest.mark.parametrize(
+    "head,expected",
+    [
+        (_PNG, "image/png"),
+        (_JPEG, "image/jpeg"),
+        (_GIF87, "image/gif"),
+        (_GIF89, "image/gif"),
+        (_WEBP, "image/webp"),
+        (_WAV, "audio/wav"),
+        (_WEBM, "video/webm"),
+        (_MP3_ID3, "audio/mpeg"),
+        (_MP3_SYNC, "audio/mpeg"),
+        (_MP4_ISOM, "video/mp4"),
+        (_MP4_MP42, "video/mp4"),
+        (_MP4_M4V, "video/mp4"),
+        (_M4A, "audio/mp4"),
+        (_MOV, "video/quicktime"),
+        (_MP4_UNKNOWN_BRAND, "video/mp4"),
+    ],
+)
+def test_inline_sniffer_recognises_supported_formats(head, expected):
+    assert _sniff_inline(head) == expected
+
+
+@pytest.mark.parametrize(
+    "head",
+    [
+        b"",
+        b"\x00" * 64,
+        b"plain text payload, not media at all, nope",
+        b"<!DOCTYPE html><html><body></body></html>",
+        b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 16,  # ELF executable
+        b"MZ\x90\x00\x03\x00" + b"\x00" * 16,  # Windows PE/DOS
+        b"#!/bin/bash\necho 'nope'\n",
+        b"RIFF" + b"\x00" * 4 + b"NOPE" + b"\x00" * 4,  # RIFF, wrong subtype
+    ],
+)
+def test_inline_sniffer_rejects_non_media(head):
+    assert _sniff_inline(head) is None
+
+
+def test_sniff_mime_truncated_inputs_do_not_crash():
+    """Tiny heads are possible (empty upload, single byte) — must not
+    raise; must return None."""
+    assert sniff_mime(b"") is None
+    assert sniff_mime(b"\x89") is None
+    assert sniff_mime(b"\x89P") is None
+
+
+def test_sniff_head_bytes_matches_longest_signature():
+    """The SNIFF_HEAD_BYTES constant should be enough for every signature
+    the inline sniffer checks. If someone adds a longer signature they
+    must bump SNIFF_HEAD_BYTES."""
+    # 12 bytes covers RIFF + subtype and ftyp + brand, the longest we check.
+    assert SNIFF_HEAD_BYTES >= 12
+
+
+@pytest.mark.parametrize(
+    "mime_type,allowed",
+    [
+        ("video/mp4", True),
+        ("video/webm", True),
+        ("video/quicktime", True),
+        ("image/png", True),
+        ("image/jpeg", True),
+        ("image/gif", True),
+        ("image/webp", True),
+        ("audio/mpeg", True),
+        ("audio/wav", True),
+        ("audio/mp4", True),
+        ("application/octet-stream", False),
+        ("text/plain", False),
+        ("application/pdf", False),
+        ("application/x-executable", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_allowed_mime(mime_type, allowed):
+    assert is_allowed_mime(mime_type) is allowed
+
+
+def test_inline_path_used_when_pymagic_absent(monkeypatch):
+    """When python-magic is not installed, sniff_mime must fall back to
+    the inline table. Exercises the always-available path."""
+    monkeypatch.setattr(mime, "_PYMAGIC", None)
+    assert sniff_mime(_PNG) == "image/png"
+    assert sniff_mime(b"plain text") is None
+
+
+def test_pymagic_path_is_tried_first(monkeypatch):
+    """When python-magic IS available, sniff_mime should try it first and
+    only fall back to inline when pymagic returns empty/raises."""
+
+    class FakeMagic:
+        def __init__(self, result: str | None):
+            self._result = result
+            self.calls = 0
+
+        def from_buffer(self, head: bytes) -> str | None:
+            self.calls += 1
+            return self._result
+
+    # Case 1: pymagic returns a valid MIME — inline table not consulted.
+    fake = FakeMagic("video/x-matroska")
+    monkeypatch.setattr(mime, "_PYMAGIC", fake)
+    assert sniff_mime(_WEBM) == "video/x-matroska"
+    assert fake.calls == 1
+
+    # Case 2: pymagic raises — fall back to inline.
+    class RaisingMagic:
+        def from_buffer(self, head: bytes) -> str:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(mime, "_PYMAGIC", RaisingMagic())
+    assert sniff_mime(_PNG) == "image/png"  # inline path
+
+    # Case 3: pymagic returns empty string — fall back to inline.
+    fake_empty = FakeMagic("")
+    monkeypatch.setattr(mime, "_PYMAGIC", fake_empty)
+    assert sniff_mime(_JPEG) == "image/jpeg"
+    assert fake_empty.calls == 1

--- a/tests/entrypoints/openai/files/test_mime.py
+++ b/tests/entrypoints/openai/files/test_mime.py
@@ -29,6 +29,14 @@ _MP4_M4V = b"\x00\x00\x00\x20ftypM4V " + b"\x00" * 4
 _M4A = b"\x00\x00\x00\x20ftypM4A " + b"\x00" * 4
 _MOV = b"\x00\x00\x00\x20ftypqt  " + b"\x00" * 4
 _MP4_UNKNOWN_BRAND = b"\x00\x00\x00\x20ftypXXXX" + b"\x00" * 4
+_HEIC = b"\x00\x00\x00\x20ftypheic" + b"\x00" * 4
+_HEIC_MIF1 = b"\x00\x00\x00\x20ftypmif1" + b"\x00" * 4
+_AVIF = b"\x00\x00\x00\x20ftypavif" + b"\x00" * 4
+# MP3 frame-sync with a RESERVED bitrate index (0xF) in byte 2 — byte 2
+# bits EEEE.FFGH, 0xFC = 1111_1100, so bitrate=0xF (reserved), must reject.
+_MP3_SYNC_BAD_BITRATE = b"\xff\xfb\xfc\x00" + b"\x00" * 12
+# MP3 frame-sync with a RESERVED sample-rate index (0x3) in byte 2 — 0x0C = 0000_1100
+_MP3_SYNC_BAD_SAMPLERATE = b"\xff\xfb\x0c\x00" + b"\x00" * 12
 
 
 @pytest.mark.parametrize(
@@ -49,10 +57,29 @@ _MP4_UNKNOWN_BRAND = b"\x00\x00\x00\x20ftypXXXX" + b"\x00" * 4
         (_M4A, "audio/mp4"),
         (_MOV, "video/quicktime"),
         (_MP4_UNKNOWN_BRAND, "video/mp4"),
+        (_HEIC, "image/heic"),
+        (_HEIC_MIF1, "image/heic"),
+        (_AVIF, "image/avif"),
     ],
 )
 def test_inline_sniffer_recognises_supported_formats(head, expected):
     assert _sniff_inline(head) == expected
+
+
+@pytest.mark.parametrize(
+    "head",
+    [
+        _MP3_SYNC_BAD_BITRATE,
+        _MP3_SYNC_BAD_SAMPLERATE,
+    ],
+)
+def test_mp3_frame_sync_validates_header_bits(head):
+    """Random binary blobs that start with \\xff\\xfb (or similar) but
+    have a reserved bitrate/sample-rate index must NOT be classified as
+    audio/mpeg — the frame-sync prefix alone is only 12 bits and
+    collides ~1/2048. The byte-2 bitrate and sample-rate bits guard
+    against false positives on random data."""
+    assert _sniff_inline(head) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/entrypoints/openai/files/test_protocol.py
+++ b/tests/entrypoints/openai/files/test_protocol.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.openai.files.protocol import (
+    FileDeleteResponse,
+    FileList,
+    FileObject,
+)
+
+
+def test_file_object_shape_matches_openai_files_api():
+    obj = FileObject(
+        id="file-abc123",
+        bytes=18432100,
+        created_at=1743800000,
+        expires_at=1743803600,
+        filename="video.mp4",
+        purpose="vision",
+    )
+    data = json.loads(obj.model_dump_json())
+    assert data == {
+        "id": "file-abc123",
+        "object": "file",
+        "bytes": 18432100,
+        "created_at": 1743800000,
+        "expires_at": 1743803600,
+        "filename": "video.mp4",
+        "purpose": "vision",
+        "status": "processed",
+        "status_details": None,
+    }
+
+
+def test_file_object_expires_at_omitted_when_none():
+    """When TTL is disabled, responses should omit `expires_at` per OpenAI
+    convention (caller uses exclude_none=True at serialization time)."""
+    obj = FileObject(
+        id="file-xyz",
+        bytes=100,
+        created_at=1,
+        filename="x.png",
+        purpose="user_data",
+        expires_at=None,
+    )
+    data = json.loads(obj.model_dump_json(exclude_none=True))
+    assert "expires_at" not in data
+    assert data["purpose"] == "user_data"
+
+
+@pytest.mark.parametrize(
+    "bad_purpose",
+    ["assistants", "fine-tune", "batch", "assistants_output", "", "VISION"],
+)
+def test_file_object_rejects_unsupported_purpose(bad_purpose):
+    with pytest.raises(ValidationError):
+        FileObject(
+            id="file-x",
+            bytes=1,
+            created_at=1,
+            filename="x",
+            purpose=bad_purpose,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("good_purpose", ["vision", "user_data"])
+def test_file_object_accepts_supported_purposes(good_purpose):
+    obj = FileObject(
+        id="file-x",
+        bytes=1,
+        created_at=1,
+        filename="x",
+        purpose=good_purpose,  # type: ignore[arg-type]
+    )
+    assert obj.purpose == good_purpose
+
+
+def test_file_list_default_is_empty():
+    fl = FileList()
+    assert fl.object == "list"
+    assert fl.data == []
+
+
+def test_file_list_populated():
+    obj = FileObject(
+        id="file-a",
+        bytes=1,
+        created_at=1,
+        filename="a.mp4",
+        purpose="vision",
+    )
+    fl = FileList(data=[obj])
+    assert len(fl.data) == 1
+    assert fl.data[0].id == "file-a"
+
+
+def test_file_delete_response():
+    dr = FileDeleteResponse(id="file-abc")
+    data = json.loads(dr.model_dump_json())
+    assert data == {"id": "file-abc", "object": "file", "deleted": True}

--- a/tests/entrypoints/openai/files/test_store.py
+++ b/tests/entrypoints/openai/files/test_store.py
@@ -1,0 +1,592 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import regex as re
+
+from vllm.config import FileUploadConfig
+from vllm.entrypoints.openai.files.store import (
+    ConcurrencyLimitExceeded,
+    FileTooLarge,
+    FileUploadStore,
+    InvalidMime,
+    QuotaExceeded,
+    new_file_id,
+    sanitize_filename,
+)
+
+# Minimal real signatures — enough for the MIME sniffer to classify. The
+# store writes these as the full file content, so sizes are tiny.
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 1024  # ~1KiB PNG-shaped
+_MP4_BYTES = b"\x00\x00\x00\x20ftypisom" + b"\x00" * 2048  # ~2KiB MP4
+_TEXT_BYTES = b"this is definitely not a media file" + b"\x00" * 128
+
+
+async def _stream(data: bytes, chunk: int = 256) -> AsyncIterator[bytes]:
+    for i in range(0, len(data), chunk):
+        yield data[i : i + chunk]
+
+
+def _mk_config(tmp_path: Path, **overrides: object) -> FileUploadConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "dir": str(tmp_path / "uploads"),
+        "ttl_seconds": 3600,
+        "max_size_mb": 1,  # tight for test control
+        "max_total_gb": 1,
+        "max_concurrent": 4,
+        "scope_header": "",
+        "disable_listing": False,
+    }
+    defaults.update(overrides)
+    return FileUploadConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_file_ids_are_128_bit_random():
+    """Security invariant: 128-bit capability handles, never colliding."""
+    ids = {new_file_id() for _ in range(10_000)}
+    assert len(ids) == 10_000
+    pattern = re.compile(r"^file-[0-9a-f]{32}$")
+    for file_id in ids:
+        assert pattern.match(file_id), file_id
+        # 32 hex chars = 128 bits; "file-" prefix = 5 chars; total = 37.
+        assert len(file_id) == 37
+
+
+def test_filename_sanitization_drops_path_components():
+    assert sanitize_filename("../etc/passwd/video.mp4") == "video.mp4"
+    assert sanitize_filename("/absolute/path/to/clip.webm") == "clip.webm"
+    assert sanitize_filename(r"C:\Windows\System32\evil.mp4") == "evil.mp4"
+    assert sanitize_filename("./a/b/c/d/e.png") == "e.png"
+
+
+def test_filename_sanitization_caps_length():
+    long = "a" * 500 + ".mp4"
+    result = sanitize_filename(long)
+    assert len(result.encode("utf-8")) <= 255
+
+
+def test_filename_sanitization_strips_control_chars():
+    assert sanitize_filename("video\x00\r\n.mp4") == "video.mp4"
+    assert sanitize_filename("x\x1bo.png") == "xo.png"
+
+
+def test_filename_sanitization_empty_input_returns_placeholder():
+    assert sanitize_filename("") == "upload.bin"
+    assert sanitize_filename("\x00\x00") == "upload.bin"
+
+
+def test_filename_sanitization_preserves_unicode():
+    assert sanitize_filename("vidéo.mp4") == "vidéo.mp4"
+
+
+# ---------------------------------------------------------------------------
+# upload + retrieve round trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_get_delete_round_trip(tmp_path):
+    store = FileUploadStore(_mk_config(tmp_path))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES),
+        filename="cat.png",
+        purpose="vision",
+        scope=None,
+    )
+    assert rec.filename == "cat.png"
+    assert rec.mime_type == "image/png"
+    assert rec.bytes == len(_PNG_BYTES)
+    assert rec.on_disk.exists()
+
+    fetched = store.get(rec.id, scope=None)
+    assert fetched is not None
+    assert fetched.id == rec.id
+
+    deleted = await store.delete(rec.id, scope=None)
+    assert deleted is True
+    assert store.get(rec.id, scope=None) is None
+    assert not rec.on_disk.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_false_for_unknown_id(tmp_path):
+    store = FileUploadStore(_mk_config(tmp_path))
+    assert await store.delete("file-" + "0" * 32, scope=None) is False
+
+
+# ---------------------------------------------------------------------------
+# streaming limits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rejects_oversize_upload(tmp_path):
+    # max_size_mb=1 → 1 MiB cap. Send 2 MiB.
+    store = FileUploadStore(_mk_config(tmp_path, max_size_mb=1))
+    big = _PNG_BYTES + b"\x00" * (2 * 1024 * 1024)
+    with pytest.raises(FileTooLarge):
+        await store.create_file(
+            stream=_stream(big),
+            filename="big.png",
+            purpose="vision",
+            scope=None,
+        )
+    # No orphan file on disk.
+    # Only the startup marker file should remain — no orphaned upload bytes.
+    assert [p.name for p in Path(store._dir).iterdir()] == [".vllm-upload-store"]  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_media_mime(tmp_path):
+    store = FileUploadStore(_mk_config(tmp_path))
+    with pytest.raises(InvalidMime):
+        await store.create_file(
+            stream=_stream(_TEXT_BYTES),
+            filename="note.txt",
+            purpose="user_data",
+            scope=None,
+        )
+    # Only the startup marker file should remain — no orphaned upload bytes.
+    assert [p.name for p in Path(store._dir).iterdir()] == [".vllm-upload-store"]  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scope_mismatch_returns_none(tmp_path):
+    """Capability non-disclosure: a file uploaded under scope A is invisible
+    to scope B (and to unscoped callers)."""
+    store = FileUploadStore(_mk_config(tmp_path))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES),
+        filename="a.png",
+        purpose="vision",
+        scope="team-alpha",
+    )
+    assert store.get(rec.id, scope="team-alpha") is not None
+    assert store.get(rec.id, scope="team-bravo") is None
+    assert store.get(rec.id, scope=None) is None
+
+
+@pytest.mark.asyncio
+async def test_list_is_scope_filtered(tmp_path):
+    store = FileUploadStore(_mk_config(tmp_path))
+    await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="a", purpose="vision", scope="a"
+    )
+    await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="b", purpose="vision", scope="a"
+    )
+    await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="c", purpose="vision", scope="b"
+    )
+    assert len(store.list(scope="a")) == 2
+    assert len(store.list(scope="b")) == 1
+    assert len(store.list(scope="c")) == 0
+    assert len(store.list(scope=None)) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_requires_matching_scope(tmp_path):
+    store = FileUploadStore(_mk_config(tmp_path))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="a", purpose="vision", scope="x"
+    )
+    # Wrong scope cannot delete.
+    assert await store.delete(rec.id, scope="y") is False
+    assert store.get(rec.id, scope="x") is not None
+    # Correct scope can.
+    assert await store.delete(rec.id, scope="x") is True
+
+
+# ---------------------------------------------------------------------------
+# quota / LRU eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_quota_eviction_drops_oldest_lru(tmp_path, monkeypatch):
+    # 3MiB quota, 1MiB cap. Upload 3 files of ~1MiB, then a 4th — oldest
+    # must be evicted.
+    config = _mk_config(tmp_path, max_size_mb=1, max_total_gb=1)
+    # Shrink the total-bytes budget under the test's control by monkeypatching.
+    store = FileUploadStore(config)
+    store._max_total_bytes = 3 * (len(_MP4_BYTES) + 2)  # noqa: SLF001
+
+    recs = []
+    for i in range(3):
+        recs.append(
+            await store.create_file(
+                stream=_stream(_MP4_BYTES),
+                filename=f"clip{i}.mp4",
+                purpose="vision",
+                scope=None,
+            )
+        )
+        # Advance last_accessed ordering by touching time.
+        await asyncio.sleep(0.01)
+
+    # 4th upload should evict the oldest (recs[0]).
+    await store.create_file(
+        stream=_stream(_MP4_BYTES),
+        filename="clip3.mp4",
+        purpose="vision",
+        scope=None,
+    )
+    assert store.get(recs[0].id, scope=None) is None, "oldest should be evicted"
+    assert store.get(recs[1].id, scope=None) is not None
+    assert store.get(recs[2].id, scope=None) is not None
+    assert not recs[0].on_disk.exists(), "on-disk bytes unlinked after eviction"
+
+
+@pytest.mark.asyncio
+async def test_eviction_does_not_block_concurrent_reads(tmp_path):
+    """Two-phase eviction: while the unlink runs outside the lock, other
+    callers must still be able to `get()` non-evicted files. This verifies
+    the snapshot-then-unlink pattern preserves read availability."""
+    config = _mk_config(tmp_path, max_size_mb=1, max_total_gb=1)
+    store = FileUploadStore(config)
+    store._max_total_bytes = 2 * (len(_MP4_BYTES) + 2)  # noqa: SLF001
+
+    # Populate two records, then race an eviction against concurrent gets.
+    a = await store.create_file(
+        stream=_stream(_MP4_BYTES), filename="a.mp4", purpose="vision", scope=None
+    )
+    await asyncio.sleep(0.01)
+    b = await store.create_file(
+        stream=_stream(_MP4_BYTES), filename="b.mp4", purpose="vision", scope=None
+    )
+
+    # Start the upload that will evict `a`, and concurrently call get(b).
+    async def upload_that_evicts():
+        return await store.create_file(
+            stream=_stream(_MP4_BYTES),
+            filename="c.mp4",
+            purpose="vision",
+            scope=None,
+        )
+
+    async def read_survivor():
+        # Poll rapidly during the upload so we land inside the critical path.
+        results = []
+        for _ in range(50):
+            results.append(store.get(b.id, scope=None))
+            await asyncio.sleep(0)
+        return results
+
+    upload_task, read_task = await asyncio.gather(upload_that_evicts(), read_survivor())
+
+    # The surviving record `b` must never have returned None during the
+    # eviction — proof that reads are not blocked by the eviction unlink.
+    assert all(r is not None for r in read_task), "reads blocked during eviction"
+    assert store.get(a.id, scope=None) is None, "oldest should have been evicted"
+    assert store.get(upload_task.id, scope=None) is not None
+
+
+@pytest.mark.asyncio
+async def test_upload_alone_exceeds_quota_is_rejected(tmp_path):
+    store = FileUploadStore(_mk_config(tmp_path))
+    store._max_total_bytes = 512  # noqa: SLF001 — smaller than one upload
+    with pytest.raises(QuotaExceeded):
+        await store.create_file(
+            stream=_stream(_MP4_BYTES),
+            filename="clip.mp4",
+            purpose="vision",
+            scope=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# TTL + touching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_touches_last_accessed(tmp_path):
+    store = FileUploadStore(_mk_config(tmp_path))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="a", purpose="vision", scope=None
+    )
+    original = rec.last_accessed
+    await asyncio.sleep(0.02)
+    store.get(rec.id, scope=None)
+    assert rec.last_accessed > original
+
+
+@pytest.mark.asyncio
+async def test_sweeper_evicts_expired(tmp_path):
+    # TTL of 0.05 seconds; manually invoke sweeper (no real sleep loop).
+    store = FileUploadStore(_mk_config(tmp_path))
+    store._ttl_seconds = 0  # noqa: SLF001 — everything expires immediately
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="a", purpose="vision", scope=None
+    )
+    # Nudge last_accessed into the past.
+    rec.last_accessed = time.time() - 10
+    await store._sweep_expired()  # noqa: SLF001
+    assert store.get(rec.id, scope=None) is None
+    assert not rec.on_disk.exists()
+
+
+@pytest.mark.asyncio
+async def test_ttl_disabled_skips_sweeper(tmp_path):
+    store = FileUploadStore(_mk_config(tmp_path, ttl_seconds=-1))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="a", purpose="vision", scope=None
+    )
+    rec.last_accessed = time.time() - 10_000
+    await store._sweep_expired()  # noqa: SLF001
+    assert store.get(rec.id, scope=None) is not None  # still present
+
+
+# ---------------------------------------------------------------------------
+# security invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_disk_name_does_not_expose_file_id(tmp_path):
+    store = FileUploadStore(_mk_config(tmp_path))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES),
+        filename="secret.png",
+        purpose="vision",
+        scope=None,
+    )
+    # The on-disk name is a sha256 of the id — never the id or filename.
+    disk_name = rec.on_disk.name
+    assert rec.id not in disk_name
+    assert "secret" not in disk_name
+    assert len(disk_name) == 64  # sha256 hex
+
+
+@pytest.mark.asyncio
+async def test_upload_dir_is_wiped_on_startup(tmp_path):
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    # Drop the marker first, simulating a prior store run (the safety
+    # check refuses to rmtree unmarked user directories).
+    (upload_dir / ".vllm-upload-store").touch()
+    (upload_dir / "leftover").write_bytes(b"previous server run")
+    store = FileUploadStore(_mk_config(tmp_path, dir=str(upload_dir)))
+    assert not (upload_dir / "leftover").exists()
+    assert store._dir == upload_dir  # noqa: SLF001
+    # Marker is re-dropped so subsequent restarts still work.
+    assert (upload_dir / ".vllm-upload-store").exists()
+
+
+def test_startup_refuses_to_wipe_unmarked_user_dir(tmp_path):
+    """Safety: if an operator points --file-upload-dir at a non-empty
+    directory that was NOT previously initialised by the store (no
+    marker file), refuse to rmtree it rather than silently destroying
+    unrelated data."""
+    upload_dir = tmp_path / "important_user_data"
+    upload_dir.mkdir()
+    (upload_dir / "do_not_delete.txt").write_bytes(b"important")
+    with pytest.raises(ValueError, match="Refusing to clear"):
+        FileUploadStore(_mk_config(tmp_path, dir=str(upload_dir)))
+    # User's data is still there.
+    assert (upload_dir / "do_not_delete.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# audit logging
+# ---------------------------------------------------------------------------
+
+
+class _ListHandler(logging.Handler):
+    """vllm's loggers set propagate=False, so pytest's caplog can't see
+    their records. Attach this handler directly to the store's logger."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.INFO)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture
+def audit_records():
+    store_logger = logging.getLogger("vllm.entrypoints.openai.files.store")
+    handler = _ListHandler()
+    store_logger.addHandler(handler)
+    try:
+        yield handler.records
+    finally:
+        store_logger.removeHandler(handler)
+
+
+def _parse_audit(records: list[logging.LogRecord]) -> list[dict]:
+    out = []
+    for r in records:
+        try:
+            out.append(json.loads(r.getMessage()))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return out
+
+
+@pytest.mark.asyncio
+async def test_audit_log_emits_on_every_operation_with_required_fields(
+    tmp_path, audit_records
+):
+    store = FileUploadStore(_mk_config(tmp_path))
+
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES),
+        filename="a.png",
+        purpose="vision",
+        scope="team",
+        client_host="203.0.113.7",
+        request_id="req-123",
+    )
+    # Retrieve + delete emit audit lines too.
+    async for _ in await store.stream_content(
+        rec.id, scope="team", client_host="203.0.113.7", request_id="req-124"
+    ):
+        pass
+    await store.delete(
+        rec.id, scope="team", client_host="203.0.113.7", request_id="req-125"
+    )
+
+    required = {"op", "file_id", "bytes", "scope", "client_host", "request_id", "ts"}
+    payloads = _parse_audit(audit_records)
+    ops_seen = [p["op"] for p in payloads]
+    for p in payloads:
+        assert required <= set(p), f"missing fields in {p}"
+    assert ops_seen == ["file.upload", "file.retrieve", "file.delete"]
+
+
+@pytest.mark.asyncio
+async def test_audit_log_includes_reason_on_rejection(tmp_path, audit_records):
+    store = FileUploadStore(_mk_config(tmp_path))
+    with pytest.raises(InvalidMime):
+        await store.create_file(
+            stream=_stream(_TEXT_BYTES),
+            filename="note.txt",
+            purpose="user_data",
+            scope=None,
+            client_host="203.0.113.7",
+        )
+    rejects = [p for p in _parse_audit(audit_records) if p.get("op") == "file.reject"]
+    assert len(rejects) == 1
+    assert rejects[0]["reason"] == "mime_mismatch"
+
+
+# ---------------------------------------------------------------------------
+# concurrency + TOCTOU race handling (Copilot review fixes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_when_concurrent_limit_hit(tmp_path):
+    """Fail-fast contract: when `max_concurrent` uploads are already in
+    flight, a new upload raises ConcurrencyLimitExceeded rather than
+    queueing indefinitely (surfaced to the API layer as 503)."""
+    # Semaphore capacity 1 makes the saturation point deterministic.
+    store = FileUploadStore(_mk_config(tmp_path, max_concurrent=1))
+
+    # Slow-stream that never completes until the test cancels it.
+    started = asyncio.Event()
+    never_finishes = asyncio.Event()
+
+    async def _hang() -> AsyncIterator[bytes]:
+        yield _PNG_BYTES
+        started.set()
+        await never_finishes.wait()
+        yield b""
+
+    first = asyncio.create_task(
+        store.create_file(
+            stream=_hang(), filename="slow.png", purpose="vision", scope=None
+        )
+    )
+    await started.wait()
+
+    # Second upload must be rejected immediately — not queued.
+    with pytest.raises(ConcurrencyLimitExceeded):
+        await store.create_file(
+            stream=_stream(_PNG_BYTES),
+            filename="x.png",
+            purpose="vision",
+            scope=None,
+        )
+
+    never_finishes.set()
+    await first  # let the slow upload drain so pytest doesn't warn
+
+
+@pytest.mark.asyncio
+async def test_read_bytes_by_id_handles_concurrent_eviction(tmp_path):
+    """TOCTOU: the record may be observed in `_records` but its on-disk
+    file could be unlinked before `read_bytes()` runs (two-phase delete
+    releases the lock between dict drop and unlink). The read must
+    return None cleanly rather than propagating FileNotFoundError."""
+    store = FileUploadStore(_mk_config(tmp_path))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="a.png", purpose="vision", scope=None
+    )
+
+    # Manually unlink while the record still exists in memory — simulates
+    # the narrow window between metadata drop and actual unlink.
+    rec.on_disk.unlink()
+    assert rec.id in store._records  # noqa: SLF001 — invariant we're probing
+
+    # Sync variant: returns None gracefully.
+    assert store.read_bytes_by_id(rec.id) is None
+    # Async variant: also returns None gracefully.
+    assert await store.read_bytes_by_id_async(rec.id) is None
+
+
+@pytest.mark.asyncio
+async def test_stream_content_fails_fast_when_file_evicted_before_open(tmp_path):
+    """TOCTOU: if the file is unlinked between `get()` and `open()`,
+    `stream_content` must raise FileNotFoundError from the call itself,
+    BEFORE returning the iterator — otherwise a 200 response starts
+    streaming and then breaks mid-flight."""
+    store = FileUploadStore(_mk_config(tmp_path))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="a.png", purpose="vision", scope=None
+    )
+
+    # Unlink the bytes without dropping the metadata record.
+    rec.on_disk.unlink()
+
+    with pytest.raises(FileNotFoundError):
+        await store.stream_content(rec.id, scope=None)
+
+
+@pytest.mark.asyncio
+async def test_read_bytes_by_id_async_does_not_race_with_deletes(tmp_path):
+    """Metadata access happens on the event-loop thread (only the disk
+    read is dispatched to an executor), so concurrent deletes mutating
+    `_records` cannot race with the lookup."""
+    store = FileUploadStore(_mk_config(tmp_path))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="a.png", purpose="vision", scope=None
+    )
+
+    # Happy path: async read returns the bytes.
+    data = await store.read_bytes_by_id_async(rec.id)
+    assert data == _PNG_BYTES
+
+    # Delete, then async read must return None (not raise).
+    assert await store.delete(rec.id, scope=None) is True
+    assert await store.read_bytes_by_id_async(rec.id) is None

--- a/tests/entrypoints/openai/files/test_store.py
+++ b/tests/entrypoints/openai/files/test_store.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -405,6 +406,33 @@ def test_startup_refuses_to_wipe_unmarked_user_dir(tmp_path):
     assert (upload_dir / "do_not_delete.txt").exists()
 
 
+def test_default_dir_uses_secure_tempdir(tmp_path, monkeypatch):
+    """Default --file-upload-dir must use Python's mkdtemp primitive
+    (0o700 perms + random suffix) rather than a PID-predictable
+    /tmp/vllm-uploads-<pid> path. On a shared host this blocks both
+    cross-user reads and pre-creation/symlink attacks."""
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    store = FileUploadStore(_mk_config(tmp_path, dir=""))
+    # Random suffix, not ending in the process PID.
+    assert store._dir.name.startswith("vllm-uploads-")  # noqa: SLF001
+    assert not store._dir.name.endswith(f"-{os.getpid()}")  # noqa: SLF001
+    # mkdtemp enforces 0o700 on POSIX.
+    assert (store._dir.stat().st_mode & 0o777) == 0o700  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_uploaded_file_is_owner_only(tmp_path):
+    """Uploaded bytes on disk must be 0o600 (owner read/write only).
+    Defense against cross-user reads on shared hosts - the 128-bit
+    capability handle is the access control layer, not filesystem
+    permissions."""
+    store = FileUploadStore(_mk_config(tmp_path))
+    rec = await store.create_file(
+        stream=_stream(_PNG_BYTES), filename="a.png", purpose="vision", scope=None
+    )
+    assert (rec.on_disk.stat().st_mode & 0o777) == 0o600
+
+
 # ---------------------------------------------------------------------------
 # audit logging
 # ---------------------------------------------------------------------------
@@ -458,9 +486,10 @@ async def test_audit_log_emits_on_every_operation_with_required_fields(
         request_id="req-123",
     )
     # Retrieve + delete emit audit lines too.
-    async for _ in await store.stream_content(
+    stream, _ = await store.stream_content(
         rec.id, scope="team", client_host="203.0.113.7", request_id="req-124"
-    ):
+    )
+    async for _ in stream:
         pass
     await store.delete(
         rec.id, scope="team", client_host="203.0.113.7", request_id="req-125"

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -11,6 +11,7 @@ from vllm.config.compilation import (
 )
 from vllm.config.device import DeviceConfig
 from vllm.config.ec_transfer import ECTransferConfig
+from vllm.config.file_upload import FileUploadConfig
 from vllm.config.kernel import KernelConfig
 from vllm.config.kv_events import KVEventsConfig
 from vllm.config.kv_transfer import KVTransferConfig
@@ -73,6 +74,8 @@ __all__ = [
     "DeviceConfig",
     # From vllm.config.ec_transfer
     "ECTransferConfig",
+    # From vllm.config.file_upload
+    "FileUploadConfig",
     # From vllm.config.kernel
     "KernelConfig",
     # From vllm.config.kv_events

--- a/vllm/config/file_upload.py
+++ b/vllm/config/file_upload.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Configuration dataclass for the opt-in `/v1/files` upload endpoint."""
+
+from pydantic import Field
+
+from vllm.config.utils import config
+
+
+@config
+class FileUploadConfig:
+    """Configuration for the `/v1/files` upload endpoint.
+
+    This subsystem is off by default. When enabled, it exposes an
+    OpenAI-compatible file upload API that lets clients upload multimodal
+    files (video/image/audio) once and reference them in subsequent
+    chat-completion requests via the `vllm-file://<id>` URL scheme.
+
+    See `docs/serving/openai_compatible_server.md` for the security posture
+    and deployment patterns.
+    """
+
+    enabled: bool = False
+    """Whether the `/v1/files` endpoint is exposed. When False (the default),
+    all `/v1/files*` paths return 404."""
+
+    dir: str = ""
+    """Directory under which uploaded file bytes are stored. Each file is
+    stored with a random sha256 on-disk name (the client `filename` is kept
+    only in metadata). If empty, defaults to `$TMPDIR/vllm-uploads-<pid>`,
+    which is cleared on server startup."""
+
+    ttl_seconds: int = 3600
+    """Time-to-live for uploaded files, in seconds. Measured from last
+    access (atime). Set to `-1` to disable time-based expiry (quota-based
+    LRU eviction still applies). When disabled, `expires_at` is omitted
+    from API responses."""
+
+    max_size_mb: int = Field(default=512, gt=0)
+    """Maximum size of a single uploaded file, in megabytes. Uploads
+    exceeding this limit are rejected with 413 during streaming (no memory
+    spike)."""
+
+    max_total_gb: int = Field(default=5, gt=0)
+    """Total disk quota across all uploaded files, in gigabytes. When a
+    new upload would exceed this limit, oldest files are evicted (LRU).
+    Uploads larger than the total quota are rejected outright."""
+
+    max_concurrent: int = Field(default=4, gt=0)
+    """Maximum number of simultaneous in-flight upload operations. Requests
+    beyond this limit receive 503. Prevents disk-fill DoS via concurrent
+    max-size uploads."""
+
+    scope_header: str = ""
+    """Name of a request header whose value scopes uploaded files. When
+    set, files are tagged at upload time with the header value, and
+    subsequent operations only succeed when the caller presents the same
+    header value. If set but the header is missing from a request, the
+    response is 400. When empty (the default), files are server-global —
+    possession of the 128-bit file ID is the sole access control.
+
+    Common values for gateway-fronted deployments:
+    - `OpenAI-Project` (native OpenAI SDK; SDK auto-sends from
+      `OPENAI_PROJECT_ID` env or the `project=...` client parameter)
+    - `X-Consumer-ID` (Kong, Apigee custom policies)
+    - `X-Auth-Request-User` (oauth2-proxy from JWT `sub` claim)"""
+
+    disable_listing: bool = False
+    """When True, the `GET /v1/files` (list) endpoint returns 404. Individual
+    file operations via known ID still work. Removes the enumeration surface
+    for capability-only deployments."""

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -420,7 +420,7 @@ async def init_app_state(
     if args.enable_file_uploads:
         from vllm.entrypoints.openai.files.api_router import init_files_state
 
-        init_files_state(state, args)
+        await init_files_state(state, args)
 
     if "realtime" in supported_tasks:
         from vllm.entrypoints.openai.realtime.api_router import init_realtime_state

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -234,6 +234,13 @@ def build_app(
 
         register_speech_to_text_api_router(app)
 
+    if args.enable_file_uploads:
+        from vllm.entrypoints.openai.files.api_router import (
+            attach_router as register_files_api_router,
+        )
+
+        register_files_api_router(app)
+
     if "realtime" in supported_tasks:
         from vllm.entrypoints.openai.realtime.api_router import (
             attach_router as register_realtime_api_router,
@@ -409,6 +416,11 @@ async def init_app_state(
         init_transcription_state(
             engine_client, state, args, request_logger, supported_tasks
         )
+
+    if args.enable_file_uploads:
+        from vllm.entrypoints.openai.files.api_router import init_files_state
+
+        init_files_state(state, args)
 
     if "realtime" in supported_tasks:
         from vllm.entrypoints.openai.realtime.api_router import init_realtime_state

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -14,7 +14,7 @@ from dataclasses import field
 from typing import Any, Literal
 
 import vllm.envs as envs
-from vllm.config import config
+from vllm.config import FileUploadConfig, config
 from vllm.engine.arg_utils import AsyncEngineArgs, optional_type
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
@@ -281,6 +281,44 @@ class FrontendArgs(BaseFrontendArgs):
     enable_flash_late_interaction: bool = True
     """If set, run pooling score MaxSim on GPU in the API server process.
     Can significantly improve late-interaction scoring performance."""
+
+    # ------------------------------------------------------------------
+    # /v1/files upload endpoint (issue #38531). All fields off/conservative
+    # by default; the endpoint is not attached unless enable_file_uploads
+    # is set. See vllm/config/file_upload.py for full semantics.
+    # ------------------------------------------------------------------
+    enable_file_uploads: bool = FileUploadConfig.enabled
+    """Enable the `/v1/files` OpenAI-compatible file upload endpoint. Off by
+    default; when set, clients can POST media files once and reference them
+    in chat-completion requests via the `vllm-file://<id>` URL scheme."""
+    file_upload_dir: str = FileUploadConfig.dir
+    """Directory for uploaded file bytes. Empty = $TMPDIR/vllm-uploads-<pid>,
+    cleared on server startup (non-persistent is a security invariant)."""
+    file_upload_ttl_seconds: int = FileUploadConfig.ttl_seconds
+    """Time-to-live for uploaded files, measured from last access. Default
+    1h. Set to -1 to disable time-based expiry (quota LRU eviction still
+    applies; `expires_at` is omitted from responses)."""
+    file_upload_max_size_mb: int = FileUploadConfig.max_size_mb
+    """Maximum size of a single uploaded file (MB). Enforced during the
+    streaming write so oversized uploads never spike server memory."""
+    file_upload_max_total_gb: int = FileUploadConfig.max_total_gb
+    """Total on-disk quota across all uploaded files (GB). LRU evicts
+    oldest files when a new upload would exceed the quota."""
+    file_upload_max_concurrent: int = FileUploadConfig.max_concurrent
+    """Maximum number of in-flight POST /v1/files operations. Prevents
+    disk-fill DoS via many concurrent max-size uploads."""
+    file_upload_scope_header: str = FileUploadConfig.scope_header
+    """Name of a request header whose value scopes uploaded files. When
+    set, files are tagged by this header's value at upload and filtered
+    on every subsequent operation. Common choices for gateway-fronted
+    deployments: `OpenAI-Project` (OpenAI SDK native), `X-Consumer-ID`
+    (Kong), `X-Auth-Request-User` (oauth2-proxy from JWT sub claim). When
+    empty, files are server-global — the 128-bit file ID is the sole
+    access control."""
+    file_upload_disable_listing: bool = FileUploadConfig.disable_listing
+    """When True, `GET /v1/files` (list) returns 404. Individual file
+    operations via known ID still work. Removes the enumeration surface
+    for capability-only deployments."""
 
     @classmethod
     def _customize_cli_kwargs(

--- a/vllm/entrypoints/openai/files/__init__.py
+++ b/vllm/entrypoints/openai/files/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/entrypoints/openai/files/api_router.py
+++ b/vllm/entrypoints/openai/files/api_router.py
@@ -3,8 +3,9 @@
 """FastAPI router for /v1/files.
 
 Wired into the app in `api_server.py:build_app` only when
-`FileUploadConfig.enabled` is True. All endpoints return 404 when the
-feature is off, by virtue of the router not being attached at all.
+`FileUploadConfig.enabled` is True. When the feature is off the router
+is still attached, but every handler short-circuits with 501 via
+`_not_configured()` so clients get a clear "not implemented" signal.
 """
 
 from __future__ import annotations

--- a/vllm/entrypoints/openai/files/api_router.py
+++ b/vllm/entrypoints/openai/files/api_router.py
@@ -200,6 +200,12 @@ def init_files_state(state, args) -> None:
     state.openai_serving_files = OpenAIServingFiles(store, config)
     # Expose the store to MediaConnector so vllm-file:// URLs resolve in
     # chat-completion requests.
+    import atexit
+
     from vllm.entrypoints.openai.files.store import register_store
 
     register_store(store)
+    # Clear the process-wide reference on interpreter shutdown so test
+    # harnesses and `uvicorn --reload` don't leave a stale store (whose
+    # asyncio.Lock is bound to a dead event loop) in module state.
+    atexit.register(register_store, None)

--- a/vllm/entrypoints/openai/files/api_router.py
+++ b/vllm/entrypoints/openai/files/api_router.py
@@ -168,14 +168,21 @@ def attach_router(app: FastAPI) -> None:
     app.include_router(router)
 
 
-def init_files_state(state, args) -> None:
+async def init_files_state(state, args) -> None:
     """Populate app.state.openai_serving_files from CLI args.
 
     Called from api_server.init_app_state when --enable-file-uploads is set.
     Creates the FileUploadConfig, FileUploadStore, and serving handler, and
     attaches both the store and the handler to app.state so downstream
     consumers (MediaConnector, shutdown hooks) can access them.
+
+    Async so that the FileUploadStore's blocking filesystem setup
+    (shutil.rmtree on the upload dir, PID lockfile acquisition) runs in
+    the default thread pool instead of stalling the event loop — the
+    rmtree can take seconds on NFS or large stale upload trees.
     """
+    import asyncio
+
     from vllm.config import FileUploadConfig
     from vllm.entrypoints.openai.files.serving import OpenAIServingFiles
     from vllm.entrypoints.openai.files.store import FileUploadStore
@@ -215,7 +222,11 @@ def init_files_state(state, args) -> None:
         scope_header=args.file_upload_scope_header,
         disable_listing=args.file_upload_disable_listing,
     )
-    store = FileUploadStore(config)
+    # FileUploadStore.__init__ does blocking filesystem I/O (mkdtemp or
+    # rmtree+mkdir+lockfile acquisition). Dispatch it to the default
+    # thread pool so the event loop stays responsive during startup.
+    loop = asyncio.get_running_loop()
+    store = await loop.run_in_executor(None, FileUploadStore, config)
     state.file_upload_store = store
     state.openai_serving_files = OpenAIServingFiles(store, config)
     # Expose the store to MediaConnector so vllm-file:// URLs resolve in

--- a/vllm/entrypoints/openai/files/api_router.py
+++ b/vllm/entrypoints/openai/files/api_router.py
@@ -185,6 +185,26 @@ def init_files_state(state, args) -> None:
         state.file_upload_store = None
         return
 
+    # Reject multi-API-server deployments. Each API server process
+    # holds a separate in-memory upload store and a separate
+    # _GLOBAL_STORE, so an upload handled by process A returns a
+    # vllm-file:// ID that process B cannot resolve. The kernel
+    # load-balances HTTP traffic across API server processes, so
+    # (N-1)/N of subsequent resolve requests would fail.
+    api_count = getattr(args, "api_server_count", None)
+    dp_size = getattr(args, "data_parallel_size", None) or 1
+    effective_api_count = api_count if api_count is not None else dp_size
+    if effective_api_count > 1:
+        raise ValueError(
+            "--enable-file-uploads is not supported with multiple API "
+            f"server processes (detected count={effective_api_count}). "
+            "Each process would hold a separate upload store, so "
+            "vllm-file:// IDs returned by one process would fail to "
+            "resolve on another. Re-run with --api-server-count=1 "
+            "(and --data-parallel-size=1 if set), or deploy behind an "
+            "external sticky-session proxy with per-backend state."
+        )
+
     config = FileUploadConfig(  # type: ignore[call-arg]
         enabled=True,
         dir=args.file_upload_dir,

--- a/vllm/entrypoints/openai/files/api_router.py
+++ b/vllm/entrypoints/openai/files/api_router.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FastAPI router for /v1/files.
+
+Wired into the app in `api_server.py:build_app` only when
+`FileUploadConfig.enabled` is True. All endpoints return 404 when the
+feature is off, by virtue of the router not being attached at all.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from http import HTTPStatus
+from typing import Annotated
+
+from fastapi import APIRouter, FastAPI, File, Form, Request, UploadFile
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.files.serving import OpenAIServingFiles
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+router = APIRouter()
+
+
+def _files(request: Request) -> OpenAIServingFiles | None:
+    return getattr(request.app.state, "openai_serving_files", None)
+
+
+async def _stream_upload_file(upload: UploadFile) -> AsyncIterator[bytes]:
+    """Yield chunks from a FastAPI UploadFile as an async iterator.
+
+    Yields:
+        64 KiB byte chunks until the upload is exhausted.
+    """
+    while True:
+        chunk = await upload.read(64 * 1024)
+        if not chunk:
+            return
+        yield chunk
+
+
+def _not_configured() -> JSONResponse:
+    return JSONResponse(
+        status_code=HTTPStatus.NOT_IMPLEMENTED.value,
+        content={
+            "error": {
+                "message": "File uploads not enabled on this server",
+                "type": "not_implemented_error",
+                "code": HTTPStatus.NOT_IMPLEMENTED.value,
+            }
+        },
+    )
+
+
+def _ok(model) -> JSONResponse:
+    return JSONResponse(content=model.model_dump(exclude_none=True))
+
+
+def _err_response(err: ErrorResponse) -> JSONResponse:
+    return JSONResponse(content=err.model_dump(), status_code=err.error.code)
+
+
+@router.post("/v1/files")
+async def create_file(
+    raw_request: Request,
+    file: Annotated[UploadFile, File()],
+    purpose: Annotated[str, Form()] = "user_data",
+) -> JSONResponse:
+    """Upload a multimodal file and return its capability handle.
+
+    The file is streamed to disk, MIME-validated against the media
+    allowlist (video/*, image/*, audio/*), and registered in the upload
+    store. Reference the returned `id` as `vllm-file://<id>` in a
+    subsequent chat completion.
+
+    Returns:
+        A JSON response with the new `FileObject` (200) or an
+        OpenAI-compatible error envelope (400/413/503).
+    """
+    handler = _files(raw_request)
+    if handler is None:
+        return _not_configured()
+    result = await handler.create_file(
+        raw_request,
+        _stream_upload_file(file),
+        file.filename or "upload.bin",
+        purpose,
+    )
+    if isinstance(result, ErrorResponse):
+        return _err_response(result)
+    return _ok(result)
+
+
+@router.get("/v1/files")
+async def list_files(raw_request: Request) -> JSONResponse:
+    """List files visible to the caller.
+
+    Returns:
+        A JSON `FileList` (200), or an error envelope (400 on missing
+        scope header, 404 when listing is disabled).
+    """
+    handler = _files(raw_request)
+    if handler is None:
+        return _not_configured()
+    result = await handler.list_files(raw_request)
+    if isinstance(result, ErrorResponse):
+        return _err_response(result)
+    return _ok(result)
+
+
+@router.get("/v1/files/{file_id}")
+async def retrieve_file(raw_request: Request, file_id: str) -> JSONResponse:
+    """Return metadata for a single uploaded file.
+
+    Returns:
+        A JSON `FileObject` (200), or an error envelope (404 on
+        unknown id or scope mismatch).
+    """
+    handler = _files(raw_request)
+    if handler is None:
+        return _not_configured()
+    result = await handler.retrieve_file(raw_request, file_id)
+    if isinstance(result, ErrorResponse):
+        return _err_response(result)
+    return _ok(result)
+
+
+@router.get("/v1/files/{file_id}/content")
+async def retrieve_content(raw_request: Request, file_id: str) -> Response:
+    """Stream the raw bytes of an uploaded file.
+
+    Returns:
+        A `StreamingResponse` of the file bytes with the sniffed MIME
+        type as `Content-Type` (200), or a JSON error envelope (404).
+    """
+    handler = _files(raw_request)
+    if handler is None:
+        return _not_configured()
+    result = await handler.retrieve_content(raw_request, file_id)
+    if isinstance(result, ErrorResponse):
+        return _err_response(result)
+    stream, media_type = result
+    return StreamingResponse(stream, media_type=media_type)
+
+
+@router.delete("/v1/files/{file_id}")
+async def delete_file(raw_request: Request, file_id: str) -> JSONResponse:
+    """Delete an uploaded file and its on-disk bytes.
+
+    Returns:
+        A JSON `FileDeleteResponse` (200), or an error envelope (404
+        on unknown id or scope mismatch).
+    """
+    handler = _files(raw_request)
+    if handler is None:
+        return _not_configured()
+    result = await handler.delete_file(raw_request, file_id)
+    if isinstance(result, ErrorResponse):
+        return _err_response(result)
+    return _ok(result)
+
+
+def attach_router(app: FastAPI) -> None:
+    """Mount the `/v1/files` routes on `app`."""
+    app.include_router(router)
+
+
+def init_files_state(state, args) -> None:
+    """Populate app.state.openai_serving_files from CLI args.
+
+    Called from api_server.init_app_state when --enable-file-uploads is set.
+    Creates the FileUploadConfig, FileUploadStore, and serving handler, and
+    attaches both the store and the handler to app.state so downstream
+    consumers (MediaConnector, shutdown hooks) can access them.
+    """
+    from vllm.config import FileUploadConfig
+    from vllm.entrypoints.openai.files.serving import OpenAIServingFiles
+    from vllm.entrypoints.openai.files.store import FileUploadStore
+
+    if not args.enable_file_uploads:
+        state.openai_serving_files = None
+        state.file_upload_store = None
+        return
+
+    config = FileUploadConfig(  # type: ignore[call-arg]
+        enabled=True,
+        dir=args.file_upload_dir,
+        ttl_seconds=args.file_upload_ttl_seconds,
+        max_size_mb=args.file_upload_max_size_mb,
+        max_total_gb=args.file_upload_max_total_gb,
+        max_concurrent=args.file_upload_max_concurrent,
+        scope_header=args.file_upload_scope_header,
+        disable_listing=args.file_upload_disable_listing,
+    )
+    store = FileUploadStore(config)
+    state.file_upload_store = store
+    state.openai_serving_files = OpenAIServingFiles(store, config)
+    # Expose the store to MediaConnector so vllm-file:// URLs resolve in
+    # chat-completion requests.
+    from vllm.entrypoints.openai.files.store import register_store
+
+    register_store(store)

--- a/vllm/entrypoints/openai/files/mime.py
+++ b/vllm/entrypoints/openai/files/mime.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Magic-byte MIME sniffing for uploaded media files.
+
+By default, uses an inline table of signatures for the supported formats
+(mp4/mov, webm/matroska, png, jpeg, gif, webp, wav, mp3). Operators who
+want broader/stricter detection can install `python-magic` — it will be
+used automatically if importable.
+
+This module intentionally has no required dependencies. The allowlist is
+narrow (`video/*`, `image/*`, `audio/*`) because the file store exists
+only to serve multimodal inputs.
+"""
+
+from __future__ import annotations
+
+# Number of head bytes required for the sniffer. All signatures below fit
+# comfortably in the first 16 bytes; 64 gives headroom for future formats.
+SNIFF_HEAD_BYTES = 64
+
+# (offset, expected_bytes, mime_type)
+_FIXED_SIGNATURES: tuple[tuple[int, bytes, str], ...] = (
+    # PNG
+    (0, b"\x89PNG\r\n\x1a\n", "image/png"),
+    # GIF87a / GIF89a
+    (0, b"GIF87a", "image/gif"),
+    (0, b"GIF89a", "image/gif"),
+    # JPEG (SOI marker + any APPn marker)
+    (0, b"\xff\xd8\xff", "image/jpeg"),
+    # Matroska / WebM (EBML header)
+    (0, b"\x1a\x45\xdf\xa3", "video/webm"),
+    # MP3 with ID3v2 tag
+    (0, b"ID3", "audio/mpeg"),
+)
+
+# MPEG-1 Audio Layer III frame sync (11 bits = 0xFFE, followed by layer bits).
+# Accept the common layer-III patterns seen in wild files without ID3 tags.
+_MP3_FRAME_SYNC_PREFIXES: tuple[bytes, ...] = (
+    b"\xff\xfb",
+    b"\xff\xf3",
+    b"\xff\xf2",
+    b"\xff\xfa",
+)
+
+# ISO Base Media Format brands. The atom layout is:
+#   [4 bytes atom size][b"ftyp"][4 bytes major brand]...
+# We check bytes [4:8] == "ftyp" then classify by major brand at [8:12].
+_ISO_VIDEO_BRANDS: frozenset[bytes] = frozenset(
+    {
+        b"isom",
+        b"iso2",
+        b"iso3",
+        b"iso4",
+        b"iso5",
+        b"iso6",
+        b"avc1",
+        b"mp41",
+        b"mp42",
+        b"dash",
+        b"msnv",
+        b"MSNV",
+        b"M4V ",
+        b"M4VH",
+        b"M4VP",
+        b"f4v ",
+        b"3gp4",
+        b"3gp5",
+        b"3gp6",
+        b"3g2a",
+    }
+)
+_ISO_AUDIO_BRANDS: frozenset[bytes] = frozenset(
+    {
+        b"M4A ",
+        b"M4B ",
+        b"M4P ",
+    }
+)
+_ISO_QUICKTIME_BRANDS: frozenset[bytes] = frozenset(
+    {
+        b"qt  ",
+    }
+)
+
+
+def _sniff_riff(head: bytes) -> str | None:
+    """RIFF container — format is determined by bytes [8:12].
+
+    Returns:
+        The MIME type for recognised RIFF subtypes (WEBP/WAVE/AVI),
+        or None when the head isn't a RIFF or the subtype is unknown.
+    """
+    if len(head) < 12 or head[0:4] != b"RIFF":
+        return None
+    subtype = head[8:12]
+    if subtype == b"WEBP":
+        return "image/webp"
+    if subtype == b"WAVE":
+        return "audio/wav"
+    if subtype == b"AVI ":
+        return "video/x-msvideo"
+    return None
+
+
+def _sniff_iso_base_media(head: bytes) -> str | None:
+    """ISO Base Media (mp4, mov, m4a, 3gp). Brand at bytes [8:12].
+
+    Returns:
+        `video/mp4`, `audio/mp4`, or `video/quicktime` for known brands;
+        `video/mp4` as a permissive fallback for unrecognised brands
+        that still have the `ftyp` atom shape; or None when the head
+        isn't an ISO Base Media container at all.
+    """
+    if len(head) < 12 or head[4:8] != b"ftyp":
+        return None
+    brand = head[8:12]
+    if brand in _ISO_VIDEO_BRANDS:
+        return "video/mp4"
+    if brand in _ISO_AUDIO_BRANDS:
+        return "audio/mp4"
+    if brand in _ISO_QUICKTIME_BRANDS:
+        return "video/quicktime"
+    # Unknown brand but still ftyp-shaped — treat as generic mp4 to avoid
+    # rejecting legitimate but rare brands. The allowlist gate below will
+    # still accept it (video/mp4 is in the allowed prefixes).
+    return "video/mp4"
+
+
+def _sniff_inline(head: bytes) -> str | None:
+    for offset, signature, mime in _FIXED_SIGNATURES:
+        if head[offset : offset + len(signature)] == signature:
+            return mime
+    for prefix in _MP3_FRAME_SYNC_PREFIXES:
+        if head.startswith(prefix):
+            return "audio/mpeg"
+    if (m := _sniff_riff(head)) is not None:
+        return m
+    if (m := _sniff_iso_base_media(head)) is not None:
+        return m
+    return None
+
+
+# Optional python-magic upgrade path. If the module is importable we use it
+# for a broader detection range; otherwise we fall back to the inline table.
+try:
+    import magic as _magic  # type: ignore[import-not-found]
+
+    _PYMAGIC: object | None = _magic.Magic(mime=True)
+except Exception:  # pragma: no cover — import side-effect path
+    _PYMAGIC = None
+
+
+def sniff_mime(head: bytes) -> str | None:
+    """Return the sniffed MIME type for the file head bytes.
+
+    Caller passes the first `SNIFF_HEAD_BYTES` bytes (or fewer for tiny
+    files). We do not mutate or retain the input.
+
+    Returns:
+        The sniffed MIME type as a string, or None when the head does
+        not match any supported signature.
+    """
+    # python-magic path (opt-in via pip install)
+    if _PYMAGIC is not None:
+        try:
+            mime = _PYMAGIC.from_buffer(head)  # type: ignore[attr-defined]
+            if isinstance(mime, str) and mime:
+                return mime
+        except Exception:
+            # Fall through to inline detection on any pymagic error.
+            pass
+    return _sniff_inline(head)
+
+
+# MIME-type prefixes that the upload store accepts. The store exists only
+# to serve multimodal inputs to the model, so the allowlist is narrow by
+# design.
+_ALLOWED_PREFIXES: tuple[str, ...] = ("video/", "image/", "audio/")
+
+
+def is_allowed_mime(mime: str | None) -> bool:
+    """Check whether a sniffed MIME type is in the media allowlist.
+
+    Returns:
+        True when `mime` starts with `video/`, `image/`, or `audio/`;
+        False for None, empty string, or any other prefix.
+    """
+    if not mime:
+        return False
+    return any(mime.startswith(p) for p in _ALLOWED_PREFIXES)

--- a/vllm/entrypoints/openai/files/mime.py
+++ b/vllm/entrypoints/openai/files/mime.py
@@ -42,6 +42,30 @@ _MP3_FRAME_SYNC_PREFIXES: tuple[bytes, ...] = (
     b"\xff\xfa",
 )
 
+
+def _is_valid_mp3_frame_header(head: bytes) -> bool:
+    """Validate byte 2 of an MPEG audio frame header.
+
+    Byte 2 layout (MSB→LSB): EEEE FFGH
+      E = bitrate index (4 bits) — 0xF is reserved/invalid
+      F = sample rate index (2 bits) — 0x3 is reserved/invalid
+      G = padding bit
+      H = private bit
+
+    A random binary blob (PDF xref stream, compiled object, encrypted
+    blob) that happens to start with `\\xff\\xfb` (or one of the other
+    2-byte sync prefixes) will match by chance ~1/2048. Rejecting the
+    clearly-invalid bitrate/sample-rate bits cuts the false-positive
+    rate substantially without adding a required dependency.
+    """
+    if len(head) < 3:
+        return False
+    byte2 = head[2]
+    # reserved bitrate index (0xF) and reserved sample rate index (0x3)
+    # both indicate corrupt / non-MPEG data
+    return (byte2 & 0xF0) != 0xF0 and (byte2 & 0x0C) != 0x0C
+
+
 # ISO Base Media Format brands. The atom layout is:
 #   [4 bytes atom size][b"ftyp"][4 bytes major brand]...
 # We check bytes [4:8] == "ftyp" then classify by major brand at [8:12].
@@ -81,6 +105,29 @@ _ISO_QUICKTIME_BRANDS: frozenset[bytes] = frozenset(
         b"qt  ",
     }
 )
+# HEIC / HEIF / AVIF use the ISO-BMFF container with `ftyp` but are
+# images, not videos. Return a dedicated image MIME so they don't slip
+# through as video/mp4 and fail later in a video decoder.
+_ISO_HEIC_BRANDS: frozenset[bytes] = frozenset(
+    {
+        b"heic",
+        b"heix",
+        b"hevc",
+        b"hevx",
+        b"heim",
+        b"heis",
+        b"hevm",
+        b"hevs",
+        b"mif1",
+        b"msf1",
+    }
+)
+_ISO_AVIF_BRANDS: frozenset[bytes] = frozenset(
+    {
+        b"avif",
+        b"avis",
+    }
+)
 
 
 def _sniff_riff(head: bytes) -> str | None:
@@ -103,13 +150,14 @@ def _sniff_riff(head: bytes) -> str | None:
 
 
 def _sniff_iso_base_media(head: bytes) -> str | None:
-    """ISO Base Media (mp4, mov, m4a, 3gp). Brand at bytes [8:12].
+    """ISO Base Media (mp4, mov, m4a, 3gp, heic, avif). Brand at bytes [8:12].
 
     Returns:
-        `video/mp4`, `audio/mp4`, or `video/quicktime` for known brands;
-        `video/mp4` as a permissive fallback for unrecognised brands
-        that still have the `ftyp` atom shape; or None when the head
-        isn't an ISO Base Media container at all.
+        `video/mp4`, `audio/mp4`, `video/quicktime`, `image/heic`, or
+        `image/avif` for known brands; `video/mp4` as a permissive
+        fallback for unrecognised brands that still have the `ftyp`
+        atom shape; or None when the head isn't an ISO Base Media
+        container at all.
     """
     if len(head) < 12 or head[4:8] != b"ftyp":
         return None
@@ -120,6 +168,10 @@ def _sniff_iso_base_media(head: bytes) -> str | None:
         return "audio/mp4"
     if brand in _ISO_QUICKTIME_BRANDS:
         return "video/quicktime"
+    if brand in _ISO_HEIC_BRANDS:
+        return "image/heic"
+    if brand in _ISO_AVIF_BRANDS:
+        return "image/avif"
     # Unknown brand but still ftyp-shaped — treat as generic mp4 to avoid
     # rejecting legitimate but rare brands. The allowlist gate below will
     # still accept it (video/mp4 is in the allowed prefixes).
@@ -131,7 +183,7 @@ def _sniff_inline(head: bytes) -> str | None:
         if head[offset : offset + len(signature)] == signature:
             return mime
     for prefix in _MP3_FRAME_SYNC_PREFIXES:
-        if head.startswith(prefix):
+        if head.startswith(prefix) and _is_valid_mp3_frame_header(head):
             return "audio/mpeg"
     if (m := _sniff_riff(head)) is not None:
         return m

--- a/vllm/entrypoints/openai/files/protocol.py
+++ b/vllm/entrypoints/openai/files/protocol.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pydantic response models for the `/v1/files` endpoint.
+
+Shapes are a conservative subset of OpenAI's Files API — enough to
+satisfy the `openai-python` SDK and LiteLLM's passthrough without
+committing to OpenAI-specific values like `purpose="assistants"`.
+"""
+
+from typing import Literal
+
+from pydantic import Field
+
+from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel
+
+# Allowed `purpose` values for uploads. Matches a conservative subset of
+# OpenAI's Files API. Values like `assistants`, `batch`, and `fine-tune` are
+# specific to OpenAI's hosted services and are rejected here with 400.
+FilePurpose = Literal["vision", "user_data"]
+
+# Valid object statuses. Uploads land as `processed` once the bytes are
+# streamed to disk and MIME-validated.
+FileStatus = Literal["uploaded", "processed", "error"]
+
+
+class FileObject(OpenAIBaseModel):
+    """An uploaded file, shaped to be compatible with OpenAI's Files API.
+
+    The `id` is a 128-bit capability handle (`file-<32 hex>`). Possession of
+    the id implies authority to access the file, subject to scope-header
+    checks when the server is configured with `--file-upload-scope-header`.
+    """
+
+    id: str
+    object: Literal["file"] = "file"
+    bytes: int
+    created_at: int
+    expires_at: int | None = None
+    filename: str
+    purpose: FilePurpose
+    status: FileStatus = "processed"
+    status_details: str | None = None
+
+
+class FileList(OpenAIBaseModel):
+    """Response shape for `GET /v1/files`.
+
+    Returned only when `--file-upload-disable-listing` is NOT set. Scoping
+    (if enabled) filters the returned data to files matching the caller's
+    scope header value.
+    """
+
+    object: Literal["list"] = "list"
+    data: list[FileObject] = Field(default_factory=list)
+
+
+class FileDeleteResponse(OpenAIBaseModel):
+    """Response shape for `DELETE /v1/files/{file_id}`."""
+
+    id: str
+    object: Literal["file"] = "file"
+    deleted: bool = True

--- a/vllm/entrypoints/openai/files/serving.py
+++ b/vllm/entrypoints/openai/files/serving.py
@@ -42,6 +42,12 @@ logger = init_logger(__name__)
 # than the 400 we want.
 _ALLOWED_PURPOSES: frozenset[str] = frozenset({"vision", "user_data"})
 
+# Cap on scope header value length. The scope is retained in memory per
+# FileRecord and included in every audit log line, so an unbounded value
+# is a memory DoS vector. 256 bytes covers realistic gateway-injected
+# identifiers (UUIDs, emails, tenant names) with headroom.
+_SCOPE_MAX_BYTES = 256
+
 
 def _err(status: HTTPStatus, message: str, err_type: str) -> ErrorResponse:
     return ErrorResponse(
@@ -71,27 +77,45 @@ class OpenAIServingFiles:
     ) -> tuple[str | None, ErrorResponse | None]:
         """Read the configured scope header from the request.
 
+        Empty-string and whitespace-only header values are rejected as
+        "missing" — a scope identifier MUST be a non-empty, non-blank
+        string. Scope values are also capped at 256 bytes to prevent
+        memory DoS (every FileRecord and every audit log line retains
+        the scope value).
+
         Returns:
             A `(scope, err)` tuple. `err` is non-None when the scope
-            header is required but absent, in which case the caller
-            should return the error directly. When scoping is disabled
-            server-side, `scope` is always None.
+            header is required but absent/empty/too-long, in which
+            case the caller should return the error directly. When
+            scoping is disabled server-side, `scope` is always None.
         """
         header_name = self._config.scope_header
         if not header_name:
             return None, None
         value = request.headers.get(header_name)
+        if value is not None:
+            value = value.strip()
         if not value:
             return None, _err(
                 HTTPStatus.BAD_REQUEST,
                 f"Scope header {header_name!r} required",
                 "invalid_request_error",
             )
+        if len(value.encode("utf-8")) > _SCOPE_MAX_BYTES:
+            return None, _err(
+                HTTPStatus.BAD_REQUEST,
+                f"Scope header {header_name!r} exceeds {_SCOPE_MAX_BYTES} bytes",
+                "invalid_request_error",
+            )
         return value, None
 
     def _record_to_object(self, record: FileRecord) -> FileObject:
+        # Compute expires_at from created_at (stable per file), matching
+        # OpenAI's Files API semantics. The previous atime-relative
+        # computation made expires_at drift forward on every access,
+        # breaking client caches that assume the value is deterministic.
         if self._ttl_enabled:
-            expires_at = int(record.last_accessed) + self._config.ttl_seconds
+            expires_at = record.created_at + self._config.ttl_seconds
         else:
             expires_at = None
         return FileObject(
@@ -229,22 +253,14 @@ class OpenAIServingFiles:
         scope, err = self._extract_scope(request)
         if err is not None:
             return err
-        record = self._store.get(file_id, scope)
-        if record is None:
-            return _err(
-                HTTPStatus.NOT_FOUND,
-                f"File {file_id!r} not found",
-                "not_found_error",
-            )
         try:
-            stream = await self._store.stream_content(
+            stream, record = await self._store.stream_content(
                 file_id,
                 scope,
                 client_host=self._client_host(request),
                 request_id=self._request_id(request),
             )
         except FileNotFoundError:
-            # Race: file evicted between get() and stream_content().
             return _err(
                 HTTPStatus.NOT_FOUND,
                 f"File {file_id!r} not found",

--- a/vllm/entrypoints/openai/files/serving.py
+++ b/vllm/entrypoints/openai/files/serving.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Business logic for /v1/files.
+
+This layer sits between the FastAPI router and the FileUploadStore. It
+extracts scope/identifying metadata from requests, converts store records
+to wire-format responses, and maps store exceptions to HTTP error
+responses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
+from vllm.entrypoints.openai.files.protocol import (
+    FileDeleteResponse,
+    FileList,
+    FileObject,
+)
+from vllm.entrypoints.openai.files.store import (
+    ConcurrencyLimitExceeded,
+    FileRecord,
+    FileStoreError,
+    FileTooLarge,
+    InvalidMime,
+    QuotaExceeded,
+)
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from fastapi import Request
+
+    from vllm.config import FileUploadConfig
+    from vllm.entrypoints.openai.files.store import FileUploadStore
+
+logger = init_logger(__name__)
+
+# Enforced locally; a Pydantic Literal on the request body would 422 rather
+# than the 400 we want.
+_ALLOWED_PURPOSES: frozenset[str] = frozenset({"vision", "user_data"})
+
+
+def _err(status: HTTPStatus, message: str, err_type: str) -> ErrorResponse:
+    return ErrorResponse(
+        error=ErrorInfo(message=message, type=err_type, code=status.value)
+    )
+
+
+class OpenAIServingFiles:
+    """Handlers for /v1/files/*.
+
+    Holds a reference to the upload store and the relevant config
+    knobs. One instance per server. All instance state is private;
+    the public surface is the async handler methods defined below.
+    """
+
+    def __init__(self, store: FileUploadStore, config: FileUploadConfig) -> None:
+        self._store = store
+        self._config = config
+        self._ttl_enabled = config.ttl_seconds >= 0
+
+    # ------------------------------------------------------------------
+    # scope extraction
+    # ------------------------------------------------------------------
+
+    def _extract_scope(
+        self, request: Request
+    ) -> tuple[str | None, ErrorResponse | None]:
+        """Read the configured scope header from the request.
+
+        Returns:
+            A `(scope, err)` tuple. `err` is non-None when the scope
+            header is required but absent, in which case the caller
+            should return the error directly. When scoping is disabled
+            server-side, `scope` is always None.
+        """
+        header_name = self._config.scope_header
+        if not header_name:
+            return None, None
+        value = request.headers.get(header_name)
+        if not value:
+            return None, _err(
+                HTTPStatus.BAD_REQUEST,
+                f"Scope header {header_name!r} required",
+                "invalid_request_error",
+            )
+        return value, None
+
+    def _record_to_object(self, record: FileRecord) -> FileObject:
+        if self._ttl_enabled:
+            expires_at = int(record.last_accessed) + self._config.ttl_seconds
+        else:
+            expires_at = None
+        return FileObject(
+            id=record.id,
+            bytes=record.bytes,
+            created_at=record.created_at,
+            expires_at=expires_at,
+            filename=record.filename,
+            purpose=record.purpose,
+            status="processed",
+        )
+
+    # ------------------------------------------------------------------
+    # request context
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _client_host(request: Request) -> str | None:
+        client = getattr(request, "client", None)
+        return getattr(client, "host", None) if client is not None else None
+
+    @staticmethod
+    def _request_id(request: Request) -> str | None:
+        return request.headers.get("x-request-id")
+
+    # ------------------------------------------------------------------
+    # handlers
+    # ------------------------------------------------------------------
+
+    async def create_file(
+        self,
+        request: Request,
+        stream: AsyncIterator[bytes],
+        filename: str,
+        purpose: str,
+    ) -> FileObject | ErrorResponse:
+        """Upload a new file. Validates purpose + scope header, streams
+        bytes into the store, and maps store exceptions to HTTP errors.
+
+        Returns:
+            The new `FileObject` on success, or an `ErrorResponse`
+            (400/413/503) mapped from the store's validation failures.
+        """
+        scope, err = self._extract_scope(request)
+        if err is not None:
+            return err
+        if purpose not in _ALLOWED_PURPOSES:
+            return _err(
+                HTTPStatus.BAD_REQUEST,
+                f"purpose must be one of {sorted(_ALLOWED_PURPOSES)}",
+                "invalid_request_error",
+            )
+        try:
+            record = await self._store.create_file(
+                stream=stream,
+                filename=filename,
+                purpose=purpose,  # type: ignore[arg-type]
+                scope=scope,
+                client_host=self._client_host(request),
+                request_id=self._request_id(request),
+            )
+        except ConcurrencyLimitExceeded as e:
+            return _err(
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                str(e),
+                "server_error",
+            )
+        except FileTooLarge as e:
+            return _err(
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                str(e),
+                "invalid_request_error",
+            )
+        except InvalidMime as e:
+            return _err(HTTPStatus.BAD_REQUEST, str(e), "invalid_request_error")
+        except QuotaExceeded as e:
+            return _err(
+                HTTPStatus.INSUFFICIENT_STORAGE,
+                str(e),
+                "server_error",
+            )
+        except FileStoreError as e:
+            return _err(HTTPStatus.INTERNAL_SERVER_ERROR, str(e), "server_error")
+        return self._record_to_object(record)
+
+    async def list_files(self, request: Request) -> FileList | ErrorResponse:
+        """Return files visible under the caller's scope (newest first).
+
+        Returns:
+            A `FileList` of visible files, or an `ErrorResponse` (400
+            on missing scope header, 404 when listing is disabled).
+        """
+        if self._config.disable_listing:
+            return _err(
+                HTTPStatus.NOT_FOUND,
+                "File listing is disabled on this server",
+                "not_found_error",
+            )
+        scope, err = self._extract_scope(request)
+        if err is not None:
+            return err
+        records = self._store.list(scope)
+        return FileList(data=[self._record_to_object(r) for r in records])
+
+    async def retrieve_file(
+        self, request: Request, file_id: str
+    ) -> FileObject | ErrorResponse:
+        """Return metadata for one file, or 404 on scope mismatch.
+
+        Returns:
+            The matching `FileObject`, or an `ErrorResponse` (400/404).
+        """
+        scope, err = self._extract_scope(request)
+        if err is not None:
+            return err
+        record = self._store.get(file_id, scope)
+        if record is None:
+            return _err(
+                HTTPStatus.NOT_FOUND,
+                f"File {file_id!r} not found",
+                "not_found_error",
+            )
+        return self._record_to_object(record)
+
+    async def retrieve_content(
+        self, request: Request, file_id: str
+    ) -> tuple[AsyncIterator[bytes], str] | ErrorResponse:
+        """Return a streaming async iterator of the file bytes plus its
+        sniffed MIME type, or 404 on scope mismatch.
+
+        Returns:
+            A `(stream, mime_type)` tuple on success, or an
+            `ErrorResponse` (400/404).
+        """
+        scope, err = self._extract_scope(request)
+        if err is not None:
+            return err
+        record = self._store.get(file_id, scope)
+        if record is None:
+            return _err(
+                HTTPStatus.NOT_FOUND,
+                f"File {file_id!r} not found",
+                "not_found_error",
+            )
+        try:
+            stream = await self._store.stream_content(
+                file_id,
+                scope,
+                client_host=self._client_host(request),
+                request_id=self._request_id(request),
+            )
+        except FileNotFoundError:
+            # Race: file evicted between get() and stream_content().
+            return _err(
+                HTTPStatus.NOT_FOUND,
+                f"File {file_id!r} not found",
+                "not_found_error",
+            )
+        return stream, record.mime_type
+
+    async def delete_file(
+        self, request: Request, file_id: str
+    ) -> FileDeleteResponse | ErrorResponse:
+        """Remove one file and its on-disk bytes, or 404 on scope mismatch.
+
+        Returns:
+            A `FileDeleteResponse` with `deleted=True` on success, or
+            an `ErrorResponse` (400/404).
+        """
+        scope, err = self._extract_scope(request)
+        if err is not None:
+            return err
+        deleted = await self._store.delete(
+            file_id,
+            scope,
+            client_host=self._client_host(request),
+            request_id=self._request_id(request),
+        )
+        if not deleted:
+            return _err(
+                HTTPStatus.NOT_FOUND,
+                f"File {file_id!r} not found",
+                "not_found_error",
+            )
+        return FileDeleteResponse(id=file_id, deleted=True)

--- a/vllm/entrypoints/openai/files/store.py
+++ b/vllm/entrypoints/openai/files/store.py
@@ -395,12 +395,12 @@ class FileUploadStore:
                             head += chunk[: SNIFF_HEAD_BYTES - len(head)]
                         await loop.run_in_executor(None, out.write, chunk)
             except BaseException:
-                on_disk.unlink(missing_ok=True)
+                await self._unlink_paths([on_disk])
                 raise
 
             mime_type = sniff_mime(head)
             if mime_type is None or not self._is_allowed_mime(mime_type):
-                on_disk.unlink(missing_ok=True)
+                await self._unlink_paths([on_disk])
                 self._audit(
                     "file.reject",
                     file_id=file_id,
@@ -576,7 +576,9 @@ class FileUploadStore:
                         return
                     yield chunk
             finally:
-                fh.close()
+                # Dispatch close to the executor too — close() can block
+                # on a buffer flush / metadata update on slow filesystems.
+                await loop.run_in_executor(None, fh.close)
 
         return _stream()
 
@@ -738,6 +740,11 @@ class FileUploadStore:
         Never holds any store lock — safe to call with `self._lock`
         released. POSIX semantics ensure concurrent open file handles
         remain valid across the unlink.
+
+        Any OSError beyond FileNotFoundError (e.g., permission denied
+        on a ro-mount, EBUSY on Windows) is logged and swallowed —
+        unlinks are best-effort cleanup and an unlink failure should
+        never cascade into a request-handling failure.
         """
         if not paths:
             return
@@ -745,7 +752,10 @@ class FileUploadStore:
 
         def _bulk_unlink() -> None:
             for p in paths:
-                p.unlink(missing_ok=True)
+                try:
+                    p.unlink(missing_ok=True)
+                except OSError as e:
+                    logger.warning("file upload: failed to unlink %s: %s", p, e)
 
         await loop.run_in_executor(None, _bulk_unlink)
 

--- a/vllm/entrypoints/openai/files/store.py
+++ b/vllm/entrypoints/openai/files/store.py
@@ -1,0 +1,744 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""File-backed upload store with TTL + LRU eviction and audit logging.
+
+Backs the `/v1/files` endpoint. Holds metadata in memory (rebuilt on
+server restart) and stores bytes on disk with random sha256 filenames.
+Per the tech-spec's capability-handle model, each file has a 128-bit
+unguessable ID and is scoped by an optional request-header value.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import secrets
+import shutil
+import time
+import unicodedata
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from vllm.entrypoints.openai.files.mime import SNIFF_HEAD_BYTES, sniff_mime
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config import FileUploadConfig
+    from vllm.entrypoints.openai.files.protocol import FilePurpose
+
+logger = init_logger(__name__)
+
+# Background sweeper runs every 5 minutes.
+_SWEEP_INTERVAL_SECONDS = 300
+
+# Streaming write chunk size — large enough to be efficient, small enough
+# that we check quota/size often.
+_CHUNK_BYTES = 64 * 1024
+
+_FILENAME_MAX_LEN = 255
+
+# Type alias for list-of-Path used in eviction/unlink signatures. Defined
+# at module scope so mypy resolves `list` to the builtin, not the
+# `FileUploadStore.list` method which shadows it inside the class body.
+_PathList = list[Path]
+
+
+class FileStoreError(Exception):
+    """Base class for file-store errors surfaced to the API layer."""
+
+
+class FileTooLarge(FileStoreError):
+    """Single upload exceeded max_size_mb."""
+
+
+class QuotaExceeded(FileStoreError):
+    """Upload would exceed max_total_gb even after LRU eviction."""
+
+
+class InvalidMime(FileStoreError):
+    """Sniffed MIME type is not in the allowlist."""
+
+
+class ConcurrencyLimitExceeded(FileStoreError):
+    """More than `max_concurrent` uploads are already in flight."""
+
+
+@dataclass
+class FileRecord:
+    """Internal metadata for one stored file.
+
+    Attributes:
+        id: 128-bit capability handle (`file-<32 hex>`).
+        filename: Sanitized client filename (metadata only; never used
+            as a filesystem path).
+        purpose: Upload purpose (`vision` or `user_data`).
+        mime_type: Sniffed MIME type, narrowed to the media allowlist.
+        bytes: Size on disk.
+        created_at: Upload wall-clock time (unix seconds).
+        last_accessed: atime-style timestamp, touched on every read.
+        scope: Scope header value at upload time, or None.
+        on_disk: Path to the bytes under the upload directory.
+        client_host: Remote host of the uploading client, for audit.
+    """
+
+    id: str
+    filename: str  # sanitized client filename (metadata only)
+    purpose: FilePurpose
+    mime_type: str
+    bytes: int
+    created_at: int
+    last_accessed: float  # monotonic-enough; uses time.time()
+    scope: str | None
+    on_disk: Path
+    # Fields below are NOT logged; they exist only for future retrieval.
+    client_host: str | None = field(default=None, repr=False)
+
+
+def sanitize_filename(raw: str) -> str:
+    """Strip path components, remove control chars, cap length.
+
+    The returned string is metadata only and never becomes part of any
+    filesystem path — but it is echoed back in API responses, so we keep
+    it clean enough to not confuse terminals or leak directory structure.
+
+    Returns:
+        A safe-to-echo filename, at most 255 UTF-8 bytes. Returns
+        `"upload.bin"` when the input collapses to empty after stripping.
+    """
+    # Drop any directory components the client may have prefixed.
+    # os.path.basename handles both separators on either host OS.
+    name = os.path.basename(raw.replace("\\", "/"))
+    # Strip control chars (cat Cc) and C1 range. Preserve ordinary printable
+    # characters including unicode letters and emoji.
+    name = "".join(
+        ch for ch in name if unicodedata.category(ch)[0] != "C" and ch not in "\r\n\t"
+    )
+    # Collapse empty strings — metadata without a filename is fine, but
+    # callers expect a non-empty string. Use a placeholder.
+    if not name:
+        name = "upload.bin"
+    # Byte-length cap (255 is the POSIX NAME_MAX; even though we don't use
+    # this on disk, we cap to keep responses reasonable).
+    encoded = name.encode("utf-8")
+    if len(encoded) > _FILENAME_MAX_LEN:
+        # Truncate on a codepoint boundary.
+        encoded = encoded[:_FILENAME_MAX_LEN]
+        name = encoded.decode("utf-8", errors="ignore")
+    return name
+
+
+def new_file_id() -> str:
+    """Generate a fresh 128-bit random capability handle.
+
+    Returns:
+        An id of the form `file-<32 hex chars>` (37 chars total).
+    """
+    return f"file-{secrets.token_hex(16)}"
+
+
+# Per-process registry so that components outside the FastAPI request cycle
+# (notably MediaConnector, which resolves vllm-file:// URLs during chat
+# completion) can reach the store without threading it through half of
+# chat_utils.py. Set once at startup via register_store().
+_GLOBAL_STORE: FileUploadStore | None = None
+
+
+def register_store(store: FileUploadStore | None) -> None:
+    """Install `store` as the process-wide upload store. Call with None to
+    clear (useful in tests)."""
+    global _GLOBAL_STORE
+    _GLOBAL_STORE = store
+
+
+def get_store() -> FileUploadStore | None:
+    """Return the process-wide upload store.
+
+    Returns:
+        The registered `FileUploadStore`, or None if file uploads are
+        not enabled on this server.
+    """
+    return _GLOBAL_STORE
+
+
+def _now_wall() -> int:
+    return int(time.time())
+
+
+def _iso_now() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class FileUploadStore:
+    """File-backed upload store. One instance per server.
+
+    Metadata lives in memory and is rebuilt on server restart (the
+    upload directory is cleared at construction time). Bytes live on
+    disk under `<dir>/<sha256(file_id)>`, so filesystem names leak
+    neither the capability handle nor the client filename.
+
+    All filesystem writes and unlinks are dispatched to a thread-pool
+    executor so the asyncio event loop stays responsive. Eviction
+    paths (quota LRU, TTL sweep, explicit delete) use a two-phase
+    pattern: metadata is removed under the store lock, then the
+    on-disk bytes are unlinked outside the lock.
+
+    All instance state is private (leading-underscore); the public
+    surface is the methods in the "public API" section below.
+    """
+
+    def __init__(self, config: FileUploadConfig) -> None:
+        self._config = config
+
+        # Resolve upload directory. Empty default = $TMPDIR/vllm-uploads-<pid>.
+        using_default_dir = not config.dir
+        if config.dir:
+            self._dir = Path(config.dir)
+        else:
+            tmp = Path(os.environ.get("TMPDIR", "/tmp"))
+            self._dir = tmp / f"vllm-uploads-{os.getpid()}"
+
+        # Clear on startup — non-persistent across restarts is a security
+        # invariant. Refuse to rmtree a user-supplied directory unless we
+        # previously marked it ourselves, so a typo like `--file-upload-dir /`
+        # never destroys unrelated data.
+        marker = self._dir / ".vllm-upload-store"
+        if self._dir.exists():
+            if using_default_dir or marker.exists():
+                shutil.rmtree(self._dir, ignore_errors=True)
+            else:
+                raise ValueError(
+                    f"Refusing to clear file upload directory {self._dir!r}: "
+                    "it is not marked as managed by vLLM. Point "
+                    "--file-upload-dir at an empty or dedicated path, "
+                    "or at a directory previously initialised by the "
+                    "upload store."
+                )
+        self._dir.mkdir(parents=True, exist_ok=True)
+        # Drop the marker so subsequent restarts can safely re-init.
+        marker.touch(exist_ok=True)
+        if not using_default_dir:
+            logger.info("File upload store using directory %s", self._dir)
+
+        self._records: dict[str, FileRecord] = {}
+        self._lock = asyncio.Lock()
+        self._upload_semaphore = asyncio.Semaphore(config.max_concurrent)
+        self._total_bytes = 0
+        self._sweeper_task: asyncio.Task | None = None
+        self._last_sweep = time.time()
+
+        self._max_size_bytes = config.max_size_mb * 1024 * 1024
+        self._max_total_bytes = config.max_total_gb * 1024 * 1024 * 1024
+        self._ttl_enabled = config.ttl_seconds >= 0
+        self._ttl_seconds = config.ttl_seconds
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Launch the TTL sweeper background task (no-op if TTL disabled)."""
+        if self._ttl_enabled and self._sweeper_task is None:
+            self._sweeper_task = asyncio.create_task(self._sweeper_loop())
+
+    async def shutdown(self) -> None:
+        """Cancel the sweeper and clean up temp directory."""
+        if self._sweeper_task is not None:
+            self._sweeper_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._sweeper_task
+            self._sweeper_task = None
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+
+    async def create_file(
+        self,
+        stream: AsyncIterator[bytes],
+        filename: str,
+        purpose: FilePurpose,
+        scope: str | None,
+        client_host: str | None = None,
+        request_id: str | None = None,
+    ) -> FileRecord:
+        """Stream an upload to disk, validate MIME, register metadata.
+
+        Writes are dispatched to a thread-pool executor per chunk so
+        the asyncio event loop stays responsive under concurrent
+        uploads. LRU eviction is performed in two phases — metadata
+        removal under the store lock, on-disk unlinks outside the lock.
+
+        Returns:
+            The registered `FileRecord` on success.
+
+        Raises:
+            ConcurrencyLimitExceeded: `max_concurrent` uploads are already
+                in flight (fail-fast rather than queue indefinitely).
+            FileTooLarge: Upload exceeds `max_size_mb`.
+            InvalidMime: Sniffed MIME type is not in the media allowlist.
+            QuotaExceeded: Upload alone exceeds `max_total_gb`.
+
+        On any failure the partial temp file is unlinked before the
+        exception propagates, so no on-disk leak occurs.
+        """
+        clean_name = sanitize_filename(filename)
+        await self._maybe_sweep()
+        # Non-blocking acquire — if we're at max_concurrent, reject with
+        # 503 rather than queueing indefinitely (documented contract).
+        if self._upload_semaphore.locked():
+            raise ConcurrencyLimitExceeded(
+                f"too many in-flight uploads "
+                f"(max_concurrent={self._config.max_concurrent})"
+            )
+        async with self._upload_semaphore:
+            file_id = new_file_id()
+            on_disk = self._on_disk_path(file_id)
+            total = 0
+            head = b""
+            loop = asyncio.get_running_loop()
+            try:
+                # `out.write` is run in an executor to keep the event
+                # loop responsive under concurrent uploads; the
+                # containing `open`/`close` is one-shot, not looped.
+                with open(on_disk, "wb") as out:
+                    async for chunk in stream:
+                        if not chunk:
+                            continue
+                        total += len(chunk)
+                        if total > self._max_size_bytes:
+                            raise FileTooLarge(
+                                f"upload exceeds max_size_mb={self._config.max_size_mb}"
+                            )
+                        if len(head) < SNIFF_HEAD_BYTES:
+                            head += chunk[: SNIFF_HEAD_BYTES - len(head)]
+                        await loop.run_in_executor(None, out.write, chunk)
+            except BaseException:
+                on_disk.unlink(missing_ok=True)
+                raise
+
+            mime_type = sniff_mime(head)
+            if mime_type is None or not self._is_allowed_mime(mime_type):
+                on_disk.unlink(missing_ok=True)
+                self._audit(
+                    "file.reject",
+                    file_id=file_id,
+                    bytes=total,
+                    scope=scope,
+                    client_host=client_host,
+                    request_id=request_id,
+                    reason="mime_mismatch",
+                )
+                raise InvalidMime(f"unsupported media type (sniffed={mime_type!r})")
+
+            # Two-phase: snapshot any LRU-eviction paths under the lock,
+            # then unlink them outside the lock (POSIX keeps open file
+            # handles valid across unlink, so concurrent readers are
+            # unaffected).
+            async with self._lock:
+                if total > self._max_total_bytes:
+                    quota_reject = True
+                    evicted_paths: _PathList = []
+                    record = None
+                else:
+                    quota_reject = False
+                    evicted_paths = self._evict_for_quota(total)
+                    record = FileRecord(
+                        id=file_id,
+                        filename=clean_name,
+                        purpose=purpose,
+                        mime_type=mime_type,
+                        bytes=total,
+                        created_at=_now_wall(),
+                        last_accessed=time.time(),
+                        scope=scope,
+                        on_disk=on_disk,
+                        client_host=client_host,
+                    )
+                    self._records[file_id] = record
+                    self._total_bytes += total
+
+            # Unlink outside the lock.
+            await self._unlink_paths(evicted_paths)
+            if quota_reject:
+                await self._unlink_paths([on_disk])
+                self._audit(
+                    "file.reject",
+                    file_id=file_id,
+                    bytes=total,
+                    scope=scope,
+                    client_host=client_host,
+                    request_id=request_id,
+                    reason="quota_full",
+                )
+                raise QuotaExceeded("upload alone exceeds max_total_gb")
+
+            assert record is not None  # quota_reject=False guarantees this
+            self._audit(
+                "file.upload",
+                file_id=file_id,
+                bytes=total,
+                scope=scope,
+                client_host=client_host,
+                request_id=request_id,
+            )
+            return record
+
+    def get(self, file_id: str, scope: str | None) -> FileRecord | None:
+        """Return the record for `file_id` if accessible under `scope`.
+
+        Touches `last_accessed` so active conversations keep their files
+        alive.
+
+        Returns:
+            The matching `FileRecord`, or None when the file doesn't
+            exist OR scope mismatches (capability non-disclosure — we
+            intentionally do not distinguish the two).
+        """
+        record = self._records.get(file_id)
+        if record is None or record.scope != scope:
+            return None
+        record.last_accessed = time.time()
+        return record
+
+    def list(self, scope: str | None) -> list[FileRecord]:
+        """All records visible under `scope`, sorted newest-first.
+
+        Returns:
+            A list of `FileRecord` entries whose scope matches `scope`.
+        """
+        visible = [r for r in self._records.values() if r.scope == scope]
+        visible.sort(key=lambda r: r.created_at, reverse=True)
+        return visible
+
+    async def delete(
+        self,
+        file_id: str,
+        scope: str | None,
+        client_host: str | None = None,
+        request_id: str | None = None,
+    ) -> bool:
+        """Remove a file and its metadata.
+
+        Metadata is removed synchronously under the store lock; the
+        on-disk bytes are unlinked outside the lock via a thread-pool
+        executor so the event loop is never blocked on filesystem I/O.
+
+        Returns:
+            True if the record existed under `scope` and was removed;
+            False otherwise (unknown id or scope mismatch).
+        """
+        async with self._lock:
+            record = self._records.get(file_id)
+            if record is None or record.scope != scope:
+                return False
+            path = self._drop_record_metadata(record)
+        await self._unlink_paths([path])
+        self._audit(
+            "file.delete",
+            file_id=file_id,
+            bytes=record.bytes,
+            scope=scope,
+            client_host=client_host,
+            request_id=request_id,
+        )
+        return True
+
+    async def stream_content(
+        self,
+        file_id: str,
+        scope: str | None,
+        client_host: str | None = None,
+        request_id: str | None = None,
+    ) -> AsyncIterator[bytes]:
+        """Async iterator yielding the file's bytes in 64 KiB chunks.
+
+        The file handle is opened eagerly (before returning the iterator)
+        so that a concurrent eviction between `get()` and the first
+        iteration surfaces as `FileNotFoundError` from this call — the
+        serving layer maps that to 404, avoiding a broken 200 response
+        stream. POSIX keeps the open inode alive across subsequent
+        unlinks, so reads after open are safe.
+
+        Returns:
+            An async iterator over byte chunks from the on-disk file.
+
+        Raises:
+            FileNotFoundError: If `file_id` does not resolve under
+                `scope`, OR the on-disk bytes were evicted between the
+                metadata lookup and the `open()` call.
+        """
+        record = self.get(file_id, scope)
+        if record is None:
+            raise FileNotFoundError(file_id)
+        loop = asyncio.get_running_loop()
+        # Open eagerly so FileNotFoundError fires BEFORE we return an
+        # iterator (i.e. before any 200 response has been streamed).
+        try:
+            fh = await loop.run_in_executor(None, open, record.on_disk, "rb")
+        except FileNotFoundError as e:
+            raise FileNotFoundError(file_id) from e
+        self._audit(
+            "file.retrieve",
+            file_id=file_id,
+            bytes=record.bytes,
+            scope=scope,
+            client_host=client_host,
+            request_id=request_id,
+        )
+
+        async def _stream() -> AsyncIterator[bytes]:
+            try:
+                while True:
+                    chunk = await loop.run_in_executor(None, fh.read, _CHUNK_BYTES)
+                    if not chunk:
+                        return
+                    yield chunk
+            finally:
+                fh.close()
+
+        return _stream()
+
+    def read_bytes(self, file_id: str, scope: str | None) -> bytes | None:
+        """Synchronous whole-file read, scope-enforced.
+
+        Returns:
+            The file bytes, or None on unknown id / scope mismatch OR
+            when the bytes were evicted between the metadata lookup and
+            the disk read (the record's file was unlinked concurrently).
+        """
+        record = self.get(file_id, scope)
+        if record is None:
+            return None
+        try:
+            return record.on_disk.read_bytes()
+        except FileNotFoundError:
+            return None
+
+    async def read_bytes_by_id_async(self, file_id: str) -> bytes | None:
+        """Scope-bypassing async read for `MediaConnector`.
+
+        Split into two phases to avoid cross-thread data races: the
+        metadata lookup (dict read + `last_accessed` mutation) happens
+        on the event-loop thread, and the blocking disk read is
+        dispatched to a thread-pool executor. This keeps `self._records`
+        a single-writer / single-reader structure (event loop only)
+        even when called from a multimodal resolution path that ran in
+        a worker thread prior to this change.
+
+        The 128-bit file ID is the capability handle here — possession
+        implies authority to access. Scope enforcement only applies to
+        the /v1/files CRUD endpoints (where the file_id may be leaked
+        via LIST). The chat-completion layer does not have access to
+        request headers in the current architecture, so we treat the
+        ID as the access control. Touches atime so files referenced
+        in a conversation stay alive.
+
+        Returns:
+            The file bytes, or None if the file does not exist OR was
+            evicted between the metadata lookup and the disk read.
+        """
+        record = self._records.get(file_id)
+        if record is None:
+            return None
+        record.last_accessed = time.time()
+        self._audit(
+            "file.resolve",
+            file_id=file_id,
+            bytes=record.bytes,
+            scope=record.scope,
+            client_host=None,
+            request_id=None,
+        )
+        loop = asyncio.get_running_loop()
+
+        def _read() -> bytes | None:
+            try:
+                return record.on_disk.read_bytes()
+            except FileNotFoundError:
+                return None
+
+        return await loop.run_in_executor(None, _read)
+
+    def read_bytes_by_id(self, file_id: str) -> bytes | None:
+        """Scope-bypassing sync read for `MediaConnector` (sync path only).
+
+        Kept for the synchronous `load_from_url` code path in
+        `MediaConnector` (non-async resolution). Prefer
+        `read_bytes_by_id_async` from async contexts to avoid blocking
+        the event loop on the disk read.
+
+        Returns:
+            The file bytes, or None if the file does not exist OR was
+            evicted between the metadata lookup and the disk read.
+        """
+        record = self._records.get(file_id)
+        if record is None:
+            return None
+        record.last_accessed = time.time()
+        self._audit(
+            "file.resolve",
+            file_id=file_id,
+            bytes=record.bytes,
+            scope=record.scope,
+            client_host=None,
+            request_id=None,
+        )
+        try:
+            return record.on_disk.read_bytes()
+        except FileNotFoundError:
+            return None
+
+    # ------------------------------------------------------------------
+    # internal
+    # ------------------------------------------------------------------
+
+    def _on_disk_path(self, file_id: str) -> Path:
+        # The ID is already random — we just need a stable filesystem name
+        # derived from it. Hashing keeps the on-disk name opaque (doesn't
+        # reveal the file_id) and safe for any filesystem.
+        import hashlib
+
+        digest = hashlib.sha256(file_id.encode()).hexdigest()
+        return self._dir / digest
+
+    def _is_allowed_mime(self, mime: str) -> bool:
+        # Re-implemented here (instead of importing) to keep a single
+        # source of truth with the store's invariants; the mime module's
+        # helper is tested separately.
+        return mime.startswith(("video/", "image/", "audio/"))
+
+    def _evict_for_quota(self, incoming_bytes: int) -> _PathList:
+        """Evict oldest-accessed records until `incoming_bytes` will fit.
+
+        Caller must hold `self._lock` and must pass the returned paths
+        to `_unlink_paths` (outside the lock) to remove the bytes.
+
+        Returns:
+            List of on-disk paths for evicted records. Empty list when
+            no eviction was required.
+        """
+        if self._total_bytes + incoming_bytes <= self._max_total_bytes:
+            return []
+        paths: _PathList = []
+        candidates = sorted(self._records.values(), key=lambda r: r.last_accessed)
+        for rec in candidates:
+            if self._total_bytes + incoming_bytes <= self._max_total_bytes:
+                break
+            paths.append(self._drop_record_metadata(rec))
+            self._audit(
+                "file.delete",
+                file_id=rec.id,
+                bytes=rec.bytes,
+                scope=rec.scope,
+                client_host=None,
+                request_id=None,
+                reason="quota_eviction",
+            )
+        return paths
+
+    def _drop_record_metadata(self, record: FileRecord) -> Path:
+        """Drop in-memory state for `record` and return its on-disk path.
+
+        Caller must hold `self._lock` when calling this and must
+        subsequently pass the returned path to `_unlink_paths` (outside
+        the lock) to actually remove the bytes from disk.
+
+        Returns:
+            The on-disk path that needs to be unlinked.
+        """
+        self._records.pop(record.id, None)
+        self._total_bytes = max(0, self._total_bytes - record.bytes)
+        return record.on_disk
+
+    async def _unlink_paths(self, paths: _PathList) -> None:
+        """Unlink a batch of on-disk files in a thread pool.
+
+        Never holds any store lock — safe to call with `self._lock`
+        released. POSIX semantics ensure concurrent open file handles
+        remain valid across the unlink.
+        """
+        if not paths:
+            return
+        loop = asyncio.get_running_loop()
+
+        def _bulk_unlink() -> None:
+            for p in paths:
+                p.unlink(missing_ok=True)
+
+        await loop.run_in_executor(None, _bulk_unlink)
+
+    async def _sweeper_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(_SWEEP_INTERVAL_SECONDS)
+                await self._sweep_expired()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning("file upload sweeper error: %s", e)
+
+    async def _maybe_sweep(self) -> None:
+        """Opportunistic sweep from create_file, so the store works without
+        a running lifespan-managed sweeper task. Cheap no-op when TTL is
+        disabled or when the last sweep was recent."""
+        if not self._ttl_enabled:
+            return
+        now = time.time()
+        if now - self._last_sweep < _SWEEP_INTERVAL_SECONDS:
+            return
+        self._last_sweep = now
+        await self._sweep_expired()
+
+    async def _sweep_expired(self) -> None:
+        """Drop records whose last-access timestamp is older than the TTL.
+
+        Two-phase: metadata removal happens under the lock, the unlink
+        batch runs outside the lock via a thread pool executor.
+        """
+        if not self._ttl_enabled:
+            return
+        cutoff = time.time() - self._ttl_seconds
+        paths: _PathList = []
+        async with self._lock:
+            expired = [r for r in self._records.values() if r.last_accessed < cutoff]
+            for rec in expired:
+                paths.append(self._drop_record_metadata(rec))
+                self._audit(
+                    "file.delete",
+                    file_id=rec.id,
+                    bytes=rec.bytes,
+                    scope=rec.scope,
+                    client_host=None,
+                    request_id=None,
+                    reason="ttl_expired",
+                )
+        await self._unlink_paths(paths)
+
+    def _audit(
+        self,
+        op: str,
+        *,
+        file_id: str,
+        bytes: int | None,
+        scope: str | None,
+        client_host: str | None,
+        request_id: str | None,
+        reason: str | None = None,
+    ) -> None:
+        payload: dict[str, object] = {
+            "op": op,
+            "file_id": file_id,
+            "bytes": bytes,
+            "scope": scope,
+            "client_host": client_host,
+            "request_id": request_id,
+            "ts": _iso_now(),
+        }
+        if reason is not None:
+            payload["reason"] = reason
+        logger.info(json.dumps(payload))

--- a/vllm/entrypoints/openai/files/store.py
+++ b/vllm/entrypoints/openai/files/store.py
@@ -11,7 +11,6 @@ unguessable ID and is scoped by an optional request-header value.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import os
 import secrets
@@ -33,7 +32,8 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-# Background sweeper runs every 5 minutes.
+# Opportunistic sweep interval: at most once per 5 minutes per store,
+# triggered from create_file (see `_maybe_sweep`). No background task.
 _SWEEP_INTERVAL_SECONDS = 300
 
 # Streaming write chunk size — large enough to be efficient, small enough
@@ -228,30 +228,12 @@ class FileUploadStore:
         self._lock = asyncio.Lock()
         self._upload_semaphore = asyncio.Semaphore(config.max_concurrent)
         self._total_bytes = 0
-        self._sweeper_task: asyncio.Task | None = None
         self._last_sweep = time.time()
 
         self._max_size_bytes = config.max_size_mb * 1024 * 1024
         self._max_total_bytes = config.max_total_gb * 1024 * 1024 * 1024
         self._ttl_enabled = config.ttl_seconds >= 0
         self._ttl_seconds = config.ttl_seconds
-
-    # ------------------------------------------------------------------
-    # lifecycle
-    # ------------------------------------------------------------------
-
-    async def start(self) -> None:
-        """Launch the TTL sweeper background task (no-op if TTL disabled)."""
-        if self._ttl_enabled and self._sweeper_task is None:
-            self._sweeper_task = asyncio.create_task(self._sweeper_loop())
-
-    async def shutdown(self) -> None:
-        """Cancel the sweeper and clean up temp directory."""
-        if self._sweeper_task is not None:
-            self._sweeper_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._sweeper_task
-            self._sweeper_task = None
 
     # ------------------------------------------------------------------
     # public API
@@ -671,16 +653,6 @@ class FileUploadStore:
                 p.unlink(missing_ok=True)
 
         await loop.run_in_executor(None, _bulk_unlink)
-
-    async def _sweeper_loop(self) -> None:
-        while True:
-            try:
-                await asyncio.sleep(_SWEEP_INTERVAL_SECONDS)
-                await self._sweep_expired()
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.warning("file upload sweeper error: %s", e)
 
     async def _maybe_sweep(self) -> None:
         """Opportunistic sweep from create_file, so the store works without

--- a/vllm/entrypoints/openai/files/store.py
+++ b/vllm/entrypoints/openai/files/store.py
@@ -15,6 +15,7 @@ import json
 import os
 import secrets
 import shutil
+import tempfile
 import time
 import unicodedata
 from collections.abc import AsyncIterator
@@ -194,34 +195,58 @@ class FileUploadStore:
     def __init__(self, config: FileUploadConfig) -> None:
         self._config = config
 
-        # Resolve upload directory. Empty default = $TMPDIR/vllm-uploads-<pid>.
+        # Resolve upload directory. Two paths:
+        #   1. No --file-upload-dir: use tempfile.mkdtemp() which enforces
+        #      0o700 permissions, uses a random suffix (no PID-predictable
+        #      path for pre-creation attacks on shared hosts), and creates
+        #      the directory atomically. No rmtree or marker needed.
+        #   2. Operator-supplied dir: acquire a PID lockfile, then apply
+        #      the marker-file safety check before clearing.
         using_default_dir = not config.dir
-        if config.dir:
-            self._dir = Path(config.dir)
+        self._lockfile: Path | None = None
+        if using_default_dir:
+            self._dir = Path(tempfile.mkdtemp(prefix="vllm-uploads-"))
         else:
-            tmp = Path(os.environ.get("TMPDIR", "/tmp"))
-            self._dir = tmp / f"vllm-uploads-{os.getpid()}"
+            self._dir = Path(config.dir)
+            # Acquire a PID lockfile adjacent to the dir BEFORE touching
+            # its contents, so two vLLM processes configured with the
+            # same --file-upload-dir can't race on rmtree + mkdir and
+            # wipe each other's in-memory records. The lockfile lives
+            # next to the dir (not inside) since the dir is cleared.
+            self._lockfile = self._dir.with_name(self._dir.name + ".lock")
+            self._lockfile.parent.mkdir(parents=True, exist_ok=True)
+            self._acquire_dir_lock()
 
-        # Clear on startup — non-persistent across restarts is a security
-        # invariant. Refuse to rmtree a user-supplied directory unless we
-        # previously marked it ourselves, so a typo like `--file-upload-dir /`
-        # never destroys unrelated data.
-        marker = self._dir / ".vllm-upload-store"
-        if self._dir.exists():
-            if using_default_dir or marker.exists():
-                shutil.rmtree(self._dir, ignore_errors=True)
-            else:
-                raise ValueError(
-                    f"Refusing to clear file upload directory {self._dir!r}: "
-                    "it is not marked as managed by vLLM. Point "
-                    "--file-upload-dir at an empty or dedicated path, "
-                    "or at a directory previously initialised by the "
-                    "upload store."
-                )
-        self._dir.mkdir(parents=True, exist_ok=True)
-        # Drop the marker so subsequent restarts can safely re-init.
-        marker.touch(exist_ok=True)
-        if not using_default_dir:
+            # Clear on startup — non-persistent across restarts is a
+            # security invariant. Refuse to rmtree a user-supplied
+            # directory unless we previously marked it ourselves, so a
+            # typo like --file-upload-dir / never destroys unrelated
+            # data. Surface rmtree failures instead of swallowing them.
+            marker = self._dir / ".vllm-upload-store"
+            if self._dir.exists():
+                if marker.exists():
+                    try:
+                        shutil.rmtree(self._dir)
+                    except OSError as e:
+                        self._release_dir_lock()
+                        raise ValueError(
+                            f"Failed to clear file upload directory "
+                            f"{self._dir!r}: {e}. Remove stale files "
+                            f"manually or point --file-upload-dir at a "
+                            f"writable path."
+                        ) from e
+                else:
+                    self._release_dir_lock()
+                    raise ValueError(
+                        f"Refusing to clear file upload directory "
+                        f"{self._dir!r}: it is not marked as managed "
+                        f"by vLLM. Point --file-upload-dir at an empty "
+                        f"or dedicated path, or at a directory "
+                        f"previously initialised by the upload store."
+                    )
+            self._dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            # Drop the marker so subsequent restarts can safely re-init.
+            marker.touch(mode=0o600, exist_ok=True)
             logger.info("File upload store using directory %s", self._dir)
 
         self._records: dict[str, FileRecord] = {}
@@ -234,6 +259,67 @@ class FileUploadStore:
         self._max_total_bytes = config.max_total_gb * 1024 * 1024 * 1024
         self._ttl_enabled = config.ttl_seconds >= 0
         self._ttl_seconds = config.ttl_seconds
+
+    # ------------------------------------------------------------------
+    # directory lock (operator-supplied --file-upload-dir only)
+    # ------------------------------------------------------------------
+
+    def _acquire_dir_lock(self) -> None:
+        """Take exclusive ownership of the upload directory via a PID file.
+
+        On conflict, probe the holder with os.kill(pid, 0). Stale locks
+        (dead PIDs) are reclaimed; live holders raise ValueError.
+        """
+        if self._lockfile is None:
+            return
+        my_pid = os.getpid()
+        while True:
+            try:
+                fd = os.open(
+                    str(self._lockfile),
+                    os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                    0o600,
+                )
+            except FileExistsError:
+                try:
+                    holder = int(self._lockfile.read_text().strip())
+                except (OSError, ValueError):
+                    # Lockfile is corrupt — treat as stale and reclaim.
+                    self._lockfile.unlink(missing_ok=True)
+                    continue
+                if holder == my_pid:
+                    return
+                try:
+                    os.kill(holder, 0)
+                except ProcessLookupError:
+                    # Holder is dead — steal the lock.
+                    self._lockfile.unlink(missing_ok=True)
+                    continue
+                except PermissionError:
+                    # PID exists and is not ours — refuse.
+                    pass
+                raise ValueError(
+                    f"File upload directory {self._dir!r} is locked by "
+                    f"PID {holder}. Another vLLM server is using it. "
+                    f"Stop the other server or use a different "
+                    f"--file-upload-dir."
+                ) from None
+            try:
+                os.write(fd, str(my_pid).encode())
+            finally:
+                os.close(fd)
+            return
+
+    def _release_dir_lock(self) -> None:
+        """Remove the PID lockfile if we own it."""
+        if self._lockfile is None:
+            return
+        try:
+            holder = int(self._lockfile.read_text().strip())
+        except (OSError, ValueError):
+            return
+        if holder == os.getpid():
+            self._lockfile.unlink(missing_ok=True)
 
     # ------------------------------------------------------------------
     # public API
@@ -284,10 +370,19 @@ class FileUploadStore:
             head = b""
             loop = asyncio.get_running_loop()
             try:
+                # Create with 0o600 so only the vLLM process user can
+                # read uploaded bytes, even if the enclosing directory
+                # permissions regress. O_EXCL guards against the
+                # theoretical (but sha256-random) path collision.
                 # `out.write` is run in an executor to keep the event
                 # loop responsive under concurrent uploads; the
                 # containing `open`/`close` is one-shot, not looped.
-                with open(on_disk, "wb") as out:
+                fd = os.open(
+                    on_disk,
+                    os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                    0o600,
+                )
+                with os.fdopen(fd, "wb") as out:
                     async for chunk in stream:
                         if not chunk:
                             continue

--- a/vllm/entrypoints/openai/files/store.py
+++ b/vllm/entrypoints/openai/files/store.py
@@ -355,7 +355,6 @@ class FileUploadStore:
         exception propagates, so no on-disk leak occurs.
         """
         clean_name = sanitize_filename(filename)
-        await self._maybe_sweep()
         # Non-blocking acquire — if we're at max_concurrent, reject with
         # 503 rather than queueing indefinitely (documented contract).
         if self._upload_semaphore.locked():
@@ -363,6 +362,10 @@ class FileUploadStore:
                 f"too many in-flight uploads "
                 f"(max_concurrent={self._config.max_concurrent})"
             )
+        # Run the opportunistic sweep AFTER the concurrency gate so that
+        # rejected callers don't pay the cost of the TTL sweep (which
+        # takes `self._lock` and serialises against concurrent writers).
+        await self._maybe_sweep()
         async with self._upload_semaphore:
             file_id = new_file_id()
             on_disk = self._on_disk_path(file_id)
@@ -531,7 +534,7 @@ class FileUploadStore:
         scope: str | None,
         client_host: str | None = None,
         request_id: str | None = None,
-    ) -> AsyncIterator[bytes]:
+    ) -> tuple[AsyncIterator[bytes], FileRecord]:
         """Async iterator yielding the file's bytes in 64 KiB chunks.
 
         The file handle is opened eagerly (before returning the iterator)
@@ -542,7 +545,10 @@ class FileUploadStore:
         unlinks, so reads after open are safe.
 
         Returns:
-            An async iterator over byte chunks from the on-disk file.
+            A `(stream, record)` tuple. The record is returned so
+            serving-layer callers can read fields like `mime_type`
+            without a second `get()` that would touch `last_accessed`
+            a second time.
 
         Raises:
             FileNotFoundError: If `file_id` does not resolve under
@@ -580,7 +586,7 @@ class FileUploadStore:
                 # on a buffer flush / metadata update on slow filesystems.
                 await loop.run_in_executor(None, fh.close)
 
-        return _stream()
+        return _stream(), record
 
     def read_bytes(self, file_id: str, scope: str | None) -> bytes | None:
         """Synchronous whole-file read, scope-enforced.
@@ -625,14 +631,6 @@ class FileUploadStore:
         if record is None:
             return None
         record.last_accessed = time.time()
-        self._audit(
-            "file.resolve",
-            file_id=file_id,
-            bytes=record.bytes,
-            scope=record.scope,
-            client_host=None,
-            request_id=None,
-        )
         loop = asyncio.get_running_loop()
 
         def _read() -> bytes | None:
@@ -641,7 +639,18 @@ class FileUploadStore:
             except FileNotFoundError:
                 return None
 
-        return await loop.run_in_executor(None, _read)
+        data = await loop.run_in_executor(None, _read)
+        if data is None:
+            return None
+        self._audit(
+            "file.resolve",
+            file_id=file_id,
+            bytes=record.bytes,
+            scope=record.scope,
+            client_host=None,
+            request_id=None,
+        )
+        return data
 
     def read_bytes_by_id(self, file_id: str) -> bytes | None:
         """Scope-bypassing sync read for `MediaConnector` (sync path only).
@@ -659,6 +668,10 @@ class FileUploadStore:
         if record is None:
             return None
         record.last_accessed = time.time()
+        try:
+            data = record.on_disk.read_bytes()
+        except FileNotFoundError:
+            return None
         self._audit(
             "file.resolve",
             file_id=file_id,
@@ -667,10 +680,7 @@ class FileUploadStore:
             client_host=None,
             request_id=None,
         )
-        try:
-            return record.on_disk.read_bytes()
-        except FileNotFoundError:
-            return None
+        return data
 
     # ------------------------------------------------------------------
     # internal

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -272,6 +272,67 @@ class MediaConnector:
 
         return media_io.load_file(filepath)
 
+    @staticmethod
+    def _resolve_vllm_file_id(url_spec: Url) -> tuple[str, object]:
+        """Extract the file id from a `vllm-file://<id>` URL and look up
+        the process-wide upload store.
+
+        Returns:
+            A `(file_id, store)` tuple.
+
+        Raises:
+            RuntimeError: If no upload store is registered on this
+                server (i.e. `--enable-file-uploads` was not set).
+        """
+        # Lazy import — the files package is only loaded when the
+        # upload subsystem is enabled, and we don't want to pay for
+        # it on every media load otherwise.
+        from vllm.entrypoints.openai.files.store import get_store
+
+        store = get_store()
+        if store is None:
+            raise RuntimeError(
+                "vllm-file:// URLs require --enable-file-uploads on the server."
+            )
+
+        file_id = url_spec.netloc or ""
+        if not file_id and url_spec.path:
+            # Some URL parsers may put the netloc into path for custom
+            # schemes. Accept either shape.
+            file_id = url_spec.path.lstrip("/")
+        return file_id, store
+
+    def _load_vllm_file_url(
+        self,
+        url_spec: Url,
+        media_io: MediaIO[_M],
+    ) -> _M:  # type: ignore[type-var]
+        """Sync-path resolver for `vllm-file://<id>` URLs. Use the async
+        variant below when running on the event loop to avoid blocking
+        on the disk read."""
+        file_id, store = self._resolve_vllm_file_id(url_spec)
+        data = store.read_bytes_by_id(file_id)  # type: ignore[attr-defined]
+        if data is None:
+            raise ValueError(f"Unknown vllm-file id: {file_id!r}")
+        return media_io.load_bytes(data)
+
+    async def _load_vllm_file_url_async(
+        self,
+        url_spec: Url,
+        media_io: MediaIO[_M],
+    ) -> _M:  # type: ignore[type-var]
+        """Event-loop-safe resolver for `vllm-file://<id>` URLs.
+
+        Runs the store metadata lookup on the event loop thread (so the
+        store's single-writer invariants hold) and dispatches only the
+        blocking disk read to a thread-pool executor inside the store.
+        """
+        file_id, store = self._resolve_vllm_file_id(url_spec)
+        data = await store.read_bytes_by_id_async(file_id)  # type: ignore[attr-defined]
+        if data is None:
+            raise ValueError(f"Unknown vllm-file id: {file_id!r}")
+        return media_io.load_bytes(data)
+
     def _assert_url_in_allowed_media_domains(self, url_spec: Url) -> None:
         if (
             self.allowed_media_domains
@@ -315,7 +376,10 @@ class MediaConnector:
         if url_spec.scheme == "file":
             return self._load_file_url(url_spec, media_io)
 
-        msg = "The URL must be either a HTTP, data or file URL."
+        if url_spec.scheme == "vllm-file":
+            return self._load_vllm_file_url(url_spec, media_io)
+
+        msg = "The URL must be a HTTP, data, file, or vllm-file URL."
         raise ValueError(msg)
 
     async def load_from_url_async(
@@ -364,7 +428,13 @@ class MediaConnector:
                 global_thread_pool, self._load_file_url, url_spec, media_io
             )
             return await future
-        msg = "The URL must be either a HTTP, data or file URL."
+        if url_spec.scheme == "vllm-file":
+            # Run on the event loop — the store's metadata structures
+            # assume single-threaded access and the async resolver
+            # dispatches the blocking disk read to an executor
+            # internally.
+            return await self._load_vllm_file_url_async(url_spec, media_io)
+        msg = "The URL must be a HTTP, data, file, or vllm-file URL."
         raise ValueError(msg)
 
     def fetch_audio(

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -324,14 +324,19 @@ class MediaConnector:
         """Event-loop-safe resolver for `vllm-file://<id>` URLs.
 
         Runs the store metadata lookup on the event loop thread (so the
-        store's single-writer invariants hold) and dispatches only the
-        blocking disk read to a thread-pool executor inside the store.
+        store's single-writer invariants hold) and dispatches the
+        blocking disk read (inside the store) AND the media decode
+        (via media_io.load_bytes) to the thread pool. Video decoders
+        in particular can block the loop for hundreds of ms to seconds
+        on large clips, matching the pattern used by the http/data/
+        file branches of `load_from_url_async`.
         """
         file_id, store = self._resolve_vllm_file_id(url_spec)
         data = await store.read_bytes_by_id_async(file_id)  # type: ignore[attr-defined]
         if data is None:
             raise ValueError(f"Unknown vllm-file id: {file_id!r}")
-        return media_io.load_bytes(data)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(global_thread_pool, media_io.load_bytes, data)
 
     def _assert_url_in_allowed_media_domains(self, url_spec: Url) -> None:
         if (

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -15,6 +15,7 @@ from urllib.request import url2pathname
 
 import numpy as np
 import numpy.typing as npt
+import regex as re
 import torch
 from PIL import Image, UnidentifiedImageError
 from urllib3.util import Url, parse_url
@@ -39,6 +40,12 @@ global_thread_pool = ThreadPoolExecutor(
 atexit.register(global_thread_pool.shutdown)
 
 MEDIA_CONNECTOR_REGISTRY = ExtensionManager()
+
+# Matches file IDs produced by FileUploadStore.new_file_id(): the literal
+# prefix "file-" followed by exactly 32 lowercase hex characters
+# (secrets.token_hex(16) = 128 bits). Validated on vllm-file:// URL
+# parsing so malformed URLs raise a clear error before hitting the store.
+_VLLM_FILE_ID_RE = re.compile(r"file-[0-9a-f]{32}")
 
 MODALITY_IO_MAP: dict[str, type[MediaIO]] = {
     "audio": AudioMediaIO,
@@ -295,11 +302,21 @@ class MediaConnector:
                 "vllm-file:// URLs require --enable-file-uploads on the server."
             )
 
-        file_id = url_spec.netloc or ""
+        # Prefer `url_spec.host` over `netloc` because netloc includes
+        # `:port` and `user@` segments. `vllm-file://file-abc:80` should
+        # resolve to `file-abc`, not `file-abc:80`. Fall through to
+        # `path` if the parser put the id there instead of netloc.
+        file_id = (url_spec.host or "").strip()
         if not file_id and url_spec.path:
-            # Some URL parsers may put the netloc into path for custom
-            # schemes. Accept either shape.
             file_id = url_spec.path.lstrip("/")
+        # Validate the `file-<32 hex>` shape before the store lookup so
+        # malformed URLs produce a clear error instead of a generic
+        # "Unknown vllm-file id" log line with the garbage value.
+        if not _VLLM_FILE_ID_RE.fullmatch(file_id):
+            raise ValueError(
+                f"Invalid vllm-file:// id: expected 'file-' followed by "
+                f"32 lowercase hex characters, got {file_id!r}"
+            )
         return file_id, store
 
     def _load_vllm_file_url(


### PR DESCRIPTION
## Purpose

Implements the `/v1/files` upload endpoint requested in **RFC issue
#38531**. Lets clients upload multimodal files once (via multipart
form) and reference them in subsequent chat completions through a new
`vllm-file://<id>` URL scheme — an alternative to base64 data URLs
(which inflate payloads and can exceed shell `ARG_MAX` for videos) and
to `file://` URLs (which require the file to already exist on the
server machine). The endpoint is **off by default**; operators
opt in with `--enable-file-uploads`.

Closes #38531.

### Answers to @DarkLight1337's questions

> **Lifecycle:** `--file-upload-ttl-seconds` (default 1h, atime-based
> expiry) + `--file-upload-max-total-gb` quota with LRU eviction
> (default 5 GB). Upload dir is cleared on server startup, so no state
> persists across restarts. Explicit `DELETE /v1/files/{id}` also
> works. Opportunistic sweeper runs inside `create_file` so no
> background task is needed.

> **Security:** Off-by-default + 128-bit capability handles
> (`file-<32 hex>`) + MIME magic-byte allowlist (video/image/audio
> only) + path confinement (sha256 on-disk names, client filename is
> metadata only, 255-byte cap, control chars stripped) + streaming
> size enforcement (no memory spikes) + structured JSON audit log +
> optional `--file-upload-scope-header` for gateway-fronted
> deployments + optional `--file-upload-disable-listing` to remove
> the enumeration surface.

### Design decisions (consensus during implementation)

| # | Question | Decision |
|---|---|---|
| 1 | Scoping model | Server-global by default. Opt-in `--file-upload-scope-header` for gateway-fronted deployments. Scope mismatches return 404, not 403 (capability non-disclosure). |
| 2 | `purpose` enum | `{"vision", "user_data"}`. Rejects OpenAI-specific values (`assistants`, `batch`, `fine-tune`) with 400. |
| 3 | `expires_at` | Default TTL 3600s. `--file-upload-ttl-seconds=-1` disables time-based expiry; `expires_at` is omitted from responses in that mode. Quota LRU still applies. |
| 4 | Streaming download | Always `StreamingResponse` + 64 KiB chunks. No size-based branching. |
| 5 | MIME validation | Inline magic-byte sniffer (no new required dependency). Optionally uses `python-magic` if installed for broader detection. |
| 6 | Config pattern | New `FileUploadConfig` `@config` dataclass, matching vLLM's `CacheConfig`/`LoRAConfig` subsystem pattern. |

### Trust model for `vllm-file://` resolution

`vllm-file://<id>` URLs resolving through `MediaConnector` are
**capability-based**: possession of the 128-bit file ID is the access
control. Scope headers are enforced on the `/v1/files` CRUD endpoints
(which could leak IDs via LIST) but **not** on multimodal resolution —
the chat-completion layer does not receive request headers in the
current architecture. Every resolution emits a `file.resolve` audit
log line, so access remains traceable.

If stricter semantics are desired for a specific deployment, a
follow-up `--file-upload-strict-scope` flag can thread the header
through `MediaConnector` (requires ~15 lines of changes to
`chat_utils.py`).

### Deployment patterns

Works out of the box with the existing OpenAI SDK (`project=` maps to
`OpenAI-Project` header) and standard gateways:

| Deployment | `--file-upload-scope-header` | Notes |
| --- | --- | --- |
| Direct OpenAI SDK client | `OpenAI-Project` | SDK auto-sends from `OPENAI_PROJECT_ID` env or `project=...` client param |
| Apigee (AssignMessage) | `OpenAI-Project` or `X-Consumer-ID` | One-line policy |
| Kong | `X-Consumer-ID` | Native on authenticated routes |
| Envoy / oauth2-proxy | `X-Auth-Request-User` | JWT `sub` claim |

Docs added in this PR:

- `docs/features/multimodal_inputs.md` — new **"Uploading Local Media
  Files"** subsection under Online Serving Video Inputs, with OpenAI
  SDK + curl examples.
- `docs/serving/openai_compatible_server.md` — new **"Files API"**
  section with the endpoint table, all `--file-upload-*` flags with
  defaults, the four gateway deployment patterns, and the full
  security posture.
- `examples/online_serving/openai_file_upload_client.py` — minimal
  runnable example (upload → reference via `vllm-file://<id>` →
  chat completion → delete).

---

## Test Plan

**118 unit + integration tests** across 6 files under
`tests/entrypoints/openai/files/`:

```bash
pytest tests/entrypoints/openai/files/ -v
```

Covers:

- `FileUploadConfig` validation (defaults, size constraints, extra-field rejection)
- MIME magic-byte sniffer (8 supported formats + ELF/PE/HTML/script rejection, pymagic fallback path)
- Store behaviour: streaming upload, 128-bit IDs, path confinement, filename sanitisation, LRU quota eviction, TTL sweep, scope non-disclosure, audit-log schema
- Pydantic protocol models (purpose allowlist, `expires_at` omission)
- Router via FastAPI `TestClient`: full round-trip, scope header enforcement (missing/present/mismatch), `disable_listing`, purpose validation, X-Request-Id propagation, feature-off 404 contract, **concurrency-limit → 503**
- `MediaConnector` `vllm-file://` scheme dispatch (sync + async, scope bypass, unknown-id/unregistered-store errors, atime touching)
- **Concurrency + TOCTOU races**: fail-fast semaphore rejection, concurrent-eviction handling in `read_bytes_by_id`/`read_bytes_by_id_async`, eager open in `stream_content`, eviction-vs-reads invariant, startup refusal to wipe unmarked user directory

**GPU end-to-end** (operator-runnable via the example client added in
this PR):

```bash
# Launch server with the feature enabled
vllm serve allenai/Molmo2-8B --trust-remote-code --max-model-len 6144 \
    --enable-file-uploads --file-upload-max-size-mb 128

# Upload + chat-completion round-trip against a real video
python examples/online_serving/openai_file_upload_client.py path/to/clip.mp4
```

---

## Test Result

**All 118 tests pass** (CPU-only, ~25s on a developer laptop):

```
118 passed, 2 warnings in 28.40s
```

**GPU end-to-end** on RTX 4090 (24 GB) with Molmo2-8B:

```
POST /v1/files (24.5 MiB Seinfeld clip, multipart form)  → 200  149 ms
POST /v1/chat/completions  (video_url=vllm-file://...)   → 200  7421 ms
    2784 prompt tokens, 87 completion tokens
    Model output: "This scene depicts a group of friends walking
    together on a busy city street. The setting is a typical urban
    environment with storefronts, parked cars, and pedestrians going
    about their day. The characters are engaged in conversation as
    they stroll along the sidewalk, with one woman gesturing
    animatedly while the others listen and respond..."
DELETE /v1/files/{id}  → 200  deleted:true
```

This is the exact failure case from #38531 (24 MB video → base64 →
`ARG_MAX` exceeded), now a 149 ms multipart upload.

---

## Self-Review Hardening Pass (post-AI-reviewer feedback)

After addressing the gemini-code-assist and copilot-pull-request-reviewer
comments, a cross-ecosystem sister-review surfaced 20+ additional items
beyond what the AI reviewers caught. Fixed in 7 commits on top of the
original feature:

| Commit | Category |
|---|---|
| `9c7e3c2f9` | Dead code removal (unwired sweeper matching PR body's "no background task" design) |
| `b25ce81b0` | Security: 0o700 dir / 0o600 files / `tempfile.mkdtemp` / PID lockfile / multi-API-server startup guard |
| `c484a6723` | Async correctness: `media_io.load_bytes` → thread pool, executor-dispatched unlinks + close, async `init_files_state` |
| `ec3c32ccd` | Protocol/audit: stable `expires_at`, scope trim+cap, MP3 bit validation, HEIC/AVIF brands, URL regex guard |
| `529d9c582` | +8 tests covering the new security and MIME behaviours |
| `3ba03d6eb` + `aea74571b` | Example expanded to demo full CRUD + multi-turn reuse |

Per-commit details in the commit messages.

**GPU re-validation** on RTX 4090 with Molmo2-8B (patched
`vllm-openai:latest` container carrying all 7 commits):

```
POST /v1/files  (24.5 MiB Seinfeld clip)         → 200   66 ms
POST /v1/chat/completions  (vllm-file://...)     → 200 3974 ms
DELETE /v1/files/{id}                            → 200

expires_at stable across 3 accesses: 1775411599 → 1775411599 → 1775411599
malformed vllm-file://../etc/passwd rejected with clear error
```

## AI-Assisted Contribution Disclosure

This PR was developed with assistance from **Claude (Anthropic)** per
vLLM's [AI Assisted Contributions guide](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions).
The human author reviewed all code changes, ran all 118 tests locally,
and validated the GPU integration end-to-end against Molmo2-8B on a
24 MiB video clip. Commits carry `Co-authored-by: Claude` trailers as
documented in the guide.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR, and link to existing issue (#38531)
- [x] The test plan, including the pytest command
- [x] The test results (all 118 tests passing + GPU end-to-end output)
- [x] Documentation update (user guide + API reference + example client)
- [ ] Release notes update (will add once this PR is close to merge)
</details>

