### PR TITLE
[Bugfix] Fix broken imports for encoder_cudagraph after partial revert

### DIFF
--- a/tests/v1/cudagraph/test_encoder_cudagraph.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph.py
@@ -14,10 +14,10 @@ from typing import Any
 
 import pytest
 import torch
-from vllm.v1.worker.gpu.mm.encoder_cudagraph import (
+from vllm.v1.worker.encoder_cudagraph import (
     EncoderCudaGraphManager,
 )
-from vllm.v1.worker.gpu.mm.encoder_cudagraph_defs import (
+from vllm.v1.worker.encoder_cudagraph_defs import (
     EncoderCudaGraphCaptureInputs,
     EncoderCudaGraphConfig,
     EncoderCudaGraphReplayBuffers,

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from vllm.multimodal.inputs import MultiModalFeatureSpec
     from vllm.multimodal.registry import _ProcessorFactories
     from vllm.sequence import IntermediateTensors
-    from vllm.v1.worker.gpu.mm.encoder_cudagraph_defs import (
+    from vllm.v1.worker.encoder_cudagraph_defs import (
         EncoderCudaGraphCaptureInputs,
         EncoderCudaGraphConfig,
         EncoderCudaGraphReplayBuffers,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1733,7 +1733,7 @@ class Qwen3VLForConditionalGeneration(
     # -- SupportsEncoderCudaGraph protocol methods --
 
     def get_encoder_cudagraph_config(self):
-        from vllm.v1.worker.gpu.mm.encoder_cudagraph_defs import (
+        from vllm.v1.worker.encoder_cudagraph_defs import (
             EncoderCudaGraphConfig,
         )
 
@@ -1818,7 +1818,7 @@ class Qwen3VLForConditionalGeneration(
         device: torch.device,
         dtype: torch.dtype,
     ):
-        from vllm.v1.worker.gpu.mm.encoder_cudagraph_defs import (
+        from vllm.v1.worker.encoder_cudagraph_defs import (
             EncoderCudaGraphCaptureInputs,
         )
 
@@ -1872,7 +1872,7 @@ class Qwen3VLForConditionalGeneration(
         mm_kwargs: dict[str, Any],
         max_batch_size: int,
     ):
-        from vllm.v1.worker.gpu.mm.encoder_cudagraph_defs import (
+        from vllm.v1.worker.encoder_cudagraph_defs import (
             EncoderCudaGraphReplayBuffers,
         )
 

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -16,7 +16,7 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import SupportsEncoderCudaGraph
 from vllm.model_executor.models.vision import get_load_balance_assignment
-from vllm.v1.worker.gpu.mm.encoder_cudagraph_defs import (
+from vllm.v1.worker.encoder_cudagraph_defs import (
     EncoderCudaGraphConfig,
 )
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -211,7 +211,7 @@ from .utils import (
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
     from vllm.v1.spec_decode.ngram_proposer import NgramProposer
-    from vllm.v1.worker.gpu.mm.encoder_cudagraph import EncoderCudaGraphManager
+    from vllm.v1.worker.encoder_cudagraph import EncoderCudaGraphManager
 
 logger = init_logger(__name__)
 
@@ -5988,7 +5988,7 @@ class GPUModelRunner(
                 SupportsEncoderCudaGraph,
                 supports_encoder_cudagraph,
             )
-            from vllm.v1.worker.gpu.mm.encoder_cudagraph import (
+            from vllm.v1.worker.encoder_cudagraph import (
                 EncoderCudaGraphManager,
             )
 


### PR DESCRIPTION
## Summary

Fixes #38982

PR #38116 relocated `encoder_cudagraph.py` and `encoder_cudagraph_defs.py` into `vllm/v1/worker/gpu/mm/`. PR #38556 then moved them back to `vllm/v1/worker/`, but **9 import statements across 5 files** were not updated and still reference the old `vllm.v1.worker.gpu.mm.encoder_cudagraph[_defs]` path.

This causes a `ModuleNotFoundError` when enabling `cudagraph_mm_encoder`:
```
ModuleNotFoundError: No module named 'vllm.v1.worker.gpu.mm.encoder_cudagraph'
```

## Fix

Updated all stale import paths to point to the correct module locations:

| File | Stale Imports Fixed |
|------|-------------------|
| `vllm/v1/worker/gpu_model_runner.py` | 2 (`TYPE_CHECKING` + runtime) |
| `vllm/model_executor/models/interfaces.py` | 1 (`TYPE_CHECKING`) |
| `vllm/model_executor/models/qwen3_vl.py` | 3 (runtime lazy imports) |
| `vllm/v1/worker/encoder_cudagraph.py` | 1 (self-referencing `_defs`) |
| `tests/v1/cudagraph/test_encoder_cudagraph.py` | 2 (test imports) |

Verified that other `vllm.v1.worker.gpu.mm.*` imports (`encoder_cache`, `encoder_runner`, `rope`) are still valid — those files were not moved.

## Test plan

- [x] `grep -r "vllm.v1.worker.gpu.mm.encoder_cudagraph"` returns zero results after fix
- [ ] `pytest tests/v1/cudagraph/test_encoder_cudagraph.py` passes (requires GPU)
- [ ] `--compilation-config '{"cudagraph_mm_encoder": true}'` no longer raises `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)