### PR TITLE
[Core] Disable HMA for eagle/MTP with sliding window models

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1248,6 +1248,18 @@ class VllmConfig:
                 # local attention.
                 need_disable_hybrid_kv_cache_manager = True
 
+        if (
+            self.speculative_config is not None
+            and self.speculative_config.use_eagle()
+            and self.model_config is not None
+            and self.model_config.get_sliding_window() is not None
+        ):
+            # Hybrid KV cache manager splits sliding window and full
+            # attention layers into different KV cache groups, which
+            # breaks the eagle/MTP drafter validation that requires
+            # all drafting layers in the same group.
+            need_disable_hybrid_kv_cache_manager = True
+
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
             # Default to disable HMA, but only if the user didn't express a preference.
             if self.kv_transfer_config is not None:


### PR DESCRIPTION
Step-3.5-Flash uses interleaved sliding window and full attention layers. When the hybrid KV cache manager (HMA) is enabled, it splits these into separate KV cache groups. The eagle/MTP drafter then fails during `validate_same_kv_cache_group()`:

```
AssertionError: All drafting layers should belong to the same kv cache group
```

There's already a guard for chunked local attention + eagle at line 1233, but no equivalent for sliding window + eagle. This adds one — when speculative decoding is used with a model that has `sliding_window` set, HMA is auto-disabled so all layers stay in one KV cache group.

The reporter confirmed that manually setting `need_disable_hybrid_kv_cache_manager = True` resolves the crash.

Fixes #38498

Signed-off-by: Bortlesboat <bortlesboat@users.noreply.github.com>