### PR TITLE
[ROCM] Optimize all-reduce performances.

### DIFF
--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -628,7 +628,7 @@ class CustomAllreduce {
 
 #if defined(USE_ROCM)
     const bool prefer_1stage_fully_connected =
-        (world_size_ <= 4 && bytes < 32 * 1024) ||
+        (world_size_ <= 4 && bytes <= 64 * 1024) ||
         (world_size_ <= 8 && bytes <= 64 * 1024);
 #else
     const bool prefer_1stage_fully_connected =

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -333,8 +333,6 @@ template <typename T, int ngpus>
 __global__ void __launch_bounds__(512, 1)
     cross_device_reduce_2stage(RankData* _dp, RankSignals sg, Signal* self_sg,
                                T* __restrict__ result, int rank, int size) {
-  int tid = blockIdx.x * blockDim.x + threadIdx.x;
-  int stride = gridDim.x * blockDim.x;
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
   int part = size / ngpus;
@@ -394,6 +392,7 @@ __global__ void __launch_bounds__(512, 1)
           write_reg.data[i] = downcast_s<T>(add_reg.data[i]);
         tmp_out[idx - start] = write_reg;
       }
+
       __syncthreads();
     }
     barrier_at_end<ngpus>(sg, self_sg, rank);

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -30,14 +30,18 @@ namespace vllm {
   } while (0)
 
 // Maximal number of blocks in allreduce kernel.
+#ifndef USE_ROCM
 constexpr int kMaxBlocks = 36;
+#else
+constexpr int kMaxBlocks = 64;
+#endif
 
 // Default number of blocks in allreduce kernel.
 #ifndef USE_ROCM
 const int defaultBlockLimit = 36;
 CUpointer_attribute rangeStartAddrAttr = CU_POINTER_ATTRIBUTE_RANGE_START_ADDR;
 #else
-const int defaultBlockLimit = 16;
+const int defaultBlockLimit = 64;
 hipPointer_attribute rangeStartAddrAttr =
     HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR;
 #endif
