### PR TITLE
[Model] Align Kimi-Audio transcription and dual-stream serving behavior

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -24,6 +24,7 @@ nav:
       - TPU: https://docs.vllm.ai/projects/tpu/en/latest/
     - Models:
       - models/supported_models.md
+      - models/kimi_audio.md
       - models/generative_models.md
       - Pooling Models: models/pooling_models
       - models/extensions

--- a/docs/models/kimi_audio.md
+++ b/docs/models/kimi_audio.md
@@ -21,11 +21,10 @@ other models.
   `moonshotai/Kimi-Audio-7B-Instruct`.
 - The discrete speech tokenizer is resolved from
   `THUDM/glm-4-voice-tokenizer` by default.
-- An optional local cache override is available through
-  `KIMI_AUDIO_SPEECH_TOKENIZER_PATH`.
-- Kimi-Audio does not require a model-specific attention backend override in
-  vLLM. It follows the same platform-default backend selection as other vLLM
-  models unless the caller explicitly configures a backend.
+- An optional local path override for the speech tokenizer is available
+  through `KIMI_AUDIO_SPEECH_TOKENIZER_PATH`.
+- An optional device override for the speech tokenizer is available through
+  `KIMI_AUDIO_SPEECH_TOKENIZER_DEVICE`.
 
 ## Required Prompt Shape
 

--- a/docs/models/kimi_audio.md
+++ b/docs/models/kimi_audio.md
@@ -1,0 +1,72 @@
+# Kimi-Audio
+
+`KimiAudioForConditionalGeneration` is supported in vLLM for the verified
+`text-output` subset of `moonshotai/Kimi-Audio-7B-Instruct`.
+
+## Supported Behavior
+
+- Audio-to-text transcription with text prompts.
+- Audio understanding with text-only responses.
+- Batched inference for the same `text-output` subset.
+- Offline inference through [`LLM.generate`](../../examples/offline_inference/audio_language.py).
+
+The current implementation keeps Kimi-Audio's model-specific prompt packing and
+dual-stream input construction inside the Kimi-Audio model and processor
+modules. This avoids changing vLLM's general multimodal runtime behavior for
+other models.
+
+## Loading And Runtime Defaults
+
+- Load the model through the Hugging Face repo id
+  `moonshotai/Kimi-Audio-7B-Instruct`.
+- The discrete speech tokenizer is resolved from
+  `THUDM/glm-4-voice-tokenizer` by default.
+- Local development overrides are optional and environment-based:
+  `KIMI_AUDIO_SPEECH_TOKENIZER_PATH` and `KIMI_AUDIO_SOURCE_ROOT`.
+- Kimi-Audio does not require a model-specific attention backend override in
+  vLLM. It follows the same platform-default backend selection as other vLLM
+  models unless the caller explicitly configures a backend.
+
+## Required Prompt Shape
+
+Kimi-Audio requests must use the official Kimi text-output prompt format with
+the audio placeholder sequence:
+
+```text
+<|im_media_begin|><|im_kimia_text_blank|><|im_media_end|><|im_kimia_speech_ct_id|>
+```
+
+The example in [`examples/offline_inference/audio_language.py`](../../examples/offline_inference/audio_language.py)
+shows the recommended pattern:
+
+- Build the prompt with
+  `vllm.model_executor.models.kimi_audio_prompt.KimiAudioPromptBuilder`.
+- Pass structured `messages` through `mm_processor_kwargs`.
+- Stop on `kimia_text_eos` before falling back to generic tokenizer EOS ids.
+
+## Current Scope
+
+The validated support boundary is:
+
+- User text plus user audio inputs.
+- Assistant text outputs.
+- Text-output prompting for transcription and audio question answering.
+
+The following capabilities are not part of the current support scope:
+
+- Audio output generation.
+- `output_type="both"`.
+- Assistant history containing `audio-text` turns.
+- The official Kimi-Audio detokenizer and vocoder path.
+
+## Validation Status
+
+The current implementation has been aligned against the official Kimi-Audio
+repository for:
+
+- English transcription on single-request and batched requests.
+- Chinese transcription on the official ASR sample.
+- Audio question answering with text-only output.
+
+These checks confirm alignment for the current `text-output` subset, but they
+do not imply support for the unsupported capabilities listed above.

--- a/docs/models/kimi_audio.md
+++ b/docs/models/kimi_audio.md
@@ -21,8 +21,8 @@ other models.
   `moonshotai/Kimi-Audio-7B-Instruct`.
 - The discrete speech tokenizer is resolved from
   `THUDM/glm-4-voice-tokenizer` by default.
-- Local development overrides are optional and environment-based:
-  `KIMI_AUDIO_SPEECH_TOKENIZER_PATH` and `KIMI_AUDIO_SOURCE_ROOT`.
+- An optional local cache override is available through
+  `KIMI_AUDIO_SPEECH_TOKENIZER_PATH`.
 - Kimi-Audio does not require a model-specific attention backend override in
   vLLM. It follows the same platform-default backend selection as other vLLM
   models unless the caller explicitly configures a backend.

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -668,6 +668,10 @@ Speech2Text models trained specifically for Automatic Speech Recognition.
 | `WhisperForConditionalGeneration` | Whisper | `openai/whisper-small`, `openai/whisper-large-v3-turbo`, etc. | | |
 
 !!! note
+    For the currently validated Kimi-Audio support boundary and prompting
+    requirements, see [Kimi-Audio](./kimi_audio.md).
+
+!!! note
     `VoxtralForConditionalGeneration` requires `mistral-common[audio]` to be installed.
 
 ## Pooling Models

--- a/examples/offline_inference/audio_language.py
+++ b/examples/offline_inference/audio_language.py
@@ -251,6 +251,7 @@ def run_kimi_audio(question: str, audio_count: int) -> ModelRequestData:
     from vllm.model_executor.models.kimi_audio_prompt import (
         KimiAudioPromptBuilder,
     )
+
     messages = [
         {"role": "user", "message_type": "text", "content": question},
         {"role": "user", "message_type": "audio"},

--- a/examples/offline_inference/audio_language.py
+++ b/examples/offline_inference/audio_language.py
@@ -32,6 +32,7 @@ class ModelRequestData(NamedTuple):
     prompt: str | None = None
     prompt_token_ids: dict[str, list[int]] | None = None
     multi_modal_data: dict[str, Any] | None = None
+    mm_processor_kwargs: dict[str, Any] | None = None
     stop_token_ids: list[int] | None = None
     lora_requests: list[LoRARequest] | None = None
 
@@ -245,18 +246,29 @@ def run_kimi_audio(question: str, audio_count: int) -> ModelRequestData:
         limit_mm_per_prompt={"audio": audio_count},
     )
 
-    # Kimi-Audio uses <|im_kimia_text_blank|> as placeholder for audio features
-    audio_placeholder = "<|im_kimia_text_blank|>" * audio_count
-    # Default prompt for transcription
     if not question:
         question = "Please transcribe the audio"
-    prompt = f"{audio_placeholder}{question}"
+    from vllm.model_executor.models.kimi_audio_prompt import (
+        KimiAudioPromptBuilder,
+    )
+    messages = [
+        {"role": "user", "message_type": "text", "content": question},
+        {"role": "user", "message_type": "audio"},
+    ]
+    prompt = KimiAudioPromptBuilder.build_transcription_prompt(
+        question,
+        audio_count=audio_count,
+    )
 
-    # Stop at EOS token (151644) to prevent repetition
+    # Stop at text EOS first, then fall back to the tokenizer EOS ids.
     return ModelRequestData(
         engine_args=engine_args,
         prompt=prompt,
-        stop_token_ids=[151644],
+        mm_processor_kwargs={
+            "messages": messages,
+            "output_type": "text",
+        },
+        stop_token_ids=[151667, 151645, 151644],
     )
 
 
@@ -654,6 +666,8 @@ def main(args):
                 }
 
         inputs = {"multi_modal_data": mm_data}
+        if req_data.mm_processor_kwargs:
+            inputs["mm_processor_kwargs"] = req_data.mm_processor_kwargs
 
         if req_data.prompt:
             inputs["prompt"] = req_data.prompt

--- a/tests/entrypoints/openai/chat_completion/test_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat.py
@@ -1131,3 +1131,25 @@ def test_chat_completion_request_n_parameter_massive_value(
             max_tokens=1,
             default_sampling_params={},
         )
+
+
+def test_build_chat_params_preserves_mm_processor_kwargs() -> None:
+    mm_processor_kwargs = {
+        "messages": [
+            {"role": "user", "message_type": "text", "content": "hello"},
+            {"role": "user", "message_type": "audio"},
+        ],
+        "output_type": "text",
+    }
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "hello"}],
+        mm_processor_kwargs=mm_processor_kwargs,
+    )
+
+    params = request.build_chat_params(
+        default_template="template",
+        default_template_content_format="string",
+    )
+
+    assert params.mm_processor_kwargs == mm_processor_kwargs

--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -5,6 +5,7 @@ from openai_harmony import (
 )
 
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
     serialize_message,
     serialize_messages,
 )
@@ -37,3 +38,25 @@ def test_serialize_messages() -> None:
     }
     msg = Message.from_dict(msg_value)
     assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]
+
+
+def test_build_chat_params_preserves_mm_processor_kwargs() -> None:
+    mm_processor_kwargs = {
+        "messages": [
+            {"role": "user", "message_type": "text", "content": "hello"},
+            {"role": "user", "message_type": "audio"},
+        ],
+        "output_type": "text",
+    }
+    request = ResponsesRequest(
+        model="test-model",
+        input="hello",
+        mm_processor_kwargs=mm_processor_kwargs,
+    )
+
+    params = request.build_chat_params(
+        default_template="template",
+        default_template_content_format="string",
+    )
+
+    assert params.mm_processor_kwargs == mm_processor_kwargs

--- a/tests/models/multimodal/generation/test_kimi_audio_unit.py
+++ b/tests/models/multimodal/generation/test_kimi_audio_unit.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import jinja2
 import numpy as np
 import pytest
 import safetensors.torch
@@ -111,7 +112,11 @@ def test_kimi_audio_prompt_builder_supports_text_history():
     )
 
 
-def test_kimi_audio_chat_template_renders_service_messages():
+@pytest.mark.parametrize(
+    "input_style",
+    ["messages", "conversation", "conversations"],
+)
+def test_kimi_audio_chat_template_renders_service_messages(input_style):
     template_path = (
         Path(__file__).resolve().parents[4]
         / "vllm"
@@ -123,18 +128,30 @@ def test_kimi_audio_chat_template_renders_service_messages():
     content = KimiAudioPromptBuilder.build_user_audio_content(
         "Please answer the question in the audio.",
     )
+    assistant = "你能不能从一数到十？"
+    conversation = [
+        {"role": "user", "content": content},
+        {"role": "assistant", "content": assistant},
+    ]
 
-    rendered, _ = hf_chat_utils.render_jinja_template(
-        [[{"role": "user", "content": content}]],
-        chat_template=template,
-    )
+    if input_style == "conversations":
+        rendered, _ = hf_chat_utils.render_jinja_template(
+            [conversation],
+            chat_template=template,
+        )
+        prompt = rendered[0]
+    else:
+        prompt = jinja2.Environment().from_string(template).render(
+            **{input_style: conversation}
+        )
 
-    assert rendered == [
+    assert prompt == (
         "<|im_kimia_user_msg_start|>Please answer the question in the audio.\n"
         "<|im_media_begin|><|im_kimia_text_blank|><|im_media_end|>"
         "<|im_kimia_speech_ct_id|><|im_msg_end|>"
-        "<|im_kimia_assistant_msg_start|>"
-    ]
+        "<|im_kimia_assistant_msg_start|>你能不能从一数到十？"
+        "<|im_kimia_text_eos|><|im_msg_end|>"
+    )
 
 
 def test_kimi_audio_tokenizer_wraps_single_conversation_for_template_render(

--- a/tests/models/multimodal/generation/test_kimi_audio_unit.py
+++ b/tests/models/multimodal/generation/test_kimi_audio_unit.py
@@ -285,6 +285,167 @@ def test_kimi_audio_build_inputs_embeds_supports_runtime_flat_tokens():
     assert torch.equal(outputs, torch.tensor([[11.0], [22.0]]))
 
 
+def test_kimi_audio_build_inputs_embeds_supports_flat_batch_multimodal_embeddings():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeLanguageModel()
+
+    outputs = KimiAudioForConditionalGeneration._build_kimi_audio_inputs_embeds(
+        model,
+        audio_token_ids=torch.tensor([10, 11, 20], dtype=torch.long),
+        text_input_ids=torch.tensor([1, 1, 2], dtype=torch.long),
+        is_continuous_mask=torch.tensor([True, False, True]),
+        multimodal_embeddings=[
+            torch.tensor([[100.0, 100.0]]),
+            torch.tensor([[200.0, 200.0]]),
+        ],
+    )
+
+    sqrt2 = 2**0.5
+    expected = torch.tensor(
+        [
+            [(10.0 + 100.0) * sqrt2 + 1.0, (10.0 + 100.0) * sqrt2 + 1.0],
+            [12.0, 12.0],
+            [(20.0 + 200.0) * sqrt2 + 2.0, (20.0 + 200.0) * sqrt2 + 2.0],
+        ]
+    )
+    assert torch.allclose(outputs, expected)
+
+
+def test_kimi_audio_runtime_slice_supports_flat_batch_request_lists():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    (
+        audio_token_ids,
+        text_input_ids,
+        is_continuous_mask,
+    ) = KimiAudioForConditionalGeneration._slice_runtime_kimi_prompt_inputs(
+        model,
+        input_ids=torch.tensor([9, 9, 9, 9, 9], dtype=torch.long),
+        positions=torch.tensor([1, 2, 3, 0, 2], dtype=torch.long),
+        audio_token_ids=[
+            torch.tensor([10, 11, 12, 13], dtype=torch.long),
+            torch.tensor([20, 21, 22], dtype=torch.long),
+        ],
+        text_input_ids=[
+            torch.tensor([1, 1, 1, 1], dtype=torch.long),
+            torch.tensor([2, 2, 2], dtype=torch.long),
+        ],
+        is_continuous_mask=[
+            torch.tensor([False, False, True, True]),
+            torch.tensor([True, False, True]),
+        ],
+    )
+
+    assert torch.equal(audio_token_ids, torch.tensor([11, 12, 13, 20, 22]))
+    assert torch.equal(text_input_ids, torch.tensor([1, 1, 1, 2, 2]))
+    assert torch.equal(
+        is_continuous_mask,
+        torch.tensor([False, True, True, True, True]),
+    )
+
+
+def test_kimi_audio_runtime_slice_flattens_batch_request_lists_for_global_positions():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    (
+        audio_token_ids,
+        text_input_ids,
+        is_continuous_mask,
+    ) = KimiAudioForConditionalGeneration._slice_runtime_kimi_prompt_inputs(
+        model,
+        input_ids=torch.tensor([9, 9, 9, 9, 9], dtype=torch.long),
+        positions=torch.tensor([0, 1, 2, 3, 4], dtype=torch.long),
+        audio_token_ids=[
+            torch.tensor([10, 11, 12], dtype=torch.long),
+            torch.tensor([20, 21], dtype=torch.long),
+        ],
+        text_input_ids=[
+            torch.tensor([1, 1, 1], dtype=torch.long),
+            torch.tensor([2, 2], dtype=torch.long),
+        ],
+        is_continuous_mask=[
+            torch.tensor([False, True, True]),
+            torch.tensor([False, True]),
+        ],
+    )
+
+    assert torch.equal(audio_token_ids, torch.tensor([10, 11, 12, 20, 21]))
+    assert torch.equal(text_input_ids, torch.tensor([1, 1, 1, 2, 2]))
+    assert torch.equal(
+        is_continuous_mask,
+        torch.tensor([False, True, True, False, True]),
+    )
+
+
+def test_kimi_audio_runtime_slice_skips_raw_prompt_path_for_batch_decode_tokens():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    (
+        audio_token_ids,
+        text_input_ids,
+        is_continuous_mask,
+    ) = KimiAudioForConditionalGeneration._slice_runtime_kimi_prompt_inputs(
+        model,
+        input_ids=torch.tensor([1, 2], dtype=torch.long),
+        positions=torch.tensor([3, 2], dtype=torch.long),
+        audio_token_ids=[
+            torch.tensor([10, 11, 12], dtype=torch.long),
+            torch.tensor([20, 21], dtype=torch.long),
+        ],
+        text_input_ids=[
+            torch.tensor([1, 1, 1], dtype=torch.long),
+            torch.tensor([2, 2], dtype=torch.long),
+        ],
+        is_continuous_mask=[
+            torch.tensor([False, True, True]),
+            torch.tensor([False, True]),
+        ],
+    )
+
+    assert audio_token_ids is None
+    assert text_input_ids is None
+    assert is_continuous_mask is None
+
+
+def test_kimi_audio_runtime_slice_supports_mixed_decode_and_prefill_batch():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    (
+        audio_token_ids,
+        text_input_ids,
+        is_continuous_mask,
+    ) = KimiAudioForConditionalGeneration._slice_runtime_kimi_prompt_inputs(
+        model,
+        input_ids=torch.tensor([99, 9, 9, 9, 9], dtype=torch.long),
+        positions=torch.tensor([3, 0, 1, 0, 2], dtype=torch.long),
+        audio_token_ids=[
+            torch.tensor([10, 11], dtype=torch.long),
+            torch.tensor([20, 21, 22], dtype=torch.long),
+        ],
+        text_input_ids=[
+            torch.tensor([1, 1], dtype=torch.long),
+            torch.tensor([2, 2, 2], dtype=torch.long),
+        ],
+        is_continuous_mask=[
+            torch.tensor([False, True]),
+            torch.tensor([False, True, True]),
+        ],
+    )
+
+    assert torch.equal(
+        audio_token_ids,
+        torch.tensor(
+            [KimiAudioProcessor.KIMIA_TEXT_BLANK, 10, 11, 20, 22],
+            dtype=torch.long,
+        ),
+    )
+    assert torch.equal(text_input_ids, torch.tensor([99, 1, 1, 2, 2]))
+    assert torch.equal(
+        is_continuous_mask,
+        torch.tensor([False, False, True, False, True]),
+    )
+
+
 def test_kimi_audio_generation_prompt_uses_prompt_builder(monkeypatch):
     captured = {}
 
@@ -676,6 +837,77 @@ def test_kimi_audio_model_builds_packed_dual_stream_embeddings():
         ]
     ).unsqueeze(0)
     assert torch.allclose(embeds, expected)
+
+
+def test_kimi_audio_forward_accepts_flat_batch_request_lists():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeLanguageModel()
+
+    outputs = KimiAudioForConditionalGeneration.forward(
+        model,
+        input_ids=torch.tensor([0, 0, 0, 0, 0], dtype=torch.long),
+        positions=torch.tensor([1, 2, 3, 0, 2], dtype=torch.long),
+        audio_token_ids=[
+            torch.tensor([10, 11, 12, 13], dtype=torch.long),
+            torch.tensor([20, 21, 22], dtype=torch.long),
+        ],
+        text_token_ids=[
+            torch.tensor([1, 1, 1, 1], dtype=torch.long),
+            torch.tensor([2, 2, 2], dtype=torch.long),
+        ],
+        is_continuous_mask=[
+            torch.tensor([False, False, False, False]),
+            torch.tensor([False, False, False]),
+        ],
+    )
+
+    expected = torch.tensor(
+        [
+            [12.0, 12.0],
+            [13.0, 13.0],
+            [14.0, 14.0],
+            [22.0, 22.0],
+            [24.0, 24.0],
+        ]
+    )
+    assert torch.equal(outputs, expected)
+
+
+def test_kimi_audio_forward_supports_mixed_decode_and_prefill_batch():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeLanguageModel()
+
+    outputs = KimiAudioForConditionalGeneration.forward(
+        model,
+        input_ids=torch.tensor([99, 0, 0, 0, 0], dtype=torch.long),
+        positions=torch.tensor([3, 0, 1, 0, 2], dtype=torch.long),
+        audio_token_ids=[
+            torch.tensor([10, 11], dtype=torch.long),
+            torch.tensor([20, 21, 22], dtype=torch.long),
+        ],
+        text_token_ids=[
+            torch.tensor([1, 1], dtype=torch.long),
+            torch.tensor([2, 2, 2], dtype=torch.long),
+        ],
+        is_continuous_mask=[
+            torch.tensor([False, True]),
+            torch.tensor([False, True, True]),
+        ],
+    )
+
+    expected = torch.tensor(
+        [
+            [
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 99.0,
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 99.0,
+            ],
+            [11.0, 11.0],
+            [12.0, 12.0],
+            [22.0, 22.0],
+            [24.0, 24.0],
+        ]
+    )
+    assert torch.equal(outputs, expected)
 
 
 def test_kimi_audio_model_matches_official_bfloat16_fusion_formula():

--- a/tests/models/multimodal/generation/test_kimi_audio_unit.py
+++ b/tests/models/multimodal/generation/test_kimi_audio_unit.py
@@ -14,9 +14,9 @@ from vllm.model_executor.models.kimi_audio_prompt import (
     KimiAudioPromptBuilder,
     KimiAudioTokenContent,
 )
-from vllm.transformers_utils.processors.kimi_audio import KimiAudioProcessor
-from vllm.transformers_utils.processors import kimi_audio_speech as speech_utils
 from vllm.tokenizers.kimi_audio import KimiAudioTokenizer
+from vllm.transformers_utils.processors import kimi_audio_speech as speech_utils
+from vllm.transformers_utils.processors.kimi_audio import KimiAudioProcessor
 
 KIMI_AUDIO_MODEL = "moonshotai/Kimi-Audio-7B-Instruct"
 
@@ -122,10 +122,40 @@ def test_kimi_audio_prompt_builder_builds_token_level_audio_text_streams():
 
     assert isinstance(packed, KimiAudioTokenContent)
     assert packed.audio_token_ids == [
-        6, 4, 1, 7, 4, 4, 4, 1, 6, 2, 152064, 152065, 3, 8, 1, 7,
+        6,
+        4,
+        1,
+        7,
+        4,
+        4,
+        4,
+        1,
+        6,
+        2,
+        152064,
+        152065,
+        3,
+        8,
+        1,
+        7,
     ]
     assert packed.text_token_ids == [
-        4, 10, 4, 4, 20, 21, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4,
+        10,
+        4,
+        4,
+        20,
+        21,
+        5,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
     ]
     assert packed.is_continuous_mask == [
         False,
@@ -162,7 +192,8 @@ def test_kimi_audio_runtime_padding_preserves_prefix_embeddings():
             model,
             input_ids=torch.arange(6, dtype=torch.long),
             kimi_inputs_embeds=kimi_inputs_embeds,
-        ))
+        )
+    )
 
     assert used_runtime_padding
     assert padded.shape == (6, 4)
