### PR TITLE
[Bug] Fix mistral version dependency

### DIFF
--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -23,7 +23,7 @@ jiwer # required for audio tests
 timm # required for internvl test
 transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test
-mistral_common[image,audio] >= 1.9.1 # required for voxtral test
+mistral_common[image,audio] >= 1.11.0 # required for voxtral test
 num2words # required for smolvlm test
 opencv-python-headless >= 4.13.0 # required for video test
 datamodel_code_generator # required for minicpm3 test

--- a/requirements/rocm-test.in
+++ b/requirements/rocm-test.in
@@ -31,7 +31,7 @@ tblib # for pickling test exceptions
 timm>=1.0.17 # required for internvl and gemma3n-mm test
 transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test
-mistral_common[image,audio]>=1.10.0 # required for voxtral test
+mistral_common[image,audio]>=1.11.0 # required for voxtral test
 num2words # required for smolvlm test
 open_clip_torch==2.32.0 # Required for nemotron_vl test, Nemotron Parse in test_common.py
 opencv-python-headless>=4.13.0 # required for video test

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -32,7 +32,7 @@ torchaudio==2.10.0
 torchvision==0.25.0
 transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test
-mistral_common[image,audio] >= 1.9.1 # required for voxtral test
+mistral_common[image,audio] >= 1.11.0 # required for voxtral test
 num2words # required for smolvlm test
 open_clip_torch==2.32.0 # Required for nemotron_vl test, Nemotron Parse in test_common.py
 opencv-python-headless >= 4.13.0 # required for video test


### PR DESCRIPTION
## Purpose

Fix mistral version dependency

In common.txt we already have `mistral_common[image] >= 1.11.0`, but for other places we are not using this version.

This will raise error like

```bash
(ApiServer_0 pid=4033928)   File "/home/yewentao256/vllm-source/vllm/entrypoints/openai/api_server.py", line 702, in run_server_worker
(ApiServer_0 pid=4033928)     shutdown_task = await build_and_serve(
(ApiServer_0 pid=4033928)                     ^^^^^^^^^^^^^^^^^^^^^^
(ApiServer_0 pid=4033928)   File "/home/yewentao256/vllm-source/vllm/entrypoints/openai/api_server.py", line 605, in build_and_serve
(ApiServer_0 pid=4033928)     app = build_app(args, supported_tasks, model_config)
(ApiServer_0 pid=4033928)           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ApiServer_0 pid=4033928)   File "/home/yewentao256/vllm-source/vllm/entrypoints/openai/api_server.py", line 196, in build_app
(ApiServer_0 pid=4033928)     register_sagemaker_api_router(app, supported_tasks, model_config)
(ApiServer_0 pid=4033928)   File "/home/yewentao256/vllm-source/vllm/entrypoints/sagemaker/api_router.py", line 112, in attach_router
(ApiServer_0 pid=4033928)     INVOCATION_TYPES = get_invocation_types(supported_tasks, model_config)
(ApiServer_0 pid=4033928)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ApiServer_0 pid=4033928)   File "/home/yewentao256/vllm-source/vllm/entrypoints/sagemaker/api_router.py", line 38, in get_invocation_types
(ApiServer_0 pid=4033928)     from vllm.entrypoints.openai.chat_completion.api_router import (
(ApiServer_0 pid=4033928)   File "/home/yewentao256/vllm-source/vllm/entrypoints/openai/chat_completion/api_router.py", line 10, in <module>
(ApiServer_0 pid=4033928)     from vllm.entrypoints.openai.chat_completion.batch_serving import OpenAIServingChatBatch
(ApiServer_0 pid=4033928)   File "/home/yewentao256/vllm-source/vllm/entrypoints/openai/chat_completion/batch_serving.py", line 18, in <module>
(ApiServer_0 pid=4033928)     from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
(ApiServer_0 pid=4033928)   File "/home/yewentao256/vllm-source/vllm/entrypoints/openai/chat_completion/serving.py", line 76, in <module>
(ApiServer_0 pid=4033928)     from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
(ApiServer_0 pid=4033928)   File "/home/yewentao256/vllm-source/vllm/tool_parsers/mistral_tool_parser.py", line 13, in <module>
(ApiServer_0 pid=4033928)     from mistral_common.protocol.instruct.tool_calls import (
(ApiServer_0 pid=4033928) ImportError: cannot import name 'NamedToolChoice' from 'mistral_common.protocol.instruct.tool_calls' (/home/yewentao256/.venv/lib/python3.12/site-packages/mistral_common/protocol/instruct/tool_calls.py)
```

This PR solves the issue