@@ -89,11 +93,18 @@ struct packed_t {
 // scalar cast functions
 DINLINE float upcast_s(half val) { return __half2float(val); }
 
+DINLINE float upcast_s(float val) { return val; }
+
 template <typename T>
 DINLINE T downcast_s(float val);
 template <>
 DINLINE half downcast_s(float val) {
   return __float2half(val);
+}
+
+template <>
+DINLINE float downcast_s(float val) {
+  return val;
 }
 
 // scalar add functions
@@ -341,25 +352,79 @@ __global__ void __launch_bounds__(512, 1)
   auto tmp_out = tmps[0];
   barrier_at_start<ngpus>(sg, self_sg, rank);
 
-  // stage 1: reduce scatter
-  for (int idx = start + tid; idx < end; idx += stride) {
-    tmp_out[idx - start] = packed_reduce<P, ngpus, A>(ptrs, idx);
-  }
-  barrier_at_end<ngpus>(sg, self_sg, rank);
+#if defined(USE_ROCM) && (defined(__gfx942__) || defined(__gfx950__))
+  if constexpr (512 % ngpus == 0) {
+    constexpr int pack_size = P::size;
+    constexpr int tnum_gpu = 512 / ngpus;
+    int warp_id = threadIdx.x / tnum_gpu;
+    int lane_id = threadIdx.x % tnum_gpu;
+    (void)lane_id;
+    int tid_rocm = blockIdx.x * tnum_gpu + lane_id;
+    int stride_rocm = gridDim.x * tnum_gpu;
+    __shared__ T tmp_smem[tnum_gpu * ngpus * pack_size];
+    for (int idx = start + tid_rocm; idx < end; idx += stride_rocm) {
+      *(reinterpret_cast<P*>(&tmp_smem[0]) + threadIdx.x) = ptrs[warp_id][idx];
+      // auto flat_src = ptrs[warp_id] + idx;
+      // using Gsrc = const __uint128_t __attribute__((address_space(1)))*;
+      // Gsrc gsrc = (Gsrc)flat_src;
+      // unsigned __int128 tmp;
+      // asm volatile("global_load_dwordx4 %0, %1 off\n\t"
+      //              "s_waitcnt vmcnt(0)\n\t"
+      //              : "=v"(tmp)
+      //              : "v"(gsrc)
+      //              : "memory");
+      // *(reinterpret_cast<P*>(&tmp_smem[0]) + threadIdx.x) =
+      //     *(reinterpret_cast<P*>(&tmp));
+      __syncthreads();
+      if (warp_id == 0) {
+        A add_reg;
+  #pragma unroll
+        for (int i = 0; i < pack_size; ++i)
+          add_reg.data[i] = upcast_s(tmp_smem[pack_size * threadIdx.x + i]);
+        constexpr int smem_gpu_loop_stride = tnum_gpu * pack_size;
+  #pragma unroll
+        for (int i = 1; i < ngpus; ++i)
+  #pragma unroll
+          for (int j = 0; j < pack_size; ++j)
+            add_reg.data[j] += upcast_s(tmp_smem[i * smem_gpu_loop_stride +
+                                                 pack_size * threadIdx.x + j]);
+        P write_reg;
+  #pragma unroll
+        for (int i = 0; i < pack_size; ++i)
+          write_reg.data[i] = downcast_s<T>(add_reg.data[i]);
+        tmp_out[idx - start] = write_reg;
+      }
+      __syncthreads();
+    }
+    barrier_at_end<ngpus>(sg, self_sg, rank);
+    for (int idx = tid_rocm; idx < largest_part; idx += stride_rocm) {
+      int dst_idx = (warp_id + rank) % ngpus * part + idx;
+      ((P*)result)[dst_idx] = tmps[warp_id][idx];
+    }
+  } else
+#endif
+  {
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = gridDim.x * blockDim.x;
+    // stage 1: reduce scatter
+    for (int idx = start + tid; idx < end; idx += stride) {
+      tmp_out[idx - start] = packed_reduce<P, ngpus, A>(ptrs, idx);
+    }
+    barrier_at_end<ngpus>(sg, self_sg, rank);
 
-  // stage 2: allgather. Note: it's important to match the tid between
-  // the two stages, because visibility across devices is only guaranteed
-  // between threads that have the same tid. If thread i computes the sum of
-  // start + i in the first stage, then thread i also gathers start + i from
-  // all ranks.
-
-  for (int idx = tid; idx < largest_part; idx += stride) {
+    // stage 2: allgather. Note: it's important to match the tid between
+    // the two stages, because visibility across devices is only guaranteed
+    // between threads that have the same tid. If thread i computes the sum of
+    // start + i in the first stage, then thread i also gathers start + i from
+    // all ranks.
+    for (int idx = tid; idx < largest_part; idx += stride) {
 #pragma unroll
-    for (int i = 0; i < ngpus; i++) {
-      int gather_from_rank = ((rank + i) % ngpus);
-      if (gather_from_rank == ngpus - 1 || idx < part) {
-        int dst_idx = gather_from_rank * part + idx;
-        ((P*)result)[dst_idx] = tmps[i][idx];
+      for (int i = 0; i < ngpus; i++) {
+        int gather_from_rank = ((rank + i) % ngpus);
+        if (gather_from_rank == ngpus - 1 || idx < part) {
+          int dst_idx = gather_from_rank * part + idx;
+          ((P*)result)[dst_idx] = tmps[i][idx];
+        }
       }
     }
   }
@@ -556,7 +621,23 @@ class CustomAllreduce {
 
     size /= d;
     auto bytes = size * sizeof(typename packed_t<T>::P);
+#if defined(USE_ROCM)
+    // Match bench_kernels ROCm policy: at most 64 blocks; small tensors use 16.
+    int effective_block_cap = (bytes <= 256 * 1024) ? 16 : 64;
+    int blocks = std::min(effective_block_cap, (size + threads - 1) / threads);
+#else
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
+#endif
+
+#if defined(USE_ROCM)
+    const bool prefer_1stage_fully_connected =
+        (world_size_ <= 4 && bytes < 32 * 1024) ||
+        (world_size_ <= 8 && bytes <= 64 * 1024);
+#else
+    const bool prefer_1stage_fully_connected =
+        (world_size_ <= 4 && bytes < 512 * 1024) ||
+        (world_size_ <= 8 && bytes < 256 * 1024);
+#endif
 
     // Check environment variable once
     const char* env_algo = std::getenv("VLLM_CUSTOM_ALLREDUCE_ALGO");
@@ -579,25 +660,24 @@ class CustomAllreduce {
 #define KL(ngpus, name)                                                       \
   name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, output, \
                                                  rank_, size);
-#define REDUCE_CASE(ngpus)                              \
-  case ngpus: {                                         \
-    if (force_1stage) {                                 \
-      KL(ngpus, cross_device_reduce_1stage);            \
-    } else if (force_2stage) {                          \
-      KL(ngpus, cross_device_reduce_2stage);            \
-    } else {                                            \
-      if (world_size_ == 2) {                           \
-        KL(ngpus, cross_device_reduce_1stage);          \
-      } else if (fully_connected_) {                    \
-        if ((world_size_ <= 4 && bytes < 512 * 1024) || \
-            (world_size_ <= 8 && bytes < 256 * 1024)) { \
-          KL(ngpus, cross_device_reduce_1stage);        \
-        } else {                                        \
-          KL(ngpus, cross_device_reduce_2stage);        \
-        }                                               \
-      }                                                 \
-    }                                                   \
-    break;                                              \
+#define REDUCE_CASE(ngpus)                       \
+  case ngpus: {                                  \
+    if (force_1stage) {                          \
+      KL(ngpus, cross_device_reduce_1stage);     \
+    } else if (force_2stage) {                   \
+      KL(ngpus, cross_device_reduce_2stage);     \
+    } else {                                     \
+      if (world_size_ == 2) {                    \
+        KL(ngpus, cross_device_reduce_1stage);   \
+      } else if (fully_connected_) {             \
+        if (prefer_1stage_fully_connected) {     \
+          KL(ngpus, cross_device_reduce_1stage); \
+        } else {                                 \
+          KL(ngpus, cross_device_reduce_2stage); \
+        }                                        \
+      }                                          \
+    }                                            \
+    break;                                       \
   }
 
     switch (world_size_) {

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -397,8 +397,11 @@ __global__ void __launch_bounds__(512, 1)
     }
     barrier_at_end<ngpus>(sg, self_sg, rank);
     for (int idx = tid_rocm; idx < largest_part; idx += stride_rocm) {
-      int dst_idx = (warp_id + rank) % ngpus * part + idx;
-      ((P*)result)[dst_idx] = tmps[warp_id][idx];
+      int gather_from_rank = (warp_id + rank) % ngpus;
+      if (gather_from_rank == ngpus - 1 || idx < part) {
+        int dst_idx = gather_from_rank * part + idx;
+        ((P*)result)[dst_idx] = tmps[warp_id][idx];
+      }
     }
   } else
 #endif
@@ -620,11 +623,7 @@ class CustomAllreduce {
 
     size /= d;
     auto bytes = size * sizeof(typename packed_t<T>::P);
-#if defined(USE_ROCM)
-    int blocks = std::min(64, (size + threads - 1) / threads);
-#else
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
-#endif
 
 #if defined(USE_ROCM)
     const bool prefer_1stage_fully_connected =

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -621,9 +621,7 @@ class CustomAllreduce {
     size /= d;
     auto bytes = size * sizeof(typename packed_t<T>::P);
 #if defined(USE_ROCM)
-    // Match bench_kernels ROCm policy: at most 64 blocks; small tensors use 16.
-    int effective_block_cap = (bytes <= 256 * 1024) ? 16 : 64;
-    int blocks = std::min(effective_block_cap, (size + threads - 1) / threads);
+    int blocks = std::min(64, (size + threads - 1) / threads);
 #else
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
 #endif


### PR DESCRIPTION

This PR tunes some all-reduce performance for mi355x. 
And change 2-stage all-reduce algorithm for CDNA cards from aiter's all-reduce.  https://github.com/ROCm/aiter/blob/main/csrc/kernels/custom_all_reduce.cu
## Changes

| Item | Before | After |
|------|--------|-------|
| `effective_limit` (bytes<=256KB) | 16 | 64 |
| algo threshold (TP<=4) | 1stage if bytes<512KB | 1stage if bytes<64KB |
| algo threshold (TP<=8) | 1stage if bytes<=64KB | 1stage if bytes<64KB |

Peak busbw = (N-1) × 76.8 GB/s: TP2=76.8, TP4=230.4, TP8=537.6 GB/s

## Performance.

### TP8 (bf16, dim=3072) — up to 47% faster, peak 537.6 GB/s

| tokens | shape | size | vllm/us | vllm/bw | vllm/%peak | dev/us | dev/bw | dev/%peak | speedup |
|--------|-------|------|---------|---------|------------|--------|--------|-----------|---------|
| 4 | (4,3072) | 24K | 6.3 | 6.8G | 1% | 6.4 | 6.7G | 1% | — |
| 8 | (8,3072) | 48K | 6.7 | 12.8G | 2% | 6.7 | 12.8G | 2% | — |
| 16 | (16,3072) | 96K | 7.6 | 22.6G | 4% | 6.8 | 25.2G | 5% | **+11%** |
| 32 | (32,3072) | 192K | 10.0 | 34.4G | 6% | 7.0 | 49.3G | 9% | **+30%** |
| 64 | (64,3072) | 384K | 13.1 | 52.6G | 10% | 7.5 | 91.4G | 17% | **+43%** |
| 128 | (128,3072) | 768K | 16.0 | 85.8G | 16% | 9.6 | 143.0G | 27% | **+40%** |
| 256 | (256,3072) | 1.5M | 24.2 | 113.9G | 21% | 12.9 | 213.9G | 40% | **+47%** |
| 512 | (512,3072) | 3M | 35.5 | 154.9G | 29% | 20.0 | 274.9G | 51% | **+44%** |
| 1024 | (1024,3072) | 6M | 58.0 | 189.9G | 35% | 34.0 | 323.5G | 60% | **+41%** |
| 2048 | (2048,3072) | 12M | 102.5 | 214.7G | 40% | 62.0 | 355.0G | 66% | **+39%** |
| 4096 | (4096,3072) | 24M | 191.7 | 229.7G | 43% | 117.1 | 376.1G | 70% | **+39%** |
| 8192 | (8192,3072) | 48M | 372.6 | 236.4G | 44% | 226.1 | 389.6G | 72% | **+39%** |
| 16384 | (16384,3072) | 96M | 724.3 | 243.2G | 45% | 443.1 | 397.5G | 74% | **+39%** |

Root cause: vllm upstream caps `effective_limit=16` for bytes<=256KB, starving 2stage of blocks. Our fix unifies to 64. Large tensors also benefit because vllm's auto-selection is suboptimal at TP8.

---

### TP4 (bf16, dim=3072) — up to 29% faster, peak 230.4 GB/s

| tokens | shape | size | vllm/us | vllm/bw | vllm/%peak | dev/us | dev/bw | dev/%peak | speedup |
|--------|-------|------|---------|---------|------------|--------|--------|-----------|---------|
| 4 | (4,3072) | 24K | 4.9 | 7.5G | 3% | 5.2 | 7.1G | 3% | — |
| 8 | (8,3072) | 48K | 5.4 | 13.7G | 6% | 5.6 | 13.3G | 6% | — |
| 16 | (16,3072) | 96K | 6.3 | 23.3G | 10% | 6.0 | 24.6G | 11% | **+5%** |
| 32 | (32,3072) | 192K | 8.0 | 37.0G | 16% | 6.5 | 45.4G | 20% | **+19%** |
| 64 | (64,3072) | 384K | 11.3 | 52.3G | 23% | 8.0 | 74.0G | 32% | **+29%** |
| 128 | (128,3072) | 768K | 14.3 | 82.8G | 36% | 11.0 | 106.8G | 46% | **+23%** |
| 256 | (256,3072) | 1.5M | 21.5 | 109.7G | 48% | 18.3 | 128.8G | 56% | **+15%** |
| 512 | (512,3072) | 3M | 36.2 | 130.3G | 57% | 32.4 | 145.7G | 63% | **+10%** |
| 1024 | (1024,3072) | 6M | 65.1 | 145.0G | 63% | 60.2 | 156.7G | 68% | **+8%** |
| 2048 | (2048,3072) | 12M | 123.3 | 153.1G | 66% | 118.4 | 159.4G | 69% | **+4%** |
| 4096 | (4096,3072) | 24M | 241.5 | 156.3G | 68% | 224.5 | 168.1G | 73% | **+7%** |
| 8192 | (8192,3072) | 48M | 475.9 | 158.7G | 69% | 442.0 | 170.8G | 74% | **+7%** |
| 16384 | (16384,3072) | 96M | 945.1 | 159.8G | 69% | 878.3 | 171.9G | 75% | **+7%** |

Root cause: vllm upstream uses 1stage for bytes<512KB on TP<=4, but sweep shows 2stage wins at ~64KB. Also benefits from blocks 16→64.

---

### TP2 (bf16, dim=3072) — no change, peak 76.8 GB/s

| tokens | shape | size | vllm/us | vllm/bw | vllm/%peak | dev/us | dev/bw | dev/%peak | speedup |
|--------|-------|------|---------|---------|------------|--------|--------|-----------|---------|
| 4 | (4,3072) | 24K | 4.4 | 5.5G | 7% | 4.2 | 5.8G | 8% | — |
| 8 | (8,3072) | 48K | 4.8 | 10.3G | 13% | 4.7 | 10.4G | 14% | — |
| 16 | (16,3072) | 96K | 5.8 | 17.0G | 22% | 5.6 | 17.6G | 23% | — |
| 32 | (32,3072) | 192K | 7.5 | 26.2G | 34% | 7.3 | 27.0G | 35% | — |
| 64 | (64,3072) | 384K | 10.7 | 36.6G | 48% | 10.7 | 36.8G | 48% | — |
| 128 | (128,3072) | 768K | 17.6 | 44.7G | 58% | 17.4 | 45.2G | 59% | — |
| 256 | (256,3072) | 1.5M | 31.2 | 50.5G | 66% | 30.8 | 51.0G | 66% | — |
| 512 | (512,3072) | 3M | 58.2 | 54.0G | 70% | 57.7 | 54.5G | 71% | — |
| 1024 | (1024,3072) | 6M | 112.6 | 55.9G | 73% | 111.4 | 56.5G | 74% | — |
| 2048 | (2048,3072) | 12M | 220.3 | 57.1G | 74% | 218.5 | 57.6G | 75% | — |
| 4096 | (4096,3072) | 24M | 434.3 | 57.9G | 75% | 432.0 | 58.3G | 76% | — |
| 8192 | (8192,3072) | 48M | 862.9 | 58.3G | 76% | 865.4 | 58.2G | 76% | — |
| 16384 | (16384,3072) | 96M | 1722.2 | 58.5G | 76% | 1732.0 | 58.1G | 76% | — |

TP2 always uses 1stage (hardcoded). Both vllm and dev behave identically. Saturates at ~76% of peak.

## Test Plan
Run MiniMax M2.5 inference on Mi355.
```bash
export VLLM_ROCM_USE_AITER=1
vllm serve MiniMaxAI/MiniMax-M2.5 \
    --tensor-parallel-size 8 \
    --enable_expert-parallel \
    --max-model-len=10240 \
    --max-num-seqs 512 \
    --block-size=32 \
    --trust-remote-code \
    --attention-backend "ROCM_AITER_FA" \
    --no-enable-prefix-caching \
    --port=30000
```

```bash
git clone https://github.com/kimbochen/bench_serving.git
cd bench_serving
python3 benchmark_serving.py \
        --model MiniMaxAI/MiniMax-M2.5 \
        --backend "vllm" \
        --base-url "http://0.0.0.0:30000" \
        --dataset-name random \
        --random-input-len 1024 \
        --random-output-len 1024 \
        --random-range-ratio 0.8 \
        --num-prompts $(( CONC * 10 )) \
        --max-concurrency "$CONC" \
        --request-rate inf \
        --ignore-eos \
        --save-result \
        --percentile-metrics 'ttft,tpot,itl,e2el' \
        --result-dir "/app/" \
```

### Performance

| Batch Size | E2E Latency (s) |  | Improvement | Interactivity (tok/s/user) |  | Improvement | TPOT (ms) |  | Improvement |
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| | Before | After | | Before | After | | Before | After | |
| 4 | 9.99 | 9.72 | **-2.7%** | 91.39 | 93.81 | **+2.6%** | 10.94 | 10.66 | **-2.6%** |
| 8 | 10.83 | 10.59 | **-2.2%** | 88.29 | 90.63 | **+2.6%** | 11.33 | 11.03 | **-2.6%** |
| 16 | 11.47 | 11.32 | **-1.3%** | 82.04 | 83.17 | **+1.4%** | 12.19 | 12.02 | **-1.4%** |
| 32 | 12.40 | 12.10 | **-2.4%** | 74.48 | 76.61 | **+2.9%** | 13.43 | 13.05 | **-2.8%** |
| 64 | 15.35 | 14.70 | **-4.2%** | 60.09 | 62.94 | **+4.7%** | 16.64 | 15.89 | **-4.5%** |
| 128 | 17.34 | 16.88 | **-2.7%** | 53.94 | 55.64 | **+3.2%** | 18.54 | 17.97 | **-3.1%** |
| 256 | 21.23 | 20.45 | **-3.7%** | 44.15 | 46.20 | **+4.6%** | 22.65 | 21.65 | **-4.4%** |
| 512 | 28.85 | 28.19 | **-2.3%** | 32.68 | 33.87 | **+3.6%** | 30.60 | 29.52 | **-3.5%** |
---

### Accuracy
```python
python3 -m lm_eval --model local-completions \
  --model_args model=MiniMaxAI/MiniMax-M2.5,base_url=http://127.0.0.1:30000/v1/completions,num_concurrent=512 \
  --tasks gsm8k
```

main:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9234|±  |0.0073|
|     |       |strict-match    |     5|exact_match|↑  |0.9212|±  |0.0074|```
```


PR:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9287|±  |0.0071|
|     |       |strict-match    |     5|exact_match|↑  |0.9249|±  |0.0073|
```
There is no significant difference in accuracy.


<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The test plan, such as providing test command.
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