@@ -175,7 +206,9 @@ def test_kimi_audio_build_inputs_embeds_supports_runtime_flat_tokens():
     model._normalize_multimodal_embeddings = lambda embeddings, batch_size: []
     model.language_model = SimpleNamespace(
         model=SimpleNamespace(
-            embed_tokens=lambda token_ids: token_ids.unsqueeze(-1).to(torch.float32)))
+            embed_tokens=lambda token_ids: token_ids.unsqueeze(-1).to(torch.float32)
+        )
+    )
 
     outputs = KimiAudioForConditionalGeneration._build_kimi_audio_inputs_embeds(
         model,
@@ -324,7 +357,9 @@ def test_kimi_audio_speech_tokenizer_prefers_local_override(monkeypatch, tmp_pat
 
     monkeypatch.setenv("KIMI_AUDIO_SPEECH_TOKENIZER_PATH", str(local_path))
 
-    resolved = speech_utils._resolve_speech_tokenizer_path("THUDM/glm-4-voice-tokenizer")
+    resolved = speech_utils._resolve_speech_tokenizer_path(
+        "THUDM/glm-4-voice-tokenizer"
+    )
 
     assert resolved == str(local_path)
 
@@ -342,17 +377,22 @@ def test_kimi_audio_speech_tokenizer_honors_device_override(monkeypatch):
 
 def test_kimi_audio_speech_tokenizer_can_import_local_whisper_vq(monkeypatch, tmp_path):
     source_root = tmp_path / "Kimi-Audio"
-    speech_dir = source_root / "kimia_infer" / "models" / "tokenizer" / "glm4" / "speech_tokenizer"
+    speech_dir = (
+        source_root
+        / "kimia_infer"
+        / "models"
+        / "tokenizer"
+        / "glm4"
+        / "speech_tokenizer"
+    )
     speech_dir.mkdir(parents=True)
     (speech_dir / "__init__.py").write_text("", encoding="utf-8")
     (speech_dir / "configuration_whisper.py").write_text(
-        "class WhisperVQConfig:\n"
-        "    pass\n",
+        "class WhisperVQConfig:\n    pass\n",
         encoding="utf-8",
     )
     (speech_dir / "modeling_whisper.py").write_text(
-        "class WhisperVQEncoder:\n"
-        "    pass\n",
+        "class WhisperVQEncoder:\n    pass\n",
         encoding="utf-8",
     )
 
@@ -446,16 +486,18 @@ def test_kimi_audio_processor_can_return_packed_kimi_token_streams():
 
     assert outputs["audio_token_ids"].tolist() == [[6, 2, 152064, 152065, 3, 8, 1, 7]]
     assert outputs["text_token_ids"].tolist() == [[4, 4, 4, 4, 4, 4, 4, 4]]
-    assert outputs["is_continuous_mask"].tolist() == [[
-        False,
-        False,
-        True,
-        True,
-        False,
-        False,
-        False,
-        False,
-    ]]
+    assert outputs["is_continuous_mask"].tolist() == [
+        [
+            False,
+            False,
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+        ]
+    ]
 
 
 def test_kimi_audio_processor_batches_packed_kimi_token_streams_per_request():
@@ -497,7 +539,9 @@ class _FakeLanguageModelCore:
         self.embed_tokens = _FakeEmbedTokens()
 
     def __call__(self, input_ids, positions, intermediate_tensors, inputs_embeds=None):
-        return inputs_embeds if inputs_embeds is not None else self.embed_tokens(input_ids)
+        return (
+            inputs_embeds if inputs_embeds is not None else self.embed_tokens(input_ids)
+        )
 
 
 class _FakeLanguageModel:
@@ -528,12 +572,16 @@ def test_kimi_audio_model_builds_packed_dual_stream_embeddings():
 
     audio_token_ids = torch.tensor([[6, 2, 152064, 152065, 3, 8, 1, 7]])
     text_token_ids = torch.tensor([[4, 4, 4, 4, 4, 4, 4, 4]])
-    is_continuous_mask = torch.tensor([[False, False, True, True, False, False, False, False]])
+    is_continuous_mask = torch.tensor(
+        [[False, False, True, True, False, False, False, False]]
+    )
     multimodal_embeddings = [
-        torch.tensor([
-            [100.0, 100.0],
-            [200.0, 200.0],
-        ])
+        torch.tensor(
+            [
+                [100.0, 100.0],
+                [200.0, 200.0],
+            ]
+        )
     ]
 
     embeds = KimiAudioForConditionalGeneration._build_kimi_audio_inputs_embeds(
@@ -545,16 +593,18 @@ def test_kimi_audio_model_builds_packed_dual_stream_embeddings():
     )
 
     sqrt2 = 2**0.5
-    expected = torch.tensor([
-        [10.0, 10.0],
-        [6.0, 6.0],
-        [(152064.0 + 100.0) * sqrt2 + 4.0, (152064.0 + 100.0) * sqrt2 + 4.0],
-        [(152065.0 + 200.0) * sqrt2 + 4.0, (152065.0 + 200.0) * sqrt2 + 4.0],
-        [7.0, 7.0],
-        [12.0, 12.0],
-        [5.0, 5.0],
-        [11.0, 11.0],
-    ]).unsqueeze(0)
+    expected = torch.tensor(
+        [
+            [10.0, 10.0],
+            [6.0, 6.0],
+            [(152064.0 + 100.0) * sqrt2 + 4.0, (152064.0 + 100.0) * sqrt2 + 4.0],
+            [(152065.0 + 200.0) * sqrt2 + 4.0, (152065.0 + 200.0) * sqrt2 + 4.0],
+            [7.0, 7.0],
+            [12.0, 12.0],
+            [5.0, 5.0],
+            [11.0, 11.0],
+        ]
+    ).unsqueeze(0)
     assert torch.allclose(embeds, expected)
 
 
@@ -562,8 +612,9 @@ def test_kimi_audio_model_matches_official_bfloat16_fusion_formula():
     model = object.__new__(KimiAudioForConditionalGeneration)
     model.language_model = _FakeLanguageModel()
     original_embed_tokens = model.language_model.model.embed_tokens
-    model.language_model.model.embed_tokens = lambda ids: original_embed_tokens(
-        ids).to(torch.bfloat16)
+    model.language_model.model.embed_tokens = lambda ids: original_embed_tokens(ids).to(
+        torch.bfloat16
+    )
 
     audio_token_ids = torch.tensor([[152064, 6]], dtype=torch.long)
     text_token_ids = torch.tensor([[4, 4]], dtype=torch.long)
@@ -581,14 +632,17 @@ def test_kimi_audio_model_matches_official_bfloat16_fusion_formula():
     )
 
     audio_emb = model.language_model.model.embed_tokens(audio_token_ids).to(
-        torch.bfloat16)
+        torch.bfloat16
+    )
     text_emb = model.language_model.model.embed_tokens(text_token_ids).to(
-        torch.bfloat16)
+        torch.bfloat16
+    )
     whisper_emb = torch.zeros_like(audio_emb)
     whisper_emb[0, 0] = torch.tensor([100.0, 100.0], dtype=torch.bfloat16)
     continuous_mask = is_continuous_mask[:, :, None].to(torch.bool)
     sqrt_two = torch.sqrt(
-        torch.tensor(2.0, dtype=audio_emb.dtype, device=audio_emb.device))
+        torch.tensor(2.0, dtype=audio_emb.dtype, device=audio_emb.device)
+    )
     expected = (
         audio_emb * (~continuous_mask)
         + ((audio_emb + whisper_emb) * sqrt_two) * continuous_mask
@@ -633,7 +687,9 @@ def test_kimi_audio_projector_matches_official_activation_and_norm():
 
 def test_kimi_audio_model_process_audio_input_accepts_feature_lists():
     model = object.__new__(KimiAudioForConditionalGeneration)
-    model.audio_tower = lambda features: torch.ones((len(features), 8, 2), dtype=torch.float32)
+    model.audio_tower = lambda features: torch.ones(
+        (len(features), 8, 2), dtype=torch.float32
+    )
     model.multi_modal_projector = lambda features: features + 3.0
 
     audio_embeds = KimiAudioForConditionalGeneration._process_audio_input(
@@ -648,7 +704,9 @@ def test_kimi_audio_model_process_audio_input_accepts_feature_lists():
 
 def test_kimi_audio_model_process_audio_input_accepts_tuple_batches():
     model = object.__new__(KimiAudioForConditionalGeneration)
-    model.audio_tower = lambda features: torch.ones((len(features), 6, 2), dtype=torch.float32)
+    model.audio_tower = lambda features: torch.ones(
+        (len(features), 6, 2), dtype=torch.float32
+    )
     model.multi_modal_projector = lambda features: features + 2.0
 
     audio_embeds = KimiAudioForConditionalGeneration._process_audio_input(
@@ -756,15 +814,18 @@ def test_kimi_audio_model_keeps_main_hidden_states_for_text_output(monkeypatch):
 
 
 def test_kimi_audio_model_compute_logits_uses_lm_head_for_text_output(monkeypatch):
-    captured = {}
+    captured: dict[str, object] = {}
     model = object.__new__(KimiAudioForConditionalGeneration)
     model.use_mimo_text_path = True
     model.mimo_output = object()
     model.language_model = SimpleNamespace(lm_head=object())
-    model.logits_processor = lambda lm_head, hidden_states, sampling_metadata: captured.setdefault(
-        "lm_head",
-        lm_head,
-    ) or hidden_states
+    model.logits_processor = (
+        lambda lm_head, hidden_states, sampling_metadata: captured.setdefault(
+            "lm_head",
+            lm_head,
+        )
+        or hidden_states
+    )
 
     monkeypatch.setattr(
         kimi_audio_model,
@@ -785,17 +846,17 @@ def test_kimi_audio_embed_input_ids_uses_all_multimodal_embeddings():
     model = object.__new__(KimiAudioForConditionalGeneration)
     model.language_model = SimpleNamespace(
         model=SimpleNamespace(
-            embed_tokens=lambda input_ids: input_ids.unsqueeze(-1).repeat(1, 2).to(
-                torch.float32
-            )
+            embed_tokens=lambda input_ids: input_ids.unsqueeze(-1)
+            .repeat(1, 2)
+            .to(torch.float32)
         )
     )
 
     input_ids = torch.tensor([10, 11, 12, 13, 14], dtype=torch.long)
     is_multimodal = torch.tensor([False, True, True, True, False])
-    multimodal_embeddings = (torch.tensor(
-        [[100.0, 100.0], [200.0, 200.0], [300.0, 300.0]]
-    ),)
+    multimodal_embeddings = (
+        torch.tensor([[100.0, 100.0], [200.0, 200.0], [300.0, 300.0]]),
+    )
 
     embeds = KimiAudioForConditionalGeneration.embed_input_ids(
         model,
@@ -823,9 +884,9 @@ def test_kimi_audio_embed_input_ids_does_not_spill_embeddings_across_segments():
     model = object.__new__(KimiAudioForConditionalGeneration)
     model.language_model = SimpleNamespace(
         model=SimpleNamespace(
-            embed_tokens=lambda input_ids: input_ids.unsqueeze(-1).repeat(1, 2).to(
-                torch.float32
-            )
+            embed_tokens=lambda input_ids: input_ids.unsqueeze(-1)
+            .repeat(1, 2)
+            .to(torch.float32)
         )
     )
 

--- a/tests/models/multimodal/generation/test_kimi_audio_unit.py
+++ b/tests/models/multimodal/generation/test_kimi_audio_unit.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import safetensors.torch
 import torch
+from transformers.utils import chat_template_utils as hf_chat_utils
 
 from tests.models.registry import HF_EXAMPLE_MODELS
 from vllm.model_executor.models import kimi_audio as kimi_audio_model
@@ -17,6 +20,10 @@ from vllm.model_executor.models.kimi_audio_prompt import (
 from vllm.tokenizers.kimi_audio import KimiAudioTokenizer
 from vllm.transformers_utils.processors import kimi_audio_speech as speech_utils
 from vllm.transformers_utils.processors.kimi_audio import KimiAudioProcessor
+from vllm.transformers_utils.processors.kimi_audio_whisper_vq import (
+    WhisperVQConfig,
+    WhisperVQEncoder,
+)
 
 KIMI_AUDIO_MODEL = "moonshotai/Kimi-Audio-7B-Instruct"
 
@@ -102,6 +109,62 @@ def test_kimi_audio_prompt_builder_supports_text_history():
         "<|im_kimia_speech_ct_id|><|im_msg_end|>"
         "<|im_kimia_assistant_msg_start|>"
     )
+
+
+def test_kimi_audio_chat_template_renders_service_messages():
+    template_path = (
+        Path(__file__).resolve().parents[4]
+        / "vllm"
+        / "transformers_utils"
+        / "chat_templates"
+        / "template_kimi_audio.jinja"
+    )
+    template = template_path.read_text()
+    content = KimiAudioPromptBuilder.build_user_audio_content(
+        "Please answer the question in the audio.",
+    )
+
+    rendered, _ = hf_chat_utils.render_jinja_template(
+        [[{"role": "user", "content": content}]],
+        chat_template=template,
+    )
+
+    assert rendered == [
+        "<|im_kimia_user_msg_start|>Please answer the question in the audio.\n"
+        "<|im_media_begin|><|im_kimia_text_blank|><|im_media_end|>"
+        "<|im_kimia_speech_ct_id|><|im_msg_end|>"
+        "<|im_kimia_assistant_msg_start|>"
+    ]
+
+
+def test_kimi_audio_tokenizer_wraps_single_conversation_for_template_render(
+    monkeypatch,
+):
+    captured = {}
+    tokenizer = object.__new__(KimiAudioTokenizer)
+    tokenizer.get_chat_template = lambda chat_template, tools=None: chat_template
+    tokenizer.encode = lambda text, add_special_tokens=False: [1, 2, 3]
+
+    def fake_render_jinja_template(conversations, **kwargs):
+        captured["conversations"] = conversations
+        captured["kwargs"] = kwargs
+        return ["rendered prompt"], []
+
+    monkeypatch.setattr(
+        "vllm.tokenizers.kimi_audio.hf_chat_utils.render_jinja_template",
+        fake_render_jinja_template,
+    )
+
+    prompt = KimiAudioTokenizer.apply_chat_template(
+        tokenizer,
+        conversation=[{"role": "user", "content": "hello"}],
+        chat_template="unused template",
+        tokenize=False,
+    )
+
+    assert prompt == "rendered prompt"
+    assert captured["conversations"] == [[{"role": "user", "content": "hello"}]]
+    assert "conversation" not in captured["kwargs"]
 
 
 def test_kimi_audio_prompt_builder_builds_token_level_audio_text_streams():
@@ -375,35 +438,42 @@ def test_kimi_audio_speech_tokenizer_honors_device_override(monkeypatch):
     assert tokenizer.device == "cpu"
 
 
-def test_kimi_audio_speech_tokenizer_can_import_local_whisper_vq(monkeypatch, tmp_path):
-    source_root = tmp_path / "Kimi-Audio"
-    speech_dir = (
-        source_root
-        / "kimia_infer"
-        / "models"
-        / "tokenizer"
-        / "glm4"
-        / "speech_tokenizer"
-    )
-    speech_dir.mkdir(parents=True)
-    (speech_dir / "__init__.py").write_text("", encoding="utf-8")
-    (speech_dir / "configuration_whisper.py").write_text(
-        "class WhisperVQConfig:\n    pass\n",
-        encoding="utf-8",
-    )
-    (speech_dir / "modeling_whisper.py").write_text(
-        "class WhisperVQEncoder:\n    pass\n",
-        encoding="utf-8",
-    )
+def test_kimi_audio_speech_tokenizer_loads_vendored_whisper_vq(tmp_path):
+    model_path = tmp_path / "glm-4-voice-tokenizer"
+    model_path.mkdir()
 
-    monkeypatch.setenv("KIMI_AUDIO_SOURCE_ROOT", str(source_root))
-    speech_utils._import_local_whisper_vq_encoder.cache_clear()
+    config = WhisperVQConfig(
+        vocab_size=32,
+        num_mel_bins=4,
+        d_model=8,
+        encoder_attention_heads=2,
+        encoder_ffn_dim=16,
+        encoder_layers=4,
+        max_source_positions=12,
+        dropout=0.0,
+        attention_dropout=0.0,
+        activation_dropout=0.0,
+        encoder_layerdrop=0.0,
+        pooling_kernel_size=2,
+        pooling_type="avg",
+        pooling_position=2,
+        quantize_vocab_size=4,
+        quantize_position=4,
+        quantize_encoder_only=True,
+        quantize_ema_decay=0.99,
+        quantize_causal_block_size=4,
+        encoder_causal_convolution=True,
+    )
+    config.save_pretrained(model_path)
 
-    imported = speech_utils._import_local_whisper_vq_encoder()
+    model = WhisperVQEncoder(config)
+    safetensors.torch.save_file(model.state_dict(), model_path / "model.safetensors")
 
-    assert imported is not None
-    assert imported[0].__name__ == "WhisperVQConfig"
-    assert imported[1].__name__ == "WhisperVQEncoder"
+    loaded = speech_utils._load_local_quantize_encoder(str(model_path), "cpu")
+
+    assert isinstance(loaded, WhisperVQEncoder)
+    assert loaded.config.quantize_encoder_only
+    assert loaded.conv1.weight.shape == model.conv1.weight.shape
 
 
 class _FakeProcessorTokenizer(_FakePromptTokenizer):

--- a/tests/models/multimodal/generation/test_kimi_audio_unit.py
+++ b/tests/models/multimodal/generation/test_kimi_audio_unit.py
@@ -1,0 +1,938 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from tests.models.registry import HF_EXAMPLE_MODELS
+from vllm.model_executor.models import kimi_audio as kimi_audio_model
+from vllm.model_executor.models.kimi_audio import KimiAudioForConditionalGeneration
+from vllm.model_executor.models.kimi_audio_prompt import (
+    KimiAudioPromptBuilder,
+    KimiAudioTokenContent,
+)
+from vllm.transformers_utils.processors.kimi_audio import KimiAudioProcessor
+from vllm.transformers_utils.processors import kimi_audio_speech as speech_utils
+from vllm.tokenizers.kimi_audio import KimiAudioTokenizer
+
+KIMI_AUDIO_MODEL = "moonshotai/Kimi-Audio-7B-Instruct"
+
+
+class _FakePromptTokenizer:
+    special_tokens = {
+        "<|im_msg_end|>": 1,
+        "<|im_media_begin|>": 2,
+        "<|im_media_end|>": 3,
+        "<|im_kimia_text_blank|>": 4,
+        "<|im_kimia_text_eos|>": 5,
+        "<|im_kimia_user_msg_start|>": 6,
+        "<|im_kimia_assistant_msg_start|>": 7,
+        "<|im_kimia_speech_ct_id|>": 8,
+        "<|im_kimia_speech_ctd_id|>": 9,
+    }
+
+    vocab = {
+        "hi": [10],
+        "hello back": [20, 21],
+    }
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return list(self.vocab.get(text, []))
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        return self.special_tokens[token]
+
+
+def test_kimi_audio_tokenizer_encodes_alignment_special_tokens():
+    model_info = HF_EXAMPLE_MODELS.get_hf_info("MoonshotKimiaForCausalLM")
+    model_info.check_available_online(on_fail="skip")
+
+    tokenizer = KimiAudioTokenizer.from_pretrained(KIMI_AUDIO_MODEL)
+
+    token_ids = tokenizer.encode(
+        "<|im_media_begin|><|im_kimia_text_blank|>"
+        "<|im_media_end|><|im_kimia_speech_ct_id|><|im_kimia_text_eos|>",
+        add_special_tokens=False,
+    )
+
+    assert token_ids == [151661, 151666, 151663, 151675, 151667]
+    assert tokenizer.convert_tokens_to_ids("<|im_kimia_speech_ctd_id|>") == 151676
+
+
+def test_kimi_audio_prompt_builder_text_output_audio_message():
+    multi_audio_placeholder = KimiAudioPromptBuilder.build_audio_placeholder(
+        audio_count=2,
+    )
+    assert multi_audio_placeholder.count("<|im_kimia_speech_ct_id|>") == 2
+
+    prompt = KimiAudioPromptBuilder.build_transcription_prompt(
+        "Please transcribe the following audio:",
+        audio_count=1,
+    )
+
+    assert prompt == (
+        "<|im_kimia_user_msg_start|>Please transcribe the following audio:\n"
+        "<|im_media_begin|><|im_kimia_text_blank|><|im_media_end|>"
+        "<|im_kimia_speech_ct_id|><|im_msg_end|>"
+        "<|im_kimia_assistant_msg_start|>"
+    )
+
+
+def test_kimi_audio_prompt_builder_supports_text_history():
+    prompt = KimiAudioPromptBuilder.build_prompt_from_messages(
+        [
+            {"role": "user", "message_type": "text", "content": "hi"},
+            {
+                "role": "assistant",
+                "message_type": "text",
+                "content": "hello back",
+            },
+            {"role": "user", "message_type": "audio", "content": "transcribe"},
+        ]
+    )
+
+    assert prompt == (
+        "<|im_kimia_user_msg_start|>hi<|im_msg_end|>"
+        "<|im_kimia_assistant_msg_start|>hello back<|im_kimia_text_eos|><|im_msg_end|>"
+        "<|im_kimia_user_msg_start|>transcribe\n"
+        "<|im_media_begin|><|im_kimia_text_blank|><|im_media_end|>"
+        "<|im_kimia_speech_ct_id|><|im_msg_end|>"
+        "<|im_kimia_assistant_msg_start|>"
+    )
+
+
+def test_kimi_audio_prompt_builder_builds_token_level_audio_text_streams():
+    tokenizer = _FakePromptTokenizer()
+
+    packed = KimiAudioPromptBuilder.build_token_content(
+        tokenizer=tokenizer,
+        messages=[
+            {"role": "user", "message_type": "text", "content": "hi"},
+            {
+                "role": "assistant",
+                "message_type": "text",
+                "content": "hello back",
+            },
+            {"role": "user", "message_type": "audio", "content": [152064, 152065]},
+        ],
+    )
+
+    assert isinstance(packed, KimiAudioTokenContent)
+    assert packed.audio_token_ids == [
+        6, 4, 1, 7, 4, 4, 4, 1, 6, 2, 152064, 152065, 3, 8, 1, 7,
+    ]
+    assert packed.text_token_ids == [
+        4, 10, 4, 4, 20, 21, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    ]
+    assert packed.is_continuous_mask == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+        False,
+        False,
+        False,
+        False,
+    ]
+
+
+def test_kimi_audio_declares_model_side_multimodal_embed_build():
+    assert KimiAudioForConditionalGeneration.supports_multimodal_raw_input_only
+    assert KimiAudioForConditionalGeneration.builds_multimodal_inputs_embeds_in_forward
+
+
+def test_kimi_audio_runtime_padding_preserves_prefix_embeddings():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.embed_input_ids = lambda input_ids: torch.full((6, 4), -1.0)
+
+    kimi_inputs_embeds = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    padded, used_runtime_padding = (
+        KimiAudioForConditionalGeneration._pad_runtime_kimi_inputs_embeds(
+            model,
+            input_ids=torch.arange(6, dtype=torch.long),
+            kimi_inputs_embeds=kimi_inputs_embeds,
+        ))
+
+    assert used_runtime_padding
+    assert padded.shape == (6, 4)
+    assert torch.equal(padded[:3], kimi_inputs_embeds)
+    assert torch.equal(padded[3:], torch.full((3, 4), -1.0))
+
+
+def test_kimi_audio_build_inputs_embeds_supports_runtime_flat_tokens():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model._normalize_multimodal_embeddings = lambda embeddings, batch_size: []
+    model.language_model = SimpleNamespace(
+        model=SimpleNamespace(
+            embed_tokens=lambda token_ids: token_ids.unsqueeze(-1).to(torch.float32)))
+
+    outputs = KimiAudioForConditionalGeneration._build_kimi_audio_inputs_embeds(
+        model,
+        audio_token_ids=torch.tensor([1, 2], dtype=torch.long),
+        text_input_ids=torch.tensor([10, 20], dtype=torch.long),
+        is_continuous_mask=torch.tensor([False, False]),
+        multimodal_embeddings=None,
+    )
+
+    assert outputs.shape == (2, 1)
+    assert torch.equal(outputs, torch.tensor([[11.0], [22.0]]))
+
+
+def test_kimi_audio_generation_prompt_uses_prompt_builder(monkeypatch):
+    captured = {}
+
+    class FakeTokenizer:
+        def encode(self, prompt: str):
+            captured["prompt"] = prompt
+            return [11, 22, 33]
+
+    monkeypatch.setattr(
+        kimi_audio_model,
+        "cached_get_tokenizer",
+        lambda *args, **kwargs: FakeTokenizer(),
+    )
+
+    audio = np.zeros(8, dtype=np.float32)
+    model_config = SimpleNamespace(
+        tokenizer="unused",
+        tokenizer_mode="kimi_audio",
+        tokenizer_revision=None,
+        trust_remote_code=True,
+    )
+    stt_config = SimpleNamespace(sample_rate=16000)
+
+    prompt = KimiAudioForConditionalGeneration.get_generation_prompt(
+        audio=audio,
+        model_config=model_config,
+        stt_config=stt_config,
+        language=None,
+        task_type="transcribe",
+        request_prompt="Please transcribe the following audio:",
+        to_language=None,
+    )
+
+    prompt_text = captured["prompt"]
+    assert prompt_text == KimiAudioPromptBuilder.build_transcription_prompt(
+        "Please transcribe the following audio:",
+        audio_count=1,
+    )
+    assert prompt["prompt_token_ids"] == [11, 22, 33]
+    assert np.array_equal(prompt["multi_modal_data"]["audio"], audio)
+    assert prompt["mm_processor_kwargs"] == {
+        "messages": [
+            {
+                "role": "user",
+                "message_type": "text",
+                "content": "Please transcribe the following audio:",
+            },
+            {
+                "role": "user",
+                "message_type": "audio",
+            },
+        ],
+        "output_type": "text",
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw_text", "expected"),
+    [
+        ("hello world<|im_kimia_text_eos|>ignored", "hello world"),
+        ("  hello world  ", "  hello world  "),
+        ("", ""),
+    ],
+)
+def test_kimi_audio_post_process_output(raw_text: str, expected: str):
+    assert KimiAudioForConditionalGeneration.post_process_output(raw_text) == expected
+
+
+class _FakeTextTokenizer:
+    def __call__(self, text, return_tensors="pt", padding=True):
+        batch = len(text)
+        return {
+            "input_ids": torch.ones((batch, 2), dtype=torch.long),
+            "attention_mask": torch.ones((batch, 2), dtype=torch.long),
+        }
+
+
+class _FakeFeatureExtractor:
+    hop_length = 4
+
+    def __call__(
+        self,
+        audios,
+        sampling_rate=16000,
+        padding=True,
+        return_attention_mask=True,
+        return_tensors="pt",
+    ):
+        assert padding == "max_length"
+        batch = len(audios)
+        return {
+            "input_features": torch.ones((batch, 3, 5), dtype=torch.float32),
+            "attention_mask": torch.ones((batch, 12), dtype=torch.long),
+        }
+
+
+class _FakeSpeechTokenizer:
+    def encode(self, audios, sampling_rate=16000):
+        if len(audios) == 1:
+            return [[152064, 152065]]
+        return [[152064, 152065], [152066]]
+
+
+def test_kimi_audio_processor_can_return_discrete_speech_tokens():
+    processor = KimiAudioProcessor(
+        feature_extractor=_FakeFeatureExtractor(),
+        tokenizer=_FakeTextTokenizer(),
+        speech_tokenizer=_FakeSpeechTokenizer(),
+    )
+
+    outputs = processor(
+        text=["hi", "hello"],
+        audio=[np.ones(7, dtype=np.float32), np.ones(5, dtype=np.float32)],
+        return_speech_token_ids=True,
+    )
+
+    assert outputs["whisper_input_features"].shape == (2, 3, 5)
+    assert outputs["feature_attention_mask"].shape == (2, 12)
+    assert outputs["audio_sample_lengths"].tolist() == [7, 5]
+    assert outputs["speech_token_ids"].tolist() == [
+        [152064, 152065],
+        [152066, -1],
+    ]
+    assert outputs["speech_attention_mask"].tolist() == [
+        [1, 1],
+        [1, 0],
+    ]
+
+
+def test_kimi_audio_speech_tokenizer_prefers_local_override(monkeypatch, tmp_path):
+    local_path = tmp_path / "glm-4-voice-tokenizer"
+    local_path.mkdir()
+
+    monkeypatch.setenv("KIMI_AUDIO_SPEECH_TOKENIZER_PATH", str(local_path))
+
+    resolved = speech_utils._resolve_speech_tokenizer_path("THUDM/glm-4-voice-tokenizer")
+
+    assert resolved == str(local_path)
+
+
+def test_kimi_audio_speech_tokenizer_honors_device_override(monkeypatch):
+    monkeypatch.setenv("KIMI_AUDIO_SPEECH_TOKENIZER_DEVICE", "cpu")
+
+    tokenizer = speech_utils.KimiAudioSpeechTokenizer(
+        model=SimpleNamespace(conv1=SimpleNamespace(weight=torch.ones(1))),
+        feature_extractor=SimpleNamespace(sampling_rate=16000, hop_length=160),
+    )
+
+    assert tokenizer.device == "cpu"
+
+
+def test_kimi_audio_speech_tokenizer_can_import_local_whisper_vq(monkeypatch, tmp_path):
+    source_root = tmp_path / "Kimi-Audio"
+    speech_dir = source_root / "kimia_infer" / "models" / "tokenizer" / "glm4" / "speech_tokenizer"
+    speech_dir.mkdir(parents=True)
+    (speech_dir / "__init__.py").write_text("", encoding="utf-8")
+    (speech_dir / "configuration_whisper.py").write_text(
+        "class WhisperVQConfig:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    (speech_dir / "modeling_whisper.py").write_text(
+        "class WhisperVQEncoder:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("KIMI_AUDIO_SOURCE_ROOT", str(source_root))
+    speech_utils._import_local_whisper_vq_encoder.cache_clear()
+
+    imported = speech_utils._import_local_whisper_vq_encoder()
+
+    assert imported is not None
+    assert imported[0].__name__ == "WhisperVQConfig"
+    assert imported[1].__name__ == "WhisperVQEncoder"
+
+
+class _FakeProcessorTokenizer(_FakePromptTokenizer):
+    def __call__(self, text, return_tensors="pt", padding=True):
+        batch = len(text)
+        return {
+            "input_ids": torch.ones((batch, 2), dtype=torch.long),
+            "attention_mask": torch.ones((batch, 2), dtype=torch.long),
+        }
+
+
+def test_kimi_audio_prompt_updates_use_speech_token_lengths():
+    processor = object.__new__(kimi_audio_model.KimiAudioMultiModalProcessor)
+    out_mm_kwargs = SimpleNamespace(
+        get_data=lambda: {
+            "speech_token_ids": torch.tensor(
+                [
+                    [152064, 152065, -1],
+                    [152066, 152067, 152068],
+                ],
+                dtype=torch.long,
+            ),
+            "speech_attention_mask": torch.tensor(
+                [
+                    [1, 1, 0],
+                    [1, 1, 1],
+                ],
+                dtype=torch.long,
+            ),
+            "feature_attention_mask": torch.ones((2, 12), dtype=torch.long),
+        }
+    )
+
+    prompt_updates = kimi_audio_model.KimiAudioMultiModalProcessor._get_prompt_updates(
+        processor,
+        mm_items=None,
+        hf_processor_mm_kwargs={},
+        out_mm_kwargs=out_mm_kwargs,
+    )
+
+    replacement = prompt_updates[0]
+    assert replacement.target == [KimiAudioProcessor.KIMIA_TEXT_BLANK]
+    assert replacement.replacement(0) == [KimiAudioProcessor.KIMIA_TEXT_BLANK] * 2
+    assert replacement.replacement(1) == [KimiAudioProcessor.KIMIA_TEXT_BLANK] * 3
+
+
+def test_kimi_audio_prompt_updates_can_use_audio_sample_lengths():
+    processor = object.__new__(kimi_audio_model.KimiAudioMultiModalProcessor)
+    out_mm_kwargs = SimpleNamespace(
+        get_data=lambda: {
+            "audio_sample_lengths": torch.tensor([232880], dtype=torch.long),
+        }
+    )
+
+    prompt_updates = kimi_audio_model.KimiAudioMultiModalProcessor._get_prompt_updates(
+        processor,
+        mm_items=None,
+        hf_processor_mm_kwargs={},
+        out_mm_kwargs=out_mm_kwargs,
+    )
+
+    replacement = prompt_updates[0]
+    assert replacement.replacement(0) == [KimiAudioProcessor.KIMIA_TEXT_BLANK] * 182
+
+
+def test_kimi_audio_processor_can_return_packed_kimi_token_streams():
+    processor = KimiAudioProcessor(
+        feature_extractor=_FakeFeatureExtractor(),
+        tokenizer=_FakeProcessorTokenizer(),
+        speech_tokenizer=_FakeSpeechTokenizer(),
+    )
+
+    outputs = processor(
+        audio=[np.ones(7, dtype=np.float32)],
+        messages=[
+            {"role": "user", "message_type": "audio"},
+        ],
+        return_packed_kimi_tokens=True,
+    )
+
+    assert outputs["audio_token_ids"].tolist() == [[6, 2, 152064, 152065, 3, 8, 1, 7]]
+    assert outputs["text_token_ids"].tolist() == [[4, 4, 4, 4, 4, 4, 4, 4]]
+    assert outputs["is_continuous_mask"].tolist() == [[
+        False,
+        False,
+        True,
+        True,
+        False,
+        False,
+        False,
+        False,
+    ]]
+
+
+def test_kimi_audio_processor_batches_packed_kimi_token_streams_per_request():
+    processor = KimiAudioProcessor(
+        feature_extractor=_FakeFeatureExtractor(),
+        tokenizer=_FakeProcessorTokenizer(),
+        speech_tokenizer=_FakeSpeechTokenizer(),
+    )
+
+    outputs = processor(
+        audio=[np.ones(7, dtype=np.float32), np.ones(5, dtype=np.float32)],
+        messages=[
+            {"role": "user", "message_type": "audio"},
+        ],
+        return_packed_kimi_tokens=True,
+    )
+
+    assert outputs["audio_token_ids"].tolist() == [
+        [6, 2, 152064, 152065, 3, 8, 1, 7],
+        [6, 2, 152066, 3, 8, 1, 7, 0],
+    ]
+    assert outputs["text_token_ids"].tolist() == [
+        [4, 4, 4, 4, 4, 4, 4, 4],
+        [4, 4, 4, 4, 4, 4, 4, 0],
+    ]
+    assert outputs["is_continuous_mask"].tolist() == [
+        [False, False, True, True, False, False, False, False],
+        [False, False, True, False, False, False, False, False],
+    ]
+
+
+class _FakeEmbedTokens:
+    def __call__(self, input_ids):
+        return input_ids.unsqueeze(-1).repeat(1, 1, 2).to(torch.float32)
+
+
+class _FakeLanguageModelCore:
+    def __init__(self):
+        self.embed_tokens = _FakeEmbedTokens()
+
+    def __call__(self, input_ids, positions, intermediate_tensors, inputs_embeds=None):
+        return inputs_embeds if inputs_embeds is not None else self.embed_tokens(input_ids)
+
+
+class _FakeLanguageModel:
+    def __init__(self):
+        self.model = _FakeLanguageModelCore()
+
+
+class _FakeTupleLanguageModelCore(_FakeLanguageModelCore):
+    def __call__(self, input_ids, positions, intermediate_tensors, inputs_embeds=None):
+        hidden_states = super().__call__(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+        )
+        return hidden_states, [hidden_states + 10.0]
+
+
+class _FakeTupleLanguageModel:
+    def __init__(self):
+        self.model = _FakeTupleLanguageModelCore()
+        self.lm_head = object()
+
+
+def test_kimi_audio_model_builds_packed_dual_stream_embeddings():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeLanguageModel()
+
+    audio_token_ids = torch.tensor([[6, 2, 152064, 152065, 3, 8, 1, 7]])
+    text_token_ids = torch.tensor([[4, 4, 4, 4, 4, 4, 4, 4]])
+    is_continuous_mask = torch.tensor([[False, False, True, True, False, False, False, False]])
+    multimodal_embeddings = [
+        torch.tensor([
+            [100.0, 100.0],
+            [200.0, 200.0],
+        ])
+    ]
+
+    embeds = KimiAudioForConditionalGeneration._build_kimi_audio_inputs_embeds(
+        model,
+        audio_token_ids=audio_token_ids,
+        text_input_ids=text_token_ids,
+        is_continuous_mask=is_continuous_mask,
+        multimodal_embeddings=multimodal_embeddings,
+    )
+
+    sqrt2 = 2**0.5
+    expected = torch.tensor([
+        [10.0, 10.0],
+        [6.0, 6.0],
+        [(152064.0 + 100.0) * sqrt2 + 4.0, (152064.0 + 100.0) * sqrt2 + 4.0],
+        [(152065.0 + 200.0) * sqrt2 + 4.0, (152065.0 + 200.0) * sqrt2 + 4.0],
+        [7.0, 7.0],
+        [12.0, 12.0],
+        [5.0, 5.0],
+        [11.0, 11.0],
+    ]).unsqueeze(0)
+    assert torch.allclose(embeds, expected)
+
+
+def test_kimi_audio_model_matches_official_bfloat16_fusion_formula():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeLanguageModel()
+    original_embed_tokens = model.language_model.model.embed_tokens
+    model.language_model.model.embed_tokens = lambda ids: original_embed_tokens(
+        ids).to(torch.bfloat16)
+
+    audio_token_ids = torch.tensor([[152064, 6]], dtype=torch.long)
+    text_token_ids = torch.tensor([[4, 4]], dtype=torch.long)
+    is_continuous_mask = torch.tensor([[True, False]])
+    multimodal_embeddings = [
+        torch.tensor([[100.0, 100.0]], dtype=torch.bfloat16),
+    ]
+
+    embeds = KimiAudioForConditionalGeneration._build_kimi_audio_inputs_embeds(
+        model,
+        audio_token_ids=audio_token_ids,
+        text_input_ids=text_token_ids,
+        is_continuous_mask=is_continuous_mask,
+        multimodal_embeddings=multimodal_embeddings,
+    )
+
+    audio_emb = model.language_model.model.embed_tokens(audio_token_ids).to(
+        torch.bfloat16)
+    text_emb = model.language_model.model.embed_tokens(text_token_ids).to(
+        torch.bfloat16)
+    whisper_emb = torch.zeros_like(audio_emb)
+    whisper_emb[0, 0] = torch.tensor([100.0, 100.0], dtype=torch.bfloat16)
+    continuous_mask = is_continuous_mask[:, :, None].to(torch.bool)
+    sqrt_two = torch.sqrt(
+        torch.tensor(2.0, dtype=audio_emb.dtype, device=audio_emb.device))
+    expected = (
+        audio_emb * (~continuous_mask)
+        + ((audio_emb + whisper_emb) * sqrt_two) * continuous_mask
+    ) + text_emb
+
+    assert torch.equal(embeds, expected)
+
+
+def test_kimi_audio_model_normalizes_chunked_multimodal_embeddings():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    normalized = KimiAudioForConditionalGeneration._normalize_multimodal_embeddings(
+        model,
+        multimodal_embeddings=[
+            torch.tensor(
+                [
+                    [[1.0, 1.0], [2.0, 2.0]],
+                    [[3.0, 3.0], [4.0, 4.0]],
+                ]
+            ),
+            torch.tensor(
+                [
+                    [[5.0, 5.0], [6.0, 6.0]],
+                    [[7.0, 7.0], [8.0, 8.0]],
+                ]
+            ),
+        ],
+        batch_size=4,
+    )
+
+    assert len(normalized) == 4
+    assert torch.equal(normalized[0], torch.tensor([[1.0, 1.0], [2.0, 2.0]]))
+    assert torch.equal(normalized[3], torch.tensor([[7.0, 7.0], [8.0, 8.0]]))
+
+
+def test_kimi_audio_projector_matches_official_activation_and_norm():
+    projector = kimi_audio_model.KimiAudioMultiModalProjector(norm_eps=1e-6)
+
+    assert isinstance(projector.vq_adaptor_activation, torch.nn.SiLU)
+    assert projector.vq_adaptor_layers_4.eps == pytest.approx(1e-6)
+
+
+def test_kimi_audio_model_process_audio_input_accepts_feature_lists():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.audio_tower = lambda features: torch.ones((len(features), 8, 2), dtype=torch.float32)
+    model.multi_modal_projector = lambda features: features + 3.0
+
+    audio_embeds = KimiAudioForConditionalGeneration._process_audio_input(
+        model,
+        {"whisper_input_features": [torch.ones((3, 5)), torch.ones((3, 5))]},
+    )
+
+    assert len(audio_embeds) == 2
+    assert audio_embeds[0].shape == (2, 8)
+    assert torch.allclose(audio_embeds[0], torch.full((2, 8), 4.0))
+
+
+def test_kimi_audio_model_process_audio_input_accepts_tuple_batches():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.audio_tower = lambda features: torch.ones((len(features), 6, 2), dtype=torch.float32)
+    model.multi_modal_projector = lambda features: features + 2.0
+
+    audio_embeds = KimiAudioForConditionalGeneration._process_audio_input(
+        model,
+        {
+            "whisper_input_features": (
+                torch.ones((3, 5)),
+                torch.ones((1, 3, 7)),
+            )
+        },
+    )
+
+    assert len(audio_embeds) == 2
+    assert audio_embeds[0].shape == (2, 8)
+    assert torch.allclose(
+        audio_embeds[1],
+        torch.tensor(
+            [
+                [3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0],
+                [3.0, 3.0, 3.0, 3.0, 2.0, 2.0, 2.0, 2.0],
+            ]
+        ),
+    )
+
+
+def test_kimi_audio_model_process_audio_input_trims_batched_padding_with_mask():
+    captured_lengths = []
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    def fake_audio_tower(features):
+        captured_lengths.append(features[0].shape[-1])
+        return torch.ones((len(features), 8, 2), dtype=torch.float32)
+
+    model.audio_tower = fake_audio_tower
+    model.multi_modal_projector = lambda features: features
+
+    _ = KimiAudioForConditionalGeneration._process_audio_input(
+        model,
+        {
+            "whisper_input_features": torch.ones((2, 3, 8), dtype=torch.float32),
+            "feature_attention_mask": torch.tensor(
+                [
+                    [1, 1, 1, 1, 1, 0, 0, 0],
+                    [1, 1, 1, 1, 1, 1, 1, 0],
+                ],
+                dtype=torch.long,
+            ),
+        },
+    )
+
+    assert captured_lengths == [5, 7]
+
+
+def test_kimi_audio_model_process_audio_input_uses_sample_length_post_encoder_trim():
+    captured = {}
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    def fake_audio_tower(features, input_lengths=None):
+        captured["feature_length"] = features[0].shape[-1]
+        captured["input_lengths"] = input_lengths
+        output_length = 1500 if input_lengths is None else input_lengths[0]
+        return torch.ones((len(features), output_length, 2), dtype=torch.float32)
+
+    model.audio_tower = fake_audio_tower
+    model.multi_modal_projector = lambda features: features
+
+    audio_embeds = KimiAudioForConditionalGeneration._process_audio_input(
+        model,
+        {
+            "whisper_input_features": torch.ones((1, 3, 3000), dtype=torch.float32),
+            "audio_sample_lengths": torch.tensor([232880], dtype=torch.long),
+            "feature_attention_mask": torch.tensor(
+                [[1] * 1456 + [0] * (3000 - 1456)],
+                dtype=torch.long,
+            ),
+        },
+    )
+
+    assert captured["feature_length"] == 3000
+    assert captured["input_lengths"] is None
+    assert audio_embeds[0].shape == (182, 8)
+
+
+def test_kimi_audio_model_keeps_main_hidden_states_for_text_output(monkeypatch):
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeTupleLanguageModel()
+    model.use_mimo_text_path = True
+    model.mimo_model = lambda positions, hidden_states: hidden_states + 5.0
+
+    monkeypatch.setattr(
+        kimi_audio_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=True),
+    )
+
+    outputs = KimiAudioForConditionalGeneration.forward(
+        model,
+        input_ids=torch.tensor([[1, 2]], dtype=torch.long),
+        positions=torch.tensor([0, 1], dtype=torch.long),
+    )
+
+    blank = float(KimiAudioProcessor.KIMIA_TEXT_BLANK)
+    expected = torch.tensor([[[1.0 + blank, 1.0 + blank], [2.0 + blank, 2.0 + blank]]])
+    assert torch.allclose(outputs, expected)
+
+
+def test_kimi_audio_model_compute_logits_uses_lm_head_for_text_output(monkeypatch):
+    captured = {}
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.use_mimo_text_path = True
+    model.mimo_output = object()
+    model.language_model = SimpleNamespace(lm_head=object())
+    model.logits_processor = lambda lm_head, hidden_states, sampling_metadata: captured.setdefault(
+        "lm_head",
+        lm_head,
+    ) or hidden_states
+
+    monkeypatch.setattr(
+        kimi_audio_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=True),
+    )
+
+    _ = KimiAudioForConditionalGeneration.compute_logits(
+        model,
+        hidden_states=torch.ones((1, 2, 3)),
+        sampling_metadata=None,
+    )
+
+    assert captured["lm_head"] is model.language_model.lm_head
+
+
+def test_kimi_audio_embed_input_ids_uses_all_multimodal_embeddings():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = SimpleNamespace(
+        model=SimpleNamespace(
+            embed_tokens=lambda input_ids: input_ids.unsqueeze(-1).repeat(1, 2).to(
+                torch.float32
+            )
+        )
+    )
+
+    input_ids = torch.tensor([10, 11, 12, 13, 14], dtype=torch.long)
+    is_multimodal = torch.tensor([False, True, True, True, False])
+    multimodal_embeddings = (torch.tensor(
+        [[100.0, 100.0], [200.0, 200.0], [300.0, 300.0]]
+    ),)
+
+    embeds = KimiAudioForConditionalGeneration.embed_input_ids(
+        model,
+        input_ids=input_ids,
+        multimodal_embeddings=multimodal_embeddings,
+        is_multimodal=is_multimodal,
+    )
+
+    sqrt2 = 2**0.5
+    blank = float(KimiAudioProcessor.KIMIA_TEXT_BLANK)
+    expected = torch.tensor(
+        [
+            [10.0 + blank, 10.0 + blank],
+            [(11.0 + blank + 100.0) * sqrt2, (11.0 + blank + 100.0) * sqrt2],
+            [(12.0 + blank + 200.0) * sqrt2, (12.0 + blank + 200.0) * sqrt2],
+            [(13.0 + blank + 300.0) * sqrt2, (13.0 + blank + 300.0) * sqrt2],
+            [14.0 + blank, 14.0 + blank],
+        ]
+    )
+
+    assert torch.allclose(embeds, expected)
+
+
+def test_kimi_audio_embed_input_ids_does_not_spill_embeddings_across_segments():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = SimpleNamespace(
+        model=SimpleNamespace(
+            embed_tokens=lambda input_ids: input_ids.unsqueeze(-1).repeat(1, 2).to(
+                torch.float32
+            )
+        )
+    )
+
+    input_ids = torch.tensor([10, 11, 12, 13, 14, 15], dtype=torch.long)
+    is_multimodal = torch.tensor([False, True, True, False, True, False])
+    multimodal_embeddings = (
+        torch.tensor([[100.0, 100.0], [101.0, 101.0], [102.0, 102.0]]),
+        torch.tensor([[200.0, 200.0]]),
+    )
+
+    embeds = KimiAudioForConditionalGeneration.embed_input_ids(
+        model,
+        input_ids=input_ids,
+        multimodal_embeddings=multimodal_embeddings,
+        is_multimodal=is_multimodal,
+    )
+
+    sqrt2 = 2**0.5
+    blank = float(KimiAudioProcessor.KIMIA_TEXT_BLANK)
+    expected = torch.tensor(
+        [
+            [10.0 + blank, 10.0 + blank],
+            [(11.0 + blank + 100.0) * sqrt2, (11.0 + blank + 100.0) * sqrt2],
+            [(12.0 + blank + 101.0) * sqrt2, (12.0 + blank + 101.0) * sqrt2],
+            [13.0 + blank, 13.0 + blank],
+            [(14.0 + blank + 200.0) * sqrt2, (14.0 + blank + 200.0) * sqrt2],
+            [15.0 + blank, 15.0 + blank],
+        ]
+    )
+
+    assert torch.allclose(embeds, expected)
+
+
+def test_kimi_audio_multimodal_processor_requests_packed_kimi_tokens():
+    captured = {}
+    processor = object.__new__(kimi_audio_model.KimiAudioMultiModalProcessor)
+    processor.info = SimpleNamespace(
+        get_hf_processor=lambda **kwargs: object(),
+        ctx=SimpleNamespace(
+            call_hf_processor=lambda hf_processor, inputs, kwargs: captured.update(
+                {
+                    "inputs": inputs,
+                    "kwargs": kwargs,
+                }
+            )
+            or kwargs
+        ),
+    )
+
+    _ = kimi_audio_model.KimiAudioMultiModalProcessor._call_hf_processor(
+        processor,
+        prompt="unused",
+        mm_data={"audios": [np.ones(4, dtype=np.float32)]},
+        mm_kwargs={"messages": [{"role": "user", "message_type": "audio"}]},
+        tok_kwargs={},
+    )
+
+    assert "audio" in captured["inputs"]
+    assert captured["kwargs"]["return_packed_kimi_tokens"] is True
+
+
+def test_kimi_audio_whisper_attention_matches_official_bias_layout():
+    config = kimi_audio_model.HFWhisperConfig(
+        d_model=8,
+        encoder_attention_heads=2,
+        encoder_ffn_dim=16,
+        activation_function="gelu",
+        num_mel_bins=3,
+        max_source_positions=10,
+        encoder_layers=1,
+    )
+
+    attention = kimi_audio_model.KimiAudioWhisperAttention(config)
+
+    assert attention.q_proj.bias is not None
+    assert attention.k_proj.bias is None
+    assert attention.v_proj.bias is not None
+
+
+def test_kimi_audio_process_audio_input_slices_after_encoder():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    captured = {}
+
+    def fake_iter_single_audio_features(input_features, feature_attention_mask):
+        captured["feature_attention_mask"] = feature_attention_mask
+        return [input_features[0]]
+
+    def fake_audio_tower(features, input_lengths=None):
+        captured["input_lengths"] = input_lengths
+        return torch.arange(16, dtype=torch.float32).view(1, 8, 2)
+
+    model._iter_single_audio_features = fake_iter_single_audio_features
+    model.audio_tower = fake_audio_tower
+    model._project_audio_features = lambda audio_features: audio_features
+
+    outputs = KimiAudioForConditionalGeneration._process_audio_input(
+        model,
+        {
+            "whisper_input_features": torch.ones((1, 3, 5), dtype=torch.float32),
+            "feature_attention_mask": torch.ones((1, 12), dtype=torch.long),
+            "audio_sample_lengths": torch.tensor([7], dtype=torch.long),
+        },
+    )
+
+    assert captured["feature_attention_mask"] is None
+    assert captured["input_lengths"] is None
+    assert len(outputs) == 1
+    assert outputs[0].shape == (4, 2)
+    assert torch.equal(outputs[0], torch.arange(8, dtype=torch.float32).view(4, 2))

--- a/tests/models/multimodal/generation/test_kimi_audio_unit.py
+++ b/tests/models/multimodal/generation/test_kimi_audio_unit.py
@@ -446,6 +446,170 @@ def test_kimi_audio_runtime_slice_supports_mixed_decode_and_prefill_batch():
     )
 
 
+def test_kimi_audio_runtime_slice_supports_single_prompt_request_after_decode():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    (
+        audio_token_ids,
+        text_input_ids,
+        is_continuous_mask,
+    ) = KimiAudioForConditionalGeneration._slice_runtime_kimi_prompt_inputs(
+        model,
+        input_ids=torch.tensor([99, 9], dtype=torch.int32),
+        positions=torch.tensor([4, 2], dtype=torch.long),
+        audio_token_ids=torch.tensor([[20, 21, 22]], dtype=torch.long),
+        text_input_ids=torch.tensor([[2, 2, 2]], dtype=torch.long),
+        is_continuous_mask=torch.tensor([[False, True, True]]),
+    )
+
+    assert torch.equal(
+        audio_token_ids,
+        torch.tensor([KimiAudioProcessor.KIMIA_TEXT_BLANK, 22], dtype=torch.long),
+    )
+    assert torch.equal(text_input_ids, torch.tensor([99, 2], dtype=torch.long))
+    assert torch.equal(is_continuous_mask, torch.tensor([False, True]))
+
+
+def test_kimi_audio_runtime_slice_supports_single_prompt_request_before_decode():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    (
+        audio_token_ids,
+        text_input_ids,
+        is_continuous_mask,
+    ) = KimiAudioForConditionalGeneration._slice_runtime_kimi_prompt_inputs(
+        model,
+        input_ids=torch.tensor([9, 9, 9, 99], dtype=torch.int32),
+        positions=torch.tensor([0, 1, 2, 4], dtype=torch.long),
+        audio_token_ids=torch.tensor([[20, 21, 22]], dtype=torch.long),
+        text_input_ids=torch.tensor([[2, 2, 2]], dtype=torch.long),
+        is_continuous_mask=torch.tensor([[False, True, True]]),
+    )
+
+    assert torch.equal(
+        audio_token_ids,
+        torch.tensor(
+            [20, 21, 22, KimiAudioProcessor.KIMIA_TEXT_BLANK],
+            dtype=torch.long,
+        ),
+    )
+    assert torch.equal(
+        text_input_ids,
+        torch.tensor([2, 2, 2, 99], dtype=torch.long),
+    )
+    assert torch.equal(
+        is_continuous_mask,
+        torch.tensor([False, True, True, False]),
+    )
+
+
+def test_kimi_audio_runtime_slice_supports_interleaved_decode_between_prompts():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+
+    (
+        audio_token_ids,
+        text_input_ids,
+        is_continuous_mask,
+    ) = KimiAudioForConditionalGeneration._slice_runtime_kimi_prompt_inputs(
+        model,
+        input_ids=torch.tensor([9, 9, 99, 8, 8], dtype=torch.int32),
+        positions=torch.tensor([0, 1, 4, 0, 1], dtype=torch.long),
+        audio_token_ids=[
+            torch.tensor([10, 11], dtype=torch.long),
+            torch.tensor([20, 21], dtype=torch.long),
+        ],
+        text_input_ids=[
+            torch.tensor([1, 1], dtype=torch.long),
+            torch.tensor([2, 2], dtype=torch.long),
+        ],
+        is_continuous_mask=[
+            torch.tensor([False, True]),
+            torch.tensor([False, True]),
+        ],
+    )
+
+    assert torch.equal(
+        audio_token_ids,
+        torch.tensor(
+            [10, 11, KimiAudioProcessor.KIMIA_TEXT_BLANK, 20, 21],
+            dtype=torch.long,
+        ),
+    )
+    assert torch.equal(
+        text_input_ids,
+        torch.tensor([1, 1, 99, 2, 2], dtype=torch.long),
+    )
+    assert torch.equal(
+        is_continuous_mask,
+        torch.tensor([False, True, False, False, True]),
+    )
+
+
+def test_kimi_audio_runtime_slice_uses_runtime_request_boundaries():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    full_audio_ids = torch.cat(
+        [
+            torch.full((176,), 7, dtype=torch.long),
+            torch.tensor([20, 21, 22, 23], dtype=torch.long),
+        ]
+    )
+    full_text_ids = torch.cat(
+        [
+            torch.full((176,), 3, dtype=torch.long),
+            torch.tensor([2, 2, 2, 2], dtype=torch.long),
+        ]
+    )
+    full_continuous_mask = torch.cat(
+        [
+            torch.zeros(176, dtype=torch.bool),
+            torch.tensor([False, True, True, False]),
+        ]
+    )
+
+    (
+        audio_token_ids,
+        text_input_ids,
+        is_continuous_mask,
+    ) = KimiAudioForConditionalGeneration._slice_runtime_kimi_prompt_inputs(
+        model,
+        input_ids=torch.tensor([91, 92, 93, 9, 9, 9, 9], dtype=torch.int32),
+        positions=torch.tensor([176, 192, 208, 176, 177, 178, 179], dtype=torch.long),
+        audio_token_ids=full_audio_ids.unsqueeze(0),
+        text_input_ids=full_text_ids.unsqueeze(0),
+        is_continuous_mask=full_continuous_mask.unsqueeze(0),
+        runtime_request_num_scheduled_tokens=torch.tensor(
+            [1, 1, 1, 4], dtype=torch.int32
+        ),
+        runtime_request_has_raw_mm_inputs=torch.tensor(
+            [False, False, False, True], dtype=torch.bool
+        ),
+    )
+
+    assert torch.equal(
+        audio_token_ids,
+        torch.tensor(
+            [
+                KimiAudioProcessor.KIMIA_TEXT_BLANK,
+                KimiAudioProcessor.KIMIA_TEXT_BLANK,
+                KimiAudioProcessor.KIMIA_TEXT_BLANK,
+                20,
+                21,
+                22,
+                23,
+            ],
+            dtype=torch.long,
+        ),
+    )
+    assert torch.equal(
+        text_input_ids,
+        torch.tensor([91, 92, 93, 2, 2, 2, 2], dtype=torch.int32),
+    )
+    assert torch.equal(
+        is_continuous_mask,
+        torch.tensor([False, False, False, False, True, True, False]),
+    )
+
+
 def test_kimi_audio_generation_prompt_uses_prompt_builder(monkeypatch):
     captured = {}
 
@@ -905,6 +1069,155 @@ def test_kimi_audio_forward_supports_mixed_decode_and_prefill_batch():
             [12.0, 12.0],
             [22.0, 22.0],
             [24.0, 24.0],
+        ]
+    )
+    assert torch.equal(outputs, expected)
+
+
+def test_kimi_audio_forward_supports_single_prompt_request_after_decode():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeLanguageModel()
+
+    outputs = KimiAudioForConditionalGeneration.forward(
+        model,
+        input_ids=torch.tensor([99, 0], dtype=torch.int32),
+        positions=torch.tensor([4, 2], dtype=torch.long),
+        audio_token_ids=torch.tensor([[20, 21, 22]], dtype=torch.long),
+        text_token_ids=torch.tensor([[2, 2, 2]], dtype=torch.long),
+        is_continuous_mask=torch.tensor([[False, True, True]]),
+    )
+
+    expected = torch.tensor(
+        [
+            [
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 99.0,
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 99.0,
+            ],
+            [24.0, 24.0],
+        ]
+    )
+    assert torch.equal(outputs, expected)
+
+
+def test_kimi_audio_forward_supports_single_prompt_request_before_decode():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeLanguageModel()
+
+    outputs = KimiAudioForConditionalGeneration.forward(
+        model,
+        input_ids=torch.tensor([0, 0, 0, 99], dtype=torch.int32),
+        positions=torch.tensor([0, 1, 2, 4], dtype=torch.long),
+        audio_token_ids=torch.tensor([[20, 21, 22]], dtype=torch.long),
+        text_token_ids=torch.tensor([[2, 2, 2]], dtype=torch.long),
+        is_continuous_mask=torch.tensor([[False, True, True]]),
+    )
+
+    expected = torch.tensor(
+        [
+            [22.0, 22.0],
+            [23.0, 23.0],
+            [24.0, 24.0],
+            [
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 99.0,
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 99.0,
+            ],
+        ]
+    )
+    assert torch.equal(outputs, expected)
+
+
+def test_kimi_audio_forward_supports_interleaved_decode_between_prompts():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeLanguageModel()
+
+    outputs = KimiAudioForConditionalGeneration.forward(
+        model,
+        input_ids=torch.tensor([0, 0, 99, 0, 0], dtype=torch.int32),
+        positions=torch.tensor([0, 1, 4, 0, 1], dtype=torch.long),
+        audio_token_ids=[
+            torch.tensor([10, 11], dtype=torch.long),
+            torch.tensor([20, 21], dtype=torch.long),
+        ],
+        text_token_ids=[
+            torch.tensor([1, 1], dtype=torch.long),
+            torch.tensor([2, 2], dtype=torch.long),
+        ],
+        is_continuous_mask=[
+            torch.tensor([False, True]),
+            torch.tensor([False, True]),
+        ],
+    )
+
+    expected = torch.tensor(
+        [
+            [11.0, 11.0],
+            [12.0, 12.0],
+            [
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 99.0,
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 99.0,
+            ],
+            [22.0, 22.0],
+            [23.0, 23.0],
+        ]
+    )
+    assert torch.equal(outputs, expected)
+
+
+def test_kimi_audio_forward_uses_runtime_request_boundaries():
+    model = object.__new__(KimiAudioForConditionalGeneration)
+    model.language_model = _FakeLanguageModel()
+    full_audio_ids = torch.cat(
+        [
+            torch.full((176,), 7, dtype=torch.long),
+            torch.tensor([20, 21, 22, 23], dtype=torch.long),
+        ]
+    )
+    full_text_ids = torch.cat(
+        [
+            torch.full((176,), 3, dtype=torch.long),
+            torch.tensor([2, 2, 2, 2], dtype=torch.long),
+        ]
+    )
+    full_continuous_mask = torch.cat(
+        [
+            torch.zeros(176, dtype=torch.bool),
+            torch.tensor([False, True, True, False]),
+        ]
+    )
+
+    outputs = KimiAudioForConditionalGeneration.forward(
+        model,
+        input_ids=torch.tensor([91, 92, 93, 0, 0, 0, 0], dtype=torch.int32),
+        positions=torch.tensor([176, 192, 208, 176, 177, 178, 179], dtype=torch.long),
+        audio_token_ids=full_audio_ids.unsqueeze(0),
+        text_token_ids=full_text_ids.unsqueeze(0),
+        is_continuous_mask=full_continuous_mask.unsqueeze(0),
+        runtime_request_num_scheduled_tokens=torch.tensor(
+            [1, 1, 1, 4], dtype=torch.int32
+        ),
+        runtime_request_has_raw_mm_inputs=torch.tensor(
+            [False, False, False, True], dtype=torch.bool
+        ),
+    )
+
+    expected = torch.tensor(
+        [
+            [
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 91.0,
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 91.0,
+            ],
+            [
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 92.0,
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 92.0,
+            ],
+            [
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 93.0,
+                KimiAudioProcessor.KIMIA_TEXT_BLANK + 93.0,
+            ],
+            [22.0, 22.0],
+            [23.0, 23.0],
+            [24.0, 24.0],
+            [25.0, 25.0],
         ]
     )
     assert torch.equal(outputs, expected)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@
 import logging
 import os
 from dataclasses import MISSING, Field, asdict, dataclass, field
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pydantic
@@ -30,6 +31,10 @@ from vllm.config.vllm import (
     OPTIMIZATION_LEVEL_TO_CONFIG,
     OptimizationLevel,
 )
