### PR TITLE
[Draft][Experimental][CUDA][VLM] Scaffold AttentionPack-style KV compression path

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -9,9 +9,10 @@ from typing import Annotated, Literal
 import pytest
 from pydantic import Field
 
-from vllm.config import AttentionConfig, CompilationConfig, config
+from vllm.config import AttentionConfig, CacheConfig, CompilationConfig, config
 from vllm.engine.arg_utils import (
     EngineArgs,
+    _validate_kv_compression_compatibility,
     contains_type,
     get_kwargs,
     get_type,
@@ -218,6 +219,39 @@ def test_media_io_kwargs_parser(arg, expected):
         args = parser.parse_args(["--media-io-kwargs", arg])
 
     assert args.media_io_kwargs == expected
+
+
+def test_kv_compression_cli_args_are_registered():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(
+        [
+            "--kv-compression-mode",
+            "attentionpack",
+            "--kv-compression-rank",
+            "16",
+            "--kv-compression-reconstruct-tokens",
+            "32",
+        ]
+    )
+
+    assert args.kv_compression_mode == "attentionpack"
+    assert args.kv_compression_rank == 16
+    assert args.kv_compression_reconstruct_tokens == 32
+
+
+def test_validate_kv_compression_compatibility_rejects_spec_decode(monkeypatch):
+    monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: True)
+    cache_config = CacheConfig(
+        enable_prefix_caching=False,
+        kv_compression_mode="attentionpack",
+        kv_compression_rank=8,
+    )
+
+    with pytest.raises(ValueError, match="speculative decoding"):
+        _validate_kv_compression_compatibility(
+            cache_config,
+            object(),  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 
 from vllm.compilation.backends import VllmBackend
 from vllm.config import (
+    CacheConfig,
     CompilationConfig,
     KernelConfig,
     ModelConfig,
@@ -1122,6 +1123,35 @@ def test_scheduler_config_init():
     with pytest.raises(AttributeError):
         # InitVar does not become an attribute
         print(SchedulerConfig.default_factory().max_model_len)
+
+
+def test_attentionpack_cache_config_requires_rank(monkeypatch):
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    with pytest.raises(ValueError, match="kv_compression_rank must be set"):
+        CacheConfig(
+            enable_prefix_caching=False,
+            kv_compression_mode="attentionpack",
+        )
+
+
+def test_attentionpack_cache_config_rejects_prefix_caching(monkeypatch):
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    with pytest.raises(ValueError, match="does not yet support prefix caching"):
+        CacheConfig(
+            kv_compression_mode="attentionpack",
+            kv_compression_rank=8,
+        )
+
+
+def test_attentionpack_cache_config_rejects_offloading(monkeypatch):
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    with pytest.raises(ValueError, match="does not yet support KV offloading"):
+        CacheConfig(
+            enable_prefix_caching=False,
+            kv_compression_mode="attentionpack",
+            kv_compression_rank=8,
+            kv_offloading_size=1.0,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -37,6 +37,7 @@ from vllm.v1.core.kv_cache_utils import (
     tensor_data,
 )
 from vllm.v1.kv_cache_interface import (
+    AttentionPackFullAttentionSpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -119,6 +120,30 @@ def new_kv_cache_spec(
         page_size_padded=page_size_padded,
         sliding_window=sliding_window,
         attention_chunk_size=attention_chunk_size,
+    )
+
+
+def test_attentionpack_spec_keeps_dense_page_accounting():
+    spec = AttentionPackFullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float32,
+        rank=8,
+        reconstruct_tokens=32,
+    )
+
+    assert spec.uses_dense_storage
+    assert spec.rank == 8
+    assert spec.reconstruct_tokens == 32
+    assert (
+        spec.page_size_bytes
+        == FullAttentionSpec(
+            block_size=16,
+            num_kv_heads=2,
+            head_size=64,
+            dtype=torch.float32,
+        ).page_size_bytes
     )
 
 

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -27,6 +27,7 @@ CacheDType = Literal[
     "int8_per_token_head",
     "fp8_per_token_head",
 ]
+KVCompressionMode = Literal["none", "attentionpack"]
 MambaDType = Literal["auto", "float32", "float16"]
 MambaCacheMode = Literal["all", "align", "none"]
 PrefixCachingHashAlgo = Literal["sha256", "sha256_cbor", "xxhash", "xxhash_cbor"]
@@ -167,6 +168,22 @@ class CacheConfig:
     """The backend to use for KV cache offloading. Supported backends include
     'native' (vLLM native CPU offloading), 'lmcache'.
     KV offloading is only activated when kv_offloading_size is set."""
+    kv_compression_mode: KVCompressionMode = "none"
+    """Experimental KV compression mode.
+
+    - "none": standard dense paged KV cache.
+    - "attentionpack": reserve an AttentionPack-style experimental path.
+      The current implementation only plumbs metadata and keeps dense storage
+      with safe fallback semantics until dedicated kernels land.
+    """
+    kv_compression_rank: int | None = Field(default=None, gt=0)
+    """Rank parameter for experimental low-rank KV compaction modes."""
+    kv_compression_reconstruct_tokens: int = Field(default=64, gt=0)
+    """Upper bound for the number of tokens to reconstruct at higher fidelity
+    in experimental KV compression paths."""
+    kv_compression_safe_fallback: bool = True
+    """Whether unsupported or unsafe experimental compression situations should
+    fall back to dense behavior instead of proceeding aggressively."""
 
     def compute_hash(self) -> str:
         """
@@ -259,7 +276,50 @@ class CacheConfig:
             )
         return cache_dtype
 
+    @model_validator(mode="after")
+    def _validate_kv_compression_config(self) -> "CacheConfig":
+        if self.kv_compression_mode == "none":
+            if self.kv_compression_rank is not None:
+                raise ValueError(
+                    "kv_compression_rank requires kv_compression_mode to be "
+                    "set to 'attentionpack'."
+                )
+            return self
+
+        if self.kv_compression_rank is None:
+            raise ValueError(
+                "kv_compression_rank must be set when kv_compression_mode is "
+                "'attentionpack'."
+            )
+
+        logger.warning(
+            "Experimental KV compression mode '%s' is enabled. The current "
+            "implementation only wires metadata and keeps dense KV storage "
+            "with safe fallback semantics until dedicated kernels land.",
+            self.kv_compression_mode,
+        )
+        return self
+
     def __post_init__(self):
+        if self.kv_compression_mode == "attentionpack":
+            from vllm.platforms import current_platform
+
+            if not current_platform.is_cuda():
+                raise ValueError(
+                    "Experimental AttentionPack KV compression is only "
+                    "supported on NVIDIA CUDA platforms."
+                )
+            if self.enable_prefix_caching:
+                raise ValueError(
+                    "Experimental AttentionPack KV compression does not yet "
+                    "support prefix caching."
+                )
+            if self.kv_offloading_size is not None:
+                raise ValueError(
+                    "Experimental AttentionPack KV compression does not yet "
+                    "support KV offloading."
+                )
+
         if self.enable_mamba_cache_stochastic_rounding:
             from vllm.platforms import current_platform
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -64,6 +64,7 @@ from vllm.config import (
 )
 from vllm.config.cache import (
     CacheDType,
+    KVCompressionMode,
     KVOffloadingBackend,
     MambaCacheMode,
     MambaDType,
@@ -370,6 +371,19 @@ def get_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
     return copy.deepcopy(_compute_kwargs(cls))
 
 
+def _validate_kv_compression_compatibility(
+    cache_config: CacheConfig,
+    speculative_config: SpeculativeConfig | None,
+) -> None:
+    if cache_config.kv_compression_mode != "attentionpack":
+        return
+    if speculative_config is not None:
+        raise ValueError(
+            "Experimental AttentionPack KV compression does not yet support "
+            "speculative decoding."
+        )
+
+
 @dataclass
 class EngineArgs:
     """Arguments for vLLM engine."""
@@ -469,6 +483,12 @@ class EngineArgs:
     offload_params: set[str] = get_field(PrefetchOffloadConfig, "offload_params")
     gpu_memory_utilization: float = CacheConfig.gpu_memory_utilization
     kv_cache_memory_bytes: int | None = CacheConfig.kv_cache_memory_bytes
+    kv_compression_mode: KVCompressionMode = CacheConfig.kv_compression_mode
+    kv_compression_rank: int | None = CacheConfig.kv_compression_rank
+    kv_compression_reconstruct_tokens: int = (
+        CacheConfig.kv_compression_reconstruct_tokens
+    )
+    kv_compression_safe_fallback: bool = CacheConfig.kv_compression_safe_fallback
     max_num_batched_tokens: int | None = None
     max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
     max_long_partial_prefills: int = SchedulerConfig.max_long_partial_prefills
@@ -1006,6 +1026,20 @@ class EngineArgs:
             "--kv-cache-memory-bytes", **cache_kwargs["kv_cache_memory_bytes"]
         )
         cache_group.add_argument("--kv-cache-dtype", **cache_kwargs["cache_dtype"])
+        cache_group.add_argument(
+            "--kv-compression-mode", **cache_kwargs["kv_compression_mode"]
+        )
+        cache_group.add_argument(
+            "--kv-compression-rank", **cache_kwargs["kv_compression_rank"]
+        )
+        cache_group.add_argument(
+            "--kv-compression-reconstruct-tokens",
+            **cache_kwargs["kv_compression_reconstruct_tokens"],
+        )
+        cache_group.add_argument(
+            "--kv-compression-safe-fallback",
+            **cache_kwargs["kv_compression_safe_fallback"],
+        )
         cache_group.add_argument(
             "--num-gpu-blocks-override", **cache_kwargs["num_gpu_blocks_override"]
         )
@@ -1603,6 +1637,10 @@ class EngineArgs:
             gpu_memory_utilization=self.gpu_memory_utilization,
             kv_cache_memory_bytes=self.kv_cache_memory_bytes,
             cache_dtype=resolved_cache_dtype,  # type: ignore[arg-type]
+            kv_compression_mode=self.kv_compression_mode,
+            kv_compression_rank=self.kv_compression_rank,
+            kv_compression_reconstruct_tokens=self.kv_compression_reconstruct_tokens,
+            kv_compression_safe_fallback=self.kv_compression_safe_fallback,
             is_attention_free=model_config.is_attention_free,
             num_gpu_blocks_override=self.num_gpu_blocks_override,
             sliding_window=sliding_window,
@@ -1620,6 +1658,7 @@ class EngineArgs:
             kv_offloading_size=self.kv_offloading_size,
             kv_offloading_backend=self.kv_offloading_backend,
         )
+        _validate_kv_compression_compatibility(cache_config, self.speculative_config)
 
         ray_runtime_env = None
         if is_ray_initialized():

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -35,6 +35,7 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.kv_cache_interface import (
+    AttentionPackFullAttentionSpec,
     FullAttentionSpec,
     KVCacheSpec,
     SlidingWindowSpec,
@@ -544,6 +545,11 @@ class Attention(nn.Module, AttentionLayerBase):
         assert self.attn_type == AttentionType.DECODER
         quant_mode = get_kv_quant_mode(self.kv_cache_dtype)
         if self.sliding_window is not None:
+            if vllm_config.cache_config.kv_compression_mode == "attentionpack":
+                raise NotImplementedError(
+                    "Experimental AttentionPack KV compression does not yet "
+                    "support sliding-window attention."
+                )
             assert not vllm_config.model_config.use_mla, (
                 "MLA is not supported for slidingwindow"
             )
@@ -556,6 +562,18 @@ class Attention(nn.Module, AttentionLayerBase):
                 sliding_window=self.sliding_window,
             )
         else:
+            if vllm_config.cache_config.kv_compression_mode == "attentionpack":
+                return AttentionPackFullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=self.num_kv_heads,
+                    head_size=self.head_size,
+                    head_size_v=self.head_size_v,
+                    dtype=self.kv_cache_torch_dtype,
+                    kv_quant_mode=quant_mode,
+                    rank=vllm_config.cache_config.kv_compression_rank,
+                    reconstruct_tokens=vllm_config.cache_config.kv_compression_reconstruct_tokens,
+                    safe_fallback=vllm_config.cache_config.kv_compression_safe_fallback,
+                )
             return FullAttentionSpec(
                 block_size=block_size,
                 num_kv_heads=self.num_kv_heads,

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -246,6 +246,25 @@ class FullAttentionSpec(AttentionSpec):
 
 
 @dataclass(frozen=True, kw_only=True)
+class AttentionPackFullAttentionSpec(FullAttentionSpec):
+    """Experimental AttentionPack-style KV metadata.
+
+    This spec intentionally inherits the dense page-size accounting from
+    ``FullAttentionSpec`` for now. That keeps allocation and runtime behavior
+    identical to the baseline dense KV path while letting the rest of the
+    stack carry compression metadata in a type-safe way.
+    """
+
+    rank: int
+    reconstruct_tokens: int
+    safe_fallback: bool = True
+
+    @property
+    def uses_dense_storage(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True, kw_only=True)
 class MLAAttentionSpec(FullAttentionSpec):
     # TODO(Lucas/Chen): less hacky way to do this
     cache_dtype_str: str | None = None


### PR DESCRIPTION
## Summary

This draft PR adds the initial scaffold for an AttentionPack-style KV compression path in vLLM for long-context VLM workloads on CUDA.

Current scope:
- experimental KV compression config / CLI
- early validation for unsupported combinations
- an experimental KV spec carrying compression metadata
- dense fallback behavior for correctness

This PR does not include low-rank KV write kernels or attention-aware decompression yet.

## Not Duplicate Work

I checked open vLLM PRs before preparing this draft.

There is nearby work on KV cache quantization/compression (for example TurboQuant-related PRs), but this PR is different in scope:
- it targets an AttentionPack-style low-rank KV compaction path
- it is focused on long-context VLM use cases
- this draft only adds the scaffold and guardrails

## Limitations

Not supported yet:
- prefix caching
- KV offloading
- speculative decoding
- non-CUDA platforms

## Tests

```bash
.venv/bin/python -m pytest tests/engine/test_arg_utils.py -q -k "kv_compression"
.venv/bin/python -m pytest tests/test_config.py -q -k "attentionpack"
.venv/bin/python -m pytest tests/v1/core/test_kv_cache_utils.py -q -k "attentionpack_spec"
```

All targeted tests passed.


