### PR TITLE
[QeRL][RL] Default to loading weights from CPU to reduce memory usage

### DIFF
--- a/vllm/distributed/weight_transfer/base.py
+++ b/vllm/distributed/weight_transfer/base.py
@@ -33,6 +33,11 @@ class WeightTransferUpdateInfo(ABC):  # noqa: B024
     """Set to True if weights are in checkpoint/original model format and need
     layerwise processing. Set to False if weights have already been processed
     into kernel format (repacking, renaming, etc.)."""
+    layerwise_cpu_buffer: bool = True
+    """Set to true to move weights to cpu after transfer. Doing this significantly
+    reduces device memory usage when weights are provided out of order and
+    `is_checkpoint_format`. Set to `False` to reduce reload latency, only recommend if
+    weights are provided in order. Default is True."""
 
 
 # API-level request classes (accept dicts for backend-agnostic serialization)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -38,6 +38,10 @@ from vllm.distributed.parallel_state import (
 from vllm.distributed.weight_transfer import WeightTransferEngineFactory
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
+from vllm.model_executor.model_loader.reload import (
+    finalize_layerwise_reload,
+    initialize_layerwise_reload,
+)
 from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
 from vllm.platforms import current_platform
 from vllm.profiler.wrapper import CudaProfilerWrapper, TorchProfilerWrapper
@@ -969,31 +973,30 @@ class Worker(WorkerBase):
         model = self.model_runner.model
 
         if typed_update_info.is_checkpoint_format:
-            from vllm.model_executor.model_loader.reload import (
-                finalize_layerwise_reload,
-                initialize_layerwise_reload,
-            )
+            # Maybe move weights to cpu for reduced gpu memory usage
+            def load_weights_fn(weights: list[tuple[str, torch.Tensor]]):
+                if typed_update_info.layerwise_cpu_buffer:
+                    weights = [(name, weight.to("cpu")) for name, weight in weights]
+
+                model.load_weights(weights)
 
             # Use layerwise reload pattern for checkpoint format weights
-            with torch.device(self.device):
-                initialize_layerwise_reload(model)
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=model.load_weights,
-                )
-                finalize_layerwise_reload(model, self.model_config)
+            initialize_layerwise_reload(model)
+            self.weight_transfer_engine.receive_weights(
+                typed_update_info,
+                load_weights=load_weights_fn,
+            )
+            finalize_layerwise_reload(model, self.model_config)
         else:
             # Weights are already in kernel format, copy directly
-            def load_weights_direct(
-                weights: list[tuple[str, torch.Tensor]],
-            ) -> None:
+            def load_weights_fn(weights: list[tuple[str, torch.Tensor]]):
                 for name, weight in weights:
                     param = model.get_parameter(name)
                     param.copy_(weight)
 
             self.weight_transfer_engine.receive_weights(
                 typed_update_info,
-                load_weights=load_weights_direct,
+                load_weights=load_weights_fn,
             )
 
         # NCCL broadcast/packed path are asynchronous.


### PR DESCRIPTION
## Purpose ##
* Reduce device memory usage when reloading weights
  * Support transferring weights over NCCL, then buffering them on cpu while layerwise reloading occurs

## Changes ##
* Add `layerwise_cpu_buffer` flag which moves tensors to the cpu before loading (but after weight transfer and unpacking)
* Remove device context while reloading which was rendered obsolete by #38442