### PR TITLE
[Bug] Fix Trtllm Fp8 MoE Weight Shuffle Memory Fragamentation

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -322,20 +322,23 @@ def _shuffle_deepseek_fp8_moe_weights(
     block_k = 128
     num_experts = w13.shape[0]
 
-    w13_shuffled: list[torch.Tensor] = []
-    w2_shuffled: list[torch.Tensor] = []
+    M13, K13 = w13.shape[1], w13.shape[2]
+    M2, K2 = w2.shape[1], w2.shape[2]
+    w13_out = torch.empty(
+        num_experts, K13 // block_k, M13, block_k, dtype=torch.uint8, device=w13.device
+    )
+    w2_out = torch.empty(
+        num_experts, K2 // block_k, M2, block_k, dtype=torch.uint8, device=w2.device
+    )
+
     for i in range(num_experts):
         t13 = shuffle_matrix_a(w13[i].view(torch.uint8), epilogue_tile_m)
-        t13 = convert_to_block_layout(t13, block_k)
-        w13_shuffled.append(t13)
+        w13_out[i] = convert_to_block_layout(t13, block_k)
 
         t2 = shuffle_matrix_a(w2[i].view(torch.uint8), epilogue_tile_m)
-        t2 = convert_to_block_layout(t2, block_k)
-        w2_shuffled.append(t2)
+        w2_out[i] = convert_to_block_layout(t2, block_k)
 
-    w13_out = torch.stack(w13_shuffled).view(torch.float8_e4m3fn)
-    w2_out = torch.stack(w2_shuffled).view(torch.float8_e4m3fn)
-    return w13_out, w2_out
+    return w13_out.view(torch.float8_e4m3fn), w2_out.view(torch.float8_e4m3fn)
 
 
 def _shuffle_mxfp8_moe_weights(


### PR DESCRIPTION
## Purpose
PR #38993 seems to cause OOM in CI test `tests/quantization/test_blackwell_moe.py::test_deepseek_fp8_block_moe_flashinfer_trtllm` due to fragamented memory allocation:
```

File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/attention/mla_attention.py", line 1025, in unified_mla_attention_with_output
--
(EngineCore pid=7079) ERROR 04-06 03:08:21 [core.py:1108]     layer.forward_impl(
(EngineCore pid=7079) ERROR 04-06 03:08:21 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/attention/mla_attention.py", line 572, in forward_impl
(EngineCore pid=7079) ERROR 04-06 03:08:21 [core.py:1108]     _ = torch.empty(
(EngineCore pid=7079) ERROR 04-06 03:08:21 [core.py:1108]         ^^^^^^^^^^^^
(EngineCore pid=7079) ERROR 04-06 03:08:21 [core.py:1108] torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.00 GiB. GPU 0 has a total capacity of 178.35 GiB of which 1.68 GiB is free. Including non-PyTorch memory, this process has 176.66 GiB memory in use. Of the allocated memory 159.21 GiB is allocated by PyTorch, with 418.00 MiB allocated in private pools (e.g., CUDA Graphs), and 16.57 GiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
```

This PR fixes this by preallocating the whole expert tensor, so it does not need to keep all individual expert tensors alive, which causes fragamentation.

## Test Plan
Check if `tests/quantization/test_blackwell_moe.py::test_deepseek_fp8_block_moe_flashinfer_trtllm` passes in CI.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
