### PR TITLE
[Perf] Remove per-step KV offload touch, touch once at request_finished

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -92,9 +92,6 @@ class OffloadingConnectorScheduler:
         num_blocks = request.num_tokens // self.offloaded_block_size
 
         assert len(request.block_hashes) // self.block_size_factor == num_blocks
-        block_hashes = self._get_block_hashes(request)
-
-        self.manager.touch(block_hashes)
 
         full_block_tokens = self.offloaded_block_size * num_blocks
         if full_block_tokens - num_computed_tokens < self.offloaded_block_size:
@@ -235,9 +232,6 @@ class OffloadingConnectorScheduler:
                 continue
             block_hashes_to_store = set(store_output.block_hashes_to_store)
 
-            block_hashes = self._get_block_hashes(req, end_idx=num_blocks)
-            self.manager.touch(block_hashes)
-
             new_block_hashes = self._get_block_hashes(
                 req, start_idx=start_block_idx, end_idx=num_blocks
             )
@@ -328,6 +322,13 @@ class OffloadingConnectorScheduler:
         # TODO(orozery): possibly kickoff offload for last block
         # which may have been deferred due to async scheduling
         self._next_stored_block_idx.pop(req_id, None)
+
+        # Touch blocks in prefix order so earlier blocks are most protected
+        # and later blocks evict first (preserving prefix dependency).
+        num_blocks = request.num_tokens // self.offloaded_block_size
+        if num_blocks > 0:
+            block_hashes = self._get_block_hashes(request, end_idx=num_blocks)
+            self.manager.touch(block_hashes)
 
         request_being_stored = req_id in self._reqs_being_stored
         return request_being_stored, None

--- a/vllm/v1/kv_offload/abstract.py
+++ b/vllm/v1/kv_offload/abstract.py
@@ -103,11 +103,12 @@ class OffloadingManager(ABC):
 
     def touch(self, block_hashes: Iterable[BlockHash]):
         """
-        Mark the given blocks as recently used.
-        This could in practice mean moving them to the end of an LRU list.
+        Mark the given blocks as recently used in prefix order.
+        Implementations should process keys in reverse so that the first
+        key (earliest prefix block) ends up as MRU (last to evict).
 
         Args:
-            block_hashes: the hashes identifying the blocks.
+            block_hashes: the hashes identifying the blocks, in prefix order.
         """
         return
 


### PR DESCRIPTION
## Summary
- Remove `manager.touch()` calls from per-step lookup (`get_num_new_matched_tokens`) and per-step store (`_get_reqs_to_store`) to avoid unnecessary overhead — newly stored blocks already have fresh LRU timestamps from insertion.
- Add a single `manager.touch()` call in `request_finished` in prefix order, so earlier prefix blocks (block 1) end up as MRU (most protected) and later blocks evict first, preserving KV cache prefix dependency.
- Update `OffloadingManager.touch()` docstring to clarify the prefix-order contract.

## Test plan
- [x] Unit test: `pytest tests/v1/kv_offload/ -v` (KV cache offloading unit tests)
- [x] E2E test with Llama 3.1 8B

AI assistance was used (Claude). This is not duplicating an existing PR.