### PR TITLE
[BugFix] --max-model-len=-1 causes over-limit requests to hang and starve the entire service

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1381,11 +1381,16 @@ class EngineCoreProc(EngineCore):
 
             # Register sockets with poller.
             poller = zmq.Poller()
+            max_model_len = getattr(self.vllm_config.model_config,
+                                    "max_model_len", None)
+            ready_payload = (msgspec.msgpack.encode({
+                "max_model_len": int(max_model_len)
+            }) if max_model_len is not None else b"")
             for input_socket in input_sockets:
                 # Send initial message to each input socket - this is required
                 # before the front-end ROUTER socket can send input messages
                 # back to us.
-                input_socket.send(b"")
+                input_socket.send(ready_payload)
                 poller.register(input_socket, zmq.POLLIN)
 
             if coord_socket is not None:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -589,8 +589,19 @@ class MPClient(EngineCoreClient):
                         f"timeout, set the environment variable: "
                         f"VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
                     )
-                identity, _ = sync_input_socket.recv_multipart()
+                identity, payload = sync_input_socket.recv_multipart()
                 identities.remove(identity)
+                if payload:
+                    try:
+                        metadata = msgspec.msgpack.decode(payload)
+                        if isinstance(metadata, dict):
+                            max_model_len = metadata.get("max_model_len")
+                            if max_model_len is not None:
+                                vllm_config.model_config.max_model_len = int(
+                                    max_model_len)
+                    except Exception:
+                        # Backward compatibility: old engine sends empty marker.
+                        pass
 
             self.core_engine: EngineIdentity = self.core_engines[0]
             self.utility_results: dict[int, AnyFuture] = {}


### PR DESCRIPTION
# Fix: `--max-model-len=-1` causes over-limit requests to hang and starve the entire service

## Purpose

In [#29431](https://github.com/vllm-project/vllm/pull/29431) (`Add --max-model-len auto to auto-fit context to available memory`), vLLM introduced support for `--max-model-len=-1/auto`, allowing max context length to be auto-fitted based on available GPU memory.

We found a synchronization issue in the current code:

- When available KV-cache GPU memory is not enough for the model-config max context length, worker-side `EngineCore` correctly auto-fits and reduces `max_model_len` after KV-cache profiling.
- Frontend-side length exposure/validation (including `/v1/models` and serving endpoints, not only OpenAI-compatible endpoints) may still keep a stale value.
- This can incorrectly accept over-limit requests at the frontend, causing long hangs, resource exhaustion, and starvation of normal requests.

This is user-visible and can lead to service unavailability.

## Root Cause

`EngineCore` runs in a subprocess and receives a copied `vllm_config` (process boundary copy semantics).

Auto-fit updates `max_model_len` inside the worker process during KV-cache initialization, but that update is not automatically synchronized back to the frontend process.

Result:
- worker runtime limit is reduced;
- frontend still validates/exposes the old limit;
- mismatch allows over-limit requests to pass frontend checks and then hang in scheduling/KV allocation.

## Concrete Example

On a 4090 24 GiB GPU (`DeepSeek-R1-Distill-Llama-8B`, `--gpu-memory-utilization 0.9`, `--max-model-len -1`), startup logs show (the exact code log format):

```text
Auto-fit max_model_len: reduced from 131072 to 30240 to fit in available GPU memory (2.66 GiB available for KV cache)
```

But `GET /v1/models` still exposes stale `max_model_len=130720`. Then send two concurrent requests: one over-limit request (`40000` tokens) and one normal request (`"say hi"`).

Before this fix:

```text
over-limit (40000 tokens) -> accepted (stale limit = 130720), hangs forever,
                              occupies all KV cache blocks
normal     ("say hi")      -> waits in queue, cannot get any KV cache block,
                              times out
```

One bad request can take down the whole service until the client disconnects.

After this fix:

```text
over-limit (40000 tokens) -> HTTP 400
normal     ("say hi")     -> HTTP 200 "Hi! How can I help you?"
```

This PR fixes the issue by embedding final `max_model_len` in the existing ZMQ ready-handshake message, requiring changes in only 2 files.

## Changes

Minimal change set (2 files only):

1. `vllm/v1/engine/core.py`
   - Reuse existing ready-handshake and include final `max_model_len` in ready payload.

2. `vllm/v1/engine/core_client.py`
   - In `MPClient`, decode ready payload and update `vllm_config.model_config.max_model_len` in-place when present.

Compatibility:
- Empty payload keeps old behavior; legacy path remains valid.

## Test Plan

Reproduction environment:
- GPU: RTX 4090 24 GiB
- Model: DeepSeek-R1-Distill-Llama-8B
- Startup args:
  - `--gpu-memory-utilization 0.9`
  - `--max-model-len -1`

Steps:
1. Start server and capture auto-fit value `X` from logs.
2. Query `/v1/models` and check whether `max_model_len == X`.
3. Build a `40000`-token request (greater than the auto-fit reduced length, but smaller than the model config max length).
4. Send it concurrently with a normal request (`"hi, how are you"`).
5. Compare behavior before/after fix:
   - over-limit request should fail fast with 400;
   - normal request should still complete with 200.

## Test Result

Before fix:
- Log showed auto-fit reduced max length to `30240`.
- `/v1/models` still showed stale value (e.g. `130720`).
- `40000`-token request was accepted, then hung and timed out.
- Resources were exhausted; normal request (`"hi, how are you"`) also blocked and timed out.

After fix:
- `/v1/models.max_model_len` is synced to auto-fit value (`30240`).
- `40000`-token request is rejected immediately (`HTTP 400`).
- Normal request succeeds (`HTTP 200`).
- Service remains available under concurrent over-limit traffic.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

Code changes in this PR were assisted by Codex and reviewed end-to-end by the submitter.