### PR TITLE
[Bugfix] Improve DCP/PCP error messages with actionable backend guidance

### DIFF
--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -28,22 +28,22 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     f"supported in {layer_impl.__class__.__name__}."
                 )
             if dcp_size > 1 and not layer_impl.need_to_return_lse_for_decode:
+                impl_name = layer_impl.__class__.__name__
                 raise RuntimeError(
                     f"DCP requires the attention implementation to return "
-                    f"the softmax LSE for decode, but "
-                    f"{layer_impl.__class__.__name__} does not support this. "
-                    f"Try using a compatible backend with "
-                    f"--attention-backend FLASH_ATTN or "
-                    f"--attention-backend FLASHINFER."
+                    f"the softmax LSE for decode, but {impl_name} does not "
+                    f"support this. Please use a different attention backend "
+                    f"via --attention-backend (e.g. FLASH_ATTN or FLASHINFER) "
+                    f"that supports returning softmax LSE for decode."
                 )
 
             if pcp_size > 1 and not layer_impl.supports_pcp:
+                impl_name = layer_impl.__class__.__name__
                 raise RuntimeError(
                     f"PCP requires attention implementation support, but "
-                    f"{layer_impl.__class__.__name__} does not support PCP. "
-                    f"Try using a compatible backend with "
-                    f"--attention-backend FLASH_ATTN or "
-                    f"--attention-backend FLASHINFER."
+                    f"{impl_name} does not support PCP. Please use a "
+                    f"different attention backend via --attention-backend "
+                    f"that supports PCP."
                 )
 
 

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -27,19 +27,23 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "MTP with cp_kv_cache_interleave_size > 1 is not "
                     f"supported in {layer_impl.__class__.__name__}."
                 )
-            if dcp_size > 1:
-                assert layer_impl.need_to_return_lse_for_decode, (
-                    "DCP requires attention impls to return"
-                    " the softmax lse for decode, but the impl "
-                    f"{layer_impl.__class__.__name__} "
-                    "does not return the softmax lse for decode."
+            if dcp_size > 1 and not layer_impl.need_to_return_lse_for_decode:
+                raise RuntimeError(
+                    f"DCP requires the attention implementation to return "
+                    f"the softmax LSE for decode, but "
+                    f"{layer_impl.__class__.__name__} does not support this. "
+                    f"Try using a compatible backend with "
+                    f"--attention-backend FLASH_ATTN or "
+                    f"--attention-backend FLASHINFER."
                 )
 
-            if pcp_size > 1:
-                assert layer_impl.supports_pcp, (
-                    "PCP requires attention impls' support, "
-                    f"but the impl {layer_impl.__class__.__name__} "
-                    "does not support PCP."
+            if pcp_size > 1 and not layer_impl.supports_pcp:
+                raise RuntimeError(
+                    f"PCP requires attention implementation support, but "
+                    f"{layer_impl.__class__.__name__} does not support PCP. "
+                    f"Try using a compatible backend with "
+                    f"--attention-backend FLASH_ATTN or "
+                    f"--attention-backend FLASHINFER."
                 )
 
 


### PR DESCRIPTION
Purpose
Fixes #28407

DCP/PCP assertions give cryptic errors with no guidance on how to fix them. Replaced bare assert with raise RuntimeError and added actionable backend suggestion.

Test Plan
Verified the error message manually. No functional behavior change — only the error message and exception type improved.

Test Result
Before:

AssertionError: DCP requires attention impls to return the softmax lse for decode, but the impl FlashInferImpl does not return the softmax lse for decode.

After:

RuntimeError: DCP requires the attention implementation to return the softmax LSE for decode, but FlashInferImpl does not support this. Try using a compatible backend with --attention-backend FLASH_ATTN or --attention-backend FLASHINFER.

 The purpose of the PR
 The test plan
 The test results