### PR TITLE
Fix Qwen3.5 reasoning tool calls embedded inside think

### DIFF
--- a/docs/design/qwen3_reasoning_tool_call_recovery.md
+++ b/docs/design/qwen3_reasoning_tool_call_recovery.md
@@ -1,0 +1,88 @@
+# Recover Qwen3 XML Tool Calls Emitted Inside `<think>`
+
+## Problem Statement
+
+This change addresses a **parsing compatibility bug** for the following setup:
+
+- `--reasoning-parser qwen3`
+- `--tool-call-parser qwen3_coder`
+
+Qwen3/Qwen3.5 models can emit XML tool-call markup such as:
+
+```text
+<tool_call>
+<function=Finish>
+<parameter=answer>
+204
+</parameter>
+</function>
+</tool_call>
+```
+
+inside the reasoning region delimited by `<think> ... </think>`.
+
+The issue is **not** that vLLM causes the model to generate tool calls inside
+`<think>`. That is model output behavior.
+
+The actual bug is that, when this output happens, vLLM loses the tool call
+during non-streaming parsing.
+
+## Root Cause
+
+In the affected path:
+
+1. `qwen3_reasoning_parser` extracts everything before `</think>` into
+   `reasoning`.
+2. downstream tool parsing inspects only `content`.
+3. any `<tool_call>...</tool_call>` block that remains inside `reasoning`
+   never reaches `qwen3_coder`.
+
+As a result, the OpenAI-compatible response can contain:
+
+- populated `reasoning`
+- empty `tool_calls`
+
+even though the model actually produced a valid XML tool call.
+
+## Minimal Fix
+
+The patch changes only:
+
+- `vllm/reasoning/qwen3_reasoning_parser.py`
+
+During non-streaming reasoning extraction:
+
+1. detect XML tool-call blocks embedded in the extracted reasoning text
+2. remove those blocks from the returned `reasoning`
+3. prepend them to the returned `content`
+
+This allows the existing `qwen3_coder` tool parser to parse them normally,
+without changing the generic OpenAI serving pipeline.
+
+## Why This Is The Right Scope
+
+This patch intentionally fixes **recovery/parsing**, not model generation.
+
+It does not try to force Qwen3.5 models to stop emitting tool calls inside
+`<think>`. Instead, it makes vLLM robust when that output pattern appears.
+
+This is the smallest change that fixes the observed benchmark failure while
+keeping the rest of the tool-calling stack unchanged.
+
+## Validation Scope
+
+The added tests validate that:
+
+- normal reasoning extraction remains unchanged
+- embedded tool calls are promoted from `reasoning` into `content`
+- promoted content remains parseable by `qwen3_coder`
+- truncated reasoning without `</think>` still recovers embedded tool calls
+- post-`</think>` content is preserved
+
+## Limitation
+
+This patch fixes the non-streaming path.
+
+Streaming recovery is not addressed here, because the streaming path would
+require additional stateful changes in the serving layer to forward reasoning
+delivered tool markup into the tool parser before `</think>` is observed.

--- a/tests/reasoning/test_qwen3_reasoning_parser.py
+++ b/tests/reasoning/test_qwen3_reasoning_parser.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+
 import pytest
 from transformers import AutoTokenizer
 
@@ -11,6 +13,7 @@ from tests.reasoning.utils import (
 )
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
+from vllm.tool_parsers.qwen3coder_tool_parser import Qwen3CoderToolParser
 
 parser_name = "qwen3"
 start_token = "<think>"
