### PR TITLE
[ci] Switch misc and LoRA CI jobs to H200 MIG slices

### DIFF
--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -4,6 +4,7 @@ depends_on:
 steps:
 - label: LoRA %N
   timeout_in_minutes: 30
+  device: h200_18gb
   source_file_dependencies:
   - vllm/lora
   - tests/lora

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -4,6 +4,7 @@ depends_on:
 steps:
 - label: V1 Spec Decode
   timeout_in_minutes: 30
+  device: h200_18gb
   source_file_dependencies:
     - vllm/
     - tests/v1/spec_decode
@@ -98,6 +99,7 @@ steps:
 
 - label: Examples
   timeout_in_minutes: 45
+  device: h200_18gb
   working_dir: "/vllm-workspace/examples"
   source_file_dependencies:
   - vllm/entrypoints
@@ -144,6 +146,7 @@ steps:
 - label: Python-only Installation
   depends_on: ~
   timeout_in_minutes: 20
+  device: h200_18gb
   source_file_dependencies:
   - tests/standalone_tests/python_only_compile.sh
   - setup.py
@@ -152,6 +155,7 @@ steps:
 
 - label: Async Engine, Inputs, Utils, Worker
   timeout_in_minutes: 50
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/detokenizer


### PR DESCRIPTION
## Summary
- Adds `device: h200_18gb` to CI test steps that were validated as passing on H200 MIG 1g.18gb slices (~18GB GPU memory) in [build 59550](https://buildkite.com/vllm/ci/builds/59550)
- These steps previously had no explicit `device:` field (defaulting to L4 GPUs)

## Jobs switched to h200_18gb (5 steps)
- **misc.yaml**: V1 Spec Decode, Examples, Python-only Installation, Async Engine/Inputs/Utils/Worker
- **lora.yaml**: LoRA %N

## Jobs NOT switched
- **V1 Core + KV + Metrics** - failing, needs investigation
- **V1 Others (CPU)** / **Async Engine, Inputs, Utils, Worker, Config (CPU)** - CPU jobs
- **Batch Invariance (H100)** / **Batch Invariance (B200)** - explicitly pinned to H100/B200
- **Acceptance Length Test** - uses `gpu: h100`
- **Metrics, Tracing (2 GPUs)** - uses `num_devices: 2`
- **LoRA TP (Distributed)** - uses `num_devices: 4`
- **V1 Sample + Logits** / **Regression** - already on `h200_18gb`

## Test plan
- [x] All switched steps passed on H200 MIG slices in [build 59550](https://buildkite.com/vllm/ci/builds/59550)
- [ ] Verify pipeline generator routes these steps to the `h200_18gb` queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)