+from vllm.model_executor.models.config import (
+    MODELS_CONFIG_MAP,
+    MoonshotKimiaForCausalLMConfig,
+)
 from vllm.platforms import current_platform
 
 
@@ -43,6 +48,24 @@ def test_compile_config_repr_succeeds():
     val = repr(config)
     assert "VllmConfig" in val
     assert "inductor_passes" in val
+
+
+def test_kimi_audio_disables_cudagraphs():
+    compilation_config = CompilationConfig(
+        mode=CompilationMode.VLLM_COMPILE,
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+    )
+    vllm_config = SimpleNamespace(compilation_config=compilation_config)
+
+    assert (
+        MODELS_CONFIG_MAP["MoonshotKimiaForCausalLM"]
+        is MoonshotKimiaForCausalLMConfig
+    )
+
+    MoonshotKimiaForCausalLMConfig.verify_and_update_config(vllm_config)
+
+    assert compilation_config.mode == CompilationMode.VLLM_COMPILE
+    assert compilation_config.cudagraph_mode == CUDAGraphMode.NONE
 
 
 def test_async_scheduling_with_pipeline_parallelism_is_allowed():

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -162,6 +162,112 @@ def _schedule_new_request(*req_ids: str) -> SchedulerOutput:
     )
 
 
+def test_extract_mm_kwargs_includes_cached_prompt_requests(monkeypatch):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.is_multimodal_raw_input_only_model = True
+    runner.device = torch.device("cpu")
+    runner.pin_memory = False
+    runner.model = SimpleNamespace(builds_multimodal_inputs_embeds_in_forward=True)
+    runner.input_batch = SimpleNamespace(
+        req_ids=["cached_prompt", "new_prompt", "cached_decode"]
+    )
+
+    cached_prompt_data = {"audio_token_ids": torch.tensor([11], dtype=torch.long)}
+    new_prompt_data = {"audio_token_ids": torch.tensor([22], dtype=torch.long)}
+    cached_decode_data = {"audio_token_ids": torch.tensor([33], dtype=torch.long)}
+
+    runner.requests = {
+        "cached_prompt": SimpleNamespace(
+            prompt_token_ids=[1, 2, 3, 4],
+            num_computed_tokens=2,
+            mm_features=[
+                SimpleNamespace(modality="audio", data=cached_prompt_data),
+            ],
+        ),
+        "new_prompt": SimpleNamespace(
+            prompt_token_ids=[5, 6, 7],
+            num_computed_tokens=0,
+            mm_features=[
+                SimpleNamespace(modality="audio", data=new_prompt_data),
+            ],
+        ),
+        "cached_decode": SimpleNamespace(
+            prompt_token_ids=[8, 9],
+            num_computed_tokens=2,
+            mm_features=[
+                SimpleNamespace(modality="audio", data=cached_decode_data),
+            ],
+        ),
+    }
+
+    captured_mm_kwargs = []
+
+    def fake_group_and_batch_mm_kwargs(mm_kwargs, device, pin_memory):
+        captured_mm_kwargs.extend(mm_kwargs)
+        yield "audio", len(mm_kwargs), {
+            "audio_token_ids": [item[1]["audio_token_ids"] for item in mm_kwargs]
+        }
+
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu_model_runner.group_and_batch_mm_kwargs",
+        fake_group_and_batch_mm_kwargs,
+    )
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[
+            NewRequestData(
+                req_id="new_prompt",
+                prompt_token_ids=[5, 6, 7],
+                mm_features=[],
+                sampling_params=None,
+                pooling_params=None,
+                block_ids=([0],),
+                num_computed_tokens=0,
+                lora_request=None,
+            )
+        ],
+        scheduled_cached_reqs=CachedRequestData(
+            req_ids=["cached_prompt", "cached_decode"],
+            resumed_req_ids=set(),
+            new_token_ids=[],
+            all_token_ids={},
+            new_block_ids=[None, None],
+            num_computed_tokens=[2, 2],
+            num_output_tokens=[0, 1],
+        ),
+        num_scheduled_tokens={
+            "cached_prompt": 2,
+            "new_prompt": 3,
+            "cached_decode": 1,
+        },
+        total_num_scheduled_tokens=6,
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    mm_kwargs = GPUModelRunner._extract_mm_kwargs(runner, scheduler_output)
+
+    assert captured_mm_kwargs == [
+        ("audio", cached_prompt_data),
+        ("audio", new_prompt_data),
+    ]
+    assert mm_kwargs["audio_token_ids"] == [
+        cached_prompt_data["audio_token_ids"],
+        new_prompt_data["audio_token_ids"],
+    ]
+    assert torch.equal(
+        mm_kwargs["runtime_request_num_scheduled_tokens"],
+        torch.tensor([2, 3, 1], dtype=torch.int32),
+    )
+    assert torch.equal(
+        mm_kwargs["runtime_request_has_raw_mm_inputs"],
+        torch.tensor([True, True, False], dtype=torch.bool),
+    )
+
+
 def _is_req_scheduled(model_runner, req_id: str) -> bool:
     return req_id in model_runner.input_batch.req_id_to_index
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -375,6 +375,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 ),
             ),
             media_io_kwargs=self.media_io_kwargs,
