### PR TITLE
Revert "[IR][RmsNorm] pass None if not has_weight" (#38961)

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -241,12 +241,8 @@ class RMSNorm(CustomOp):
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """PyTorch-native implementation equivalent to forward()."""
         if residual is None:
-            # TODO(luka): address the weight=None passing issue more generally
             return ir.ops.rms_norm(
-                x,
-                self.weight.data if self.has_weight else None,
-                self.variance_epsilon,
-                self.variance_size_override,
+                x, self.weight.data, self.variance_epsilon, self.variance_size_override
             )
 
         return self.forward_static(


### PR DESCRIPTION
## Revert of https://github.com/vllm-project/vllm/pull/38961

**Reason:** This PR is linked to 3 new CI failures in nightly build [#59777](https://buildkite.com/vllm/ci/builds/59777):

- **e2e Core (1 GPU)** — `test_mamba_prefix_cache` crashed with `RuntimeError: Expected weight.dtype() == input.dtype() to be true` in `rms_norm_per_block_quant`
- **LM Eval Qwen3.5 Models (B200)** — Qwen3.5-35B-A3B-FP8-DEP2 server exited unexpectedly during startup
- **LM Eval Small Models (B200)** — Qwen3-Next-FP8-EP2 GSM8K accuracy catastrophically dropped to 0.02 (expected 0.77)

The change to pass `None` when `has_weight` is false in `layernorm.py` appears to cause dtype mismatches in the `rms_norm_per_block_quant` kernel path.

---
Auto-generated by CI failure analyzer.