### PR TITLE
[ci] Switch multimodal CI jobs to H200 MIG slices

### DIFF
--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -36,6 +36,7 @@ steps:
 
 - label: "Multi-Modal Models (Standard) 3: llava + qwen2_vl"
   timeout_in_minutes: 45
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal
@@ -90,6 +91,7 @@ steps:
 
 - label: Multi-Modal Accuracy Eval (Small Models) # 50min
   timeout_in_minutes: 70
+  device: h200_18gb
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   source_file_dependencies:
   - vllm/multimodal/
@@ -100,6 +102,7 @@ steps:
 
 - label: Multi-Modal Models (Extended Generation 1)
   optional: true
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal/generation
@@ -116,6 +119,7 @@ steps:
 
 - label: Multi-Modal Models (Extended Generation 2)
   optional: true
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal/generation
@@ -125,6 +129,7 @@ steps:
 
 - label: Multi-Modal Models (Extended Generation 3)
   optional: true
+  device: h200_18gb
   source_file_dependencies:
   - vllm/
   - tests/models/multimodal/generation


### PR DESCRIPTION
## Summary
- Adds `device: h200_18gb` to 5 multimodal CI test steps that were validated as passing on H200 MIG 1g.18gb slices (~18GB GPU memory) in [build 59550](https://buildkite.com/vllm/ci/builds/59550)
- These steps previously had no explicit `device:` field (defaulting to L4 GPUs)

## Jobs switched to h200_18gb (5 steps)
- **Multi-Modal Models (Standard) 3: llava + qwen2_vl**
- **Multi-Modal Accuracy Eval (Small Models)**
- **Multi-Modal Models (Extended Generation 1)**
- **Multi-Modal Models (Extended Generation 2)**
- **Multi-Modal Models (Extended Generation 3)**

## Jobs NOT switched
- **Multi-Modal Models (Standard) 4: other + whisper** — failed in build 59550
- Jobs that already have `device: h200_18gb` (Standard 1, Standard 2, Multi-Modal Processor, Extended Pooling)
- CPU jobs (Multi-Modal Processor (CPU))

## Test plan
- [x] All 5 switched steps passed on H200 MIG slices in [build 59550](https://buildkite.com/vllm/ci/builds/59550)
- [ ] Verify pipeline generator routes these steps to the `h200_18gb` queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)