### PR TITLE
fix(reasoning): prevent streaming end-token desync in base and other parsers

### DIFF
--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -110,7 +110,7 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # Check if start token is present in previous or delta.
         # Keep compatibility with models that don't generate start tokens.
         if self.start_token_id in previous_token_ids:
-            if self.end_token_id in delta_token_ids:
+            if self.end_token in delta_text:
                 # start token in previous, end token in delta,
                 # extract reasoning content
                 end_index = delta_text.find(self.end_token)
@@ -119,6 +119,10 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 return DeltaMessage(
                     reasoning=reasoning, content=content if content else None
                 )
+            elif self.end_token_id in delta_token_ids:
+                # end token ID arrived but text is still buffered
+                # (output_text_buffer_length delay); wait for text flush
+                return None
             elif self.end_token_id in previous_token_ids:
                 # start token in previous, end token in previous,
                 # reasoning content continues
@@ -128,7 +132,7 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 # reasoning content continues
                 return DeltaMessage(reasoning=delta_text)
         elif self.start_token_id in delta_token_ids:
-            if self.end_token_id in delta_token_ids:
+            if self.end_token in delta_text and self.start_token in delta_text:
                 # start token in delta, end token in delta,
                 # extract reasoning content
                 start_index = delta_text.find(self.start_token)
@@ -138,6 +142,9 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 return DeltaMessage(
                     reasoning=reasoning, content=content if content else None
                 )
+            elif self.end_token_id in delta_token_ids:
+                # end token ID arrived but text is still buffered; wait
+                return None
             else:
                 # start token in delta, no end token in delta,
                 # reasoning content continues

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -47,7 +47,7 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
             and self.start_token_id not in previous_token_ids
             and self.start_token_id not in delta_token_ids
         ):
-            if self.end_token_id in delta_token_ids:
+            if self.end_token in delta_text:
                 # end token in delta with more tokens,
                 # extract reasoning content and content
                 end_index = delta_text.find(self.end_token)
@@ -57,6 +57,10 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
                     reasoning=reasoning,
                     content=content if content else None,
                 )
+            elif self.end_token_id in delta_token_ids:
+                # end token ID arrived but text is still buffered
+                # (output_text_buffer_length delay); wait for text flush
+                return None
             elif self.end_token_id in previous_token_ids:
                 # end token in previous, thinking content ends
                 return DeltaMessage(content=delta_text)

--- a/vllm/reasoning/ernie45_reasoning_parser.py
+++ b/vllm/reasoning/ernie45_reasoning_parser.py
@@ -87,7 +87,7 @@ class Ernie45ReasoningParser(BaseThinkingReasoningParser):
 
         # No <think> in previous or delta, also need to check for </think>.
         # Because the model may have generated </think> without <think>
-        if self.end_token_id in delta_token_ids:
+        if self.end_token in delta_text:
             # </think> in delta with more tokens,
             # extract reasoning content and content
             think_end_index = delta_text.find(self.end_token)
@@ -104,6 +104,10 @@ class Ernie45ReasoningParser(BaseThinkingReasoningParser):
                 reasoning=reasoning,
                 content=content if content else None,
             )
+        elif self.end_token_id in delta_token_ids:
+            # end token ID arrived but text is still buffered
+            # (output_text_buffer_length delay); wait for text flush
+            return None
         elif self.end_token_id in previous_token_ids:
             # </think> in previous, thinking content ends
             content = delta_text

--- a/vllm/reasoning/step3p5_reasoning_parser.py
+++ b/vllm/reasoning/step3p5_reasoning_parser.py
@@ -140,11 +140,15 @@ class Step3p5ReasoningParser(BaseThinkingReasoningParser):
             self.start_token_id not in previous_token_ids
             and self.start_token_id not in delta_token_ids
         ):
-            if self.end_token_id in delta_token_ids:
+            if self.end_token in delta_text:
                 end_index = delta_text.find(self.end_token)
                 reasoning = delta_text[:end_index]
                 content = delta_text[end_index + len(self.end_token) :]
                 ret = DeltaMessage(reasoning=reasoning, content=content or None)
+            elif self.end_token_id in delta_token_ids:
+                # end token ID arrived but text is still buffered
+                # (output_text_buffer_length delay); wait for text flush
+                return None
             elif self.end_token_id in previous_token_ids:
                 ret = DeltaMessage(content=delta_text)
             else:


### PR DESCRIPTION
## Summary

Fixes text/token-ID desync in streaming reasoning parsers when `stop` sequences are configured. PR #38864 fixed this for Qwen3 only — this PR applies the same fix pattern to:

- **`BaseThinkingReasoningParser`** (basic_parsers.py) — fixes SeedOSS, Gemma4, Step3p5, and Mistral parsers via inheritance
- **`DeepSeekR1ReasoningParser`** — fixes NemotronV3 and DeepSeekV3 via inheritance  
- **`Ernie45ReasoningParser`** — standalone fix
- **`Step3p5ReasoningParser`** — standalone compatibility path fix

### Root cause

When `stop` sequences set `output_text_buffer_length`, visible text is delayed while token IDs arrive immediately. Parsers checked `end_token_id in delta_token_ids` and assumed the end token string was in `delta_text` — but it was still buffered. This caused `delta_text.find(end_token)` to return -1 and misroute the `</think>` tag into content.

### Fix pattern

1. Check `self.end_token in delta_text` first (text-based, resilient to buffering)
2. If `end_token_id` is in `delta_token_ids` but text hasn't arrived yet, return `None` (wait for flush)

Same pattern as #38864 (Qwen3).

### Parsers affected

| Parser | Fix method | Status |
|--------|-----------|--------|
| BaseThinkingReasoningParser | Direct fix | This PR |
| SeedOSSReasoningParser | Inherits base fix | Auto-fixed |
| Gemma4ReasoningParser | Delegates to base | Auto-fixed |
| MistralReasoningParser | Inherits base fix | Auto-fixed |
| DeepSeekR1ReasoningParser | Direct fix | This PR |
| NemotronV3ReasoningParser | Inherits DeepSeek fix | Auto-fixed |
| DeepSeekV3ReasoningParser | Delegates to DeepSeek | Auto-fixed |
| Ernie45ReasoningParser | Direct fix | This PR |
| Step3p5ReasoningParser | Direct fix (compat path) | This PR |
| Qwen3ReasoningParser | Already fixed in #38864 | N/A |

Related: #38789, #38864, #17468

## Test plan

- [ ] Verify streaming reasoning output with `stop` sequences on models using base parser
- [ ] Verify DeepSeek-R1 streaming with stop sequences
- [ ] Verify existing reasoning tests pass