### PR TITLE
[vLLM IR] Cache the fx_replacement to avoid re-tracing the same impl

### DIFF
--- a/vllm/compilation/passes/ir/lowering_pass.py
+++ b/vllm/compilation/passes/ir/lowering_pass.py
@@ -88,6 +88,10 @@ class VllmIRLoweringPass(VllmInductorPass):
             # Use str(shape) because dynamic shapes contain SymInt
             # which is not hashable.
             return (str(val.shape), val.dtype, val.device)
+        if isinstance(val, (list, tuple)):
+            return tuple(VllmIRLoweringPass._make_arg_meta(v) for v in val)
+        if isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+            return str(val)
         return val
 
     def _get_or_trace_replacement(

--- a/vllm/compilation/passes/ir/lowering_pass.py
+++ b/vllm/compilation/passes/ir/lowering_pass.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from typing import Any
 
+import torch
 from torch import fx
 from torch._inductor.pattern_matcher import (
     CallFunctionVarArgs,
     Match,
     PatternMatcherPass,
+    fwd_only,
     register_graph_pattern,
 )
 from torch._ops import OpOverload, OpOverloadPacket
@@ -64,12 +67,52 @@ class VllmIRLoweringPass(VllmInductorPass):
         self.selected_impls: dict[str, dict[str, str]] = defaultdict(lambda: {})
         self.ops = [ir_op.torch_op for ir_op in IrOp.registry.values()]
 
+        # Cache traced replacement graphs to avoid re-tracing the same impl.
+        # Key: (impl_fn, arg_metadata_tuple)
+        # Value: traced GraphModule
+        self._replacement_cache: dict[
+            tuple[Callable, tuple[Any, ...]], fx.GraphModule
+        ] = {}
+
         # Look for any call_function node where the target is a vLLM IR op.
         # Then, lower_matched_op will select, trace, and insert the implementation.
         register_graph_pattern(
             CallFunctionVarArgs(self.ops),
             pass_dict=self.patterns,
         )(self.lower_matched_op)
+
+    @staticmethod
+    def _make_arg_meta(val: Any) -> Any:
+        """Extract hashable metadata from a fake tensor or scalar value."""
+        if isinstance(val, torch.Tensor):
+            # Use str(shape) because dynamic shapes contain SymInt
+            # which is not hashable.
+            return (str(val.shape), val.dtype, val.device)
+        return val
+
+    def _get_or_trace_replacement(
+        self,
+        impl_fn: Callable,
+        example_vals: tuple[Any, ...],
+    ) -> fx.GraphModule:
+        """
+        Return a cached traced replacement graph, or trace and cache a new one.
+        """
+        cache_key = (
+            impl_fn,
+            tuple(self._make_arg_meta(v) for v in example_vals),
+        )
+
+        if cache_key not in self._replacement_cache:
+            replacement = fwd_only(impl_fn, example_vals)
+            self._replacement_cache[cache_key] = replacement
+            logger.debug(
+                "Traced replacement for %s (cache size: %d)",
+                getattr(impl_fn, "__name__", impl_fn),
+                len(self._replacement_cache),
+            )
+
+        return self._replacement_cache[cache_key]
 
     def lower_matched_op(self, match: Match, *args, **kwargs):
         # TODO(luka) I think args and kwargs are for the match, but just use the node?
@@ -87,17 +130,33 @@ class VllmIRLoweringPass(VllmInductorPass):
 
         # replace_by_example wants node args, not the fake tensors
         # TODO(luka): Use aot_export_module to get functionalized graph
-        # TODO(luka): Cache the fx_replacement to avoid re-tracing the same impl
 
         # Defaults not present on node.args but required for replacement tracing
         bound_args = ir_op._py_signature.bind(*node.args)
         bound_args.apply_defaults()
-        match.replace_by_example(ir_op_impl.impl_fn, bound_args.args)
+
+        # Get example values from the node args for tracing
+        example_vals = fx.map_arg(
+            bound_args.args,
+            lambda arg: arg.meta["val"]
+            if "val" in arg.meta
+            else arg.meta["example_value"],
+        )
+
+        # Get or trace the replacement graph (cached)
+        replacement = self._get_or_trace_replacement(
+            ir_op_impl.impl_fn, tuple(example_vals)
+        )
+
+        match.replace_with_graph(replacement, bound_args.args)
 
     @VllmInductorPass.time_and_log
     def __call__(self, graph: fx.Graph) -> None:
         # clear at the beginning instead of end, so that tests can inspect
         self.selected_impls.clear()
+        # Note: _replacement_cache is NOT cleared here. The traced replacement
+        # graph for a given (impl_fn, arg_shapes) is valid across subgraphs,
+        # so we keep it alive for the lifetime of this pass instance.
 
         count = self.patterns.apply(graph)
         logger.debug("VllmIRLoweringPass lowered %d vLLM IR nodes", count)


### PR DESCRIPTION



## Purpose

- Cache the `fwd_only` trace result in `VllmIRLoweringPass` to avoid re-tracing the same `impl_fn` + arg shapes across subgraphs
- Use `match.replace_with_graph` with cached `GraphModule` instead of `match.replace_by_example` which re-traces every time

## Test Plan

```
VLLM_LOGGING_LEVEL=DEBUG vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct
```

## Test Result

Didn't hit cache: 30ms

hit cache: 1.5ms

```
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/passes/vllm_inductor_pass.py:84] NoOpEliminationPass completed in 0.7 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/passes/vllm_inductor_pass.py:84] PostCleanupPass completed in 1.3 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/.../ir/lowering_pass.py:110] Traced replacement for rms_norm (cache size: 1)
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/.../ir/lowering_pass.py:110] Traced replacement for rms_norm (cache size: 2)
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/.../ir/lowering_pass.py:110] Traced replacement for rms_norm (cache size: 3)
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/.../ir/lowering_pass.py:171] VllmIRLoweringPass lowered 3 vLLM IR nodes
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/.../ir/lowering_pass.py:185] Selected implementations: rms_norm=native*3
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/passes/vllm_inductor_pass.py:84] VllmIRLoweringPass completed in 30.9 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/passes/vllm_inductor_pass.py:84] PostCleanupPass completed in 1.7 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/.../utility/fix_functionalization.py:203] De-functionalized 0 nodes, removed 0 nodes
(EngineCore pid=634293) DEBUG 04-05 16:53:12 [compilation/passes/vllm_inductor_pass.py:84] FixFunctionalizationPass completed in 0.2 ms
(APIServer pid=633825) DEBUG 04-05 16:53:13 [v1/engine/utils.py:1122] Waiting for 1 local, 0 remote core engine proc(s) to start.
(EngineCore pid=634293) INFO 04-05 16:53:18 [compilation/backends.py:372] Cache the graph of compile range (1, 2048) for later use
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/backends.py:377] Store the 0-th graph for compile range(1, 2048) from inductor_standalone via handle ('artifact_compile_range_1_2048_subgraph_0', '/root/.cache/vllm/torch_compile_cache/607d5a75c8/rank_0_0/backbone/artifact_compile_range_1_2048_subgraph_0')
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/.../utility/noop_elimination.py:105] Removed 0 no-op reshapes and slices
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/passes/vllm_inductor_pass.py:84] NoOpEliminationPass completed in 0.7 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/passes/vllm_inductor_pass.py:84] PostCleanupPass completed in 1.8 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/.../ir/lowering_pass.py:171] VllmIRLoweringPass lowered 2 vLLM IR nodes
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/.../ir/lowering_pass.py:185] Selected implementations: rms_norm=native*2
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/passes/vllm_inductor_pass.py:84] VllmIRLoweringPass completed in 1.5 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/passes/vllm_inductor_pass.py:84] PostCleanupPass completed in 2.1 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/.../utility/fix_functionalization.py:203] De-functionalized 0 nodes, removed 0 nodes
(EngineCore pid=634293) DEBUG 04-05 16:53:18 [compilation/passes/vllm_inductor_pass.py:84] FixFunctionalizationPass completed in 0.4 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:20 [compilation/backends.py:377] Store the 1-th graph for compile range(1, 2048) from inductor_standalone via handle ('artifact_compile_range_1_2048_subgraph_1', '/root/.cache/vllm/torch_compile_cache/607d5a75c8/rank_0_0/backbone/artifact_compile_range_1_2048_subgraph_1')
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/backends.py:377] Store the 2-th graph for compile range(1, 2048) from inductor_standalone via handle ('artifact_compile_range_1_2048_subgraph_2', '/root/.cache/vllm/torch_compile_cache/607d5a75c8/rank_0_0/backbone/artifact_compile_range_1_2048_subgraph_2')
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/.../utility/noop_elimination.py:105] Removed 0 no-op reshapes and slices
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/passes/vllm_inductor_pass.py:84] NoOpEliminationPass completed in 0.7 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/passes/vllm_inductor_pass.py:84] PostCleanupPass completed in 1.8 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/.../ir/lowering_pass.py:171] VllmIRLoweringPass lowered 2 vLLM IR nodes
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/.../ir/lowering_pass.py:185] Selected implementations: rms_norm=native*2
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/passes/vllm_inductor_pass.py:84] VllmIRLoweringPass completed in 1.4 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/passes/vllm_inductor_pass.py:84] PostCleanupPass completed in 2.1 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/.../utility/fix_functionalization.py:203] De-functionalized 0 nodes, removed 0 nodes
(EngineCore pid=634293) DEBUG 04-05 16:53:21 [compilation/passes/vllm_inductor_pass.py:84] FixFunctionalizationPass completed in 0.2 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:22 [compilation/backends.py:377] Store the 4-th graph for compile range(1, 2048) from inductor_standalone via handle ('artifact_compile_range_1_2048_subgraph_4', '/root/.cache/vllm/torch_compile_cache/607d5a75c8/rank_0_0/backbone/artifact_compile_range_1_2048_subgraph_4')
(APIServer pid=633825) DEBUG 04-05 16:53:23 [v1/engine/utils.py:1122] Waiting for 1 local, 0 remote core engine proc(s) to start.
(EngineCore pid=634293) DEBUG 04-05 16:53:25 [compilation/.../utility/noop_elimination.py:105] Removed 0 no-op reshapes and slices
(EngineCore pid=634293) DEBUG 04-05 16:53:25 [compilation/passes/vllm_inductor_pass.py:84] NoOpEliminationPass completed in 0.7 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:25 [compilation/passes/vllm_inductor_pass.py:84] PostCleanupPass completed in 0.2 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:25 [compilation/.../ir/lowering_pass.py:171] VllmIRLoweringPass lowered 0 vLLM IR nodes
(EngineCore pid=634293) DEBUG 04-05 16:53:25 [compilation/.../ir/lowering_pass.py:185] Selected implementations:
(EngineCore pid=634293) DEBUG 04-05 16:53:25 [compilation/passes/vllm_inductor_pass.py:84] VllmIRLoweringPass completed in 0.4 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:25 [compilation/passes/vllm_inductor_pass.py:84] PostCleanupPass completed in 0.2 ms
(EngineCore pid=634293) DEBUG 04-05 16:53:25 [compilation/.../utility/fix_functionalization.py:203] De-functionalized 0 nodes, removed 0 nodes
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

