### PR TITLE
[Bugfix][MoE] Fix hardcoded SharedExperts output buffer size for DBO ubatches

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -582,6 +582,7 @@ class FusedMoE(CustomOp):
             quant_method=self.quant_method,
             reduce_results=self.reduce_results,
             enable_dbo=self.vllm_config.parallel_config.enable_dbo,
+            num_ubatches=max(self.vllm_config.parallel_config.num_ubatches, 1),
         )
 
     # TODO(bnell): This method is provided as a hook so vllm/lora/layers/fused_moe.py

--- a/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py
@@ -196,6 +196,7 @@ class DefaultMoERunner(MoERunner):
         self.quant_method = quant_method
         self.reduce_results = reduce_results
         self.enable_dbo = enable_dbo
+        self.num_ubatches = num_ubatches
 
         self.shared_experts: SharedExperts | None = None
         if shared_experts is not None:
@@ -266,9 +267,9 @@ class DefaultMoERunner(MoERunner):
 
         moe = self.moe_config
 
-        if self.enable_dbo:
-            states_shape = (2, moe.max_num_tokens, self.moe_config.hidden_dim)
-            logits_shape = (2, moe.max_num_tokens, self.moe_config.num_logical_experts)
+        if self.num_ubatches > 1:
+            states_shape = (self.num_ubatches, moe.max_num_tokens, self.moe_config.hidden_dim)
+            logits_shape = (self.num_ubatches, moe.max_num_tokens, self.moe_config.num_logical_experts)
         else:
             states_shape = (moe.max_num_tokens, self.moe_config.hidden_dim)
             logits_shape = (moe.max_num_tokens, self.moe_config.num_logical_experts)
@@ -668,7 +669,7 @@ class DefaultMoERunner(MoERunner):
         assert orig is not None
         slice_size = end - start
         orig_slice = orig[start:end, :]
-        if self.enable_dbo:
+        if self.num_ubatches > 1:
             assert out_slice.dim() == 3
             batch_buffer_idx = dbo_current_ubatch_id()
             out_slice = out_slice[batch_buffer_idx, :]

--- a/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py
@@ -186,6 +186,7 @@ class DefaultMoERunner(MoERunner):
         quant_method: FusedMoEMethodBase,
         reduce_results: bool,
         enable_dbo: bool,
+        num_ubatches: int = 1,
     ):
         super().__init__()
         self.moe_config = moe_config
@@ -208,7 +209,7 @@ class DefaultMoERunner(MoERunner):
                 # flags derived from the quant_method's MK.
                 reduce_results=reduce_results,
                 quant_method=quant_method,
-                enable_dbo=enable_dbo,
+                num_ubatches=num_ubatches,
             )
 
         # Chunked all2all staging tensor

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -67,9 +67,9 @@ class SharedExperts:
         # The SharedExperts need to handle DBO since they can be called from
         # an MK's finalize method.  We keep a list of outputs indexed by current
         # DBO ubatch id to handle this case.  If DBO is not enabled, the
-        # index is always 0 and the second output list element is ignored.
+        # index is always 0 and only one output slot is needed.
         self.enable_dbo = enable_dbo
-        self._output: list[torch.Tensor | None] = [None, None]
+        self._output: list[torch.Tensor | None] = [None] * (2 if enable_dbo else 1)
         self._layer = layer
         self._moe_config = moe_config
         self._quant_method = quant_method

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -54,7 +54,7 @@ class SharedExperts:
         moe_config: FusedMoEConfig,
         quant_method: QuantizeMethodBase,
         reduce_results: bool,
-        enable_dbo: bool,
+        num_ubatches: int = 1,
     ):
         from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
             FusedMoEMethodBase,
@@ -66,10 +66,10 @@ class SharedExperts:
 
         # The SharedExperts need to handle DBO since they can be called from
         # an MK's finalize method.  We keep a list of outputs indexed by current
-        # DBO ubatch id to handle this case.  If DBO is not enabled, the
+        # DBO ubatch id to handle this case.  If ubatching is not enabled, the
         # index is always 0 and only one output slot is needed.
-        self.enable_dbo = enable_dbo
-        self._output: list[torch.Tensor | None] = [None] * (2 if enable_dbo else 1)
+        self._num_ubatches = num_ubatches
+        self._output: list[torch.Tensor | None] = [None] * self._num_ubatches
         self._layer = layer
         self._moe_config = moe_config
         self._quant_method = quant_method
@@ -177,7 +177,7 @@ class SharedExperts:
 
     @property
     def _output_idx(self) -> int:
-        return dbo_current_ubatch_id() if self.enable_dbo else 0
+        return dbo_current_ubatch_id() if self._num_ubatches > 1 else 0
 
     @property
     def output(self) -> torch.Tensor:


### PR DESCRIPTION
## Summary

  The `SharedExperts` class hardcodes its output buffer to `[None, None]` regardless of the actual number of `ubatches` configured. This mirrors the same bug that was fixed in `WorkspaceManager` in #38853 (cc @yewentao256 and @LucasWilkinson based on similar fix)

# Test plan

- No new tests — this is a one-line buffer sizing fix matching an already-landed pattern (#38853)
- I will however be testing the default non-DBO path to ensure its not affected

[test_moe-smoke-505passed.log](https://github.com/user-attachments/files/26490027/test_moe-smoke-505passed.log)
[test_moe-full-3537passed.log](https://github.com/user-attachments/files/26490028/test_moe-full-3537passed.log)

These were tested against a tiny qwen3-0.6B no DBO. If we need I can test DBO path too