### PR TITLE
Fix Gemma4 NVFP4 expert scale suffix mapping

### DIFF
--- a/tests/model_executor/test_gemma4_weight_loading.py
+++ b/tests/model_executor/test_gemma4_weight_loading.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.model_executor.models.gemma4 import Gemma4Model
+
+
+class _FakeParam:
+    def __init__(self) -> None:
+        self.weight_loader = Mock()
+
+
+class _FakeGemma4Model:
+    def __init__(self, param_names: list[str]) -> None:
+        self.config = SimpleNamespace(num_experts=1)
+        self.quant_config = None
+        self._params = {name: _FakeParam() for name in param_names}
+
+    def named_parameters(self):
+        return list(self._params.items())
+
+    def named_buffers(self):
+        return []
+
+    def named_modules(self):
+        return []
+
+
+@pytest.mark.parametrize(
+    ("name", "loaded_weight", "expected_param", "expected_shard"),
+    [
+        (
+            "layers.0.moe.experts.0.down_proj",
+            torch.randn(4, 8),
+            "layers.0.moe.experts.w2_weight",
+            "w2",
+        ),
+        (
+            "layers.0.moe.experts.0.down_proj.weight_scale",
+            torch.tensor(1.0),
+            "layers.0.moe.experts.w2_weight_scale",
+            "w2",
+        ),
+        (
+            "layers.0.moe.experts.0.down_proj.weight_scale_2",
+            torch.tensor(1.0),
+            "layers.0.moe.experts.w2_weight_scale_2",
+            "w2",
+        ),
+        (
+            "layers.0.moe.experts.0.down_proj.input_scale",
+            torch.tensor(1.0),
+            "layers.0.moe.experts.w2_input_scale",
+            "w2",
+        ),
+        (
+            "layers.0.moe.experts.0.gate_proj.weight_scale_2",
+            torch.tensor(1.0),
+            "layers.0.moe.experts.w13_weight_scale_2",
+            "w1",
+        ),
+        (
+            "layers.0.moe.experts.0.up_proj.input_scale",
+            torch.tensor(1.0),
+            "layers.0.moe.experts.w13_input_scale",
+            "w3",
+        ),
+    ],
+)
+def test_gemma4_load_weights_maps_expert_scale_suffixes(
+    name: str,
+    loaded_weight: torch.Tensor,
+    expected_param: str,
+    expected_shard: str,
+) -> None:
+    model = _FakeGemma4Model([expected_param])
+    param = model._params[expected_param]
+
+    loaded_params = Gemma4Model.load_weights(model, [(name, loaded_weight)])
+
+    param.weight_loader.assert_called_once_with(
+        param,
+        loaded_weight,
+        expected_param,
+        shard_id=expected_shard,
+        expert_id=0,
+    )
+    assert expected_param in loaded_params

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -84,6 +84,38 @@ def _get_text_config(config):
     return config
 
 
