### PR TITLE
[QeRL] Reduce memory usage for wide MoEs via inplace quantization

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1022,22 +1022,17 @@ class Fp8OnlineMoEMethod(Fp8MoEMethod):
 
         # Minimize memory usage by writing quantized values into input buffer;
         # Linear processing guarantees that reads happen before writes
-        w2 = layer.w2_weight.view(dtype=fp8_dtype).view(2, *layer.w2_weight.shape)
-        for expert in range(layer.local_num_experts):
-            w2[0, expert, :, :], w2_scale[expert] = ops.scaled_fp8_quant(
-                layer.w2_weight[expert, :, :]
-            )
-        del layer.w2_weight
-        w2 = w2[0]
-
-        # Process w13 after w2 because w2 is smaller
         w13 = layer.w13_weight.view(dtype=fp8_dtype).view(2, *layer.w13_weight.shape)
+        w2 = layer.w2_weight.view(dtype=fp8_dtype).view(2, *layer.w2_weight.shape)
         for expert in range(layer.local_num_experts):
             w13[0, expert, :, :], w13_scale[expert] = ops.scaled_fp8_quant(
                 layer.w13_weight[expert, :, :]
             )
-        del layer.w13_weight
-        w13 = w13[0]
+            w2[0, expert, :, :], w2_scale[expert] = ops.scaled_fp8_quant(
+                layer.w2_weight[expert, :, :]
+            )
+        del layer.w13_weight, layer.w2_weight
+        w13, w2 = w13[0], w2[0]
 
         # Shuffle weights to runtime format and setup kernel.
         self._setup_kernel(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1011,14 +1011,19 @@ class Fp8OnlineMoEMethod(Fp8MoEMethod):
             return
 
         fp8_dtype = current_platform.fp8_dtype()
-        w13 = torch.empty_like(layer.w13_weight, dtype=fp8_dtype)
-        w2 = torch.empty_like(layer.w2_weight, dtype=fp8_dtype)
+        # w13 = torch.empty_like(layer.w13_weight, dtype=fp8_dtype)
+        # w2 = torch.empty_like(layer.w2_weight, dtype=fp8_dtype)
         w13_scale = torch.ones(
-            layer.num_experts, device=w13.device, dtype=torch.float32
+            layer.num_experts, device=layer.w13_weight.device, dtype=torch.float32
         )
-        w2_scale = torch.ones(layer.num_experts, device=w2.device, dtype=torch.float32)
+        w2_scale = torch.ones(
+            layer.num_experts, device=layer.w2_weight.device, dtype=torch.float32
+        )
         layer.w13_input_scale = None
         layer.w2_input_scale = None
+
+        w13 = layer.w13_weight.view(dtype=fp8_dtype).view(2, *layer.w13_weight.shape)
+        w2 = layer.w2_weight.view(dtype=fp8_dtype).view(2, *layer.w2_weight.shape)
 
         for expert in range(layer.local_num_experts):
             w13[expert, :, :], w13_scale[expert] = ops.scaled_fp8_quant(
@@ -1027,6 +1032,9 @@ class Fp8OnlineMoEMethod(Fp8MoEMethod):
             w2[expert, :, :], w2_scale[expert] = ops.scaled_fp8_quant(
                 layer.w2_weight[expert, :, :]
             )
+
+        w13 = layer.w13_weight[0]
+        w2 = layer.w2_weight[0]
 
         # Shuffle weights to runtime format and setup kernel.
         self._setup_kernel(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1011,30 +1011,33 @@ class Fp8OnlineMoEMethod(Fp8MoEMethod):
             return
 
         fp8_dtype = current_platform.fp8_dtype()
-        # w13 = torch.empty_like(layer.w13_weight, dtype=fp8_dtype)
-        # w2 = torch.empty_like(layer.w2_weight, dtype=fp8_dtype)
-        w13_scale = torch.ones(
+        w13_scale = torch.empty(
             layer.num_experts, device=layer.w13_weight.device, dtype=torch.float32
         )
-        w2_scale = torch.ones(
+        w2_scale = torch.empty(
             layer.num_experts, device=layer.w2_weight.device, dtype=torch.float32
         )
         layer.w13_input_scale = None
         layer.w2_input_scale = None
 
-        w13 = layer.w13_weight.view(dtype=fp8_dtype).view(2, *layer.w13_weight.shape)
+        # Minimize memory usage by writing quantized values into input buffer;
+        # Linear processing guarantees that reads happen before writes
         w2 = layer.w2_weight.view(dtype=fp8_dtype).view(2, *layer.w2_weight.shape)
-
         for expert in range(layer.local_num_experts):
-            w13[expert, :, :], w13_scale[expert] = ops.scaled_fp8_quant(
-                layer.w13_weight[expert, :, :]
-            )
-            w2[expert, :, :], w2_scale[expert] = ops.scaled_fp8_quant(
+            w2[0, expert, :, :], w2_scale[expert] = ops.scaled_fp8_quant(
                 layer.w2_weight[expert, :, :]
             )
+        del layer.w2_weight
+        w2 = w2[0]
 
-        w13 = layer.w13_weight[0]
-        w2 = layer.w2_weight[0]
+        # Process w13 after w2 because w2 is smaller
+        w13 = layer.w13_weight.view(dtype=fp8_dtype).view(2, *layer.w13_weight.shape)
+        for expert in range(layer.local_num_experts):
+            w13[0, expert, :, :], w13_scale[expert] = ops.scaled_fp8_quant(
+                layer.w13_weight[expert, :, :]
+            )
+        del layer.w13_weight
+        w13 = w13[0]
 
         # Shuffle weights to runtime format and setup kernel.
         self._setup_kernel(

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -93,7 +93,7 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     for layer in model.modules():
         info = get_layerwise_info(layer)
 
-        # Skip if the layer has already been initialized (shared tensors)
+        # Skip if the layer has already been initialized
         if info.can_load():
             continue
 

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -93,7 +93,7 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     for layer in model.modules():
         info = get_layerwise_info(layer)
 
-        # Skip if the layer has already been initialized
+        # Skip if the layer has already been initialized (shared tensors)
         if info.can_load():
             continue
 


### PR DESCRIPTION
## Purpose ##
* Modestly reduce memory usage when online-quantizing very large MoEs, especially wide models with many experts

## Changes ##
Previously, we allocated all memory up-front. Ignoring the buffers used to quantize one expert, this led to the following memory usage:
```
W13 + W2 + W13_fp8 + W2_fp8 + W13_fp8 = 1.5 * (W13 + W2)
```
Kimi K2 (1T parameters, W2 = 22.6 Gb/ep_size + 11.3 Gb/ep_size):
```
W13 = 22.6 Gb/ep_size
W2 = 11.3 Gb/ep_size
... = 51 Gb/ep_size
```

Now, the only extra memory required is the buffer used to quantize one expert, which is negligibly small:
```
W13 + W2 + W13_fp8 = 1.0 * (W13 + W2)
```
Kimi K2 (1T parameters, W2 = 22.6 Gb/ep_size + 11.3 Gb/ep_size):
```
W13 = 22.6 Gb/ep_size
W2 = 11.3 Gb/ep_size
... = 34 Gb/ep_size
```

## Testing ##
* Regression online quantize and reload tests pass
* Local testing:
```python3
from vllm import LLM
llm = LLM("inference-optimization/DeepSeek-V3-debug-multiply", quantization="fp8", tensor_parallel_size=2, enable_expert_parallel=True)
llm.generate("3 4 = ")  # 12

llm.collective_rpc("reload_weights", kwargs={"weights_path": "inference-optimization/DeepSeek-V3-debug-add"})
llm.generate("3 4 = ")  # 7
```
