### PR TITLE
[ROCm] Remove unnecessary fp8 roundtrip in gather cache NHD dequant

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -113,9 +113,11 @@ if current_platform.is_rocm():
                 k_scale = tl.load(k_scale_ptr)
                 v_scale = tl.load(v_scale_ptr)
                 k_reg = (k_reg.to(tl.float32) * k_scale).to(
-                    key_ptr_offset.dtype.element_ty)
+                    key_ptr_offset.dtype.element_ty
+                )
                 v_reg = (v_reg.to(tl.float32) * v_scale).to(
-                    value_ptr_offset.dtype.element_ty)
+                    value_ptr_offset.dtype.element_ty
+                )
             tl.store(key_ptr_offset + col_offsets, k_reg)
             tl.store(value_ptr_offset + col_offsets, v_reg)
 

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -112,10 +112,8 @@ if current_platform.is_rocm():
             if DEQUANT:
                 k_scale = tl.load(k_scale_ptr)
                 v_scale = tl.load(v_scale_ptr)
-                k_dtype = k_reg.dtype
-                v_dtype = v_reg.dtype
-                k_reg = (k_reg.to(tl.float32) * k_scale).to(k_dtype)
-                v_reg = (v_reg.to(tl.float32) * v_scale).to(v_dtype)
+                k_reg = (k_reg.to(tl.float32) * k_scale)
+                v_reg = (v_reg.to(tl.float32) * v_scale)
             tl.store(key_ptr_offset + col_offsets, k_reg)
             tl.store(value_ptr_offset + col_offsets, v_reg)
 

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -112,8 +112,10 @@ if current_platform.is_rocm():
             if DEQUANT:
                 k_scale = tl.load(k_scale_ptr)
                 v_scale = tl.load(v_scale_ptr)
-                k_reg = (k_reg.to(tl.float32) * k_scale)
-                v_reg = (v_reg.to(tl.float32) * v_scale)
+                k_reg = (k_reg.to(tl.float32) * k_scale).to(
+                    key_ptr_offset.dtype.element_ty)
+                v_reg = (v_reg.to(tl.float32) * v_scale).to(
+                    value_ptr_offset.dtype.element_ty)
             tl.store(key_ptr_offset + col_offsets, k_reg)
             tl.store(value_ptr_offset + col_offsets, v_reg)
 


### PR DESCRIPTION
In the `cp_mha_gather_cache_kernel` NHD DEQUANT path, after loading fp8 values from the KV cache and multiplying by scale (in float32), the result is cast back to the original fp8 dtype before being stored to the output buffer:

```python
k_dtype = k_reg.dtype          # fp8
k_reg = (k_reg.to(tl.float32) * k_scale).to(k_dtype)  # float32 -> fp8 roundtrip
tl.store(key_ptr_offset + col_offsets, k_reg)           # stored to bf16 buffer
```

The output workspace is allocated with `model_config.dtype` (typically bf16) at line 584. Triton auto-casts on store, so the roundtrip through fp8 just loses precision for no benefit.

After this fix, the dequantized float32 values are stored directly and Triton handles the bf16 cast. This matches what you'd expect from a dequantization path — the whole point is to get OUT of fp8.

No duplicate PRs found. AI assistance was used for code search; all changes reviewed by human submitter.