+def _map_gemma4_expert_param_name(
+    name: str,
+    param_name_prefix: str,
+    weight_name: str,
+) -> str | None:
+    """Map Gemma4 expert checkpoint names to FusedMoE parameter names.
+
+    Gemma4's exploded expert weights may include layer/module prefixes before
+    the expert-specific portion of the checkpoint name. Bare expert weights
+    arrive without a `.weight` suffix, while quantized expert scales keep
+    dotted suffixes such as `.weight_scale_2` and `.input_scale`. FusedMoE
+    stores all of these as underscore-separated parameter names.
+    """
+    expert_part_start = name.rfind(weight_name)
+    if expert_part_start == -1:
+        return None
+    if expert_part_start > 0 and name[expert_part_start - 1] != ".":
+        return None
+
+    layer_prefix = name[:expert_part_start]
+    expert_part = name[expert_part_start:]
+
+    if expert_part == weight_name:
+        expert_suffix = "weight"
+    elif expert_part.startswith(weight_name + "."):
+        expert_suffix = expert_part[len(weight_name) + 1 :]
+    else:
+        return None
+
+    return f"{layer_prefix}{param_name_prefix}{expert_suffix}"
+
+
 class Gemma4MLP(nn.Module):
     def __init__(
         self,
@@ -1263,12 +1295,12 @@ class Gemma4Model(nn.Module):
         #   "experts.0.gate_proj.weight" -> "experts.w13_weight"
         num_experts = getattr(self.config, "num_experts", None) or 0
         expert_params_mapping = [
-            # (param_name, weight_name, expert_id, shard_id)
+            # (param_name_prefix, weight_name, expert_id, shard_id)
             (
                 "experts.w13_"
                 if proj_name in ["gate_proj", "up_proj"]
                 else "experts.w2_",
-                f"experts.{expert_id}.{proj_name}.",
+                f"experts.{expert_id}.{proj_name}",
                 expert_id,
                 shard_id,
             )
@@ -1323,41 +1355,36 @@ class Gemma4Model(nn.Module):
                 break
             else:
                 for (
-                    param_name,
+                    param_name_prefix,
                     weight_name,
                     expert_id,
                     shard_id,
                 ) in expert_params_mapping:
-                    # Match both:
-                    #  - Bare weights: "experts.0.down_proj" (from 3D explosion)
-                    #  - With suffix: "experts.0.down_proj.weight_scale" (2D quantized)
-                    # weight_name has trailing dot, so check with and without it
-                    weight_name_base = weight_name.rstrip(".")
-                    if weight_name in name:
-                        # Has suffix (e.g., .weight_scale)
-                        moe_name = name.replace(weight_name, param_name)
-                    elif name.endswith(weight_name_base):
-                        # Bare weight (no suffix)
-                        moe_name = name.replace(
-                            weight_name_base, param_name.rstrip("_") + "_weight"
-                        )
-                    else:
+                    moe_name = _map_gemma4_expert_param_name(
+                        name, param_name_prefix, weight_name
+                    )
+                    if moe_name is None:
                         continue
                     if moe_name not in params_dict:
                         continue
                     if is_pp_missing_parameter(moe_name, self):
                         continue
                     param = params_dict[moe_name]
+                    expert_suffix = moe_name.removeprefix(param_name_prefix)
                     # Expert weights are already in the correct
                     # orientation for FusedMoE after _weight_iterator:
                     #   gate/up: [I, H] → w1/w3 expects [I, H]
                     #   down:    [H, I] → w2 expects [H, I]
-                    # Scales and other quantization params may be 1D or scalar.
+                    if moe_name.endswith("_weight"):
+                        assert loaded_weight.dim() == 2, (
+                            f"Expected 2D expert weight for {weight_name}, "
+                            f"got shape {loaded_weight.shape}"
+                        )
                     weight_loader = param.weight_loader
                     weight_loader(
                         param,
                         loaded_weight,
-                        moe_name,  # Pass mapped name (handles both weights and scales)
+                        moe_name,
                         shard_id=shard_id,
                         expert_id=expert_id,
                     )

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1370,7 +1370,6 @@ class Gemma4Model(nn.Module):
                     if is_pp_missing_parameter(moe_name, self):
                         continue
                     param = params_dict[moe_name]
-                    expert_suffix = moe_name.removeprefix(param_name_prefix)
                     # Expert weights are already in the correct
                     # orientation for FusedMoE after _weight_iterator:
                     #   gate/up: [I, H] → w1/w3 expects [I, H]


### PR DESCRIPTION
## Summary
Fixes #38912.

Gemma4 MoE expert checkpoint tensors can arrive as bare weights or as suffixed scale tensors like .weight_scale, .weight_scale_2, and .input_scale. The previous mapping only handled the bare weight case cleanly and could generate invalid names like experts.w2_weight.weight_scale.

This patch maps expert checkpoint names to the correct FusedMoE parameter names before dispatching to the expert weight_loader, and adds a regression test covering the NVFP4 suffix variants.

## Why this is not duplicating an existing PR
- gh issue view 38912 --repo vllm-project/vllm --comments --json comments returned an empty comments list.
- gh pr list --repo vllm-project/vllm --state open --search "38912 in:body" --json number,title,url returned [].
- gh pr list --repo vllm-project/vllm --state open --search "Gemma4 NVFP4 expert_params_mapping" --json number,title,url returned [].

## Testing
- uv venv --python 3.12 --seed --managed-python
- uv pip install -r requirements/lint.txt
- pre-commit install
- VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto
- uv pip install -r requirements/test.in
- pre-commit run
- .venv/bin/python -m pytest tests/model_executor/test_gemma4_weight_loading.py -v

Results:
- pre-commit run: passed
- pytest tests/model_executor/test_gemma4_weight_loading.py -v: 6 passed

## AI assistance
AI assistance was used to analyze the issue, implement the fix, and add the regression test.

## Note
Opening this as a draft first so the human submitter can complete final line-by-line review per the repository's AI-assisted contribution policy.