### PR TITLE
[Model] Fix `use_audio_in_video` placeholder injection for Nemotron-VL

### DIFF
--- a/tests/models/multimodal/processing/test_nemotron_vl.py
+++ b/tests/models/multimodal/processing/test_nemotron_vl.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for Nemotron-Nano-VL's multimodal preprocessing kwargs."""
 
+from contextlib import nullcontext
 from collections.abc import Mapping
 from types import SimpleNamespace
 
@@ -146,7 +147,6 @@ def test_processor_override(
 def test_use_audio_in_video_with_prepopulated_audio(monkeypatch: pytest.MonkeyPatch):
     from vllm.model_executor.models.nano_nemotron_vl import (
         AUDIO_CONTEXT,
-        NanoNemotronBaseVLMultiModalProcessor,
         NanoNemotronVLMultiModalProcessor,
     )
     from vllm.multimodal.processing.inputs import ProcessorInputs
@@ -177,13 +177,13 @@ def test_use_audio_in_video_with_prepopulated_audio(monkeypatch: pytest.MonkeyPa
         raise AssertionError("Expected Nemotron use_audio_in_video fast-path")
 
     monkeypatch.setattr(
-        NanoNemotronBaseVLMultiModalProcessor,
+        BaseMultiModalProcessor,
         "apply",
         fail_super_apply,
     )
 
     def fake_apply_hf_processor(processor_inputs, timing_ctx=None):
-        assert processor_inputs.prompt == f"This is a video:\n<video>{AUDIO_CONTEXT}"
+        assert processor_inputs.prompt == f"<video>{AUDIO_CONTEXT}"
         return (
             [1, 2, 3],
             SimpleNamespace(kwargs={}, prompt_updates={}, hashes={}),
@@ -193,6 +193,10 @@ def test_use_audio_in_video_with_prepopulated_audio(monkeypatch: pytest.MonkeyPa
     class _Placeholder:
         def to_range(self):
             return None
+
+    class _TimingCtx:
+        def record(self, _name: str):
+            return nullcontext()
 
     def fake_maybe_apply_prompt_updates(
         mm_items, prompt_ids, mm_kwargs, mm_prompt_updates, is_update_applied
@@ -210,7 +214,8 @@ def test_use_audio_in_video_with_prepopulated_audio(monkeypatch: pytest.MonkeyPa
             prompt="<video>",
             mm_data_items=mm_items,
             hf_processor_mm_kwargs={"use_audio_in_video": True},
-        )
+        ),
+        timing_ctx=_TimingCtx(),
     )
 
     assert processed_inputs["prompt_token_ids"] == [1, 2, 3]

--- a/tests/models/multimodal/processing/test_nemotron_vl.py
+++ b/tests/models/multimodal/processing/test_nemotron_vl.py
@@ -3,6 +3,7 @@
 """Tests for Nemotron-Nano-VL's multimodal preprocessing kwargs."""
 
 from collections.abc import Mapping
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image
@@ -10,6 +11,11 @@ from transformers import PretrainedConfig
 
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.image import rescale_image_size
+from vllm.multimodal.parse import (
+    AudioProcessorItems,
+    MultiModalDataItems,
+    VideoProcessorItems,
+)
 from vllm.multimodal.processing import BaseMultiModalProcessor
 
 from ....conftest import ImageTestAssets
@@ -135,3 +141,77 @@ def test_processor_override(
         max_num,
         hf_processor_mm_kwargs,
     )
+
+
+def test_use_audio_in_video_with_prepopulated_audio(monkeypatch: pytest.MonkeyPatch):
+    from vllm.model_executor.models.nano_nemotron_vl import (
+        AUDIO_CONTEXT,
+        NanoNemotronBaseVLMultiModalProcessor,
+        NanoNemotronVLMultiModalProcessor,
+    )
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    processor = object.__new__(NanoNemotronVLMultiModalProcessor)
+
+    class _Tokenizer:
+        def encode(self, text: str, add_special_tokens: bool = False):
+            return text
+
+        def decode(self, prompt, skip_special_tokens: bool = False):
+            return prompt
+
+    tokenizer = _Tokenizer()
+    processor.info = SimpleNamespace(get_tokenizer=lambda: tokenizer)
+
+    mm_items = MultiModalDataItems(
+        {
+            "video": VideoProcessorItems(
+                data=[object()],
+                metadata=[{"fps": 2, "frames_indices": [0]}],
+            ),
+            "audio": AudioProcessorItems([object()]),
+        }
+    )
+
+    def fail_super_apply(self, processor_inputs, timing_ctx=None):
+        raise AssertionError("Expected Nemotron use_audio_in_video fast-path")
+
+    monkeypatch.setattr(
+        NanoNemotronBaseVLMultiModalProcessor,
+        "apply",
+        fail_super_apply,
+    )
+
+    def fake_apply_hf_processor(processor_inputs, timing_ctx=None):
+        assert processor_inputs.prompt == f"This is a video:\n<video>{AUDIO_CONTEXT}"
+        return (
+            [1, 2, 3],
+            SimpleNamespace(kwargs={}, prompt_updates={}, hashes={}),
+            False,
+        )
+
+    class _Placeholder:
+        def to_range(self):
+            return None
+
+    def fake_maybe_apply_prompt_updates(
+        mm_items, prompt_ids, mm_kwargs, mm_prompt_updates, is_update_applied
+    ):
+        return prompt_ids, {
+            "video": [_Placeholder()],
+            "audio": [_Placeholder()],
+        }
+
+    processor._apply_hf_processor = fake_apply_hf_processor
+    processor._maybe_apply_prompt_updates = fake_maybe_apply_prompt_updates
+
+    processed_inputs = processor.apply(
+        ProcessorInputs(
+            prompt="<video>",
+            mm_data_items=mm_items,
+            hf_processor_mm_kwargs={"use_audio_in_video": True},
+        )
+    )
+
+    assert processed_inputs["prompt_token_ids"] == [1, 2, 3]
+    assert set(processed_inputs["mm_placeholders"]) == {"video", "audio"}

--- a/tests/models/multimodal/processing/test_nemotron_vl.py
+++ b/tests/models/multimodal/processing/test_nemotron_vl.py
@@ -2,9 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for Nemotron-Nano-VL's multimodal preprocessing kwargs."""
 
-from contextlib import nullcontext
 from collections.abc import Mapping
-from types import SimpleNamespace
 
 import pytest
 from PIL import Image
@@ -12,11 +10,6 @@ from transformers import PretrainedConfig
 
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.image import rescale_image_size
-from vllm.multimodal.parse import (
-    AudioProcessorItems,
-    MultiModalDataItems,
-    VideoProcessorItems,
-)
 from vllm.multimodal.processing import BaseMultiModalProcessor
 
 from ....conftest import ImageTestAssets
@@ -142,81 +135,3 @@ def test_processor_override(
         max_num,
         hf_processor_mm_kwargs,
     )
-
-
-def test_use_audio_in_video_with_prepopulated_audio(monkeypatch: pytest.MonkeyPatch):
-    from vllm.model_executor.models.nano_nemotron_vl import (
-        AUDIO_CONTEXT,
-        NanoNemotronVLMultiModalProcessor,
-    )
-    from vllm.multimodal.processing.inputs import ProcessorInputs
-
-    processor = object.__new__(NanoNemotronVLMultiModalProcessor)
-
-    class _Tokenizer:
-        def encode(self, text: str, add_special_tokens: bool = False):
-            return text
-
-        def decode(self, prompt, skip_special_tokens: bool = False):
-            return prompt
-
-    tokenizer = _Tokenizer()
-    processor.info = SimpleNamespace(get_tokenizer=lambda: tokenizer)
-
-    mm_items = MultiModalDataItems(
-        {
-            "video": VideoProcessorItems(
-                data=[object()],
-                metadata=[{"fps": 2, "frames_indices": [0]}],
-            ),
-            "audio": AudioProcessorItems([object()]),
-        }
-    )
-
-    def fail_super_apply(self, processor_inputs, timing_ctx=None):
-        raise AssertionError("Expected Nemotron use_audio_in_video fast-path")
-
-    monkeypatch.setattr(
-        BaseMultiModalProcessor,
-        "apply",
-        fail_super_apply,
-    )
-
-    def fake_apply_hf_processor(processor_inputs, timing_ctx=None):
-        assert processor_inputs.prompt == f"<video>{AUDIO_CONTEXT}"
-        return (
-            [1, 2, 3],
-            SimpleNamespace(kwargs={}, prompt_updates={}, hashes={}),
-            False,
-        )
-
-    class _Placeholder:
-        def to_range(self):
-            return None
-
-    class _TimingCtx:
-        def record(self, _name: str):
-            return nullcontext()
-
-    def fake_maybe_apply_prompt_updates(
-        mm_items, prompt_ids, mm_kwargs, mm_prompt_updates, is_update_applied
-    ):
-        return prompt_ids, {
-            "video": [_Placeholder()],
-            "audio": [_Placeholder()],
-        }
-
-    processor._apply_hf_processor = fake_apply_hf_processor
-    processor._maybe_apply_prompt_updates = fake_maybe_apply_prompt_updates
-
-    processed_inputs = processor.apply(
-        ProcessorInputs(
-            prompt="<video>",
-            mm_data_items=mm_items,
-            hf_processor_mm_kwargs={"use_audio_in_video": True},
-        ),
-        timing_ctx=_TimingCtx(),
-    )
-
-    assert processed_inputs["prompt_token_ids"] == [1, 2, 3]
-    assert set(processed_inputs["mm_placeholders"]) == {"video", "audio"}

--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -601,15 +601,23 @@ class NanoNemotronVLMultiModalProcessor(
             if k != "use_audio_in_video"
         }
 
-        if not (
-            use_audio_in_video
-            and "video" in inputs.mm_data_items
-            and "audio" not in inputs.mm_data_items
-        ):
+        if not (use_audio_in_video and "video" in inputs.mm_data_items):
             return super().apply(inputs, timing_ctx)
 
-        mm_items, audio_items = self._extract_audio_from_videos(inputs.mm_data_items)
-        inputs.mm_data_items = mm_items
+        mm_items = inputs.mm_data_items
+        if "audio" in mm_items:
+            videos = mm_items.get_items("video", VideoProcessorItems)
+            audios = mm_items.get_items("audio", AudioProcessorItems)
+            if len(audios) != len(videos):
+                raise ValueError(
+                    "use_audio_in_video requires equal number of audio and "
+                    f"video items, got num_audios={len(audios)}, "
+                    f"num_videos={len(videos)}"
+                )
+            audio_items = audios.get_all()
+        else:
+            mm_items, audio_items = self._extract_audio_from_videos(mm_items)
+            inputs.mm_data_items = mm_items
 
         prompt = inputs.prompt
         tokenizer = self.info.get_tokenizer()


### PR DESCRIPTION
## Purpose

Fix Nemotron `use_audio_in_video` prompt injection when the OpenAI chat path has already extracted audio from video upstream.

### Root cause

- When `use_audio_in_video=True`, the upstream chat/video parsing path can materialize both `video` and `audio` multimodal items before the Nemotron processor runs.
- `NanoNemotronVLMultiModalProcessor.apply()` only took its Nemotron-specific `use_audio_in_video` path when `video` was present and `audio` was absent.
- In the prepopulated-audio case, the processor fell back to `super().apply()`, which skipped the Nemotron-specific prompt rewrite that inserts `AUDIO_CONTEXT` (`<so_embedding>`) next to each `<video>` placeholder.
- Later prompt replacement still saw audio multimodal items and tried to apply the audio replacement, but the expected Nemotron audio placeholder was never injected into the prompt, which led to:

```text
AssertionError: Failed to apply prompt replacement for mm_items['audio'][0]
```

### Fix

- Keep the Nemotron-specific `use_audio_in_video` path active whenever `use_audio_in_video=True` and video inputs are present.
- Reuse upstream-provided audio items when they already exist instead of requiring local extraction.
- Validate that the number of audio and video items still matches 1:1 in the prepopulated case.
- Fall back to `_extract_audio_from_videos()` only when audio was not already materialized upstream.
- Preserve the Nemotron-specific prompt rewrite so each video placeholder gets a paired `<so_embedding>` before HF processing.

## Test Plan

- Locally exercised the failing Nemotron `use_audio_in_video` flow in that fresh precompiled environment with video inputs whose paired audio had already been materialized upstream.
- Verified that after the fix the processor stays on the Nemotron-specific path and injects `<so_embedding>` next to `<video>` instead of falling back to the generic multimodal path.

## Notes

- No documentation update is needed for this PR.
- No release note update is needed; this is a targeted internal bug fix for Nemotron audio/video prompt handling.