+            mm_processor_kwargs=self.mm_processor_kwargs,
         )
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -302,6 +302,7 @@ class ResponsesRequest(OpenAIBaseModel):
                 ),
             ),
             media_io_kwargs=self.media_io_kwargs,
+            mm_processor_kwargs=self.mm_processor_kwargs,
         )
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -190,6 +190,24 @@ class JambaForSequenceClassificationConfig(VerifyAndUpdateConfig):
             pooler_config.use_activation = False
 
 
+class MoonshotKimiaForCausalLMConfig(VerifyAndUpdateConfig):
+    @staticmethod
+    def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+        # Kimi-Audio's dual-stream prompt assembly is correct under eager mode
+        # and torch.compile, but cudagraph replay reuses stale runtime-aligned
+        # Kimi prompt chunks and corrupts output. Keep compile enabled and only
+        # disable cudagraph capture for this model.
+        from vllm.config.compilation import CUDAGraphMode
+
+        compilation_config = vllm_config.compilation_config
+        if compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+            compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+            logger.info(
+                "MoonshotKimiaForCausalLM disables cudagraphs to preserve "
+                "correct Kimi-Audio dual-stream generation."
+            )
+
+
 class JinaRobertaModelConfig(VerifyAndUpdateConfig):
     @staticmethod
     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
@@ -600,6 +618,7 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "LlamaNemotronVLModel": LlamaNemotronVLConfig,
     "Mamba2ForCausalLM": MambaModelConfig,
     "MambaForCausalLM": MambaModelConfig,
+    "MoonshotKimiaForCausalLM": MoonshotKimiaForCausalLMConfig,
     "NemotronHForCausalLM": NemotronHForCausalLMConfig,
     "NemotronHPuzzleForCausalLM": NemotronHForCausalLMConfig,
     "NemotronH_Nano_VL_V2": NemotronHNanoVLV2Config,

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -121,6 +121,13 @@ class SupportsMultiModal(Protocol):
     in their raw form and not input embeddings.
     """
 
+    builds_multimodal_inputs_embeds_in_forward: ClassVar[bool] = False
+    """
+    A flag that indicates this model needs the runtime to pass raw multimodal
+    kwargs and encoder outputs through `forward`, instead of pre-merging them
+    with the generic `embed_input_ids` path in the worker.
+    """
+
     _processor_factory: ClassVar[_ProcessorFactories]
     """
     Set internally by `MultiModalRegistry.register_processor`.

--- a/vllm/model_executor/models/kimi_audio.py
+++ b/vllm/model_executor/models/kimi_audio.py
@@ -8,11 +8,16 @@ from typing import Any, ClassVar, Literal
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from transformers import BatchFeature
 from transformers import WhisperConfig as HFWhisperConfig
 from transformers.activations import ACT2FN
 from transformers.models.whisper.modeling_whisper import sinusoids
-from flash_attn import flash_attn_func
+
+try:
+    from flash_attn import flash_attn_func
+except ModuleNotFoundError:
+    flash_attn_func = None
 
 from vllm.config import ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
@@ -123,14 +128,24 @@ class KimiAudioWhisperAttention(nn.Module):
             self.num_heads,
             self.head_dim,
         )
-        attn_output = flash_attn_func(
-            query_states,
-            key_states,
-            value_states,
-            dropout_p=0.0,
-            softmax_scale=self.scaling,
-            causal=False,
-        )
+        if flash_attn_func is not None:
+            attn_output = flash_attn_func(
+                query_states,
+                key_states,
+                value_states,
+                dropout_p=0.0,
+                softmax_scale=self.scaling,
+                causal=False,
+            )
+        else:
+            attn_output = F.scaled_dot_product_attention(
+                query_states.transpose(1, 2),
+                key_states.transpose(1, 2),
+                value_states.transpose(1, 2),
+                dropout_p=0.0,
+                is_causal=False,
+                scale=self.scaling,
+            ).transpose(1, 2)
         attn_output = attn_output.reshape(batch_size, seq_len, self.embed_dim)
         return self.out_proj(attn_output)
 

--- a/vllm/model_executor/models/kimi_audio.py
+++ b/vllm/model_executor/models/kimi_audio.py
@@ -17,7 +17,7 @@ from flash_attn import flash_attn_func
 from vllm.config import ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.distributed import get_pp_group
-from vllm.inputs.data import PromptType, TokensPrompt
+from vllm.inputs import PromptType, TokensPrompt
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead

