### PR TITLE
Fix gemma4 _parse_tool_arguments truncating quoted strings

### DIFF
--- a/vllm/tool_parsers/gemma4_utils.py
+++ b/vllm/tool_parsers/gemma4_utils.py
@@ -66,10 +66,9 @@ def _parse_tool_arguments(args_str: str) -> dict[str, str]:
     if not args_str or not args_str.strip():
         return {}
 
-    # Replace Gemma4 escape tokens with standard quotes.
-    cleaned = args_str.replace(_ESCAPE_TOKEN, '"')
-
     # Try JSON parsing first (handles nested values, arrays, etc.).
+    # Replace Gemma4 escape tokens with standard quotes for JSON attempt.
+    cleaned = args_str.replace(_ESCAPE_TOKEN, '"')
     try:
         parsed = json.loads("{" + cleaned + "}")
         # Ensure all values are strings for consistency.
@@ -77,9 +76,11 @@ def _parse_tool_arguments(args_str: str) -> dict[str, str]:
     except (json.JSONDecodeError, ValueError):
         pass
 
-    # Fallback: extract key:"value" pairs (allow optional space after colon).
+    # Fallback: extract key:<|"|>value<|"|> pairs using the original
+    # escape-token delimiters so that internal quotes are preserved.
     arguments = {}
-    for key, value in re.findall(r'(\w+):\s*"([^"]*)"', cleaned):
+    for key, value in re.findall(r'(\w+):\s*<\|"\|>(.*?)<\|"\|>',
+                                 args_str):
         arguments[key] = value
 
     if not arguments:


### PR DESCRIPTION
## Summary
- Fixed `_parse_tool_arguments` in `gemma4_utils.py` truncating string values that contain internal quotes
- The fallback regex now uses `<|"|>` escape-token delimiters directly on the original `args_str` instead of first replacing them with `"` and then matching `[^"]*`, which stopped at the first internal quote
- The `<|"|>` replacement is now scoped only to the `json.loads` attempt where it is needed

## Test plan
- [ ] Verify parsing of tool arguments with values containing internal quotes (e.g. `query:<|"|>What is "machine learning"?<|"|>`)
- [ ] Verify normal tool argument parsing still works (no internal quotes)
- [ ] Verify JSON-parseable arguments still take the fast path via `json.loads`
- [ ] Run `pytest tests/tool_parsers/ -v` for existing tool parser tests

Fixes #39069

🤖 Generated with [Claude Code](https://claude.com/claude-code)