@@ -222,6 +225,117 @@ def test_reasoning(
 
     assert reasoning == param_dict["reasoning"]
     assert content == param_dict["content"]
+
+
+class _FakeQwen3ToolTokenizer:
+    def get_vocab(self):
+        return {
+            "<think>": 1,
+            "</think>": 2,
+            "<tool_call>": 3,
+            "</tool_call>": 4,
+        }
+
+
+def test_embedded_tool_call_is_promoted_from_reasoning_into_content():
+    request = ChatCompletionRequest(messages=[], model="test-model")
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        _FakeQwen3ToolTokenizer()
+    )
+
+    reasoning, content = parser.extract_reasoning(
+        """<think>The verification confirms my solution:
+- s = 2.5 km/h
+- t = 24 minutes
+- Total time at speed 3 km/h = 204 minutes
+
+<tool_call>
+<function=Finish>
+<parameter=answer>
+204
+</parameter>
+</function>
+</tool_call>
+</think>""",
+        request=request,
+    )
+
+    assert reasoning == (
+        "The verification confirms my solution:\n"
+        "- s = 2.5 km/h\n"
+        "- t = 24 minutes\n"
+        "- Total time at speed 3 km/h = 204 minutes"
+    )
+    assert content == (
+        "<tool_call>\n"
+        "<function=Finish>\n"
+        "<parameter=answer>\n"
+        "204\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+
+
+def test_promoted_qwen3_reasoning_tool_call_remains_parseable():
+    request = ChatCompletionRequest(messages=[], model="test-model")
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        _FakeQwen3ToolTokenizer()
+    )
+    tool_parser = Qwen3CoderToolParser(_FakeQwen3ToolTokenizer(), tools=None)
+
+    _, content = parser.extract_reasoning(
+        """<think>verify result
+<tool_call>
+<function=Finish>
+<parameter=answer>
+204
+</parameter>
+</function>
+</tool_call></think>assistant trailing text""",
+        request=request,
+    )
+
+    assert content is not None
+    assert "assistant trailing text" in content
+
+    tool_call_info = tool_parser.extract_tool_calls(content, request=request)
+
+    assert tool_call_info.tools_called is True
+    assert len(tool_call_info.tool_calls) == 1
+    tool_call = tool_call_info.tool_calls[0]
+    assert tool_call.function.name == "Finish"
+    assert json.loads(tool_call.function.arguments) == {"answer": "204"}
+
+
+def test_truncated_qwen3_reasoning_still_recovers_embedded_tool_call():
+    request = ChatCompletionRequest(messages=[], model="test-model")
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        _FakeQwen3ToolTokenizer()
+    )
+
+    reasoning, content = parser.extract_reasoning(
+        """verify result
+<tool_call>
+<function=Finish>
+<parameter=answer>
+204
+</parameter>
+</function>
+</tool_call>""",
+        request=request,
+    )
+
+    assert reasoning == "verify result"
+    assert content == (
+        "<tool_call>\n"
+        "<function=Finish>\n"
+        "<parameter=answer>\n"
+        "204\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
 
 
 # Multi-token delta tests: simulate real-world streaming where a single

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -11,6 +12,12 @@ if TYPE_CHECKING:
     from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
     from vllm.tokenizers import TokenizerLike
+
+
+_EMBEDDED_TOOL_CALL_RE = re.compile(
+    r"<tool_call>(.*?)</tool_call>|<tool_call>.*$",
+    re.DOTALL,
+)
 
 
 class Qwen3ReasoningParser(BaseThinkingReasoningParser):
@@ -51,6 +58,46 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         """The token that ends reasoning content."""
         return "</think>"
 
+    @staticmethod
+    def _split_embedded_tool_calls(
+        reasoning: str | None,
+        content: str | None,
+    ) -> tuple[str | None, str | None]:
+        """Promote tool-call XML blocks out of reasoning into content.
+
+        Qwen3.5 models can emit XML tool calls before `</think>`. The serving
+        stack parses reasoning before tool calls, so these embedded tool calls
+        would otherwise be lost because downstream tool parsers only inspect
+        the content channel.
+        """
+        if (
+            not reasoning
+            or "<tool_call>" not in reasoning
+            or "<function=" not in reasoning
+        ):
+            return reasoning, content
+
+        extracted_blocks: list[str] = []
+
+        def _collect_or_keep(match: re.Match[str]) -> str:
+            block = match.group(0)
+            if "<function=" not in block:
+                return block
+            extracted_blocks.append(block.strip())
+            return ""
+
+        remaining_reasoning = _EMBEDDED_TOOL_CALL_RE.sub(_collect_or_keep, reasoning)
+        remaining_reasoning = remaining_reasoning.strip() or None
+
+        if not extracted_blocks:
+            return reasoning, content
+
+        content_parts = ["\n\n".join(extracted_blocks)]
+        if content:
+            content_parts.append(content)
+        merged_content = "\n\n".join(part for part in content_parts if part) or None
+        return remaining_reasoning, merged_content
+
     def extract_reasoning(
         self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
     ) -> tuple[str | None, str | None]:
@@ -84,13 +131,13 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
                 return None, model_output
             # Thinking enabled but no </think>: output was truncated.
             # Everything generated so far is reasoning.
-            return model_output, None
+            return self._split_embedded_tool_calls(model_output, None)
 
         # Extract reasoning content from the model output.
         reasoning, _, content = model_output.partition(self.end_token)
 
         final_content = content or None
-        return reasoning, final_content
+        return self._split_embedded_tool_calls(reasoning, final_content)
 
     def extract_reasoning_streaming(
         self,


### PR DESCRIPTION
## Summary

This PR fixes a Qwen3/Qwen3.5 non-streaming compatibility issue when using:

- `--reasoning-parser qwen3`
- `--tool-call-parser qwen3_coder`

Qwen models can emit XML tool calls inside `<think> ... </think>`. The current
non-streaming pipeline extracts reasoning first and only parses tool calls from
`content`, so valid XML tool calls embedded in reasoning are lost.

This patch updates `qwen3_reasoning_parser` to promote valid XML tool-call
blocks out of `reasoning` into `content`, allowing the existing `qwen3_coder`
tool parser to recover them without changing the generic serving stack.

## Why this scope

This PR fixes parser recovery, not model generation behavior. It does not try to
prevent Qwen3.5 from emitting tool calls inside `<think>`; it makes vLLM robust
when that output pattern appears.

## Tests

Added tests cover:

- unchanged behavior for normal reasoning extraction
- embedded tool call promotion from reasoning to content
- successful parsing by `qwen3_coder`
- truncated reasoning recovery without `</think>`
- preservation of post-`</think>` content

## Limitation

This change fixes the non-streaming path. Streaming recovery would require
additional serving-layer changes and is intentionally left out of this minimal
patch.
