### PR TITLE
Fix RMSNorm hidden_size validation crash for weightless norms

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -207,7 +207,7 @@ class RMSNorm(CustomOp):
             x = x + residual
             residual = x.to(orig_dtype)
 
-        if x.shape[-1] != hidden_size:
+        if weight is not None and x.shape[-1] != hidden_size:
             raise ValueError(
                 f"Expected hidden_size to be {hidden_size}, but found: {x.shape[-1]}"
             )

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -212,6 +212,10 @@ class RMSNorm(CustomOp):
                 f"Expected hidden_size to be {hidden_size}, but found: {x.shape[-1]}"
             )
 
+        # When weight is None (weightless norm), use input dim for validation
+        if weight is None:
+            hidden_size = x.shape[-1]
+
         if variance_size_override is None:
             x_var = x
         else:
@@ -266,7 +270,10 @@ class RMSNorm(CustomOp):
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         if residual is None and not envs.VLLM_BATCH_INVARIANT:
             return ir.ops.rms_norm(
-                x, self.weight.data, self.variance_epsilon, self.variance_size_override
+                x,
+                self.weight.data if self.has_weight else None,
+                self.variance_epsilon,
+                self.variance_size_override,
             )
 
         if self.variance_size_override is not None:
@@ -313,13 +320,15 @@ class RMSNorm(CustomOp):
                     )
                     return x, residual
 
+        weight = self.weight.data if self.has_weight else torch.ones(
+            x.shape[-1], device=x.device, dtype=x.dtype)
         if residual is not None:
             return fused_add_rms_norm(
-                x, residual, self.weight.data, self.variance_epsilon
+                x, residual, weight, self.variance_epsilon
             )
         else:
             assert envs.VLLM_BATCH_INVARIANT
-            return rms_norm_batch_invariant(x, self.weight.data, self.variance_epsilon)
+            return rms_norm_batch_invariant(x, weight, self.variance_epsilon)
 
     def forward_hip(
         self,
@@ -328,19 +337,24 @@ class RMSNorm(CustomOp):
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         if residual is None and not envs.VLLM_BATCH_INVARIANT:
             return ir.ops.rms_norm(
-                x, self.weight.data, self.variance_epsilon, self.variance_size_override
+                x,
+                self.weight.data if self.has_weight else None,
+                self.variance_epsilon,
+                self.variance_size_override,
             )
 
         if self.variance_size_override is not None:
             return self.forward_native(x, residual)
 
+        weight = self.weight.data if self.has_weight else torch.ones(
+            x.shape[-1], device=x.device, dtype=x.dtype)
         if residual is not None:
             return self.rocm_norm_func_with_add(
-                x, residual, self.weight.data, self.variance_epsilon
+                x, residual, weight, self.variance_epsilon
             )
         else:
             assert envs.VLLM_BATCH_INVARIANT
-            return rms_norm_batch_invariant(x, self.weight.data, self.variance_epsilon)
+            return rms_norm_batch_invariant(x, weight, self.variance_epsilon)
 
     def forward_xpu(
         self,

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -320,15 +320,21 @@ class RMSNorm(CustomOp):
                     )
                     return x, residual
 
-        weight = self.weight.data if self.has_weight else torch.ones(
-            x.shape[-1], device=x.device, dtype=x.dtype)
+        # When has_weight is False, fall back to forward_native which
+        # handles weightless norms via forward_static without allocating
+        # a dummy ones tensor on every call.
+        if not self.has_weight:
+            return self.forward_native(x, residual)
+
         if residual is not None:
             return fused_add_rms_norm(
-                x, residual, weight, self.variance_epsilon
+                x, residual, self.weight.data, self.variance_epsilon
             )
         else:
             assert envs.VLLM_BATCH_INVARIANT
-            return rms_norm_batch_invariant(x, weight, self.variance_epsilon)
+            return rms_norm_batch_invariant(
+                x, self.weight.data, self.variance_epsilon
+            )
 
     def forward_hip(
         self,
@@ -346,15 +352,21 @@ class RMSNorm(CustomOp):
         if self.variance_size_override is not None:
             return self.forward_native(x, residual)
 
-        weight = self.weight.data if self.has_weight else torch.ones(
-            x.shape[-1], device=x.device, dtype=x.dtype)
+        # When has_weight is False, fall back to forward_native which
+        # handles weightless norms via forward_static without allocating
+        # a dummy ones tensor on every call.
+        if not self.has_weight:
+            return self.forward_native(x, residual)
+
         if residual is not None:
             return self.rocm_norm_func_with_add(
-                x, residual, weight, self.variance_epsilon
+                x, residual, self.weight.data, self.variance_epsilon
             )
         else:
             assert envs.VLLM_BATCH_INVARIANT
-            return rms_norm_batch_invariant(x, weight, self.variance_epsilon)
+            return rms_norm_batch_invariant(
+                x, self.weight.data, self.variance_epsilon
+            )
 
     def forward_xpu(
         self,


### PR DESCRIPTION
## Summary

- Fixes `ValueError: Expected hidden_size to be 5376, but found: 72` when running Gemma4 vision models
- When `replace_rms_norm_class` replaces RMSNorm modules, it passes the LM `hidden_size` even for vision encoder norms with a different dimension. For norms with `with_scale=False` (like Gemma4's `v_norm`), no `weight` is registered, so the hidden_size correction code (which reads `weight.shape`) is skipped, leaving the wrong value. The `forward_static` validation then raises a `ValueError`.
- The fix skips the `hidden_size` validation when `weight is None`, since a weightless RMSNorm just computes `x / sqrt(mean(x^2) + eps)` and does not depend on `hidden_size`.

Fixes #39061

## Why this is not a duplicate

- No open PRs address issue #39061.

## Test plan

- [ ] Verify Gemma4 vision encoder no longer crashes on forward pass
- [ ] Verify standard RMSNorm (with weight) still validates hidden_size correctly
- [ ] Run `pytest tests/models/multimodal/ -v -k gemma` if Gemma4 tests exist

## AI Assistance

This PR was created with AI assistance (Claude). All changes have been reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>