### PR TITLE
[ROCm] Set HSA_NO_SCRATCH_RECLAIM=1 in platform init for non-Docker users

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -123,6 +123,20 @@ def _sync_hip_cuda_env_vars():
 # Sync at import time - catches misconfigurations from process start.
 _sync_hip_cuda_env_vars()
 
+
+def _set_rocm_env_defaults():
+    """Set env vars required for ROCm stability.
+
+    HSA_NO_SCRATCH_RECLAIM is needed for RCCL on ROCm 7.1+ to prevent
+    hangs during collective operations. The Docker image already sets
+    this, but bare-metal and pip-install users need it too.
+    """
+    if os.environ.get("HSA_NO_SCRATCH_RECLAIM") is None:
+        os.environ["HSA_NO_SCRATCH_RECLAIM"] = "1"
+
+
+_set_rocm_env_defaults()
+
 # AMDSMI utils
 # Note that NVML is not affected by `{CUDA/HIP}_VISIBLE_DEVICES`,
 # all the related functions work on real physical device ids.


### PR DESCRIPTION
The Dockerfile already sets `HSA_NO_SCRATCH_RECLAIM=1` (required for RCCL on ROCm 7.1+), but users running vLLM from pip or bare metal don't get this and hit hangs during collective ops like CUDA graph capture.

This sets the env var at platform import time in `vllm/platforms/rocm.py`, right next to the existing `_sync_hip_cuda_env_vars()` call. It respects any existing value if the user has already set it.

Reproducer from the issue -- this hangs at ~52% without the env var:
```
vllm bench throughput --model Qwen/Qwen3-0.6B --enforce-eager
```

Fixes #36989

Signed-off-by: Bortlesboat <bortlesboat@users.noreply.github.com>