--- a/vllm/model_executor/models/kimi_audio.py
+++ b/vllm/model_executor/models/kimi_audio.py
@@ -1061,6 +1061,8 @@ class KimiAudioForConditionalGeneration(
         audio_token_ids: torch.Tensor | list[torch.Tensor],
         text_input_ids: torch.Tensor | list[torch.Tensor] | None,
         is_continuous_mask: torch.Tensor | list[torch.Tensor] | None,
+        runtime_request_num_scheduled_tokens: torch.Tensor | Sequence[int] | None = None,
+        runtime_request_has_raw_mm_inputs: torch.Tensor | Sequence[bool] | None = None,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
         """Align raw Kimi prompt tensors to the scheduled runtime chunk.
 
@@ -1112,6 +1114,97 @@ class KimiAudioForConditionalGeneration(
                 return tensors[0]
             return torch.cat(tensors, dim=0)
 
+        def _as_runtime_request_metadata(
+            value: torch.Tensor | Sequence[int] | Sequence[bool] | None,
+            *,
+            dtype: torch.dtype,
+        ) -> torch.Tensor | None:
+            if value is None:
+                return None
+            if isinstance(value, torch.Tensor):
+                if value.dim() == 1:
+                    return value.to(dtype=dtype)
+                if value.dim() == 2 and value.shape[0] == 1:
+                    return value.squeeze(0).to(dtype=dtype)
+                return None
+            if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+                return None
+            return torch.as_tensor(list(value), dtype=dtype)
+
+        def _slice_single_request_runtime_tokens(
+            *,
+            seq_input_ids: torch.Tensor,
+            seq_positions: torch.Tensor,
+            audio_tensor: torch.Tensor,
+            text_tensor: torch.Tensor | None,
+            mask_tensor: torch.Tensor | None,
+        ) -> tuple[
+            torch.Tensor | None,
+            torch.Tensor | None,
+            torch.Tensor | None,
+        ] | None:
+            if (
+                seq_positions.dim() != 1
+                or seq_positions.numel() != seq_input_ids.numel()
+            ):
+                return None
+            if seq_positions.numel() == 0:
+                return None
+
+            prompt_tokens = int(audio_tensor.shape[-1])
+            seq_positions = seq_positions.to(
+                device=audio_tensor.device,
+                dtype=torch.long,
+            )
+            if int(seq_positions.min().item()) < 0:
+                return None
+
+            prompt_mask = seq_positions < prompt_tokens
+            if not prompt_mask.any():
+                return None, None, None
+
+            audio_output = torch.full(
+                seq_input_ids.shape,
+                fill_value=KimiAudioProcessor.KIMIA_TEXT_BLANK,
+                dtype=audio_tensor.dtype,
+                device=audio_tensor.device,
+            )
+            text_output = seq_input_ids.to(
+                device=audio_tensor.device,
+                dtype=(
+                    text_tensor.dtype
+                    if text_tensor is not None
+                    else seq_input_ids.dtype
+                ),
+            ).clone()
+            mask_output = (
+                torch.zeros(
+                    seq_input_ids.shape,
+                    dtype=mask_tensor.dtype,
+                    device=audio_tensor.device,
+                )
+                if mask_tensor is not None
+                else None
+            )
+
+            selected_positions = seq_positions[prompt_mask]
+            audio_output[prompt_mask] = audio_tensor.index_select(
+                0,
+                selected_positions,
+            )
+            if text_tensor is not None:
+                text_output[prompt_mask] = text_tensor.index_select(
+                    0,
+                    selected_positions.to(device=text_tensor.device),
+                ).to(device=audio_tensor.device)
+            if mask_output is not None:
+                mask_output[prompt_mask] = mask_tensor.index_select(
+                    0,
+                    selected_positions.to(device=mask_tensor.device),
+                ).to(device=audio_tensor.device)
+
+            return audio_output, text_output, mask_output
+
         def _slice_request_tensor(
             tensor: torch.Tensor,
             seq_positions: torch.Tensor,
@@ -1158,13 +1251,144 @@ class KimiAudioForConditionalGeneration(
                 if audio_request_tensors is not None
                 else None
             )
+            runtime_request_token_counts = _as_runtime_request_metadata(
+                runtime_request_num_scheduled_tokens,
+                dtype=torch.long,
+            )
+            runtime_request_has_raw_mm = _as_runtime_request_metadata(
+                runtime_request_has_raw_mm_inputs,
+                dtype=torch.bool,
+            )
+            if (
+                audio_request_tensors is not None
+                and runtime_request_token_counts is not None
+                and runtime_request_has_raw_mm is not None
+                and runtime_request_token_counts.numel()
+                == runtime_request_has_raw_mm.numel()
+                and int(runtime_request_token_counts.sum().item())
+                == input_ids.numel()
+            ):
+                expected_raw_mm_requests = int(
+                    runtime_request_has_raw_mm.sum().item()
+                )
+                if expected_raw_mm_requests == len(audio_request_tensors):
+                    if (
+                        text_request_tensors is not None
+                        and len(text_request_tensors) != expected_raw_mm_requests
+                    ):
+                        text_request_tensors = None
+                    if (
+                        mask_request_tensors is not None
+                        and len(mask_request_tensors) != expected_raw_mm_requests
+                    ):
+                        mask_request_tensors = None
+
+                    if expected_raw_mm_requests == 0:
+                        return None, None, None
+
+                    audio_dtype = audio_request_tensors[0].dtype
+                    mask_dtype = (
+                        mask_request_tensors[0].dtype
+                        if mask_request_tensors is not None
+                        and len(mask_request_tensors) > 0
+                        else torch.bool
+                    )
+                    audio_segment_outputs: list[torch.Tensor] = []
+                    text_segment_outputs: list[torch.Tensor] = []
+                    mask_segment_outputs: list[torch.Tensor] | None = (
+                        [] if mask_request_tensors is not None else None
+                    )
+                    prompt_req_idx = 0
+                    token_offset = 0
+
+                    for num_tokens, has_raw_mm in zip(
+                        runtime_request_token_counts.tolist(),
+                        runtime_request_has_raw_mm.tolist(),
+                    ):
+                        seq_len = int(num_tokens)
+                        if seq_len <= 0:
+                            continue
+
+                        next_offset = token_offset + seq_len
+                        seq_input_ids = input_ids[token_offset:next_offset]
+                        seq_positions = positions[token_offset:next_offset]
+                        token_offset = next_offset
+
+                        sliced_segment = None
+                        if has_raw_mm:
+                            sliced_segment = _slice_single_request_runtime_tokens(
+                                seq_input_ids=seq_input_ids,
+                                seq_positions=seq_positions,
+                                audio_tensor=audio_request_tensors[prompt_req_idx],
+                                text_tensor=(
+                                    text_request_tensors[prompt_req_idx]
+                                    if text_request_tensors is not None
+                                    else None
+                                ),
+                                mask_tensor=(
+                                    mask_request_tensors[prompt_req_idx]
+                                    if mask_request_tensors is not None
+                                    else None
+                                ),
+                            )
+                            prompt_req_idx += 1
+
+                        if sliced_segment is not None and sliced_segment[0] is not None:
+                            audio_segment_outputs.append(sliced_segment[0])
+                            text_segment_outputs.append(sliced_segment[1])
+                            if mask_segment_outputs is not None:
+                                mask_segment_outputs.append(sliced_segment[2])
+                            continue
+
+                        audio_segment_outputs.append(
+                            torch.full(
+                                seq_input_ids.shape,
+                                fill_value=KimiAudioProcessor.KIMIA_TEXT_BLANK,
+                                dtype=audio_dtype,
+                                device=input_ids.device,
+                            )
+                        )
+                        text_segment_outputs.append(seq_input_ids)
+                        if mask_segment_outputs is not None:
+                            mask_segment_outputs.append(
+                                torch.zeros(
+                                    seq_input_ids.shape,
+                                    dtype=mask_dtype,
+                                    device=input_ids.device,
+                                )
+                            )
+
+                    if prompt_req_idx == len(audio_request_tensors):
+                        return (
+                            _cat_request_tensors(audio_segment_outputs),
+                            _cat_request_tensors(text_segment_outputs),
+                            _cat_request_tensors(mask_segment_outputs),
+                        )
+            if audio_request_tensors is not None and len(audio_request_tensors) == 1:
+                single_request_runtime_tokens = _slice_single_request_runtime_tokens(
+                    seq_input_ids=input_ids,
+                    seq_positions=positions,
+                    audio_tensor=audio_request_tensors[0],
+                    text_tensor=(
+                        text_request_tensors[0]
+                        if text_request_tensors is not None
+                        else None
+                    ),
+                    mask_tensor=(
+                        mask_request_tensors[0]
+                        if mask_request_tensors is not None
+                        else None
+                    ),
+                )
+                if single_request_runtime_tokens is not None:
+                    return single_request_runtime_tokens
             if audio_request_tensors is not None and len(audio_request_tensors) == 1:
                 audio_token_ids = audio_request_tensors[0]
                 if text_request_tensors is not None:
                     text_input_ids = text_request_tensors[0]
                 if mask_request_tensors is not None:
                     is_continuous_mask = mask_request_tensors[0]
-            if audio_request_tensors is not None and len(audio_request_tensors) > 1:
+            if audio_request_tensors is not None:
                 if positions.dim() == 1 and positions.numel() == len(
                     audio_request_tensors
                 ):
@@ -1199,27 +1423,71 @@ class KimiAudioForConditionalGeneration(
                     position_segments = []
                     input_segments = []
 
+                if (
+                    len(audio_request_tensors) > 0
+                    and len(position_segments) == len(audio_request_tensors)
+                ):
+                    decode_only_segments = [
+                        seq_positions.numel() > 0
+                        and int(seq_positions.min().item()) >= int(tensor.shape[-1])
+                        for seq_positions, tensor in zip(
+                            position_segments,
+                            audio_request_tensors,
+                        )
+                    ]
+                    if decode_only_segments and all(decode_only_segments):
+                        return None, None, None
+
                 if len(position_segments) >= len(audio_request_tensors):
-                    leading_text_only_segments = (
-                        len(position_segments) - len(audio_request_tensors)
-                    )
                     mask_dtype = (
                         mask_request_tensors[0].dtype
                         if mask_request_tensors is not None
                         and len(mask_request_tensors) > 0
                         else torch.bool
                     )
+                    audio_dtype = audio_request_tensors[0].dtype
                     audio_segment_outputs: list[torch.Tensor] = []
-                    text_segment_outputs: list[torch.Tensor] | None = []
+                    text_segment_outputs: list[torch.Tensor] = []
                     mask_segment_outputs: list[torch.Tensor] | None = (
                         [] if mask_request_tensors is not None else None
                     )
+                    request_idx = 0
 
-                    for seq_input_ids in input_segments[:leading_text_only_segments]:
+                    for seg_idx, seq_positions in enumerate(position_segments):
+                        seq_input_ids = input_segments[seg_idx]
+
+                        sliced_segment = None
+                        if request_idx < len(audio_request_tensors):
+                            sliced_segment = _slice_single_request_runtime_tokens(
+                                seq_input_ids=seq_input_ids,
+                                seq_positions=seq_positions,
+                                audio_tensor=audio_request_tensors[request_idx],
+                                text_tensor=(
+                                    text_request_tensors[request_idx]
+                                    if text_request_tensors is not None
+                                    else None
+                                ),
+                                mask_tensor=(
+                                    mask_request_tensors[request_idx]
+                                    if mask_request_tensors is not None
+                                    else None
+                                ),
+                            )
+
+                        if sliced_segment is not None and sliced_segment[0] is not None:
+                            audio_segment_outputs.append(sliced_segment[0])
+                            text_segment_outputs.append(sliced_segment[1])
+                            if mask_segment_outputs is not None:
+                                mask_segment_outputs.append(sliced_segment[2])
+                            request_idx += 1
+                            continue
+
                         audio_segment_outputs.append(
-                            torch.full_like(
-                                seq_input_ids,
+                            torch.full(
+                                seq_input_ids.shape,
                                 fill_value=KimiAudioProcessor.KIMIA_TEXT_BLANK,
+                                dtype=audio_dtype,
+                                device=seq_input_ids.device,
                             )
                         )
                         text_segment_outputs.append(seq_input_ids)
@@ -1232,36 +1500,12 @@ class KimiAudioForConditionalGeneration(
                                 )
                             )
 
-                    for request_idx, seq_positions in enumerate(
-                        position_segments[leading_text_only_segments:]
-                    ):
-                        audio_segment_outputs.append(
-                            _slice_request_tensor(
-                                audio_request_tensors[request_idx],
-                                seq_positions,
-                            )
+                    if request_idx == len(audio_request_tensors):
+                        return (
+                            _cat_request_tensors(audio_segment_outputs),
+                            _cat_request_tensors(text_segment_outputs),
+                            _cat_request_tensors(mask_segment_outputs),
                         )
-                        text_segment_outputs.append(
-                            input_segments[leading_text_only_segments + request_idx]
-                            if text_request_tensors is None
-                            else _slice_request_tensor(
-                                text_request_tensors[request_idx],
-                                seq_positions,
-                            )
-                        )
-                        if mask_segment_outputs is not None:
-                            mask_segment_outputs.append(
-                                _slice_request_tensor(
-                                    mask_request_tensors[request_idx],
-                                    seq_positions,
-                                )
-                            )
-
-                    return (
-                        _cat_request_tensors(audio_segment_outputs),
-                        _cat_request_tensors(text_segment_outputs),
-                        _cat_request_tensors(mask_segment_outputs),
-                    )
                 audio_token_ids = _cat_request_tensors(audio_request_tensors)
                 if text_request_tensors is not None:
                     text_input_ids = _cat_request_tensors(text_request_tensors)
@@ -1404,6 +1648,14 @@ class KimiAudioForConditionalGeneration(
         audio_token_ids = kwargs.pop("audio_token_ids", None)
         text_input_ids = kwargs.pop("text_token_ids", None)
         is_continuous_mask = kwargs.pop("is_continuous_mask", None)
+        runtime_request_num_scheduled_tokens = kwargs.pop(
+            "runtime_request_num_scheduled_tokens",
+            None,
+        )
+        runtime_request_has_raw_mm_inputs = kwargs.pop(
+            "runtime_request_has_raw_mm_inputs",
+            None,
+        )
         multimodal_embeddings = kwargs.get("multimodal_embeddings")
 
         model_input_ids = input_ids
@@ -1439,6 +1691,12 @@ class KimiAudioForConditionalGeneration(
                 audio_token_ids=audio_token_ids,
                 text_input_ids=text_input_ids,
                 is_continuous_mask=is_continuous_mask,
+                runtime_request_num_scheduled_tokens=(
+                    runtime_request_num_scheduled_tokens
+                ),
+                runtime_request_has_raw_mm_inputs=(
+                    runtime_request_has_raw_mm_inputs
+                ),
             )
             if inputs_embeds is None:
                 kimi_inputs_embeds = self._build_kimi_audio_inputs_embeds(

--- a/vllm/model_executor/models/kimi_audio.py
+++ b/vllm/model_executor/models/kimi_audio.py
@@ -976,6 +976,8 @@ class KimiAudioForConditionalGeneration(
                 multimodal_embeddings,
                 batch_size=audio_inputs_embeds.shape[0],
             )
+            if flatten_runtime_batch and len(normalized_mm_embeds) > 1:
+                normalized_mm_embeds = [torch.cat(normalized_mm_embeds, dim=0)]
             if normalized_mm_embeds:
                 whisper_embeds = torch.zeros_like(audio_inputs_embeds)
                 for batch_idx, mm_embeds in enumerate(normalized_mm_embeds):
@@ -1056,10 +1058,10 @@ class KimiAudioForConditionalGeneration(
         *,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
-        audio_token_ids: torch.Tensor,
-        text_input_ids: torch.Tensor | None,
-        is_continuous_mask: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+        audio_token_ids: torch.Tensor | list[torch.Tensor],
+        text_input_ids: torch.Tensor | list[torch.Tensor] | None,
+        is_continuous_mask: torch.Tensor | list[torch.Tensor] | None,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
         """Align raw Kimi prompt tensors to the scheduled runtime chunk.
 
         In the v1 runtime, prefix caching or chunked prefill may schedule only a
@@ -1070,6 +1072,203 @@ class KimiAudioForConditionalGeneration(
         """
         if input_ids is None:
             return audio_token_ids, text_input_ids, is_continuous_mask
+
+        def _as_request_tensor_list(
+            value: torch.Tensor | list[torch.Tensor] | None,
+            *,
+            batch_size: int,
+        ) -> list[torch.Tensor] | None:
+            if value is None:
+                return None
+            if isinstance(value, torch.Tensor):
+                if value.dim() == 1:
+                    return [value]
+                if value.dim() == 2 and value.shape[0] == batch_size:
+                    return [row for row in value]
+                return None
+            if not isinstance(value, (list, tuple)):
+                return None
+            normalized: list[torch.Tensor] = []
+            for item in value:
+                tensor = item if isinstance(item, torch.Tensor) else torch.as_tensor(
+                    item,
+                    device=input_ids.device,
+                )
+                if tensor.dim() == 2 and tensor.shape[0] == 1:
+                    tensor = tensor.squeeze(0)
+                if tensor.dim() != 1:
+                    return None
+                normalized.append(tensor)
+            return normalized
+
+        def _cat_request_tensors(
+            tensors: list[torch.Tensor] | None,
+        ) -> torch.Tensor | None:
+            if tensors is None:
+                return None
+            if len(tensors) == 0:
+                return None
+            if len(tensors) == 1:
+                return tensors[0]
+            return torch.cat(tensors, dim=0)
+
+        def _slice_request_tensor(
+            tensor: torch.Tensor,
+            seq_positions: torch.Tensor,
+        ) -> torch.Tensor:
+            if seq_positions.numel() == 0:
+                return tensor[:0]
+            prompt_tokens = tensor.shape[-1]
+            seq_positions = seq_positions.to(
+                device=tensor.device,
+                dtype=torch.long,
+            )
+            if (
+                int(seq_positions.min().item()) >= 0
+                and int(seq_positions.max().item()) < prompt_tokens
+            ):
+                return tensor.index_select(0, seq_positions)
+            return tensor
+
+        if input_ids.dim() == 1:
+            audio_request_tensors = _as_request_tensor_list(
+                audio_token_ids,
+                batch_size=(
+                    len(audio_token_ids)
+                    if isinstance(audio_token_ids, (list, tuple))
+                    else int(audio_token_ids.shape[0])
+                    if isinstance(audio_token_ids, torch.Tensor)
+                    and audio_token_ids.dim() == 2
+                    else 1
+                ),
+            )
+            text_request_tensors = (
+                _as_request_tensor_list(
+                    text_input_ids,
+                    batch_size=len(audio_request_tensors),
+                )
+                if audio_request_tensors is not None
+                else None
+            )
+            mask_request_tensors = (
+                _as_request_tensor_list(
+                    is_continuous_mask,
+                    batch_size=len(audio_request_tensors),
+                )
+                if audio_request_tensors is not None
+                else None
+            )
+            if audio_request_tensors is not None and len(audio_request_tensors) == 1:
+                audio_token_ids = audio_request_tensors[0]
+                if text_request_tensors is not None:
+                    text_input_ids = text_request_tensors[0]
+                if mask_request_tensors is not None:
+                    is_continuous_mask = mask_request_tensors[0]
+            if audio_request_tensors is not None and len(audio_request_tensors) > 1:
+                if positions.dim() == 1 and positions.numel() == len(
+                    audio_request_tensors
+                ):
+                    request_positions = positions.to(dtype=torch.long).tolist()
+                    decode_only = [
+                        pos >= int(tensor.shape[-1])
+                        for pos, tensor in zip(
+                            request_positions,
+                            audio_request_tensors,
+                        )
+                    ]
+                    if all(decode_only):
+                        return None, None, None
+                if positions.dim() == 1:
+                    split_points = (positions[1:] <= positions[:-1]).nonzero(
+                        as_tuple=True
+                    )[0] + 1
+                    position_segments = torch.tensor_split(
+                        positions,
+                        split_points.tolist(),
+                    )
+                    input_segments = torch.tensor_split(
+                        input_ids,
+                        split_points.tolist(),
+                    )
+                elif positions.dim() == 2 and positions.shape[0] == len(
+                    audio_request_tensors
+                ):
+                    position_segments = [row for row in positions]
+                    input_segments = [row for row in input_ids]
+                else:
+                    position_segments = []
+                    input_segments = []
+
+                if len(position_segments) >= len(audio_request_tensors):
+                    leading_text_only_segments = (
+                        len(position_segments) - len(audio_request_tensors)
+                    )
+                    mask_dtype = (
+                        mask_request_tensors[0].dtype
+                        if mask_request_tensors is not None
+                        and len(mask_request_tensors) > 0
+                        else torch.bool
+                    )
+                    audio_segment_outputs: list[torch.Tensor] = []
+                    text_segment_outputs: list[torch.Tensor] | None = []
+                    mask_segment_outputs: list[torch.Tensor] | None = (
+                        [] if mask_request_tensors is not None else None
+                    )
+
+                    for seq_input_ids in input_segments[:leading_text_only_segments]:
+                        audio_segment_outputs.append(
+                            torch.full_like(
+                                seq_input_ids,
+                                fill_value=KimiAudioProcessor.KIMIA_TEXT_BLANK,
+                            )
+                        )
+                        text_segment_outputs.append(seq_input_ids)
+                        if mask_segment_outputs is not None:
+                            mask_segment_outputs.append(
+                                torch.zeros(
+                                    seq_input_ids.shape,
+                                    dtype=mask_dtype,
+                                    device=seq_input_ids.device,
+                                )
+                            )
+
+                    for request_idx, seq_positions in enumerate(
+                        position_segments[leading_text_only_segments:]
+                    ):
+                        audio_segment_outputs.append(
+                            _slice_request_tensor(
+                                audio_request_tensors[request_idx],
+                                seq_positions,
+                            )
+                        )
+                        text_segment_outputs.append(
+                            input_segments[leading_text_only_segments + request_idx]
+                            if text_request_tensors is None
+                            else _slice_request_tensor(
+                                text_request_tensors[request_idx],
+                                seq_positions,
+                            )
+                        )
+                        if mask_segment_outputs is not None:
+                            mask_segment_outputs.append(
+                                _slice_request_tensor(
+                                    mask_request_tensors[request_idx],
+                                    seq_positions,
+                                )
+                            )
+
+                    return (
+                        _cat_request_tensors(audio_segment_outputs),
+                        _cat_request_tensors(text_segment_outputs),
+                        _cat_request_tensors(mask_segment_outputs),
+                    )
+                audio_token_ids = _cat_request_tensors(audio_request_tensors)
+                if text_request_tensors is not None:
+                    text_input_ids = _cat_request_tensors(text_request_tensors)
+                if mask_request_tensors is not None:
+                    is_continuous_mask = _cat_request_tensors(
+                        mask_request_tensors
+                    )
 
         scheduled_tokens = input_ids.shape[-1]
         prompt_tokens = audio_token_ids.shape[-1]
@@ -1095,6 +1294,8 @@ class KimiAudioForConditionalGeneration(
             return audio_token_ids, text_input_ids, is_continuous_mask
         if seq_positions.numel() == 0:
             return audio_token_ids, text_input_ids, is_continuous_mask
+        if int(seq_positions.min().item()) >= prompt_tokens:
+            return None, None, None
         if int(seq_positions.min().item()) < 0:
             return audio_token_ids, text_input_ids, is_continuous_mask
         if int(seq_positions.max().item()) >= prompt_tokens:
@@ -1207,17 +1408,23 @@ class KimiAudioForConditionalGeneration(
 
         model_input_ids = input_ids
         if audio_token_ids is not None:
-            if input_ids is not None and input_ids.dim() == 1:
+            if (
+                input_ids is not None
+                and input_ids.dim() == 1
+                and isinstance(audio_token_ids, torch.Tensor)
+            ):
                 if audio_token_ids.dim() == 2 and audio_token_ids.shape[0] == 1:
                     audio_token_ids = audio_token_ids.squeeze(0)
                 if (
                     text_input_ids is not None
+                    and isinstance(text_input_ids, torch.Tensor)
                     and text_input_ids.dim() == 2
                     and text_input_ids.shape[0] == 1
                 ):
                     text_input_ids = text_input_ids.squeeze(0)
                 if (
                     is_continuous_mask is not None
+                    and isinstance(is_continuous_mask, torch.Tensor)
                     and is_continuous_mask.dim() == 2
                     and is_continuous_mask.shape[0] == 1
                 ):

--- a/vllm/model_executor/models/kimi_audio.py
+++ b/vllm/model_executor/models/kimi_audio.py
@@ -1051,6 +1051,71 @@ class KimiAudioForConditionalGeneration(
 
         return padded_inputs_embeds, True
 
+    def _slice_runtime_kimi_prompt_inputs(
+        self,
+        *,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        audio_token_ids: torch.Tensor,
+        text_input_ids: torch.Tensor | None,
+        is_continuous_mask: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+        """Align raw Kimi prompt tensors to the scheduled runtime chunk.
+
+        In the v1 runtime, prefix caching or chunked prefill may schedule only a
+        suffix of the original prompt. The raw dual-stream Kimi tensors are
+        still stored at full prompt length, so we need to slice them to the
+        positions of the currently scheduled tokens before building
+        `inputs_embeds`.
+        """
+        if input_ids is None:
+            return audio_token_ids, text_input_ids, is_continuous_mask
+
+        scheduled_tokens = input_ids.shape[-1]
+        prompt_tokens = audio_token_ids.shape[-1]
+        if scheduled_tokens >= prompt_tokens:
+            return audio_token_ids, text_input_ids, is_continuous_mask
+
+        if positions.numel() == 0:
+            return audio_token_ids, text_input_ids, is_continuous_mask
+
+        def _normalize_index(index: torch.Tensor) -> torch.Tensor | None:
+            if index.dim() == 1:
+                return index
+            if index.dim() == 2 and index.shape[0] == 1:
+                return index.squeeze(0)
+            return None
+
+        seq_positions = _normalize_index(positions)
+        if seq_positions is None:
+            return audio_token_ids, text_input_ids, is_continuous_mask
+
+        seq_positions = seq_positions.to(device=audio_token_ids.device).long()
+        if seq_positions.numel() != scheduled_tokens:
+            return audio_token_ids, text_input_ids, is_continuous_mask
+        if seq_positions.numel() == 0:
+            return audio_token_ids, text_input_ids, is_continuous_mask
+        if int(seq_positions.min().item()) < 0:
+            return audio_token_ids, text_input_ids, is_continuous_mask
+        if int(seq_positions.max().item()) >= prompt_tokens:
+            return audio_token_ids, text_input_ids, is_continuous_mask
+
+        def _slice_seq(tensor: torch.Tensor | None) -> torch.Tensor | None:
+            if tensor is None:
+                return None
+            if tensor.dim() == 1:
+                return tensor.index_select(0, seq_positions)
+            if tensor.dim() == 2 and tensor.shape[0] == 1:
+                sliced = tensor[0].index_select(0, seq_positions)
+                return sliced.unsqueeze(0)
+            return tensor
+
+        return (
+            _slice_seq(audio_token_ids),
+            _slice_seq(text_input_ids),
+            _slice_seq(is_continuous_mask),
+        )
+
     def embed_input_ids(
         self,
         input_ids: torch.Tensor,
@@ -1157,6 +1222,17 @@ class KimiAudioForConditionalGeneration(
                     and is_continuous_mask.shape[0] == 1
                 ):
                     is_continuous_mask = is_continuous_mask.squeeze(0)
+            (
+                audio_token_ids,
+                text_input_ids,
+                is_continuous_mask,
+            ) = self._slice_runtime_kimi_prompt_inputs(
+                input_ids=input_ids,
+                positions=positions,
+                audio_token_ids=audio_token_ids,
+                text_input_ids=text_input_ids,
+                is_continuous_mask=is_continuous_mask,
+            )
             if inputs_embeds is None:
                 kimi_inputs_embeds = self._build_kimi_audio_inputs_embeds(
                     audio_token_ids=audio_token_ids,

--- a/vllm/model_executor/models/kimi_audio.py
+++ b/vllm/model_executor/models/kimi_audio.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """Inference-only Kimi-Audio model compatible with HuggingFace weights."""
+
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, ClassVar, Literal
 
@@ -246,9 +247,9 @@ class KimiAudioWhisperEncoder(nn.Module):
                 target_length = min(target_length, max(0, normalized_lengths[idx]))
             embeds = embeds[:, :target_length, :]
 
-            embeds = (
-                embeds + self.embed_positions.weight[: embeds.size(-2), :]
-            ).to(embeds.dtype)
+            embeds = (embeds + self.embed_positions.weight[: embeds.size(-2), :]).to(
+                embeds.dtype
+            )
 
             hidden_states.append(embeds)
             input_is_batched = embeds.ndim > 2
@@ -552,7 +553,9 @@ class KimiAudioMimoModel(nn.Module):
             self.layers = nn.ModuleList()
             self.norm = PPMissingLayer()
 
-    def forward(self, positions: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, positions: torch.Tensor, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
         residual = None
         for layer in self.layers:
             hidden_states, residual = layer(positions, hidden_states, residual)
@@ -616,6 +619,7 @@ class KimiAudioForConditionalGeneration(
     SupportsTranscription,
 ):
     """Kimi-Audio model for ASR transcription."""
+
     supports_multimodal_raw_input_only: ClassVar[bool] = True
     builds_multimodal_inputs_embeds_in_forward: ClassVar[bool] = True
 
@@ -772,7 +776,10 @@ class KimiAudioForConditionalGeneration(
     def _iter_single_audio_features(
         self,
         input_features: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
-        feature_attention_mask: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...] | None = None,
+        feature_attention_mask: torch.Tensor
+        | list[torch.Tensor]
+        | tuple[torch.Tensor, ...]
+        | None = None,
     ) -> list[torch.Tensor]:
         if isinstance(feature_attention_mask, torch.Tensor):
             if feature_attention_mask.dim() == 1:
@@ -795,7 +802,9 @@ class KimiAudioForConditionalGeneration(
                 return [
                     self._trim_single_audio_features(
                         input_features,
-                        None if feature_attention_masks is None else feature_attention_masks[0],
+                        None
+                        if feature_attention_masks is None
+                        else feature_attention_masks[0],
                     ).unsqueeze(0)
                 ]
             if input_features.dim() == 3:
@@ -807,7 +816,9 @@ class KimiAudioForConditionalGeneration(
                         else feature_attention_masks[idx]
                     )
                     normalized_features.append(
-                        self._trim_single_audio_features(feature, feature_mask).unsqueeze(0)
+                        self._trim_single_audio_features(
+                            feature, feature_mask
+                        ).unsqueeze(0)
                     )
                 return normalized_features
             msg = (
@@ -826,12 +837,15 @@ class KimiAudioForConditionalGeneration(
                 raise TypeError(msg)
             feature_mask = (
                 None
-                if feature_attention_masks is None or idx >= len(feature_attention_masks)
+                if feature_attention_masks is None
+                or idx >= len(feature_attention_masks)
                 else feature_attention_masks[idx]
             )
             if features.dim() == 2:
                 normalized_features.append(
-                    self._trim_single_audio_features(features, feature_mask).unsqueeze(0)
+                    self._trim_single_audio_features(features, feature_mask).unsqueeze(
+                        0
+                    )
                 )
             elif features.dim() == 3:
                 for inner_idx, feature in enumerate(features.unbind(dim=0)):
@@ -843,7 +857,9 @@ class KimiAudioForConditionalGeneration(
                     ):
                         inner_mask = feature_mask[inner_idx]
                     normalized_features.append(
-                        self._trim_single_audio_features(feature, inner_mask).unsqueeze(0)
+                        self._trim_single_audio_features(feature, inner_mask).unsqueeze(
+                            0
+                        )
                     )
             else:
                 msg = (
@@ -878,9 +894,11 @@ class KimiAudioForConditionalGeneration(
         if isinstance(audio_sample_lengths, torch.Tensor):
             sample_lengths = [int(length) for length in audio_sample_lengths.tolist()]
         else:
-            sample_lengths = [] if audio_sample_lengths is None else [
-                int(length) for length in audio_sample_lengths
-            ]
+            sample_lengths = (
+                []
+                if audio_sample_lengths is None
+                else [int(length) for length in audio_sample_lengths]
+            )
         projected_embeds: list[torch.Tensor] = []
         normalized_features = self._iter_single_audio_features(
             input_features,
@@ -982,7 +1000,8 @@ class KimiAudioForConditionalGeneration(
                         2.0,
                         dtype=audio_inputs_embeds.dtype,
                         device=audio_inputs_embeds.device,
-                    ))
+                    )
+                )
                 encoder_input_addwith_discrete_token = (
                     audio_inputs_embeds + whisper_embeds
                 ) * sqrt_two
@@ -996,7 +1015,11 @@ class KimiAudioForConditionalGeneration(
             output = audio_inputs_embeds + text_inputs_embeds
             return output.squeeze(0) if flatten_runtime_batch else output
 
-        return audio_inputs_embeds.squeeze(0) if flatten_runtime_batch else audio_inputs_embeds
+        return (
+            audio_inputs_embeds.squeeze(0)
+            if flatten_runtime_batch
+            else audio_inputs_embeds
+        )
 
     def _pad_runtime_kimi_inputs_embeds(
         self,
@@ -1047,10 +1070,9 @@ class KimiAudioForConditionalGeneration(
             input_ids,
             fill_value=KimiAudioProcessor.KIMIA_TEXT_BLANK,
         )
-        inputs_embeds = (
-            self.language_model.model.embed_tokens(input_ids)
-            + self.language_model.model.embed_tokens(blank_audio_ids)
-        )
+        inputs_embeds = self.language_model.model.embed_tokens(
+            input_ids
+        ) + self.language_model.model.embed_tokens(blank_audio_ids)
 
         if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
             return inputs_embeds
@@ -1061,7 +1083,9 @@ class KimiAudioForConditionalGeneration(
         for embed in multimodal_embeddings:
             if isinstance(embed, (list, tuple)):
                 embedding_items.extend(
-                    tensor if tensor.dim() == 2 else tensor.reshape(-1, tensor.shape[-1])
+                    tensor
+                    if tensor.dim() == 2
+                    else tensor.reshape(-1, tensor.shape[-1])
                     for tensor in embed
                     if isinstance(tensor, torch.Tensor)
                 )
@@ -1144,10 +1168,13 @@ class KimiAudioForConditionalGeneration(
                     self._pad_runtime_kimi_inputs_embeds(
                         input_ids=input_ids,
                         kimi_inputs_embeds=kimi_inputs_embeds,
-                    ))
+                    )
+                )
                 model_input_ids = input_ids if used_runtime_padding else audio_token_ids
             else:
-                model_input_ids = input_ids if input_ids is not None else audio_token_ids
+                model_input_ids = (
+                    input_ids if input_ids is not None else audio_token_ids
+                )
         elif inputs_embeds is None and model_input_ids is not None:
             inputs_embeds = self.embed_input_ids(
                 model_input_ids,
@@ -1176,8 +1203,9 @@ class KimiAudioForConditionalGeneration(
         if not get_pp_group().is_last_rank:
             return None
 
-        logits = self.logits_processor(self.language_model.lm_head,
-                                       hidden_states, sampling_metadata)
+        logits = self.logits_processor(
+            self.language_model.lm_head, hidden_states, sampling_metadata
+        )
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/kimi_audio.py
+++ b/vllm/model_executor/models/kimi_audio.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """Inference-only Kimi-Audio model compatible with HuggingFace weights."""
-
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, ClassVar, Literal
 
@@ -11,10 +10,17 @@ import torch
 import torch.nn as nn
 from transformers import BatchFeature
 from transformers import WhisperConfig as HFWhisperConfig
+from transformers.activations import ACT2FN
+from transformers.models.whisper.modeling_whisper import sinusoids
+from flash_attn import flash_attn_func
 
 from vllm.config import ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
-from vllm.inputs import PromptType, TokensPrompt
+from vllm.distributed import get_pp_group
+from vllm.inputs.data import PromptType, TokensPrompt
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.model_loader import DefaultModelLoader
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.interfaces import (
@@ -22,13 +28,15 @@ from vllm.model_executor.models.interfaces import (
     SupportsPP,
     SupportsTranscription,
 )
+from vllm.model_executor.models.kimi_audio_prompt import KimiAudioPromptBuilder
+from vllm.model_executor.models.qwen2 import Qwen2DecoderLayer
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
+    PPMissingLayer,
     WeightsMapper,
     init_vllm_registered_model,
     maybe_prefix,
 )
-from vllm.model_executor.models.whisper import WhisperEncoder
 from vllm.model_executor.models.whisper_utils import ISO639_1_SUPPORTED_LANGS
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import MultiModalFieldConfig
@@ -53,9 +61,19 @@ from vllm.tokenizers import cached_get_tokenizer
 from vllm.tokenizers.kimi_audio import KimiAudioTokenizer
 from vllm.transformers_utils.processor import cached_feature_extractor_from_config
 from vllm.transformers_utils.processors.kimi_audio import KimiAudioProcessor
+from vllm.transformers_utils.processors.kimi_audio_speech import (
+    cached_get_kimi_audio_speech_tokenizer,
+)
+from vllm.v1.sample.metadata import SamplingMetadata
 
 # Kimi-Audio constants
 KIMIA_WHISPER_SUBFOLDER = "whisper-large-v3"
+
+
+def _get_kimi_audio_token_length(sample_length: int) -> int:
+    if sample_length <= 0:
+        return 0
+    return (sample_length - 1) // (160 * 8) + 1
 
 
 def _get_feat_extract_output_lengths(input_lengths: torch.Tensor) -> torch.Tensor:
@@ -72,65 +90,164 @@ def _get_feat_extract_output_lengths(input_lengths: torch.Tensor) -> torch.Tenso
     return output_lengths
 
 
-class KimiAudioWhisperEncoder(WhisperEncoder):
-    """WhisperEncoder for Kimi-Audio with packed_modules_mapping."""
+class KimiAudioWhisperAttention(nn.Module):
+    def __init__(self, config: HFWhisperConfig):
+        super().__init__()
+        self.embed_dim = config.d_model
+        self.num_heads = config.encoder_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        self.scaling = self.head_dim**-0.5
 
-    # packed_modules_mapping for Q/K/V fusion during weight loading
-    packed_modules_mapping = {
-        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
-    }
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        query_states = self.q_proj(hidden_states).view(
+            batch_size,
+            seq_len,
+            self.num_heads,
+            self.head_dim,
+        )
+        key_states = self.k_proj(hidden_states).view(
+            batch_size,
+            seq_len,
+            self.num_heads,
+            self.head_dim,
+        )
+        value_states = self.v_proj(hidden_states).view(
+            batch_size,
+            seq_len,
+            self.num_heads,
+            self.head_dim,
+        )
+        attn_output = flash_attn_func(
+            query_states,
+            key_states,
+            value_states,
+            dropout_p=0.0,
+            softmax_scale=self.scaling,
+            causal=False,
+        )
+        attn_output = attn_output.reshape(batch_size, seq_len, self.embed_dim)
+        return self.out_proj(attn_output)
+
+
+class KimiAudioWhisperEncoderLayer(nn.Module):
+    def __init__(self, config: HFWhisperConfig):
+        super().__init__()
+        self.self_attn = KimiAudioWhisperAttention(config)
+        self.self_attn_layer_norm = nn.LayerNorm(config.d_model)
+        self.fc1 = nn.Linear(config.d_model, config.encoder_ffn_dim)
+        self.fc2 = nn.Linear(config.encoder_ffn_dim, config.d_model)
+        self.final_layer_norm = nn.LayerNorm(config.d_model)
+        self.activation_fn = ACT2FN[config.activation_function]
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.self_attn_layer_norm(hidden_states)
+        hidden_states = residual + self.self_attn(hidden_states)
+
+        residual = hidden_states
+        hidden_states = self.final_layer_norm(hidden_states)
+        hidden_states = self.activation_fn(self.fc1(hidden_states))
+        hidden_states = self.fc2(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class KimiAudioWhisperEncoder(nn.Module):
+    """Kimi-Audio specific Whisper encoder aligned to the official custom code."""
 
     def __init__(
         self, *, vllm_config: VllmConfig, prefix: str = "", init_in_fp32: bool = False
     ):
-        # Load Whisper config from subfolder (authoritative source)
-        # Kimi-Audio stores Whisper config in whisper-large-v3/config.json
+        super().__init__()
         model_path = vllm_config.model_config.model
-
-        # Load WhisperConfig from the subfolder
         whisper_config = HFWhisperConfig.from_pretrained(
             model_path,
             subfolder=KIMIA_WHISPER_SUBFOLDER,
         )
-
-        super().__init__(
-            vllm_config=vllm_config.with_hf_config(whisper_config),
-            prefix=prefix,
-            init_in_fp32=init_in_fp32,
+        self.config = whisper_config
+        embed_dim = whisper_config.d_model
+        self.num_mel_bins = whisper_config.num_mel_bins
+        self.max_source_positions = whisper_config.max_source_positions
+        self.conv1 = nn.Conv1d(self.num_mel_bins, embed_dim, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv1d(
+            embed_dim,
+            embed_dim,
+            kernel_size=3,
+            stride=2,
+            padding=1,
         )
+        self.embed_positions = nn.Embedding(self.max_source_positions, embed_dim)
+        with torch.no_grad():
+            self.embed_positions.weight.copy_(
+                sinusoids(*self.embed_positions.weight.shape)
+            )
+        self.layers = nn.ModuleList(
+            [
+                KimiAudioWhisperEncoderLayer(whisper_config)
+                for _ in range(whisper_config.encoder_layers)
+            ]
+        )
+        self.layer_norm = nn.LayerNorm(whisper_config.d_model)
 
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-        ]
-        params_dict = dict(self.named_parameters())
-        loaded_params: set[str] = set()
-        for name, loaded_weight in weights:
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
+    def forward(
+        self,
+        input_features: torch.Tensor | list[torch.Tensor],
+        input_lengths: Sequence[int] | torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if isinstance(input_lengths, torch.Tensor):
+            normalized_lengths = [int(length) for length in input_lengths.tolist()]
+        elif input_lengths is None:
+            normalized_lengths = []
+        else:
+            normalized_lengths = [int(length) for length in input_lengths]
 
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
+        hidden_states = []
+        input_is_batched = False
+        if isinstance(input_features, torch.Tensor):
+            if input_features.dim() == 3:
+                feature_iter = list(input_features.unbind(dim=0))
+            elif input_features.dim() == 2:
+                feature_iter = [input_features]
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
+                raise ValueError(
+                    "input_features must be 2D or 3D, "
+                    f"but got shape {tuple(input_features.shape)}."
+                )
+        else:
+            feature_iter = list(input_features)
+        for idx, features in enumerate(feature_iter):
+            embeds = nn.functional.gelu(self.conv1(features))
+            embeds = nn.functional.gelu(self.conv2(embeds))
+            embeds = embeds.transpose(-1, -2)
 
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
-            loaded_params.add(name)
-        return loaded_params
+            target_length = embeds.shape[-2]
+            if normalized_lengths and idx < len(normalized_lengths):
+                target_length = min(target_length, max(0, normalized_lengths[idx]))
+            embeds = embeds[:, :target_length, :]
+
+            embeds = (
+                embeds + self.embed_positions.weight[: embeds.size(-2), :]
+            ).to(embeds.dtype)
+
+            hidden_states.append(embeds)
+            input_is_batched = embeds.ndim > 2
+
+        if input_is_batched:
+            hidden_states = torch.cat(hidden_states)
+        else:
+            hidden_states = torch.stack(hidden_states, dim=0)
+
+        for encoder_layer in self.layers:
+            hidden_states = encoder_layer(hidden_states)
+
+        hidden_states = self.layer_norm(hidden_states)
+        return hidden_states
 
 
 # -----------------------------------------------------------------------------
@@ -151,6 +268,9 @@ class KimiAudioProcessingInfo(BaseProcessingInfo):
         return KimiAudioProcessor(
             feature_extractor=feature_extractor,
             tokenizer=self.get_tokenizer(),
+            speech_tokenizer=cached_get_kimi_audio_speech_tokenizer(
+                getattr(self.ctx.model_config.hf_config, "kimia_token_offset", 152064),
+            ),
         )
 
     def get_feature_extractor(self, **kwargs: object):
@@ -211,6 +331,7 @@ class KimiAudioDummyInputsBuilder(BaseDummyInputsBuilder[KimiAudioProcessingInfo
                 KimiAudioProcessor.KIMIA_MEDIA_BEGIN,
                 KimiAudioProcessor.KIMIA_TEXT_BLANK,
                 KimiAudioProcessor.KIMIA_MEDIA_END,
+                KimiAudioProcessor.KIMIA_SPEECH_CT_ID,
             ]
             * num_audios
         )
@@ -222,6 +343,12 @@ class KimiAudioDummyInputsBuilder(BaseDummyInputsBuilder[KimiAudioProcessingInfo
 _KIMIAUDIO_FIELD_CONFIG = {
     "whisper_input_features": MultiModalFieldConfig.batched("audio"),
     "feature_attention_mask": MultiModalFieldConfig.batched("audio"),
+    "audio_sample_lengths": MultiModalFieldConfig.batched("audio"),
+    "speech_token_ids": MultiModalFieldConfig.batched("audio"),
+    "speech_attention_mask": MultiModalFieldConfig.batched("audio"),
+    "audio_token_ids": MultiModalFieldConfig.batched("audio"),
+    "text_token_ids": MultiModalFieldConfig.batched("audio"),
+    "is_continuous_mask": MultiModalFieldConfig.batched("audio"),
 }
 
 
@@ -257,6 +384,7 @@ class KimiAudioMultiModalProcessor(BaseMultiModalProcessor[KimiAudioProcessingIn
         # Convert mm_data format: {'audios': [...]} -> {'audio': ...}
         mm_data = dict(mm_data)
         audios = mm_data.pop("audios", [])
+        processor_kwargs = dict(**mm_kwargs, **tok_kwargs)
 
         # Convert audio format: [(array, sr), ...] -> [array, ...]
         # KimiAudioProcessor expects raw numpy arrays
@@ -272,11 +400,17 @@ class KimiAudioMultiModalProcessor(BaseMultiModalProcessor[KimiAudioProcessingIn
                     audio_arrays.append(aud)
             mm_data["audio"] = audio_arrays
 
+        if (
+            processor_kwargs.get("messages") is not None
+            and "return_packed_kimi_tokens" not in processor_kwargs
+        ):
+            processor_kwargs["return_packed_kimi_tokens"] = True
+
         # Use the context's call_hf_processor for proper handling
         return self.info.ctx.call_hf_processor(
             self.info.get_hf_processor(**mm_kwargs),
             dict(text=prompt, **mm_data),
-            dict(**mm_kwargs, **tok_kwargs),
+            processor_kwargs,
         )
 
     def _get_mm_fields_config(
@@ -294,22 +428,31 @@ class KimiAudioMultiModalProcessor(BaseMultiModalProcessor[KimiAudioProcessingIn
         out_mm_kwargs,
     ) -> Sequence[PromptReplacement]:
         """Get prompt updates for audio tokens."""
-        # Get audio feature lengths from processed output
         out_mm_data = out_mm_kwargs.get_data()
+        speech_attention_mask = out_mm_data.get("speech_attention_mask")
+        speech_token_ids = out_mm_data.get("speech_token_ids")
         feature_attention_mask = out_mm_data.get("feature_attention_mask")
+        audio_sample_lengths = out_mm_data.get("audio_sample_lengths")
 
-        if feature_attention_mask is not None:
-            audio_output_lens = _get_feat_extract_output_lengths(
+        prompt_audio_lengths: list[int] = []
+        if speech_attention_mask is not None:
+            prompt_audio_lengths = speech_attention_mask.sum(-1).tolist()
+        elif speech_token_ids is not None:
+            prompt_audio_lengths = speech_token_ids.ne(-1).sum(-1).tolist()
+        elif audio_sample_lengths is not None:
+            prompt_audio_lengths = [
+                _get_kimi_audio_token_length(int(length))
+                for length in audio_sample_lengths.tolist()
+            ]
+        elif feature_attention_mask is not None:
+            prompt_audio_lengths = _get_feat_extract_output_lengths(
                 feature_attention_mask.sum(-1)
-            )
-            audio_output_lengths = audio_output_lens.tolist()
-        else:
-            audio_output_lengths = []
+            ).tolist()
 
         def get_replacement_kimiaudio(item_idx: int):
             num_features = (
-                audio_output_lengths[item_idx]
-                if item_idx < len(audio_output_lengths)
+                prompt_audio_lengths[item_idx]
+                if item_idx < len(prompt_audio_lengths)
                 else 376
             )
             if num_features == 0:
@@ -343,6 +486,7 @@ class KimiAudioMultiModalProjector(nn.Module):
         self,
         whisper_dim: int = 5120,  # Kimi-Audio custom Whisper encoder dim
         llm_dim: int = 3584,
+        norm_eps: float = 1e-6,
         prefix: str = "",
     ):
         super().__init__()
@@ -352,18 +496,97 @@ class KimiAudioMultiModalProjector(nn.Module):
         # VQ-Adaptor layers (exact checkpoint structure)
         # layers.0: Linear[5120 → 3584]
         self.vq_adaptor_layers_0 = nn.Linear(whisper_dim, llm_dim)
+        self.vq_adaptor_activation = nn.SiLU()
         # layers.3: Linear[3584 → 3584]
         self.vq_adaptor_layers_3 = nn.Linear(llm_dim, llm_dim)
         # layers.4: LayerNorm[3584]
-        self.vq_adaptor_layers_4 = nn.LayerNorm(llm_dim)
+        self.vq_adaptor_layers_4 = nn.LayerNorm(llm_dim, eps=norm_eps)
 
     def forward(self, audio_features: torch.Tensor) -> torch.Tensor:
         # Project: [B, T, 5120] → [B, T, 3584]
         hidden = self.vq_adaptor_layers_0(audio_features)
-        hidden = torch.nn.functional.gelu(hidden)
+        hidden = self.vq_adaptor_activation(hidden)
         hidden = self.vq_adaptor_layers_3(hidden)
         hidden = self.vq_adaptor_layers_4(hidden)
         return hidden
+
+
+class KimiAudioMimoModel(nn.Module):
+    """Kimi-Audio text-output decoder stack kept local to this model."""
+
+    def __init__(self, *, config, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        quant_config = vllm_config.quant_config
+        cache_config = vllm_config.cache_config
+
+        self.num_layers = getattr(config, "kimia_mimo_layers", 0)
+        if get_pp_group().is_last_rank and self.num_layers > 0:
+            self.layers = nn.ModuleList(
+                [
+                    Qwen2DecoderLayer(
+                        config=config,
+                        cache_config=cache_config,
+                        quant_config=quant_config,
+                        prefix=f"{prefix}.layers.{idx}",
+                    )
+                    for idx in range(self.num_layers)
+                ]
+            )
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.layers = nn.ModuleList()
+            self.norm = PPMissingLayer()
+
+    def forward(self, positions: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(positions, hidden_states, residual)
+
+        if residual is None:
+            return hidden_states
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                if weight_loader == default_weight_loader:
+                    weight_loader(param, loaded_weight)
+                else:
+                    weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+            loaded_params.add(name)
+        return loaded_params
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -378,6 +601,8 @@ class KimiAudioForConditionalGeneration(
     SupportsTranscription,
 ):
     """Kimi-Audio model for ASR transcription."""
+    supports_multimodal_raw_input_only: ClassVar[bool] = True
+    builds_multimodal_inputs_embeds_in_forward: ClassVar[bool] = True
 
     # Kimi-Audio supports a subset of Whisper's supported languages
     supported_languages: ClassVar[Mapping[str, str]] = {
@@ -399,16 +624,20 @@ class KimiAudioForConditionalGeneration(
             # Embeddings and output
             "model.embed_tokens.": "language_model.model.embed_tokens.",
             "model.norm.": "language_model.model.norm.",
+            # Kimi-Audio text-output branch
+            "model.mimo_layers.": "mimo_model.layers.",
+            "model.mimo_norm.": "mimo_model.norm.",
             "lm_head.": "language_model.lm_head.",
-        },
-        orig_to_new_substr={
-            ".fc1.": ".mlp.fc1.",
-            ".fc2.": ".mlp.fc2.",
+            "mimo_output.": "mimo_output.",
         },
     )
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
 
     # Audio placeholder token sequence
-    AUDIO_PLACEHOLDER = "<|im_media_begin|><|im_kimia_text_blank|><|im_media_end|>"
+    AUDIO_PLACEHOLDER = KimiAudioPromptBuilder.AUDIO_PLACEHOLDER
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
@@ -429,24 +658,68 @@ class KimiAudioForConditionalGeneration(
             )
         ]
 
-        with self._mark_tower_model(vllm_config, "audio"):
-            self.audio_tower = KimiAudioWhisperEncoder(
-                vllm_config=vllm_config,
-                prefix=maybe_prefix(prefix, "audio_tower"),
-            )
-            self.multi_modal_projector = KimiAudioMultiModalProjector(
-                whisper_dim=getattr(self.config, "kimia_adaptor_input_dim", 5120),
-                llm_dim=self.config.hidden_size,
-                prefix=maybe_prefix(prefix, "multi_modal_projector"),
-            )
+        self.audio_tower = KimiAudioWhisperEncoder(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "audio_tower"),
+        )
 
-        with self._mark_language_model(vllm_config):
-            self.language_model = init_vllm_registered_model(
-                vllm_config=vllm_config.with_hf_config(
-                    self.config, architectures=["Qwen2ForCausalLM"]
-                ),
-                prefix=maybe_prefix(prefix, "language_model"),
+        self.multi_modal_projector = KimiAudioMultiModalProjector(
+            whisper_dim=getattr(self.config, "kimia_adaptor_input_dim", 5120),
+            llm_dim=self.config.hidden_size,
+            norm_eps=self.config.rms_norm_eps,
+            prefix=maybe_prefix(prefix, "multi_modal_projector"),
+        )
+
+        self.language_model = init_vllm_registered_model(
+            vllm_config=vllm_config.with_hf_config(
+                self.config, architectures=["Qwen2ForCausalLM"]
+            ),
+            prefix=maybe_prefix(prefix, "language_model"),
+        )
+
+        # Official Kimi-Audio remote code uses lm_head for text tokens and
+        # mimo_output for the audio stream. Keep the MIMO modules loaded for
+        # future audio-output work, but do not route the text-output subset
+        # through them.
+        self.use_mimo_text_path = (
+            get_pp_group().world_size == 1
+            and getattr(self.config, "kimia_mimo_layers", 0) > 0
+        )
+        self.kimia_mimo_transformer_from_layer_index = getattr(
+            self.config,
+            "kimia_mimo_transformer_from_layer_index",
+            -1,
+        )
+        self.mimo_model = KimiAudioMimoModel(
+            config=self.config,
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "mimo_model"),
+        )
+        if get_pp_group().is_last_rank:
+            self.mimo_output = ParallelLMHead(
+                self.config.vocab_size,
+                self.config.hidden_size,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "mimo_output"),
             )
+        else:
+            self.mimo_output = PPMissingLayer()
+
+        if self.use_mimo_text_path:
+            tapped_layer = self.kimia_mimo_transformer_from_layer_index + 1
+            start_layer = getattr(self.language_model.model, "start_layer", 0)
+            end_layer = getattr(self.language_model.model, "end_layer", 0)
+            if start_layer < tapped_layer <= end_layer:
+                self.language_model.model._set_aux_hidden_state_layers(
+                    (tapped_layer - start_layer,)
+                )
+            else:
+                self.use_mimo_text_path = False
+
+        self.logits_processor = LogitsProcessor(
+            self.config.vocab_size,
+            self.config.vocab_size,
+        )
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors
@@ -458,33 +731,160 @@ class KimiAudioForConditionalGeneration(
         whisper_input_features = kwargs.pop("whisper_input_features", None)
         if whisper_input_features is None:
             return None
+        feature_attention_mask = kwargs.pop("feature_attention_mask", None)
+        audio_sample_lengths = kwargs.pop("audio_sample_lengths", None)
 
-        return {"whisper_input_features": whisper_input_features}
+        return {
+            "whisper_input_features": whisper_input_features,
+            "feature_attention_mask": feature_attention_mask,
+            "audio_sample_lengths": audio_sample_lengths,
+        }
 
-    def _process_audio_input(
-        self, audio_input: dict[str, torch.Tensor]
+    def _project_audio_features(
+        self,
+        audio_features: torch.Tensor,
     ) -> torch.Tensor:
-        input_features = audio_input["whisper_input_features"]
-
-        # KimiAudioWhisperEncoder expects list of tensors
-        if input_features.dim() == 3:
-            input_features = input_features.unbind(dim=0)
-
-        # Run through Whisper encoder
-        audio_features = self.audio_tower(input_features)
-
         # Reshape for 4x downsampling (Whisper outputs at 50Hz, need 12.5Hz)
         B, T, D = audio_features.shape
         if T % 4 != 0:
             pad_len = 4 - (T % 4)
             audio_features = torch.nn.functional.pad(audio_features, (0, 0, 0, pad_len))
-            T = audio_features.shape[1]  # Update T after padding
+            T = audio_features.shape[1]
 
         audio_features = audio_features.reshape(B, T // 4, D * 4)
+        return self.multi_modal_projector(audio_features)
 
-        # Project to LLM dimension
-        audio_embeds = self.multi_modal_projector(audio_features)
-        return audio_embeds
+    def _iter_single_audio_features(
+        self,
+        input_features: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
+        feature_attention_mask: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...] | None = None,
+    ) -> list[torch.Tensor]:
+        if isinstance(feature_attention_mask, torch.Tensor):
+            if feature_attention_mask.dim() == 1:
+                feature_attention_masks = [feature_attention_mask]
+            elif feature_attention_mask.dim() == 2:
+                feature_attention_masks = list(feature_attention_mask.unbind(dim=0))
+            else:
+                msg = (
+                    "feature_attention_mask must be a 1D or 2D tensor, but got "
+                    f"shape {tuple(feature_attention_mask.shape)}."
+                )
+                raise ValueError(msg)
+        elif feature_attention_mask is None:
+            feature_attention_masks = None
+        else:
+            feature_attention_masks = list(feature_attention_mask)
+
+        if isinstance(input_features, torch.Tensor):
+            if input_features.dim() == 2:
+                return [
+                    self._trim_single_audio_features(
+                        input_features,
+                        None if feature_attention_masks is None else feature_attention_masks[0],
+                    ).unsqueeze(0)
+                ]
+            if input_features.dim() == 3:
+                normalized_features: list[torch.Tensor] = []
+                for idx, feature in enumerate(input_features.unbind(dim=0)):
+                    feature_mask = (
+                        None
+                        if feature_attention_masks is None
+                        else feature_attention_masks[idx]
+                    )
+                    normalized_features.append(
+                        self._trim_single_audio_features(feature, feature_mask).unsqueeze(0)
+                    )
+                return normalized_features
+            msg = (
+                "whisper_input_features must be a 2D or 3D tensor when passed "
+                f"directly, but got shape {tuple(input_features.shape)}."
+            )
+            raise ValueError(msg)
+
+        normalized_features: list[torch.Tensor] = []
+        for idx, features in enumerate(input_features):
+            if not isinstance(features, torch.Tensor):
+                msg = (
+                    "whisper_input_features must contain tensors, but found "
+                    f"{type(features)!r}."
+                )
+                raise TypeError(msg)
+            feature_mask = (
+                None
+                if feature_attention_masks is None or idx >= len(feature_attention_masks)
+                else feature_attention_masks[idx]
+            )
+            if features.dim() == 2:
+                normalized_features.append(
+                    self._trim_single_audio_features(features, feature_mask).unsqueeze(0)
+                )
+            elif features.dim() == 3:
+                for inner_idx, feature in enumerate(features.unbind(dim=0)):
+                    inner_mask = feature_mask
+                    if (
+                        isinstance(feature_mask, torch.Tensor)
+                        and feature_mask.dim() == 2
+                        and inner_idx < feature_mask.shape[0]
+                    ):
+                        inner_mask = feature_mask[inner_idx]
+                    normalized_features.append(
+                        self._trim_single_audio_features(feature, inner_mask).unsqueeze(0)
+                    )
+            else:
+                msg = (
+                    "whisper_input_features entries must be 2D or 3D tensors, "
+                    f"but got shape {tuple(features.shape)}."
+                )
+                raise ValueError(msg)
+
+        return normalized_features
+
+    def _trim_single_audio_features(
+        self,
+        features: torch.Tensor,
+        feature_attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if feature_attention_mask is None:
+            return features
+
+        valid_length = int(feature_attention_mask.sum().item())
+        if valid_length <= 0:
+            return features
+
+        trimmed_length = min(valid_length, features.shape[-1])
+        return features[..., :trimmed_length]
+
+    def _process_audio_input(
+        self, audio_input: dict[str, torch.Tensor]
+    ) -> list[torch.Tensor]:
+        input_features = audio_input["whisper_input_features"]
+        feature_attention_mask = audio_input.get("feature_attention_mask")
+        audio_sample_lengths = audio_input.get("audio_sample_lengths")
+        if isinstance(audio_sample_lengths, torch.Tensor):
+            sample_lengths = [int(length) for length in audio_sample_lengths.tolist()]
+        else:
+            sample_lengths = [] if audio_sample_lengths is None else [
+                int(length) for length in audio_sample_lengths
+            ]
+        projected_embeds: list[torch.Tensor] = []
+        normalized_features = self._iter_single_audio_features(
+            input_features,
+            None if sample_lengths else feature_attention_mask,
+        )
+        for idx, single_feature in enumerate(normalized_features):
+            token_length = (
+                _get_kimi_audio_token_length(sample_lengths[idx])
+                if idx < len(sample_lengths)
+                else 0
+            )
+            # Match the official tokenize_waveform path: run the full Whisper
+            # encoder sequence first, then slice to token_len * 4 afterwards.
+            audio_features = self.audio_tower([single_feature])
+            if token_length > 0:
+                audio_features = audio_features[:, : token_length * 4, :]
+            audio_embeds = self._project_audio_features(audio_features)
+            projected_embeds.append(audio_embeds.squeeze(0))
+        return projected_embeds
 
     def embed_multimodal(self, **kwargs: object) -> list[torch.Tensor] | None:
         audio_input = self._parse_and_validate_audio_input(**kwargs)
@@ -492,15 +892,126 @@ class KimiAudioForConditionalGeneration(
             return []
 
         audio_embeds = self._process_audio_input(audio_input)
+        return audio_embeds
 
-        # audio_embeds shape: [batch_size, seq_len, hidden_dim]
-        # Return as list of 2D tensors, one per batch item
-        if audio_embeds.dim() == 3:
-            # Unbind batch dimension: [B, T, D] -> list of B tensors [T, D]
-            return list(audio_embeds.unbind(dim=0))
+    def _normalize_multimodal_embeddings(
+        self,
+        multimodal_embeddings: tuple[torch.Tensor, ...] | list[torch.Tensor] | None,
+        batch_size: int,
+    ) -> list[torch.Tensor]:
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return []
+
+        if len(multimodal_embeddings) == batch_size:
+            return [embed for embed in multimodal_embeddings]
+
+        normalized_embeds: list[torch.Tensor] = []
+        for embed in multimodal_embeddings:
+            if not isinstance(embed, torch.Tensor):
+                continue
+            if embed.dim() == 3:
+                normalized_embeds.extend(embed.unbind(dim=0))
+            else:
+                normalized_embeds.append(embed)
+
+        if normalized_embeds:
+            return normalized_embeds
+
+        first = multimodal_embeddings[0]
+        return [first] if isinstance(first, torch.Tensor) else []
+
+    def _build_kimi_audio_inputs_embeds(
+        self,
+        *,
+        audio_token_ids: torch.Tensor,
+        text_input_ids: torch.Tensor | None,
+        is_continuous_mask: torch.Tensor | None,
+        multimodal_embeddings: tuple[torch.Tensor, ...] | list[torch.Tensor] | None,
+    ) -> torch.Tensor:
+        flatten_runtime_batch = audio_token_ids.dim() == 1
+        if flatten_runtime_batch:
+            audio_token_ids = audio_token_ids.unsqueeze(0)
+            if text_input_ids is not None and text_input_ids.dim() == 1:
+                text_input_ids = text_input_ids.unsqueeze(0)
+            if is_continuous_mask is not None and is_continuous_mask.dim() == 1:
+                is_continuous_mask = is_continuous_mask.unsqueeze(0)
+
+        audio_inputs_embeds = self.language_model.model.embed_tokens(audio_token_ids)
+
+        if is_continuous_mask is not None and is_continuous_mask.any():
+            normalized_mm_embeds = self._normalize_multimodal_embeddings(
+                multimodal_embeddings,
+                batch_size=audio_inputs_embeds.shape[0],
+            )
+            if normalized_mm_embeds:
+                whisper_embeds = torch.zeros_like(audio_inputs_embeds)
+                for batch_idx, mm_embeds in enumerate(normalized_mm_embeds):
+                    batch_mask = is_continuous_mask[batch_idx].to(torch.bool)
+                    if not batch_mask.any():
+                        continue
+                    num_mm_tokens = int(batch_mask.sum().item())
+                    num_audio_embeds = int(mm_embeds.shape[0])
+                    num_to_use = min(num_mm_tokens, num_audio_embeds)
+                    if num_to_use <= 0:
+                        continue
+                    positions = batch_mask.nonzero(as_tuple=True)[0][:num_to_use]
+                    used_mm_embeds = mm_embeds[:num_to_use].to(
+                        dtype=audio_inputs_embeds.dtype,
+                        device=audio_inputs_embeds.device,
+                    )
+                    whisper_embeds[batch_idx, positions] = used_mm_embeds
+
+                continuous_mask = is_continuous_mask[:, :, None].to(torch.bool)
+                sqrt_two = torch.sqrt(
+                    torch.tensor(
+                        2.0,
+                        dtype=audio_inputs_embeds.dtype,
+                        device=audio_inputs_embeds.device,
+                    ))
+                encoder_input_addwith_discrete_token = (
+                    audio_inputs_embeds + whisper_embeds
+                ) * sqrt_two
+                audio_inputs_embeds = (
+                    audio_inputs_embeds * (~continuous_mask)
+                    + encoder_input_addwith_discrete_token * continuous_mask
+                )
+
+        if text_input_ids is not None and torch.any(text_input_ids != 0):
+            text_inputs_embeds = self.language_model.model.embed_tokens(text_input_ids)
+            output = audio_inputs_embeds + text_inputs_embeds
+            return output.squeeze(0) if flatten_runtime_batch else output
+
+        return audio_inputs_embeds.squeeze(0) if flatten_runtime_batch else audio_inputs_embeds
+
+    def _pad_runtime_kimi_inputs_embeds(
+        self,
+        input_ids: torch.Tensor | None,
+        kimi_inputs_embeds: torch.Tensor,
+    ) -> tuple[torch.Tensor, bool]:
+        if input_ids is None:
+            return kimi_inputs_embeds, False
+
+        expected_tokens = input_ids.shape[-1]
+        actual_tokens = kimi_inputs_embeds.shape[-2]
+        if expected_tokens == actual_tokens:
+            return kimi_inputs_embeds, False
+
+        # The v1 runtime may pad prompt tokens for scheduling/compilation while
+        # Kimi raw dual-stream tensors still describe only the scheduled prefix.
+        padded_inputs_embeds = self.embed_input_ids(input_ids)
+        if input_ids.dim() == 1 and kimi_inputs_embeds.dim() == 2:
+            padded_inputs_embeds[:actual_tokens] = kimi_inputs_embeds
+        elif input_ids.dim() == 2 and kimi_inputs_embeds.dim() == 3:
+            padded_inputs_embeds[:, :actual_tokens] = kimi_inputs_embeds
         else:
-            # Single sample: [T, D] -> wrap in list
-            return [audio_embeds]
+            msg = (
+                "Unsupported Kimi runtime embedding padding shapes: "
+                f"input_ids={tuple(input_ids.shape)}, "
+                f"inputs_embeds={tuple(kimi_inputs_embeds.shape)}."
+            )
+            raise ValueError(msg)
+
+        return padded_inputs_embeds, True
 
     def embed_input_ids(
         self,
@@ -508,6 +1019,7 @@ class KimiAudioForConditionalGeneration(
         multimodal_embeddings: tuple[torch.Tensor, ...] | None = None,
         *,
         is_multimodal: torch.Tensor | None = None,
+        handle_oov_mm_token: bool = False,
     ) -> torch.Tensor:
         """Embed input IDs and fuse with audio embeddings.
 
@@ -516,54 +1028,61 @@ class KimiAudioForConditionalGeneration(
         For PP compatibility, we use the is_multimodal mask from vLLM engine
         which is correctly computed per pipeline stage.
         """
-        # Get text embeddings
-        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+        blank_audio_ids = torch.full_like(
+            input_ids,
+            fill_value=KimiAudioProcessor.KIMIA_TEXT_BLANK,
+        )
+        inputs_embeds = (
+            self.language_model.model.embed_tokens(input_ids)
+            + self.language_model.model.embed_tokens(blank_audio_ids)
+        )
 
         if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
             return inputs_embeds
-
-        # is_multimodal must be provided for PP to work correctly
         if is_multimodal is None or not is_multimodal.any():
             return inputs_embeds
 
-        # multimodal_embeddings[0] contains audio embeddings
-        audio_embeds = multimodal_embeddings[0]
+        embedding_items: list[torch.Tensor] = []
+        for embed in multimodal_embeddings:
+            if isinstance(embed, (list, tuple)):
+                embedding_items.extend(
+                    tensor if tensor.dim() == 2 else tensor.reshape(-1, tensor.shape[-1])
+                    for tensor in embed
+                    if isinstance(tensor, torch.Tensor)
+                )
+            elif isinstance(embed, torch.Tensor):
+                if embed.dim() == 3:
+                    embedding_items.extend(embed.unbind(dim=0))
+                else:
+                    embedding_items.append(embed)
 
-        # Handle different tensor structures
-        if isinstance(audio_embeds, (list, tuple)):
-            audio_embeds = torch.cat(audio_embeds, dim=0)
-        elif audio_embeds.dim() == 3:
-            audio_embeds = audio_embeds.reshape(-1, audio_embeds.shape[-1])
+        if not embedding_items:
+            return inputs_embeds
 
-        # In PP, audio_embeds count should match is_multimodal.sum()
-        # For now, use embeddings sequentially
-        # (works for non-PP, PP needs vLLM infra fix)
-        num_mm_tokens = is_multimodal.sum().item()
-        num_audio_embeds = audio_embeds.shape[0]
-
-        # Use the minimum of available embeddings and positions
-        # This ensures we don't access out-of-bounds
-        num_to_use = min(num_audio_embeds, num_mm_tokens)
-
-        # Get positions for the tokens we'll actually process
         mm_positions = is_multimodal.nonzero(as_tuple=True)[0]
-        actual_mm_mask = torch.zeros_like(is_multimodal)
-        actual_mm_mask[mm_positions[:num_to_use]] = True
+        if mm_positions.numel() == 0:
+            return inputs_embeds
 
-        # Use corresponding embeddings
-        used_audio_embeds = audio_embeds[:num_to_use]
+        split_points = (mm_positions[1:] != mm_positions[:-1] + 1).nonzero(
+            as_tuple=True
+        )[0] + 1
+        mm_segments = torch.tensor_split(mm_positions, split_points.tolist())
 
-        # Save text embeddings at multimodal positions
-        text_at_mm_positions = inputs_embeds[actual_mm_mask].clone()
+        for segment_positions, audio_embeds in zip(mm_segments, embedding_items):
+            if segment_positions.numel() == 0:
+                continue
+            if audio_embeds.dim() != 2:
+                audio_embeds = audio_embeds.reshape(-1, audio_embeds.shape[-1])
+            num_to_use = min(int(segment_positions.numel()), int(audio_embeds.shape[0]))
+            if num_to_use <= 0:
+                continue
 
-        # Replace text with audio at multimodal positions
-        inputs_embeds[actual_mm_mask] = used_audio_embeds.to(dtype=inputs_embeds.dtype)
-
-        # Apply Kimi-Audio's unique fusion formula: (text + audio) × √2
-        inputs_embeds[actual_mm_mask] = (
-            inputs_embeds[actual_mm_mask] + text_at_mm_positions
-        ) * (2**0.5)
-
+            actual_positions = segment_positions[:num_to_use]
+            used_audio_embeds = audio_embeds[:num_to_use].to(dtype=inputs_embeds.dtype)
+            text_at_positions = inputs_embeds[actual_positions].clone()
+            inputs_embeds[actual_positions] = (
+                used_audio_embeds + text_at_positions
+            ) * (2**0.5)
         return inputs_embeds
 
     def forward(
@@ -577,34 +1096,82 @@ class KimiAudioForConditionalGeneration(
         if intermediate_tensors is not None:
             inputs_embeds = None
 
-        hidden_states = self.language_model.model(
-            input_ids,
+        audio_token_ids = kwargs.pop("audio_token_ids", None)
+        text_input_ids = kwargs.pop("text_token_ids", None)
+        is_continuous_mask = kwargs.pop("is_continuous_mask", None)
+        multimodal_embeddings = kwargs.get("multimodal_embeddings")
+
+        model_input_ids = input_ids
+        if audio_token_ids is not None:
+            if input_ids is not None and input_ids.dim() == 1:
+                if audio_token_ids.dim() == 2 and audio_token_ids.shape[0] == 1:
+                    audio_token_ids = audio_token_ids.squeeze(0)
+                if (
+                    text_input_ids is not None
+                    and text_input_ids.dim() == 2
+                    and text_input_ids.shape[0] == 1
+                ):
+                    text_input_ids = text_input_ids.squeeze(0)
+                if (
+                    is_continuous_mask is not None
+                    and is_continuous_mask.dim() == 2
+                    and is_continuous_mask.shape[0] == 1
+                ):
+                    is_continuous_mask = is_continuous_mask.squeeze(0)
+            if inputs_embeds is None:
+                kimi_inputs_embeds = self._build_kimi_audio_inputs_embeds(
+                    audio_token_ids=audio_token_ids,
+                    text_input_ids=text_input_ids,
+                    is_continuous_mask=is_continuous_mask,
+                    multimodal_embeddings=multimodal_embeddings,
+                )
+                inputs_embeds, used_runtime_padding = (
+                    self._pad_runtime_kimi_inputs_embeds(
+                        input_ids=input_ids,
+                        kimi_inputs_embeds=kimi_inputs_embeds,
+                    ))
+                model_input_ids = input_ids if used_runtime_padding else audio_token_ids
+            else:
+                model_input_ids = input_ids if input_ids is not None else audio_token_ids
+        elif inputs_embeds is None and model_input_ids is not None:
+            inputs_embeds = self.embed_input_ids(
+                model_input_ids,
+                multimodal_embeddings=multimodal_embeddings,
+                is_multimodal=kwargs.get("is_multimodal"),
+            )
+
+        model_output = self.language_model.model(
+            model_input_ids,
             positions,
             intermediate_tensors,
             inputs_embeds=inputs_embeds,
         )
 
-        return hidden_states
+        if isinstance(model_output, tuple):
+            hidden_states, _aux_hidden_states = model_output
+            return hidden_states
+
+        return model_output
 
     def compute_logits(
         self,
         hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata | None = None,
     ) -> torch.Tensor | None:
-        return self.language_model.compute_logits(hidden_states)
+        if not get_pp_group().is_last_rank:
+            return None
+
+        logits = self.logits_processor(self.language_model.lm_head,
+                                       hidden_states, sampling_metadata)
+        return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        """Load weights, skipping MIMO layers (TTS-only) for ASR."""
-        # Filter out MIMO/TTS weights since we only do ASR (speech-to-text)
+        """Load weights for the Kimi-Audio text-output subset."""
         skipped_patterns = [
             # Audio tower
             "model.",
-            # MIMO/TTS
-            "mimo_layers.",
-            "mimo_output.",
-            "mimo_norm.",
         ]
 
-        # Load main model weights (LLM + projector) with mapper
         loader = AutoWeightsLoader(self, skip_prefixes=skipped_patterns)
         loaded = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         return loaded
@@ -650,27 +1217,28 @@ class KimiAudioForConditionalGeneration(
                 "Supported task types are 'transcribe' and 'translate'."
             )
 
-        # Incorporate request_prompt as context/instruction if provided
-        user_content = (
-            f"{request_prompt}\n{cls.AUDIO_PLACEHOLDER}"
-            if request_prompt
-            else cls.AUDIO_PLACEHOLDER
+        prompt = KimiAudioPromptBuilder.build_transcription_prompt(
+            request_prompt=request_prompt,
         )
-
-        prompt = (
-            f"<|im_kimia_user_msg_start|>{user_content}"
-            f"<|im_msg_end|><|im_kimia_assistant_msg_start|>"
-        )
+        messages: list[dict[str, object]] = [
+            {"role": "user", "message_type": "text", "content": request_prompt},
+            {"role": "user", "message_type": "audio"},
+        ]
 
         prompt_token_ids = tokenizer.encode(prompt)
 
         return TokensPrompt(
             prompt_token_ids=prompt_token_ids,
             multi_modal_data={"audio": audio},
+            mm_processor_kwargs={
+                "messages": messages,
+                "output_type": "text",
+            },
         )
 
     @classmethod
     def post_process_output(cls, text: str) -> str:
         if not text:
             return ""
-        return text.strip()
+        text = text.split("<|im_kimia_text_eos|>", 1)[0]
+        return text

--- a/vllm/model_executor/models/kimi_audio_prompt.py
+++ b/vllm/model_executor/models/kimi_audio_prompt.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Prompt builder helpers for the Kimi-Audio text-output subset."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+class _KimiAudioTokenizerLike(Protocol):
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]: ...
+
+    def convert_tokens_to_ids(self, token: str) -> int: ...
+
+
+@dataclass
+class KimiAudioTokenContent:
+    audio_token_ids: list[int] = field(default_factory=list)
+    text_token_ids: list[int] = field(default_factory=list)
+    is_continuous_mask: list[bool] = field(default_factory=list)
+
+    def audio_append(self, token_id: int, *, is_continuous: bool = False) -> None:
+        self.audio_token_ids.append(token_id)
+        self.is_continuous_mask.append(is_continuous)
+
+    def text_append(self, token_id: int) -> None:
+        self.text_token_ids.append(token_id)
+
+    def audio_extend(
+        self,
+        token_ids: Sequence[int],
+        *,
+        is_continuous: bool = False,
+    ) -> None:
+        self.audio_token_ids.extend(token_ids)
+        self.is_continuous_mask.extend([is_continuous] * len(token_ids))
+
+    def text_extend(self, token_ids: Sequence[int]) -> None:
+        self.text_token_ids.extend(token_ids)
+
+    def merge(self, other: "KimiAudioTokenContent") -> None:
+        self.audio_token_ids.extend(other.audio_token_ids)
+        self.text_token_ids.extend(other.text_token_ids)
+        self.is_continuous_mask.extend(other.is_continuous_mask)
+
+    def validate(self) -> None:
+        if not (
+            len(self.audio_token_ids)
+            == len(self.text_token_ids)
+            == len(self.is_continuous_mask)
+        ):
+            raise ValueError(
+                "Kimi-Audio packed content lengths diverged: "
+                f"audio={len(self.audio_token_ids)} "
+                f"text={len(self.text_token_ids)} "
+                f"mask={len(self.is_continuous_mask)}"
+            )
+
+
+@dataclass(frozen=True)
+class KimiAudioSpecialTokenIds:
+    msg_end: int
+    media_begin: int
+    media_end: int
+    text_blank: int
+    text_eos: int
+    user_msg_start: int
+    assistant_msg_start: int
+    speech_ct: int
+    speech_ctd: int
+
+    @classmethod
+    def from_tokenizer(
+        cls,
+        tokenizer: _KimiAudioTokenizerLike,
+    ) -> "KimiAudioSpecialTokenIds":
+        return cls(
+            msg_end=tokenizer.convert_tokens_to_ids("<|im_msg_end|>"),
+            media_begin=tokenizer.convert_tokens_to_ids("<|im_media_begin|>"),
+            media_end=tokenizer.convert_tokens_to_ids("<|im_media_end|>"),
+            text_blank=tokenizer.convert_tokens_to_ids("<|im_kimia_text_blank|>"),
+            text_eos=tokenizer.convert_tokens_to_ids("<|im_kimia_text_eos|>"),
+            user_msg_start=tokenizer.convert_tokens_to_ids(
+                "<|im_kimia_user_msg_start|>"
+            ),
+            assistant_msg_start=tokenizer.convert_tokens_to_ids(
+                "<|im_kimia_assistant_msg_start|>"
+            ),
+            speech_ct=tokenizer.convert_tokens_to_ids("<|im_kimia_speech_ct_id|>"),
+            speech_ctd=tokenizer.convert_tokens_to_ids(
+                "<|im_kimia_speech_ctd_id|>"
+            ),
+        )
+
+
+class KimiAudioPromptBuilder:
+    """Build official-style text-output prompts for Kimi-Audio.
+
+    This builder intentionally targets the subset currently supported by vLLM:
+    user text, user audio, assistant text, and assistant generation prompts.
+    """
+
+    USER_START = "<|im_kimia_user_msg_start|>"
+    ASSISTANT_START = "<|im_kimia_assistant_msg_start|>"
+    MSG_END = "<|im_msg_end|>"
+    MEDIA_BEGIN = "<|im_media_begin|>"
+    MEDIA_END = "<|im_media_end|>"
+    TEXT_BLANK = "<|im_kimia_text_blank|>"
+    TEXT_EOS = "<|im_kimia_text_eos|>"
+    SPEECH_CT = "<|im_kimia_speech_ct_id|>"
+    SPEECH_CTD = "<|im_kimia_speech_ctd_id|>"
+
+    AUDIO_PLACEHOLDER = f"{MEDIA_BEGIN}{TEXT_BLANK}{MEDIA_END}{SPEECH_CT}"
+
+    @classmethod
+    def build_audio_placeholder(cls, *, audio_count: int = 1) -> str:
+        if audio_count < 0:
+            raise ValueError("audio_count must be non-negative")
+        return cls.AUDIO_PLACEHOLDER * audio_count
+
+    @classmethod
+    def build_user_audio_content(
+        cls,
+        request_prompt: str = "",
+        *,
+        audio_count: int = 1,
+    ) -> str:
+        audio_placeholder = cls.build_audio_placeholder(audio_count=audio_count)
+        request_prompt = request_prompt.strip()
+        if request_prompt:
+            return f"{request_prompt}\n{audio_placeholder}"
+        return audio_placeholder
+
+    @classmethod
+    def build_message(
+        cls,
+        *,
+        role: str,
+        content: str = "",
+        message_type: str = "text",
+        add_text_eos: bool | None = None,
+        add_msg_end: bool = True,
+        output_type: str = "text",
+        audio_count: int = 1,
+    ) -> str:
+        if role not in {"user", "assistant"}:
+            raise ValueError(f"Unsupported role: {role}")
+        if message_type not in {"text", "audio", None}:
+            raise ValueError(f"Unsupported message_type: {message_type}")
+        if output_type not in {"text", "both"}:
+            raise ValueError(f"Unsupported output_type: {output_type}")
+
+        role_prefix = cls.USER_START if role == "user" else cls.ASSISTANT_START
+
+        if add_text_eos is None:
+            add_text_eos = role == "assistant" and message_type == "text"
+
+        body = content.strip() if message_type == "text" and content else content
+        if message_type == "audio":
+            control_token = cls.SPEECH_CT if output_type == "text" else cls.SPEECH_CTD
+            body = (
+                f"{cls.MEDIA_BEGIN}{cls.TEXT_BLANK}{cls.MEDIA_END}{control_token}"
+                * audio_count
+            )
+            if content:
+                text_content = content.strip()
+                body = f"{text_content}\n{body}" if text_content else body
+        elif message_type is None:
+            body = ""
+
+        suffix = ""
+        if add_text_eos:
+            suffix += cls.TEXT_EOS
+        if add_msg_end:
+            suffix += cls.MSG_END
+
+        return f"{role_prefix}{body}{suffix}"
+
+    @classmethod
+    def build_prompt_from_messages(
+        cls,
+        messages: Sequence[dict[str, object]],
+        *,
+        add_generation_prompt: bool = True,
+        output_type: str = "text",
+    ) -> str:
+        prompt_parts: list[str] = []
+
+        for message in messages:
+            role = str(message["role"])
+            message_type = str(message.get("message_type") or "text")
+            content = str(message.get("content") or "")
+            audio_count = int(message.get("audio_count", 1) or 1)
+            prompt_parts.append(
+                cls.build_message(
+                    role=role,
+                    content=content,
+                    message_type=message_type,
+                    add_msg_end=True,
+                    output_type=output_type,
+                    audio_count=audio_count,
+                )
+            )
+
+        if add_generation_prompt:
+            prompt_parts.append(
+                cls.build_message(
+                    role="assistant",
+                    message_type=None,
+                    add_text_eos=False,
+                    add_msg_end=False,
+                    output_type=output_type,
+                )
+            )
+
+        return "".join(prompt_parts)
+
+    @classmethod
+    def build_transcription_prompt(
+        cls,
+        request_prompt: str = "",
+        *,
+        audio_count: int = 1,
+    ) -> str:
+        return cls.build_prompt_from_messages(
+            [
+                {
+                    "role": "user",
+                    "message_type": "audio",
+                    "content": request_prompt,
+                    "audio_count": audio_count,
+                }
+            ],
+            add_generation_prompt=True,
+            output_type="text",
+        )
+
+    @classmethod
+    def _encode_text(
+        cls,
+        tokenizer: _KimiAudioTokenizerLike,
+        text: str,
+    ) -> list[int]:
+        if not text:
+            return []
+        return list(tokenizer.encode(text, add_special_tokens=False))
+
+    @classmethod
+    def build_token_content(
+        cls,
+        *,
+        tokenizer: _KimiAudioTokenizerLike,
+        messages: Sequence[dict[str, object]],
+        output_type: str = "text",
+        add_generation_prompt: bool = True,
+    ) -> KimiAudioTokenContent:
+        special = KimiAudioSpecialTokenIds.from_tokenizer(tokenizer)
+        packed_messages: list[KimiAudioTokenContent] = []
+        previous_role: str | None = None
+
+        for idx, message in enumerate(messages):
+            role = str(message["role"])
+            message_type = message.get("message_type") or "text"
+            content = message.get("content")
+            tokenize_role = previous_role is None or role != previous_role
+
+            if idx == len(messages) - 1:
+                has_ct_token = True
+                has_msg_end_token = True
+            else:
+                next_role = str(messages[idx + 1]["role"])
+                has_ct_token = next_role != role
+                has_msg_end_token = next_role != role
+
+            packed_messages.append(
+                cls.build_tokenized_message(
+                    tokenizer=tokenizer,
+                    special_tokens=special,
+                    role=role,
+                    message_type=message_type,
+                    content=content,
+                    tokenize_role=tokenize_role,
+                    has_ct_token=has_ct_token,
+                    has_msg_end_token=has_msg_end_token,
+                    output_type=output_type,
+                )
+            )
+            previous_role = role
+
+        if add_generation_prompt:
+            packed_messages.append(
+                cls.build_tokenized_message(
+                    tokenizer=tokenizer,
+                    special_tokens=special,
+                    role="assistant",
+                    message_type=None,
+                    content=None,
+                    tokenize_role=True,
+                    has_ct_token=False,
+                    has_msg_end_token=False,
+                    output_type=output_type,
+                )
+            )
+
+        merged = KimiAudioTokenContent()
+        for message in packed_messages:
+            merged.merge(message)
+        merged.validate()
+        return merged
+
+    @classmethod
+    def build_tokenized_message(
+        cls,
+        *,
+        tokenizer: _KimiAudioTokenizerLike,
+        special_tokens: KimiAudioSpecialTokenIds,
+        role: str,
+        message_type: object,
+        content: object,
+        tokenize_role: bool,
+        has_ct_token: bool,
+        has_msg_end_token: bool,
+        output_type: str,
+    ) -> KimiAudioTokenContent:
+        if role not in {"user", "assistant"}:
+            raise ValueError(f"Unsupported role: {role}")
+        if message_type not in {"text", "audio", None}:
+            raise ValueError(f"Unsupported message_type: {message_type}")
+        if output_type not in {"text", "both"}:
+            raise ValueError(f"Unsupported output_type: {output_type}")
+
+        packed = KimiAudioTokenContent()
+        if tokenize_role:
+            if role == "user":
+                packed.audio_append(special_tokens.user_msg_start)
+            else:
+                packed.audio_append(special_tokens.assistant_msg_start)
+            packed.text_append(special_tokens.text_blank)
+
+        if message_type == "text":
+            text = str(content or "")
+            text_token_ids = cls._encode_text(tokenizer, text)
+            packed.text_extend(text_token_ids)
+            packed.audio_extend(
+                [special_tokens.text_blank] * len(text_token_ids),
+                is_continuous=False,
+            )
+            if role == "assistant":
+                packed.text_append(special_tokens.text_eos)
+                packed.audio_append(special_tokens.text_blank)
+        elif message_type == "audio":
+            speech_token_ids = [int(token) for token in (content or [])]
+            packed.audio_append(special_tokens.media_begin)
+            packed.audio_extend(speech_token_ids, is_continuous=True)
+            packed.audio_append(special_tokens.media_end)
+            packed.text_extend(
+                [special_tokens.text_blank] * (len(speech_token_ids) + 2)
+            )
+            if has_ct_token:
+                control_token = (
+                    special_tokens.speech_ct
+                    if output_type == "text"
+                    else special_tokens.speech_ctd
+                )
+                packed.audio_append(control_token)
+                packed.text_append(special_tokens.text_blank)
+        elif message_type is None:
+            pass
+
+        if has_msg_end_token:
+            packed.audio_append(special_tokens.msg_end)
+            packed.text_append(special_tokens.text_blank)
+
+        packed.validate()
+        return packed

--- a/vllm/model_executor/models/kimi_audio_prompt.py
+++ b/vllm/model_executor/models/kimi_audio_prompt.py
@@ -41,7 +41,7 @@ class KimiAudioTokenContent:
     def text_extend(self, token_ids: Sequence[int]) -> None:
         self.text_token_ids.extend(token_ids)
 
-    def merge(self, other: "KimiAudioTokenContent") -> None:
+    def merge(self, other: KimiAudioTokenContent) -> None:
         self.audio_token_ids.extend(other.audio_token_ids)
         self.text_token_ids.extend(other.text_token_ids)
         self.is_continuous_mask.extend(other.is_continuous_mask)
@@ -76,7 +76,7 @@ class KimiAudioSpecialTokenIds:
     def from_tokenizer(
         cls,
         tokenizer: _KimiAudioTokenizerLike,
-    ) -> "KimiAudioSpecialTokenIds":
+    ) -> KimiAudioSpecialTokenIds:
         return cls(
             msg_end=tokenizer.convert_tokens_to_ids("<|im_msg_end|>"),
             media_begin=tokenizer.convert_tokens_to_ids("<|im_media_begin|>"),
@@ -90,9 +90,7 @@ class KimiAudioSpecialTokenIds:
                 "<|im_kimia_assistant_msg_start|>"
             ),
             speech_ct=tokenizer.convert_tokens_to_ids("<|im_kimia_speech_ct_id|>"),
-            speech_ctd=tokenizer.convert_tokens_to_ids(
-                "<|im_kimia_speech_ctd_id|>"
-            ),
+            speech_ctd=tokenizer.convert_tokens_to_ids("<|im_kimia_speech_ctd_id|>"),
         )
 
 

--- a/vllm/tokenizers/kimi_audio.py
+++ b/vllm/tokenizers/kimi_audio.py
@@ -179,9 +179,12 @@ class KimiAudioTokenizer(TokenizerLike):
             "<|im_media_begin|>": 151661,
             "<|im_media_end|>": 151663,
             "<|im_kimia_text_blank|>": 151666,
+            "<|im_kimia_text_eos|>": 151667,
             "<|im_msg_end|>": 151645,
             "<|im_kimia_user_msg_start|>": 151670,
             "<|im_kimia_assistant_msg_start|>": 151671,
+            "<|im_kimia_speech_ct_id|>": 151675,
+            "<|im_kimia_speech_ctd_id|>": 151676,
         }
 
         for token_str, token_id in kimiaudio_special_tokens.items():
@@ -291,9 +294,12 @@ class KimiAudioTokenizer(TokenizerLike):
                 "<|im_media_begin|>",
                 "<|im_media_end|>",
                 "<|im_kimia_text_blank|>",
+                "<|im_kimia_text_eos|>",
                 "<|im_msg_end|>",
                 "<|im_kimia_user_msg_start|>",
                 "<|im_kimia_assistant_msg_start|>",
+                "<|im_kimia_speech_ct_id|>",
+                "<|im_kimia_speech_ctd_id|>",
             },
         )
         if truncation:

--- a/vllm/tokenizers/kimi_audio.py
+++ b/vllm/tokenizers/kimi_audio.py
@@ -404,13 +404,15 @@ class KimiAudioTokenizer(TokenizerLike):
             raise ValueError(
                 "No chat template available. Provide `chat_template` explicitly."
             )
+        render_kwargs = dict(kwargs)
+        render_kwargs.pop("conversation", None)
         # Use render_jinja_template instead of apply_chat_template
         # Note: render_jinja_template returns ([prompts], [generation_indices])
         rendered, _ = hf_chat_utils.render_jinja_template(
-            conversation,
+            [conversation],
             chat_template=template,
             tools=tools,
-            **kwargs,
+            **render_kwargs,
         )
         # Extract the first (and usually only) prompt
         prompt = rendered[0] if rendered else ""

--- a/vllm/transformers_utils/chat_templates/template_kimi_audio.jinja
+++ b/vllm/transformers_utils/chat_templates/template_kimi_audio.jinja
@@ -8,6 +8,6 @@
     {% if message['role'] == 'user' -%}
         <|im_kimia_user_msg_start|>{{ message['content'] }}<|im_msg_end|><|im_kimia_assistant_msg_start|>
     {%- elif message['role'] == 'assistant' -%}
-        {{ message['content'] }}<|im_kimia_text_eos|>
+        {{ message['content'] }}<|im_kimia_text_eos|><|im_msg_end|>
     {%- endif -%}
 {% endfor -%}

--- a/vllm/transformers_utils/chat_templates/template_kimi_audio.jinja
+++ b/vllm/transformers_utils/chat_templates/template_kimi_audio.jinja
@@ -1,8 +1,16 @@
-{% set messages = conversations[0] if conversations else [] -%}
-{% if messages and messages[0]['role'] == 'system' -%}
-    {% set loop_messages = messages[1:] -%}
+{% if messages is defined -%}
+    {% set kimi_messages = messages -%}
+{% elif conversation is defined -%}
+    {% set kimi_messages = conversation -%}
+{% elif conversations is defined and conversations -%}
+    {% set kimi_messages = conversations[0] -%}
 {% else -%}
-    {% set loop_messages = messages -%}
+    {% set kimi_messages = [] -%}
+{% endif -%}
+{% if kimi_messages and kimi_messages[0]['role'] == 'system' -%}
+    {% set loop_messages = kimi_messages[1:] -%}
+{% else -%}
+    {% set loop_messages = kimi_messages -%}
 {% endif -%}
 {% for message in loop_messages -%}
     {% if message['role'] == 'user' -%}

--- a/vllm/transformers_utils/processors/kimi_audio.py
+++ b/vllm/transformers_utils/processors/kimi_audio.py
@@ -17,10 +17,18 @@
 # limitations under the License.
 """Processor for Kimi-Audio ASR model."""
 
+from collections.abc import Sequence
+
 import numpy as np
+import torch
 from transformers import BatchFeature, ProcessorMixin
 from transformers.audio_utils import AudioInput
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
+
+from vllm.model_executor.models.kimi_audio_prompt import KimiAudioPromptBuilder
+from vllm.transformers_utils.processors.kimi_audio_speech import (
+    KimiAudioSpeechTokenizer,
+)
 
 
 class KimiAudioProcessor(ProcessorMixin):
@@ -33,13 +41,158 @@ class KimiAudioProcessor(ProcessorMixin):
     KIMIA_MEDIA_BEGIN: int = 151661
     KIMIA_MEDIA_END: int = 151663
     KIMIA_TEXT_BLANK: int = 151666
+    KIMIA_TEXT_EOS: int = 151667
+    KIMIA_SPEECH_CT_ID: int = 151675
+    KIMIA_SPEECH_CTD_ID: int = 151676
 
     # Audio processing constants
     AUDIO_SEQ_LEN: int = 376
 
-    def __init__(self, feature_extractor=None, tokenizer=None, **kwargs):
+    def __init__(
+        self,
+        feature_extractor=None,
+        tokenizer=None,
+        speech_tokenizer: KimiAudioSpeechTokenizer | None = None,
+        **kwargs,
+    ):
         self.feature_extractor = feature_extractor
         self.tokenizer = tokenizer
+        self.speech_tokenizer = speech_tokenizer
+
+    def _normalize_audio(
+        self,
+        audio: AudioInput | None,
+    ) -> tuple[list[np.ndarray], list[int]]:
+        if audio is None:
+            return [], []
+        if isinstance(audio, np.ndarray):
+            audio = [audio]
+
+        normalized_audio: list[np.ndarray] = []
+        audio_lengths: list[int] = []
+        for aud in audio:
+            if isinstance(aud, torch.Tensor):
+                aud = aud.detach().cpu().numpy()
+            aud_np = np.asarray(aud, dtype=np.float32)
+            normalized_audio.append(aud_np)
+            audio_lengths.append(int(aud_np.shape[-1]))
+        return normalized_audio, audio_lengths
+
+    def _build_speech_token_tensors(
+        self,
+        speech_token_lists: Sequence[Sequence[int]],
+    ) -> dict[str, torch.Tensor]:
+        max_len = max((len(tokens) for tokens in speech_token_lists), default=0)
+        if max_len <= 0:
+            return {}
+
+        speech_token_ids = torch.full(
+            (len(speech_token_lists), max_len),
+            fill_value=-1,
+            dtype=torch.long,
+        )
+        speech_attention_mask = torch.zeros(
+            (len(speech_token_lists), max_len),
+            dtype=torch.long,
+        )
+        for row_idx, token_ids in enumerate(speech_token_lists):
+            token_count = len(token_ids)
+            if token_count == 0:
+                continue
+            speech_token_ids[row_idx, :token_count] = torch.tensor(
+                token_ids,
+                dtype=torch.long,
+            )
+            speech_attention_mask[row_idx, :token_count] = 1
+
+        return {
+            "speech_token_ids": speech_token_ids,
+            "speech_attention_mask": speech_attention_mask,
+        }
+
+    def _build_packed_kimi_token_tensors(
+        self,
+        messages: Sequence[dict[str, object]],
+        speech_token_lists: Sequence[Sequence[int]],
+        *,
+        output_type: str,
+    ) -> dict[str, torch.Tensor]:
+        audio_message_count = sum(
+            1 for message in messages if message.get("message_type") == "audio"
+        )
+        if audio_message_count <= 0:
+            audio_message_count = 1
+
+        if len(speech_token_lists) <= audio_message_count:
+            message_batches = [messages]
+            speech_batches = [speech_token_lists]
+        elif audio_message_count == 1:
+            message_batches = [messages] * len(speech_token_lists)
+            speech_batches = [[token_ids] for token_ids in speech_token_lists]
+        elif len(speech_token_lists) % audio_message_count == 0:
+            batch_size = len(speech_token_lists) // audio_message_count
+            message_batches = [messages] * batch_size
+            speech_batches = [
+                speech_token_lists[i * audio_message_count : (i + 1) * audio_message_count]
+                for i in range(batch_size)
+            ]
+        else:
+            raise ValueError(
+                "The number of audio token sequences does not match the number "
+                "of audio messages in the provided Kimi-Audio prompt template."
+            )
+
+        audio_token_rows: list[list[int]] = []
+        text_token_rows: list[list[int]] = []
+        is_continuous_rows: list[list[bool]] = []
+
+        for message_batch, speech_batch in zip(message_batches, speech_batches):
+            speech_iter = iter(speech_batch)
+            packed_messages: list[dict[str, object]] = []
+            for message in message_batch:
+                packed_message = dict(message)
+                if packed_message.get("message_type") == "audio":
+                    packed_message["content"] = list(next(speech_iter, []))
+                packed_messages.append(packed_message)
+
+            packed = KimiAudioPromptBuilder.build_token_content(
+                tokenizer=self.tokenizer,
+                messages=packed_messages,
+                output_type=output_type,
+                add_generation_prompt=True,
+            )
+            audio_token_rows.append(packed.audio_token_ids)
+            text_token_rows.append(packed.text_token_ids)
+            is_continuous_rows.append(packed.is_continuous_mask)
+
+        max_len = max((len(row) for row in audio_token_rows), default=0)
+        padded_audio_rows = [
+            row + [0] * (max_len - len(row))
+            for row in audio_token_rows
+        ]
+        padded_text_rows = [
+            row + [0] * (max_len - len(row))
+            for row in text_token_rows
+        ]
+        padded_mask_rows = [
+            row + [False] * (max_len - len(row))
+            for row in is_continuous_rows
+        ]
+
+        return {
+            "audio_token_ids": torch.tensor(
+                padded_audio_rows,
+                dtype=torch.long,
+            ),
+            "text_token_ids": torch.tensor(
+                padded_text_rows,
+                dtype=torch.long,
+            ),
+            "is_continuous_mask": torch.tensor(
+                padded_mask_rows,
+                dtype=torch.bool,
+            ),
+        }
 
     def __call__(
         self,
@@ -50,44 +203,31 @@ class KimiAudioProcessor(ProcessorMixin):
         | None = None,
         audio: AudioInput | None = None,
         return_tensors: str = "pt",
+        return_speech_token_ids: bool = False,
+        return_packed_kimi_tokens: bool = False,
+        messages: Sequence[dict[str, object]] | None = None,
+        output_type: str = "text",
+        audio_sampling_rate: int = 16000,
         **kwargs,
     ) -> BatchFeature:
         if text is not None:
             if not isinstance(text, list):
                 text = [text]
-
             text_inputs = self.tokenizer(
                 text, return_tensors=return_tensors, padding=True
             )
         else:
             text_inputs = {}
 
-        if audio is not None:
-            # Ensure audio is a list
-            if isinstance(audio, np.ndarray):
-                audio = [audio]
-
-            # Pad audio to hop length (required by WhisperFeatureExtractor)
-            hop_length = self.feature_extractor.hop_length
-            padded_audio = []
-            for aud in audio:
-                length = aud.shape[-1]
-                if length % hop_length != 0:
-                    pad_length = hop_length - (length % hop_length)
-                    aud = np.pad(
-                        aud, (0, pad_length), mode="constant", constant_values=0
-                    )
-                padded_audio.append(aud)
-
-            # Use feature_extractor directly like Qwen3ASR does
+        padded_audio, audio_lengths = self._normalize_audio(audio)
+        if padded_audio:
             audio_inputs = self.feature_extractor(
                 padded_audio,
-                sampling_rate=16000,
-                padding=True,
+                sampling_rate=audio_sampling_rate,
+                padding="max_length",
                 return_attention_mask=True,
                 return_tensors=return_tensors,
             )
-            # Rename to match Kimi-Audio expectations
             if "input_features" in audio_inputs:
                 audio_inputs["whisper_input_features"] = audio_inputs.pop(
                     "input_features"
@@ -96,8 +236,40 @@ class KimiAudioProcessor(ProcessorMixin):
                 audio_inputs["feature_attention_mask"] = audio_inputs.pop(
                     "attention_mask"
                 )
+            audio_inputs["audio_sample_lengths"] = torch.tensor(
+                audio_lengths,
+                dtype=torch.long,
+            )
         else:
             audio_inputs = {}
+
+        speech_token_lists: list[list[int]] = []
+        need_speech_tokens = (
+            padded_audio
+            and self.speech_tokenizer is not None
+            and (return_speech_token_ids or return_packed_kimi_tokens)
+        )
+        if need_speech_tokens:
+            speech_token_lists = self.speech_tokenizer.encode(
+                padded_audio,
+                sampling_rate=audio_sampling_rate,
+            )
+
+        if return_speech_token_ids and speech_token_lists:
+            audio_inputs.update(self._build_speech_token_tensors(speech_token_lists))
+
+        if return_packed_kimi_tokens:
+            if messages is None:
+                raise ValueError(
+                    "messages must be provided when return_packed_kimi_tokens=True"
+                )
+            audio_inputs.update(
+                self._build_packed_kimi_token_tensors(
+                    messages,
+                    speech_token_lists,
+                    output_type=output_type,
+                )
+            )
 
         return BatchFeature(
             data={**text_inputs, **audio_inputs},

--- a/vllm/transformers_utils/processors/kimi_audio.py
+++ b/vllm/transformers_utils/processors/kimi_audio.py
@@ -133,7 +133,9 @@ class KimiAudioProcessor(ProcessorMixin):
             batch_size = len(speech_token_lists) // audio_message_count
             message_batches = [messages] * batch_size
             speech_batches = [
-                speech_token_lists[i * audio_message_count : (i + 1) * audio_message_count]
+                speech_token_lists[
+                    i * audio_message_count : (i + 1) * audio_message_count
+                ]
                 for i in range(batch_size)
             ]
         else:
@@ -167,16 +169,11 @@ class KimiAudioProcessor(ProcessorMixin):
 
         max_len = max((len(row) for row in audio_token_rows), default=0)
         padded_audio_rows = [
-            row + [0] * (max_len - len(row))
-            for row in audio_token_rows
+            row + [0] * (max_len - len(row)) for row in audio_token_rows
         ]
-        padded_text_rows = [
-            row + [0] * (max_len - len(row))
-            for row in text_token_rows
-        ]
+        padded_text_rows = [row + [0] * (max_len - len(row)) for row in text_token_rows]
         padded_mask_rows = [
-            row + [False] * (max_len - len(row))
-            for row in is_continuous_rows
+            row + [False] * (max_len - len(row)) for row in is_continuous_rows
         ]
 
         return {
@@ -250,7 +247,9 @@ class KimiAudioProcessor(ProcessorMixin):
             and (return_speech_token_ids or return_packed_kimi_tokens)
         )
         if need_speech_tokens:
-            speech_token_lists = self.speech_tokenizer.encode(
+            speech_tokenizer = self.speech_tokenizer
+            assert speech_tokenizer is not None
+            speech_token_lists = speech_tokenizer.encode(
                 padded_audio,
                 sampling_rate=audio_sampling_rate,
             )

--- a/vllm/transformers_utils/processors/kimi_audio_speech.py
+++ b/vllm/transformers_utils/processors/kimi_audio_speech.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import os
-import sys
 from collections.abc import Sequence
 from functools import lru_cache
 from glob import glob
@@ -19,10 +18,14 @@ import torchaudio
 from huggingface_hub import snapshot_download
 from transformers import AutoModel, WhisperFeatureExtractor
 
+from vllm.transformers_utils.processors.kimi_audio_whisper_vq import (
+    WhisperVQConfig,
+    WhisperVQEncoder,
+)
+
 KIMIA_SPEECH_TOKENIZER_REPO = "THUDM/glm-4-voice-tokenizer"
 KIMIA_SPEECH_TOKENIZER_ENV = "KIMI_AUDIO_SPEECH_TOKENIZER_PATH"
 KIMIA_SPEECH_TOKENIZER_DEVICE_ENV = "KIMI_AUDIO_SPEECH_TOKENIZER_DEVICE"
-KIMI_AUDIO_SOURCE_ROOT_ENV = "KIMI_AUDIO_SOURCE_ROOT"
 
 
 def _resolve_speech_tokenizer_path(model_name_or_path: str) -> str:
@@ -39,56 +42,9 @@ def _resolve_speech_tokenizer_path(model_name_or_path: str) -> str:
         return model_name_or_path
 
 
-def _resolve_kimi_audio_source_root() -> str | None:
-    env_path = os.environ.get(KIMI_AUDIO_SOURCE_ROOT_ENV)
-    if env_path and os.path.isdir(env_path):
-        return env_path
-
-    return None
-
-
-@lru_cache(maxsize=1)
-def _import_local_whisper_vq_encoder() -> tuple[Any, Any] | None:
-    source_root = _resolve_kimi_audio_source_root()
-    if source_root is None:
-        return None
-
-    speech_tokenizer_file = os.path.join(
-        source_root,
-        "kimia_infer",
-        "models",
-        "tokenizer",
-        "glm4",
-        "speech_tokenizer",
-        "modeling_whisper.py",
-    )
-    if not os.path.isfile(speech_tokenizer_file):
-        return None
-
-    if source_root not in sys.path:
-        sys.path.insert(0, source_root)
-
-    from kimia_infer.models.tokenizer.glm4.speech_tokenizer import (
-        configuration_whisper as whisper_config,
-    )
-    from kimia_infer.models.tokenizer.glm4.speech_tokenizer import (
-        modeling_whisper as whisper_modeling,
-    )
-
-    WhisperVQConfig = whisper_config.WhisperVQConfig
-    WhisperVQEncoder = whisper_modeling.WhisperVQEncoder
-
-    return WhisperVQConfig, WhisperVQEncoder
-
-
 def _load_local_quantize_encoder(
     model_path: str, device: torch.device | str
-) -> Any | None:
-    imported = _import_local_whisper_vq_encoder()
-    if imported is None:
-        return None
-
-    WhisperVQConfig, WhisperVQEncoder = imported
+) -> Any:
     config = WhisperVQConfig.from_pretrained(model_path)
     config.quantize_encoder_only = True
     model = WhisperVQEncoder(config)

--- a/vllm/transformers_utils/processors/kimi_audio_speech.py
+++ b/vllm/transformers_utils/processors/kimi_audio_speech.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 import os
 import sys
-from glob import glob
 from collections.abc import Sequence
 from functools import lru_cache
+from glob import glob
 from typing import Any
 
 import numpy as np
@@ -68,17 +68,22 @@ def _import_local_whisper_vq_encoder() -> tuple[Any, Any] | None:
     if source_root not in sys.path:
         sys.path.insert(0, source_root)
 
-    from kimia_infer.models.tokenizer.glm4.speech_tokenizer.configuration_whisper import (
-        WhisperVQConfig,
+    from kimia_infer.models.tokenizer.glm4.speech_tokenizer import (
+        configuration_whisper as whisper_config,
     )
-    from kimia_infer.models.tokenizer.glm4.speech_tokenizer.modeling_whisper import (
-        WhisperVQEncoder,
+    from kimia_infer.models.tokenizer.glm4.speech_tokenizer import (
+        modeling_whisper as whisper_modeling,
     )
+
+    WhisperVQConfig = whisper_config.WhisperVQConfig
+    WhisperVQEncoder = whisper_modeling.WhisperVQEncoder
 
     return WhisperVQConfig, WhisperVQEncoder
 
 
-def _load_local_quantize_encoder(model_path: str, device: torch.device | str) -> Any | None:
+def _load_local_quantize_encoder(
+    model_path: str, device: torch.device | str
+) -> Any | None:
     imported = _import_local_whisper_vq_encoder()
     if imported is None:
         return None
@@ -90,7 +95,7 @@ def _load_local_quantize_encoder(model_path: str, device: torch.device | str) ->
     state_dict = {}
     for path in glob(os.path.join(model_path, "model*.safetensors")):
         with safetensors.safe_open(path, framework="pt", device="cpu") as weights_file:
-            for key in weights_file.keys():
+            for key in tuple(weights_file.keys()):
                 state_dict[key] = weights_file.get_tensor(key)
 
     model.load_state_dict(state_dict, strict=True)
@@ -111,8 +116,8 @@ class KimiAudioSpeechTokenizer:
         self.model_name_or_path = model_name_or_path
         self.token_offset = token_offset
         env_device = os.environ.get(KIMIA_SPEECH_TOKENIZER_DEVICE_ENV)
-        self.device = device or env_device or (
-            "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = (
+            device or env_device or ("cuda" if torch.cuda.is_available() else "cpu")
         )
         self._model = model
         self._feature_extractor = feature_extractor
@@ -126,11 +131,15 @@ class KimiAudioSpeechTokenizer:
                 self.device,
             )
             if self._model is None:
-                self._model = AutoModel.from_pretrained(
-                    resolved_model_path,
-                    trust_remote_code=True,
-                    local_files_only=resolved_model_path != self.model_name_or_path,
-                ).eval().to(self.device)
+                self._model = (
+                    AutoModel.from_pretrained(
+                        resolved_model_path,
+                        trust_remote_code=True,
+                        local_files_only=resolved_model_path != self.model_name_or_path,
+                    )
+                    .eval()
+                    .to(self.device)
+                )
         if self._feature_extractor is None:
             self._feature_extractor = WhisperFeatureExtractor.from_pretrained(
                 resolved_model_path,
@@ -175,19 +184,23 @@ class KimiAudioSpeechTokenizer:
             if audio_tensor.dim() == 1:
                 audio_tensor = audio_tensor.unsqueeze(0)
             audio_tensor = audio_tensor.to(dtype=torch.float32, device=self.device)
-            audio_tensor = self._resample_if_needed(audio_tensor, sampling_rate, target_sr)
+            audio_tensor = self._resample_if_needed(
+                audio_tensor, sampling_rate, target_sr
+            )
             mono_audio = audio_tensor[0].detach().cpu().numpy()
             if mono_audio.size == 0:
                 continue
 
             time_step = 0
             while time_step * target_sr < mono_audio.shape[0]:
-                segment = mono_audio[time_step * target_sr : (time_step + 30) * target_sr]
+                segment = mono_audio[
+                    time_step * target_sr : (time_step + 30) * target_sr
+                ]
                 segments.append(segment)
                 segment_to_audio_idx.append(audio_idx)
                 time_step += 30
 
-        all_speech_tokens = [[] for _ in range(len(audios))]
+        all_speech_tokens: list[list[int]] = [[] for _ in range(len(audios))]
         if not segments:
             return all_speech_tokens
 
@@ -218,8 +231,10 @@ class KimiAudioSpeechTokenizer:
                     attention_mask=attention_mask,
                 )
                 speech_tokens = outputs.quantized_token_ids
-                attention_mask = attention_mask[:, :: model.conv1.stride[0] * model.conv2.stride[0]]
-                attention_mask = attention_mask[:, :: pooling_kernel_size]
+                attention_mask = attention_mask[
+                    :, :: model.conv1.stride[0] * model.conv2.stride[0]
+                ]
+                attention_mask = attention_mask[:, ::pooling_kernel_size]
 
                 for i in range(len(speech_tokens)):
                     audio_idx = segment_to_audio_idx[start + i]

--- a/vllm/transformers_utils/processors/kimi_audio_speech.py
+++ b/vllm/transformers_utils/processors/kimi_audio_speech.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Discrete speech-token extraction helpers for Kimi-Audio."""
+
+from __future__ import annotations
+
+import os
+import sys
+from glob import glob
+from collections.abc import Sequence
+from functools import lru_cache
+from typing import Any
+
+import numpy as np
+import safetensors
+import torch
+import torchaudio
+from huggingface_hub import snapshot_download
+from transformers import AutoModel, WhisperFeatureExtractor
+
+KIMIA_SPEECH_TOKENIZER_REPO = "THUDM/glm-4-voice-tokenizer"
+KIMIA_SPEECH_TOKENIZER_ENV = "KIMI_AUDIO_SPEECH_TOKENIZER_PATH"
+KIMIA_SPEECH_TOKENIZER_DEVICE_ENV = "KIMI_AUDIO_SPEECH_TOKENIZER_DEVICE"
+KIMI_AUDIO_SOURCE_ROOT_ENV = "KIMI_AUDIO_SOURCE_ROOT"
+
+
+def _resolve_speech_tokenizer_path(model_name_or_path: str) -> str:
+    if os.path.isdir(model_name_or_path):
+        return model_name_or_path
+
+    env_path = os.environ.get(KIMIA_SPEECH_TOKENIZER_ENV)
+    if env_path and os.path.isdir(env_path):
+        return env_path
+
+    try:
+        return snapshot_download(model_name_or_path, local_files_only=True)
+    except Exception:
+        return model_name_or_path
+
+
+def _resolve_kimi_audio_source_root() -> str | None:
+    env_path = os.environ.get(KIMI_AUDIO_SOURCE_ROOT_ENV)
+    if env_path and os.path.isdir(env_path):
+        return env_path
+
+    return None
+
+
+@lru_cache(maxsize=1)
+def _import_local_whisper_vq_encoder() -> tuple[Any, Any] | None:
+    source_root = _resolve_kimi_audio_source_root()
+    if source_root is None:
+        return None
+
+    speech_tokenizer_file = os.path.join(
+        source_root,
+        "kimia_infer",
+        "models",
+        "tokenizer",
+        "glm4",
+        "speech_tokenizer",
+        "modeling_whisper.py",
+    )
+    if not os.path.isfile(speech_tokenizer_file):
+        return None
+
+    if source_root not in sys.path:
+        sys.path.insert(0, source_root)
+
+    from kimia_infer.models.tokenizer.glm4.speech_tokenizer.configuration_whisper import (
+        WhisperVQConfig,
+    )
+    from kimia_infer.models.tokenizer.glm4.speech_tokenizer.modeling_whisper import (
+        WhisperVQEncoder,
+    )
+
+    return WhisperVQConfig, WhisperVQEncoder
+
+
+def _load_local_quantize_encoder(model_path: str, device: torch.device | str) -> Any | None:
+    imported = _import_local_whisper_vq_encoder()
+    if imported is None:
+        return None
+
+    WhisperVQConfig, WhisperVQEncoder = imported
+    config = WhisperVQConfig.from_pretrained(model_path)
+    config.quantize_encoder_only = True
+    model = WhisperVQEncoder(config)
+    state_dict = {}
+    for path in glob(os.path.join(model_path, "model*.safetensors")):
+        with safetensors.safe_open(path, framework="pt", device="cpu") as weights_file:
+            for key in weights_file.keys():
+                state_dict[key] = weights_file.get_tensor(key)
+
+    model.load_state_dict(state_dict, strict=True)
+    model.eval().to(device)
+    return model
+
+
+class KimiAudioSpeechTokenizer:
+    def __init__(
+        self,
+        model_name_or_path: str = KIMIA_SPEECH_TOKENIZER_REPO,
+        *,
+        token_offset: int = 152064,
+        device: torch.device | str | None = None,
+        model: Any | None = None,
+        feature_extractor: WhisperFeatureExtractor | None = None,
+    ) -> None:
+        self.model_name_or_path = model_name_or_path
+        self.token_offset = token_offset
+        env_device = os.environ.get(KIMIA_SPEECH_TOKENIZER_DEVICE_ENV)
+        self.device = device or env_device or (
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+        self._model = model
+        self._feature_extractor = feature_extractor
+        self._resamplers: dict[int, torchaudio.transforms.Resample] = {}
+
+    def _ensure_loaded(self) -> tuple[Any, WhisperFeatureExtractor]:
+        resolved_model_path = _resolve_speech_tokenizer_path(self.model_name_or_path)
+        if self._model is None:
+            self._model = _load_local_quantize_encoder(
+                resolved_model_path,
+                self.device,
+            )
+            if self._model is None:
+                self._model = AutoModel.from_pretrained(
+                    resolved_model_path,
+                    trust_remote_code=True,
+                    local_files_only=resolved_model_path != self.model_name_or_path,
+                ).eval().to(self.device)
+        if self._feature_extractor is None:
+            self._feature_extractor = WhisperFeatureExtractor.from_pretrained(
+                resolved_model_path,
+                local_files_only=resolved_model_path != self.model_name_or_path,
+            )
+        return self._model, self._feature_extractor
+
+    def _resample_if_needed(
+        self,
+        audio: torch.Tensor,
+        sample_rate: int,
+        target_sr: int,
+    ) -> torch.Tensor:
+        if sample_rate == target_sr:
+            return audio
+        resampler = self._resamplers.get(sample_rate)
+        if resampler is None:
+            resampler = torchaudio.transforms.Resample(
+                orig_freq=sample_rate,
+                new_freq=target_sr,
+            ).to(self.device)
+            self._resamplers[sample_rate] = resampler
+        return resampler(audio)
+
+    def encode(
+        self,
+        audios: Sequence[np.ndarray | torch.Tensor],
+        *,
+        sampling_rate: int = 16000,
+    ) -> list[list[int]]:
+        model, feature_extractor = self._ensure_loaded()
+        dtype = model.conv1.weight.dtype
+        target_sr = int(feature_extractor.sampling_rate)
+
+        segments: list[np.ndarray] = []
+        segment_to_audio_idx: list[int] = []
+        for audio_idx, audio in enumerate(audios):
+            if isinstance(audio, np.ndarray):
+                audio_tensor = torch.from_numpy(audio)
+            else:
+                audio_tensor = audio.detach().cpu()
+            if audio_tensor.dim() == 1:
+                audio_tensor = audio_tensor.unsqueeze(0)
+            audio_tensor = audio_tensor.to(dtype=torch.float32, device=self.device)
+            audio_tensor = self._resample_if_needed(audio_tensor, sampling_rate, target_sr)
+            mono_audio = audio_tensor[0].detach().cpu().numpy()
+            if mono_audio.size == 0:
+                continue
+
+            time_step = 0
+            while time_step * target_sr < mono_audio.shape[0]:
+                segment = mono_audio[time_step * target_sr : (time_step + 30) * target_sr]
+                segments.append(segment)
+                segment_to_audio_idx.append(audio_idx)
+                time_step += 30
+
+        all_speech_tokens = [[] for _ in range(len(audios))]
+        if not segments:
+            return all_speech_tokens
+
+        pooling_kernel_size = getattr(model.config, "pooling_kernel_size", 1) or 1
+        stride = (
+            model.conv1.stride[0]
+            * model.conv2.stride[0]
+            * pooling_kernel_size
+            * feature_extractor.hop_length
+        )
+
+        batch_size = 128
+        with torch.no_grad():
+            for start in range(0, len(segments), batch_size):
+                batch_segments = segments[start : start + batch_size]
+                features = feature_extractor(
+                    batch_segments,
+                    sampling_rate=target_sr,
+                    return_attention_mask=True,
+                    return_tensors="pt",
+                    padding="longest",
+                    pad_to_multiple_of=stride,
+                )
+                input_features = features["input_features"].to(self.device).to(dtype)
+                attention_mask = features["attention_mask"].to(self.device)
+                outputs = model(
+                    input_features=input_features,
+                    attention_mask=attention_mask,
+                )
+                speech_tokens = outputs.quantized_token_ids
+                attention_mask = attention_mask[:, :: model.conv1.stride[0] * model.conv2.stride[0]]
+                attention_mask = attention_mask[:, :: pooling_kernel_size]
+
+                for i in range(len(speech_tokens)):
+                    audio_idx = segment_to_audio_idx[start + i]
+                    valid_tokens = speech_tokens[i][attention_mask[i].bool()].tolist()
+                    all_speech_tokens[audio_idx].extend(
+                        int(token) + int(self.token_offset) for token in valid_tokens
+                    )
+
+        return all_speech_tokens
+
+
+@lru_cache(maxsize=4)
+def cached_get_kimi_audio_speech_tokenizer(
+    token_offset: int = 152064,
+    model_name_or_path: str = KIMIA_SPEECH_TOKENIZER_REPO,
+) -> KimiAudioSpeechTokenizer:
+    return KimiAudioSpeechTokenizer(
+        model_name_or_path=model_name_or_path,
+        token_offset=token_offset,
+    )

--- a/vllm/transformers_utils/processors/kimi_audio_whisper_vq.py
+++ b/vllm/transformers_utils/processors/kimi_audio_whisper_vq.py
@@ -1,0 +1,471 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Minimal WhisperVQ encoder used by Kimi-Audio speech tokenization.
+
+This module intentionally vendors only the encoder-side inference path needed
+to extract discrete speech tokens from `THUDM/glm-4-voice-tokenizer`.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import WhisperConfig
+from transformers.modeling_outputs import BaseModelOutput
+from transformers.models.whisper.modeling_whisper import (
+    WhisperEncoderLayer,
+    WhisperPreTrainedModel,
+)
+
+
+@dataclass
+class QuantizedBaseModelOutput(BaseModelOutput):
+    quantized_token_ids: Optional[torch.LongTensor] = None
+
+
+class WhisperVQConfig(WhisperConfig):
+    def __init__(
+        self,
+        pooling_kernel_size=None,
+        pooling_type="max",
+        pooling_position=0,
+        quantize_vocab_size=None,
+        quantize_position=16,
+        quantize_commit_coefficient=0.25,
+        quantize_loss_scale=1.0,
+        quantize_ema_decay=None,
+        quantize_restart_interval=None,
+        quantize_encoder_only=False,
+        quantize_causal_encoder=False,
+        quantize_causal_block_size=None,
+        skip_language_detection=False,
+        encoder_causal_attention=False,
+        encoder_causal_convolution=False,
+        **kwargs,
+    ):
+        self.pooling_kernel_size = pooling_kernel_size
+        self.pooling_type = pooling_type
+        self.pooling_position = pooling_position
+        self.quantize_vocab_size = quantize_vocab_size
+        self.quantize_position = quantize_position
+        self.quantize_commit_coefficient = quantize_commit_coefficient
+        self.quantize_loss_scale = quantize_loss_scale
+        self.quantize_ema_decay = quantize_ema_decay
+        self.quantize_restart_interval = quantize_restart_interval
+        self.quantize_encoder_only = quantize_encoder_only
+        self.quantize_causal_encoder = quantize_causal_encoder
+        self.quantize_causal_block_size = quantize_causal_block_size
+        self.skip_language_detection = skip_language_detection
+        self.encoder_causal_attention = encoder_causal_attention
+        self.encoder_causal_convolution = encoder_causal_convolution
+        super().__init__(**kwargs)
+
+
+def vector_quantize(
+    inputs: torch.Tensor,
+    codebook: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    embedding_size = codebook.size(1)
+    flattened = inputs.reshape(-1, embedding_size)
+    codebook_sqr = torch.sum(codebook**2, dim=1)
+    inputs_sqr = torch.sum(flattened**2, dim=1, keepdim=True)
+    distances = torch.addmm(
+        codebook_sqr + inputs_sqr,
+        flattened,
+        codebook.t(),
+        alpha=-2.0,
+        beta=1.0,
+    )
+    indices = torch.argmin(distances, dim=1)
+    codes = torch.index_select(codebook, dim=0, index=indices).view_as(inputs)
+    return codes, indices
+
+
+def sinusoids(
+    length: int,
+    channels: int,
+    max_timescale: float = 10000,
+) -> torch.Tensor:
+    if channels % 2 != 0:
+        raise ValueError(
+            "Number of channels must be divisible by 2 for sinusoidal "
+            f"positional embeddings, got {channels}."
+        )
+    log_timescale_increment = math.log(max_timescale) / (channels // 2 - 1)
+    inv_timescales = torch.exp(
+        -log_timescale_increment * torch.arange(channels // 2)
+    )
+    scaled_time = torch.arange(length).view(-1, 1) * inv_timescales.view(1, -1)
+    return torch.cat([scaled_time.sin(), scaled_time.cos()], dim=1)
+
+
+class CausalConv1d(nn.Conv1d):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=1,
+        padding=0,
+        dilation=1,
+        groups=1,
+        bias=True,
+        **kwargs,
+    ):
+        super().__init__(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=0,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+            **kwargs,
+        )
+        self.left_padding = dilation * (kernel_size - 1)
+
+    def forward(self, inp: torch.Tensor) -> torch.Tensor:
+        return super().forward(F.pad(inp, (self.left_padding, 0)))
+
+
+class WhisperVQEncoder(WhisperPreTrainedModel):
+    config_class = WhisperVQConfig
+
+    def __init__(self, config: WhisperVQConfig):
+        if not getattr(config, "_attn_implementation", None):
+            config._attn_implementation = (
+                "sdpa"
+                if hasattr(torch.nn.functional, "scaled_dot_product_attention")
+                else "eager"
+            )
+        super().__init__(config)
+        self.config = config
+        self.dropout = config.dropout
+        self.layerdrop = config.encoder_layerdrop
+
+        embed_dim = config.d_model
+        self.num_mel_bins = config.num_mel_bins
+        self.padding_idx = config.pad_token_id
+        self.max_source_positions = config.max_source_positions
+        self.embed_scale = math.sqrt(embed_dim) if config.scale_embedding else 1.0
+
+        conv_class = CausalConv1d if config.encoder_causal_convolution else nn.Conv1d
+        self.conv1 = conv_class(
+            self.num_mel_bins,
+            embed_dim,
+            kernel_size=3,
+            padding=1,
+        )
+        self.conv2 = conv_class(
+            embed_dim,
+            embed_dim,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+        )
+
+        self.embed_positions = nn.Embedding(self.max_source_positions, embed_dim)
+        self.embed_positions.requires_grad_(False)
+
+        num_layers = (
+            config.quantize_position
+            if config.quantize_encoder_only
+            else config.encoder_layers
+        )
+        self.layers = nn.ModuleList(
+            [WhisperEncoderLayer(config) for _ in range(num_layers)]
+        )
+        self.layer_norm = (
+            None
+            if config.quantize_encoder_only
+            else nn.LayerNorm(config.d_model)
+        )
+
+        self.gradient_checkpointing = False
+        self.pooling_layer: nn.Module | None = None
+        self.codebook: nn.Embedding | None = None
+        self.embed_positions2: nn.Embedding | None = None
+
+        self._init_pooling_layer()
+        self._init_quantize_layer()
+        self.post_init()
+
+    def _init_weights(self, module):
+        super()._init_weights(module)
+        if isinstance(module, WhisperVQEncoder):
+            with torch.no_grad():
+                module.embed_positions.weight.copy_(
+                    sinusoids(*module.embed_positions.weight.shape)
+                )
+                if module.embed_positions2 is not None:
+                    max_positions = module.embed_positions2.weight.shape[0]
+                    module.embed_positions2.weight.copy_(
+                        module.embed_positions.weight[:max_positions]
+                    )
+
+    def _init_pooling_layer(self) -> None:
+        if self.config.pooling_kernel_size is None:
+            return
+        if self.config.pooling_type == "max":
+            self.pooling_layer = nn.MaxPool1d(
+                kernel_size=self.config.pooling_kernel_size
+            )
+        elif self.config.pooling_type == "avg":
+            self.pooling_layer = nn.AvgPool1d(
+                kernel_size=self.config.pooling_kernel_size
+            )
+        else:
+            raise NotImplementedError(
+                f"Pooling type {self.config.pooling_type} not implemented"
+            )
+
+    def _init_quantize_layer(self) -> None:
+        if self.config.quantize_vocab_size is None:
+            return
+        if self.config.pooling_position is not None:
+            assert self.config.quantize_position >= self.config.pooling_position
+        self.codebook = nn.Embedding(
+            self.config.quantize_vocab_size,
+            self.config.d_model,
+        )
+        max_source_positions = self.max_source_positions
+        if self.config.pooling_kernel_size is not None:
+            max_source_positions = math.ceil(
+                max_source_positions / self.config.pooling_kernel_size
+            )
+        self.embed_positions2 = nn.Embedding(
+            max_source_positions,
+            self.config.d_model,
+        )
+        if self.config.quantize_ema_decay is not None:
+            self.codebook.weight.requires_grad = False
+            self.register_buffer(
+                "ema_count",
+                torch.ones(self.config.quantize_vocab_size, dtype=torch.float),
+            )
+            self.register_buffer(
+                "ema_weight",
+                self.codebook.weight.data.clone().float(),
+            )
+
+    def _freeze_parameters(self):
+        for param in self.parameters():
+            param.requires_grad = False
+        self._requires_grad = False
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.conv1
+
+    def set_input_embeddings(self, value: nn.Module):
+        self.conv1 = value
+
+    def get_block_causal_attention_mask(
+        self,
+        attention_mask: torch.Tensor,
+        *,
+        block_size: int,
+    ) -> torch.Tensor:
+        dtype = self.conv1.weight.dtype
+        _, seq_length = attention_mask.shape
+        causal_mask = torch.tril(
+            torch.ones(
+                1,
+                seq_length,
+                seq_length,
+                dtype=torch.bool,
+                device=attention_mask.device,
+            )
+        )
+        block_square_mask = []
+        for start in range(0, seq_length, block_size):
+            end = min(start + block_size, seq_length)
+            length = end - start
+            block_square_mask.append(causal_mask.new_ones((length, length)))
+        block_square_mask = torch.block_diag(*block_square_mask)
+        block_causal_mask = causal_mask | block_square_mask
+        block_causal_mask = block_causal_mask & attention_mask[:, None, :]
+        block_causal_mask = block_causal_mask.to(dtype=dtype)
+        block_causal_mask = (1.0 - block_causal_mask) * torch.finfo(dtype).min
+        return block_causal_mask.unsqueeze(1)
+
+    def forward(
+        self,
+        input_features: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        head_mask: torch.Tensor | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        quantized_token_ids: torch.LongTensor | None = None,
+    ):
+        batch_size, _, seq_length = input_features.shape
+        stride = self.conv1.stride[0] * self.conv2.stride[0]
+        seq_length = seq_length // stride
+
+        if attention_mask is None:
+            attention_mask = torch.ones(
+                (batch_size, input_features.shape[-1]),
+                dtype=torch.long,
+                device=input_features.device,
+            )
+        attention_mask = attention_mask[:, ::stride]
+
+        if self.config.quantize_causal_block_size is not None:
+            extended_attention_mask = self.get_block_causal_attention_mask(
+                attention_mask,
+                block_size=self.config.quantize_causal_block_size,
+            )
+        else:
+            extended_attention_mask = self.get_extended_attention_mask(
+                attention_mask,
+                (batch_size, seq_length),
+            )
+
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        inputs_embeds = F.gelu(self.conv1(input_features))
+        inputs_embeds = F.gelu(self.conv2(inputs_embeds))
+        hidden_states = inputs_embeds.permute(0, 2, 1)
+        hidden_states = hidden_states + self.embed_positions.weight[:seq_length]
+        hidden_states = F.dropout(
+            hidden_states,
+            p=self.dropout,
+            training=self.training,
+        )
+
+        encoder_states = () if output_hidden_states else None
+        all_attentions = () if output_attentions else None
+
+        if head_mask is not None:
+            assert head_mask.size()[0] == len(self.layers), (
+                "The head_mask should be specified for "
+                f"{len(self.layers)} layers, but got {head_mask.size()[0]}."
+            )
+
+        for idx, encoder_layer in enumerate(self.layers):
+            if output_hidden_states:
+                encoder_states = encoder_states + (hidden_states,)
+
+            to_drop = False
+            if self.training:
+                if torch.rand([]) < self.layerdrop:
+                    to_drop = True
+
+            if to_drop:
+                layer_outputs = (None, None)
+            else:
+                layer_outputs = encoder_layer(
+                    hidden_states,
+                    extended_attention_mask,
+                    layer_head_mask=(
+                        head_mask[idx] if head_mask is not None else None
+                    ),
+                    output_attentions=output_attentions,
+                )
+                hidden_states = layer_outputs[0]
+
+            if output_attentions:
+                all_attentions = all_attentions + (layer_outputs[1],)
+
+            if (
+                idx + 1 == self.config.pooling_position
+                and self.config.pooling_kernel_size is not None
+            ):
+                hidden_states = hidden_states.permute(0, 2, 1)
+                if (
+                    hidden_states.shape[-1] % self.config.pooling_kernel_size
+                    != 0
+                ):
+                    hidden_states = F.pad(
+                        hidden_states,
+                        (
+                            0,
+                            self.config.pooling_kernel_size
+                            - hidden_states.shape[-1]
+                            % self.config.pooling_kernel_size,
+                        ),
+                    )
+                assert self.pooling_layer is not None
+                hidden_states = self.pooling_layer(hidden_states).permute(0, 2, 1)
+                attention_mask = attention_mask[:, ::self.config.pooling_kernel_size]
+                if self.config.quantize_causal_block_size is not None:
+                    extended_attention_mask = self.get_block_causal_attention_mask(
+                        attention_mask,
+                        block_size=(
+                            self.config.quantize_causal_block_size
+                            // self.config.pooling_kernel_size
+                        ),
+                    )
+                else:
+                    extended_attention_mask = self.get_extended_attention_mask(
+                        attention_mask,
+                        (
+                            batch_size,
+                            seq_length // self.config.pooling_kernel_size,
+                        ),
+                    )
+
+            if (
+                idx + 1 == self.config.quantize_position
+                and self.config.quantize_vocab_size is not None
+            ):
+                assert self.codebook is not None
+                assert self.embed_positions2 is not None
+                if quantized_token_ids is not None:
+                    hidden_states = self.codebook(quantized_token_ids)
+                else:
+                    hidden_quantized, flat_indices = vector_quantize(
+                        hidden_states,
+                        self.codebook.weight,
+                    )
+                    quantized_token_ids = flat_indices.reshape(
+                        batch_size,
+                        hidden_quantized.shape[1],
+                    )
+                    hidden_states = hidden_quantized
+                hidden_states = hidden_states + self.embed_positions2.weight[
+                    : hidden_states.shape[1]
+                ]
+
+        if self.layer_norm is not None:
+            hidden_states = self.layer_norm(hidden_states)
+        if output_hidden_states:
+            encoder_states = encoder_states + (hidden_states,)
+
+        if not return_dict:
+            return tuple(
+                value
+                for value in (
+                    hidden_states,
+                    encoder_states,
+                    all_attentions,
+                    quantized_token_ids,
+                )
+                if value is not None
+            )
+
+        return QuantizedBaseModelOutput(
+            last_hidden_state=hidden_states,
+            hidden_states=encoder_states,
+            attentions=all_attentions,
+            quantized_token_ids=quantized_token_ids,
+        )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3220,8 +3220,7 @@ class GPUModelRunner(
                 **self._init_model_kwargs(),
                 **self._extract_mm_kwargs(scheduler_output),
             }
-            if getattr(self.model,
-                       "builds_multimodal_inputs_embeds_in_forward", False):
+            if getattr(self.model, "builds_multimodal_inputs_embeds_in_forward", False):
                 # Some models need raw multimodal kwargs plus encoder outputs to
                 # build aligned inputs_embeds inside `forward`, instead of using
                 # the generic text-token-based merge path.
@@ -3240,10 +3239,10 @@ class GPUModelRunner(
 
                 # TODO(woosuk): Avoid the copy. Optimize.
                 self.inputs_embeds.gpu[:num_scheduled_tokens].copy_(
-                    inputs_embeds_scheduled)
+                    inputs_embeds_scheduled
+                )
 
-                input_ids, inputs_embeds = self._prepare_mm_inputs(
-                    num_input_tokens)
+                input_ids, inputs_embeds = self._prepare_mm_inputs(num_input_tokens)
         elif self.enable_prompt_embeds and is_first_rank:
             # Get the input embeddings for the tokens that are not input embeds,
             # then put them into the appropriate positions.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3216,24 +3216,34 @@ class GPUModelRunner(
             ) as ec_connector_output:
                 self._execute_mm_encoder(scheduler_output)
                 mm_embeds, is_mm_embed = self._gather_mm_embeddings(scheduler_output)
-
-            # NOTE(woosuk): To unify token ids and soft tokens (vision
-            # embeddings), we always use embeddings (rather than token ids)
-            # as input to the multimodal model, even when the input is text.
-            inputs_embeds_scheduled = self.model.embed_input_ids(
-                self.input_ids.gpu[:num_scheduled_tokens],
-                multimodal_embeddings=mm_embeds,
-                is_multimodal=is_mm_embed,
-            )
-
-            # TODO(woosuk): Avoid the copy. Optimize.
-            self.inputs_embeds.gpu[:num_scheduled_tokens].copy_(inputs_embeds_scheduled)
-
-            input_ids, inputs_embeds = self._prepare_mm_inputs(num_input_tokens)
             model_kwargs = {
                 **self._init_model_kwargs(),
                 **self._extract_mm_kwargs(scheduler_output),
             }
+            if getattr(self.model,
+                       "builds_multimodal_inputs_embeds_in_forward", False):
+                # Some models need raw multimodal kwargs plus encoder outputs to
+                # build aligned inputs_embeds inside `forward`, instead of using
+                # the generic text-token-based merge path.
+                input_ids = self.input_ids.gpu[:num_input_tokens]
+                inputs_embeds = None
+                model_kwargs["multimodal_embeddings"] = mm_embeds
+            else:
+                # NOTE(woosuk): To unify token ids and soft tokens (vision
+                # embeddings), we always use embeddings (rather than token ids)
+                # as input to the multimodal model, even when the input is text.
+                inputs_embeds_scheduled = self.model.embed_input_ids(
+                    self.input_ids.gpu[:num_scheduled_tokens],
+                    multimodal_embeddings=mm_embeds,
+                    is_multimodal=is_mm_embed,
+                )
+
+                # TODO(woosuk): Avoid the copy. Optimize.
+                self.inputs_embeds.gpu[:num_scheduled_tokens].copy_(
+                    inputs_embeds_scheduled)
+
+                input_ids, inputs_embeds = self._prepare_mm_inputs(
+                    num_input_tokens)
         elif self.enable_prompt_embeds and is_first_rank:
             # Get the input embeddings for the tokens that are not input embeds,
             # then put them into the appropriate positions.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1532,8 +1532,34 @@ class GPUModelRunner(
             return {}
 
         mm_kwargs = list[tuple[str, MultiModalKwargsItem]]()
-        for req in scheduler_output.scheduled_new_reqs:
-            for feature in req.mm_features:
+        include_runtime_request_metadata = bool(
+            getattr(
+                self.model,
+                "builds_multimodal_inputs_embeds_in_forward",
+                False,
+            )
+        )
+        runtime_request_num_scheduled_tokens: list[int] = []
+        runtime_request_has_raw_mm_inputs: list[bool] = []
+        for req_id in self.input_batch.req_ids:
+            num_scheduled_tokens = scheduler_output.num_scheduled_tokens.get(req_id, 0)
+            if num_scheduled_tokens <= 0:
+                continue
+
+            if include_runtime_request_metadata:
+                runtime_request_num_scheduled_tokens.append(num_scheduled_tokens)
+
+            req_state = self.requests[req_id]
+            prompt_token_ids = req_state.prompt_token_ids
+            prompt_len = len(prompt_token_ids) if prompt_token_ids is not None else 0
+            needs_raw_mm_inputs = req_state.num_computed_tokens < prompt_len
+            if include_runtime_request_metadata:
+                runtime_request_has_raw_mm_inputs.append(needs_raw_mm_inputs)
+            if not needs_raw_mm_inputs:
+                # Pure decode steps do not need the raw multimodal prompt tensors.
+                continue
+
+            for feature in req_state.mm_features:
                 if feature.data is not None:
                     mm_kwargs.append((feature.modality, feature.data))
 
@@ -1545,6 +1571,18 @@ class GPUModelRunner(
             pin_memory=self.pin_memory,
         ):
             mm_kwargs_combined.update(mm_kwargs_batch)
+
+        if include_runtime_request_metadata and runtime_request_num_scheduled_tokens:
+            mm_kwargs_combined["runtime_request_num_scheduled_tokens"] = torch.tensor(
+                runtime_request_num_scheduled_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            mm_kwargs_combined["runtime_request_has_raw_mm_inputs"] = torch.tensor(
+                runtime_request_has_raw_mm_inputs,
+                dtype=torch.bool,
+                device=self.device,
+            )
 
         return mm_kwargs_combined
 


### PR DESCRIPTION
## Purpose

This PR completes the Kimi-Audio text-output alignment work in vLLM.

It adds the required speech-tokenizer / WhisperVQ runtime support inside
vLLM, and fixes output mismatches in service, mixed-batch decode, and concurrent dual-stream decode. It
also updates the Kimi-Audio docs and regression coverage accordingly.

Related PR: #36127

## Test Plan

- `python3 -m pytest tests/models/multimodal/generation/test_kimi_audio_unit.py -q`
- `python3 -m pytest tests/entrypoints/openai/chat_completion/test_chat.py -k
build_chat_params_preserves_mm_processor_kwargs -q`
- `python3 -m pytest tests/entrypoints/openai/responses/test_protocol.py -k
build_chat_params_preserves_mm_processor_kwargs -q`
- `python3 -m pytest tests/test_config.py -k kimi_audio_disables_cudagraphs -q`
- `python3 -m pytest tests/v1/worker/test_gpu_model_runner.py -k
extract_mm_kwargs_includes_cached_prompt_requests -q`
- Start a vLLM server with `moonshotai/Kimi-Audio-7B-Instruct` and verify real `/v1/audio/transcriptions`
requests on Kimi-Audio sample audios.

## Test Result

- `tests/models/multimodal/generation/test_kimi_audio_unit.py`: `53 passed`
- All targeted regression tests listed above passed.
- Real server-side validation matched the expected Kimi-Audio outputs for the aligned sample set, including
concurrent dual-stream requests.

### Test Examples

English and Chinese audio download links:
- https://github.com/MoonshotAI/Kimi-Audio/tree/master/finetune_codes/demo_data/audio_understanding/audios
- https://github.com/MoonshotAI/Kimi-Audio/tree/master/test_audios

**run server**

```
vllm serve moonshotai/Kimi-Audio-7B-Instruct \
  --host 0.0.0.0 \
  --port 8090 \
  --tokenizer-mode kimi_audio \
  --trust-remote-code \
  --max-model-len 4096 \
  --max-num-seqs 8 \
  --limit-mm-per-prompt '{"audio":1}' \
  --gpu-memory-utilization 0.8
```

**send request**

```
curl -sS -X POST http://127.0.0.1:8090/v1/audio/transcriptions \
  -F model=moonshotai/Kimi-Audio-7B-Instruct \
  -F language=zh \
  -F prompt='请将音频内容转换为文字。' \
  -F max_completion_tokens=256 \
  -F use_beam_search=true \
  -F file=@/Kimi-Audio/test_audios/asr_example.wav
```

#### One Of English Examples

+ Audio name: librispeech_1263-139804-0002.flac
+ Prompt: `Please transcribe the following audio into English.`
+ Inference result: `And are capable of receiving regular instruction at the age of five months strange as it may seem this sphere which for convenience we will call brief`

#### Chinese Example

+ Audio name: asr_example.wav
+ Prompt: `请将音频内容转换为文字。`
+ Inference result: `这并不是告别这是一个篇章的结束也是新篇章的开始`

AI assistance disclosure: This PR includes AI-assisted code. All changes were reviewed and validated end to
end by the submitter.