### PR TITLE
[Deprecation] Deprecate cprofile and cprofile_context

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -206,8 +206,8 @@ Both the `vllm.utils.profiling.cprofile` and `vllm.utils.profiling.cprofile_cont
 used to profile a section of code.
 
 !!! note
-    The legacy import paths `vllm.utils.cprofile` and `vllm.utils.cprofile_context` are deprecated.
-    Please use `vllm.utils.profiling.cprofile` and `vllm.utils.profiling.cprofile_context` instead.
+    The `vllm.utils.profiling` helpers are deprecated and will be removed in
+    `v0.21`. Please use Python's `cProfile` module directly instead.
 
 ### Example usage - decorator
 

--- a/vllm/utils/profiling.py
+++ b/vllm/utils/profiling.py
@@ -8,7 +8,13 @@ from collections.abc import Callable
 from functools import wraps
 from typing import Any
 
+from typing_extensions import deprecated
 
+
+@deprecated(
+    "vllm.utils.profiling.cprofile_context() is deprecated and will be removed "
+    "in v0.21. Use Python's cProfile module directly instead."
+)
 @contextlib.contextmanager
 def cprofile_context(save_file: str | None = None):
     """Run a cprofile
@@ -32,6 +38,10 @@ def cprofile_context(save_file: str | None = None):
             prof.print_stats(sort="cumtime")
 
 
+@deprecated(
+    "vllm.utils.profiling.cprofile() is deprecated and will be removed in "
+    "v0.21. Use Python's cProfile module directly instead."
+)
 def cprofile(save_file: str | None = None, enabled: bool = True):
     """Decorator to profile a Python method using cProfile.
 


### PR DESCRIPTION
## Purpose

Deprecate cprofile and cprofile_context as these are not used at all inside vLLM

But since we have document describing this so it is a better idea to go for a deprecate period instead of deleting it directly.
